### PR TITLE
Mark branches merged into cleanup branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Status indicators stack on each branch:
 - `●` yellow: ahead/behind upstream — shows `+N/-N` counts
 - `●` red: dirty worktree — shows `N files +X/-Y` (lines added/deleted)
 - `●` purple: no upstream or upstream gone
+- `merged` cyan: branch is fully merged into the cleanup branch (`main` or `master`)
 
 Branches ahead of upstream show up to 5 unpushed commit messages, with overflow count. When the root branch is dirty, `enter` opens a full-screen diff overlay. `t` opens or attaches to a tmux/Zellij session and `c` opens VSCode at the worktree path (root branch only). `d` deletes non-worktree branches, with a force-retry prompt on failure. Deletion requires destructive mode to be enabled first (`D`).
 

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -54,6 +54,8 @@ type Branch struct {
 	Ahead         int
 	Behind        int
 	Unpushed      []string
+	Merged        bool
+	MergedInto    string
 	IsWorktree    bool
 	WorktreePaths []string
 	WorktreeStale []bool // parallel to WorktreePaths; true when directory is missing
@@ -228,6 +230,9 @@ func ListBranches(repoPath string) ([]Branch, error) {
 	}
 
 	lines := splitLines(out)
+	rootBranch := rootWorktreeBranch(repoPath, wtMap)
+	cleanupBranch := defaultCleanupBranch(repoPath, lines, rootBranch)
+
 	branches := make([]Branch, 0, len(lines))
 	for _, line := range lines {
 		if line == "" {
@@ -251,6 +256,10 @@ func ListBranches(repoPath string) ([]Branch, error) {
 			b.WorktreePaths = wtPaths
 			b.WorktreeStale = checkStale(wtPaths)
 			populateDirtyStatus(&b, wtPaths)
+		}
+		if cleanupBranch != "" && b.Name != cleanupBranch && b.Name != rootBranch && branchMergedInto(repoPath, b.Name, cleanupBranch) {
+			b.Merged = true
+			b.MergedInto = cleanupBranch
 		}
 
 		branches = append(branches, b)
@@ -315,6 +324,45 @@ func branchAheadBehind(repoPath, branchName, upstream string) (int, int, error) 
 	return ahead, behind, nil
 }
 
+func rootWorktreeBranch(repoPath string, wtMap map[string][]string) string {
+	for branch, paths := range wtMap {
+		for _, path := range paths {
+			if path == repoPath {
+				return branch
+			}
+		}
+	}
+	return strings.TrimSpace(maybeGitCmd(repoPath, "branch", "--show-current"))
+}
+
+func defaultCleanupBranch(repoPath string, branchLines []string, fallback string) string {
+	branches := make(map[string]bool, len(branchLines))
+	for _, line := range branchLines {
+		b, _ := ParseBranchLine(line)
+		if b.Name != "" {
+			branches[b.Name] = true
+		}
+	}
+	for _, name := range []string{"main", "master"} {
+		if branches[name] {
+			return name
+		}
+	}
+	if fallback != "" && branches[fallback] {
+		return fallback
+	}
+	ref := strings.TrimSpace(maybeGitCmd(repoPath, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"))
+	ref = strings.TrimPrefix(ref, "origin/")
+	if branches[ref] {
+		return ref
+	}
+	return ""
+}
+
+func branchMergedInto(repoPath, branchName, cleanupBranch string) bool {
+	return gitCmdRun(repoPath, "merge-base", "--is-ancestor", branchName, cleanupBranch) == nil
+}
+
 func unpushedCommits(repoPath, branchName, upstream string) []string {
 	out, err := gitCmd(repoPath, "log", "--oneline", upstream+".."+branchName)
 	if err != nil {
@@ -363,6 +411,14 @@ func firstWorktreePath(paths []string) string {
 	return paths[0]
 }
 
+func maybeGitCmd(dir string, args ...string) string {
+	out, err := gitCmd(dir, args...)
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
 func gitCmd(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
@@ -371,6 +427,12 @@ func gitCmd(dir string, args ...string) (string, error) {
 		return "", err
 	}
 	return string(out), nil
+}
+
+func gitCmdRun(dir string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	return cmd.Run()
 }
 
 func splitLines(s string) []string {

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -257,6 +257,8 @@ func ListBranches(repoPath string) ([]Branch, error) {
 			b.WorktreeStale = checkStale(wtPaths)
 			populateDirtyStatus(&b, wtPaths)
 		}
+		// Do not mark the user's active root worktree branch as a cleanup
+		// candidate, even when it is technically an ancestor of cleanupBranch.
 		if cleanupBranch != "" && b.Name != cleanupBranch && b.Name != rootBranch && branchMergedInto(repoPath, b.Name, cleanupBranch) {
 			b.Merged = true
 			b.MergedInto = cleanupBranch
@@ -348,6 +350,8 @@ func defaultCleanupBranch(repoPath string, branchLines []string, fallback string
 			return name
 		}
 	}
+	// Repos without main/master fall back to the root worktree branch, treating
+	// branches already merged into that active branch as cleanup candidates.
 	if fallback != "" && branches[fallback] {
 		return fallback
 	}

--- a/gitquery/gitquery_test.go
+++ b/gitquery/gitquery_test.go
@@ -34,6 +34,17 @@ func initRepo(t *testing.T, dir string) {
 	run(t, dir, "git", "commit", "-m", "init")
 }
 
+// initRepoWithInitialBranch creates a git repo in dir with one commit on initialBranch.
+func initRepoWithInitialBranch(t *testing.T, dir, initialBranch string) {
+	t.Helper()
+	run(t, dir, "git", "init", "-b", initialBranch)
+	run(t, dir, "git", "config", "user.email", "test@test.com")
+	run(t, dir, "git", "config", "user.name", "Test")
+	writeFile(t, dir, "README.md", "init")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "initial")
+}
+
 // initBranchRepo creates a git repo in a new temp dir with one commit. Returns the dir.
 func initBranchRepo(t *testing.T) string {
 	t.Helper()
@@ -581,6 +592,118 @@ func TestListBranches_UntrackedOnlyDirtyWorktree(t *testing.T) {
 	}
 	if b.FilesChanged != 1 {
 		t.Errorf("expected FilesChanged = 1, got %d", b.FilesChanged)
+	}
+}
+
+func TestListBranches_MergedDetectionMain(t *testing.T) {
+	repo := realPath(t, t.TempDir())
+	initRepoWithInitialBranch(t, repo, "main")
+
+	run(t, repo, "git", "checkout", "-b", "merged-branch")
+	writeFile(t, repo, "merged.txt", "merged\n")
+	run(t, repo, "git", "add", ".")
+	run(t, repo, "git", "commit", "-m", "merged branch commit")
+	run(t, repo, "git", "checkout", "main")
+	run(t, repo, "git", "merge", "--no-ff", "merged-branch", "-m", "merge merged branch")
+
+	run(t, repo, "git", "checkout", "-b", "unmerged-branch")
+	writeFile(t, repo, "unmerged.txt", "unmerged\n")
+	run(t, repo, "git", "add", ".")
+	run(t, repo, "git", "commit", "-m", "unmerged branch commit")
+	run(t, repo, "git", "checkout", "main")
+
+	branches, err := gitquery.ListBranches(repo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	merged := findBranch(branches, "merged-branch")
+	if merged == nil {
+		t.Fatal("merged-branch not found")
+	}
+	if !merged.Merged {
+		t.Fatal("expected merged-branch to be marked merged")
+	}
+	if merged.MergedInto != "main" {
+		t.Errorf("expected MergedInto %q, got %q", "main", merged.MergedInto)
+	}
+
+	unmerged := findBranch(branches, "unmerged-branch")
+	if unmerged == nil {
+		t.Fatal("unmerged-branch not found")
+	}
+	if unmerged.Merged {
+		t.Error("unmerged-branch should not be marked merged")
+	}
+
+	main := findBranch(branches, "main")
+	if main == nil {
+		t.Fatal("main not found")
+	}
+	if main.Merged {
+		t.Error("cleanup branch main should not be marked merged")
+	}
+}
+
+func TestListBranches_MergedDetectionMaster(t *testing.T) {
+	repo := realPath(t, t.TempDir())
+	initRepoWithInitialBranch(t, repo, "master")
+
+	run(t, repo, "git", "checkout", "-b", "merged-branch")
+	writeFile(t, repo, "merged.txt", "merged\n")
+	run(t, repo, "git", "add", ".")
+	run(t, repo, "git", "commit", "-m", "merged branch commit")
+	run(t, repo, "git", "checkout", "master")
+	run(t, repo, "git", "merge", "--no-ff", "merged-branch", "-m", "merge merged branch")
+
+	branches, err := gitquery.ListBranches(repo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	merged := findBranch(branches, "merged-branch")
+	if merged == nil {
+		t.Fatal("merged-branch not found")
+	}
+	if !merged.Merged {
+		t.Fatal("expected merged-branch to be marked merged")
+	}
+	if merged.MergedInto != "master" {
+		t.Errorf("expected MergedInto %q, got %q", "master", merged.MergedInto)
+	}
+
+	master := findBranch(branches, "master")
+	if master == nil {
+		t.Fatal("master not found")
+	}
+	if master.Merged {
+		t.Error("cleanup branch master should not be marked merged")
+	}
+}
+
+func TestListBranches_MergedWorktreeBranchStatusPreserved(t *testing.T) {
+	repo := realPath(t, t.TempDir())
+	initRepoWithInitialBranch(t, repo, "main")
+
+	run(t, repo, "git", "branch", "worktree-branch")
+	wtDir := realPath(t, t.TempDir())
+	wtPath := filepath.Join(wtDir, "wt-branch")
+	run(t, repo, "git", "worktree", "add", wtPath, "worktree-branch")
+
+	branches, err := gitquery.ListBranches(repo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	b := findBranch(branches, "worktree-branch")
+	if b == nil {
+		t.Fatal("worktree-branch not found")
+	}
+	if !b.IsWorktree {
+		t.Error("expected worktree-branch to preserve worktree status")
+	}
+	if !b.Merged {
+		t.Error("expected worktree-branch at main to be marked merged")
 	}
 }
 

--- a/gitquery/gitquery_test.go
+++ b/gitquery/gitquery_test.go
@@ -707,6 +707,48 @@ func TestListBranches_MergedWorktreeBranchStatusPreserved(t *testing.T) {
 	}
 }
 
+func TestListBranches_RootBranchExcludedFromMergedDetection(t *testing.T) {
+	repo := realPath(t, t.TempDir())
+	initRepoWithInitialBranch(t, repo, "main")
+
+	run(t, repo, "git", "checkout", "-b", "develop")
+	writeFile(t, repo, "develop.txt", "develop\n")
+	run(t, repo, "git", "add", ".")
+	run(t, repo, "git", "commit", "-m", "develop commit")
+
+	run(t, repo, "git", "checkout", "main")
+	run(t, repo, "git", "merge", "--no-ff", "develop", "-m", "merge develop")
+	run(t, repo, "git", "branch", "old-topic")
+	run(t, repo, "git", "checkout", "develop")
+
+	branches, err := gitquery.ListBranches(repo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	develop := findBranch(branches, "develop")
+	if develop == nil {
+		t.Fatal("develop not found")
+	}
+	if develop.Merged {
+		t.Error("root branch develop should not be marked merged")
+	}
+	if develop.MergedInto != "" {
+		t.Errorf("expected empty MergedInto for root branch, got %q", develop.MergedInto)
+	}
+
+	oldTopic := findBranch(branches, "old-topic")
+	if oldTopic == nil {
+		t.Fatal("old-topic not found")
+	}
+	if !oldTopic.Merged {
+		t.Error("expected non-root old-topic branch to be marked merged")
+	}
+	if oldTopic.MergedInto != "main" {
+		t.Errorf("expected old-topic MergedInto %q, got %q", "main", oldTopic.MergedInto)
+	}
+}
+
 func TestBranchDiff_ReturnsDiffForDirtyWorktree(t *testing.T) {
 	repo := realPath(t, initBranchRepo(t))
 

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1357,7 +1357,7 @@ func TestModel_WorktreeBranchesFilteredFromBranchView(t *testing.T) {
 	branches := []gitquery.Branch{
 		{Name: "feat-a"},
 		{Name: "main", IsWorktree: true, WorktreePaths: []string{"/dev/alpha"}},
-		{Name: "wt-branch", IsWorktree: true, WorktreePaths: []string{"/dev/alpha-wt"}},
+		{Name: "wt-branch", Merged: true, MergedInto: "main", IsWorktree: true, WorktreePaths: []string{"/dev/alpha-wt"}},
 		{Name: "feat-b"},
 	}
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -68,7 +68,7 @@ var (
 	lockedStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("14"))
 	noUpstreamStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
 	aheadBehindStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
-	mergedStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("14"))
+	mergedStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
 	dirtyRedStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
 	diffAddStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
 	diffDelStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -68,6 +68,7 @@ var (
 	lockedStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("14"))
 	noUpstreamStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
 	aheadBehindStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
+	mergedStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("14"))
 	dirtyRedStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
 	diffAddStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
 	diffDelStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
@@ -289,16 +290,16 @@ func renderStatusBarWithState(width, mode int, overlay OverlayState, activePane 
 		}
 	case mode == 2:
 		keys := "  |  tab: pane  q/esc: quit"
+		if !destructive {
+			keys += "  D: destructive mode"
+		}
 		if activePane == 1 {
 			keys += "  t: terminal  c: code"
 			if destructive {
 				keys += "  " + dirtyRedStyle.Render("d: delete")
 			}
 		}
-		if !destructive {
-			keys += "  D: destructive mode"
-		}
-		hints = " " + cleanStyle.Render("✔") + " clean  " + aheadBehindStyle.Render("●") + " ahead/behind  " + dirtyRedStyle.Render("●") + " dirty  " + noUpstreamStyle.Render("●") + " no upstream" + keys
+		hints = " " + cleanStyle.Render("✔") + " clean  " + aheadBehindStyle.Render("●") + " ahead/behind  " + dirtyRedStyle.Render("●") + " dirty  " + noUpstreamStyle.Render("●") + " no upstream  " + mergedStyle.Render("merged") + keys
 	case mode == 1:
 		hints = "  tab: pane  q/esc: quit  ↑/↓ select"
 		if activePane == 1 && !staleSelected {
@@ -370,6 +371,9 @@ func renderBranchPaneSelected(rows []gitquery.BranchRow, selected, scroll, width
 		}
 		if !b.HasUpstream || b.UpstreamGone {
 			indicators += noUpstreamStyle.Render(" ●")
+		}
+		if b.Merged {
+			indicators += mergedStyle.Render(" merged")
 		}
 		if indicators == "" {
 			indicators = cleanStyle.Render(" ✔")

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestStatusBar_BranchesModeContainsIndicatorLegend(t *testing.T) {
 	bar := RenderStatusBar(120, 2, 0, 1, true, false, false)
-	for _, legend := range []string{"✔ clean", "● ahead/behind", "● dirty", "● no upstream"} {
+	for _, legend := range []string{"✔ clean", "● ahead/behind", "● dirty", "● no upstream", "merged"} {
 		if !strings.Contains(bar, legend) {
 			t.Errorf("branches mode status bar should contain legend %q", legend)
 		}
@@ -547,6 +547,23 @@ func TestBranchPane_UnpushedCommitsShown(t *testing.T) {
 	}
 	if !strings.Contains(joined, "Add feature") {
 		t.Error("should show second unpushed commit message")
+	}
+}
+
+func TestBranchPane_MergedBranchShowsCleanupCandidate(t *testing.T) {
+	rows := []gitquery.BranchRow{
+		{Branch: gitquery.Branch{Name: "merged-feat", HasUpstream: true, Merged: true, MergedInto: "main"}},
+	}
+	lines := renderBranchPane(rows, 80, 10)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "merged-feat") {
+		t.Error("should show merged branch name")
+	}
+	if !strings.Contains(joined, "merged") {
+		t.Errorf("should show merged cleanup indicator, got %q", joined)
+	}
+	if strings.Contains(joined, "✔") {
+		t.Errorf("merged branch should not also render clean-only indicator, got %q", joined)
 	}
 }
 


### PR DESCRIPTION
## Summary
- detect local branches fully merged into the repo cleanup branch (`main`, `master`, or fallback)
- render a `merged` indicator in the branches pane and status legend
- preserve root pinning and hidden non-root worktree branch behavior

## Tests
- `gofmt -l .`
- `make test`
- `make build`

Closes #67