### PR TITLE
Refactor model state into generic panes

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -4,30 +4,22 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/brian-bell/wtui/gitquery"
+	"github.com/brian-bell/wtui/model/pane"
 	"github.com/brian-bell/wtui/scanner"
 	"github.com/brian-bell/wtui/ui"
 )
 
 // Model is the bubbletea application model.
 type Model struct {
-	repos            []scanner.Repo
-	selected         int
+	repos            pane.Pane[scanner.Repo]
 	width            int
 	height           int
 	mode             ui.Mode
-	rows             []gitquery.BranchRow
-	stashes          []gitquery.Stash
-	branchSelected   int
-	stashSelected    int
-	worktrees        []gitquery.Worktree
-	worktreeSelected int
-	worktreeScroll   int
-	commits          []gitquery.Commit
-	commitSelected   int
-	commitScroll     int
-	reflogs          []gitquery.ReflogEntry
-	reflogSelected   int
-	reflogScroll     int
+	rows             pane.Pane[gitquery.BranchRow]
+	stashes          pane.Pane[gitquery.Stash]
+	worktrees        pane.Pane[gitquery.Worktree]
+	commits          pane.Pane[gitquery.Commit]
+	reflogs          pane.Pane[gitquery.ReflogEntry]
 	overlay          ui.OverlayState
 	overlayDiff      string
 	overlayScroll    int
@@ -36,39 +28,46 @@ type Model struct {
 	confirmForce     bool
 	worktreeInput    string
 	worktreeInputErr string
-	branchScroll     int
-	repoScroll       int
-	stashScroll      int
 	activePane       int // 0=left (repos), 1=right (content)
 	destructive      bool
 	transientError   string
 	searchActive     bool
-	repoSearch       string
-	itemSearch       string
 }
 
 // New creates a Model from discovered repos.
 func New(repos []scanner.Repo) Model {
-	return Model{repos: repos, mode: ui.ModeWorktrees}
+	m := Model{
+		repos:     newRepoPane().SetItems(repos),
+		rows:      newBranchPane(),
+		stashes:   newStashPane(),
+		worktrees: newWorktreePane(),
+		commits:   newCommitPane(),
+		reflogs:   newReflogPane(),
+		mode:      ui.ModeWorktrees,
+	}
+	return m
 }
 
-func (m Model) Selected() int                   { return m.selected }
-func (m Model) Width() int                      { return m.width }
-func (m Model) Height() int                     { return m.height }
-func (m Model) Mode() ui.Mode                   { return m.mode }
-func (m Model) Rows() []gitquery.BranchRow      { return m.rows }
-func (m Model) Stashes() []gitquery.Stash       { return m.stashes }
-func (m Model) BranchSelected() int             { return m.branchSelected }
-func (m Model) StashSelected() int              { return m.stashSelected }
-func (m Model) Worktrees() []gitquery.Worktree  { return m.worktrees }
-func (m Model) WorktreeSelected() int           { return m.worktreeSelected }
-func (m Model) WorktreeScroll() int             { return m.worktreeScroll }
-func (m Model) Commits() []gitquery.Commit      { return m.commits }
-func (m Model) CommitSelected() int             { return m.commitSelected }
-func (m Model) CommitScroll() int               { return m.commitScroll }
-func (m Model) Reflogs() []gitquery.ReflogEntry { return m.reflogs }
-func (m Model) ReflogSelected() int             { return m.reflogSelected }
-func (m Model) ReflogScroll() int               { return m.reflogScroll }
+func (m Model) Selected() int              { _, selected, _ := m.repos.View(); return selected }
+func (m Model) Width() int                 { return m.width }
+func (m Model) Height() int                { return m.height }
+func (m Model) Mode() ui.Mode              { return m.mode }
+func (m Model) Rows() []gitquery.BranchRow { rows, _, _ := m.rows.View(); return rows }
+func (m Model) Stashes() []gitquery.Stash  { stashes, _, _ := m.stashes.View(); return stashes }
+func (m Model) BranchSelected() int        { _, selected, _ := m.rows.View(); return selected }
+func (m Model) StashSelected() int         { _, selected, _ := m.stashes.View(); return selected }
+func (m Model) Worktrees() []gitquery.Worktree {
+	worktrees, _, _ := m.worktrees.View()
+	return worktrees
+}
+func (m Model) WorktreeSelected() int           { _, selected, _ := m.worktrees.View(); return selected }
+func (m Model) WorktreeScroll() int             { _, _, scroll := m.worktrees.View(); return scroll }
+func (m Model) Commits() []gitquery.Commit      { commits, _, _ := m.commits.View(); return commits }
+func (m Model) CommitSelected() int             { _, selected, _ := m.commits.View(); return selected }
+func (m Model) CommitScroll() int               { _, _, scroll := m.commits.View(); return scroll }
+func (m Model) Reflogs() []gitquery.ReflogEntry { reflogs, _, _ := m.reflogs.View(); return reflogs }
+func (m Model) ReflogSelected() int             { _, selected, _ := m.reflogs.View(); return selected }
+func (m Model) ReflogScroll() int               { _, _, scroll := m.reflogs.View(); return scroll }
 func (m Model) Overlay() ui.OverlayState        { return m.overlay }
 func (m Model) OverlayDiff() string             { return m.overlayDiff }
 func (m Model) OverlayScroll() int              { return m.overlayScroll }
@@ -76,27 +75,27 @@ func (m Model) ConfirmPrompt() string           { return m.confirmPrompt }
 func (m Model) ConfirmForce() bool              { return m.confirmForce }
 func (m Model) WorktreeInput() string           { return m.worktreeInput }
 func (m Model) WorktreeInputErr() string        { return m.worktreeInputErr }
-func (m Model) BranchScroll() int               { return m.branchScroll }
-func (m Model) RepoScroll() int                 { return m.repoScroll }
-func (m Model) StashScroll() int                { return m.stashScroll }
+func (m Model) BranchScroll() int               { _, _, scroll := m.rows.View(); return scroll }
+func (m Model) RepoScroll() int                 { _, _, scroll := m.repos.View(); return scroll }
+func (m Model) StashScroll() int                { _, _, scroll := m.stashes.View(); return scroll }
 func (m Model) ActivePane() int                 { return m.activePane }
 func (m Model) Destructive() bool               { return m.destructive }
 func (m Model) TransientError() string          { return m.transientError }
 func (m Model) SearchActive() bool              { return m.searchActive }
-func (m Model) RepoSearch() string              { return m.repoSearch }
-func (m Model) ItemSearch() string              { return m.itemSearch }
+func (m Model) RepoSearch() string              { return m.repos.Query() }
+func (m Model) ItemSearch() string              { return m.activeItemPaneQuery() }
 
 func (m Model) Init() tea.Cmd {
 	return m.fetchForMode()
 }
 
 func (m Model) View() string {
-	repos := m.filteredRepos()
-	worktrees := m.filteredWorktrees()
-	rows := m.filteredRows()
-	stashes := m.filteredStashes()
-	commits := m.filteredCommits()
-	reflogs := m.filteredReflogs()
+	repos, selected, repoScroll := m.repos.View()
+	worktrees, worktreeSelected, worktreeScroll := m.worktrees.View()
+	rows, branchSelected, branchScroll := m.rows.View()
+	stashes, stashSelected, stashScroll := m.stashes.View()
+	commits, commitSelected, commitScroll := m.commits.View()
+	reflogs, reflogSelected, reflogScroll := m.reflogs.View()
 	if len(repos) == 0 {
 		worktrees = nil
 		rows = nil
@@ -106,14 +105,14 @@ func (m Model) View() string {
 	}
 	return ui.Render(ui.RenderParams{
 		Repos:            repos,
-		Selected:         m.selected,
+		Selected:         selected,
 		Width:            m.width,
 		Height:           m.height,
 		Mode:             m.mode,
 		Branches:         rows,
 		Stashes:          stashes,
-		BranchSelected:   m.branchSelected,
-		StashSelected:    m.stashSelected,
+		BranchSelected:   branchSelected,
+		StashSelected:    stashSelected,
 		Overlay:          m.overlay,
 		OverlayDiff:      m.overlayDiff,
 		OverlayScroll:    m.overlayScroll,
@@ -121,24 +120,24 @@ func (m Model) View() string {
 		ConfirmForce:     m.confirmForce,
 		WorktreeInput:    m.worktreeInput,
 		WorktreeInputErr: m.worktreeInputErr,
-		BranchScroll:     m.branchScroll,
-		RepoScroll:       m.repoScroll,
-		StashScroll:      m.stashScroll,
+		BranchScroll:     branchScroll,
+		RepoScroll:       repoScroll,
+		StashScroll:      stashScroll,
 		ActivePane:       m.activePane,
 		Destructive:      m.destructive,
 		Worktrees:        worktrees,
-		WorktreeSelected: m.worktreeSelected,
-		WorktreeScroll:   m.worktreeScroll,
+		WorktreeSelected: worktreeSelected,
+		WorktreeScroll:   worktreeScroll,
 		Commits:          commits,
-		CommitSelected:   m.commitSelected,
-		CommitScroll:     m.commitScroll,
+		CommitSelected:   commitSelected,
+		CommitScroll:     commitScroll,
 		Reflogs:          reflogs,
-		ReflogSelected:   m.reflogSelected,
-		ReflogScroll:     m.reflogScroll,
+		ReflogSelected:   reflogSelected,
+		ReflogScroll:     reflogScroll,
 		TransientError:   m.transientError,
 		SearchActive:     m.searchActive,
-		RepoSearch:       m.repoSearch,
-		ItemSearch:       m.itemSearch,
+		RepoSearch:       m.repos.Query(),
+		ItemSearch:       m.activeItemPaneQuery(),
 		FetchAvailable:   m.canFetch(),
 		PullAvailable:    m.canPull(),
 	})
@@ -153,12 +152,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		m = m.ensureRepoVisible()
-		m = m.ensureBranchVisible()
-		m = m.ensureStashVisible()
-		m = m.ensureWorktreeVisible()
-		m = m.ensureCommitVisible()
-		m = m.ensureReflogVisible()
+		m = m.clampSelectionsAfterFilter()
 	case BranchResultMsg:
 		return m.handleBranchResult(msg), nil
 	case StashResultMsg:
@@ -233,55 +227,35 @@ func (m Model) selectedRow() (gitquery.BranchRow, bool) {
 	if _, ok := m.currentRepoPath(); !ok {
 		return gitquery.BranchRow{}, false
 	}
-	rows := m.filteredRows()
-	if m.branchSelected < 0 || m.branchSelected >= len(rows) {
-		return gitquery.BranchRow{}, false
-	}
-	return rows[m.branchSelected], true
+	return m.rows.Selected()
 }
 
 func (m Model) selectedWorktree() (gitquery.Worktree, bool) {
 	if _, ok := m.currentRepoPath(); !ok {
 		return gitquery.Worktree{}, false
 	}
-	worktrees := m.filteredWorktrees()
-	if m.worktreeSelected < 0 || m.worktreeSelected >= len(worktrees) {
-		return gitquery.Worktree{}, false
-	}
-	return worktrees[m.worktreeSelected], true
+	return m.worktrees.Selected()
 }
 
 func (m Model) selectedStash() (gitquery.Stash, bool) {
 	if _, ok := m.currentRepoPath(); !ok {
 		return gitquery.Stash{}, false
 	}
-	stashes := m.filteredStashes()
-	if m.stashSelected < 0 || m.stashSelected >= len(stashes) {
-		return gitquery.Stash{}, false
-	}
-	return stashes[m.stashSelected], true
+	return m.stashes.Selected()
 }
 
 func (m Model) selectedCommit() (gitquery.Commit, bool) {
 	if _, ok := m.currentRepoPath(); !ok {
 		return gitquery.Commit{}, false
 	}
-	commits := m.filteredCommits()
-	if m.commitSelected < 0 || m.commitSelected >= len(commits) {
-		return gitquery.Commit{}, false
-	}
-	return commits[m.commitSelected], true
+	return m.commits.Selected()
 }
 
 func (m Model) selectedReflog() (gitquery.ReflogEntry, bool) {
 	if _, ok := m.currentRepoPath(); !ok {
 		return gitquery.ReflogEntry{}, false
 	}
-	reflogs := m.filteredReflogs()
-	if m.reflogSelected < 0 || m.reflogSelected >= len(reflogs) {
-		return gitquery.ReflogEntry{}, false
-	}
-	return reflogs[m.reflogSelected], true
+	return m.reflogs.Selected()
 }
 
 func (m Model) isSelectedBranchDirtyWorktree() bool {
@@ -289,125 +263,65 @@ func (m Model) isSelectedBranchDirtyWorktree() bool {
 	return ok && row.Branch.Dirty && row.Branch.IsWorktree
 }
 
-func (m Model) ensureStashVisible() Model {
+func (m Model) reflowStashes() Model {
 	contentHeight := m.height - ui.StashContentOverhead
 	if contentHeight <= 0 {
 		contentHeight = 1
 	}
 	rightContentWidth := m.width - ui.LeftPaneWidth - 2
-	line := 0
-	for i, s := range m.filteredStashes() {
-		if i == m.stashSelected {
-			break
-		}
-		line += ui.StashLineCount(s.Message, rightContentWidth)
-	}
-	if m.stashScroll > line {
-		m.stashScroll = line
-	}
-	if line >= m.stashScroll+contentHeight {
-		m.stashScroll = line - contentHeight + 1
-	}
+	m.stashes = m.stashes.Reflow(contentHeight, rightContentWidth)
 	return m
 }
 
-func (m Model) ensureRepoVisible() Model {
+func (m Model) reflowRepos() Model {
 	contentHeight := m.height - ui.RepoContentOverhead
 	if contentHeight <= 0 {
 		contentHeight = 1
 	}
-	if len(m.filteredRepos()) == 0 {
-		m.repoScroll = 0
-		return m
-	}
-	if m.repoScroll > m.selected {
-		m.repoScroll = m.selected
-	}
-	if m.selected >= m.repoScroll+contentHeight {
-		m.repoScroll = m.selected - contentHeight + 1
-	}
+	m.repos = m.repos.Reflow(contentHeight, ui.LeftPaneWidth-2)
 	return m
 }
 
-func (m Model) ensureWorktreeVisible() Model {
+func (m Model) reflowWorktrees() Model {
 	contentHeight := m.height - ui.WorktreeContentOverhead
 	if contentHeight <= 0 {
 		contentHeight = 16
 	}
-	if len(m.filteredWorktrees()) == 0 {
-		m.worktreeScroll = 0
-		return m
-	}
-	if m.worktreeScroll > m.worktreeSelected {
-		m.worktreeScroll = m.worktreeSelected
-	}
-	if m.worktreeSelected >= m.worktreeScroll+contentHeight {
-		m.worktreeScroll = m.worktreeSelected - contentHeight + 1
-	}
+	m.worktrees = m.worktrees.Reflow(contentHeight, m.contentWidth())
 	return m
 }
 
-func (m Model) ensureReflogVisible() Model {
+func (m Model) reflowReflogs() Model {
 	contentHeight := m.height - ui.BranchContentOverhead
 	if contentHeight <= 0 {
 		contentHeight = 16
 	}
-	if len(m.filteredReflogs()) == 0 {
-		m.reflogScroll = 0
-		return m
-	}
-	if m.reflogScroll > m.reflogSelected {
-		m.reflogScroll = m.reflogSelected
-	}
-	if m.reflogSelected >= m.reflogScroll+contentHeight {
-		m.reflogScroll = m.reflogSelected - contentHeight + 1
-	}
+	m.reflogs = m.reflogs.Reflow(contentHeight, m.contentWidth())
 	return m
 }
 
-func (m Model) ensureCommitVisible() Model {
+func (m Model) reflowCommits() Model {
 	contentHeight := m.height - ui.BranchContentOverhead
 	if contentHeight <= 0 {
 		contentHeight = 16
 	}
-	if len(m.filteredCommits()) == 0 {
-		m.commitScroll = 0
-		return m
-	}
-	if m.commitScroll > m.commitSelected {
-		m.commitScroll = m.commitSelected
-	}
-	if m.commitSelected >= m.commitScroll+contentHeight {
-		m.commitScroll = m.commitSelected - contentHeight + 1
-	}
+	m.commits = m.commits.Reflow(contentHeight, m.contentWidth())
 	return m
 }
 
-func (m Model) ensureBranchVisible() Model {
+func (m Model) reflowBranches() Model {
 	contentHeight := m.height - ui.BranchContentOverhead
 	if contentHeight <= 0 {
 		contentHeight = 16
 	}
-	line := 0
-	for i, row := range m.filteredRows() {
-		if i == m.branchSelected {
-			break
-		}
-		line++
-		if !row.IsExpansion {
-			n := len(row.Branch.Unpushed)
-			if n > 5 {
-				line += 6
-			} else {
-				line += n
-			}
-		}
-	}
-	if m.branchScroll > line {
-		m.branchScroll = line
-	}
-	if line >= m.branchScroll+contentHeight {
-		m.branchScroll = line - contentHeight + 1
-	}
+	m.rows = m.rows.Reflow(contentHeight, m.contentWidth())
 	return m
+}
+
+func (m Model) contentWidth() int {
+	width := m.width - ui.LeftPaneWidth - 2
+	if width < 0 {
+		return 0
+	}
+	return width
 }

--- a/model/model.go
+++ b/model/model.go
@@ -48,26 +48,26 @@ func New(repos []scanner.Repo) Model {
 	return m
 }
 
-func (m Model) Selected() int              { _, selected, _ := m.repos.View(); return selected }
+func (m Model) Selected() int              { return m.repos.SelectedIndex() }
 func (m Model) Width() int                 { return m.width }
 func (m Model) Height() int                { return m.height }
 func (m Model) Mode() ui.Mode              { return m.mode }
 func (m Model) Rows() []gitquery.BranchRow { rows, _, _ := m.rows.View(); return rows }
 func (m Model) Stashes() []gitquery.Stash  { stashes, _, _ := m.stashes.View(); return stashes }
-func (m Model) BranchSelected() int        { _, selected, _ := m.rows.View(); return selected }
-func (m Model) StashSelected() int         { _, selected, _ := m.stashes.View(); return selected }
+func (m Model) BranchSelected() int        { return m.rows.SelectedIndex() }
+func (m Model) StashSelected() int         { return m.stashes.SelectedIndex() }
 func (m Model) Worktrees() []gitquery.Worktree {
 	worktrees, _, _ := m.worktrees.View()
 	return worktrees
 }
-func (m Model) WorktreeSelected() int           { _, selected, _ := m.worktrees.View(); return selected }
-func (m Model) WorktreeScroll() int             { _, _, scroll := m.worktrees.View(); return scroll }
+func (m Model) WorktreeSelected() int           { return m.worktrees.SelectedIndex() }
+func (m Model) WorktreeScroll() int             { return m.worktrees.Scroll() }
 func (m Model) Commits() []gitquery.Commit      { commits, _, _ := m.commits.View(); return commits }
-func (m Model) CommitSelected() int             { _, selected, _ := m.commits.View(); return selected }
-func (m Model) CommitScroll() int               { _, _, scroll := m.commits.View(); return scroll }
+func (m Model) CommitSelected() int             { return m.commits.SelectedIndex() }
+func (m Model) CommitScroll() int               { return m.commits.Scroll() }
 func (m Model) Reflogs() []gitquery.ReflogEntry { reflogs, _, _ := m.reflogs.View(); return reflogs }
-func (m Model) ReflogSelected() int             { _, selected, _ := m.reflogs.View(); return selected }
-func (m Model) ReflogScroll() int               { _, _, scroll := m.reflogs.View(); return scroll }
+func (m Model) ReflogSelected() int             { return m.reflogs.SelectedIndex() }
+func (m Model) ReflogScroll() int               { return m.reflogs.Scroll() }
 func (m Model) Overlay() ui.OverlayState        { return m.overlay }
 func (m Model) OverlayDiff() string             { return m.overlayDiff }
 func (m Model) OverlayScroll() int              { return m.overlayScroll }
@@ -75,9 +75,9 @@ func (m Model) ConfirmPrompt() string           { return m.confirmPrompt }
 func (m Model) ConfirmForce() bool              { return m.confirmForce }
 func (m Model) WorktreeInput() string           { return m.worktreeInput }
 func (m Model) WorktreeInputErr() string        { return m.worktreeInputErr }
-func (m Model) BranchScroll() int               { _, _, scroll := m.rows.View(); return scroll }
-func (m Model) RepoScroll() int                 { _, _, scroll := m.repos.View(); return scroll }
-func (m Model) StashScroll() int                { _, _, scroll := m.stashes.View(); return scroll }
+func (m Model) BranchScroll() int               { return m.rows.Scroll() }
+func (m Model) RepoScroll() int                 { return m.repos.Scroll() }
+func (m Model) StashScroll() int                { return m.stashes.Scroll() }
 func (m Model) ActivePane() int                 { return m.activePane }
 func (m Model) Destructive() bool               { return m.destructive }
 func (m Model) TransientError() string          { return m.transientError }

--- a/model/model_filter.go
+++ b/model/model_filter.go
@@ -3,222 +3,182 @@ package model
 import (
 	"fmt"
 	"strings"
-	"unicode"
 
 	"github.com/brian-bell/wtui/gitquery"
+	"github.com/brian-bell/wtui/model/pane"
 	"github.com/brian-bell/wtui/scanner"
 	"github.com/brian-bell/wtui/ui"
 )
 
+func fixedHeight[T any](T, int) int {
+	return 1
+}
+
+func newRepoPane() pane.Pane[scanner.Repo] {
+	return pane.New(func(repo scanner.Repo) string {
+		return repo.DisplayName + " " + repo.Path
+	}, fixedHeight[scanner.Repo])
+}
+
+func newWorktreePane() pane.Pane[gitquery.Worktree] {
+	return pane.New(func(wt gitquery.Worktree) string {
+		return strings.Join([]string{wt.BranchName, wt.Path, wt.LockReason}, " ")
+	}, fixedHeight[gitquery.Worktree])
+}
+
+func newBranchPane() pane.Pane[gitquery.BranchRow] {
+	return pane.New(branchSearchText, func(row gitquery.BranchRow, _ int) int {
+		if row.IsExpansion {
+			return 1
+		}
+		n := len(row.Branch.Unpushed)
+		if n > 5 {
+			n = 6
+		}
+		return 1 + n
+	})
+}
+
+func newStashPane() pane.Pane[gitquery.Stash] {
+	return pane.New(func(stash gitquery.Stash) string {
+		return fmt.Sprintf("stash@{%d} %s %s", stash.Index, stash.Date, stash.Message)
+	}, func(stash gitquery.Stash, width int) int {
+		return ui.StashLineCount(stash.Message, width)
+	})
+}
+
+func newCommitPane() pane.Pane[gitquery.Commit] {
+	return pane.New(func(commit gitquery.Commit) string {
+		return strings.Join([]string{commit.Hash, commit.Author, commit.Date, commit.Subject}, " ")
+	}, fixedHeight[gitquery.Commit])
+}
+
+func newReflogPane() pane.Pane[gitquery.ReflogEntry] {
+	return pane.New(func(entry gitquery.ReflogEntry) string {
+		return strings.Join([]string{entry.Hash, entry.Selector, entry.Date, entry.Subject}, " ")
+	}, fixedHeight[gitquery.ReflogEntry])
+}
+
 func (m Model) activeSearchQuery() string {
 	if m.activePane == 0 {
-		return m.repoSearch
+		return m.repos.Query()
 	}
-	return m.itemSearch
+	return m.activeItemPaneQuery()
+}
+
+func (m Model) activeItemPaneQuery() string {
+	switch m.mode {
+	case ui.ModeWorktrees:
+		return m.worktrees.Query()
+	case ui.ModeBranches:
+		return m.rows.Query()
+	case ui.ModeStashes:
+		return m.stashes.Query()
+	case ui.ModeHistory:
+		return m.commits.Query()
+	case ui.ModeReflog:
+		return m.reflogs.Query()
+	default:
+		return ""
+	}
 }
 
 func (m Model) setActiveSearchQuery(query string) Model {
 	if m.activePane == 0 {
-		m.repoSearch = query
-		m.selected = 0
-		m.repoScroll = 0
-		return m
+		m.repos = m.repos.SetQuery(query)
+		return m.reflowRepos()
 	}
 
-	m.itemSearch = query
+	m.worktrees = m.worktrees.SetQueryPreserveIndex(query)
+	m.rows = m.rows.SetQueryPreserveIndex(query)
+	m.stashes = m.stashes.SetQueryPreserveIndex(query)
+	m.commits = m.commits.SetQueryPreserveIndex(query)
+	m.reflogs = m.reflogs.SetQueryPreserveIndex(query)
+
 	switch m.mode {
 	case ui.ModeWorktrees:
-		m.worktreeSelected = 0
-		m.worktreeScroll = 0
+		m.worktrees = m.worktrees.SetQuery(query)
+		m = m.reflowWorktrees()
 	case ui.ModeBranches:
-		m.branchSelected = 0
-		m.branchScroll = 0
+		m.rows = m.rows.SetQuery(query)
+		m = m.reflowBranches()
 	case ui.ModeStashes:
-		m.stashSelected = 0
-		m.stashScroll = 0
+		m.stashes = m.stashes.SetQuery(query)
+		m = m.reflowStashes()
 	case ui.ModeHistory:
-		m.commitSelected = 0
-		m.commitScroll = 0
+		m.commits = m.commits.SetQuery(query)
+		m = m.reflowCommits()
 	case ui.ModeReflog:
-		m.reflogSelected = 0
-		m.reflogScroll = 0
+		m.reflogs = m.reflogs.SetQuery(query)
+		m = m.reflowReflogs()
 	}
 	return m
 }
 
 func (m Model) clampSelectionsAfterFilter() Model {
-	repos := m.filteredRepos()
-	if len(repos) == 0 {
-		m.selected = 0
-		m.repoScroll = 0
-	} else if m.selected >= len(repos) {
-		m.selected = len(repos) - 1
-	}
-
-	m.worktreeSelected = clampIndex(m.worktreeSelected, len(m.filteredWorktrees()))
-	m.branchSelected = clampIndex(m.branchSelected, len(m.filteredRows()))
-	m.stashSelected = clampIndex(m.stashSelected, len(m.filteredStashes()))
-	m.commitSelected = clampIndex(m.commitSelected, len(m.filteredCommits()))
-	m.reflogSelected = clampIndex(m.reflogSelected, len(m.filteredReflogs()))
-
-	m = m.ensureRepoVisible()
-	m = m.ensureWorktreeVisible()
-	m = m.ensureBranchVisible()
-	m = m.ensureStashVisible()
-	m = m.ensureCommitVisible()
-	m = m.ensureReflogVisible()
+	m = m.reflowRepos()
+	m = m.reflowWorktrees()
+	m = m.reflowBranches()
+	m = m.reflowStashes()
+	m = m.reflowCommits()
+	m = m.reflowReflogs()
 	return m
 }
 
 func (m Model) selectFilteredRepo(repoPath string) Model {
-	for i, repo := range m.filteredRepos() {
-		if repo.Path == repoPath {
-			m.selected = i
-			return m
-		}
-	}
-	return m
-}
-
-func clampIndex(index, length int) int {
-	if length <= 0 || index < 0 {
-		return 0
-	}
-	if index >= length {
-		return length - 1
-	}
-	return index
+	m.repos = m.repos.SelectFunc(func(repo scanner.Repo) bool {
+		return repo.Path == repoPath
+	})
+	return m.reflowRepos()
 }
 
 func (m Model) filteredRepos() []scanner.Repo {
-	if m.repoSearch == "" {
-		return m.repos
-	}
-	var filtered []scanner.Repo
-	for _, repo := range m.repos {
-		if fuzzyMatch(m.repoSearch, repo.DisplayName+" "+repo.Path) {
-			filtered = append(filtered, repo)
-		}
-	}
-	return filtered
+	repos, _, _ := m.repos.View()
+	return repos
 }
 
 func (m Model) filteredRows() []gitquery.BranchRow {
 	if len(m.filteredRepos()) == 0 {
 		return nil
 	}
-	if m.itemSearch == "" {
-		return m.rows
-	}
-	var filtered []gitquery.BranchRow
-	for _, row := range m.rows {
-		if fuzzyMatch(m.itemSearch, branchSearchText(row)) {
-			filtered = append(filtered, row)
-		}
-	}
-	return filtered
+	rows, _, _ := m.rows.View()
+	return rows
 }
 
 func (m Model) filteredStashes() []gitquery.Stash {
 	if len(m.filteredRepos()) == 0 {
 		return nil
 	}
-	if m.itemSearch == "" {
-		return m.stashes
-	}
-	var filtered []gitquery.Stash
-	for _, stash := range m.stashes {
-		if fuzzyMatch(m.itemSearch, fmt.Sprintf("stash@{%d} %s %s", stash.Index, stash.Date, stash.Message)) {
-			filtered = append(filtered, stash)
-		}
-	}
-	return filtered
+	stashes, _, _ := m.stashes.View()
+	return stashes
 }
 
 func (m Model) filteredWorktrees() []gitquery.Worktree {
 	if len(m.filteredRepos()) == 0 {
 		return nil
 	}
-	if m.itemSearch == "" {
-		return m.worktrees
-	}
-	var filtered []gitquery.Worktree
-	for _, wt := range m.worktrees {
-		if fuzzyMatch(m.itemSearch, strings.Join([]string{wt.BranchName, wt.Path, wt.LockReason}, " ")) {
-			filtered = append(filtered, wt)
-		}
-	}
-	return filtered
+	worktrees, _, _ := m.worktrees.View()
+	return worktrees
 }
 
 func (m Model) filteredCommits() []gitquery.Commit {
 	if len(m.filteredRepos()) == 0 {
 		return nil
 	}
-	if m.itemSearch == "" {
-		return m.commits
-	}
-	var filtered []gitquery.Commit
-	for _, commit := range m.commits {
-		if fuzzyMatch(m.itemSearch, strings.Join([]string{commit.Hash, commit.Author, commit.Date, commit.Subject}, " ")) {
-			filtered = append(filtered, commit)
-		}
-	}
-	return filtered
+	commits, _, _ := m.commits.View()
+	return commits
 }
 
 func (m Model) filteredReflogs() []gitquery.ReflogEntry {
 	if len(m.filteredRepos()) == 0 {
 		return nil
 	}
-	if m.itemSearch == "" {
-		return m.reflogs
-	}
-	var filtered []gitquery.ReflogEntry
-	for _, entry := range m.reflogs {
-		if fuzzyMatch(m.itemSearch, strings.Join([]string{entry.Hash, entry.Selector, entry.Date, entry.Subject}, " ")) {
-			filtered = append(filtered, entry)
-		}
-	}
-	return filtered
+	reflogs, _, _ := m.reflogs.View()
+	return reflogs
 }
 
 func branchSearchText(row gitquery.BranchRow) string {
 	parts := []string{row.Branch.Name, row.WorktreePath}
 	parts = append(parts, row.Branch.Unpushed...)
 	return strings.Join(parts, " ")
-}
-
-func fuzzyMatch(query, target string) bool {
-	query = strings.TrimSpace(query)
-	if query == "" {
-		return true
-	}
-
-	if fuzzyMatchRunes(query, target) {
-		return true
-	}
-
-	tokens := strings.FieldsFunc(query, func(r rune) bool { return unicode.IsSpace(r) })
-	if len(tokens) <= 1 {
-		return false
-	}
-	for _, token := range tokens {
-		if !fuzzyMatchRunes(token, target) {
-			return false
-		}
-	}
-	return true
-}
-
-func fuzzyMatchRunes(query, target string) bool {
-	q := []rune(strings.ToLower(query))
-	t := []rune(strings.ToLower(target))
-	next := 0
-	for _, r := range t {
-		if next < len(q) && q[next] == r {
-			next++
-		}
-	}
-	return next == len(q)
 }

--- a/model/model_filter.go
+++ b/model/model_filter.go
@@ -137,14 +137,6 @@ func (m Model) filteredRepos() []scanner.Repo {
 	return repos
 }
 
-func (m Model) filteredRows() []gitquery.BranchRow {
-	if len(m.filteredRepos()) == 0 {
-		return nil
-	}
-	rows, _, _ := m.rows.View()
-	return rows
-}
-
 func (m Model) filteredStashes() []gitquery.Stash {
 	if len(m.filteredRepos()) == 0 {
 		return nil

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -158,26 +158,14 @@ func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 	case "tab":
 		m.activePane = 1
 	case "up", "k":
-		repos := m.filteredRepos()
-		if len(repos) > 0 {
-			if m.selected > 0 {
-				m.selected--
-			} else {
-				m.selected = len(repos) - 1
-			}
-			m = m.ensureRepoVisible()
+		if len(m.filteredRepos()) > 0 {
+			m.repos = m.repos.Move(-1, m.repoContentHeight(), ui.LeftPaneWidth-2)
 			m = m.resetRightPaneCursors()
 			return m, m.fetchForMode()
 		}
 	case "down", "j":
-		repos := m.filteredRepos()
-		if len(repos) > 0 {
-			if m.selected < len(repos)-1 {
-				m.selected++
-			} else {
-				m.selected = 0
-			}
-			m = m.ensureRepoVisible()
+		if len(m.filteredRepos()) > 0 {
+			m.repos = m.repos.Move(1, m.repoContentHeight(), ui.LeftPaneWidth-2)
 			m = m.resetRightPaneCursors()
 			return m, m.fetchForMode()
 		}
@@ -291,34 +279,21 @@ func (m Model) handleCursorDown() (tea.Model, tea.Cmd) {
 	return m.moveCursor(1), nil
 }
 
-// moveItemCursor advances a cursor by delta within [0,count), wrapping around
-// at both ends. When there are no items it leaves the cursor unchanged.
-func moveItemCursor(selected, count, delta int) int {
-	if count <= 0 {
-		return selected
-	}
-	return ((selected+delta)%count + count) % count
-}
-
 // moveCursor moves the selected item in the active right-pane view by delta
 // (-1 for up, +1 for down) and keeps the new selection visible.
 func (m Model) moveCursor(delta int) Model {
+	h, w := m.contentHeightForMode(), m.contentWidth()
 	switch m.mode {
 	case ui.ModeWorktrees:
-		m.worktreeSelected = moveItemCursor(m.worktreeSelected, len(m.filteredWorktrees()), delta)
-		m = m.ensureWorktreeVisible()
+		m.worktrees = m.worktrees.Move(delta, h, w)
 	case ui.ModeBranches:
-		m.branchSelected = moveItemCursor(m.branchSelected, len(m.filteredRows()), delta)
-		m = m.ensureBranchVisible()
+		m.rows = m.rows.Move(delta, h, w)
 	case ui.ModeStashes:
-		m.stashSelected = moveItemCursor(m.stashSelected, len(m.filteredStashes()), delta)
-		m = m.ensureStashVisible()
+		m.stashes = m.stashes.Move(delta, h, w)
 	case ui.ModeHistory:
-		m.commitSelected = moveItemCursor(m.commitSelected, len(m.filteredCommits()), delta)
-		m = m.ensureCommitVisible()
+		m.commits = m.commits.Move(delta, h, w)
 	case ui.ModeReflog:
-		m.reflogSelected = moveItemCursor(m.reflogSelected, len(m.filteredReflogs()), delta)
-		m = m.ensureReflogVisible()
+		m.reflogs = m.reflogs.Move(delta, h, w)
 	}
 	return m
 }
@@ -649,32 +624,61 @@ func (m Model) clearWorktreeInput() Model {
 // is intentionally preserved across mode switches so users can inspect another
 // pane and return to the same selected worktree.
 func (m Model) resetModeCursors() Model {
-	m.branchSelected = 0
-	m.branchScroll = 0
-	m.stashSelected = 0
-	m.stashScroll = 0
-	m.commitSelected = 0
-	m.commitScroll = 0
-	m.reflogSelected = 0
-	m.reflogScroll = 0
+	m.rows = m.rows.ResetSelection()
+	m.stashes = m.stashes.ResetSelection()
+	m.commits = m.commits.ResetSelection()
+	m.reflogs = m.reflogs.ResetSelection()
 	return m
 }
 
 func (m Model) resetRightPaneCursors() Model {
-	m.branchSelected = 0
-	m.stashSelected = 0
-	m.branchScroll = 0
-	m.stashScroll = 0
-	m.worktreeSelected = 0
-	m.worktreeScroll = 0
-	m.commitSelected = 0
-	m.commitScroll = 0
-	m.reflogSelected = 0
-	m.reflogScroll = 0
-	m.rows = nil
-	m.stashes = nil
-	m.worktrees = nil
-	m.commits = nil
-	m.reflogs = nil
+	m.rows = m.rows.SetItems(nil).ResetSelection()
+	m.stashes = m.stashes.SetItems(nil).ResetSelection()
+	m.worktrees = m.worktrees.SetItems(nil).ResetSelection()
+	m.commits = m.commits.SetItems(nil).ResetSelection()
+	m.reflogs = m.reflogs.SetItems(nil).ResetSelection()
 	return m
+}
+
+func (m Model) repoContentHeight() int {
+	height := m.height - ui.RepoContentOverhead
+	if height <= 0 {
+		return 1
+	}
+	return height
+}
+
+func (m Model) rightContentHeight() int {
+	height := m.height - ui.BranchContentOverhead
+	if height <= 0 {
+		return 16
+	}
+	return height
+}
+
+func (m Model) contentHeightForMode() int {
+	switch m.mode {
+	case ui.ModeWorktrees:
+		return m.worktreeContentHeight()
+	case ui.ModeStashes:
+		return m.stashContentHeight()
+	default:
+		return m.rightContentHeight()
+	}
+}
+
+func (m Model) worktreeContentHeight() int {
+	height := m.height - ui.WorktreeContentOverhead
+	if height <= 0 {
+		return 16
+	}
+	return height
+}
+
+func (m Model) stashContentHeight() int {
+	height := m.height - ui.StashContentOverhead
+	if height <= 0 {
+		return 1
+	}
+	return height
 }

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -166,11 +166,11 @@ type ActionFailedMsg struct {
 // --- Message handlers ---
 
 func (m Model) currentRepoPath() (string, bool) {
-	repos := m.filteredRepos()
-	if len(repos) == 0 || m.selected >= len(repos) {
+	repo, ok := m.repos.Selected()
+	if !ok {
 		return "", false
 	}
-	return repos[m.selected].Path, true
+	return repo.Path, true
 }
 
 func (m Model) isCurrentRepo(repoPath string) bool {
@@ -180,7 +180,7 @@ func (m Model) isCurrentRepo(repoPath string) bool {
 
 func (m Model) handleWorktreeResult(msg WorktreeResultMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.worktrees = msg.Worktrees
+		m.worktrees = m.worktrees.SetItems(msg.Worktrees)
 		m = m.clampSelectionsAfterFilter()
 	}
 	return m
@@ -190,8 +190,8 @@ func (m Model) handleWorktreeRemoved(msg WorktreeRemovedMsg) (tea.Model, tea.Cmd
 	if !m.isCurrentRepo(msg.RepoPath) {
 		return m, nil
 	}
-	if m.worktreeSelected >= len(m.worktrees)-1 && m.worktreeSelected > 0 {
-		m.worktreeSelected--
+	if m.WorktreeSelected() >= len(m.Worktrees())-1 && m.WorktreeSelected() > 0 {
+		m.worktrees = m.worktrees.Move(-1, m.worktreeContentHeight(), m.contentWidth())
 	}
 	if msg.BranchName == "" {
 		return m, m.fetchWorktrees()
@@ -218,8 +218,8 @@ func (m Model) handleWorktreeRemoved(msg WorktreeRemovedMsg) (tea.Model, tea.Cmd
 
 func (m Model) handleWorktreePruned(msg WorktreePrunedMsg) (tea.Model, tea.Cmd) {
 	if m.isCurrentRepo(msg.RepoPath) {
-		if m.worktreeSelected >= len(m.worktrees)-1 && m.worktreeSelected > 0 {
-			m.worktreeSelected--
+		if m.WorktreeSelected() >= len(m.Worktrees())-1 && m.WorktreeSelected() > 0 {
+			m.worktrees = m.worktrees.Move(-1, m.worktreeContentHeight(), m.contentWidth())
 		}
 		return m, m.fetchWorktrees()
 	}
@@ -276,8 +276,7 @@ func (m Model) handleWorktreeCreated(msg WorktreeCreatedMsg) (tea.Model, tea.Cmd
 		return m, nil
 	}
 	m.mode = ui.ModeWorktrees
-	m.worktreeSelected = 0
-	m.worktreeScroll = 0
+	m.worktrees = m.worktrees.ResetSelection()
 	return m, m.fetchWorktrees()
 }
 
@@ -315,7 +314,7 @@ func (m Model) handleBranchResult(msg BranchResultMsg) Model {
 				break
 			}
 		}
-		m.rows = filtered
+		m.rows = m.rows.SetItems(filtered)
 		m = m.clampSelectionsAfterFilter()
 	}
 	return m
@@ -323,7 +322,7 @@ func (m Model) handleBranchResult(msg BranchResultMsg) Model {
 
 func (m Model) handleStashResult(msg StashResultMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.stashes = msg.Stashes
+		m.stashes = m.stashes.SetItems(msg.Stashes)
 		m = m.clampSelectionsAfterFilter()
 	}
 	return m
@@ -356,8 +355,8 @@ func (m Model) handleBranchDiffResult(msg BranchDiffResultMsg) Model {
 
 func (m Model) handleStashDropped(msg StashDroppedMsg) (tea.Model, tea.Cmd) {
 	if m.isCurrentRepo(msg.RepoPath) {
-		if m.stashSelected >= len(m.stashes)-1 && m.stashSelected > 0 {
-			m.stashSelected--
+		if m.StashSelected() >= len(m.Stashes())-1 && m.StashSelected() > 0 {
+			m.stashes = m.stashes.Move(-1, m.stashContentHeight(), m.contentWidth())
 		}
 		return m, m.fetchStashes()
 	}
@@ -426,7 +425,7 @@ func (m Model) handleActionFailed(msg ActionFailedMsg) Model {
 
 func (m Model) handleCommitResult(msg CommitResultMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.commits = msg.Commits
+		m.commits = m.commits.SetItems(msg.Commits)
 		m = m.clampSelectionsAfterFilter()
 	}
 	return m
@@ -434,7 +433,7 @@ func (m Model) handleCommitResult(msg CommitResultMsg) Model {
 
 func (m Model) handleReflogResult(msg ReflogResultMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.reflogs = msg.Reflogs
+		m.reflogs = m.reflogs.SetItems(msg.Reflogs)
 		m = m.clampSelectionsAfterFilter()
 	}
 	return m

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -603,6 +603,86 @@ func TestModel_BackspaceOnEmptyItemFilterInputClearsFilter(t *testing.T) {
 	}
 }
 
+func TestModel_RightPaneSearchIsSharedAcrossModesAndEscapeClearsIt(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: []gitquery.Branch{
+		{Name: "main"},
+		{Name: "feature/auth"},
+		{Name: "bugfix"},
+	}})
+	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: []gitquery.Stash{
+		{Index: 0, Date: "2026-03-18", Message: "feature auth work"},
+		{Index: 1, Date: "2026-03-18", Message: "bugfix stash"},
+	}})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	for _, r := range []rune("work") {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	if m.ItemSearch() != "work" {
+		t.Fatalf("expected right-pane search to remain work after mode switch, got %q", m.ItemSearch())
+	}
+	stashes := m.Stashes()
+	if len(stashes) != 1 || stashes[0].Message != "feature auth work" {
+		t.Fatalf("expected shared filter to leave only feature auth work stash, got %#v", stashes)
+	}
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd != nil {
+		t.Fatalf("expected esc to clear right-pane search without quitting, got %T", cmd)
+	}
+	if m.ItemSearch() != "" || m.SearchActive() {
+		t.Fatalf("expected right-pane filter cleared and inactive, got query=%q active=%v", m.ItemSearch(), m.SearchActive())
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	view := m.View()
+	for _, name := range []string{"main", "feature/auth", "bugfix"} {
+		if !strings.Contains(view, name) {
+			t.Fatalf("clearing shared filter should restore branch %s", name)
+		}
+	}
+}
+
+func TestModel_RightPaneFilterAppliesToAsyncReplacement(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: []gitquery.Branch{
+		{Name: "feature/auth"},
+		{Name: "bugfix"},
+	}})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	for _, r := range []rune("api") {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: []gitquery.Branch{
+		{Name: "feature/api"},
+		{Name: "release"},
+		{Name: "bugfix"},
+	}})
+
+	if m.ItemSearch() != "api" {
+		t.Fatalf("expected async replacement to keep item search api, got %q", m.ItemSearch())
+	}
+	view := m.View()
+	if !strings.Contains(view, "feature/api") {
+		t.Fatal("active filter should apply to replacement branch result")
+	}
+	for _, name := range []string{"release", "bugfix"} {
+		if strings.Contains(view, name) {
+			t.Fatalf("active filter should hide replacement branch %s", name)
+		}
+	}
+	if m.BranchSelected() != 0 {
+		t.Fatalf("expected filtered replacement to clamp selection to top, got %d", m.BranchSelected())
+	}
+}
+
 // --- Right pane navigation ---
 
 func TestModel_RightPaneUpDownDoesNotMoveRepoSelection(t *testing.T) {
@@ -874,6 +954,27 @@ func TestModel_StashScrollAccountsForLongMessages(t *testing.T) {
 	// Scroll should have advanced since stash 2 starts at line 4, viewport is only 3 lines
 	if m.StashScroll() == 0 {
 		t.Error("expected scroll to advance for long-message stashes")
+	}
+}
+
+func TestModel_StashCursorUsesStashViewportAtTinyHeight(t *testing.T) {
+	stashes := []gitquery.Stash{
+		{Index: 0, Date: "2026-03-18", Message: "first"},
+		{Index: 1, Date: "2026-03-18", Message: "second"},
+		{Index: 2, Date: "2026-03-18", Message: "third"},
+	}
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: ui.StashContentOverhead})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: stashes})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.StashSelected() != 1 {
+		t.Fatalf("expected stash cursor at 1, got %d", m.StashSelected())
+	}
+	if m.StashScroll() != 1 {
+		t.Fatalf("expected one-line stash viewport to scroll to 1, got %d", m.StashScroll())
 	}
 }
 

--- a/model/pane/pane.go
+++ b/model/pane/pane.go
@@ -175,16 +175,8 @@ func (p Pane[T]) clampScroll(viewHeight, width int) Pane[T] {
 	if viewHeight <= 0 {
 		viewHeight = 1
 	}
-	maxScroll := p.totalHeight(width) - viewHeight
-	if maxScroll < 0 {
-		maxScroll = 0
-	}
-	if p.scroll < 0 {
-		p.scroll = 0
-	}
-	if p.scroll > maxScroll {
-		p.scroll = maxScroll
-	}
+	maxScroll := max(p.totalHeight(width)-viewHeight, 0)
+	p.scroll = min(max(p.scroll, 0), maxScroll)
 	return p
 }
 

--- a/model/pane/pane.go
+++ b/model/pane/pane.go
@@ -96,6 +96,16 @@ func (p Pane[T]) Len() int {
 	return len(p.filtered)
 }
 
+// SelectedIndex returns the cursor position within the filtered view.
+func (p Pane[T]) SelectedIndex() int {
+	return p.selected
+}
+
+// Scroll returns the current visual-line scroll offset.
+func (p Pane[T]) Scroll() int {
+	return p.scroll
+}
+
 // Query returns the active fuzzy filter query.
 func (p Pane[T]) Query() string {
 	return p.query

--- a/model/pane/pane.go
+++ b/model/pane/pane.go
@@ -1,0 +1,232 @@
+package pane
+
+import (
+	"strings"
+	"unicode"
+)
+
+// SearchText returns the haystack one item is fuzzy-matched against.
+type SearchText[T any] func(item T) string
+
+// ItemHeight returns how many visual lines an item occupies at a given content
+// width.
+type ItemHeight[T any] func(item T, width int) int
+
+// Pane is a filtered, scrollable, single-selection list. It is a value type:
+// mutators return a new Pane.
+type Pane[T any] struct {
+	items    []T
+	filtered []T
+	selected int
+	scroll   int
+	query    string
+	search   SearchText[T]
+	height   ItemHeight[T]
+}
+
+// New creates an empty Pane.
+func New[T any](search SearchText[T], height ItemHeight[T]) Pane[T] {
+	return Pane[T]{search: search, height: height}
+}
+
+// SetItems replaces the source items and refreshes the filtered view.
+func (p Pane[T]) SetItems(items []T) Pane[T] {
+	p.items = items
+	p = p.refilter()
+	p = p.clamp()
+	return p
+}
+
+// SetQuery updates the fuzzy filter query and resets selection to the top.
+func (p Pane[T]) SetQuery(q string) Pane[T] {
+	p.query = q
+	p.selected = 0
+	p.scroll = 0
+	p = p.refilter()
+	return p.clamp()
+}
+
+// SetQueryPreserveIndex updates the fuzzy filter query while keeping the
+// current cursor index when it still fits the new filtered view.
+func (p Pane[T]) SetQueryPreserveIndex(q string) Pane[T] {
+	p.query = q
+	p = p.refilter()
+	return p.clamp()
+}
+
+// Move advances the selection by delta, wrapping around, and keeps it visible.
+func (p Pane[T]) Move(delta, viewHeight, viewWidth int) Pane[T] {
+	if len(p.filtered) == 0 {
+		return p
+	}
+	p.selected = ((p.selected+delta)%len(p.filtered) + len(p.filtered)) % len(p.filtered)
+	return p.Reflow(viewHeight, viewWidth)
+}
+
+// SelectFunc selects the first filtered item matching pred.
+func (p Pane[T]) SelectFunc(pred func(T) bool) Pane[T] {
+	for i, item := range p.filtered {
+		if pred(item) {
+			p.selected = i
+			return p
+		}
+	}
+	return p
+}
+
+// ResetSelection moves the cursor and scroll offset to the top without
+// changing items or query.
+func (p Pane[T]) ResetSelection() Pane[T] {
+	p.selected = 0
+	p.scroll = 0
+	return p.clamp()
+}
+
+// Selected returns the selected filtered item.
+func (p Pane[T]) Selected() (T, bool) {
+	var zero T
+	if p.selected < 0 || p.selected >= len(p.filtered) {
+		return zero, false
+	}
+	return p.filtered[p.selected], true
+}
+
+// Len returns the number of filtered items.
+func (p Pane[T]) Len() int {
+	return len(p.filtered)
+}
+
+// Query returns the active fuzzy filter query.
+func (p Pane[T]) Query() string {
+	return p.query
+}
+
+// Reflow keeps the selected item visible for the current viewport dimensions.
+func (p Pane[T]) Reflow(viewHeight, viewWidth int) Pane[T] {
+	if viewHeight <= 0 {
+		viewHeight = 1
+	}
+	if len(p.filtered) == 0 {
+		p.scroll = 0
+		return p
+	}
+
+	line := 0
+	for i, item := range p.filtered {
+		if i == p.selected {
+			break
+		}
+		line += p.itemHeight(item, viewWidth)
+	}
+	if p.scroll > line {
+		p.scroll = line
+	}
+	if line >= p.scroll+viewHeight {
+		p.scroll = line - viewHeight + 1
+	}
+	return p.clampScroll(viewHeight, viewWidth)
+}
+
+// View returns the filtered items, selected index, and visual line scroll.
+func (p Pane[T]) View() ([]T, int, int) {
+	return p.filtered, p.selected, p.scroll
+}
+
+func (p Pane[T]) refilter() Pane[T] {
+	if strings.TrimSpace(p.query) == "" {
+		p.filtered = p.items
+		return p
+	}
+	p.filtered = nil
+	for _, item := range p.items {
+		if p.search != nil && fuzzyMatch(p.query, p.search(item)) {
+			p.filtered = append(p.filtered, item)
+		}
+	}
+	return p
+}
+
+func (p Pane[T]) clamp() Pane[T] {
+	if len(p.filtered) == 0 {
+		p.selected = 0
+		p.scroll = 0
+		return p
+	}
+	if p.selected < 0 {
+		p.selected = 0
+	}
+	if p.selected >= len(p.filtered) {
+		p.selected = len(p.filtered) - 1
+	}
+	return p.clampScroll(1, 0)
+}
+
+func (p Pane[T]) clampScroll(viewHeight, width int) Pane[T] {
+	if viewHeight <= 0 {
+		viewHeight = 1
+	}
+	maxScroll := p.totalHeight(width) - viewHeight
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if p.scroll < 0 {
+		p.scroll = 0
+	}
+	if p.scroll > maxScroll {
+		p.scroll = maxScroll
+	}
+	return p
+}
+
+func (p Pane[T]) totalHeight(width int) int {
+	total := 0
+	for _, item := range p.filtered {
+		total += p.itemHeight(item, width)
+	}
+	return total
+}
+
+func (p Pane[T]) itemHeight(item T, width int) int {
+	if p.height == nil {
+		return 1
+	}
+	height := p.height(item, width)
+	if height < 1 {
+		return 1
+	}
+	return height
+}
+
+func fuzzyMatch(query, target string) bool {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return true
+	}
+
+	if fuzzyMatchRunes(query, target) {
+		return true
+	}
+
+	tokens := strings.FieldsFunc(query, func(r rune) bool { return unicode.IsSpace(r) })
+	if len(tokens) <= 1 {
+		return false
+	}
+	for _, token := range tokens {
+		if !fuzzyMatchRunes(token, target) {
+			return false
+		}
+	}
+	return true
+}
+
+func fuzzyMatchRunes(query, target string) bool {
+	q := []rune(strings.ToLower(query))
+	t := []rune(strings.ToLower(target))
+	next := 0
+	for _, r := range t {
+		if next < len(q) && q[next] == r {
+			next++
+		}
+	}
+	return next == len(q)
+}

--- a/model/pane/pane_test.go
+++ b/model/pane/pane_test.go
@@ -1,0 +1,239 @@
+package pane
+
+import "testing"
+
+type testItem struct {
+	name  string
+	lines int
+}
+
+func fixedTestPane(items []testItem) Pane[testItem] {
+	return New(func(item testItem) string {
+		return item.name
+	}, func(testItem, int) int {
+		return 1
+	}).SetItems(items)
+}
+
+func TestPaneMoveWrapsAndKeepsFixedHeightSelectionVisible(t *testing.T) {
+	items := []testItem{
+		{name: "one"},
+		{name: "two"},
+		{name: "three"},
+		{name: "four"},
+	}
+	p := fixedTestPane(items)
+
+	p = p.Move(-1, 2, 80)
+	_, selected, scroll := p.View()
+	if selected != 3 {
+		t.Fatalf("expected selection to wrap to 3, got %d", selected)
+	}
+	if scroll != 2 {
+		t.Fatalf("expected scroll to show wrapped selection, got %d", scroll)
+	}
+
+	p = p.Move(1, 2, 80)
+	_, selected, scroll = p.View()
+	if selected != 0 {
+		t.Fatalf("expected selection to wrap to 0, got %d", selected)
+	}
+	if scroll != 0 {
+		t.Fatalf("expected scroll to return to top, got %d", scroll)
+	}
+}
+
+func TestPaneQueryFiltersWithCaseInsensitiveFuzzyAndMultiTokenAnd(t *testing.T) {
+	items := []testItem{
+		{name: "feature/auth /repos/auth"},
+		{name: "bugfix/ui /repos/web"},
+		{name: "release notes /repos/docs"},
+	}
+	p := fixedTestPane(items)
+
+	p = p.SetQuery("FA")
+	filtered, selected, scroll := p.View()
+	if len(filtered) != 1 || filtered[0].name != "feature/auth /repos/auth" {
+		t.Fatalf("expected fuzzy query to match feature/auth, got %#v", filtered)
+	}
+	if selected != 0 || scroll != 0 {
+		t.Fatalf("query should reset cursor and scroll, got selected=%d scroll=%d", selected, scroll)
+	}
+
+	p = p.SetQuery("bug web")
+	filtered, _, _ = p.View()
+	if len(filtered) != 1 || filtered[0].name != "bugfix/ui /repos/web" {
+		t.Fatalf("expected multi-token query to require both tokens, got %#v", filtered)
+	}
+
+	p = p.SetQuery("missing")
+	filtered, selected, scroll = p.View()
+	if len(filtered) != 0 {
+		t.Fatalf("expected no matches, got %#v", filtered)
+	}
+	if selected != 0 || scroll != 0 {
+		t.Fatalf("empty filtered view should clamp to top, got selected=%d scroll=%d", selected, scroll)
+	}
+}
+
+func TestPaneSetItemsClampsSelectionAndSelectFuncFindsFilteredItem(t *testing.T) {
+	items := []testItem{
+		{name: "alpha"},
+		{name: "bravo"},
+		{name: "charlie"},
+	}
+	p := fixedTestPane(items).Move(2, 2, 80)
+
+	p = p.SetItems(items[:1])
+	filtered, selected, scroll := p.View()
+	if len(filtered) != 1 || selected != 0 || scroll != 0 {
+		t.Fatalf("expected replacement to clamp to the only item, len=%d selected=%d scroll=%d", len(filtered), selected, scroll)
+	}
+
+	p = fixedTestPane(items).SetQuery("a").SelectFunc(func(item testItem) bool {
+		return item.name == "charlie"
+	})
+	selectedItem, ok := p.Selected()
+	if !ok || selectedItem.name != "charlie" {
+		t.Fatalf("expected SelectFunc to select charlie, got item=%#v ok=%v", selectedItem, ok)
+	}
+	_, selected, _ = p.View()
+	if selected != 2 {
+		t.Fatalf("expected charlie at filtered index 2, got %d", selected)
+	}
+}
+
+func TestPaneSetQueryPreserveIndexKeepsCursorWhenPossible(t *testing.T) {
+	items := []testItem{
+		{name: "alpha feature"},
+		{name: "bravo feature"},
+		{name: "charlie bugfix"},
+	}
+	p := fixedTestPane(items).Move(1, 2, 80)
+
+	p = p.SetQueryPreserveIndex("feature")
+	selectedItem, ok := p.Selected()
+	if !ok || selectedItem.name != "bravo feature" {
+		t.Fatalf("expected preserved cursor on bravo feature, got item=%#v ok=%v", selectedItem, ok)
+	}
+	_, selected, _ := p.View()
+	if selected != 1 {
+		t.Fatalf("expected selected index 1 after preserved query, got %d", selected)
+	}
+
+	p = p.SetQueryPreserveIndex("alpha")
+	selectedItem, ok = p.Selected()
+	if !ok || selectedItem.name != "alpha feature" {
+		t.Fatalf("expected cursor to clamp to alpha feature, got item=%#v ok=%v", selectedItem, ok)
+	}
+}
+
+func TestPaneMoveOnEmptyAndSingleItemLists(t *testing.T) {
+	var empty Pane[testItem]
+	empty = empty.Move(1, 2, 80)
+	if _, selected, scroll := empty.View(); selected != 0 || scroll != 0 {
+		t.Fatalf("empty pane should stay at top, selected=%d scroll=%d", selected, scroll)
+	}
+
+	p := fixedTestPane([]testItem{{name: "only"}})
+	p = p.Move(1, 2, 80).Move(-1, 2, 80)
+	if _, selected, scroll := p.View(); selected != 0 || scroll != 0 {
+		t.Fatalf("single item pane should stay at top, selected=%d scroll=%d", selected, scroll)
+	}
+}
+
+func TestPaneVariableHeightScrollUsesVisualLines(t *testing.T) {
+	items := []testItem{
+		{name: "short", lines: 1},
+		{name: "long", lines: 4},
+		{name: "target", lines: 1},
+	}
+	p := New(func(item testItem) string {
+		return item.name
+	}, func(item testItem, width int) int {
+		return item.lines
+	}).SetItems(items)
+
+	p = p.Move(2, 3, 80)
+	_, selected, scroll := p.View()
+	if selected != 2 {
+		t.Fatalf("expected selected index 2, got %d", selected)
+	}
+	if scroll != 3 {
+		t.Fatalf("expected scroll to account for prior 5 visual lines, got %d", scroll)
+	}
+
+	p = p.Reflow(6, 80)
+	_, _, scroll = p.View()
+	if scroll != 0 {
+		t.Fatalf("larger viewport should clamp scroll when all lines fit, got %d", scroll)
+	}
+
+	p = p.Move(-1, 3, 80)
+	_, selected, scroll = p.View()
+	if selected != 1 {
+		t.Fatalf("expected selected index 1, got %d", selected)
+	}
+	if scroll != 0 {
+		t.Fatalf("selected row first line is visible, so scroll should stay at 0, got %d", scroll)
+	}
+}
+
+func TestPaneReflowClampsScrollAfterViewportShrink(t *testing.T) {
+	items := []testItem{
+		{name: "one", lines: 2},
+		{name: "two", lines: 2},
+		{name: "three", lines: 2},
+	}
+	p := New(func(item testItem) string {
+		return item.name
+	}, func(item testItem, width int) int {
+		return item.lines
+	}).SetItems(items)
+
+	p = p.Move(2, 5, 80)
+	_, _, scroll := p.View()
+	if scroll != 0 {
+		t.Fatalf("expected selected item to fit in tall viewport without scrolling, got %d", scroll)
+	}
+
+	p = p.Reflow(1, 80)
+	_, selected, scroll := p.View()
+	if selected != 2 {
+		t.Fatalf("expected selection to remain on index 2, got %d", selected)
+	}
+	if scroll != 4 {
+		t.Fatalf("expected shrink to scroll to selected visual line 4, got %d", scroll)
+	}
+
+	p = p.Move(10, 1, 80)
+	_, _, scroll = p.View()
+	if scroll < 0 || scroll > 5 {
+		t.Fatalf("scroll should stay within visual bounds, got %d", scroll)
+	}
+}
+
+func TestPaneReflowClampsScrollToTotalLinesMinusViewport(t *testing.T) {
+	items := []testItem{
+		{name: "one", lines: 2},
+		{name: "two", lines: 2},
+		{name: "three", lines: 2},
+	}
+	p := New(func(item testItem) string {
+		return item.name
+	}, func(item testItem, width int) int {
+		return item.lines
+	}).SetItems(items)
+
+	p = p.Move(2, 1, 80)
+	_, _, scroll := p.View()
+	if scroll != 4 {
+		t.Fatalf("expected narrow viewport to scroll to selected visual line 4, got %d", scroll)
+	}
+
+	p = p.Reflow(5, 80)
+	_, _, scroll = p.View()
+	if scroll != 1 {
+		t.Fatalf("expected scroll to clamp to total lines minus viewport, got %d", scroll)
+	}
+}


### PR DESCRIPTION
## Summary
- Move repo and right-pane filtering, selection, and scroll state into a generic `model/pane` abstraction.
- Preserve shared right-pane search behavior across modes while keeping inactive pane cursors stable.
- Add integration coverage for shared search, async replacement, and tiny-height stash scrolling.

## Testing
- `gofmt -l .` passed.
- `make test` passed.
- `make build` passed.
- Added/updated unit tests for the new pane abstraction and model-level regression paths.