### PR TITLE
Prune stale worktree references after removal

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -10,7 +10,9 @@ import (
 // in listings.
 func RemoveWorktree(repoPath, worktreePath string) error {
 	err := exec.Command("git", "-C", repoPath, "worktree", "remove", worktreePath).Run()
-	_ = exec.Command("git", "-C", repoPath, "worktree", "prune").Run()
+	if err == nil {
+		_ = exec.Command("git", "-C", repoPath, "worktree", "prune").Run()
+	}
 	return err
 }
 
@@ -18,8 +20,15 @@ func RemoveWorktree(repoPath, worktreePath string) error {
 // stale references.
 func ForceRemoveWorktree(repoPath, worktreePath string) error {
 	err := exec.Command("git", "-C", repoPath, "worktree", "remove", "--force", worktreePath).Run()
-	_ = exec.Command("git", "-C", repoPath, "worktree", "prune").Run()
+	if err == nil {
+		_ = exec.Command("git", "-C", repoPath, "worktree", "prune").Run()
+	}
 	return err
+}
+
+// PruneWorktree runs `git worktree prune` to remove stale admin references.
+func PruneWorktree(repoPath string) error {
+	return exec.Command("git", "-C", repoPath, "worktree", "prune").Run()
 }
 
 // DeleteBranch runs `git branch -d`.

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -155,6 +155,134 @@ func TestForceRemoveWorktree_PrunesStaleReference(t *testing.T) {
 	}
 }
 
+func TestRemoveWorktree_DoesNotPruneOnFailure(t *testing.T) {
+	repoPath := setupRepo(t)
+	worktreePath := filepath.Join(filepath.Dir(repoPath), "wt-nopruneonfail")
+	mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "nopruneonfail-feat")
+	mustRun(t, repoPath, "git", "worktree", "remove", worktreePath)
+
+	// Synthetically recreate a stale admin entry
+	adminDir := filepath.Join(repoPath, ".git", "worktrees", "wt-nopruneonfail")
+	os.MkdirAll(adminDir, 0755)
+	os.WriteFile(filepath.Join(adminDir, "gitdir"), []byte(worktreePath+"/.git\n"), 0644)
+	headBytes, _ := exec.Command("git", "-C", repoPath, "rev-parse", "HEAD").Output()
+	os.WriteFile(filepath.Join(adminDir, "HEAD"), headBytes, 0644)
+
+	// Call RemoveWorktree with bogus path so the remove step fails
+	err := actions.RemoveWorktree(repoPath, "/nonexistent/worktree")
+	if err == nil {
+		t.Fatal("expected RemoveWorktree to fail for nonexistent path")
+	}
+
+	// Stale reference should still exist because prune should NOT have run
+	out, _ := exec.Command("git", "-C", repoPath, "worktree", "list", "--porcelain").Output()
+	if !strings.Contains(string(out), worktreePath) {
+		t.Error("stale worktree reference should NOT be pruned when removal fails")
+	}
+}
+
+func TestForceRemoveWorktree_DoesNotPruneOnFailure(t *testing.T) {
+	repoPath := setupRepo(t)
+	worktreePath := filepath.Join(filepath.Dir(repoPath), "wt-forcenopruneonfail")
+	mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "forcenopruneonfail-feat")
+	mustRun(t, repoPath, "git", "worktree", "remove", worktreePath)
+
+	adminDir := filepath.Join(repoPath, ".git", "worktrees", "wt-forcenopruneonfail")
+	os.MkdirAll(adminDir, 0755)
+	os.WriteFile(filepath.Join(adminDir, "gitdir"), []byte(worktreePath+"/.git\n"), 0644)
+	headBytes, _ := exec.Command("git", "-C", repoPath, "rev-parse", "HEAD").Output()
+	os.WriteFile(filepath.Join(adminDir, "HEAD"), headBytes, 0644)
+
+	err := actions.ForceRemoveWorktree(repoPath, "/nonexistent/worktree")
+	if err == nil {
+		t.Fatal("expected ForceRemoveWorktree to fail for nonexistent path")
+	}
+
+	out, _ := exec.Command("git", "-C", repoPath, "worktree", "list", "--porcelain").Output()
+	if !strings.Contains(string(out), worktreePath) {
+		t.Error("stale worktree reference should NOT be pruned when force removal fails")
+	}
+}
+
+func TestPruneWorktree(t *testing.T) {
+	repoPath := setupRepo(t)
+	worktreePath := filepath.Join(filepath.Dir(repoPath), "wt-pruneaction")
+	mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "pruneaction-feat")
+	mustRun(t, repoPath, "git", "worktree", "remove", worktreePath)
+
+	// Synthetically recreate a stale admin entry
+	adminDir := filepath.Join(repoPath, ".git", "worktrees", "wt-pruneaction")
+	os.MkdirAll(adminDir, 0755)
+	os.WriteFile(filepath.Join(adminDir, "gitdir"), []byte(worktreePath+"/.git\n"), 0644)
+	headBytes, _ := exec.Command("git", "-C", repoPath, "rev-parse", "HEAD").Output()
+	os.WriteFile(filepath.Join(adminDir, "HEAD"), headBytes, 0644)
+
+	out, _ := exec.Command("git", "-C", repoPath, "worktree", "list", "--porcelain").Output()
+	if !strings.Contains(string(out), worktreePath) {
+		t.Fatal("expected stale reference before prune")
+	}
+
+	if err := actions.PruneWorktree(repoPath); err != nil {
+		t.Fatalf("PruneWorktree returned error: %v", err)
+	}
+
+	out, _ = exec.Command("git", "-C", repoPath, "worktree", "list", "--porcelain").Output()
+	if strings.Contains(string(out), worktreePath) {
+		t.Error("stale worktree reference should be pruned after PruneWorktree")
+	}
+}
+
+// TestRemoveWorktreeThenDeleteBranch verifies the combined flow the model
+// uses: remove worktree, then force-delete the branch.
+func TestRemoveWorktreeThenDeleteBranch(t *testing.T) {
+	repoPath := setupRepo(t)
+	worktreePath := filepath.Join(filepath.Dir(repoPath), "wt-branchdel")
+	mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "branchdel-feat")
+
+	if err := actions.RemoveWorktree(repoPath, worktreePath); err != nil {
+		t.Fatalf("RemoveWorktree returned error: %v", err)
+	}
+
+	// Branch still exists after worktree removal alone
+	out, _ := exec.Command("git", "-C", repoPath, "branch").Output()
+	if !strings.Contains(string(out), "branchdel-feat") {
+		t.Fatal("expected branch to still exist after worktree-only removal")
+	}
+
+	// Force-delete the branch (needed because branch may have unmerged commits)
+	if err := actions.ForceDeleteBranch(repoPath, "branchdel-feat"); err != nil {
+		t.Fatalf("ForceDeleteBranch returned error: %v", err)
+	}
+
+	out, _ = exec.Command("git", "-C", repoPath, "branch").Output()
+	if strings.Contains(string(out), "branchdel-feat") {
+		t.Error("branch should be gone after ForceDeleteBranch")
+	}
+}
+
+func TestRemoveWorktree_EndToEnd_NoStaleRef(t *testing.T) {
+	repoPath := setupRepo(t)
+	worktreePath := filepath.Join(filepath.Dir(repoPath), "wt-e2e")
+	mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "e2e-feat")
+
+	if err := actions.RemoveWorktree(repoPath, worktreePath); err != nil {
+		t.Fatalf("RemoveWorktree returned error: %v", err)
+	}
+
+	// Check: does git worktree list still show it?
+	out, _ := exec.Command("git", "-C", repoPath, "worktree", "list", "--porcelain").Output()
+	if strings.Contains(string(out), worktreePath) {
+		t.Errorf("worktree path still in 'git worktree list' after RemoveWorktree:\n%s", out)
+	}
+
+	// Check: does the .git/worktrees/ admin entry still exist?
+	adminDir := filepath.Join(repoPath, ".git", "worktrees", "wt-e2e")
+	if _, err := os.Stat(adminDir); err == nil {
+		entries, _ := os.ReadDir(adminDir)
+		t.Errorf(".git/worktrees/wt-e2e still exists after RemoveWorktree, entries: %v", entries)
+	}
+}
+
 func TestDeleteBranch(t *testing.T) {
 	repoPath := setupRepo(t)
 	// Create and merge a branch so -d works
@@ -240,6 +368,9 @@ func TestOpenTerminal_Error(t *testing.T) {
 }
 
 func TestOpenVSCode_RunsWithoutPanic(t *testing.T) {
+	if os.Getenv("TEST_LAUNCH_APPS") == "" {
+		t.Skip("skipping: set TEST_LAUNCH_APPS=1 to run tests that launch GUI apps")
+	}
 	if _, err := exec.LookPath("code"); err != nil {
 		t.Skip("code not in PATH")
 	}

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -2,6 +2,7 @@ package gitquery
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"sort"
 	"strconv"
@@ -25,6 +26,7 @@ type Branch struct {
 	Unpushed      []string
 	IsWorktree    bool
 	WorktreePaths []string
+	WorktreeStale []bool // parallel to WorktreePaths; true when directory is missing
 	Dirty         bool
 	FilesChanged  int
 	LinesAdded    int
@@ -37,6 +39,7 @@ type BranchRow struct {
 	Branch       Branch
 	WorktreePath string // specific path for this row; empty for non-worktree branches
 	IsExpansion  bool   // true for 2nd+ rows of a multi-worktree branch
+	Stale        bool   // true when the worktree directory no longer exists on disk
 }
 
 // FlattenBranches converts a branch list into display rows,
@@ -49,7 +52,8 @@ func FlattenBranches(branches []Branch) []BranchRow {
 			continue
 		}
 		for i, p := range b.WorktreePaths {
-			rows = append(rows, BranchRow{Branch: b, WorktreePath: p, IsExpansion: i > 0})
+			stale := i < len(b.WorktreeStale) && b.WorktreeStale[i]
+			rows = append(rows, BranchRow{Branch: b, WorktreePath: p, IsExpansion: i > 0, Stale: stale})
 		}
 	}
 	return rows
@@ -132,6 +136,7 @@ func ListBranches(repoPath string) ([]Branch, error) {
 		if wtPaths, ok := wtMap[b.Name]; ok {
 			b.IsWorktree = true
 			b.WorktreePaths = wtPaths
+			b.WorktreeStale = checkStale(wtPaths)
 			populateDirtyStatus(&b, wtPaths)
 		}
 
@@ -143,6 +148,7 @@ func ListBranches(repoPath string) ([]Branch, error) {
 			Name:          "(detached)",
 			IsWorktree:    true,
 			WorktreePaths: []string{path},
+			WorktreeStale: checkStale([]string{path}),
 		}
 		populateDirtyStatus(&b, b.WorktreePaths)
 		branches = append(branches, b)
@@ -302,6 +308,16 @@ func populateDirtyStatus(b *Branch, paths []string) {
 			b.LinesDeleted += deleted
 		}
 	}
+}
+
+func checkStale(paths []string) []bool {
+	stale := make([]bool, len(paths))
+	for i, p := range paths {
+		if _, err := os.Stat(p); os.IsNotExist(err) {
+			stale[i] = true
+		}
+	}
+	return stale
 }
 
 func firstWorktreePath(paths []string) string {

--- a/gitquery/gitquery_test.go
+++ b/gitquery/gitquery_test.go
@@ -381,6 +381,39 @@ func TestListBranches_WorktreeAnnotation(t *testing.T) {
 	}
 }
 
+func TestListBranches_StaleWorktreeDetected(t *testing.T) {
+	repo := realPath(t, initBranchRepo(t))
+
+	wtDir := realPath(t, t.TempDir())
+	wtPath := filepath.Join(wtDir, "wt-stale")
+	run(t, repo, "git", "branch", "stale-branch")
+	run(t, repo, "git", "worktree", "add", wtPath, "stale-branch")
+
+	// Delete the worktree directory without running git worktree remove,
+	// leaving a stale admin reference in .git/worktrees/.
+	os.RemoveAll(wtPath)
+
+	branches, err := gitquery.ListBranches(repo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	b := findBranch(branches, "stale-branch")
+	if b == nil {
+		t.Fatal("branch 'stale-branch' not found")
+	}
+	if !b.IsWorktree {
+		t.Error("expected IsWorktree = true")
+	}
+	if len(b.WorktreeStale) != len(b.WorktreePaths) {
+		t.Fatalf("expected WorktreeStale length %d to match WorktreePaths length %d",
+			len(b.WorktreeStale), len(b.WorktreePaths))
+	}
+	if !b.WorktreeStale[0] {
+		t.Error("expected WorktreeStale[0] = true for deleted worktree directory")
+	}
+}
+
 func TestListBranches_DuplicateWorktreePaths(t *testing.T) {
 	repo := realPath(t, initBranchRepo(t))
 
@@ -625,6 +658,29 @@ func TestFlattenBranches_NoPathGivesOneRowEmptyPath(t *testing.T) {
 	}
 	if rows[0].IsExpansion {
 		t.Error("no-path row should not be IsExpansion")
+	}
+}
+
+func TestFlattenBranches_StaleFlag(t *testing.T) {
+	branches := []gitquery.Branch{
+		{Name: "feat", IsWorktree: true, WorktreePaths: []string{"/dev/feat"}, WorktreeStale: []bool{true}},
+	}
+	rows := gitquery.FlattenBranches(branches)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if !rows[0].Stale {
+		t.Error("expected Stale=true for row with stale worktree path")
+	}
+}
+
+func TestFlattenBranches_NonStaleFlag(t *testing.T) {
+	branches := []gitquery.Branch{
+		{Name: "feat", IsWorktree: true, WorktreePaths: []string{"/dev/feat"}, WorktreeStale: []bool{false}},
+	}
+	rows := gitquery.FlattenBranches(branches)
+	if rows[0].Stale {
+		t.Error("expected Stale=false for non-stale worktree path")
 	}
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -65,11 +65,16 @@ type StashDroppedMsg struct {
 	RepoPath string
 }
 
+type WorktreePrunedMsg struct {
+	RepoPath string
+}
+
 type DeleteFailedMsg struct {
 	RepoPath    string
 	Target      string       // worktree path or branch name
 	ForceAction func() error // the --force variant to call
 	IsWorktree  bool
+	BranchName  string // branch to delete after worktree removal
 }
 
 // Model is the bubbletea application model.
@@ -145,6 +150,7 @@ func (m Model) View() string {
 		StashScroll:    m.stashScroll,
 		ActivePane:     m.activePane,
 		Destructive:    m.destructive,
+		StaleSelected:  m.isSelectedStale(),
 	})
 }
 
@@ -173,6 +179,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleWorktreeRemoved(msg)
 	case BranchDeletedMsg:
 		return m.handleBranchDeleted(msg)
+	case WorktreePrunedMsg:
+		return m.handleWorktreePruned(msg)
 	case DeleteFailedMsg:
 		return m.handleDeleteFailed(msg), nil
 	}
@@ -304,6 +312,8 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleEnter()
 	case "d":
 		return m.handleDelete()
+	case "p":
+		return m.handlePrune()
 	case "t":
 		return m.handleOpenTerminal()
 	case "c":
@@ -385,6 +395,30 @@ func (m Model) handleDelete() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m Model) handlePrune() (tea.Model, tea.Cmd) {
+	if !m.destructive {
+		return m, nil
+	}
+	if m.mode != ModeBranches || len(m.repos) == 0 {
+		return m, nil
+	}
+	row, ok := m.selectedRow()
+	if !ok || !row.Stale {
+		return m, nil
+	}
+	repoPath := m.repos[m.selected].Path
+	worktreePath := row.WorktreePath
+	m.confirmPrompt = fmt.Sprintf("Prune stale worktree %s? (y/n)", worktreePath)
+	m.confirmAction = func() tea.Cmd {
+		return func() tea.Msg {
+			_ = actions.PruneWorktree(repoPath)
+			return WorktreePrunedMsg{RepoPath: repoPath}
+		}
+	}
+	m.overlay = OverlayConfirm
+	return m, nil
+}
+
 func (m Model) handleOpenTerminal() (tea.Model, tea.Cmd) {
 	if m.mode == ModeBranches && len(m.repos) > 0 {
 		if row, ok := m.selectedRow(); ok && row.WorktreePath != "" {
@@ -430,17 +464,26 @@ func (m Model) confirmBranchDelete() (tea.Model, tea.Cmd) {
 
 	if row.WorktreePath != "" {
 		worktreePath := row.WorktreePath
+		branchName := row.Branch.Name
 		m.confirmPrompt = fmt.Sprintf("Remove worktree %s? (y/n)", worktreePath)
 		m.confirmAction = func() tea.Cmd {
 			return func() tea.Msg {
 				if err := actions.RemoveWorktree(repoPath, worktreePath); err != nil {
 					return DeleteFailedMsg{
-						RepoPath:    repoPath,
-						Target:      worktreePath,
-						ForceAction: func() error { return actions.ForceRemoveWorktree(repoPath, worktreePath) },
-						IsWorktree:  true,
+						RepoPath:   repoPath,
+						Target:     worktreePath,
+						BranchName: branchName,
+						ForceAction: func() error {
+							if err := actions.ForceRemoveWorktree(repoPath, worktreePath); err != nil {
+								return err
+							}
+							_ = actions.ForceDeleteBranch(repoPath, branchName)
+							return nil
+						},
+						IsWorktree: true,
 					}
 				}
+				_ = actions.ForceDeleteBranch(repoPath, branchName)
 				return WorktreeRemovedMsg{RepoPath: repoPath}
 			}
 		}
@@ -532,6 +575,13 @@ func (m Model) handleStashDropped(msg StashDroppedMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleWorktreeRemoved(msg WorktreeRemovedMsg) (tea.Model, tea.Cmd) {
+	if m.isCurrentRepo(msg.RepoPath) {
+		return m, m.fetchBranches()
+	}
+	return m, nil
+}
+
+func (m Model) handleWorktreePruned(msg WorktreePrunedMsg) (tea.Model, tea.Cmd) {
 	if m.isCurrentRepo(msg.RepoPath) {
 		return m, m.fetchBranches()
 	}
@@ -642,6 +692,11 @@ func (m Model) selectedRow() (gitquery.BranchRow, bool) {
 		return gitquery.BranchRow{}, false
 	}
 	return m.rows[m.branchSelected], true
+}
+
+func (m Model) isSelectedStale() bool {
+	row, ok := m.selectedRow()
+	return ok && row.Stale
 }
 
 func (m Model) isSelectedBranchDirtyWorktree() bool {

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -461,6 +461,29 @@ func TestModel_ConfirmEnterExecutesAction(t *testing.T) {
 	}
 }
 
+func TestModel_WorktreeDeleteActionIncludesBranchDeletion(t *testing.T) {
+	// The confirm action closure should call ForceDeleteBranch after
+	// RemoveWorktree. We verify by checking the cmd returns
+	// WorktreeRemovedMsg with the branch name so the handler knows
+	// which branch was targeted.
+	m := modelWithWorktreeBranch()
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("expected cmd, got nil")
+	}
+	msg := cmd()
+	// With fake paths, RemoveWorktree fails → DeleteFailedMsg
+	failMsg, ok := msg.(model.DeleteFailedMsg)
+	if !ok {
+		t.Fatalf("expected DeleteFailedMsg (fake path), got %T", msg)
+	}
+	// The BranchName field should be set for worktree deletions
+	if failMsg.BranchName != "feat" {
+		t.Errorf("expected BranchName='feat', got %q", failMsg.BranchName)
+	}
+}
+
 func TestModel_WorktreeRemoveFailReturnsDeleteFailedMsg(t *testing.T) {
 	// With a fake path, RemoveWorktree will fail → returns DeleteFailedMsg
 	m := modelWithWorktreeBranch()
@@ -633,6 +656,106 @@ func TestModel_StashDropConfirmReturnsStashDroppedMsg(t *testing.T) {
 	msg := cmd()
 	if _, ok := msg.(model.StashDroppedMsg); !ok {
 		t.Errorf("expected StashDroppedMsg, got %T", msg)
+	}
+}
+
+// --- Prune stale worktree ---
+
+func staleBranch() gitquery.Branch {
+	return gitquery.Branch{
+		Name:          "stale-feat",
+		IsWorktree:    true,
+		WorktreePaths: []string{"/dev/alpha/stale-feat"},
+		WorktreeStale: []bool{true},
+	}
+}
+
+func modelWithStaleBranch() model.Model {
+	m := model.New(testRepos())
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{staleBranch()},
+	})
+	m = inRightPane(m)
+	m = enableDestructive(m)
+	return m
+}
+
+func TestModel_PKeyOnStaleWorktreeOpensConfirm(t *testing.T) {
+	m := modelWithStaleBranch()
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if m.Overlay() != model.OverlayConfirm {
+		t.Errorf("expected OverlayConfirm, got %d", m.Overlay())
+	}
+	if !strings.Contains(m.ConfirmPrompt(), "Prune") {
+		t.Errorf("expected 'Prune' in prompt, got %q", m.ConfirmPrompt())
+	}
+	if !strings.Contains(m.ConfirmPrompt(), "/dev/alpha/stale-feat") {
+		t.Errorf("expected worktree path in prompt, got %q", m.ConfirmPrompt())
+	}
+}
+
+func TestModel_PKeyNoOpWithoutDestructiveMode(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{staleBranch()},
+	})
+	m = inRightPane(m)
+	// destructive mode NOT enabled
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if m.Overlay() != model.OverlayNone {
+		t.Errorf("expected OverlayNone without destructive mode, got %d", m.Overlay())
+	}
+}
+
+func TestModel_PKeyNoOpOnNonStaleWorktree(t *testing.T) {
+	m := modelWithWorktreeBranch() // worktree exists (not stale)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if m.Overlay() != model.OverlayNone {
+		t.Errorf("expected OverlayNone on non-stale worktree, got %d", m.Overlay())
+	}
+}
+
+func TestModel_PKeyNoOpOnNonWorktreeBranch(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{{Name: "plain"}},
+	})
+	m = inRightPane(m)
+	m = enableDestructive(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if m.Overlay() != model.OverlayNone {
+		t.Errorf("expected OverlayNone on non-worktree branch, got %d", m.Overlay())
+	}
+}
+
+func TestModel_PKeyConfirmReturnsPrunedMsg(t *testing.T) {
+	m := modelWithStaleBranch()
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if m.Overlay() != model.OverlayNone {
+		t.Errorf("expected overlay closed after confirm, got %d", m.Overlay())
+	}
+	if cmd == nil {
+		t.Fatal("expected cmd after prune confirm, got nil")
+	}
+	msg := cmd()
+	if _, ok := msg.(model.WorktreePrunedMsg); !ok {
+		t.Fatalf("expected WorktreePrunedMsg, got %T", msg)
+	}
+}
+
+func TestModel_WorktreePrunedMsgRefreshesBranches(t *testing.T) {
+	m := model.New(testRepos())
+	m, cmd := update(m, model.WorktreePrunedMsg{RepoPath: "/dev/alpha"})
+	if cmd == nil {
+		t.Fatal("expected fetchBranches cmd after WorktreePrunedMsg, got nil")
+	}
+	msg := cmd()
+	if _, ok := msg.(model.BranchResultMsg); !ok {
+		t.Fatalf("expected BranchResultMsg from fetch, got %T", msg)
 	}
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -74,6 +74,7 @@ type RenderParams struct {
 	StashScroll    int
 	ActivePane     int
 	Destructive    bool
+	StaleSelected  bool
 }
 
 // Render produces the full terminal view string.
@@ -90,7 +91,7 @@ func Render(p RenderParams) string {
 		return renderOverlay(p)
 	}
 
-	statusBar := RenderStatusBar(p.Width, p.Mode, p.Overlay, p.ActivePane, p.Destructive)
+	statusBar := RenderStatusBar(p.Width, p.Mode, p.Overlay, p.ActivePane, p.Destructive, p.StaleSelected)
 
 	// Border colors based on active pane
 	activeBorderColor := lipgloss.Color("12")
@@ -188,7 +189,7 @@ func renderModeHeader(mode, width int) string {
 }
 
 // RenderStatusBar produces the bottom status bar (hints only, no mode tabs).
-func RenderStatusBar(width, mode, overlay, activePane int, destructive bool) string {
+func RenderStatusBar(width, mode, overlay, activePane int, destructive, staleSelected bool) string {
 	var hints string
 	if overlay == 3 {
 		hints = "  y: confirm  n/esc: cancel"
@@ -207,6 +208,9 @@ func RenderStatusBar(width, mode, overlay, activePane int, destructive bool) str
 			keys += "  t: terminal  c: code"
 			if destructive {
 				keys += "  " + dirtyRedStyle.Render("d: delete")
+				if staleSelected {
+					keys += "  " + dirtyRedStyle.Render("p: prune")
+				}
 			}
 		}
 		if !destructive {
@@ -252,22 +256,26 @@ func renderBranchPaneSelected(rows []gitquery.BranchRow, selected, scroll, width
 		branch := branchStyle.Render(b.Name)
 
 		var indicators string
-		if b.Ahead > 0 || b.Behind > 0 {
-			indicators += aheadBehindStyle.Render(" ●")
-			indicators += fmt.Sprintf(" +%d/-%d", b.Ahead, b.Behind)
-		}
-		if b.Dirty {
-			indicators += dirtyRedStyle.Render(" ●")
-			indicators += fmt.Sprintf(" %d files ", b.FilesChanged)
-			indicators += diffAddStyle.Render(fmt.Sprintf("+%d", b.LinesAdded))
-			indicators += "/" + diffDelStyle.Render(fmt.Sprintf("-%d", b.LinesDeleted))
-		}
-		if !b.HasUpstream || b.UpstreamGone {
-			indicators += noUpstreamStyle.Render(" ●")
-		}
+		if row.Stale {
+			indicators = dirtyRedStyle.Render(" ✗") + " " + dirtyRedStyle.Render("stale")
+		} else {
+			if b.Ahead > 0 || b.Behind > 0 {
+				indicators += aheadBehindStyle.Render(" ●")
+				indicators += fmt.Sprintf(" +%d/-%d", b.Ahead, b.Behind)
+			}
+			if b.Dirty {
+				indicators += dirtyRedStyle.Render(" ●")
+				indicators += fmt.Sprintf(" %d files ", b.FilesChanged)
+				indicators += diffAddStyle.Render(fmt.Sprintf("+%d", b.LinesAdded))
+				indicators += "/" + diffDelStyle.Render(fmt.Sprintf("-%d", b.LinesDeleted))
+			}
+			if !b.HasUpstream || b.UpstreamGone {
+				indicators += noUpstreamStyle.Render(" ●")
+			}
 
-		if indicators == "" {
-			indicators = cleanStyle.Render(" ✔")
+			if indicators == "" {
+				indicators = cleanStyle.Render(" ✔")
+			}
 		}
 
 		var locationLabel string
@@ -390,7 +398,7 @@ func renderStashPane(stashes []gitquery.Stash, selected, scroll, width, height i
 }
 
 func renderOverlay(p RenderParams) string {
-	statusBar := RenderStatusBar(p.Width, p.Mode, p.Overlay, p.ActivePane, p.Destructive)
+	statusBar := RenderStatusBar(p.Width, p.Mode, p.Overlay, p.ActivePane, p.Destructive, p.StaleSelected)
 	contentHeight := p.Height - 1
 
 	// Confirmation dialog overlay

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestStatusBar_Mode1ContainsIndicatorLegend(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true)
+	bar := RenderStatusBar(120, 1, 0, 1, true, false)
 	for _, legend := range []string{"✔ clean", "● ahead/behind", "● dirty", "● no upstream"} {
 		if !strings.Contains(bar, legend) {
 			t.Errorf("mode 1 status bar should contain legend %q", legend)
@@ -21,7 +21,7 @@ func TestStatusBar_Mode1ContainsIndicatorLegend(t *testing.T) {
 }
 
 func TestStatusBar_IndicatorLegendSpacing(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true)
+	bar := RenderStatusBar(120, 1, 0, 1, true, false)
 	for _, pair := range [][2]string{
 		{"clean", "●"},
 	} {
@@ -39,14 +39,14 @@ func TestStatusBar_IndicatorLegendSpacing(t *testing.T) {
 }
 
 func TestStatusBar_Mode2OmitsIndicatorLegend(t *testing.T) {
-	bar := RenderStatusBar(120, 2, 0, 1, true)
+	bar := RenderStatusBar(120, 2, 0, 1, true, false)
 	if strings.Contains(bar, "clean") {
 		t.Error("mode 2 status bar should not contain indicator legend")
 	}
 }
 
 func TestStatusBar_PipeSeparatesLegendAndHints(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true)
+	bar := RenderStatusBar(120, 1, 0, 1, true, false)
 	upstreamIdx := strings.Index(bar, "no upstream")
 	tabIdx := strings.Index(bar, "tab: pane")
 	if upstreamIdx == -1 || tabIdx == -1 {
@@ -59,7 +59,7 @@ func TestStatusBar_PipeSeparatesLegendAndHints(t *testing.T) {
 }
 
 func TestStatusBar_TabAndQuitBeforeOtherHints(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true)
+	bar := RenderStatusBar(120, 1, 0, 1, true, false)
 	tabIdx := strings.Index(bar, "tab: pane")
 	tIdx := strings.Index(bar, "t: terminal")
 	if tabIdx == -1 || tIdx == -1 {
@@ -75,7 +75,7 @@ func TestStatusBar_TabAndQuitBeforeOtherHints(t *testing.T) {
 }
 
 func TestStatusBar_ActionHintsHiddenWhenLeftPaneActive(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 0, true) // activePane=0 (left), destructive=true
+	bar := RenderStatusBar(120, 1, 0, 0, true, false) // activePane=0 (left), destructive=true
 	for _, hint := range []string{"t: terminal", "c: code", "d: delete"} {
 		if strings.Contains(bar, hint) {
 			t.Errorf("hint %q should be hidden when left pane is active", hint)
@@ -90,7 +90,7 @@ func TestStatusBar_ActionHintsHiddenWhenLeftPaneActive(t *testing.T) {
 }
 
 func TestStatusBar_ActionHintsShownWhenRightPaneActive(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true) // activePane=1 (right)
+	bar := RenderStatusBar(120, 1, 0, 1, true, false) // activePane=1 (right)
 	for _, hint := range []string{"t: terminal", "c: code", "d: delete"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("hint %q should be shown when right pane is active", hint)
@@ -99,7 +99,7 @@ func TestStatusBar_ActionHintsShownWhenRightPaneActive(t *testing.T) {
 }
 
 func TestStatusBar_KeyHintSpacingIs2(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true)
+	bar := RenderStatusBar(120, 1, 0, 1, true, false)
 	for _, pair := range [][2]string{
 		{"tab: pane", "q/esc: quit"},
 		{"t: terminal", "c: code"},
@@ -412,6 +412,23 @@ func TestBranchPane_DetachedWorktreeRow(t *testing.T) {
 	}
 }
 
+func TestBranchPane_StaleWorktreeShowsStaleIndicator(t *testing.T) {
+	rows := []gitquery.BranchRow{
+		{Branch: gitquery.Branch{Name: "stale-feat", HasUpstream: true, IsWorktree: true}, WorktreePath: "/dev/gone", Stale: true},
+	}
+	lines := renderBranchPane(rows, 60, 10)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "✗") {
+		t.Error("stale worktree should show ✗ indicator")
+	}
+	if strings.Contains(joined, "✔") {
+		t.Error("stale worktree should NOT show ✔ indicator")
+	}
+	if !strings.Contains(joined, "stale") {
+		t.Error("stale worktree should show 'stale' label")
+	}
+}
+
 func TestBranchPane_NonWorktreeNoAnnotation(t *testing.T) {
 	rows := []gitquery.BranchRow{
 		{Branch: gitquery.Branch{Name: "feat", HasUpstream: true, IsWorktree: false}},
@@ -612,8 +629,29 @@ func TestRender_ForceConfirmDialogShowsPrompt(t *testing.T) {
 	}
 }
 
+func TestStatusBar_PruneHintShownWhenStale(t *testing.T) {
+	bar := RenderStatusBar(120, 1, 0, 1, true, true)
+	if !strings.Contains(bar, "p: prune") {
+		t.Errorf("expected 'p: prune' hint when stale worktree selected, got %q", bar)
+	}
+}
+
+func TestStatusBar_PruneHintHiddenWhenNotStale(t *testing.T) {
+	bar := RenderStatusBar(120, 1, 0, 1, true, false)
+	if strings.Contains(bar, "p: prune") {
+		t.Error("'p: prune' should not appear when no stale worktree selected")
+	}
+}
+
+func TestStatusBar_PruneHintHiddenWithoutDestructive(t *testing.T) {
+	bar := RenderStatusBar(120, 1, 0, 1, false, true)
+	if strings.Contains(bar, "p: prune") {
+		t.Error("'p: prune' should not appear without destructive mode")
+	}
+}
+
 func TestStatusBar_Mode2HintsSpacing(t *testing.T) {
-	bar := RenderStatusBar(120, 2, 0, 1, true)
+	bar := RenderStatusBar(120, 2, 0, 1, true, false)
 	for _, pair := range [][2]string{
 		{"tab: pane", "q/esc: quit"},
 		{"↑/↓ select", "enter: diff"},


### PR DESCRIPTION
## Summary

- `RemoveWorktree` and `ForceRemoveWorktree` now run `git worktree prune` after removal to clean up stale admin entries in `.git/worktrees/`
- Fixes worktrees persisting in branch listings after their directories are removed
- On modern git (2.50+) the prune is a no-op; on older versions it clears stale references that `git worktree remove` leaves behind

## Test plan

- [ ] Run `make test` — all pass
- [ ] Create a worktree, delete it via the app, verify it no longer appears in the branch list
- [ ] Force-delete a dirty worktree, verify it no longer appears in the branch list