### PR TITLE
Handle diffable branch cursor selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ WORKTREE_ROOT=~/projects ./bin/wt
 | `←`/`h` | Switch to previous mode |
 | `→`/`l` | Switch to next mode |
 | `1`/`2` | Jump to branches / stashes mode |
-| `enter` | View stash diff (stashes mode) |
+| `enter` | View dirty branch diff in branches mode or stash diff in stashes mode |
 | `esc`/`q` | Close overlay or quit |
 
 ### Branches view (mode 1)
@@ -46,7 +46,7 @@ The right pane shows all local branches alphabetically with stacking indicators:
 - `●` red: dirty worktree — shows `N files +X/-Y` (lines added/deleted)
 - `●` purple: no upstream or upstream gone
 
-Worktree branches are annotated with `[<path>]`. If the same branch is checked out in more than one worktree, the UI shows `[<path1>, <path2>, ...]`. Detached worktrees appear as `(detached)` rows with their path annotation. Branches ahead of upstream show up to 5 unpushed commit messages, with overflow count.
+Worktree branches are annotated with `[<path>]`. If the same branch is checked out in more than one worktree, the UI shows `[<path1>, <path2>, ...]`. Detached worktrees appear as `(detached)` rows with their path annotation. Branches ahead of upstream show up to 5 unpushed commit messages, with overflow count. When a branch is dirty and is a worktree, `enter` opens a full-screen diff overlay for that worktree.
 
 ### Stashes view (mode 2)
 

--- a/model/model.go
+++ b/model/model.go
@@ -20,8 +20,9 @@ const (
 type OverlayState int
 
 const (
-	OverlayNone      OverlayState = 0
-	OverlayStashDiff OverlayState = 1
+	OverlayNone       OverlayState = 0
+	OverlayStashDiff  OverlayState = 1
+	OverlayBranchDiff OverlayState = 2
 )
 
 // BranchResultMsg is sent when branch data is fetched asynchronously.
@@ -43,19 +44,27 @@ type StashDiffResultMsg struct {
 	Diff     string
 }
 
+// BranchDiffResultMsg is sent when a branch diff is fetched asynchronously.
+type BranchDiffResultMsg struct {
+	RepoPath   string
+	BranchName string
+	Diff       string
+}
+
 // Model is the bubbletea application model.
 type Model struct {
-	repos         []scanner.Repo
-	selected      int
-	width         int
-	height        int
-	mode          Mode
-	branches      []gitquery.Branch
-	stashes       []gitquery.Stash
-	stashSelected int
-	overlay       OverlayState
-	overlayDiff   string
-	overlayScroll int
+	repos          []scanner.Repo
+	selected       int
+	width          int
+	height         int
+	mode           Mode
+	branches       []gitquery.Branch
+	stashes        []gitquery.Stash
+	branchSelected int
+	stashSelected  int
+	overlay        OverlayState
+	overlayDiff    string
+	overlayScroll  int
 }
 
 // New creates a Model from discovered repos.
@@ -69,6 +78,7 @@ func (m Model) Height() int                 { return m.height }
 func (m Model) Mode() Mode                  { return m.mode }
 func (m Model) Branches() []gitquery.Branch { return m.branches }
 func (m Model) Stashes() []gitquery.Stash   { return m.stashes }
+func (m Model) BranchSelected() int         { return m.branchSelected }
 func (m Model) StashSelected() int          { return m.stashSelected }
 func (m Model) Overlay() OverlayState       { return m.overlay }
 func (m Model) OverlayDiff() string         { return m.overlayDiff }
@@ -85,6 +95,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case BranchResultMsg:
 		if m.selected < len(m.repos) && msg.RepoPath == m.repos[m.selected].Path {
 			m.branches = msg.Branches
+			if count := diffableBranchCount(m.branches); count == 0 || m.branchSelected >= count {
+				m.branchSelected = 0
+			}
 		}
 	case StashResultMsg:
 		if m.selected < len(m.repos) && msg.RepoPath == m.repos[m.selected].Path {
@@ -93,6 +106,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case StashDiffResultMsg:
 		if m.selected < len(m.repos) && msg.RepoPath == m.repos[m.selected].Path {
 			m.overlayDiff = msg.Diff
+		}
+	case BranchDiffResultMsg:
+		if m.selected < len(m.repos) && msg.RepoPath == m.repos[m.selected].Path {
+			if branch, ok := m.selectedBranch(); ok && branch.Name == msg.BranchName {
+				m.overlayDiff = msg.Diff
+			}
 		}
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -126,43 +145,64 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch key {
 	case "up", "k":
+		if m.mode == ModeBranches {
+			if count := diffableBranchCount(m.branches); count > 0 && m.branchSelected > 0 {
+				m.branchSelected--
+				return m, nil
+			}
+		}
 		if m.mode == ModeStashes && m.stashSelected > 0 {
 			m.stashSelected--
 		}
 	case "down", "j":
+		if m.mode == ModeBranches {
+			if count := diffableBranchCount(m.branches); count > 0 && m.branchSelected < count-1 {
+				m.branchSelected++
+				return m, nil
+			}
+		}
 		if m.mode == ModeStashes && len(m.stashes) > 0 && m.stashSelected < len(m.stashes)-1 {
 			m.stashSelected++
 		}
 	case "left", "h":
 		if m.mode > ModeBranches {
 			m.mode--
+			m.branchSelected = 0
 			m.stashSelected = 0
 			return m, m.fetchForMode()
 		}
 	case "right", "l":
 		if m.mode < ModeStashes {
 			m.mode++
+			m.branchSelected = 0
 			m.stashSelected = 0
 			return m, m.fetchForMode()
 		}
 	case "1":
 		if m.mode != ModeBranches {
 			m.mode = ModeBranches
+			m.branchSelected = 0
 			return m, m.fetchBranches()
 		}
 	case "2":
 		if m.mode != ModeStashes {
 			m.mode = ModeStashes
+			m.branchSelected = 0
 			m.stashSelected = 0
 			return m, m.fetchStashes()
 		}
 	case "tab":
 		if len(m.repos) > 0 {
 			m.selected = (m.selected + 1) % len(m.repos)
+			m.branchSelected = 0
 			m.stashSelected = 0
 			return m, m.fetchForMode()
 		}
 	case "enter":
+		if m.mode == ModeBranches && m.isSelectedBranchDirtyWorktree() {
+			m.overlay = OverlayBranchDiff
+			return m, m.fetchBranchDiff()
+		}
 		if m.mode == ModeStashes && len(m.stashes) > 0 {
 			m.overlay = OverlayStashDiff
 			return m, m.fetchStashDiff()
@@ -175,17 +215,18 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) View() string {
 	return ui.Render(ui.RenderParams{
-		Repos:         m.repos,
-		Selected:      m.selected,
-		Width:         m.width,
-		Height:        m.height,
-		Mode:          int(m.mode),
-		Branches:      m.branches,
-		Stashes:       m.stashes,
-		StashSelected: m.stashSelected,
-		Overlay:       int(m.overlay),
-		OverlayDiff:   m.overlayDiff,
-		OverlayScroll: m.overlayScroll,
+		Repos:          m.repos,
+		Selected:       m.selected,
+		Width:          m.width,
+		Height:         m.height,
+		Mode:           int(m.mode),
+		Branches:       m.branches,
+		Stashes:        m.stashes,
+		BranchSelected: m.branchSelected,
+		StashSelected:  m.stashSelected,
+		Overlay:        int(m.overlay),
+		OverlayDiff:    m.overlayDiff,
+		OverlayScroll:  m.overlayScroll,
 	})
 }
 
@@ -219,6 +260,64 @@ func (m Model) fetchStashes() tea.Cmd {
 		stashes, _ := gitquery.ListStashes(repoPath)
 		return StashResultMsg{RepoPath: repoPath, Stashes: stashes}
 	}
+}
+
+func (m Model) fetchBranchDiff() tea.Cmd {
+	if len(m.repos) == 0 {
+		return nil
+	}
+	branch, ok := m.selectedBranch()
+	if !ok || !branch.Dirty || !branch.IsWorktree {
+		return nil
+	}
+
+	repoPath := m.repos[m.selected].Path
+	worktreePath := repoPath
+	if len(branch.WorktreePaths) > 0 {
+		worktreePath = branch.WorktreePaths[0]
+	}
+	branchName := branch.Name
+
+	return func() tea.Msg {
+		diff, _ := gitquery.BranchDiff(worktreePath)
+		return BranchDiffResultMsg{
+			RepoPath:   repoPath,
+			BranchName: branchName,
+			Diff:       diff,
+		}
+	}
+}
+
+func (m Model) selectedBranch() (gitquery.Branch, bool) {
+	if m.branchSelected < 0 {
+		return gitquery.Branch{}, false
+	}
+	index := 0
+	for _, branch := range m.branches {
+		if !branch.Dirty || !branch.IsWorktree {
+			continue
+		}
+		if index == m.branchSelected {
+			return branch, true
+		}
+		index++
+	}
+	return gitquery.Branch{}, false
+}
+
+func (m Model) isSelectedBranchDirtyWorktree() bool {
+	branch, ok := m.selectedBranch()
+	return ok && branch.Dirty && branch.IsWorktree
+}
+
+func diffableBranchCount(branches []gitquery.Branch) int {
+	count := 0
+	for _, branch := range branches {
+		if branch.Dirty && branch.IsWorktree {
+			count++
+		}
+	}
+	return count
 }
 
 func (m Model) fetchStashDiff() tea.Cmd {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -216,6 +216,128 @@ func TestModel_ModeSwitchPreservesSelection(t *testing.T) {
 	}
 }
 
+func TestModel_BranchCursorSkipsNonDiffableBranches(t *testing.T) {
+	branches := []gitquery.Branch{
+		{Name: "clean-1"},
+		{Name: "dirty-1", IsWorktree: true, Dirty: true, WorktreePaths: []string{"/dev/alpha"}},
+		{Name: "clean-2"},
+		{Name: "dirty-2", IsWorktree: true, Dirty: true, WorktreePaths: []string{"/dev/alpha"}},
+	}
+
+	m := model.New(testRepos())
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: branches,
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected diff cmd for first dirty branch, got nil")
+	}
+	msg := cmd()
+	diffMsg, ok := msg.(model.BranchDiffResultMsg)
+	if !ok {
+		t.Fatalf("expected BranchDiffResultMsg, got %T", msg)
+	}
+	if diffMsg.BranchName != "dirty-1" {
+		t.Fatalf("expected first diffable branch dirty-1, got %q", diffMsg.BranchName)
+	}
+
+	m2 := model.New(testRepos())
+	m2, _ = update(m2, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
+	m2, _ = update(m2, tea.KeyMsg{Type: tea.KeyDown})
+	m2, cmd = update(m2, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected diff cmd for second dirty branch, got nil")
+	}
+	msg = cmd()
+	diffMsg, ok = msg.(model.BranchDiffResultMsg)
+	if !ok {
+		t.Fatalf("expected BranchDiffResultMsg, got %T", msg)
+	}
+	if diffMsg.BranchName != "dirty-2" {
+		t.Fatalf("expected second diffable branch dirty-2, got %q", diffMsg.BranchName)
+	}
+
+	m3 := model.New(testRepos())
+	m3, _ = update(m3, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
+	m3, _ = update(m3, tea.KeyMsg{Type: tea.KeyDown})
+	m3, _ = update(m3, tea.KeyMsg{Type: tea.KeyDown})
+	m3, cmd = update(m3, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected diff cmd after clamping at last dirty branch, got nil")
+	}
+	msg = cmd()
+	diffMsg, ok = msg.(model.BranchDiffResultMsg)
+	if !ok {
+		t.Fatalf("expected BranchDiffResultMsg, got %T", msg)
+	}
+	if diffMsg.BranchName != "dirty-2" {
+		t.Fatalf("expected cursor to clamp at dirty-2, got %q", diffMsg.BranchName)
+	}
+}
+
+func TestModel_EnterOpensBranchDiffOverlayForDirtyWorktree(t *testing.T) {
+	m := model.New(testRepos())
+	branches := []gitquery.Branch{
+		{
+			Name:          "feat",
+			IsWorktree:    true,
+			Dirty:         true,
+			WorktreePaths: []string{"/dev/alpha"},
+		},
+		{Name: "main"},
+	}
+	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.Overlay() != model.OverlayBranchDiff {
+		t.Errorf("expected OverlayBranchDiff, got %d", m.Overlay())
+	}
+	if cmd == nil {
+		t.Fatal("expected fetchBranchDiff cmd, got nil")
+	}
+	msg := cmd()
+	if _, ok := msg.(model.BranchDiffResultMsg); !ok {
+		t.Errorf("expected BranchDiffResultMsg, got %T", msg)
+	}
+}
+
+func TestModel_EnterDoesNothingForCleanBranch(t *testing.T) {
+	m := model.New(testRepos())
+	branches := []gitquery.Branch{
+		{
+			Name:       "feat",
+			IsWorktree: true,
+			Dirty:      false,
+		},
+	}
+	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.Overlay() != model.OverlayNone {
+		t.Errorf("expected OverlayNone, got %d", m.Overlay())
+	}
+	if cmd != nil {
+		t.Fatalf("expected no command for clean branch, got %T", cmd)
+	}
+}
+
+func TestModel_StaleBranchDiffResultDiscarded(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab}) // select bravo
+
+	m, _ = update(m, model.BranchDiffResultMsg{
+		RepoPath:   "/dev/alpha",
+		BranchName: "feat",
+		Diff:       "diff --git a/f.txt b/f.txt",
+	})
+
+	if m.OverlayDiff() != "" {
+		t.Errorf("expected stale branch diff discarded, got %q", m.OverlayDiff())
+	}
+}
+
 func TestModel_InitFiresFetchBranches(t *testing.T) {
 	m := model.New(testRepos())
 	cmd := m.Init()

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -26,6 +26,7 @@ var (
 	stashDateStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
 	stashMsgStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
 	stashSelStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true).Reverse(true)
+	branchSelStyle    = lipgloss.NewStyle().Bold(true).Reverse(true)
 	noUpstreamStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
 	aheadBehindStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
 	dirtyRedStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
@@ -36,17 +37,18 @@ var (
 
 // RenderParams holds everything the renderer needs.
 type RenderParams struct {
-	Repos         []scanner.Repo
-	Selected      int
-	Width         int
-	Height        int
-	Mode          int
-	Branches      []gitquery.Branch
-	Stashes       []gitquery.Stash
-	StashSelected int
-	Overlay       int
-	OverlayDiff   string
-	OverlayScroll int
+	Repos          []scanner.Repo
+	Selected       int
+	Width          int
+	Height         int
+	Mode           int
+	Branches       []gitquery.Branch
+	Stashes        []gitquery.Stash
+	BranchSelected int
+	StashSelected  int
+	Overlay        int
+	OverlayDiff    string
+	OverlayScroll  int
 }
 
 // Render produces the full terminal view string.
@@ -78,7 +80,7 @@ func Render(p RenderParams) string {
 	var rightLines []string
 	switch {
 	case p.Mode == 1 && len(p.Branches) > 0:
-		rightLines = renderBranchPane(p.Branches, rightWidth, contentHeight)
+		rightLines = renderBranchPaneSelected(p.Branches, p.BranchSelected, rightWidth, contentHeight)
 	case p.Mode == 2 && len(p.Stashes) > 0:
 		rightLines = renderStashPane(p.Stashes, p.StashSelected, rightWidth, contentHeight)
 	default:
@@ -126,7 +128,7 @@ func RenderStatusBar(width, mode, overlay int) string {
 	} else if mode == 2 {
 		hints = "  ↑/↓ select  enter: diff  tab: repo  ←/→: mode  q/esc: quit"
 	} else {
-		hints = "  " + cleanStyle.Render("✔") + " clean  " + aheadBehindStyle.Render("●") + " ahead/behind  " + dirtyRedStyle.Render("●") + " dirty  " + noUpstreamStyle.Render("●") + " no upstream  tab: repo  ←/→: mode  q/esc: quit"
+		hints = "  ↑/↓ enter  " + cleanStyle.Render("✔") + " clean  " + aheadBehindStyle.Render("●") + " ahead/behind  " + dirtyRedStyle.Render("●") + " dirty  " + noUpstreamStyle.Render("●") + " no upstream  tab: repo  ←/→: mode  q/esc: quit"
 	}
 
 	text := "  " + strings.Join(parts, " ") + hints
@@ -162,7 +164,12 @@ func renderRepoList(repos []scanner.Repo, selected, height int) []string {
 }
 
 func renderBranchPane(branches []gitquery.Branch, width, height int) []string {
+	return renderBranchPaneSelected(branches, 0, width, height)
+}
+
+func renderBranchPaneSelected(branches []gitquery.Branch, selected, width, height int) []string {
 	var content []string
+	diffableIndex := 0
 
 	for _, b := range branches {
 		branch := branchStyle.Render(b.Name)
@@ -192,7 +199,13 @@ func renderBranchPane(branches []gitquery.Branch, width, height int) []string {
 		}
 
 		line := "  " + branch + indicators + annotation
+		if b.Dirty && b.IsWorktree && diffableIndex == selected {
+			line = branchSelStyle.Render(" > " + strings.TrimPrefix(line, "  "))
+		}
 		content = append(content, line)
+		if b.Dirty && b.IsWorktree {
+			diffableIndex++
+		}
 
 		// Unpushed commits (max 5)
 		maxShow := 5

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -227,6 +227,42 @@ func TestBranchPane_NonWorktreeNoAnnotation(t *testing.T) {
 	}
 }
 
+func TestRender_HighlightsSelectedDiffableBranch(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected: 0,
+		Width:    80,
+		Height:   10,
+		Mode:     1,
+		Branches: []gitquery.Branch{
+			{Name: "clean"},
+			{Name: "dirty", IsWorktree: true, Dirty: true, WorktreePaths: []string{"/a"}},
+		},
+		BranchSelected: 0,
+	})
+	if !strings.Contains(view, "> dirty") {
+		t.Error("selected diffable branch should render with a visible cursor")
+	}
+	if strings.Contains(view, "> clean") {
+		t.Error("non-diffable branch should not be highlighted")
+	}
+}
+
+func TestRender_HidesBranchCursorWhenNoDiffableBranches(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:          []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:       0,
+		Width:          80,
+		Height:         10,
+		Mode:           1,
+		Branches:       []gitquery.Branch{{Name: "clean-1"}, {Name: "clean-2"}},
+		BranchSelected: 0,
+	})
+	if strings.Contains(view, "> clean-1") || strings.Contains(view, "> clean-2") {
+		t.Error("branch cursor should be hidden when there are no diffable branches")
+	}
+}
+
 func TestBranchPane_UnpushedCommitsShown(t *testing.T) {
 	branches := []gitquery.Branch{
 		{Name: "feat", HasUpstream: true, Ahead: 2,


### PR DESCRIPTION
Closes #17

- Branch mode cursor now skips non-diffable branches
- No cursor is shown when no diffable branches exist
- Added tests for cursor movement and no-cursor rendering

Manual testing:
- Start wt against a repo with at least one dirty worktree branch and one clean branch
- In branches mode, use up/down to move only between dirty worktree branches
- Press enter on a dirty worktree branch and confirm the full-screen diff overlay opens
- Press esc or q to close the overlay
- Press enter on a clean branch and confirm nothing happens
