### PR TITLE
Add history view mode (mode 3) to right pane

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 // RemoveWorktree runs `git worktree remove` for the given worktree path,
@@ -45,6 +46,13 @@ func ForceDeleteBranch(repoPath, name string) error {
 func DropStash(repoPath string, index int) error {
 	ref := fmt.Sprintf("stash@{%d}", index)
 	return exec.Command("git", "-C", repoPath, "stash", "drop", ref).Run()
+}
+
+// CopyToClipboard copies text to the system clipboard using pbcopy.
+func CopyToClipboard(text string) error {
+	cmd := exec.Command("pbcopy")
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
 }
 
 // OpenTerminal opens a new Terminal window at the given path.

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -367,6 +367,24 @@ func TestOpenTerminal_Error(t *testing.T) {
 	}
 }
 
+func TestCopyToClipboard(t *testing.T) {
+	if _, err := exec.LookPath("pbcopy"); err != nil {
+		t.Skip("pbcopy not available")
+	}
+	err := actions.CopyToClipboard("test-hash-abc123")
+	if err != nil {
+		t.Fatalf("CopyToClipboard returned error: %v", err)
+	}
+	// Verify clipboard contents
+	out, err := exec.Command("pbpaste").Output()
+	if err != nil {
+		t.Fatalf("pbpaste failed: %v", err)
+	}
+	if string(out) != "test-hash-abc123" {
+		t.Errorf("expected clipboard %q, got %q", "test-hash-abc123", string(out))
+	}
+}
+
 func TestOpenVSCode_RunsWithoutPanic(t *testing.T) {
 	if os.Getenv("TEST_LAUNCH_APPS") == "" {
 		t.Skip("skipping: set TEST_LAUNCH_APPS=1 to run tests that launch GUI apps")

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -16,6 +16,14 @@ type Stash struct {
 	Message string
 }
 
+// Commit represents a single git commit entry.
+type Commit struct {
+	Hash    string
+	Author  string
+	Date    string
+	Subject string
+}
+
 // Branch represents a local git branch with its status.
 type Branch struct {
 	Name          string
@@ -57,6 +65,43 @@ func FlattenBranches(branches []Branch) []BranchRow {
 		}
 	}
 	return rows
+}
+
+// ListCommits returns the most recent 50 commits for the given repo path.
+func ListCommits(repoPath string) ([]Commit, error) {
+	text, err := gitCmd(repoPath, "log", "--format=%h%x00%an%x00%ar%x00%s", "-n", "50")
+	if err != nil {
+		return nil, fmt.Errorf("listing commits: %w", err)
+	}
+
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil, nil
+	}
+
+	var commits []Commit
+	for _, line := range strings.Split(text, "\n") {
+		parts := strings.SplitN(line, "\x00", 4)
+		if len(parts) != 4 {
+			continue
+		}
+		commits = append(commits, Commit{
+			Hash:    parts[0],
+			Author:  parts[1],
+			Date:    parts[2],
+			Subject: parts[3],
+		})
+	}
+	return commits, nil
+}
+
+// CommitDiff returns the full git show output for a specific commit.
+func CommitDiff(repoPath string, hash string) (string, error) {
+	out, err := gitCmd(repoPath, "show", hash)
+	if err != nil {
+		return "", fmt.Errorf("commit diff for %s: %w", hash, err)
+	}
+	return out, nil
 }
 
 // ListStashes returns stash entries for the given repo path.

--- a/gitquery/gitquery_test.go
+++ b/gitquery/gitquery_test.go
@@ -1,6 +1,7 @@
 package gitquery_test
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -681,6 +682,136 @@ func TestFlattenBranches_NonStaleFlag(t *testing.T) {
 	rows := gitquery.FlattenBranches(branches)
 	if rows[0].Stale {
 		t.Error("expected Stale=false for non-stale worktree path")
+	}
+}
+
+// --- Commit tests ---
+
+func TestListCommits_ReturnsCommits(t *testing.T) {
+	dir := realPath(t, t.TempDir())
+	initRepo(t, dir)
+
+	writeFile(t, dir, "a.txt", "one")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "second commit")
+
+	writeFile(t, dir, "b.txt", "two")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "third commit")
+
+	commits, err := gitquery.ListCommits(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(commits) != 3 {
+		t.Fatalf("expected 3 commits, got %d", len(commits))
+	}
+	// Newest first
+	if commits[0].Subject != "third commit" {
+		t.Errorf("expected first commit subject %q, got %q", "third commit", commits[0].Subject)
+	}
+	if commits[0].Hash == "" {
+		t.Error("expected non-empty Hash")
+	}
+	if commits[0].Author != "Test" {
+		t.Errorf("expected Author %q, got %q", "Test", commits[0].Author)
+	}
+	if commits[0].Date == "" {
+		t.Error("expected non-empty Date")
+	}
+}
+
+func TestListCommits_Limit50(t *testing.T) {
+	dir := realPath(t, t.TempDir())
+	initRepo(t, dir)
+
+	for i := 0; i < 54; i++ {
+		writeFile(t, dir, "f.txt", fmt.Sprintf("v%d", i))
+		run(t, dir, "git", "add", ".")
+		run(t, dir, "git", "commit", "-m", fmt.Sprintf("commit %d", i))
+	}
+
+	commits, err := gitquery.ListCommits(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(commits) != 50 {
+		t.Fatalf("expected 50 commits, got %d", len(commits))
+	}
+}
+
+func TestListCommits_NewestFirst(t *testing.T) {
+	dir := realPath(t, t.TempDir())
+	initRepo(t, dir)
+
+	writeFile(t, dir, "a.txt", "one")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "older")
+
+	writeFile(t, dir, "b.txt", "two")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "newer")
+
+	commits, err := gitquery.ListCommits(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(commits) < 2 {
+		t.Fatal("expected at least 2 commits")
+	}
+	if commits[0].Subject != "newer" {
+		t.Errorf("expected newest commit first, got %q", commits[0].Subject)
+	}
+	if commits[1].Subject != "older" {
+		t.Errorf("expected older commit second, got %q", commits[1].Subject)
+	}
+}
+
+func TestListCommits_InvalidPath(t *testing.T) {
+	_, err := gitquery.ListCommits("/no/such/path")
+	if err == nil {
+		t.Fatal("expected error for invalid path, got nil")
+	}
+}
+
+func TestCommitDiff_ReturnsDiff(t *testing.T) {
+	dir := realPath(t, t.TempDir())
+	initRepo(t, dir)
+
+	writeFile(t, dir, "a.txt", "changed")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "change a file")
+
+	commits, err := gitquery.ListCommits(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(commits) == 0 {
+		t.Fatal("expected at least one commit")
+	}
+
+	diff, err := gitquery.CommitDiff(dir, commits[0].Hash)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff == "" {
+		t.Fatal("expected non-empty diff")
+	}
+	if !strings.Contains(diff, "diff --git") {
+		t.Error("expected diff to contain 'diff --git'")
+	}
+	if !strings.Contains(diff, "change a file") {
+		t.Error("expected diff to contain commit message")
+	}
+}
+
+func TestCommitDiff_InvalidHash(t *testing.T) {
+	dir := realPath(t, t.TempDir())
+	initRepo(t, dir)
+
+	_, err := gitquery.CommitDiff(dir, "0000000000000000")
+	if err == nil {
+		t.Fatal("expected error for invalid hash, got nil")
 	}
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -17,6 +17,7 @@ type Mode int
 const (
 	ModeBranches Mode = iota + 1
 	ModeStashes
+	ModeHistory
 )
 
 // OverlayState represents what overlay (if any) is displayed.
@@ -27,6 +28,7 @@ const (
 	OverlayStashDiff
 	OverlayBranchDiff
 	OverlayConfirm
+	OverlayCommitDiff
 )
 
 // --- Messages ---
@@ -69,6 +71,19 @@ type WorktreePrunedMsg struct {
 	RepoPath string
 }
 
+type CommitResultMsg struct {
+	RepoPath string
+	Commits  []gitquery.Commit
+}
+
+type CommitDiffResultMsg struct {
+	RepoPath string
+	Hash     string
+	Diff     string
+}
+
+type ClipboardResultMsg struct{}
+
 type DeleteFailedMsg struct {
 	RepoPath    string
 	Target      string       // worktree path or branch name
@@ -88,6 +103,9 @@ type Model struct {
 	stashes        []gitquery.Stash
 	branchSelected int
 	stashSelected  int
+	commits        []gitquery.Commit
+	commitSelected int
+	commitScroll   int
 	overlay        OverlayState
 	overlayDiff    string
 	overlayScroll  int
@@ -114,6 +132,9 @@ func (m Model) Rows() []gitquery.BranchRow { return m.rows }
 func (m Model) Stashes() []gitquery.Stash  { return m.stashes }
 func (m Model) BranchSelected() int        { return m.branchSelected }
 func (m Model) StashSelected() int         { return m.stashSelected }
+func (m Model) Commits() []gitquery.Commit { return m.commits }
+func (m Model) CommitSelected() int        { return m.commitSelected }
+func (m Model) CommitScroll() int          { return m.commitScroll }
 func (m Model) Overlay() OverlayState      { return m.overlay }
 func (m Model) OverlayDiff() string        { return m.overlayDiff }
 func (m Model) OverlayScroll() int         { return m.overlayScroll }
@@ -151,6 +172,9 @@ func (m Model) View() string {
 		ActivePane:     m.activePane,
 		Destructive:    m.destructive,
 		StaleSelected:  m.isSelectedStale(),
+		Commits:        m.commits,
+		CommitSelected: m.commitSelected,
+		CommitScroll:   m.commitScroll,
 	})
 }
 
@@ -181,6 +205,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleBranchDeleted(msg)
 	case WorktreePrunedMsg:
 		return m.handleWorktreePruned(msg)
+	case CommitResultMsg:
+		return m.handleCommitResult(msg), nil
+	case CommitDiffResultMsg:
+		return m.handleCommitDiffResult(msg), nil
+	case ClipboardResultMsg:
+		return m, nil
 	case DeleteFailedMsg:
 		return m.handleDeleteFailed(msg), nil
 	}
@@ -284,19 +314,25 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			m.mode--
 			m.branchSelected = 0
 			m.stashSelected = 0
+			m.commitSelected = 0
+			m.commitScroll = 0
 			return m, m.fetchForMode()
 		}
 	case "right", "l":
-		if m.mode < ModeStashes {
+		if m.mode < ModeHistory {
 			m.mode++
 			m.branchSelected = 0
 			m.stashSelected = 0
+			m.commitSelected = 0
+			m.commitScroll = 0
 			return m, m.fetchForMode()
 		}
 	case "1":
 		if m.mode != ModeBranches {
 			m.mode = ModeBranches
 			m.branchSelected = 0
+			m.commitSelected = 0
+			m.commitScroll = 0
 			return m, m.fetchBranches()
 		}
 	case "2":
@@ -304,8 +340,19 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			m.mode = ModeStashes
 			m.branchSelected = 0
 			m.stashSelected = 0
+			m.commitSelected = 0
+			m.commitScroll = 0
 			return m, m.fetchStashes()
 		}
+	case "3":
+		if m.mode != ModeHistory {
+			m.mode = ModeHistory
+			m.commitSelected = 0
+			m.commitScroll = 0
+			return m, m.fetchCommits()
+		}
+	case "y":
+		return m.handleCopyHash()
 	case "tab":
 		m.activePane = 0
 	case "enter":
@@ -344,6 +391,14 @@ func (m Model) handleCursorUp() (tea.Model, tea.Cmd) {
 		}
 		m = m.ensureStashVisible()
 	}
+	if m.mode == ModeHistory && len(m.commits) > 0 {
+		if m.commitSelected > 0 {
+			m.commitSelected--
+		} else {
+			m.commitSelected = len(m.commits) - 1
+		}
+		m = m.ensureCommitVisible()
+	}
 	return m, nil
 }
 
@@ -365,6 +420,14 @@ func (m Model) handleCursorDown() (tea.Model, tea.Cmd) {
 		}
 		m = m.ensureStashVisible()
 	}
+	if m.mode == ModeHistory && len(m.commits) > 0 {
+		if m.commitSelected < len(m.commits)-1 {
+			m.commitSelected++
+		} else {
+			m.commitSelected = 0
+		}
+		m = m.ensureCommitVisible()
+	}
 	return m, nil
 }
 
@@ -379,11 +442,18 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 		m.overlay = OverlayStashDiff
 		return m, m.fetchStashDiff()
 	}
+	if m.mode == ModeHistory && len(m.commits) > 0 {
+		m.overlay = OverlayCommitDiff
+		return m, m.fetchCommitDiff()
+	}
 	return m, nil
 }
 
 func (m Model) handleDelete() (tea.Model, tea.Cmd) {
 	if !m.destructive {
+		return m, nil
+	}
+	if m.mode == ModeHistory {
 		return m, nil
 	}
 	if m.mode == ModeStashes && len(m.stashes) > 0 && len(m.repos) > 0 {
@@ -420,6 +490,10 @@ func (m Model) handlePrune() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleOpenTerminal() (tea.Model, tea.Cmd) {
+	if m.mode == ModeHistory && len(m.repos) > 0 {
+		path := m.repos[m.selected].Path
+		return m, func() tea.Msg { _ = actions.OpenTerminal(path); return nil }
+	}
 	if m.mode == ModeBranches && len(m.repos) > 0 {
 		if row, ok := m.selectedRow(); ok && row.WorktreePath != "" {
 			path := row.WorktreePath
@@ -430,6 +504,10 @@ func (m Model) handleOpenTerminal() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleOpenCode() (tea.Model, tea.Cmd) {
+	if m.mode == ModeHistory && len(m.repos) > 0 {
+		path := m.repos[m.selected].Path
+		return m, func() tea.Msg { _ = actions.OpenVSCode(path); return nil }
+	}
 	if m.mode == ModeBranches && len(m.repos) > 0 {
 		if row, ok := m.selectedRow(); ok && row.WorktreePath != "" {
 			path := row.WorktreePath
@@ -520,8 +598,11 @@ func (m Model) resetRightPaneCursors() Model {
 	m.stashSelected = 0
 	m.branchScroll = 0
 	m.stashScroll = 0
+	m.commitSelected = 0
+	m.commitScroll = 0
 	m.rows = nil
 	m.stashes = nil
+	m.commits = nil
 	return m
 }
 
@@ -613,6 +694,36 @@ func (m Model) handleDeleteFailed(msg DeleteFailedMsg) Model {
 	return m
 }
 
+func (m Model) handleCommitResult(msg CommitResultMsg) Model {
+	if m.isCurrentRepo(msg.RepoPath) {
+		m.commits = msg.Commits
+		if len(m.commits) == 0 || m.commitSelected >= len(m.commits) {
+			m.commitSelected = 0
+		}
+	}
+	return m
+}
+
+func (m Model) handleCommitDiffResult(msg CommitDiffResultMsg) Model {
+	if m.isCurrentRepo(msg.RepoPath) {
+		if m.commitSelected < len(m.commits) && m.commits[m.commitSelected].Hash == msg.Hash {
+			m.overlayDiff = msg.Diff
+		}
+	}
+	return m
+}
+
+func (m Model) handleCopyHash() (tea.Model, tea.Cmd) {
+	if m.mode != ModeHistory || len(m.commits) == 0 {
+		return m, nil
+	}
+	hash := m.commits[m.commitSelected].Hash
+	return m, func() tea.Msg {
+		_ = actions.CopyToClipboard(hash)
+		return ClipboardResultMsg{}
+	}
+}
+
 // --- Fetch commands ---
 
 func (m Model) fetchForMode() tea.Cmd {
@@ -621,6 +732,8 @@ func (m Model) fetchForMode() tea.Cmd {
 		return m.fetchBranches()
 	case ModeStashes:
 		return m.fetchStashes()
+	case ModeHistory:
+		return m.fetchCommits()
 	}
 	return nil
 }
@@ -685,6 +798,29 @@ func (m Model) fetchStashDiff() tea.Cmd {
 	}
 }
 
+func (m Model) fetchCommits() tea.Cmd {
+	if len(m.repos) == 0 {
+		return nil
+	}
+	repoPath := m.repos[m.selected].Path
+	return func() tea.Msg {
+		commits, _ := gitquery.ListCommits(repoPath)
+		return CommitResultMsg{RepoPath: repoPath, Commits: commits}
+	}
+}
+
+func (m Model) fetchCommitDiff() tea.Cmd {
+	if len(m.repos) == 0 || len(m.commits) == 0 {
+		return nil
+	}
+	repoPath := m.repos[m.selected].Path
+	hash := m.commits[m.commitSelected].Hash
+	return func() tea.Msg {
+		diff, _ := gitquery.CommitDiff(repoPath, hash)
+		return CommitDiffResultMsg{RepoPath: repoPath, Hash: hash, Diff: diff}
+	}
+}
+
 // --- Helpers ---
 
 func (m Model) selectedRow() (gitquery.BranchRow, bool) {
@@ -736,6 +872,20 @@ func (m Model) ensureRepoVisible() Model {
 	}
 	if m.selected >= m.repoScroll+contentHeight {
 		m.repoScroll = m.selected - contentHeight + 1
+	}
+	return m
+}
+
+func (m Model) ensureCommitVisible() Model {
+	contentHeight := m.height - ui.BranchContentOverhead
+	if contentHeight <= 0 {
+		contentHeight = 16
+	}
+	if m.commitScroll > m.commitSelected {
+		m.commitScroll = m.commitSelected
+	}
+	if m.commitSelected >= m.commitScroll+contentHeight {
+		m.commitScroll = m.commitSelected - contentHeight + 1
 	}
 	return m
 }

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -99,6 +99,115 @@ func TestModel_EnterDoesNothingForCleanBranch(t *testing.T) {
 	}
 }
 
+// --- History (mode 3) actions ---
+
+func modelInMode3WithCommits() model.Model {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
+	return m
+}
+
+func TestModel_EnterInHistoryOpensCommitDiffOverlay(t *testing.T) {
+	m := modelInMode3WithCommits()
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.Overlay() != model.OverlayCommitDiff {
+		t.Errorf("expected OverlayCommitDiff, got %d", m.Overlay())
+	}
+	if cmd == nil {
+		t.Fatal("expected fetchCommitDiff cmd, got nil")
+	}
+	msg := cmd()
+	if _, ok := msg.(model.CommitDiffResultMsg); !ok {
+		t.Errorf("expected CommitDiffResultMsg, got %T", msg)
+	}
+}
+
+func TestModel_EnterInHistoryNoCommitsIsNoOp(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	// No commits loaded
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.Overlay() != model.OverlayNone {
+		t.Errorf("expected OverlayNone, got %d", m.Overlay())
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd, got %T", cmd)
+	}
+}
+
+func TestModel_CommitDiffResultStoresDiff(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
+	m, _ = update(m, model.CommitDiffResultMsg{RepoPath: "/dev/alpha", Hash: "abc1234", Diff: "diff --git a/f.txt"})
+	if m.OverlayDiff() != "diff --git a/f.txt" {
+		t.Errorf("expected diff stored, got %q", m.OverlayDiff())
+	}
+}
+
+func TestModel_StaleCommitDiffResultDiscarded(t *testing.T) {
+	m := model.New(testRepos())
+	m = selectBravo(m)
+	m, _ = update(m, model.CommitDiffResultMsg{RepoPath: "/dev/alpha", Hash: "abc1234", Diff: "stale"})
+	if m.OverlayDiff() != "" {
+		t.Errorf("expected stale commit diff discarded, got %q", m.OverlayDiff())
+	}
+}
+
+func TestModel_YKeyCopiesHashInMode3(t *testing.T) {
+	m := modelInMode3WithCommits()
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Error("expected non-nil cmd for y key in mode 3")
+	}
+}
+
+func TestModel_YKeyNoOpInMode1(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd != nil {
+		t.Errorf("expected nil cmd for y key in mode 1, got %T", cmd)
+	}
+}
+
+func TestModel_YKeyNoOpWithNoCommits(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd != nil {
+		t.Errorf("expected nil cmd for y key with no commits, got %T", cmd)
+	}
+}
+
+func TestModel_DKeyNoOpInHistoryMode(t *testing.T) {
+	m := modelInMode3WithCommits()
+	m = enableDestructive(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if m.Overlay() != model.OverlayNone {
+		t.Errorf("expected OverlayNone in history mode, got %d", m.Overlay())
+	}
+}
+
+func TestModel_TKeyInHistoryFiresCmd(t *testing.T) {
+	m := modelInMode3WithCommits()
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	if cmd == nil {
+		t.Error("expected non-nil cmd for t key in history mode")
+	}
+}
+
+func TestModel_CKeyInHistoryFiresCmd(t *testing.T) {
+	m := modelInMode3WithCommits()
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	if cmd == nil {
+		t.Error("expected non-nil cmd for c key in history mode")
+	}
+}
+
 // --- Stash overlay ---
 
 func TestModel_EnterOpensOverlay(t *testing.T) {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -551,17 +551,34 @@ func TestModel_ModeSwitchOnKeyPress(t *testing.T) {
 	}
 }
 
-func TestModel_Key3IsNoOp(t *testing.T) {
+func TestModel_Key3SwitchesToHistoryMode(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	if m.Mode() != 3 {
+		t.Errorf("expected mode 3, got %d", m.Mode())
+	}
+}
+
+func TestModel_SwitchToMode3FiresFetchCommits(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	if cmd == nil {
+		t.Fatal("expected fetchCommits cmd on switch to mode 3, got nil")
+	}
+	msg := cmd()
+	if _, ok := msg.(model.CommitResultMsg); !ok {
+		t.Errorf("expected CommitResultMsg, got %T", msg)
+	}
+}
+
+func TestModel_Key4IsNoOp(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	if m.Mode() != 1 {
 		t.Errorf("expected mode unchanged at 1, got %d", m.Mode())
-	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
-	if m.Mode() != 2 {
-		t.Errorf("expected mode unchanged at 2, got %d", m.Mode())
 	}
 }
 
@@ -624,11 +641,32 @@ func TestModel_ModeClampsAtEdges(t *testing.T) {
 	if m.Mode() != 1 {
 		t.Errorf("expected mode 1 (clamped), got %d", m.Mode())
 	}
-	// Go to mode 2, right should stay at 2
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})
+	// Go to mode 3, right should stay at 3
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 2
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 3
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // still 3
+	if m.Mode() != 3 {
+		t.Errorf("expected mode 3 (clamped), got %d", m.Mode())
+	}
+}
+
+func TestModel_RightFromStashesGoesToHistory(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}) // stashes
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})                     // history
+	if m.Mode() != 3 {
+		t.Errorf("expected mode 3, got %d", m.Mode())
+	}
+}
+
+func TestModel_LeftFromHistoryGoesToStashes(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // history
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft})                      // stashes
 	if m.Mode() != 2 {
-		t.Errorf("expected mode 2 (clamped), got %d", m.Mode())
+		t.Errorf("expected mode 2, got %d", m.Mode())
 	}
 }
 
@@ -786,6 +824,103 @@ func TestModel_StashDroppedMsgTriggersStashFetch(t *testing.T) {
 	msg := cmd()
 	if _, ok := msg.(model.StashResultMsg); !ok {
 		t.Errorf("expected StashResultMsg, got %T", msg)
+	}
+}
+
+// --- Commit result handlers ---
+
+func testCommits() []gitquery.Commit {
+	return []gitquery.Commit{
+		{Hash: "abc1234", Author: "alice", Date: "2 hours ago", Subject: "Fix login bug"},
+		{Hash: "def5678", Author: "bob", Date: "3 days ago", Subject: "Add profile page"},
+		{Hash: "ghi9012", Author: "alice", Date: "1 week ago", Subject: "Refactor DB layer"},
+	}
+}
+
+func TestModel_CommitResultUpdatesState(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
+	if len(m.Commits()) != 3 {
+		t.Fatalf("expected 3 commits, got %d", len(m.Commits()))
+	}
+}
+
+func TestModel_StaleCommitResultDiscarded(t *testing.T) {
+	m := model.New(testRepos())
+	m = selectBravo(m) // selected=bravo
+	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
+	if len(m.Commits()) != 0 {
+		t.Errorf("expected stale commit result discarded, got %d commits", len(m.Commits()))
+	}
+}
+
+func TestModel_CommitCursorWraps(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
+	// Wrap backward from 0 to last
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
+	if m.CommitSelected() != 2 {
+		t.Errorf("expected CommitSelected to wrap to 2, got %d", m.CommitSelected())
+	}
+	// Wrap forward from last to 0
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.CommitSelected() != 0 {
+		t.Errorf("expected CommitSelected to wrap to 0, got %d", m.CommitSelected())
+	}
+}
+
+func TestModel_CommitScrollFollowsCursor(t *testing.T) {
+	commits := make([]gitquery.Commit, 20)
+	for i := range commits {
+		commits[i] = gitquery.Commit{Hash: fmt.Sprintf("abc%04d", i), Author: "test", Date: "now", Subject: fmt.Sprintf("commit %d", i)}
+	}
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: ui.BranchContentOverhead + 3})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: commits})
+
+	// Move cursor past viewport
+	for i := 0; i < 10; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if m.CommitScroll() == 0 {
+		t.Error("expected scroll to advance when cursor moves past viewport")
+	}
+}
+
+func TestModel_ModeSwitchResetsCommitCursors(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.CommitSelected() != 2 {
+		t.Fatalf("expected CommitSelected 2, got %d", m.CommitSelected())
+	}
+	// Switch away and back
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	if m.CommitSelected() != 0 {
+		t.Errorf("expected CommitSelected reset to 0, got %d", m.CommitSelected())
+	}
+}
+
+func TestModel_RepoSwitchClearsCommits(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
+	if len(m.Commits()) != 3 {
+		t.Fatal("expected 3 commits")
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab}) // switch to left pane
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if len(m.Commits()) != 0 {
+		t.Errorf("expected commits cleared on repo switch, got %d", len(m.Commits()))
 	}
 }
 

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -63,7 +63,7 @@ func TestModel_ViewMode2ShowsPlaceholder(t *testing.T) {
 	}
 }
 
-func TestModel_ViewModeHeaderShowsTwoModes(t *testing.T) {
+func TestModel_ViewModeHeaderShowsThreeModes(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 
@@ -75,6 +75,9 @@ func TestModel_ViewModeHeaderShowsTwoModes(t *testing.T) {
 	if !strings.Contains(view, "2 stashes") {
 		t.Error("mode 1 active: right pane header should show inactive '2 stashes'")
 	}
+	if !strings.Contains(view, "3 history") {
+		t.Error("mode 1 active: right pane header should show inactive '3 history'")
+	}
 
 	// Switch to mode 2
 	m = inRightPane(m)
@@ -85,6 +88,19 @@ func TestModel_ViewModeHeaderShowsTwoModes(t *testing.T) {
 	}
 	if !strings.Contains(view, "1 branches") {
 		t.Error("mode 2 active: right pane header should show inactive '1 branches'")
+	}
+
+	// Switch to mode 3
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})
+	view = m.View()
+	if !strings.Contains(view, "[3] history") {
+		t.Error("mode 3 active: right pane header should contain '[3] history'")
+	}
+	if !strings.Contains(view, "1 branches") {
+		t.Error("mode 3 active: right pane header should show inactive '1 branches'")
+	}
+	if !strings.Contains(view, "2 stashes") {
+		t.Error("mode 3 active: right pane header should show inactive '2 stashes'")
 	}
 }
 
@@ -204,6 +220,55 @@ func TestModel_ViewDestructiveModeShowsDeleteHint(t *testing.T) {
 	view := m.View()
 	if !strings.Contains(view, "d: delete") {
 		t.Error("destructive mode should show 'd: delete'")
+	}
+}
+
+func TestModel_ViewMode3ShowsPlaceholder(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+
+	view := m.View()
+	if !strings.Contains(view, "nothing here yet") {
+		t.Error("mode 3 with no commits should show placeholder")
+	}
+}
+
+func TestModel_ViewMode3ShowsCommitContent(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
+
+	view := m.View()
+	if !strings.Contains(view, "Fix login bug") {
+		t.Error("view should contain commit subject 'Fix login bug'")
+	}
+	if !strings.Contains(view, "alice") {
+		t.Error("view should contain author 'alice'")
+	}
+}
+
+func TestModel_StatusBarMode3ShowsHistoryKeys(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+
+	view := m.View()
+	if !strings.Contains(view, "enter: diff") {
+		t.Error("mode 3 status bar should mention 'enter: diff'")
+	}
+	if !strings.Contains(view, "y: copy hash") {
+		t.Error("mode 3 status bar should mention 'y: copy hash'")
+	}
+	if !strings.Contains(view, "t: terminal") {
+		t.Error("mode 3 status bar should mention 't: terminal'")
+	}
+	if !strings.Contains(view, "c: code") {
+		t.Error("mode 3 status bar should mention 'c: code'")
 	}
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -75,6 +75,9 @@ type RenderParams struct {
 	ActivePane     int
 	Destructive    bool
 	StaleSelected  bool
+	Commits        []gitquery.Commit
+	CommitSelected int
+	CommitScroll   int
 }
 
 // Render produces the full terminal view string.
@@ -137,9 +140,11 @@ func Render(p RenderParams) string {
 	// Hide cursor in right pane when left pane is active
 	branchSel := p.BranchSelected
 	stashSel := p.StashSelected
+	commitSel := p.CommitSelected
 	if p.ActivePane == 0 {
 		branchSel = -1
 		stashSel = -1
+		commitSel = -1
 	}
 
 	var rightLines []string
@@ -148,6 +153,8 @@ func Render(p RenderParams) string {
 		rightLines = renderBranchPaneSelected(p.Branches, branchSel, p.BranchScroll, rightContentWidth, rightContentHeight, repoPath)
 	case p.Mode == 2 && len(p.Stashes) > 0:
 		rightLines = renderStashPane(p.Stashes, stashSel, p.StashScroll, rightContentWidth, rightContentHeight)
+	case p.Mode == 3 && len(p.Commits) > 0:
+		rightLines = renderCommitPane(p.Commits, commitSel, p.CommitScroll, rightContentWidth, rightContentHeight)
 	default:
 		rightLines = renderPlaceholderPane(rightContentWidth, rightContentHeight)
 	}
@@ -173,6 +180,7 @@ func renderModeHeader(mode, width int) string {
 	}{
 		{1, "branches"},
 		{2, "stashes"},
+		{3, "history"},
 	}
 
 	var parts []string
@@ -195,6 +203,8 @@ func RenderStatusBar(width, mode, overlay, activePane int, destructive, staleSel
 		hints = "  y: confirm  n/esc: cancel"
 	} else if overlay != 0 {
 		hints = "  ↑/↓ scroll  esc: close"
+	} else if mode == 3 {
+		hints = "  tab: pane  q/esc: quit  ↑/↓ select  enter: diff  y: copy hash  t: terminal  c: code"
 	} else if mode == 2 {
 		hints = "  tab: pane  q/esc: quit  ↑/↓ select  enter: diff"
 		if destructive {
@@ -384,6 +394,33 @@ func renderStashPane(stashes []gitquery.Stash, selected, scroll, width, height i
 				content = append(content, contLine)
 			}
 		}
+	}
+
+	// Apply scroll offset
+	if scroll > len(content) {
+		scroll = len(content)
+	}
+	visible := content[scroll:]
+
+	lines := make([]string, height)
+	copy(lines, visible)
+	return lines
+}
+
+func renderCommitPane(commits []gitquery.Commit, selected, scroll, width, height int) []string {
+	var content []string
+	for i, c := range commits {
+		hashStr := diffHdrStyle.Render(c.Hash)
+		authorStr := branchStyle.Render(c.Author)
+		dateStr := stashDateStyle.Render(c.Date)
+		subjectStr := stashMsgStyle.Render(c.Subject)
+		line := fmt.Sprintf("   %s  %s  %s  %s", hashStr, authorStr, dateStr, subjectStr)
+
+		if i == selected {
+			line = stashSelStyle.Width(width).Render(fmt.Sprintf(" > %s  %s  %s  %s", c.Hash, c.Author, c.Date, c.Subject))
+		}
+
+		content = append(content, truncateToWidth(line, width))
 	}
 
 	// Apply scroll offset

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -732,3 +732,88 @@ func TestBranchPane_NonWorktreeBranchShowsNoLabel(t *testing.T) {
 		t.Error("non-worktree branch should not show [root]")
 	}
 }
+
+// --- History (mode 3) tests ---
+
+func TestModeHeader_ShowsThreeModes(t *testing.T) {
+	header := renderModeHeader(3, 60)
+	if !strings.Contains(header, "[3] history") {
+		t.Error("expected active '[3] history' in header")
+	}
+	if !strings.Contains(header, "1 branches") {
+		t.Error("expected inactive '1 branches' in header")
+	}
+	if !strings.Contains(header, "2 stashes") {
+		t.Error("expected inactive '2 stashes' in header")
+	}
+}
+
+func TestStatusBar_Mode3ShowsHistoryHints(t *testing.T) {
+	bar := RenderStatusBar(120, 3, 0, 1, false, false)
+	for _, hint := range []string{"enter: diff", "y: copy hash", "t: terminal", "c: code"} {
+		if !strings.Contains(bar, hint) {
+			t.Errorf("mode 3 status bar should contain %q", hint)
+		}
+	}
+}
+
+func TestStatusBar_Mode3OmitsDeleteHint(t *testing.T) {
+	bar := RenderStatusBar(120, 3, 0, 1, true, false)
+	if strings.Contains(bar, "d: delete") {
+		t.Error("mode 3 status bar should not contain 'd: delete'")
+	}
+	if strings.Contains(bar, "d: drop") {
+		t.Error("mode 3 status bar should not contain 'd: drop'")
+	}
+}
+
+func TestStatusBar_Mode3OmitsDestructiveHint(t *testing.T) {
+	bar := RenderStatusBar(120, 3, 0, 1, false, false)
+	if strings.Contains(bar, "D: destructive mode") {
+		t.Error("mode 3 status bar should not contain 'D: destructive mode'")
+	}
+}
+
+func TestCommitPane_ShowsCommitDetails(t *testing.T) {
+	commits := []gitquery.Commit{
+		{Hash: "abc1234", Author: "alice", Date: "2 hours ago", Subject: "Fix login bug"},
+		{Hash: "def5678", Author: "bob", Date: "3 days ago", Subject: "Add profile page"},
+	}
+	lines := renderCommitPane(commits, 0, 0, 80, 10)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "abc1234") {
+		t.Error("expected hash 'abc1234' in output")
+	}
+	if !strings.Contains(joined, "alice") {
+		t.Error("expected author 'alice' in output")
+	}
+	if !strings.Contains(joined, "2 hours ago") {
+		t.Error("expected date '2 hours ago' in output")
+	}
+	if !strings.Contains(joined, "Fix login bug") {
+		t.Error("expected subject 'Fix login bug' in output")
+	}
+}
+
+func TestCommitPane_ScrollsToSelectedCommit(t *testing.T) {
+	commits := make([]gitquery.Commit, 20)
+	for i := range commits {
+		commits[i] = gitquery.Commit{
+			Hash:    fmt.Sprintf("abc%04d", i),
+			Author:  "test",
+			Date:    "now",
+			Subject: fmt.Sprintf("commit-%d", i),
+		}
+	}
+	// Scroll past first 10, show 5 lines
+	lines := renderCommitPane(commits, 12, 10, 80, 5)
+	joined := strings.Join(lines, "\n")
+	// commit-10 should be visible (it's at offset 0 after scroll)
+	if !strings.Contains(joined, "commit-10") {
+		t.Error("expected 'commit-10' visible after scroll")
+	}
+	// commit-9 should not be visible (before scroll)
+	if strings.Contains(joined, "commit-9") {
+		t.Error("expected 'commit-9' not visible after scroll")
+	}
+}


### PR DESCRIPTION
## Summary

- Add a third right-pane view mode (`3` key / right arrow from stashes) showing the 50 most recent commits from the repo root checkout
- Each commit row displays short hash, author, relative date, and subject line
- `enter` opens a full-screen diff overlay via `git show <hash>`
- `y` copies the selected commit hash to the clipboard via `pbcopy`
- `t`/`c` open terminal/VSCode at the repo root path
- `d` key is a no-op in history mode (nothing to destroy)
- Mode header updated to show `[1] branches  2 stashes  3 history`
- Status bar shows history-specific hints: `enter: diff  y: copy hash  t: terminal  c: code`
- Adjacent-only mode switching (no wrapping): branches ↔ stashes ↔ history

Closes #33

## Test plan

- [x] `gofmt -l .` produces zero output
- [x] `make test` passes (25+ new tests across gitquery, model, ui, and actions)
- [x] `make build` succeeds
- [x] Manual: launch TUI, select a repo, press `3` to see commit history
- [x] Manual: navigate with up/down, verify cursor wrapping and scroll
- [x] Manual: press `enter` to view commit diff, `esc` to close
- [x] Manual: press `y` to copy hash, verify with `pbpaste`
- [x] Manual: verify `left`/`right` cycling between all three modes
- [x] Manual: press `t`/`c` in history mode to open terminal/VSCode at repo root