### PR TITLE
Add GitHub release packaging and version output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -25,3 +28,24 @@ jobs:
 
       - name: Build
         run: make build
+
+  release-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build release snapshot
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,3 @@ jobs:
           args: release --snapshot --clean --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,4 +29,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .claude/worktrees/
 .env
 bin/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,20 +33,3 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
   algorithm: sha256
-
-brews:
-  - name: wtui
-    ids:
-      - wtui
-    repository:
-      owner: brian-bell
-      name: homebrew-tap
-      branch: main
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
-    commit_msg_template: "Update wtui formula to {{ .Tag }}"
-    homepage: "https://github.com/brian-bell/wtui"
-    description: "Terminal UI for managing git worktrees across repositories"
-    license: "MIT"
-    test: |
-      system "#{bin}/wtui", "--version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+project_name: wtui
+
+builds:
+  - id: wtui
+    main: ./cmd/wtui
+    binary: wtui
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - >-
+        -s -w
+        -X github.com/brian-bell/wtui/internal/version.Version={{ if .IsSnapshot }}{{ .Version }}{{ else }}{{ .Tag }}{{ end }}
+        -X github.com/brian-bell/wtui/internal/version.Commit={{ .ShortCommit }}
+        -X github.com/brian-bell/wtui/internal/version.Date={{ .Date }}
+
+archives:
+  - id: wtui
+    ids:
+      - wtui
+    formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  algorithm: sha256
+
+brews:
+  - name: wtui
+    ids:
+      - wtui
+    repository:
+      owner: brian-bell
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    commit_msg_template: "Update wtui formula to {{ .Tag }}"
+    homepage: "https://github.com/brian-bell/wtui"
+    description: "Terminal UI for managing git worktrees across repositories"
+    license: "MIT"
+    test: |
+      system "#{bin}/wtui", "--version"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Brian Bell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 BIN_DIR  = bin
 BINARY   = $(BIN_DIR)/wtui
+VERSION_PACKAGE = github.com/brian-bell/wtui/internal/version
+COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+DATE    := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS := -X $(VERSION_PACKAGE).Version=dev -X $(VERSION_PACKAGE).Commit=$(COMMIT) -X $(VERSION_PACKAGE).Date=$(DATE)
 
 .PHONY: build test run clean tidy
 
 build:
-	go build -o $(BINARY) ./cmd/wtui
+	mkdir -p $(BIN_DIR)
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/wtui
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -6,12 +6,6 @@ A terminal UI for managing git worktrees across repositories.
 
 ## Install
 
-### Homebrew
-
-```bash
-brew install brian-bell/tap/wtui
-```
-
 ### GitHub Releases
 
 Download a pre-built macOS or Linux binary from the

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ A terminal UI for managing git worktrees across repositories.
 
 ## Install
 
+### Homebrew
+
+```bash
+brew install brian-bell/tap/wtui
+```
+
+### GitHub Releases
+
+Download a pre-built macOS or Linux binary from the
+[GitHub Releases](https://github.com/brian-bell/wtui/releases) page.
+
+### Go Install
+
+```bash
+go install github.com/brian-bell/wtui/cmd/wtui@latest
+```
+
+### Build from Source
+
 ```bash
 git clone https://github.com/brian-bell/wtui.git
 cd wtui

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -1,16 +1,27 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/brian-bell/wtui/internal/version"
 	"github.com/brian-bell/wtui/model"
 	"github.com/brian-bell/wtui/scanner"
 )
 
 func main() {
+	versionFlag := flag.Bool("version", false, "print version and exit")
+	flag.BoolVar(versionFlag, "v", false, "print version and exit")
+	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(version.String())
+		return
+	}
+
 	root := os.Getenv("WORKTREE_ROOT")
 
 	repos, err := scanner.Scan(scanner.ScanOptions{Root: root})

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,24 +1,7 @@
 # Release Process
 
 This project releases with GoReleaser. A pushed semver tag creates GitHub
-Release artifacts and updates the Homebrew formula in `brian-bell/homebrew-tap`.
-
-## One-Time Prerequisites
-
-The release workflow assumes these are already done before the first tag:
-
-- Public repository `brian-bell/homebrew-tap` exists.
-- Repository secret `HOMEBREW_TAP_GITHUB_TOKEN` exists in `brian-bell/wtui`.
-- The token is a fine-grained GitHub PAT scoped to `brian-bell/homebrew-tap`
-  with `Contents: read and write`.
-- The token owner can push to the tap repository's default branch.
-
-GoReleaser writes `Formula/wtui.rb` on release. The formula declares the MIT
-license and runs `wtui --version` as its Homebrew test.
-
-GoReleaser marks formula publishing as deprecated upstream in favor of casks,
-but this project intentionally uses a formula because the install target is
-`brew install brian-bell/tap/wtui`.
+Release artifacts with checksums and generated release notes.
 
 ## First Release
 
@@ -47,15 +30,7 @@ The first release tag is `v0.1.0`.
    - `wtui_0.1.0_linux_arm64.tar.gz`
    - `wtui_0.1.0_checksums.txt`
 7. Verify the release notes were generated from commits since the previous tag.
-8. Verify the Homebrew formula was committed to `brian-bell/homebrew-tap`.
-9. Verify Homebrew install and version output:
-
-   ```bash
-   brew install brian-bell/tap/wtui
-   wtui --version
-   ```
-
-10. Verify the Go install fallback:
+8. Verify the Go install fallback:
 
     ```bash
     go install github.com/brian-bell/wtui/cmd/wtui@v0.1.0
@@ -73,5 +48,4 @@ The first release tag is `v0.1.0`.
    git push origin vX.Y.Z
    ```
 
-4. Verify GitHub Release artifacts, generated release notes, Homebrew formula
-   update, `brew upgrade wtui`, and `wtui --version`.
+4. Verify GitHub Release artifacts, generated release notes, and `wtui --version`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,77 @@
+# Release Process
+
+This project releases with GoReleaser. A pushed semver tag creates GitHub
+Release artifacts and updates the Homebrew formula in `brian-bell/homebrew-tap`.
+
+## One-Time Prerequisites
+
+The release workflow assumes these are already done before the first tag:
+
+- Public repository `brian-bell/homebrew-tap` exists.
+- Repository secret `HOMEBREW_TAP_GITHUB_TOKEN` exists in `brian-bell/wtui`.
+- The token is a fine-grained GitHub PAT scoped to `brian-bell/homebrew-tap`
+  with `Contents: read and write`.
+- The token owner can push to the tap repository's default branch.
+
+GoReleaser writes `Formula/wtui.rb` on release. The formula declares the MIT
+license and runs `wtui --version` as its Homebrew test.
+
+GoReleaser marks formula publishing as deprecated upstream in favor of casks,
+but this project intentionally uses a formula because the install target is
+`brew install brian-bell/tap/wtui`.
+
+## First Release
+
+The first release tag is `v0.1.0`.
+
+1. Confirm the latest `main` build is green.
+2. Confirm `.github/workflows/ci.yml` has passed the `release-snapshot` job.
+3. Optional local check if GoReleaser is installed:
+
+   ```bash
+   goreleaser release --snapshot --clean --skip=publish
+   ```
+
+4. Create and push the annotated tag:
+
+   ```bash
+   git tag -a v0.1.0 -m "v0.1.0"
+   git push origin v0.1.0
+   ```
+
+5. Watch the `Release` workflow for the tag.
+6. Verify the GitHub Release has these artifacts:
+   - `wtui_0.1.0_darwin_amd64.tar.gz`
+   - `wtui_0.1.0_darwin_arm64.tar.gz`
+   - `wtui_0.1.0_linux_amd64.tar.gz`
+   - `wtui_0.1.0_linux_arm64.tar.gz`
+   - `wtui_0.1.0_checksums.txt`
+7. Verify the release notes were generated from commits since the previous tag.
+8. Verify the Homebrew formula was committed to `brian-bell/homebrew-tap`.
+9. Verify Homebrew install and version output:
+
+   ```bash
+   brew install brian-bell/tap/wtui
+   wtui --version
+   ```
+
+10. Verify the Go install fallback:
+
+    ```bash
+    go install github.com/brian-bell/wtui/cmd/wtui@v0.1.0
+    wtui --version
+    ```
+
+## Later Releases
+
+1. Land the release changes on `main`.
+2. Wait for CI, including `release-snapshot`, to pass.
+3. Tag the release with the next semver tag:
+
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+4. Verify GitHub Release artifacts, generated release notes, Homebrew formula
+   update, `brew upgrade wtui`, and `wtui --version`.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,31 @@
+package version
+
+import "fmt"
+
+const (
+	defaultVersion = "dev"
+	defaultCommit  = "unknown"
+	defaultDate    = "unknown"
+)
+
+var (
+	Version = defaultVersion
+	Commit  = defaultCommit
+	Date    = defaultDate
+)
+
+func String() string {
+	return fmt.Sprintf(
+		"wtui %s (%s) built %s",
+		valueOrDefault(Version, defaultVersion),
+		valueOrDefault(Commit, defaultCommit),
+		valueOrDefault(Date, defaultDate),
+	)
+}
+
+func valueOrDefault(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,6 +1,9 @@
 package version
 
-import "fmt"
+import (
+	"fmt"
+	"runtime/debug"
+)
 
 const (
 	defaultVersion = "dev"
@@ -12,15 +15,53 @@ var (
 	Version = defaultVersion
 	Commit  = defaultCommit
 	Date    = defaultDate
+
+	readBuildInfo = debug.ReadBuildInfo
 )
 
 func String() string {
+	version, commit, date := resolvedValues()
+
 	return fmt.Sprintf(
 		"wtui %s (%s) built %s",
-		valueOrDefault(Version, defaultVersion),
-		valueOrDefault(Commit, defaultCommit),
-		valueOrDefault(Date, defaultDate),
+		version,
+		commit,
+		date,
 	)
+}
+
+func resolvedValues() (string, string, string) {
+	version := valueOrDefault(Version, defaultVersion)
+	commit := valueOrDefault(Commit, defaultCommit)
+	date := valueOrDefault(Date, defaultDate)
+
+	if version != defaultVersion || commit != defaultCommit || date != defaultDate {
+		return version, commit, date
+	}
+
+	info, ok := readBuildInfo()
+	if !ok || info == nil {
+		return version, commit, date
+	}
+
+	if isUsefulModuleVersion(info.Main.Version) {
+		version = info.Main.Version
+	}
+
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			commit = valueOrDefault(setting.Value, commit)
+		case "vcs.time":
+			date = valueOrDefault(setting.Value, date)
+		}
+	}
+
+	return version, commit, date
+}
+
+func isUsefulModuleVersion(version string) bool {
+	return version != "" && version != "(devel)"
 }
 
 func valueOrDefault(value, fallback string) string {

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,50 @@
+package version
+
+import "testing"
+
+func TestString(t *testing.T) {
+	originalVersion, originalCommit, originalDate := Version, Commit, Date
+	t.Cleanup(func() {
+		Version, Commit, Date = originalVersion, originalCommit, originalDate
+	})
+
+	tests := []struct {
+		name    string
+		version string
+		commit  string
+		date    string
+		want    string
+	}{
+		{
+			name:    "defaults",
+			version: "dev",
+			commit:  "unknown",
+			date:    "unknown",
+			want:    "wtui dev (unknown) built unknown",
+		},
+		{
+			name:    "release build",
+			version: "v0.1.0",
+			commit:  "abc1234",
+			date:    "2026-04-19T10:20:30Z",
+			want:    "wtui v0.1.0 (abc1234) built 2026-04-19T10:20:30Z",
+		},
+		{
+			name:    "empty values fall back",
+			version: "",
+			commit:  "",
+			date:    "",
+			want:    "wtui dev (unknown) built unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Version, Commit, Date = tt.version, tt.commit, tt.date
+
+			if got := String(); got != tt.want {
+				t.Fatalf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,12 +1,20 @@
 package version
 
-import "testing"
+import (
+	"runtime/debug"
+	"testing"
+)
 
 func TestString(t *testing.T) {
 	originalVersion, originalCommit, originalDate := Version, Commit, Date
+	originalReadBuildInfo := readBuildInfo
 	t.Cleanup(func() {
 		Version, Commit, Date = originalVersion, originalCommit, originalDate
+		readBuildInfo = originalReadBuildInfo
 	})
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return nil, false
+	}
 
 	tests := []struct {
 		name    string
@@ -46,5 +54,61 @@ func TestString(t *testing.T) {
 				t.Fatalf("String() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestStringFallsBackToBuildInfoWhenLdflagsDefault(t *testing.T) {
+	originalVersion, originalCommit, originalDate := Version, Commit, Date
+	originalReadBuildInfo := readBuildInfo
+	t.Cleanup(func() {
+		Version, Commit, Date = originalVersion, originalCommit, originalDate
+		readBuildInfo = originalReadBuildInfo
+	})
+
+	Version, Commit, Date = defaultVersion, defaultCommit, defaultDate
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Path:    "github.com/brian-bell/wtui",
+				Version: "v0.1.0",
+			},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abcdef1234567890"},
+				{Key: "vcs.time", Value: "2026-04-19T10:20:30Z"},
+			},
+		}, true
+	}
+
+	want := "wtui v0.1.0 (abcdef1234567890) built 2026-04-19T10:20:30Z"
+	if got := String(); got != want {
+		t.Fatalf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestStringPrefersLdflagsOverBuildInfo(t *testing.T) {
+	originalVersion, originalCommit, originalDate := Version, Commit, Date
+	originalReadBuildInfo := readBuildInfo
+	t.Cleanup(func() {
+		Version, Commit, Date = originalVersion, originalCommit, originalDate
+		readBuildInfo = originalReadBuildInfo
+	})
+
+	Version, Commit, Date = "v0.2.0", "ldflags-commit", "2026-05-10T12:00:00Z"
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{
+				Path:    "github.com/brian-bell/wtui",
+				Version: "v0.1.0",
+			},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "build-info-commit"},
+				{Key: "vcs.time", Value: "2026-04-19T10:20:30Z"},
+			},
+		}, true
+	}
+
+	want := "wtui v0.2.0 (ldflags-commit) built 2026-05-10T12:00:00Z"
+	if got := String(); got != want {
+		t.Fatalf("String() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

This implements the release artifact and versioning work from PRD #58, with Homebrew tap publishing removed from the scope of this PR:

- add an internal version package with ldflag-backed Version, Commit, and Date values
- wire `wtui --version` and `wtui -v` to print build metadata and exit before scanning/repos/UI startup
- inject dev build metadata from `make build`
- add GoReleaser v2 config for darwin/linux amd64/arm64 tarballs, SHA256 checksums, and generated release notes
- add PR snapshot release validation and a tag-driven GitHub Releases workflow
- add MIT licensing, README install docs for GitHub Releases / `go install` / source builds, and manual `v0.1.0` release instructions

## Notes

- Homebrew tap publishing, tap repo setup, and `HOMEBREW_TAP_GITHUB_TOKEN` are intentionally not included.
- This PR does not create GitHub issues or cut the `v0.1.0` tag.

## Verification

- [x] `make test`
- [x] `make build`
- [x] `bin/wtui --version`
- [x] `bin/wtui -v`
- [x] `gofmt -l .`
- [x] `git diff --check`
- [x] `goreleaser check`
- [x] `goreleaser release --snapshot --clean --skip=publish`

## Release checklist after merge

- [x] Confirm `release-snapshot` passes on main
- [x] Tag `v0.1.0`
- [ ] Verify GitHub Release artifacts, checksums, generated release notes, and `wtui --version`
- [ ] Verify `go install github.com/brian-bell/wtui/cmd/wtui@v0.1.0`