### PR TITLE
Add ModeWorktrees as mode 1 and shift existing modes

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -15,7 +15,8 @@ import (
 type Mode int
 
 const (
-	ModeBranches Mode = iota + 1
+	ModeWorktrees Mode = iota + 1
+	ModeBranches
 	ModeStashes
 	ModeHistory
 )
@@ -121,7 +122,7 @@ type Model struct {
 
 // New creates a Model from discovered repos.
 func New(repos []scanner.Repo) Model {
-	return Model{repos: repos, mode: ModeBranches}
+	return Model{repos: repos, mode: ModeWorktrees}
 }
 
 func (m Model) Selected() int              { return m.selected }
@@ -147,7 +148,7 @@ func (m Model) ActivePane() int            { return m.activePane }
 func (m Model) Destructive() bool          { return m.destructive }
 
 func (m Model) Init() tea.Cmd {
-	return m.fetchBranches()
+	return m.fetchForMode()
 }
 
 func (m Model) View() string {
@@ -310,7 +311,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 	case "down", "j":
 		return m.handleCursorDown()
 	case "left", "h":
-		if m.mode > ModeBranches {
+		if m.mode > ModeWorktrees {
 			m.mode--
 			m.branchSelected = 0
 			m.stashSelected = 0
@@ -328,14 +329,24 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			return m, m.fetchForMode()
 		}
 	case "1":
+		if m.mode != ModeWorktrees {
+			m.mode = ModeWorktrees
+			m.branchSelected = 0
+			m.stashSelected = 0
+			m.commitSelected = 0
+			m.commitScroll = 0
+			return m, nil
+		}
+	case "2":
 		if m.mode != ModeBranches {
 			m.mode = ModeBranches
 			m.branchSelected = 0
+			m.stashSelected = 0
 			m.commitSelected = 0
 			m.commitScroll = 0
 			return m, m.fetchBranches()
 		}
-	case "2":
+	case "3":
 		if m.mode != ModeStashes {
 			m.mode = ModeStashes
 			m.branchSelected = 0
@@ -344,7 +355,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			m.commitScroll = 0
 			return m, m.fetchStashes()
 		}
-	case "3":
+	case "4":
 		if m.mode != ModeHistory {
 			m.mode = ModeHistory
 			m.commitSelected = 0
@@ -728,6 +739,8 @@ func (m Model) handleCopyHash() (tea.Model, tea.Cmd) {
 
 func (m Model) fetchForMode() tea.Cmd {
 	switch m.mode {
+	case ModeWorktrees:
+		return nil
 	case ModeBranches:
 		return m.fetchBranches()
 	case ModeStashes:

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -19,8 +19,8 @@ func TestModel_EnterStillRequiresDirtyWorktree(t *testing.T) {
 		{Name: "clean-2"},
 	}
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
-	m = inRightPane(m)
 
 	// Cursor at clean-1 (index 0): enter is no-op
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -62,8 +62,8 @@ func TestModel_EnterOpensBranchDiffOverlayForDirtyWorktree(t *testing.T) {
 		},
 		{Name: "main"},
 	}
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
-	m = inRightPane(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.Overlay() != model.OverlayBranchDiff {
@@ -87,8 +87,8 @@ func TestModel_EnterDoesNothingForCleanBranch(t *testing.T) {
 			Dirty:      false,
 		},
 	}
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
-	m = inRightPane(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.Overlay() != model.OverlayNone {
@@ -101,16 +101,16 @@ func TestModel_EnterDoesNothingForCleanBranch(t *testing.T) {
 
 // --- History (mode 3) actions ---
 
-func modelInMode3WithCommits() model.Model {
+func modelInHistoryWithCommits() model.Model {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
 	return m
 }
 
 func TestModel_EnterInHistoryOpensCommitDiffOverlay(t *testing.T) {
-	m := modelInMode3WithCommits()
+	m := modelInHistoryWithCommits()
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.Overlay() != model.OverlayCommitDiff {
 		t.Errorf("expected OverlayCommitDiff, got %d", m.Overlay())
@@ -127,7 +127,7 @@ func TestModel_EnterInHistoryOpensCommitDiffOverlay(t *testing.T) {
 func TestModel_EnterInHistoryNoCommitsIsNoOp(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	// No commits loaded
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.Overlay() != model.OverlayNone {
@@ -156,15 +156,15 @@ func TestModel_StaleCommitDiffResultDiscarded(t *testing.T) {
 	}
 }
 
-func TestModel_YKeyCopiesHashInMode3(t *testing.T) {
-	m := modelInMode3WithCommits()
+func TestModel_YKeyCopiesHashInHistoryMode(t *testing.T) {
+	m := modelInHistoryWithCommits()
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if cmd == nil {
 		t.Error("expected non-nil cmd for y key in mode 3")
 	}
 }
 
-func TestModel_YKeyNoOpInMode1(t *testing.T) {
+func TestModel_YKeyNoOpInWorktreesMode(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
@@ -176,7 +176,7 @@ func TestModel_YKeyNoOpInMode1(t *testing.T) {
 func TestModel_YKeyNoOpWithNoCommits(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if cmd != nil {
 		t.Errorf("expected nil cmd for y key with no commits, got %T", cmd)
@@ -184,7 +184,7 @@ func TestModel_YKeyNoOpWithNoCommits(t *testing.T) {
 }
 
 func TestModel_DKeyNoOpInHistoryMode(t *testing.T) {
-	m := modelInMode3WithCommits()
+	m := modelInHistoryWithCommits()
 	m = enableDestructive(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	if m.Overlay() != model.OverlayNone {
@@ -193,7 +193,7 @@ func TestModel_DKeyNoOpInHistoryMode(t *testing.T) {
 }
 
 func TestModel_TKeyInHistoryFiresCmd(t *testing.T) {
-	m := modelInMode3WithCommits()
+	m := modelInHistoryWithCommits()
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
 	if cmd == nil {
 		t.Error("expected non-nil cmd for t key in history mode")
@@ -201,7 +201,7 @@ func TestModel_TKeyInHistoryFiresCmd(t *testing.T) {
 }
 
 func TestModel_CKeyInHistoryFiresCmd(t *testing.T) {
-	m := modelInMode3WithCommits()
+	m := modelInHistoryWithCommits()
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
 	if cmd == nil {
 		t.Error("expected non-nil cmd for c key in history mode")
@@ -213,7 +213,7 @@ func TestModel_CKeyInHistoryFiresCmd(t *testing.T) {
 func TestModel_EnterOpensOverlay(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.Overlay() != model.OverlayStashDiff {
@@ -239,7 +239,7 @@ func TestModel_StashDiffResultStoresDiff(t *testing.T) {
 func TestModel_EscClosesOverlay(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	// Now close overlay with esc
@@ -258,7 +258,7 @@ func TestModel_EscClosesOverlay(t *testing.T) {
 func TestModel_QClosesOverlayNotQuit(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	// Close with q
@@ -277,7 +277,7 @@ func TestModel_QClosesOverlayNotQuit(t *testing.T) {
 func TestModel_OverlayScrollUpDown(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, model.StashDiffResultMsg{RepoPath: "/dev/alpha", Index: 0, Diff: "line1\nline2\nline3"})
@@ -300,13 +300,13 @@ func TestModel_OverlayScrollUpDown(t *testing.T) {
 func TestModel_ModeKeysIgnoredInOverlay(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	// Press "1" — should not change mode
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	if m.Mode() != 2 {
-		t.Errorf("expected mode unchanged at 2, got %d", m.Mode())
+	if m.Mode() != 3 {
+		t.Errorf("expected mode unchanged at 3 (stashes), got %d", m.Mode())
 	}
 	if m.Overlay() != model.OverlayStashDiff {
 		t.Errorf("expected overlay still open, got %d", m.Overlay())
@@ -317,13 +317,13 @@ func TestModel_ModeKeysIgnoredInOverlay(t *testing.T) {
 
 func TestModel_DKeyNoOpInReadOnlyMode(t *testing.T) {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{
 			{Name: "feat", IsWorktree: true, Dirty: true, WorktreePaths: []string{"/dev/alpha/feat"}},
 		},
 	})
-	m = inRightPane(m)
 	// d should be no-op in read-only mode (default)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	if m.Overlay() != model.OverlayNone {
@@ -345,13 +345,13 @@ func TestModel_ShiftDTogglesDestructiveOn(t *testing.T) {
 
 func TestModel_DKeyWorksInDestructiveMode(t *testing.T) {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{
 			{Name: "feat", IsWorktree: true, Dirty: true, WorktreePaths: []string{"/dev/alpha/feat"}},
 		},
 	})
-	m = inRightPane(m)
 	// Enable destructive mode
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 	// Now d should work
@@ -364,7 +364,7 @@ func TestModel_DKeyWorksInDestructiveMode(t *testing.T) {
 func TestModel_DKeyNoOpInReadOnlyModeStashes(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	if m.Overlay() != model.OverlayNone {
@@ -419,13 +419,13 @@ func TestModel_ShiftDNoOpDuringConfirmOverlay(t *testing.T) {
 
 func TestModel_ShiftDNoOpDuringDiffOverlay(t *testing.T) {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{
 			{Name: "feat", IsWorktree: true, Dirty: true, WorktreePaths: []string{"/dev/alpha/feat"}},
 		},
 	})
-	m = inRightPane(m)
 	// Open diff overlay
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.Overlay() == model.OverlayNone {
@@ -457,11 +457,11 @@ func enableDestructive(m model.Model) model.Model {
 
 func modelWithWorktreeBranch() model.Model {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{worktreeBranch()},
 	})
-	m = inRightPane(m)
 	m = enableDestructive(m)
 	return m
 }
@@ -479,11 +479,11 @@ func TestModel_DKeyOpensConfirmOverlay(t *testing.T) {
 
 func TestModel_DKeyOnNonWorktreeBranchOpensDeleteConfirm(t *testing.T) {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{{Name: "main"}},
 	})
-	m = inRightPane(m)
 	m = enableDestructive(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	if m.Overlay() != model.OverlayConfirm {
@@ -610,11 +610,11 @@ func TestModel_WorktreeRemoveFailReturnsDeleteFailedMsg(t *testing.T) {
 func TestModel_BranchDeleteFailReturnsDeleteFailedMsg(t *testing.T) {
 	// With a fake repo path, DeleteBranch will fail → returns DeleteFailedMsg
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{{Name: "feat"}},
 	})
-	m = inRightPane(m)
 	m = enableDestructive(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
@@ -716,7 +716,7 @@ func TestModel_ForceConfirmWorktreeYReturnsWorktreeRemovedMsg(t *testing.T) {
 func TestModel_ConfirmDialogBlocksModeSwitch(t *testing.T) {
 	m := modelWithWorktreeBranch()
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	if m.Mode() != model.ModeBranches {
 		t.Errorf("confirm dialog should block mode switch, mode changed to %d", m.Mode())
 	}
@@ -724,17 +724,17 @@ func TestModel_ConfirmDialogBlocksModeSwitch(t *testing.T) {
 
 // --- Stash drop ---
 
-func modelInMode2WithStashes() model.Model {
+func modelInStashesWithStashes() model.Model {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	m = enableDestructive(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 	return m
 }
 
-func TestModel_DKeyInMode2OpensConfirmDialog(t *testing.T) {
-	m := modelInMode2WithStashes()
+func TestModel_DKeyInStashesModeOpensConfirmDialog(t *testing.T) {
+	m := modelInStashesWithStashes()
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	if m.Overlay() != model.OverlayConfirm {
 		t.Errorf("expected OverlayConfirm, got %d", m.Overlay())
@@ -744,10 +744,10 @@ func TestModel_DKeyInMode2OpensConfirmDialog(t *testing.T) {
 	}
 }
 
-func TestModel_DKeyInMode2WithNoStashesDoesNothing(t *testing.T) {
+func TestModel_DKeyInStashesModeWithNoStashesDoesNothing(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	// No stashes loaded
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	if m.Overlay() != model.OverlayNone {
@@ -756,7 +756,7 @@ func TestModel_DKeyInMode2WithNoStashesDoesNothing(t *testing.T) {
 }
 
 func TestModel_StashDropConfirmReturnsStashDroppedMsg(t *testing.T) {
-	m := modelInMode2WithStashes()
+	m := modelInStashesWithStashes()
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if cmd == nil {
@@ -781,11 +781,11 @@ func staleBranch() gitquery.Branch {
 
 func modelWithStaleBranch() model.Model {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{staleBranch()},
 	})
-	m = inRightPane(m)
 	m = enableDestructive(m)
 	return m
 }
@@ -806,11 +806,11 @@ func TestModel_PKeyOnStaleWorktreeOpensConfirm(t *testing.T) {
 
 func TestModel_PKeyNoOpWithoutDestructiveMode(t *testing.T) {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{staleBranch()},
 	})
-	m = inRightPane(m)
 	// destructive mode NOT enabled
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
 	if m.Overlay() != model.OverlayNone {
@@ -828,11 +828,11 @@ func TestModel_PKeyNoOpOnNonStaleWorktree(t *testing.T) {
 
 func TestModel_PKeyNoOpOnNonWorktreeBranch(t *testing.T) {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{{Name: "plain"}},
 	})
-	m = inRightPane(m)
 	m = enableDestructive(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
 	if m.Overlay() != model.OverlayNone {
@@ -872,13 +872,13 @@ func TestModel_WorktreePrunedMsgRefreshesBranches(t *testing.T) {
 
 func TestModel_TKey_WorktreeBranch_FiresCmd(t *testing.T) {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{
 			{Name: "main", IsWorktree: true, WorktreePaths: []string{"/dev/alpha"}},
 		},
 	})
-	m = inRightPane(m)
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
 	if cmd == nil {
 		t.Error("expected non-nil cmd when pressing t on a worktree branch")
@@ -887,13 +887,13 @@ func TestModel_TKey_WorktreeBranch_FiresCmd(t *testing.T) {
 
 func TestModel_CKey_WorktreeBranch_FiresCmd(t *testing.T) {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{
 			{Name: "main", IsWorktree: true, WorktreePaths: []string{"/dev/alpha"}},
 		},
 	})
-	m = inRightPane(m)
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
 	if cmd == nil {
 		t.Error("expected non-nil cmd when pressing c on a worktree branch")
@@ -902,13 +902,13 @@ func TestModel_CKey_WorktreeBranch_FiresCmd(t *testing.T) {
 
 func TestModel_TKey_NonWorktreeBranch_NoCmd(t *testing.T) {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{
 			{Name: "stale-branch"},
 		},
 	})
-	m = inRightPane(m)
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
 	if cmd != nil {
 		t.Error("expected nil cmd when pressing t on a non-worktree branch")
@@ -917,13 +917,13 @@ func TestModel_TKey_NonWorktreeBranch_NoCmd(t *testing.T) {
 
 func TestModel_CKey_NonWorktreeBranch_NoCmd(t *testing.T) {
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/alpha",
 		Branches: []gitquery.Branch{
 			{Name: "stale-branch"},
 		},
 	})
-	m = inRightPane(m)
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
 	if cmd != nil {
 		t.Error("expected nil cmd when pressing c on a non-worktree branch")
@@ -935,12 +935,12 @@ func TestModel_CKey_NonWorktreeBranch_NoCmd(t *testing.T) {
 func TestModel_MultiWorktreeExpandsToRows(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = inBranchesMode(m)
 	// Branch with 2 worktree paths — should expand to 2 navigable rows
 	branches := []gitquery.Branch{
 		{Name: "feat", IsWorktree: true, WorktreePaths: []string{"/dev/feat-A", "/dev/feat-B"}},
 	}
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
-	m = inRightPane(m)
 	if m.BranchSelected() != 0 {
 		t.Errorf("expected cursor at 0 initially, got %d", m.BranchSelected())
 	}
@@ -959,11 +959,11 @@ func TestModel_MultiWorktreeExpandsToRows(t *testing.T) {
 func TestModel_DKeyOnExpansionRowTargetsSpecificPath(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = inBranchesMode(m)
 	branches := []gitquery.Branch{
 		{Name: "feat", IsWorktree: true, WorktreePaths: []string{"/dev/feat-A", "/dev/feat-B"}},
 	}
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
-	m = inRightPane(m)
 	m = enableDestructive(m)
 	// Navigate to expansion row (index 1 = /dev/feat-B)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -48,6 +48,13 @@ func selectBravo(m model.Model) model.Model {
 	return m
 }
 
+// inBranchesMode switches to right pane and selects branches mode (mode 2).
+func inBranchesMode(m model.Model) model.Model {
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	return m
+}
+
 // --- Init & basics ---
 
 func TestModel_InitialActivePaneIsLeft(t *testing.T) {
@@ -64,22 +71,31 @@ func TestModel_InitialSelection(t *testing.T) {
 	}
 }
 
-func TestModel_DefaultModeIsBranches(t *testing.T) {
+func TestModel_DefaultModeIsWorktrees(t *testing.T) {
 	m := model.New(testRepos())
 	if m.Mode() != 1 {
-		t.Errorf("expected default mode 1, got %d", m.Mode())
+		t.Errorf("expected default mode ModeWorktrees (1), got %d", m.Mode())
 	}
 }
 
-func TestModel_InitFiresFetchBranches(t *testing.T) {
+func TestModel_InitReturnsNilForWorktreesMode(t *testing.T) {
 	m := model.New(testRepos())
 	cmd := m.Init()
+	if cmd != nil {
+		t.Error("Init should return nil for ModeWorktrees (no data to fetch yet)")
+	}
+}
+
+func TestModel_SwitchToBranchesFiresFetch(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
 	if cmd == nil {
-		t.Fatal("expected fetchBranches cmd from Init, got nil")
+		t.Fatal("expected fetchBranches cmd from switch to mode 2, got nil")
 	}
 	msg := cmd()
 	if _, ok := msg.(model.BranchResultMsg); !ok {
-		t.Errorf("expected BranchResultMsg from Init, got %T", msg)
+		t.Errorf("expected BranchResultMsg, got %T", msg)
 	}
 }
 
@@ -142,10 +158,10 @@ func TestModel_TabTogglesPaneFocus(t *testing.T) {
 func TestModel_TabDoesNotChangeMode(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // left → right
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}) // mode 2
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // mode 3 (stashes)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // right → left
-	if m.Mode() != 2 {
-		t.Errorf("expected mode unchanged at 2, got %d", m.Mode())
+	if m.Mode() != 3 {
+		t.Errorf("expected mode unchanged at 3, got %d", m.Mode())
 	}
 }
 
@@ -153,12 +169,20 @@ func TestModel_TabDoesNotChangeMode(t *testing.T) {
 
 func TestModel_LeftPaneDownNavigatesRepos(t *testing.T) {
 	m := model.New(testRepos())
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if m.Selected() != 1 {
 		t.Errorf("expected selected 1 after down in left pane, got %d", m.Selected())
 	}
+}
+
+func TestModel_LeftPaneDownFiresFetchInBranchMode(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}) // branches
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // back to left pane
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if cmd == nil {
-		t.Error("expected fetch cmd after repo navigation, got nil")
+		t.Error("expected fetch cmd after repo navigation in branches mode, got nil")
 	}
 }
 
@@ -211,7 +235,7 @@ func TestModel_RepoSwitchClearsRightPaneData(t *testing.T) {
 
 func TestModel_LeftPaneDownResetsRightPaneCursors(t *testing.T) {
 	m := model.New(testRepos())
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab}) // switch to right pane
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: []gitquery.Branch{
 		{Name: "a"}, {Name: "b"}, {Name: "c"},
 	}})
@@ -281,8 +305,8 @@ func TestModel_UpDownNavigatesAllBranches(t *testing.T) {
 		{Name: "dirty-2", IsWorktree: true, Dirty: true, WorktreePaths: []string{"/dev/alpha"}},
 	}
 	m := model.New(testRepos())
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
-	m = inRightPane(m)
 
 	if m.BranchSelected() != 0 {
 		t.Errorf("expected cursor at 0, got %d", m.BranchSelected())
@@ -314,7 +338,7 @@ func TestModel_UpDownNavigatesAllBranches(t *testing.T) {
 func TestModel_StashCursorWraps(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 	// Wrap backward from 0 to last
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
@@ -336,14 +360,13 @@ func TestModel_BranchScrollFollowsCursor(t *testing.T) {
 	}
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: ui.BranchContentOverhead + 3}) // 3 content lines
+	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
 
 	// Cursor starts at 0, scroll at 0
 	if m.BranchScroll() != 0 {
 		t.Errorf("expected scroll 0 at start, got %d", m.BranchScroll())
 	}
-
-	m = inRightPane(m)
 	// Move cursor down past the viewport
 	for i := 0; i < 9; i++ {
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
@@ -469,7 +492,7 @@ func TestModel_StashScrollFollowsCursor(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: ui.BranchContentOverhead + contentHeight})
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: stashes})
 
 	if m.StashScroll() != 0 {
@@ -520,7 +543,7 @@ func TestModel_StashScrollAccountsForLongMessages(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 50 + ui.LeftPaneWidth + 2, Height: ui.BranchContentOverhead + contentHeight})
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: stashes})
 
 	// Move to stash 2 (each takes 2 lines, so stash 2 starts at visual line 4)
@@ -540,32 +563,32 @@ func TestModel_StashScrollAccountsForLongMessages(t *testing.T) {
 func TestModel_ModeSwitchOnKeyPress(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
-	if m.Mode() != 2 {
-		t.Errorf("expected mode 2, got %d", m.Mode())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	if m.Mode() != 3 {
+		t.Errorf("expected mode 3 (stashes), got %d", m.Mode())
 	}
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
 	if m.Mode() != 1 {
-		t.Errorf("expected mode 1, got %d", m.Mode())
+		t.Errorf("expected mode 1 (worktrees), got %d", m.Mode())
 	}
 }
 
-func TestModel_Key3SwitchesToHistoryMode(t *testing.T) {
+func TestModel_Key4SwitchesToHistoryMode(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
-	if m.Mode() != 3 {
-		t.Errorf("expected mode 3, got %d", m.Mode())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+	if m.Mode() != 4 {
+		t.Errorf("expected mode 4, got %d", m.Mode())
 	}
 }
 
-func TestModel_SwitchToMode3FiresFetchCommits(t *testing.T) {
+func TestModel_SwitchToHistoryFiresFetchCommits(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	if cmd == nil {
-		t.Fatal("expected fetchCommits cmd on switch to mode 3, got nil")
+		t.Fatal("expected fetchCommits cmd on switch to mode 4, got nil")
 	}
 	msg := cmd()
 	if _, ok := msg.(model.CommitResultMsg); !ok {
@@ -573,18 +596,48 @@ func TestModel_SwitchToMode3FiresFetchCommits(t *testing.T) {
 	}
 }
 
-func TestModel_Key4IsNoOp(t *testing.T) {
+func TestModel_NumberKeysSwitchToCorrectModes(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
+
+	// Key 2 → ModeBranches
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	if m.Mode() != 2 {
+		t.Errorf("key 2: expected mode 2 (ModeBranches), got %d", m.Mode())
+	}
+
+	// Key 3 → ModeStashes
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	if m.Mode() != 3 {
+		t.Errorf("key 3: expected mode 3 (ModeStashes), got %d", m.Mode())
+	}
+
+	// Key 4 → ModeHistory
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+	if m.Mode() != 4 {
+		t.Errorf("key 4: expected mode 4 (ModeHistory), got %d", m.Mode())
+	}
+
+	// Key 1 → ModeWorktrees
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	if m.Mode() != 1 {
+		t.Errorf("key 1: expected mode 1 (ModeWorktrees), got %d", m.Mode())
+	}
+}
+
+func TestModel_Key5IsNoOp(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
 	if m.Mode() != 1 {
 		t.Errorf("expected mode unchanged at 1, got %d", m.Mode())
 	}
 }
 
-func TestModel_Pressing1WhileInMode1NoFetch(t *testing.T) {
+func TestModel_PressingCurrentModeKeyNoFetch(t *testing.T) {
 	m := model.New(testRepos())
-	// Already in mode 1; pressing 1 should not fire a redundant fetch
+	m = inRightPane(m)
+	// Already in mode 1 (worktrees); pressing 1 should not fire a redundant fetch
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
 	if cmd != nil {
 		t.Error("pressing 1 while already in mode 1 should not fire fetch")
@@ -595,28 +648,28 @@ func TestModel_ModeSwitchPreservesSelection(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})                      // select bravo (left pane)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // switch to right pane
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}) // mode 2
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // mode 3 (stashes)
 	if m.Selected() != 1 {
 		t.Errorf("expected selection preserved at 1, got %d", m.Selected())
 	}
 }
 
-func TestModel_RightSwitchesToMode2(t *testing.T) {
+func TestModel_RightFromWorktreesSwitchesToBranches(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})
 	if m.Mode() != 2 {
-		t.Errorf("expected mode 2, got %d", m.Mode())
+		t.Errorf("expected mode 2 (branches), got %d", m.Mode())
 	}
 }
 
-func TestModel_LeftSwitchesToMode1(t *testing.T) {
+func TestModel_LeftFromBranchesSwitchesToWorktrees(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // branches
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft})  // worktrees
 	if m.Mode() != 1 {
-		t.Errorf("expected mode 1, got %d", m.Mode())
+		t.Errorf("expected mode 1 (worktrees), got %d", m.Mode())
 	}
 }
 
@@ -625,74 +678,115 @@ func TestModel_HLSwitchModes(t *testing.T) {
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
 	if m.Mode() != 2 {
-		t.Errorf("expected mode 2, got %d", m.Mode())
+		t.Errorf("expected mode 2 (branches), got %d", m.Mode())
 	}
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
 	if m.Mode() != 1 {
-		t.Errorf("expected mode 1, got %d", m.Mode())
+		t.Errorf("expected mode 1 (worktrees), got %d", m.Mode())
+	}
+}
+
+func TestModel_RightCyclesThroughAllFourModes(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	// Start at ModeWorktrees (1)
+	if m.Mode() != 1 {
+		t.Fatalf("expected starting mode 1, got %d", m.Mode())
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 2
+	if m.Mode() != 2 {
+		t.Errorf("expected mode 2 after first right, got %d", m.Mode())
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 3
+	if m.Mode() != 3 {
+		t.Errorf("expected mode 3 after second right, got %d", m.Mode())
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 4
+	if m.Mode() != 4 {
+		t.Errorf("expected mode 4 after third right, got %d", m.Mode())
+	}
+}
+
+func TestModel_LeftCyclesBackThroughAllFourModes(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	// Go to mode 4
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+	// Left through 3, 2, 1
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft}) // 3
+	if m.Mode() != 3 {
+		t.Errorf("expected mode 3 after first left, got %d", m.Mode())
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft}) // 2
+	if m.Mode() != 2 {
+		t.Errorf("expected mode 2 after second left, got %d", m.Mode())
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft}) // 1
+	if m.Mode() != 1 {
+		t.Errorf("expected mode 1 after third left, got %d", m.Mode())
 	}
 }
 
 func TestModel_ModeClampsAtEdges(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	// Already at mode 1, left should stay at 1
+	// Already at mode 1 (ModeWorktrees), left should stay at 1
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft})
 	if m.Mode() != 1 {
 		t.Errorf("expected mode 1 (clamped), got %d", m.Mode())
 	}
-	// Go to mode 3, right should stay at 3
+	// Go to mode 4 (ModeHistory), right should stay at 4
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 2
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 3
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // still 3
-	if m.Mode() != 3 {
-		t.Errorf("expected mode 3 (clamped), got %d", m.Mode())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 4
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // still 4
+	if m.Mode() != 4 {
+		t.Errorf("expected mode 4 (clamped), got %d", m.Mode())
 	}
 }
 
 func TestModel_RightFromStashesGoesToHistory(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}) // stashes
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // stashes
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})                     // history
-	if m.Mode() != 3 {
-		t.Errorf("expected mode 3, got %d", m.Mode())
+	if m.Mode() != 4 {
+		t.Errorf("expected mode 4, got %d", m.Mode())
 	}
 }
 
 func TestModel_LeftFromHistoryGoesToStashes(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // history
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}}) // history
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft})                      // stashes
-	if m.Mode() != 2 {
-		t.Errorf("expected mode 2, got %d", m.Mode())
+	if m.Mode() != 3 {
+		t.Errorf("expected mode 3, got %d", m.Mode())
 	}
 }
 
 func TestModel_ModeSwitchViaArrowFiresFetch(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	// Right to mode 2 should fetch stashes
+	// Right to mode 2 (branches) should fetch branches
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
 	if cmd == nil {
-		t.Fatal("expected fetch cmd on mode switch to 2, got nil")
+		t.Fatal("expected fetch cmd on mode switch to branches, got nil")
 	}
-	// Left back to mode 1 should fetch worktrees
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})
-	_, cmd = update(m, tea.KeyMsg{Type: tea.KeyLeft})
+	// Right to mode 3 (stashes) should fetch stashes
+	_, cmd = update(m, tea.KeyMsg{Type: tea.KeyRight})
 	if cmd == nil {
-		t.Fatal("expected fetch cmd on mode switch to 1, got nil")
+		t.Fatal("expected fetch cmd on mode switch to stashes, got nil")
 	}
 }
 
-func TestModel_Mode1SwitchFiresFetchBranches(t *testing.T) {
+func TestModel_SwitchToBranchesFiresFetchBranches(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
-	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // stashes
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
 	if cmd == nil {
-		t.Fatal("expected fetch cmd on switch to mode 1, got nil")
+		t.Fatal("expected fetch cmd on switch to mode 2, got nil")
 	}
 	msg := cmd()
 	if _, ok := msg.(model.BranchResultMsg); !ok {
@@ -700,12 +794,12 @@ func TestModel_Mode1SwitchFiresFetchBranches(t *testing.T) {
 	}
 }
 
-func TestModel_SwitchToMode2FiresFetchStashes(t *testing.T) {
+func TestModel_SwitchToStashesFiresFetchStashes(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	if cmd == nil {
-		t.Fatal("expected fetchStashes cmd on switch to mode 2, got nil")
+		t.Fatal("expected fetchStashes cmd on switch to mode 3, got nil")
 	}
 	msg := cmd()
 	if _, ok := msg.(model.StashResultMsg); !ok {
@@ -857,7 +951,7 @@ func TestModel_StaleCommitResultDiscarded(t *testing.T) {
 func TestModel_CommitCursorWraps(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
 	// Wrap backward from 0 to last
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
@@ -879,7 +973,7 @@ func TestModel_CommitScrollFollowsCursor(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: ui.BranchContentOverhead + 3})
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: commits})
 
 	// Move cursor past viewport
@@ -894,7 +988,7 @@ func TestModel_CommitScrollFollowsCursor(t *testing.T) {
 func TestModel_ModeSwitchResetsCommitCursors(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
@@ -903,7 +997,7 @@ func TestModel_ModeSwitchResetsCommitCursors(t *testing.T) {
 	}
 	// Switch away and back
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	if m.CommitSelected() != 0 {
 		t.Errorf("expected CommitSelected reset to 0, got %d", m.CommitSelected())
 	}
@@ -912,7 +1006,7 @@ func TestModel_ModeSwitchResetsCommitCursors(t *testing.T) {
 func TestModel_RepoSwitchClearsCommits(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
 	if len(m.Commits()) != 3 {
 		t.Fatal("expected 3 commits")

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -13,6 +13,7 @@ import (
 func TestModel_ViewShowsBranchData(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = inBranchesMode(m)
 	branches := []gitquery.Branch{
 		{Name: "main", HasUpstream: true},
 		{Name: "feature/auth", HasUpstream: true, Ahead: 2, Behind: 1,
@@ -51,56 +52,85 @@ func TestModel_ViewContainsExpectedContent(t *testing.T) {
 	}
 }
 
-func TestModel_ViewMode2ShowsPlaceholder(t *testing.T) {
+func TestModel_ViewWorktreesModeShowsPlaceholder(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: 24})
-	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	// Load branch data — worktrees mode should still show placeholder, not branches
+	branches := []gitquery.Branch{{Name: "main", HasUpstream: true}}
+	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
 
 	view := m.View()
 	if !strings.Contains(view, "nothing here yet") {
-		t.Error("mode 2 should show placeholder")
+		t.Error("ModeWorktrees should show placeholder even when branch data is loaded")
+	}
+	if strings.Contains(view, "main") {
+		t.Error("ModeWorktrees should NOT show branch data")
 	}
 }
 
-func TestModel_ViewModeHeaderShowsThreeModes(t *testing.T) {
+func TestModel_ViewStashesModeShowsPlaceholder(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+
+	view := m.View()
+	if !strings.Contains(view, "nothing here yet") {
+		t.Error("ModeStashes with no data should show placeholder")
+	}
+}
+
+func TestModel_ViewModeHeaderShowsFourModes(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 
 	view := m.View()
-	// Mode 1 active — mode header in right pane
-	if !strings.Contains(view, "[1] branches") {
-		t.Error("mode 1 active: right pane header should contain '[1] branches'")
+	// Mode 1 (worktrees) active
+	if !strings.Contains(view, "[1] worktrees") {
+		t.Error("mode 1 active: right pane header should contain '[1] worktrees'")
 	}
-	if !strings.Contains(view, "2 stashes") {
-		t.Error("mode 1 active: right pane header should show inactive '2 stashes'")
+	if !strings.Contains(view, "2 branches") {
+		t.Error("mode 1 active: right pane header should show inactive '2 branches'")
 	}
-	if !strings.Contains(view, "3 history") {
-		t.Error("mode 1 active: right pane header should show inactive '3 history'")
+	if !strings.Contains(view, "3 stashes") {
+		t.Error("mode 1 active: right pane header should show inactive '3 stashes'")
+	}
+	if !strings.Contains(view, "4 history") {
+		t.Error("mode 1 active: right pane header should show inactive '4 history'")
 	}
 
-	// Switch to mode 2
+	// Switch to mode 2 (branches)
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})
 	view = m.View()
-	if !strings.Contains(view, "[2] stashes") {
-		t.Error("mode 2 active: right pane header should contain '[2] stashes'")
+	if !strings.Contains(view, "[2] branches") {
+		t.Error("mode 2 active: right pane header should contain '[2] branches'")
 	}
-	if !strings.Contains(view, "1 branches") {
-		t.Error("mode 2 active: right pane header should show inactive '1 branches'")
+	if !strings.Contains(view, "1 worktrees") {
+		t.Error("mode 2 active: right pane header should show inactive '1 worktrees'")
 	}
 
-	// Switch to mode 3
+	// Switch to mode 3 (stashes)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})
 	view = m.View()
-	if !strings.Contains(view, "[3] history") {
-		t.Error("mode 3 active: right pane header should contain '[3] history'")
+	if !strings.Contains(view, "[3] stashes") {
+		t.Error("mode 3 active: right pane header should contain '[3] stashes'")
 	}
-	if !strings.Contains(view, "1 branches") {
-		t.Error("mode 3 active: right pane header should show inactive '1 branches'")
+
+	// Switch to mode 4 (history)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})
+	view = m.View()
+	if !strings.Contains(view, "[4] history") {
+		t.Error("mode 4 active: right pane header should contain '[4] history'")
 	}
-	if !strings.Contains(view, "2 stashes") {
-		t.Error("mode 3 active: right pane header should show inactive '2 stashes'")
+	if !strings.Contains(view, "1 worktrees") {
+		t.Error("mode 4 active: right pane header should show inactive '1 worktrees'")
+	}
+	if !strings.Contains(view, "2 branches") {
+		t.Error("mode 4 active: right pane header should show inactive '2 branches'")
+	}
+	if !strings.Contains(view, "3 stashes") {
+		t.Error("mode 4 active: right pane header should show inactive '3 stashes'")
 	}
 }
 
@@ -114,11 +144,11 @@ func TestModel_ViewStatusBarShowsKeyHints(t *testing.T) {
 	}
 }
 
-func TestModel_ViewMode2ShowsStashContent(t *testing.T) {
+func TestModel_ViewStashesModeShowsStashContent(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 
 	view := m.View()
@@ -134,7 +164,7 @@ func TestModel_ViewOverlayShowsDiff(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, model.StashDiffResultMsg{RepoPath: "/dev/alpha", Index: 0, Diff: "diff --git a/f.txt\n--- a/f.txt\n+++ b/f.txt"})
@@ -148,31 +178,31 @@ func TestModel_ViewOverlayShowsDiff(t *testing.T) {
 	}
 }
 
-func TestModel_StatusBarMode2ShowsStashKeys(t *testing.T) {
+func TestModel_StatusBarStashesModeShowsStashKeys(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // mode 2
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // stashes
 
 	view := m.View()
 	if !strings.Contains(view, "enter") {
-		t.Error("mode 2 status bar should mention 'enter'")
+		t.Error("stashes status bar should mention 'enter'")
 	}
 	if !strings.Contains(view, "↑/↓") {
-		t.Error("mode 2 status bar should mention '↑/↓'")
+		t.Error("stashes status bar should mention '↑/↓'")
 	}
 }
 
-func TestModel_StatusBarMode2ShowsDropHint(t *testing.T) {
+func TestModel_StatusBarStashesModeShowsDropHint(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}}) // enable destructive
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})                     // mode 2
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // stashes
 
 	view := m.View()
 	if !strings.Contains(view, "d: drop") {
-		t.Error("mode 2 status bar should mention 'd: drop' in destructive mode")
+		t.Error("stashes status bar should mention 'd: drop' in destructive mode")
 	}
 }
 
@@ -181,7 +211,7 @@ func TestModel_StatusBarMode2ShowsDropHint(t *testing.T) {
 func TestModel_ViewReadOnlyHidesDeleteHint(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
-	m = inRightPane(m)
+	m = inBranchesMode(m)
 
 	view := m.View()
 	if strings.Contains(view, "d: delete") {
@@ -193,7 +223,7 @@ func TestModel_ViewReadOnlyHidesDropHint(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // mode 2
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // stashes
 
 	view := m.View()
 	if strings.Contains(view, "d: drop") {
@@ -204,6 +234,7 @@ func TestModel_ViewReadOnlyHidesDropHint(t *testing.T) {
 func TestModel_ViewReadOnlyShowsDestructiveModeHint(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inBranchesMode(m)
 
 	view := m.View()
 	if !strings.Contains(view, "D: destructive mode") {
@@ -214,7 +245,7 @@ func TestModel_ViewReadOnlyShowsDestructiveModeHint(t *testing.T) {
 func TestModel_ViewDestructiveModeShowsDeleteHint(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
-	m = inRightPane(m)
+	m = inBranchesMode(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 
 	view := m.View()
@@ -223,23 +254,23 @@ func TestModel_ViewDestructiveModeShowsDeleteHint(t *testing.T) {
 	}
 }
 
-func TestModel_ViewMode3ShowsPlaceholder(t *testing.T) {
+func TestModel_ViewHistoryModeShowsPlaceholder(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: 24})
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 
 	view := m.View()
 	if !strings.Contains(view, "nothing here yet") {
-		t.Error("mode 3 with no commits should show placeholder")
+		t.Error("history mode with no commits should show placeholder")
 	}
 }
 
-func TestModel_ViewMode3ShowsCommitContent(t *testing.T) {
+func TestModel_ViewHistoryModeShowsCommitContent(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
 
 	view := m.View()
@@ -251,11 +282,11 @@ func TestModel_ViewMode3ShowsCommitContent(t *testing.T) {
 	}
 }
 
-func TestModel_StatusBarMode3ShowsHistoryKeys(t *testing.T) {
+func TestModel_StatusBarHistoryModeShowsHistoryKeys(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 
 	view := m.View()
 	if !strings.Contains(view, "enter: diff") {
@@ -275,6 +306,7 @@ func TestModel_StatusBarMode3ShowsHistoryKeys(t *testing.T) {
 func TestModel_ViewDestructiveModeHidesDestructiveHint(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inBranchesMode(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 
 	view := m.View()

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -149,11 +149,11 @@ func Render(p RenderParams) string {
 
 	var rightLines []string
 	switch {
-	case p.Mode == 1 && len(p.Branches) > 0:
+	case p.Mode == 2 && len(p.Branches) > 0:
 		rightLines = renderBranchPaneSelected(p.Branches, branchSel, p.BranchScroll, rightContentWidth, rightContentHeight, repoPath)
-	case p.Mode == 2 && len(p.Stashes) > 0:
+	case p.Mode == 3 && len(p.Stashes) > 0:
 		rightLines = renderStashPane(p.Stashes, stashSel, p.StashScroll, rightContentWidth, rightContentHeight)
-	case p.Mode == 3 && len(p.Commits) > 0:
+	case p.Mode == 4 && len(p.Commits) > 0:
 		rightLines = renderCommitPane(p.Commits, commitSel, p.CommitScroll, rightContentWidth, rightContentHeight)
 	default:
 		rightLines = renderPlaceholderPane(rightContentWidth, rightContentHeight)
@@ -178,9 +178,10 @@ func renderModeHeader(mode, width int) string {
 		key  int
 		name string
 	}{
-		{1, "branches"},
-		{2, "stashes"},
-		{3, "history"},
+		{1, "worktrees"},
+		{2, "branches"},
+		{3, "stashes"},
+		{4, "history"},
 	}
 
 	var parts []string
@@ -203,16 +204,16 @@ func RenderStatusBar(width, mode, overlay, activePane int, destructive, staleSel
 		hints = "  y: confirm  n/esc: cancel"
 	} else if overlay != 0 {
 		hints = "  ↑/↓ scroll  esc: close"
-	} else if mode == 3 {
+	} else if mode == 4 {
 		hints = "  tab: pane  q/esc: quit  ↑/↓ select  enter: diff  y: copy hash  t: terminal  c: code"
-	} else if mode == 2 {
+	} else if mode == 3 {
 		hints = "  tab: pane  q/esc: quit  ↑/↓ select  enter: diff"
 		if destructive {
 			hints += "  " + dirtyRedStyle.Render("d: drop")
 		} else {
 			hints += "  D: destructive mode"
 		}
-	} else {
+	} else if mode == 2 {
 		keys := "  |  tab: pane  q/esc: quit"
 		if activePane == 1 {
 			keys += "  t: terminal  c: code"
@@ -227,6 +228,8 @@ func RenderStatusBar(width, mode, overlay, activePane int, destructive, staleSel
 			keys += "  D: destructive mode"
 		}
 		hints = " " + cleanStyle.Render("✔") + " clean  " + aheadBehindStyle.Render("●") + " ahead/behind  " + dirtyRedStyle.Render("●") + " dirty  " + noUpstreamStyle.Render("●") + " no upstream" + keys
+	} else {
+		hints = "  tab: pane  q/esc: quit"
 	}
 
 	return statusStyle.Width(width).Render(hints)

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -11,17 +11,17 @@ import (
 	"github.com/brian-bell/wtui/scanner"
 )
 
-func TestStatusBar_Mode1ContainsIndicatorLegend(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true, false)
+func TestStatusBar_BranchesModeContainsIndicatorLegend(t *testing.T) {
+	bar := RenderStatusBar(120, 2, 0, 1, true, false)
 	for _, legend := range []string{"✔ clean", "● ahead/behind", "● dirty", "● no upstream"} {
 		if !strings.Contains(bar, legend) {
-			t.Errorf("mode 1 status bar should contain legend %q", legend)
+			t.Errorf("branches mode status bar should contain legend %q", legend)
 		}
 	}
 }
 
 func TestStatusBar_IndicatorLegendSpacing(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true, false)
+	bar := RenderStatusBar(120, 2, 0, 1, true, false)
 	for _, pair := range [][2]string{
 		{"clean", "●"},
 	} {
@@ -38,15 +38,15 @@ func TestStatusBar_IndicatorLegendSpacing(t *testing.T) {
 	}
 }
 
-func TestStatusBar_Mode2OmitsIndicatorLegend(t *testing.T) {
-	bar := RenderStatusBar(120, 2, 0, 1, true, false)
+func TestStatusBar_StashesModeOmitsIndicatorLegend(t *testing.T) {
+	bar := RenderStatusBar(120, 3, 0, 1, true, false)
 	if strings.Contains(bar, "clean") {
-		t.Error("mode 2 status bar should not contain indicator legend")
+		t.Error("stashes mode status bar should not contain indicator legend")
 	}
 }
 
 func TestStatusBar_PipeSeparatesLegendAndHints(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true, false)
+	bar := RenderStatusBar(120, 2, 0, 1, true, false)
 	upstreamIdx := strings.Index(bar, "no upstream")
 	tabIdx := strings.Index(bar, "tab: pane")
 	if upstreamIdx == -1 || tabIdx == -1 {
@@ -59,7 +59,7 @@ func TestStatusBar_PipeSeparatesLegendAndHints(t *testing.T) {
 }
 
 func TestStatusBar_TabAndQuitBeforeOtherHints(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true, false)
+	bar := RenderStatusBar(120, 2, 0, 1, true, false)
 	tabIdx := strings.Index(bar, "tab: pane")
 	tIdx := strings.Index(bar, "t: terminal")
 	if tabIdx == -1 || tIdx == -1 {
@@ -75,7 +75,7 @@ func TestStatusBar_TabAndQuitBeforeOtherHints(t *testing.T) {
 }
 
 func TestStatusBar_ActionHintsHiddenWhenLeftPaneActive(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 0, true, false) // activePane=0 (left), destructive=true
+	bar := RenderStatusBar(120, 2, 0, 0, true, false) // activePane=0 (left), destructive=true
 	for _, hint := range []string{"t: terminal", "c: code", "d: delete"} {
 		if strings.Contains(bar, hint) {
 			t.Errorf("hint %q should be hidden when left pane is active", hint)
@@ -90,7 +90,7 @@ func TestStatusBar_ActionHintsHiddenWhenLeftPaneActive(t *testing.T) {
 }
 
 func TestStatusBar_ActionHintsShownWhenRightPaneActive(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true, false) // activePane=1 (right)
+	bar := RenderStatusBar(120, 2, 0, 1, true, false) // activePane=1 (right)
 	for _, hint := range []string{"t: terminal", "c: code", "d: delete"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("hint %q should be shown when right pane is active", hint)
@@ -99,7 +99,7 @@ func TestStatusBar_ActionHintsShownWhenRightPaneActive(t *testing.T) {
 }
 
 func TestStatusBar_KeyHintSpacingIs2(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true, false)
+	bar := RenderStatusBar(120, 2, 0, 1, true, false)
 	for _, pair := range [][2]string{
 		{"tab: pane", "q/esc: quit"},
 		{"t: terminal", "c: code"},
@@ -119,16 +119,16 @@ func TestStatusBar_KeyHintSpacingIs2(t *testing.T) {
 }
 
 func TestModeHeader_ShowsActiveMode(t *testing.T) {
-	header := renderModeHeader(1, 40)
-	if !strings.Contains(header, "[1] branches") {
+	header := renderModeHeader(1, 60)
+	if !strings.Contains(header, "[1] worktrees") {
 		t.Error("mode header should show active mode 1 bracketed")
 	}
 	if strings.Contains(header, "[2]") {
 		t.Error("inactive mode 2 should not be bracketed")
 	}
-	header = renderModeHeader(2, 40)
-	if !strings.Contains(header, "[2] stashes") {
-		t.Error("mode header should show active mode 2 bracketed")
+	header = renderModeHeader(3, 60)
+	if !strings.Contains(header, "[3] stashes") {
+		t.Error("mode header should show active mode 3 bracketed")
 	}
 }
 
@@ -153,8 +153,8 @@ func TestRender_ModeHeaderInRightPane(t *testing.T) {
 		Height:   10,
 		Mode:     1,
 	})
-	if !strings.Contains(view, "[1] branches") {
-		t.Error("render should contain mode header '[1] branches' in right pane")
+	if !strings.Contains(view, "[1] worktrees") {
+		t.Error("render should contain mode header '[1] worktrees' in right pane")
 	}
 }
 
@@ -447,7 +447,7 @@ func TestRender_HighlightsSelectedBranch(t *testing.T) {
 		Selected: 0,
 		Width:    80,
 		Height:   10,
-		Mode:     1,
+		Mode:     2,
 		Branches: []gitquery.BranchRow{
 			{Branch: gitquery.Branch{Name: "clean"}},
 			{Branch: gitquery.Branch{Name: "dirty", IsWorktree: true, Dirty: true}, WorktreePath: "/a"},
@@ -469,7 +469,7 @@ func TestRender_HighlightsSecondBranch(t *testing.T) {
 		Selected: 0,
 		Width:    80,
 		Height:   10,
-		Mode:     1,
+		Mode:     2,
 		Branches: []gitquery.BranchRow{
 			{Branch: gitquery.Branch{Name: "clean"}},
 			{Branch: gitquery.Branch{Name: "dirty", IsWorktree: true, Dirty: true}, WorktreePath: "/a"},
@@ -491,7 +491,7 @@ func TestRender_HidesCursorWhenLeftPaneActive(t *testing.T) {
 		Selected: 0,
 		Width:    80,
 		Height:   10,
-		Mode:     1,
+		Mode:     2,
 		Branches: []gitquery.BranchRow{
 			{Branch: gitquery.Branch{Name: "main"}},
 		},
@@ -630,28 +630,28 @@ func TestRender_ForceConfirmDialogShowsPrompt(t *testing.T) {
 }
 
 func TestStatusBar_PruneHintShownWhenStale(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true, true)
+	bar := RenderStatusBar(120, 2, 0, 1, true, true)
 	if !strings.Contains(bar, "p: prune") {
 		t.Errorf("expected 'p: prune' hint when stale worktree selected, got %q", bar)
 	}
 }
 
 func TestStatusBar_PruneHintHiddenWhenNotStale(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, true, false)
+	bar := RenderStatusBar(120, 2, 0, 1, true, false)
 	if strings.Contains(bar, "p: prune") {
 		t.Error("'p: prune' should not appear when no stale worktree selected")
 	}
 }
 
 func TestStatusBar_PruneHintHiddenWithoutDestructive(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, false, true)
+	bar := RenderStatusBar(120, 2, 0, 1, false, true)
 	if strings.Contains(bar, "p: prune") {
 		t.Error("'p: prune' should not appear without destructive mode")
 	}
 }
 
-func TestStatusBar_Mode2HintsSpacing(t *testing.T) {
-	bar := RenderStatusBar(120, 2, 0, 1, true, false)
+func TestStatusBar_StashesModeHintsSpacing(t *testing.T) {
+	bar := RenderStatusBar(120, 3, 0, 1, true, false)
 	for _, pair := range [][2]string{
 		{"tab: pane", "q/esc: quit"},
 		{"↑/↓ select", "enter: diff"},
@@ -735,21 +735,24 @@ func TestBranchPane_NonWorktreeBranchShowsNoLabel(t *testing.T) {
 
 // --- History (mode 3) tests ---
 
-func TestModeHeader_ShowsThreeModes(t *testing.T) {
-	header := renderModeHeader(3, 60)
-	if !strings.Contains(header, "[3] history") {
-		t.Error("expected active '[3] history' in header")
+func TestModeHeader_ShowsFourModes(t *testing.T) {
+	header := renderModeHeader(4, 80)
+	if !strings.Contains(header, "[4] history") {
+		t.Error("expected active '[4] history' in header")
 	}
-	if !strings.Contains(header, "1 branches") {
-		t.Error("expected inactive '1 branches' in header")
+	if !strings.Contains(header, "1 worktrees") {
+		t.Error("expected inactive '1 worktrees' in header")
 	}
-	if !strings.Contains(header, "2 stashes") {
-		t.Error("expected inactive '2 stashes' in header")
+	if !strings.Contains(header, "2 branches") {
+		t.Error("expected inactive '2 branches' in header")
+	}
+	if !strings.Contains(header, "3 stashes") {
+		t.Error("expected inactive '3 stashes' in header")
 	}
 }
 
-func TestStatusBar_Mode3ShowsHistoryHints(t *testing.T) {
-	bar := RenderStatusBar(120, 3, 0, 1, false, false)
+func TestStatusBar_HistoryModeShowsHistoryHints(t *testing.T) {
+	bar := RenderStatusBar(120, 4, 0, 1, false, false)
 	for _, hint := range []string{"enter: diff", "y: copy hash", "t: terminal", "c: code"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("mode 3 status bar should contain %q", hint)
@@ -757,8 +760,8 @@ func TestStatusBar_Mode3ShowsHistoryHints(t *testing.T) {
 	}
 }
 
-func TestStatusBar_Mode3OmitsDeleteHint(t *testing.T) {
-	bar := RenderStatusBar(120, 3, 0, 1, true, false)
+func TestStatusBar_HistoryModeOmitsDeleteHint(t *testing.T) {
+	bar := RenderStatusBar(120, 4, 0, 1, true, false)
 	if strings.Contains(bar, "d: delete") {
 		t.Error("mode 3 status bar should not contain 'd: delete'")
 	}
@@ -767,8 +770,8 @@ func TestStatusBar_Mode3OmitsDeleteHint(t *testing.T) {
 	}
 }
 
-func TestStatusBar_Mode3OmitsDestructiveHint(t *testing.T) {
-	bar := RenderStatusBar(120, 3, 0, 1, false, false)
+func TestStatusBar_HistoryModeOmitsDestructiveHint(t *testing.T) {
+	bar := RenderStatusBar(120, 4, 0, 1, false, false)
 	if strings.Contains(bar, "D: destructive mode") {
 		t.Error("mode 3 status bar should not contain 'D: destructive mode'")
 	}


### PR DESCRIPTION
## Summary

Closes #37

- Add `ModeWorktrees` as mode 1, shifting `ModeBranches`→2, `ModeStashes`→3, `ModeHistory`→4
- Default mode is `ModeWorktrees` which shows a "nothing here yet" placeholder
- Number keys 1/2/3/4 jump to the correct modes; left/right cycle through all four
- Mode header displays four tabs: `[1] worktrees  2 branches  3 stashes  4 history`
- `Init()` returns nil for worktrees mode (no data to fetch yet)
- Status bar shows basic nav hints for worktrees mode
- All existing tests updated for new mode numbering; new tests cover four-mode navigation, bounds, and placeholder rendering

## Test plan

- [x] `make test` passes (all packages)
- [x] `gofmt -l .` produces no output
- [x] `make build` succeeds
- [x] Manual: run `make run`, verify worktrees tab shows placeholder
- [x] Manual: verify number keys 1-4 switch modes correctly
- [x] Manual: verify left/right arrows cycle through all four modes
- [x] Manual: verify mode header shows four tabs with correct highlighting