### PR TITLE
Add Homebrew cask publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,3 +33,17 @@ archives:
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
   algorithm: sha256
+
+homebrew_casks:
+  - name: wtui
+    ids:
+      - wtui
+    binaries:
+      - wtui
+    directory: Casks
+    homepage: "https://github.com/brian-bell/wtui"
+    description: "Terminal UI for managing git worktrees across repositories"
+    repository:
+      owner: brian-bell
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ A terminal UI for managing git worktrees across repositories.
 
 ## Install
 
+### Homebrew
+
+```bash
+brew install --cask brian-bell/tap/wtui
+```
+
 ### GitHub Releases
 
 Download a pre-built macOS or Linux binary from the

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,7 +1,29 @@
 # Release Process
 
 This project releases with GoReleaser. A pushed semver tag creates GitHub
-Release artifacts with checksums and generated release notes.
+Release artifacts with checksums, generated release notes, and a Homebrew cask.
+
+## Homebrew Tap Setup
+
+Homebrew casks are published to `brian-bell/homebrew-tap`. Homebrew exposes
+that repository as the short tap name `brian-bell/tap`, so users install wtui
+with:
+
+```bash
+brew install --cask brian-bell/tap/wtui
+```
+
+GoReleaser commits the generated cask to `Casks/wtui.rb` in the tap repository.
+The release workflow needs a repository secret named
+`HOMEBREW_TAP_GITHUB_TOKEN` because the default `GITHUB_TOKEN` cannot write to
+another repository.
+
+Create a GitHub personal access token with contents write access to
+`brian-bell/homebrew-tap`, then add it to this repository as:
+
+```text
+HOMEBREW_TAP_GITHUB_TOKEN
+```
 
 ## First Release
 
@@ -30,7 +52,14 @@ The first release tag is `v0.1.0`.
    - `wtui_0.1.0_linux_arm64.tar.gz`
    - `wtui_0.1.0_checksums.txt`
 7. Verify the release notes were generated from commits since the previous tag.
-8. Verify the Go install fallback:
+8. Verify the Homebrew cask:
+
+   ```bash
+   brew install --cask brian-bell/tap/wtui
+   wtui --version
+   ```
+
+9. Verify the Go install fallback:
 
     ```bash
     go install github.com/brian-bell/wtui/cmd/wtui@v0.1.0
@@ -48,4 +77,5 @@ The first release tag is `v0.1.0`.
    git push origin vX.Y.Z
    ```
 
-4. Verify GitHub Release artifacts, generated release notes, and `wtui --version`.
+4. Verify GitHub Release artifacts, generated release notes, the cask commit in
+   `brian-bell/homebrew-tap`, and `wtui --version`.


### PR DESCRIPTION
## Summary

- add GoReleaser `homebrew_casks` publishing for `wtui` to `brian-bell/homebrew-tap`
- pass `HOMEBREW_TAP_GITHUB_TOKEN` through the release workflow
- lead README installs with `brew install --cask brian-bell/tap/wtui` and document tap secret setup in the release runbook

## Validation

- `gofmt -l .`
- `make test`
- `make build`
- `go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean --skip=publish`

Closes #65