### PR TITLE
Add Branch struct, ListBranches(), and BranchDiff() in gitquery

### DIFF
--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -217,7 +217,7 @@ func ListBranches(repoPath string) ([]Branch, error) {
 
 // BranchDiff returns the diff output for a worktree.
 func BranchDiff(worktreePath string) (string, error) {
-	return gitCmd(worktreePath, "diff")
+	return gitCmd(worktreePath, "diff", "HEAD")
 }
 
 // branchWorktreeMap returns a map of branch name -> worktree path.

--- a/gitquery/gitquery_test.go
+++ b/gitquery/gitquery_test.go
@@ -718,6 +718,8 @@ func TestBranchDiff_ReturnsDiffForDirtyWorktree(t *testing.T) {
 	run(t, repo, "git", "worktree", "add", wtPath, "diff-branch")
 
 	writeFile(t, wtPath, "README.md", "changed\n")
+	writeFile(t, wtPath, "staged.txt", "staged content\n")
+	run(t, wtPath, "git", "add", "staged.txt")
 
 	diff, err := gitquery.BranchDiff(wtPath)
 	if err != nil {
@@ -728,7 +730,10 @@ func TestBranchDiff_ReturnsDiffForDirtyWorktree(t *testing.T) {
 		t.Error("expected diff output to contain 'diff --git'")
 	}
 	if !strings.Contains(diff, "changed") {
-		t.Error("expected diff output to contain the changed content")
+		t.Error("expected diff output to contain unstaged changes")
+	}
+	if !strings.Contains(diff, "staged content") {
+		t.Error("expected diff output to contain staged changes")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #15

- Adds `Branch` struct with fields: `Name`, `HasUpstream`, `UpstreamGone`, `Ahead`, `Behind`, `Unpushed`, `IsWorktree`, `WorktreePath`, `Dirty`, `FilesChanged`, `LinesAdded`, `LinesDeleted`
- `ListBranches(repoPath)` gathers all data in one call: `git for-each-ref` for branch names + upstream refs, `git worktree list --porcelain` for worktree mapping, per-branch `rev-list --left-right` using explicit upstream refs (not `@{upstream}`), `log --oneline` for unpushed commits, `status --porcelain` + `diff HEAD --numstat` for dirty worktree stats. Returns `[]Branch` sorted alphabetically.
- `BranchDiff(repoPath, worktreePath)` returns `git diff` output for a worktree
- Old types (`Worktree`, `Stash`, `ListWorktrees`, etc.) are untouched

## Test plan

- [x] 9 new tests using real temp git repos (no mocks):
  - Branch discovery and alphabetical sorting
  - Upstream with correct ahead/behind counts
  - No upstream (HasUpstream = false)
  - Upstream gone (UpstreamGone = true)
  - Worktree annotation (IsWorktree, WorktreePath for both linked and main worktree)
  - Dirty worktree (Dirty, FilesChanged, LinesAdded, LinesDeleted)
  - Unpushed commit messages (most recent first)
  - BranchDiff returns diff for dirty worktree
  - BranchDiff returns empty for clean worktree
- [x] All existing Worktree and Stash tests continue to pass