### PR TITLE
Combined cleanup: fix force-delete path and add coverage

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -1002,6 +1002,7 @@ func (m Model) handleWorktreeRemoved(msg WorktreeRemovedMsg) (tea.Model, tea.Cmd
 					RepoPath:    repoPath,
 					Target:      branchName,
 					ForceAction: func() error { return actions.ForceDeleteBranch(repoPath, branchName) },
+					SuccessMsg:  WorktreeDeleteCompletedMsg{RepoPath: repoPath},
 				}
 			}
 			return WorktreeDeleteCompletedMsg{RepoPath: repoPath}

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -731,6 +731,94 @@ func TestModel_WorktreeRemovedShowsBranchConfirm(t *testing.T) {
 	}
 }
 
+func TestModel_CombinedCleanupConfirmYReturnsCmd(t *testing.T) {
+	m := model.New(testRepos())
+	m = inWorktreesMode(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+		{Path: "/dev/alpha-feat", BranchName: "feat"},
+	}})
+	// Trigger branch confirm
+	m, _ = update(m, model.WorktreeRemovedMsg{RepoPath: "/dev/alpha", BranchName: "feat"})
+	if m.Overlay() != model.OverlayConfirm {
+		t.Fatalf("expected OverlayConfirm, got %d", m.Overlay())
+	}
+	// Confirm branch deletion
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if m.Overlay() != model.OverlayNone {
+		t.Errorf("expected overlay closed after confirm, got %d", m.Overlay())
+	}
+	if cmd == nil {
+		t.Fatal("expected branch delete cmd after confirm, got nil")
+	}
+	// Fake path causes DeleteBranch to fail → DeleteFailedMsg
+	msg := cmd()
+	if _, ok := msg.(model.DeleteFailedMsg); !ok {
+		t.Errorf("expected DeleteFailedMsg from branch delete on fake path, got %T", msg)
+	}
+}
+
+func TestModel_CombinedCleanupConfirmNClosesDialog(t *testing.T) {
+	m := model.New(testRepos())
+	m = inWorktreesMode(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+		{Path: "/dev/alpha-feat", BranchName: "feat"},
+	}})
+	m, _ = update(m, model.WorktreeRemovedMsg{RepoPath: "/dev/alpha", BranchName: "feat"})
+	// Decline branch deletion
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if m.Overlay() != model.OverlayNone {
+		t.Errorf("expected overlay closed after cancel, got %d", m.Overlay())
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd after cancel, got %T", cmd)
+	}
+}
+
+func TestModel_CombinedCleanupForceDeleteReturnsWorktreeDeleteCompletedMsg(t *testing.T) {
+	// Full end-to-end: worktree removed → "Also delete branch?" confirmed →
+	// DeleteBranch fails (fake path) → "Force delete?" shown → force confirmed →
+	// should return WorktreeDeleteCompletedMsg, not BranchDeletedMsg.
+	m := model.New(testRepos())
+	m = inWorktreesMode(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+		{Path: "/dev/alpha-feat", BranchName: "feat"},
+	}})
+	// Worktree removed → branch confirm dialog
+	m, _ = update(m, model.WorktreeRemovedMsg{RepoPath: "/dev/alpha", BranchName: "feat"})
+	if m.Overlay() != model.OverlayConfirm {
+		t.Fatalf("expected branch confirm overlay, got %d", m.Overlay())
+	}
+	// Confirm branch deletion → DeleteBranch fails on fake path → DeleteFailedMsg
+	_, branchDeleteCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if branchDeleteCmd == nil {
+		t.Fatal("expected branch delete cmd, got nil")
+	}
+	deleteFailedMsg := branchDeleteCmd()
+	if _, ok := deleteFailedMsg.(model.DeleteFailedMsg); !ok {
+		t.Fatalf("expected DeleteFailedMsg from fake-path branch delete, got %T", deleteFailedMsg)
+	}
+	// Process DeleteFailedMsg → force confirm shown
+	m, _ = update(m, deleteFailedMsg)
+	if m.Overlay() != model.OverlayConfirm {
+		t.Fatalf("expected force confirm overlay, got %d", m.Overlay())
+	}
+	if !m.ConfirmForce() {
+		t.Fatal("expected ConfirmForce=true for force confirm")
+	}
+	// Confirm force-delete
+	_, forceCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if forceCmd == nil {
+		t.Fatal("expected force cmd, got nil")
+	}
+	result := forceCmd()
+	if _, ok := result.(model.WorktreeDeleteCompletedMsg); !ok {
+		t.Errorf("force-delete in combined cleanup should return WorktreeDeleteCompletedMsg, got %T", result)
+	}
+}
+
 // --- Worktree prune ---
 
 func TestModel_PKeyRequiresDestructiveMode(t *testing.T) {


### PR DESCRIPTION
## Summary

- The combined worktree+branch cleanup flow was already implemented: after removing a worktree, the model shows "Also delete branch X? (y/n)" for non-detached worktrees.
- **Bug fixed**: The `DeleteFailedMsg` emitted when branch deletion fails in the combined cleanup was missing `SuccessMsg`. This caused a force-delete to return `BranchDeletedMsg` (triggering an unexpected `fetchBranches()` call in the wrong context) instead of `WorktreeDeleteCompletedMsg`. Added `SuccessMsg: WorktreeDeleteCompletedMsg{...}` to keep the message type consistent throughout the combined cleanup flow.
- **Tests added**: Three new tests covering the end-to-end combined cleanup scenarios that were previously untested.

## Changed files

- `model/model.go` — Added `SuccessMsg` to `DeleteFailedMsg` in `handleWorktreeRemoved` so the force-delete path stays in the worktrees message context.
- `model/model_action_test.go` — Added:
  - `TestModel_CombinedCleanupConfirmYReturnsCmd`: confirming the branch prompt fires the delete command
  - `TestModel_CombinedCleanupConfirmNClosesDialog`: cancelling closes the overlay with no side effects
  - `TestModel_CombinedCleanupForceDeleteReturnsWorktreeDeleteCompletedMsg`: end-to-end force-delete path returns `WorktreeDeleteCompletedMsg` (was the failing test driving the fix)

## Test plan

- [x] All existing tests pass (`make test`)
- [x] Three new tests cover confirm, cancel, and force-delete paths of combined cleanup
- [x] `gofmt -l .` reports no formatting issues