### PR TITLE
Separate parsing from execution in gitquery

### DIFF
--- a/docs/go-review.md
+++ b/docs/go-review.md
@@ -1,0 +1,27 @@
+# TODO
+
+- [ ] Address code review findings
+  - P0 Bug Risk
+    - model/model.go:946 — Force-delete error silently discarded; UI sends success even when `ForceAction()` fails
+  - P1 Robustness
+    - model/model.go fetch commands — All five data-fetch commands discard errors with `_ :=`; no feedback on failure
+    - model/model.go diff commands — All five diff-fetch commands discard errors; empty overlay indistinguishable from "no changes"
+    - model/model.go:655,762 — `DropStash` and `PruneWorktree` errors discarded; success message sent unconditionally
+    - gitquery/gitquery.go:511-518 — `gitCmd` uses `cmd.Output()` which discards stderr; git error messages lost
+    - gitquery/gitquery.go:497 — Uses deprecated `os.IsNotExist()` instead of `errors.Is(err, fs.ErrNotExist)`
+  - P2 Maintainability
+    - model/model.go:363-459 — ~100 lines of duplicated cursor/scroll reset across mode-switch keys; extract `resetModeState()`
+    - model/model.go:464-563 — `handleCursorUp`/`handleCursorDown` are mirror images; extract `moveCursor(delta)`
+    - gitquery/gitquery.go — `populateWorktreeDirtyStatus` and `populateDirtyStatus` duplicate status-parsing logic
+    - ui/ui.go:441-477 — `renderCommitPane` and `renderReflogPane` are structurally identical
+    - model/model.go + ui/ui.go — `Model` (27 fields) and `RenderParams` (~20 fields) mirror each other tightly
+    - model/model.go:1222-1263 — Three `ensure*Visible` functions are identical; extract `clampScroll()`
+    - scanner/scanner.go:46-84 — `MaxDepth` option exists but only depths 1-2 work
+  - P3 Style
+    - ui/ui.go:76 — `RenderParams.Mode` is `int` instead of named `Mode` type; magic numbers throughout
+    - model/model.go:1277-1278 — Magic numbers `5`/`6` duplicate `maxShow` from ui.go
+    - ui/ui.go:316-318 — `renderBranchPane` is dead production code (only used in tests)
+    - model/model.go:1225,1239 — Inconsistent fallback values across `ensure*Visible` functions
+    - actions/actions.go:59-65 — Platform-specific commands (`pbcopy`, `open -a Terminal`) undocumented
+    - gitquery/gitquery.go:284 — `refFormat` constant is opaque; needs comment
+    - model/model.go:619-630 — `openAtPath` returns nil `tea.Msg`, discarding action errors

--- a/docs/improve-codebase-architecture.md
+++ b/docs/improve-codebase-architecture.md
@@ -1,0 +1,31 @@
+# Refactoring Candidates
+
+Architectural deepening opportunities identified via codebase exploration. Ordered by impact.
+
+## 1. Deepen `actions/` — from shallow wrappers to workflow-owning module
+
+- **Cluster:** `actions/` (66 lines) + workflow logic scattered in `model/model.go` (confirm dialogs, retry-on-failure, multi-step sequences)
+- **Why they're coupled:** Model orchestrates multi-step action workflows: "remove worktree → optionally delete branch → handle failure → offer force retry". The `actions/` package just wraps `exec.Command` — the real action logic lives in `model/`. Actions is one of the shallowest modules possible: 9 functions, each 2-5 lines, interface ≈ implementation.
+- **Dependency category:** Same-process, side-effectful (executes git/system commands)
+- **Test impact:** Model's action tests (`model_action_test.go`, 1,353 lines) would partially shift to action-level boundary tests. Currently model tests construct `tea.Msg` results manually to simulate git operations.
+
+## 2. Decouple `ui/` from `gitquery` types — introduce render-oriented types at the boundary
+
+- **Cluster:** `ui/ui.go` (637 lines) imports `gitquery` directly to access 5 struct types (`BranchRow`, `Stash`, `Worktree`, `Commit`, `ReflogEntry`). `model/` also imports both.
+- **Why they're coupled:** `ui.RenderParams` contains `[]gitquery.Worktree`, `[]gitquery.Commit`, etc. Any field added/renamed/removed in gitquery ripples into ui rendering functions. The ui package reaches deep into gitquery struct internals (e.g., `branch.Unpushed`, `worktree.FilesChanged`).
+- **Dependency category:** Shared data types creating transitive compile-time coupling
+- **Test impact:** UI tests currently construct gitquery types directly. With render-oriented types, ui tests would be self-contained. gitquery tests wouldn't change.
+
+## 3. Extract per-mode list behavior in `model/` — reduce the 5x cursor/scroll/fetch pattern
+
+- **Cluster:** `model/model.go` repeats the same pattern 5 times (one per mode): cursor field + scroll field + `ensure*Visible()` + `fetch*()` + result handler + enter handler + delete handler. ~600 lines of structurally similar code.
+- **Why they're coupled:** Each mode (Worktrees, Branches, Stashes, History, Reflog) implements the same "scrollable list with selection" concept but with mode-specific data types and actions. Adding a new mode requires touching 8+ locations.
+- **Dependency category:** Internal structural duplication within a single package
+- **Test impact:** Mode-specific tests in `model_test.go` (navigation) and `model_action_test.go` (actions) could partially consolidate. Currently 198 tests with significant structural repetition across modes.
+
+## 4. Make `gitquery/` testable without real git repos — separate parsing from execution
+
+- **Cluster:** `gitquery/gitquery.go` (527 lines) mixes `exec.Command` calls with string parsing logic. 6 pure parsing helpers exist but are interleaved with 10+ side-effectful functions.
+- **Why they're coupled:** Functions like `ListBranches()` execute git commands, parse output, then call more git commands based on parsed results — all in one flow. The pure parsing logic (splitting worktree blocks, parsing branch lines) is tested only through integration tests that create real git repos.
+- **Dependency category:** I/O execution mixed with pure data transformation
+- **Test impact:** Current gitquery tests (1,147 lines) create real temporary git repos for every test. Separating parsing would allow fast unit tests for the parsing logic and focused integration tests for the git interaction.

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -208,29 +208,7 @@ func ListStashes(repoPath string) ([]Stash, error) {
 	if err != nil {
 		return nil, fmt.Errorf("listing stashes: %w", err)
 	}
-
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return nil, nil
-	}
-
-	var stashes []Stash
-	for _, line := range strings.Split(text, "\n") {
-		parts := strings.SplitN(line, "\x00", 3)
-		if len(parts) != 3 {
-			continue
-		}
-		// parts[0] is like "stash@{0}"
-		idxStr := strings.TrimPrefix(parts[0], "stash@{")
-		idxStr = strings.TrimSuffix(idxStr, "}")
-		idx, _ := strconv.Atoi(idxStr)
-		stashes = append(stashes, Stash{
-			Index:   idx,
-			Date:    parts[1],
-			Message: parts[2],
-		})
-	}
-	return stashes, nil
+	return ParseStashList(text), nil
 }
 
 // StashDiff returns the diff for a specific stash entry.

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -96,27 +96,25 @@ func ListWorktrees(repoPath string) ([]Worktree, error) {
 
 	var worktrees []Worktree
 	first := true
-	for _, block := range splitWorktreeBlocks(out) {
-		wt := parseWorktreeBlock(block)
-		if wt.isBare {
+	for _, wt := range ParseWorktreeList(out) {
+		if wt.IsBare {
 			continue
 		}
 
 		w := Worktree{
-			Path:     wt.path,
-			Detached: wt.detached,
+			Path:     wt.Path,
+			Detached: wt.Detached,
 			IsMain:   first,
 		}
-		if wt.detached {
+		if wt.Detached {
 			w.BranchName = ""
 		} else {
-			w.BranchName = wt.branch
+			w.BranchName = wt.Branch
 		}
 		first = false
 		worktrees = append(worktrees, w)
 	}
 
-	// Batch stale detection for all worktrees
 	paths := make([]string, len(worktrees))
 	for i := range worktrees {
 		paths[i] = worktrees[i].Path
@@ -280,51 +278,6 @@ func BranchDiff(worktreePath string) (string, error) {
 	return gitCmd(worktreePath, "diff", "HEAD")
 }
 
-// worktreeInfo is internal data parsed from git worktree list output.
-type worktreeInfo struct {
-	path     string
-	branch   string
-	isBare   bool
-	detached bool
-}
-
-func splitWorktreeBlocks(output string) []string {
-	var blocks []string
-	var current []string
-	for _, line := range strings.Split(strings.TrimRight(output, "\n"), "\n") {
-		if line == "" {
-			if len(current) > 0 {
-				blocks = append(blocks, strings.Join(current, "\n"))
-				current = nil
-			}
-			continue
-		}
-		current = append(current, line)
-	}
-	if len(current) > 0 {
-		blocks = append(blocks, strings.Join(current, "\n"))
-	}
-	return blocks
-}
-
-func parseWorktreeBlock(block string) worktreeInfo {
-	var wt worktreeInfo
-	for _, line := range strings.Split(block, "\n") {
-		switch {
-		case strings.HasPrefix(line, "worktree "):
-			wt.path = strings.TrimPrefix(line, "worktree ")
-		case strings.HasPrefix(line, "branch refs/heads/"):
-			wt.branch = strings.TrimPrefix(line, "branch refs/heads/")
-		case line == "bare":
-			wt.isBare = true
-		case line == "detached":
-			wt.detached = true
-			wt.branch = "(detached)"
-		}
-	}
-	return wt
-}
-
 // branchWorktreeMap returns a map of branch name -> worktree paths and detached worktree paths.
 func branchWorktreeMap(repoPath string) (map[string][]string, []string, error) {
 	out, err := gitCmd(repoPath, "worktree", "list", "--porcelain")
@@ -334,17 +287,16 @@ func branchWorktreeMap(repoPath string) (map[string][]string, []string, error) {
 
 	m := make(map[string][]string)
 	var detachedPaths []string
-	for _, block := range splitWorktreeBlocks(out) {
-		wt := parseWorktreeBlock(block)
-		if wt.isBare {
+	for _, wt := range ParseWorktreeList(out) {
+		if wt.IsBare {
 			continue
 		}
-		if wt.detached {
-			detachedPaths = append(detachedPaths, wt.path)
+		if wt.Detached {
+			detachedPaths = append(detachedPaths, wt.Path)
 			continue
 		}
-		if wt.branch != "" {
-			m[wt.branch] = append(m[wt.branch], wt.path)
+		if wt.Branch != "" {
+			m[wt.Branch] = append(m[wt.Branch], wt.Path)
 		}
 	}
 	return m, detachedPaths, nil

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -176,26 +176,7 @@ func ListReflog(repoPath string) ([]ReflogEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("listing reflog: %w", err)
 	}
-
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return nil, nil
-	}
-
-	var entries []ReflogEntry
-	for _, line := range strings.Split(text, "\n") {
-		parts := strings.SplitN(line, "\x00", 4)
-		if len(parts) != 4 {
-			continue
-		}
-		entries = append(entries, ReflogEntry{
-			Hash:     parts[0],
-			Selector: parts[1],
-			Date:     parts[2],
-			Subject:  parts[3],
-		})
-	}
-	return entries, nil
+	return ParseReflog(text), nil
 }
 
 // ReflogDiff returns the diff for a reflog entry by running git diff <hash>^ <hash>.

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -231,7 +231,7 @@ func ListBranches(repoPath string) ([]Branch, error) {
 		if line == "" {
 			continue
 		}
-		b, upstream := parseBranchLine(line)
+		b, upstream := ParseBranchLine(line)
 
 		if b.HasUpstream && !b.UpstreamGone {
 			ahead, behind, err := branchAheadBehind(repoPath, b.Name, upstream)
@@ -348,22 +348,6 @@ func branchWorktreeMap(repoPath string) (map[string][]string, []string, error) {
 		}
 	}
 	return m, detachedPaths, nil
-}
-
-func parseBranchLine(line string) (Branch, string) {
-	parts := strings.SplitN(line, "\t", 3)
-	b := Branch{Name: parts[0]}
-
-	var upstream string
-	if len(parts) > 1 && parts[1] != "" {
-		b.HasUpstream = true
-		upstream = parts[1]
-		if len(parts) > 2 && strings.Contains(parts[2], "gone") {
-			b.UpstreamGone = true
-		}
-	}
-
-	return b, upstream
 }
 
 func branchAheadBehind(repoPath, branchName, upstream string) (int, int, error) {

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"sort"
-	"strconv"
 	"strings"
 )
 
@@ -372,14 +371,7 @@ func branchAheadBehind(repoPath, branchName, upstream string) (int, int, error) 
 	if err != nil {
 		return 0, 0, err
 	}
-
-	parts := strings.Fields(strings.TrimSpace(out))
-	if len(parts) != 2 {
-		return 0, 0, nil
-	}
-
-	ahead, _ := strconv.Atoi(parts[0])
-	behind, _ := strconv.Atoi(parts[1])
+	ahead, behind := ParseAheadBehind(out)
 	return ahead, behind, nil
 }
 

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -149,16 +149,7 @@ func populateWorktreeDirtyStatus(wt *Worktree) {
 	if err != nil {
 		return
 	}
-	for _, line := range splitLines(diffOut) {
-		fields := strings.Fields(line)
-		if len(fields) < 3 {
-			continue
-		}
-		added, _ := strconv.Atoi(fields[0])
-		deleted, _ := strconv.Atoi(fields[1])
-		wt.LinesAdded += added
-		wt.LinesDeleted += deleted
-	}
+	wt.LinesAdded, wt.LinesDeleted = ParseNumstat(diffOut)
 }
 
 // ListCommits returns the most recent 50 commits for the given repo path.
@@ -417,17 +408,9 @@ func populateDirtyStatus(b *Branch, paths []string) {
 		if err != nil {
 			continue
 		}
-		for _, line := range splitLines(diffOut) {
-			fields := strings.Fields(line)
-			if len(fields) < 3 {
-				continue
-			}
-			// Binary files show "-\t-\tfilename"; Atoi returns 0 for "-".
-			added, _ := strconv.Atoi(fields[0])
-			deleted, _ := strconv.Atoi(fields[1])
-			b.LinesAdded += added
-			b.LinesDeleted += deleted
-		}
+		a, d := ParseNumstat(diffOut)
+		b.LinesAdded += a
+		b.LinesDeleted += d
 	}
 }
 

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -167,26 +167,7 @@ func ListCommits(repoPath string) ([]Commit, error) {
 	if err != nil {
 		return nil, fmt.Errorf("listing commits: %w", err)
 	}
-
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return nil, nil
-	}
-
-	var commits []Commit
-	for _, line := range strings.Split(text, "\n") {
-		parts := strings.SplitN(line, "\x00", 4)
-		if len(parts) != 4 {
-			continue
-		}
-		commits = append(commits, Commit{
-			Hash:    parts[0],
-			Author:  parts[1],
-			Date:    parts[2],
-			Subject: parts[3],
-		})
-	}
-	return commits, nil
+	return ParseCommitLog(text), nil
 }
 
 // ListReflog returns the most recent 50 HEAD reflog entries for the given repo path.

--- a/gitquery/parse.go
+++ b/gitquery/parse.go
@@ -5,6 +5,24 @@ import (
 	"strings"
 )
 
+// ParseBranchLine parses one line of git for-each-ref --format=%(refname:short)\t%(upstream)\t%(upstream:track).
+// Returns the branch (with Name, HasUpstream, UpstreamGone populated) and the upstream ref string.
+func ParseBranchLine(line string) (Branch, string) {
+	parts := strings.SplitN(line, "\t", 3)
+	b := Branch{Name: parts[0]}
+
+	var upstream string
+	if len(parts) > 1 && parts[1] != "" {
+		b.HasUpstream = true
+		upstream = parts[1]
+		if len(parts) > 2 && strings.Contains(parts[2], "gone") {
+			b.UpstreamGone = true
+		}
+	}
+
+	return b, upstream
+}
+
 // ParseReflog parses the output of git reflog --format=%h%x00%gd%x00%ar%x00%gs.
 func ParseReflog(text string) []ReflogEntry {
 	text = strings.TrimSpace(text)

--- a/gitquery/parse.go
+++ b/gitquery/parse.go
@@ -99,6 +99,58 @@ func ParseNumstat(text string) (int, int) {
 	return added, deleted
 }
 
+// WorktreeInfo holds data parsed from one block of git worktree list --porcelain output.
+type WorktreeInfo struct {
+	Path     string
+	Branch   string
+	IsBare   bool
+	Detached bool
+}
+
+// ParseWorktreeList parses the full output of git worktree list --porcelain
+// into a slice of WorktreeInfo entries.
+func ParseWorktreeList(output string) []WorktreeInfo {
+	output = strings.TrimRight(output, "\n")
+	if strings.TrimSpace(output) == "" {
+		return nil
+	}
+
+	var result []WorktreeInfo
+	var current []string
+	for _, line := range strings.Split(output, "\n") {
+		if line == "" {
+			if len(current) > 0 {
+				result = append(result, parseOneWorktreeBlock(strings.Join(current, "\n")))
+				current = nil
+			}
+			continue
+		}
+		current = append(current, line)
+	}
+	if len(current) > 0 {
+		result = append(result, parseOneWorktreeBlock(strings.Join(current, "\n")))
+	}
+	return result
+}
+
+func parseOneWorktreeBlock(block string) WorktreeInfo {
+	var wt WorktreeInfo
+	for _, line := range strings.Split(block, "\n") {
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			wt.Path = strings.TrimPrefix(line, "worktree ")
+		case strings.HasPrefix(line, "branch refs/heads/"):
+			wt.Branch = strings.TrimPrefix(line, "branch refs/heads/")
+		case line == "bare":
+			wt.IsBare = true
+		case line == "detached":
+			wt.Detached = true
+			wt.Branch = "(detached)"
+		}
+	}
+	return wt
+}
+
 // ParseCommitLog parses the output of git log --format=%h%x00%an%x00%ar%x00%s.
 func ParseCommitLog(text string) []Commit {
 	text = strings.TrimSpace(text)

--- a/gitquery/parse.go
+++ b/gitquery/parse.go
@@ -2,6 +2,29 @@ package gitquery
 
 import "strings"
 
+// ParseReflog parses the output of git reflog --format=%h%x00%gd%x00%ar%x00%gs.
+func ParseReflog(text string) []ReflogEntry {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+
+	var entries []ReflogEntry
+	for _, line := range strings.Split(text, "\n") {
+		parts := strings.SplitN(line, "\x00", 4)
+		if len(parts) != 4 {
+			continue
+		}
+		entries = append(entries, ReflogEntry{
+			Hash:     parts[0],
+			Selector: parts[1],
+			Date:     parts[2],
+			Subject:  parts[3],
+		})
+	}
+	return entries
+}
+
 // ParseCommitLog parses the output of git log --format=%h%x00%an%x00%ar%x00%s.
 func ParseCommitLog(text string) []Commit {
 	text = strings.TrimSpace(text)

--- a/gitquery/parse.go
+++ b/gitquery/parse.go
@@ -1,6 +1,9 @@
 package gitquery
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // ParseReflog parses the output of git reflog --format=%h%x00%gd%x00%ar%x00%gs.
 func ParseReflog(text string) []ReflogEntry {
@@ -23,6 +26,31 @@ func ParseReflog(text string) []ReflogEntry {
 		})
 	}
 	return entries
+}
+
+// ParseStashList parses the output of git stash list --format=%gd%x00%ai%x00%s.
+func ParseStashList(text string) []Stash {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+
+	var stashes []Stash
+	for _, line := range strings.Split(text, "\n") {
+		parts := strings.SplitN(line, "\x00", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		idxStr := strings.TrimPrefix(parts[0], "stash@{")
+		idxStr = strings.TrimSuffix(idxStr, "}")
+		idx, _ := strconv.Atoi(idxStr)
+		stashes = append(stashes, Stash{
+			Index:   idx,
+			Date:    parts[1],
+			Message: parts[2],
+		})
+	}
+	return stashes
 }
 
 // ParseCommitLog parses the output of git log --format=%h%x00%an%x00%ar%x00%s.

--- a/gitquery/parse.go
+++ b/gitquery/parse.go
@@ -111,7 +111,7 @@ type WorktreeInfo struct {
 // into a slice of WorktreeInfo entries.
 func ParseWorktreeList(output string) []WorktreeInfo {
 	output = strings.TrimRight(output, "\n")
-	if strings.TrimSpace(output) == "" {
+	if output == "" {
 		return nil
 	}
 

--- a/gitquery/parse.go
+++ b/gitquery/parse.go
@@ -1,0 +1,26 @@
+package gitquery
+
+import "strings"
+
+// ParseCommitLog parses the output of git log --format=%h%x00%an%x00%ar%x00%s.
+func ParseCommitLog(text string) []Commit {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+
+	var commits []Commit
+	for _, line := range strings.Split(text, "\n") {
+		parts := strings.SplitN(line, "\x00", 4)
+		if len(parts) != 4 {
+			continue
+		}
+		commits = append(commits, Commit{
+			Hash:    parts[0],
+			Author:  parts[1],
+			Date:    parts[2],
+			Subject: parts[3],
+		})
+	}
+	return commits
+}

--- a/gitquery/parse.go
+++ b/gitquery/parse.go
@@ -53,6 +53,23 @@ func ParseStashList(text string) []Stash {
 	return stashes
 }
 
+// ParseNumstat parses the output of git diff --numstat.
+// Returns total lines added and deleted. Binary files (shown as - -) contribute 0.
+func ParseNumstat(text string) (int, int) {
+	var added, deleted int
+	for _, line := range splitLines(text) {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		a, _ := strconv.Atoi(fields[0])
+		d, _ := strconv.Atoi(fields[1])
+		added += a
+		deleted += d
+	}
+	return added, deleted
+}
+
 // ParseCommitLog parses the output of git log --format=%h%x00%an%x00%ar%x00%s.
 func ParseCommitLog(text string) []Commit {
 	text = strings.TrimSpace(text)

--- a/gitquery/parse.go
+++ b/gitquery/parse.go
@@ -53,6 +53,17 @@ func ParseStashList(text string) []Stash {
 	return stashes
 }
 
+// ParseAheadBehind parses the output of git rev-list --count --left-right.
+func ParseAheadBehind(text string) (int, int) {
+	parts := strings.Fields(strings.TrimSpace(text))
+	if len(parts) != 2 {
+		return 0, 0
+	}
+	ahead, _ := strconv.Atoi(parts[0])
+	behind, _ := strconv.Atoi(parts[1])
+	return ahead, behind
+}
+
 // ParseNumstat parses the output of git diff --numstat.
 // Returns total lines added and deleted. Binary files (shown as - -) contribute 0.
 func ParseNumstat(text string) (int, int) {

--- a/gitquery/parse_test.go
+++ b/gitquery/parse_test.go
@@ -202,3 +202,64 @@ func TestParseAheadBehind_MalformedInput(t *testing.T) {
 		t.Errorf("expected (0, 0), got (%d, %d)", ahead, behind)
 	}
 }
+
+func TestParseBranchLine_WithUpstream(t *testing.T) {
+	line := "feature\trefs/remotes/origin/feature\t"
+
+	b, upstream := gitquery.ParseBranchLine(line)
+
+	if b.Name != "feature" {
+		t.Errorf("expected Name %q, got %q", "feature", b.Name)
+	}
+	if !b.HasUpstream {
+		t.Error("expected HasUpstream = true")
+	}
+	if b.UpstreamGone {
+		t.Error("expected UpstreamGone = false")
+	}
+	if upstream != "refs/remotes/origin/feature" {
+		t.Errorf("expected upstream %q, got %q", "refs/remotes/origin/feature", upstream)
+	}
+}
+
+func TestParseBranchLine_UpstreamGone(t *testing.T) {
+	line := "old-feature\trefs/remotes/origin/old-feature\t[gone]"
+
+	b, _ := gitquery.ParseBranchLine(line)
+
+	if !b.HasUpstream {
+		t.Error("expected HasUpstream = true")
+	}
+	if !b.UpstreamGone {
+		t.Error("expected UpstreamGone = true")
+	}
+}
+
+func TestParseBranchLine_NoUpstream(t *testing.T) {
+	line := "local-only\t\t"
+
+	b, upstream := gitquery.ParseBranchLine(line)
+
+	if b.Name != "local-only" {
+		t.Errorf("expected Name %q, got %q", "local-only", b.Name)
+	}
+	if b.HasUpstream {
+		t.Error("expected HasUpstream = false")
+	}
+	if upstream != "" {
+		t.Errorf("expected empty upstream, got %q", upstream)
+	}
+}
+
+func TestParseBranchLine_NameOnly(t *testing.T) {
+	line := "main"
+
+	b, _ := gitquery.ParseBranchLine(line)
+
+	if b.Name != "main" {
+		t.Errorf("expected Name %q, got %q", "main", b.Name)
+	}
+	if b.HasUpstream {
+		t.Error("expected HasUpstream = false")
+	}
+}

--- a/gitquery/parse_test.go
+++ b/gitquery/parse_test.go
@@ -87,3 +87,41 @@ func TestParseReflog_MalformedLineSkipped(t *testing.T) {
 		t.Fatalf("expected 1 entry (malformed skipped), got %d", len(entries))
 	}
 }
+
+func TestParseStashList_ParsesMultipleStashes(t *testing.T) {
+	input := "stash@{0}\x002024-01-15 10:30:00 -0500\x00WIP on main: abc1234 some work\nstash@{1}\x002024-01-14 09:00:00 -0500\x00On main: save progress\n"
+
+	stashes := gitquery.ParseStashList(input)
+
+	if len(stashes) != 2 {
+		t.Fatalf("expected 2 stashes, got %d", len(stashes))
+	}
+	if stashes[0].Index != 0 {
+		t.Errorf("expected Index 0, got %d", stashes[0].Index)
+	}
+	if stashes[0].Message != "WIP on main: abc1234 some work" {
+		t.Errorf("expected Message %q, got %q", "WIP on main: abc1234 some work", stashes[0].Message)
+	}
+	if stashes[1].Index != 1 {
+		t.Errorf("expected Index 1, got %d", stashes[1].Index)
+	}
+	if stashes[1].Date != "2024-01-14 09:00:00 -0500" {
+		t.Errorf("expected Date %q, got %q", "2024-01-14 09:00:00 -0500", stashes[1].Date)
+	}
+}
+
+func TestParseStashList_EmptyInput(t *testing.T) {
+	if stashes := gitquery.ParseStashList(""); stashes != nil {
+		t.Errorf("expected nil, got %v", stashes)
+	}
+}
+
+func TestParseStashList_MalformedLineSkipped(t *testing.T) {
+	input := "stash@{0}\x002024-01-15 10:30:00 -0500\x00WIP\nbroken\n"
+
+	stashes := gitquery.ParseStashList(input)
+
+	if len(stashes) != 1 {
+		t.Fatalf("expected 1 stash (malformed skipped), got %d", len(stashes))
+	}
+}

--- a/gitquery/parse_test.go
+++ b/gitquery/parse_test.go
@@ -49,3 +49,41 @@ func TestParseCommitLog_MalformedLineSkipped(t *testing.T) {
 		t.Fatalf("expected 2 commits (malformed skipped), got %d", len(commits))
 	}
 }
+
+func TestParseReflog_ParsesMultipleEntries(t *testing.T) {
+	input := "abc1234\x00HEAD@{0}\x002 hours ago\x00commit: Add feature\nabc5678\x00HEAD@{1}\x003 days ago\x00checkout: moving from main to feat\n"
+
+	entries := gitquery.ParseReflog(input)
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	if entries[0].Hash != "abc1234" {
+		t.Errorf("expected Hash %q, got %q", "abc1234", entries[0].Hash)
+	}
+	if entries[0].Selector != "HEAD@{0}" {
+		t.Errorf("expected Selector %q, got %q", "HEAD@{0}", entries[0].Selector)
+	}
+	if entries[0].Date != "2 hours ago" {
+		t.Errorf("expected Date %q, got %q", "2 hours ago", entries[0].Date)
+	}
+	if entries[0].Subject != "commit: Add feature" {
+		t.Errorf("expected Subject %q, got %q", "commit: Add feature", entries[0].Subject)
+	}
+}
+
+func TestParseReflog_EmptyInput(t *testing.T) {
+	if entries := gitquery.ParseReflog(""); entries != nil {
+		t.Errorf("expected nil, got %v", entries)
+	}
+}
+
+func TestParseReflog_MalformedLineSkipped(t *testing.T) {
+	input := "abc1234\x00HEAD@{0}\x002 hours ago\x00commit: Add feature\nbadline\n"
+
+	entries := gitquery.ParseReflog(input)
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (malformed skipped), got %d", len(entries))
+	}
+}

--- a/gitquery/parse_test.go
+++ b/gitquery/parse_test.go
@@ -263,3 +263,82 @@ func TestParseBranchLine_NameOnly(t *testing.T) {
 		t.Error("expected HasUpstream = false")
 	}
 }
+
+func TestParseWorktreeList_ParsesMultipleWorktrees(t *testing.T) {
+	input := "worktree /home/user/project\nbranch refs/heads/main\n\nworktree /home/user/project-feature\nbranch refs/heads/feature\n\n"
+
+	infos := gitquery.ParseWorktreeList(input)
+
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 worktrees, got %d", len(infos))
+	}
+	if infos[0].Path != "/home/user/project" {
+		t.Errorf("expected Path %q, got %q", "/home/user/project", infos[0].Path)
+	}
+	if infos[0].Branch != "main" {
+		t.Errorf("expected Branch %q, got %q", "main", infos[0].Branch)
+	}
+	if infos[0].IsBare || infos[0].Detached {
+		t.Error("expected IsBare=false, Detached=false")
+	}
+	if infos[1].Path != "/home/user/project-feature" {
+		t.Errorf("expected Path %q, got %q", "/home/user/project-feature", infos[1].Path)
+	}
+	if infos[1].Branch != "feature" {
+		t.Errorf("expected Branch %q, got %q", "feature", infos[1].Branch)
+	}
+}
+
+func TestParseWorktreeList_BareWorktree(t *testing.T) {
+	input := "worktree /home/user/project.git\nbare\n\n"
+
+	infos := gitquery.ParseWorktreeList(input)
+
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 worktree, got %d", len(infos))
+	}
+	if !infos[0].IsBare {
+		t.Error("expected IsBare = true")
+	}
+}
+
+func TestParseWorktreeList_DetachedWorktree(t *testing.T) {
+	input := "worktree /home/user/project-detached\ndetached\n\n"
+
+	infos := gitquery.ParseWorktreeList(input)
+
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 worktree, got %d", len(infos))
+	}
+	if !infos[0].Detached {
+		t.Error("expected Detached = true")
+	}
+	if infos[0].Branch != "(detached)" {
+		t.Errorf("expected Branch %q, got %q", "(detached)", infos[0].Branch)
+	}
+}
+
+func TestParseWorktreeList_EmptyInput(t *testing.T) {
+	if infos := gitquery.ParseWorktreeList(""); infos != nil {
+		t.Errorf("expected nil, got %v", infos)
+	}
+}
+
+func TestParseWorktreeList_MixedTypes(t *testing.T) {
+	input := "worktree /home/user/repo.git\nbare\n\nworktree /home/user/repo\nbranch refs/heads/main\n\nworktree /home/user/repo-detached\ndetached\n\n"
+
+	infos := gitquery.ParseWorktreeList(input)
+
+	if len(infos) != 3 {
+		t.Fatalf("expected 3 worktrees, got %d", len(infos))
+	}
+	if !infos[0].IsBare {
+		t.Error("expected first to be bare")
+	}
+	if infos[1].Branch != "main" {
+		t.Errorf("expected second branch %q, got %q", "main", infos[1].Branch)
+	}
+	if !infos[2].Detached {
+		t.Error("expected third to be detached")
+	}
+}

--- a/gitquery/parse_test.go
+++ b/gitquery/parse_test.go
@@ -159,6 +159,13 @@ func TestParseNumstat_BinaryFilesIgnored(t *testing.T) {
 	}
 }
 
+func TestParseNumstat_WhitespaceOnlyInput(t *testing.T) {
+	added, deleted := gitquery.ParseNumstat("  \n  \n")
+	if added != 0 || deleted != 0 {
+		t.Errorf("expected (0, 0), got (%d, %d)", added, deleted)
+	}
+}
+
 func TestParseNumstat_MalformedLineSkipped(t *testing.T) {
 	input := "3\t1\tfile.go\nbadline\n2\t0\tother.go\n"
 
@@ -242,6 +249,20 @@ func TestParseBranchLine_NoUpstream(t *testing.T) {
 
 	if b.Name != "local-only" {
 		t.Errorf("expected Name %q, got %q", "local-only", b.Name)
+	}
+	if b.HasUpstream {
+		t.Error("expected HasUpstream = false")
+	}
+	if upstream != "" {
+		t.Errorf("expected empty upstream, got %q", upstream)
+	}
+}
+
+func TestParseBranchLine_EmptyInput(t *testing.T) {
+	b, upstream := gitquery.ParseBranchLine("")
+
+	if b.Name != "" {
+		t.Errorf("expected empty Name, got %q", b.Name)
 	}
 	if b.HasUpstream {
 		t.Error("expected HasUpstream = false")

--- a/gitquery/parse_test.go
+++ b/gitquery/parse_test.go
@@ -125,3 +125,49 @@ func TestParseStashList_MalformedLineSkipped(t *testing.T) {
 		t.Fatalf("expected 1 stash (malformed skipped), got %d", len(stashes))
 	}
 }
+
+func TestParseNumstat_ParsesAddedDeleted(t *testing.T) {
+	input := "3\t1\tfile.go\n10\t5\tother.go\n"
+
+	added, deleted := gitquery.ParseNumstat(input)
+
+	if added != 13 {
+		t.Errorf("expected added 13, got %d", added)
+	}
+	if deleted != 6 {
+		t.Errorf("expected deleted 6, got %d", deleted)
+	}
+}
+
+func TestParseNumstat_EmptyInput(t *testing.T) {
+	added, deleted := gitquery.ParseNumstat("")
+	if added != 0 || deleted != 0 {
+		t.Errorf("expected (0, 0), got (%d, %d)", added, deleted)
+	}
+}
+
+func TestParseNumstat_BinaryFilesIgnored(t *testing.T) {
+	input := "3\t1\ttext.go\n-\t-\tbinary.png\n"
+
+	added, deleted := gitquery.ParseNumstat(input)
+
+	if added != 3 {
+		t.Errorf("expected added 3, got %d", added)
+	}
+	if deleted != 1 {
+		t.Errorf("expected deleted 1, got %d", deleted)
+	}
+}
+
+func TestParseNumstat_MalformedLineSkipped(t *testing.T) {
+	input := "3\t1\tfile.go\nbadline\n2\t0\tother.go\n"
+
+	added, deleted := gitquery.ParseNumstat(input)
+
+	if added != 5 {
+		t.Errorf("expected added 5, got %d", added)
+	}
+	if deleted != 1 {
+		t.Errorf("expected deleted 1, got %d", deleted)
+	}
+}

--- a/gitquery/parse_test.go
+++ b/gitquery/parse_test.go
@@ -171,3 +171,34 @@ func TestParseNumstat_MalformedLineSkipped(t *testing.T) {
 		t.Errorf("expected deleted 1, got %d", deleted)
 	}
 }
+
+func TestParseAheadBehind_ParsesCounts(t *testing.T) {
+	ahead, behind := gitquery.ParseAheadBehind("3\t2\n")
+	if ahead != 3 {
+		t.Errorf("expected ahead 3, got %d", ahead)
+	}
+	if behind != 2 {
+		t.Errorf("expected behind 2, got %d", behind)
+	}
+}
+
+func TestParseAheadBehind_ZeroCounts(t *testing.T) {
+	ahead, behind := gitquery.ParseAheadBehind("0\t0\n")
+	if ahead != 0 || behind != 0 {
+		t.Errorf("expected (0, 0), got (%d, %d)", ahead, behind)
+	}
+}
+
+func TestParseAheadBehind_EmptyInput(t *testing.T) {
+	ahead, behind := gitquery.ParseAheadBehind("")
+	if ahead != 0 || behind != 0 {
+		t.Errorf("expected (0, 0), got (%d, %d)", ahead, behind)
+	}
+}
+
+func TestParseAheadBehind_MalformedInput(t *testing.T) {
+	ahead, behind := gitquery.ParseAheadBehind("notanumber")
+	if ahead != 0 || behind != 0 {
+		t.Errorf("expected (0, 0), got (%d, %d)", ahead, behind)
+	}
+}

--- a/gitquery/parse_test.go
+++ b/gitquery/parse_test.go
@@ -1,0 +1,51 @@
+package gitquery_test
+
+import (
+	"testing"
+
+	"github.com/brian-bell/wtui/gitquery"
+)
+
+func TestParseCommitLog_ParsesMultipleCommits(t *testing.T) {
+	input := "abc1234\x00Alice\x002 hours ago\x00Add feature\nabc5678\x00Bob\x003 days ago\x00Fix bug\n"
+
+	commits := gitquery.ParseCommitLog(input)
+
+	if len(commits) != 2 {
+		t.Fatalf("expected 2 commits, got %d", len(commits))
+	}
+	if commits[0].Hash != "abc1234" {
+		t.Errorf("expected Hash %q, got %q", "abc1234", commits[0].Hash)
+	}
+	if commits[0].Author != "Alice" {
+		t.Errorf("expected Author %q, got %q", "Alice", commits[0].Author)
+	}
+	if commits[0].Date != "2 hours ago" {
+		t.Errorf("expected Date %q, got %q", "2 hours ago", commits[0].Date)
+	}
+	if commits[0].Subject != "Add feature" {
+		t.Errorf("expected Subject %q, got %q", "Add feature", commits[0].Subject)
+	}
+	if commits[1].Hash != "abc5678" {
+		t.Errorf("expected Hash %q, got %q", "abc5678", commits[1].Hash)
+	}
+}
+
+func TestParseCommitLog_EmptyInput(t *testing.T) {
+	if commits := gitquery.ParseCommitLog(""); commits != nil {
+		t.Errorf("expected nil, got %v", commits)
+	}
+	if commits := gitquery.ParseCommitLog("  \n"); commits != nil {
+		t.Errorf("expected nil for whitespace, got %v", commits)
+	}
+}
+
+func TestParseCommitLog_MalformedLineSkipped(t *testing.T) {
+	input := "abc1234\x00Alice\x002 hours ago\x00Add feature\ngarbage line\nabc5678\x00Bob\x003 days ago\x00Fix bug\n"
+
+	commits := gitquery.ParseCommitLog(input)
+
+	if len(commits) != 2 {
+		t.Fatalf("expected 2 commits (malformed skipped), got %d", len(commits))
+	}
+}


### PR DESCRIPTION
## Summary

- Extract 7 pure parsing functions from `gitquery/gitquery.go` into a new `gitquery/parse.go` file
- Add 23 fast unit tests in `gitquery/parse_test.go` using string literals (no git repos needed)
- Deduplicate numstat parsing that was duplicated across `populateDirtyStatus` and `populateWorktreeDirtyStatus`
- Export new `WorktreeInfo` type replacing the private `worktreeInfo`
- No public API changes — all existing consumers unaffected

### Extracted parsers

| Function | Extracted from | Purpose |
|----------|---------------|---------|
| `ParseCommitLog` | `ListCommits` | NUL-delimited commit log fields |
| `ParseReflog` | `ListReflog` | NUL-delimited reflog fields |
| `ParseStashList` | `ListStashes` | NUL-delimited stash fields + index extraction |
| `ParseNumstat` | `populateDirtyStatus` (x2) | `git diff --numstat` added/deleted counts |
| `ParseAheadBehind` | `branchAheadBehind` | `git rev-list --left-right` counts |
| `ParseBranchLine` | `parseBranchLine` | `git for-each-ref` line with upstream info |
| `ParseWorktreeList` | `splitWorktreeBlocks` + `parseWorktreeBlock` | `git worktree list --porcelain` output |

### Motivation

REFACTOR.md #4: `gitquery/gitquery.go` mixed `exec.Command` calls with string parsing logic. Pure parsing helpers were interleaved with side-effectful functions and only tested through integration tests that create real git repos. Separating parsing enables fast, deterministic unit tests and clearer code organization.

## Test plan

- [ ] All 69 tests pass (`make test`) — 46 existing integration + 23 new unit
- [ ] `gofmt -l .` produces no output
- [ ] `go vet ./gitquery/` passes
- [ ] Existing integration tests unchanged — full git pipeline still covered