### PR TITLE
Consolidate modal state handling

### DIFF
--- a/model/modal/modal.go
+++ b/model/modal/modal.go
@@ -1,0 +1,270 @@
+package modal
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type Kind int
+
+const (
+	None Kind = iota
+	Confirm
+	Input
+	Diff
+)
+
+type DiffKind int
+
+const (
+	DiffStash DiffKind = iota + 1
+	DiffBranch
+	DiffCommit
+	DiffWorktree
+	DiffReflog
+)
+
+type Outcome int
+
+const (
+	Ignored Outcome = iota
+	Consumed
+	Accepted
+	Cancelled
+)
+
+// Modal is the single in-process state machine for transient modal UI. Its
+// zero value is closed.
+type Modal struct {
+	kind     Kind
+	prompt   string
+	force    bool
+	action   func() tea.Cmd
+	input    string
+	inputErr string
+	validate func(string) error
+	submit   func(string) tea.Cmd
+	diffKind DiffKind
+	diff     string
+	scroll   int
+	request  uint64
+}
+
+type View struct {
+	Kind     Kind
+	Prompt   string
+	Force    bool
+	Input    string
+	InputErr string
+	DiffKind DiffKind
+	Diff     string
+	Scroll   int
+	Request  uint64
+}
+
+func OpenConfirm(prompt string, action func() tea.Cmd) Modal {
+	return Modal{kind: Confirm, prompt: prompt, action: action}
+}
+
+func OpenForce(prompt string, action func() tea.Cmd) Modal {
+	return Modal{kind: Confirm, prompt: prompt, force: true, action: action}
+}
+
+func OpenInput(prompt, initial string, validate func(string) error, submit func(string) tea.Cmd) Modal {
+	return Modal{
+		kind:     Input,
+		prompt:   prompt,
+		input:    initial,
+		validate: validate,
+		submit:   submit,
+	}
+}
+
+func OpenDiff(kind DiffKind, body string) Modal {
+	return Modal{kind: Diff, diffKind: kind, diff: body}
+}
+
+func (m Modal) WithRequest(request uint64) Modal {
+	if m.kind == Diff {
+		m.request = request
+	}
+	return m
+}
+
+func (m Modal) SetDiff(body string) Modal {
+	if m.kind == Diff {
+		m.diff = body
+		if m.scroll > maxDiffScroll(body) {
+			m.scroll = maxDiffScroll(body)
+		}
+	}
+	return m
+}
+
+func (m Modal) SetDiffFor(kind DiffKind, body string) Modal {
+	if m.kind == Diff && m.diffKind == kind {
+		m.diff = body
+		if m.scroll > maxDiffScroll(body) {
+			m.scroll = maxDiffScroll(body)
+		}
+	}
+	return m
+}
+
+func (m Modal) SetDiffForRequest(kind DiffKind, request uint64, body string) Modal {
+	if request != 0 && m.kind == Diff && m.diffKind == kind && m.request == request {
+		m.diff = body
+		if m.scroll > maxDiffScroll(body) {
+			m.scroll = maxDiffScroll(body)
+		}
+	}
+	return m
+}
+
+func (m Modal) SetInputError(err string) Modal {
+	if m.kind == Input {
+		m.inputErr = err
+	}
+	return m
+}
+
+func (m Modal) IsOpen() bool {
+	return m.kind != None
+}
+
+func (m Modal) View() View {
+	return View{
+		Kind:     m.kind,
+		Prompt:   m.prompt,
+		Force:    m.force,
+		Input:    m.input,
+		InputErr: m.inputErr,
+		DiffKind: m.diffKind,
+		Diff:     m.diff,
+		Scroll:   m.scroll,
+		Request:  m.request,
+	}
+}
+
+func (m Modal) Update(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
+	switch m.kind {
+	case Confirm:
+		return m.updateConfirm(msg)
+	case Input:
+		return m.updateInput(msg)
+	case Diff:
+		return m.updateDiff(msg)
+	default:
+		return m, Ignored, nil
+	}
+}
+
+func (m Modal) updateConfirm(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
+	switch msg.String() {
+	case "y", "enter":
+		cmd := deferAction(m.action)
+		if cmd == nil {
+			return Modal{}, Accepted, nil
+		}
+		return Modal{}, Accepted, cmd
+	case "n", "q", "esc":
+		return Modal{}, Cancelled, nil
+	default:
+		return m, Consumed, nil
+	}
+}
+
+func (m Modal) updateInput(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		input := strings.TrimSpace(m.input)
+		if m.validate != nil {
+			if err := m.validate(input); err != nil {
+				m.inputErr = err.Error()
+				return m, Consumed, nil
+			}
+		}
+		cmd := deferSubmit(m.submit, input)
+		if cmd == nil {
+			return Modal{}, Accepted, nil
+		}
+		return Modal{}, Accepted, cmd
+	case "esc", "ctrl+c":
+		return Modal{}, Cancelled, nil
+	case "backspace", "ctrl+h":
+		runes := []rune(m.input)
+		if len(runes) > 0 {
+			m.input = string(runes[:len(runes)-1])
+			m.inputErr = ""
+		}
+		return m, Consumed, nil
+	case "ctrl+u":
+		m.input = ""
+		m.inputErr = ""
+		return m, Consumed, nil
+	default:
+		if msg.Type == tea.KeyRunes {
+			m.input += string(msg.Runes)
+			m.inputErr = ""
+			return m, Consumed, nil
+		}
+		return m, Consumed, nil
+	}
+}
+
+func deferAction(action func() tea.Cmd) tea.Cmd {
+	if action == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		cmd := action()
+		if cmd == nil {
+			return nil
+		}
+		return cmd()
+	}
+}
+
+func deferSubmit(submit func(string) tea.Cmd, input string) tea.Cmd {
+	if submit == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		cmd := submit(input)
+		if cmd == nil {
+			return nil
+		}
+		return cmd()
+	}
+}
+
+func (m Modal) updateDiff(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
+	switch msg.String() {
+	case "q", "esc":
+		return Modal{}, Cancelled, nil
+	case "up", "k":
+		if m.scroll > 0 {
+			m.scroll--
+		}
+		return m, Consumed, nil
+	case "down", "j":
+		if m.scroll < maxDiffScroll(m.diff) {
+			m.scroll++
+		}
+		return m, Consumed, nil
+	default:
+		return m, Consumed, nil
+	}
+}
+
+func maxDiffScroll(body string) int {
+	if body == "" {
+		return 0
+	}
+	lines := strings.Count(body, "\n") + 1
+	if lines <= 1 {
+		return 0
+	}
+	return lines - 1
+}

--- a/model/modal/modal.go
+++ b/model/modal/modal.go
@@ -92,26 +92,6 @@ func (m Modal) WithRequest(request uint64) Modal {
 	return m
 }
 
-func (m Modal) SetDiff(body string) Modal {
-	if m.kind == Diff {
-		m.diff = body
-		if m.scroll > maxDiffScroll(body) {
-			m.scroll = maxDiffScroll(body)
-		}
-	}
-	return m
-}
-
-func (m Modal) SetDiffFor(kind DiffKind, body string) Modal {
-	if m.kind == Diff && m.diffKind == kind {
-		m.diff = body
-		if m.scroll > maxDiffScroll(body) {
-			m.scroll = maxDiffScroll(body)
-		}
-	}
-	return m
-}
-
 func (m Modal) SetDiffForRequest(kind DiffKind, request uint64, body string) Modal {
 	if request != 0 && m.kind == Diff && m.diffKind == kind && m.request == request {
 		m.diff = body

--- a/model/modal/modal_test.go
+++ b/model/modal/modal_test.go
@@ -2,6 +2,7 @@ package modal_test
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -152,8 +153,7 @@ func TestInputInvalidSubmitStaysOpenWithError(t *testing.T) {
 }
 
 func TestDiffScrollsClampsAndCloses(t *testing.T) {
-	m := modal.OpenDiff(modal.DiffWorktree, "")
-	m = m.SetDiff("line 1\nline 2")
+	m := modal.OpenDiff(modal.DiffWorktree, "line 1\nline 2")
 
 	m, out, _ := m.Update(keyRunes("j"))
 	if out != modal.Consumed {
@@ -186,15 +186,15 @@ func TestDiffScrollsClampsAndCloses(t *testing.T) {
 	}
 }
 
-func TestDiffSetForIgnoresWrongKind(t *testing.T) {
-	m := modal.OpenDiff(modal.DiffCommit, "")
-	m = m.SetDiffFor(modal.DiffStash, "stale stash diff")
+func TestDiffSetForRequestIgnoresWrongKind(t *testing.T) {
+	m := modal.OpenDiff(modal.DiffCommit, "").WithRequest(7)
+	m = m.SetDiffForRequest(modal.DiffStash, 7, "stale stash diff")
 
 	if got := m.View().Diff; got != "" {
 		t.Fatalf("expected wrong-kind diff ignored, got %q", got)
 	}
 
-	m = m.SetDiffFor(modal.DiffCommit, "commit diff")
+	m = m.SetDiffForRequest(modal.DiffCommit, 7, "commit diff")
 	if got := m.View().Diff; got != "commit diff" {
 		t.Fatalf("expected matching diff stored, got %q", got)
 	}
@@ -216,6 +216,15 @@ func TestDiffSetForRequestIgnoresWrongRequest(t *testing.T) {
 	m = m.SetDiffForRequest(modal.DiffWorktree, 7, "current diff")
 	if got := m.View().Diff; got != "current diff" {
 		t.Fatalf("expected matching request diff stored, got %q", got)
+	}
+}
+
+func TestWeakDiffSettersAreNotPublicAPI(t *testing.T) {
+	modalType := reflect.TypeOf(modal.Modal{})
+	for _, name := range []string{"SetDiff", "SetDiffFor"} {
+		if _, ok := modalType.MethodByName(name); ok {
+			t.Fatalf("%s should not be exported; use SetDiffForRequest for async diff results", name)
+		}
 	}
 }
 

--- a/model/modal/modal_test.go
+++ b/model/modal/modal_test.go
@@ -1,0 +1,237 @@
+package modal_test
+
+import (
+	"errors"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/brian-bell/wtui/model/modal"
+)
+
+type sentinelMsg string
+
+func keyRunes(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func TestConfirmAcceptReturnsActionCommandAndCloses(t *testing.T) {
+	calls := 0
+	m := modal.OpenConfirm("Delete branch feat? (y/n)", func() tea.Cmd {
+		calls++
+		return func() tea.Msg { return sentinelMsg("deleted") }
+	})
+
+	next, out, cmd := m.Update(keyRunes("y"))
+
+	if out != modal.Accepted {
+		t.Fatalf("expected Accepted, got %v", out)
+	}
+	if next.IsOpen() {
+		t.Fatal("expected modal closed after accept")
+	}
+	if cmd == nil {
+		t.Fatal("expected action command")
+	}
+	if calls != 0 {
+		t.Fatalf("expected action factory deferred until command runs, got %d calls", calls)
+	}
+	if got := cmd(); got != sentinelMsg("deleted") {
+		t.Fatalf("expected sentinel message, got %T %[1]v", got)
+	}
+	if calls != 1 {
+		t.Fatalf("expected action factory called once, got %d", calls)
+	}
+
+	_, _, cmd = next.Update(keyRunes("y"))
+	if cmd != nil {
+		t.Fatal("closed modal should not return another action command")
+	}
+	if calls != 1 {
+		t.Fatalf("expected action factory still called once, got %d", calls)
+	}
+}
+
+func TestConfirmCancelClosesWithoutCommand(t *testing.T) {
+	for _, key := range []tea.KeyMsg{keyRunes("n"), keyRunes("q"), {Type: tea.KeyEscape}} {
+		m := modal.OpenConfirm("Drop stash? (y/n)", func() tea.Cmd {
+			t.Fatal("cancel must not invoke action")
+			return nil
+		})
+
+		next, out, cmd := m.Update(key)
+
+		if out != modal.Cancelled {
+			t.Fatalf("expected Cancelled for %q, got %v", key.String(), out)
+		}
+		if next.IsOpen() {
+			t.Fatalf("expected modal closed for %q", key.String())
+		}
+		if cmd != nil {
+			t.Fatalf("expected nil command for %q, got %T", key.String(), cmd)
+		}
+	}
+}
+
+func TestInputEditsValidatesAndSubmitsTrimmedValue(t *testing.T) {
+	var submitted string
+	m := modal.OpenInput(
+		"New worktree",
+		"",
+		func(input string) error {
+			if input == "" {
+				return errors.New("enter a name")
+			}
+			return nil
+		},
+		func(input string) tea.Cmd {
+			submitted = input
+			return func() tea.Msg { return sentinelMsg("created") }
+		},
+	)
+
+	m, _, _ = m.Update(keyRunes("featx"))
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+
+	if got := m.View().Input; got != "feat" {
+		t.Fatalf("expected input %q, got %q", "feat", got)
+	}
+
+	m, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if out != modal.Accepted {
+		t.Fatalf("expected Accepted, got %v", out)
+	}
+	if m.IsOpen() {
+		t.Fatal("expected input modal closed after valid submit")
+	}
+	if cmd == nil {
+		t.Fatal("expected submit command")
+	}
+	if submitted != "" {
+		t.Fatalf("expected submit deferred until command runs, got %q", submitted)
+	}
+	if got := cmd(); got != sentinelMsg("created") {
+		t.Fatalf("expected sentinel message, got %T %[1]v", got)
+	}
+	if submitted != "feat" {
+		t.Fatalf("expected trimmed submitted value %q, got %q", "feat", submitted)
+	}
+}
+
+func TestInputInvalidSubmitStaysOpenWithError(t *testing.T) {
+	m := modal.OpenInput(
+		"New worktree",
+		"   ",
+		func(input string) error {
+			if input == "" {
+				return errors.New("enter a name")
+			}
+			return nil
+		},
+		func(string) tea.Cmd {
+			t.Fatal("invalid input must not submit")
+			return nil
+		},
+	)
+
+	next, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if out != modal.Consumed {
+		t.Fatalf("expected Consumed, got %v", out)
+	}
+	if !next.IsOpen() {
+		t.Fatal("expected input modal to remain open")
+	}
+	if got := next.View().InputErr; got != "enter a name" {
+		t.Fatalf("expected validation error, got %q", got)
+	}
+	if cmd != nil {
+		t.Fatalf("expected nil command, got %T", cmd)
+	}
+}
+
+func TestDiffScrollsClampsAndCloses(t *testing.T) {
+	m := modal.OpenDiff(modal.DiffWorktree, "")
+	m = m.SetDiff("line 1\nline 2")
+
+	m, out, _ := m.Update(keyRunes("j"))
+	if out != modal.Consumed {
+		t.Fatalf("expected Consumed for scroll, got %v", out)
+	}
+	if got := m.View().Scroll; got != 1 {
+		t.Fatalf("expected scroll 1, got %d", got)
+	}
+
+	m, _, _ = m.Update(keyRunes("j"))
+	if got := m.View().Scroll; got != 1 {
+		t.Fatalf("expected scroll clamped at max line index 1, got %d", got)
+	}
+
+	m, _, _ = m.Update(keyRunes("k"))
+	m, _, _ = m.Update(keyRunes("k"))
+	if got := m.View().Scroll; got != 0 {
+		t.Fatalf("expected scroll clamped at 0, got %d", got)
+	}
+
+	m, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	if out != modal.Cancelled {
+		t.Fatalf("expected Cancelled, got %v", out)
+	}
+	if m.IsOpen() {
+		t.Fatal("expected diff modal closed")
+	}
+	if cmd != nil {
+		t.Fatalf("expected nil command, got %T", cmd)
+	}
+}
+
+func TestDiffSetForIgnoresWrongKind(t *testing.T) {
+	m := modal.OpenDiff(modal.DiffCommit, "")
+	m = m.SetDiffFor(modal.DiffStash, "stale stash diff")
+
+	if got := m.View().Diff; got != "" {
+		t.Fatalf("expected wrong-kind diff ignored, got %q", got)
+	}
+
+	m = m.SetDiffFor(modal.DiffCommit, "commit diff")
+	if got := m.View().Diff; got != "commit diff" {
+		t.Fatalf("expected matching diff stored, got %q", got)
+	}
+}
+
+func TestDiffSetForRequestIgnoresWrongRequest(t *testing.T) {
+	m := modal.OpenDiff(modal.DiffWorktree, "").WithRequest(7)
+
+	m = m.SetDiffForRequest(modal.DiffWorktree, 0, "missing request diff")
+	if got := m.View().Diff; got != "" {
+		t.Fatalf("expected zero-request diff ignored, got %q", got)
+	}
+
+	m = m.SetDiffForRequest(modal.DiffWorktree, 6, "stale diff")
+	if got := m.View().Diff; got != "" {
+		t.Fatalf("expected wrong-request diff ignored, got %q", got)
+	}
+
+	m = m.SetDiffForRequest(modal.DiffWorktree, 7, "current diff")
+	if got := m.View().Diff; got != "current diff" {
+		t.Fatalf("expected matching request diff stored, got %q", got)
+	}
+}
+
+func TestViewSnapshotsKindSpecificState(t *testing.T) {
+	force := modal.OpenForce("Force delete feat? (y/n)", func() tea.Cmd { return nil }).View()
+	if force.Kind != modal.Confirm || !force.Force || force.Prompt == "" {
+		t.Fatalf("unexpected force confirm view: %#v", force)
+	}
+
+	input := modal.OpenInput("New worktree", "feat", nil, func(string) tea.Cmd { return nil }).View()
+	if input.Kind != modal.Input || input.Input != "feat" {
+		t.Fatalf("unexpected input view: %#v", input)
+	}
+
+	diff := modal.OpenDiff(modal.DiffReflog, "body").View()
+	if diff.Kind != modal.Diff || diff.DiffKind != modal.DiffReflog || diff.Diff != "body" {
+		t.Fatalf("unexpected diff view: %#v", diff)
+	}
+}

--- a/model/model.go
+++ b/model/model.go
@@ -4,6 +4,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/brian-bell/wtui/gitquery"
+	"github.com/brian-bell/wtui/model/modal"
 	"github.com/brian-bell/wtui/model/pane"
 	"github.com/brian-bell/wtui/scanner"
 	"github.com/brian-bell/wtui/ui"
@@ -11,27 +12,21 @@ import (
 
 // Model is the bubbletea application model.
 type Model struct {
-	repos            pane.Pane[scanner.Repo]
-	width            int
-	height           int
-	mode             ui.Mode
-	rows             pane.Pane[gitquery.BranchRow]
-	stashes          pane.Pane[gitquery.Stash]
-	worktrees        pane.Pane[gitquery.Worktree]
-	commits          pane.Pane[gitquery.Commit]
-	reflogs          pane.Pane[gitquery.ReflogEntry]
-	overlay          ui.OverlayState
-	overlayDiff      string
-	overlayScroll    int
-	confirmPrompt    string
-	confirmAction    func() tea.Cmd
-	confirmForce     bool
-	worktreeInput    string
-	worktreeInputErr string
-	activePane       int // 0=left (repos), 1=right (content)
-	destructive      bool
-	transientError   string
-	searchActive     bool
+	repos          pane.Pane[scanner.Repo]
+	width          int
+	height         int
+	mode           ui.Mode
+	rows           pane.Pane[gitquery.BranchRow]
+	stashes        pane.Pane[gitquery.Stash]
+	worktrees      pane.Pane[gitquery.Worktree]
+	commits        pane.Pane[gitquery.Commit]
+	reflogs        pane.Pane[gitquery.ReflogEntry]
+	modal          modal.Modal
+	diffRequestSeq uint64
+	activePane     int // 0=left (repos), 1=right (content)
+	destructive    bool
+	transientError string
+	searchActive   bool
 }
 
 // New creates a Model from discovered repos.
@@ -68,13 +63,13 @@ func (m Model) CommitScroll() int               { return m.commits.Scroll() }
 func (m Model) Reflogs() []gitquery.ReflogEntry { reflogs, _, _ := m.reflogs.View(); return reflogs }
 func (m Model) ReflogSelected() int             { return m.reflogs.SelectedIndex() }
 func (m Model) ReflogScroll() int               { return m.reflogs.Scroll() }
-func (m Model) Overlay() ui.OverlayState        { return m.overlay }
-func (m Model) OverlayDiff() string             { return m.overlayDiff }
-func (m Model) OverlayScroll() int              { return m.overlayScroll }
-func (m Model) ConfirmPrompt() string           { return m.confirmPrompt }
-func (m Model) ConfirmForce() bool              { return m.confirmForce }
-func (m Model) WorktreeInput() string           { return m.worktreeInput }
-func (m Model) WorktreeInputErr() string        { return m.worktreeInputErr }
+func (m Model) Overlay() ui.OverlayState        { return m.overlayState() }
+func (m Model) OverlayDiff() string             { return m.modal.View().Diff }
+func (m Model) OverlayScroll() int              { return m.modal.View().Scroll }
+func (m Model) ConfirmPrompt() string           { return m.modal.View().Prompt }
+func (m Model) ConfirmForce() bool              { return m.modal.View().Force }
+func (m Model) WorktreeInput() string           { return m.modal.View().Input }
+func (m Model) WorktreeInputErr() string        { return m.modal.View().InputErr }
 func (m Model) BranchScroll() int               { return m.rows.Scroll() }
 func (m Model) RepoScroll() int                 { return m.repos.Scroll() }
 func (m Model) StashScroll() int                { return m.stashes.Scroll() }
@@ -103,6 +98,7 @@ func (m Model) View() string {
 		commits = nil
 		reflogs = nil
 	}
+	modalView := m.modal.View()
 	return ui.Render(ui.RenderParams{
 		Repos:            repos,
 		Selected:         selected,
@@ -113,13 +109,13 @@ func (m Model) View() string {
 		Stashes:          stashes,
 		BranchSelected:   branchSelected,
 		StashSelected:    stashSelected,
-		Overlay:          m.overlay,
-		OverlayDiff:      m.overlayDiff,
-		OverlayScroll:    m.overlayScroll,
-		ConfirmPrompt:    m.confirmPrompt,
-		ConfirmForce:     m.confirmForce,
-		WorktreeInput:    m.worktreeInput,
-		WorktreeInputErr: m.worktreeInputErr,
+		Overlay:          m.overlayState(),
+		OverlayDiff:      modalView.Diff,
+		OverlayScroll:    modalView.Scroll,
+		ConfirmPrompt:    modalView.Prompt,
+		ConfirmForce:     modalView.Force,
+		WorktreeInput:    modalView.Input,
+		WorktreeInputErr: modalView.InputErr,
 		BranchScroll:     branchScroll,
 		RepoScroll:       repoScroll,
 		StashScroll:      stashScroll,
@@ -141,6 +137,36 @@ func (m Model) View() string {
 		FetchAvailable:   m.canFetch(),
 		PullAvailable:    m.canPull(),
 	})
+}
+
+func (m Model) overlayState() ui.OverlayState {
+	view := m.modal.View()
+	switch view.Kind {
+	case modal.Confirm:
+		return ui.OverlayConfirm
+	case modal.Input:
+		return ui.OverlayWorktreeInput
+	case modal.Diff:
+		switch view.DiffKind {
+		case modal.DiffStash:
+			return ui.OverlayStashDiff
+		case modal.DiffBranch:
+			return ui.OverlayBranchDiff
+		case modal.DiffCommit:
+			return ui.OverlayCommitDiff
+		case modal.DiffWorktree:
+			return ui.OverlayWorktreeDiff
+		case modal.DiffReflog:
+			return ui.OverlayReflogDiff
+		}
+	}
+	return ui.OverlayNone
+}
+
+func (m Model) openDiff(kind modal.DiffKind) Model {
+	m.diffRequestSeq++
+	m.modal = modal.OpenDiff(kind, "").WithRequest(m.diffRequestSeq)
+	return m
 }
 
 // --- Update ---

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -158,6 +158,7 @@ func TestModel_WorktreeDiffResultAfterClosedOverlayIgnored(t *testing.T) {
 	m, _ = update(m, model.WorktreeDiffResultMsg{
 		RepoPath:     "/dev/alpha",
 		WorktreePath: "/dev/alpha",
+		DiffRequest:  1,
 		Diff:         "stale worktree diff",
 	})
 

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -97,13 +97,16 @@ func TestModel_EnterOnEmptyWorktreeListIsNoOp(t *testing.T) {
 
 func TestModel_WorktreeDiffResultStoresDiff(t *testing.T) {
 	m := model.New(testRepos())
+	m = inRightPane(m)
 	wts := []gitquery.Worktree{
 		{Path: "/dev/alpha", BranchName: "main", Dirty: true},
 	}
 	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: wts})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, model.WorktreeDiffResultMsg{
 		RepoPath:     "/dev/alpha",
 		WorktreePath: "/dev/alpha",
+		DiffRequest:  1,
 		Diff:         "diff --git a/f.txt",
 	})
 	if m.OverlayDiff() != "diff --git a/f.txt" {
@@ -140,6 +143,57 @@ func TestModel_WorktreeDiffResultDiscardedIfWorktreePathChanged(t *testing.T) {
 	})
 	if m.OverlayDiff() != "" {
 		t.Errorf("expected diff discarded for wrong worktree path, got %q", m.OverlayDiff())
+	}
+}
+
+func TestModel_WorktreeDiffResultAfterClosedOverlayIgnored(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", Dirty: true},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEscape})
+
+	m, _ = update(m, model.WorktreeDiffResultMsg{
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha",
+		Diff:         "stale worktree diff",
+	})
+
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected overlay to remain closed, got %d", m.Overlay())
+	}
+	if m.OverlayDiff() != "" {
+		t.Fatalf("expected closed overlay to ignore stale diff, got %q", m.OverlayDiff())
+	}
+}
+
+func TestModel_WorktreeDiffResultFromOlderRequestIgnoredAfterReopen(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", Dirty: true},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})  // request 1
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEscape}) // close before result arrives
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})  // request 2 for same target
+
+	m, _ = update(m, model.WorktreeDiffResultMsg{
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha",
+		DiffRequest:  2,
+		Diff:         "new diff",
+	})
+	m, _ = update(m, model.WorktreeDiffResultMsg{
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha",
+		DiffRequest:  1,
+		Diff:         "stale old diff",
+	})
+
+	if m.OverlayDiff() != "new diff" {
+		t.Fatalf("expected stale request ignored after reopen, got %q", m.OverlayDiff())
 	}
 }
 
@@ -443,6 +497,55 @@ func TestModel_EnterOpensBranchDiffOverlayForDirtyWorktree(t *testing.T) {
 	}
 }
 
+func TestModel_BranchDiffResultForWrongWorktreePathIgnored(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{
+			{
+				Name:          "feat",
+				IsWorktree:    true,
+				Dirty:         true,
+				WorktreePaths: []string{"/dev/alpha"},
+			},
+		},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, _ = update(m, model.BranchDiffResultMsg{
+		RepoPath:    "/dev/alpha",
+		BranchName:  "feat",
+		DiffRequest: 1,
+		Diff:        "missing path diff",
+	})
+	if m.OverlayDiff() != "" {
+		t.Fatalf("expected missing worktree path diff ignored, got %q", m.OverlayDiff())
+	}
+
+	m, _ = update(m, model.BranchDiffResultMsg{
+		RepoPath:     "/dev/alpha",
+		BranchName:   "feat",
+		WorktreePath: "/dev/elsewhere",
+		DiffRequest:  1,
+		Diff:         "wrong path diff",
+	})
+	if m.OverlayDiff() != "" {
+		t.Fatalf("expected wrong worktree path diff ignored, got %q", m.OverlayDiff())
+	}
+
+	m, _ = update(m, model.BranchDiffResultMsg{
+		RepoPath:     "/dev/alpha",
+		BranchName:   "feat",
+		WorktreePath: "/dev/alpha",
+		DiffRequest:  1,
+		Diff:         "matching path diff",
+	})
+	if m.OverlayDiff() != "matching path diff" {
+		t.Fatalf("expected matching worktree path diff stored, got %q", m.OverlayDiff())
+	}
+}
+
 func TestModel_EnterDoesNothingForCleanBranch(t *testing.T) {
 	m := model.New(testRepos())
 	branches := []gitquery.Branch{
@@ -500,8 +603,11 @@ func TestModel_EnterInHistoryNoCommitsIsNoOp(t *testing.T) {
 
 func TestModel_CommitDiffResultStoresDiff(t *testing.T) {
 	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
-	m, _ = update(m, model.CommitDiffResultMsg{RepoPath: "/dev/alpha", Hash: "abc1234", Diff: "diff --git a/f.txt"})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, model.CommitDiffResultMsg{RepoPath: "/dev/alpha", Hash: "abc1234", DiffRequest: 1, Diff: "diff --git a/f.txt"})
 	if m.OverlayDiff() != "diff --git a/f.txt" {
 		t.Errorf("expected diff stored, got %q", m.OverlayDiff())
 	}
@@ -608,9 +714,116 @@ func TestModel_EnterOpensOverlay(t *testing.T) {
 
 func TestModel_StashDiffResultStoresDiff(t *testing.T) {
 	m := model.New(testRepos())
-	m, _ = update(m, model.StashDiffResultMsg{RepoPath: "/dev/alpha", Index: 0, Diff: "diff --git a/f.txt"})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, model.StashDiffResultMsg{
+		RepoPath:    "/dev/alpha",
+		Index:       0,
+		DiffRequest: 1,
+		Diff:        "missing identity diff",
+	})
+	if m.OverlayDiff() != "" {
+		t.Fatalf("expected missing stash identity diff ignored, got %q", m.OverlayDiff())
+	}
+	stash := testStashes()[0]
+	m, _ = update(m, model.StashDiffResultMsg{
+		RepoPath:    "/dev/alpha",
+		Index:       stash.Index,
+		Date:        stash.Date,
+		Message:     stash.Message,
+		DiffRequest: 1,
+		Diff:        "diff --git a/f.txt",
+	})
 	if m.OverlayDiff() != "diff --git a/f.txt" {
 		t.Errorf("expected diff stored, got %q", m.OverlayDiff())
+	}
+}
+
+func TestModel_StaleStashDiffDoesNotPopulateCommitOverlay(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEscape})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, model.StashDiffResultMsg{RepoPath: "/dev/alpha", Index: 0, Diff: "stale stash diff"})
+
+	if m.Overlay() != ui.OverlayCommitDiff {
+		t.Fatalf("expected commit diff overlay to remain open, got %d", m.Overlay())
+	}
+	if m.OverlayDiff() != "" {
+		t.Fatalf("expected stale stash diff ignored by commit overlay, got %q", m.OverlayDiff())
+	}
+}
+
+func TestModel_StaleStashDiffForOldIndexIgnored(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEscape})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, _ = update(m, model.StashDiffResultMsg{RepoPath: "/dev/alpha", Index: 0, Diff: "old index diff"})
+	if m.OverlayDiff() != "" {
+		t.Fatalf("expected old-index stash diff ignored, got %q", m.OverlayDiff())
+	}
+
+	currentStash := testStashes()[1]
+	m, _ = update(m, model.StashDiffResultMsg{
+		RepoPath:    "/dev/alpha",
+		Index:       currentStash.Index,
+		Date:        currentStash.Date,
+		Message:     currentStash.Message,
+		DiffRequest: 2,
+		Diff:        "current index diff",
+	})
+	if m.OverlayDiff() != "current index diff" {
+		t.Fatalf("expected current-index stash diff stored, got %q", m.OverlayDiff())
+	}
+}
+
+func TestModel_StaleStashDiffForChangedIdentityIgnored(t *testing.T) {
+	oldStash := gitquery.Stash{Index: 0, Date: "2026-03-18 10:00:00 -0700", Message: "old stash"}
+	newStash := gitquery.Stash{Index: 0, Date: "2026-03-19 10:00:00 -0700", Message: "new stash"}
+
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: []gitquery.Stash{oldStash}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: []gitquery.Stash{newStash}})
+
+	m, _ = update(m, model.StashDiffResultMsg{
+		RepoPath:    "/dev/alpha",
+		Index:       oldStash.Index,
+		Date:        oldStash.Date,
+		Message:     oldStash.Message,
+		DiffRequest: 1,
+		Diff:        "old stash diff",
+	})
+	if m.OverlayDiff() != "" {
+		t.Fatalf("expected changed stash identity to reject stale diff, got %q", m.OverlayDiff())
+	}
+
+	m, _ = update(m, model.StashDiffResultMsg{
+		RepoPath:    "/dev/alpha",
+		Index:       newStash.Index,
+		Date:        newStash.Date,
+		Message:     newStash.Message,
+		DiffRequest: 1,
+		Diff:        "new stash diff",
+	})
+	if m.OverlayDiff() != "new stash diff" {
+		t.Fatalf("expected matching stash identity diff stored, got %q", m.OverlayDiff())
 	}
 }
 
@@ -658,7 +871,15 @@ func TestModel_OverlayScrollUpDown(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	m, _ = update(m, model.StashDiffResultMsg{RepoPath: "/dev/alpha", Index: 0, Diff: "line1\nline2\nline3"})
+	scrollStash := testStashes()[0]
+	m, _ = update(m, model.StashDiffResultMsg{
+		RepoPath:    "/dev/alpha",
+		Index:       scrollStash.Index,
+		Date:        scrollStash.Date,
+		Message:     scrollStash.Message,
+		DiffRequest: 1,
+		Diff:        "line1\nline2\nline3",
+	})
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if m.OverlayScroll() != 1 {
@@ -1844,7 +2065,8 @@ func TestModel_EnterInReflogOpensReflogDiffOverlay(t *testing.T) {
 
 func TestModel_ReflogDiffResultStoresDiff(t *testing.T) {
 	m := modelInReflogWithEntries()
-	m, _ = update(m, model.ReflogDiffResultMsg{RepoPath: "/dev/alpha", Hash: "abc1234", Diff: "diff --git a/f.txt"})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, model.ReflogDiffResultMsg{RepoPath: "/dev/alpha", Hash: "abc1234", DiffRequest: 1, Diff: "diff --git a/f.txt"})
 	if m.OverlayDiff() != "diff --git a/f.txt" {
 		t.Errorf("expected diff stored, got %q", m.OverlayDiff())
 	}

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -161,6 +161,7 @@ func (m Model) fetchBranchDiff() tea.Cmd {
 		worktreePath = repoPath
 	}
 	branchName := row.Branch.Name
+	diffRequest := m.modal.View().Request
 
 	return func() tea.Msg {
 		diff, err := gitquery.BranchDiff(worktreePath)
@@ -168,9 +169,11 @@ func (m Model) fetchBranchDiff() tea.Cmd {
 			return FetchErrorMsg{RepoPath: repoPath, Pane: "branch diff", Err: fmt.Sprintf("failed to load diff: %v", err)}
 		}
 		return BranchDiffResultMsg{
-			RepoPath:   repoPath,
-			BranchName: branchName,
-			Diff:       diff,
+			RepoPath:     repoPath,
+			BranchName:   branchName,
+			WorktreePath: worktreePath,
+			DiffRequest:  diffRequest,
+			Diff:         diff,
 		}
 	}
 }
@@ -185,6 +188,7 @@ func (m Model) fetchWorktreeDiff() tea.Cmd {
 		return nil
 	}
 	worktreePath := wt.Path
+	diffRequest := m.modal.View().Request
 	return func() tea.Msg {
 		diff, err := gitquery.BranchDiff(worktreePath)
 		if err != nil {
@@ -193,6 +197,7 @@ func (m Model) fetchWorktreeDiff() tea.Cmd {
 		return WorktreeDiffResultMsg{
 			RepoPath:     repoPath,
 			WorktreePath: worktreePath,
+			DiffRequest:  diffRequest,
 			Diff:         diff,
 		}
 	}
@@ -208,12 +213,22 @@ func (m Model) fetchStashDiff() tea.Cmd {
 		return nil
 	}
 	index := stash.Index
+	stashDate := stash.Date
+	stashMessage := stash.Message
+	diffRequest := m.modal.View().Request
 	return func() tea.Msg {
 		diff, err := gitquery.StashDiff(repoPath, index)
 		if err != nil {
 			return FetchErrorMsg{RepoPath: repoPath, Pane: "stash diff", Err: fmt.Sprintf("failed to load diff: %v", err)}
 		}
-		return StashDiffResultMsg{RepoPath: repoPath, Index: index, Diff: diff}
+		return StashDiffResultMsg{
+			RepoPath:    repoPath,
+			Index:       index,
+			Date:        stashDate,
+			Message:     stashMessage,
+			DiffRequest: diffRequest,
+			Diff:        diff,
+		}
 	}
 }
 
@@ -255,12 +270,13 @@ func (m Model) fetchReflogDiff() tea.Cmd {
 		return nil
 	}
 	hash := entry.Hash
+	diffRequest := m.modal.View().Request
 	return func() tea.Msg {
 		diff, err := gitquery.ReflogDiff(repoPath, hash)
 		if err != nil {
 			return FetchErrorMsg{RepoPath: repoPath, Pane: "reflog diff", Err: fmt.Sprintf("failed to load diff: %v", err)}
 		}
-		return ReflogDiffResultMsg{RepoPath: repoPath, Hash: hash, Diff: diff}
+		return ReflogDiffResultMsg{RepoPath: repoPath, Hash: hash, DiffRequest: diffRequest, Diff: diff}
 	}
 }
 
@@ -274,11 +290,12 @@ func (m Model) fetchCommitDiff() tea.Cmd {
 		return nil
 	}
 	hash := commit.Hash
+	diffRequest := m.modal.View().Request
 	return func() tea.Msg {
 		diff, err := gitquery.CommitDiff(repoPath, hash)
 		if err != nil {
 			return FetchErrorMsg{RepoPath: repoPath, Pane: "commit diff", Err: fmt.Sprintf("failed to load diff: %v", err)}
 		}
-		return CommitDiffResultMsg{RepoPath: repoPath, Hash: hash, Diff: diff}
+		return CommitDiffResultMsg{RepoPath: repoPath, Hash: hash, DiffRequest: diffRequest, Diff: diff}
 	}
 }

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -2,28 +2,21 @@ package model
 
 import (
 	"fmt"
-	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/brian-bell/wtui/actions"
+	"github.com/brian-bell/wtui/model/modal"
 	"github.com/brian-bell/wtui/ui"
 )
 
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	if m.overlay == ui.OverlayConfirm {
-		return m.handleConfirmKey(key)
-	}
-	if m.overlay == ui.OverlayWorktreeInput {
-		return m.handleWorktreeInputKey(msg)
-	}
-	if m.overlay != ui.OverlayNone {
-		if m.activePane == 0 {
-			return m.handleLeftPaneKey(key)
-		}
-		return m.handleOverlayKey(key)
+	if m.modal.IsOpen() {
+		var cmd tea.Cmd
+		m.modal, _, cmd = m.modal.Update(msg)
+		return m, cmd
 	}
 
 	m.transientError = ""
@@ -113,46 +106,6 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // --- Key handlers by context ---
 
-func (m Model) handleConfirmKey(key string) (tea.Model, tea.Cmd) {
-	switch key {
-	case "y", "enter":
-		action := m.confirmAction
-		m = m.clearConfirm()
-		return m, action()
-	case "n", "q", "esc":
-		m = m.clearConfirm()
-	}
-	return m, nil
-}
-
-func (m Model) handleWorktreeInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	key := msg.String()
-	switch key {
-	case "enter":
-		input := strings.TrimSpace(m.worktreeInput)
-		if input == "" {
-			m.worktreeInputErr = "Enter a branch, tag, or new branch name"
-			return m, nil
-		}
-		m = m.clearWorktreeInput()
-		return m, m.createWorktree(input)
-	case "esc", "ctrl+c":
-		m = m.clearWorktreeInput()
-	case "backspace", "ctrl+h":
-		runes := []rune(m.worktreeInput)
-		if len(runes) > 0 {
-			m.worktreeInput = string(runes[:len(runes)-1])
-			m.worktreeInputErr = ""
-		}
-	default:
-		if len(msg.Runes) > 0 {
-			m.worktreeInput += string(msg.Runes)
-			m.worktreeInputErr = ""
-		}
-	}
-	return m, nil
-}
-
 func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 	switch key {
 	case "tab":
@@ -171,22 +124,6 @@ func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 		}
 	case "q", "ctrl+c", "esc":
 		return m, tea.Quit
-	}
-	return m, nil
-}
-
-func (m Model) handleOverlayKey(key string) (tea.Model, tea.Cmd) {
-	switch key {
-	case "q", "esc":
-		m.overlay = ui.OverlayNone
-		m.overlayDiff = ""
-		m.overlayScroll = 0
-	case "up", "k":
-		if m.overlayScroll > 0 {
-			m.overlayScroll--
-		}
-	case "down", "j":
-		m.overlayScroll++
 	}
 	return m, nil
 }
@@ -304,25 +241,25 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 	if m.mode == ui.ModeWorktrees {
 		wt, ok := m.selectedWorktree()
 		if ok && wt.Dirty && !wt.Stale {
-			m.overlay = ui.OverlayWorktreeDiff
+			m = m.openDiff(modal.DiffWorktree)
 			return m, m.fetchWorktreeDiff()
 		}
 		return m, nil
 	}
 	if m.mode == ui.ModeBranches && m.isSelectedBranchDirtyWorktree() {
-		m.overlay = ui.OverlayBranchDiff
+		m = m.openDiff(modal.DiffBranch)
 		return m, m.fetchBranchDiff()
 	}
 	if m.mode == ui.ModeStashes && len(m.filteredStashes()) > 0 {
-		m.overlay = ui.OverlayStashDiff
+		m = m.openDiff(modal.DiffStash)
 		return m, m.fetchStashDiff()
 	}
 	if m.mode == ui.ModeHistory && len(m.filteredCommits()) > 0 {
-		m.overlay = ui.OverlayCommitDiff
+		m = m.openDiff(modal.DiffCommit)
 		return m, m.fetchCommitDiff()
 	}
 	if m.mode == ui.ModeReflog && len(m.filteredReflogs()) > 0 {
-		m.overlay = ui.OverlayReflogDiff
+		m = m.openDiff(modal.DiffReflog)
 		return m, m.fetchReflogDiff()
 	}
 	return m, nil
@@ -351,10 +288,20 @@ func (m Model) handleNewWorktree() (tea.Model, tea.Cmd) {
 	if _, ok := m.currentRepoPath(); !ok {
 		return m, nil
 	}
-	m.overlay = ui.OverlayWorktreeInput
-	m.worktreeInput = ""
-	m.worktreeInputErr = ""
+	m.modal = modal.OpenInput(
+		"New worktree",
+		"",
+		validateWorktreeInput,
+		func(input string) tea.Cmd { return m.createWorktree(input) },
+	)
 	return m, nil
+}
+
+func validateWorktreeInput(input string) error {
+	if input == "" {
+		return fmt.Errorf("Enter a branch, tag, or new branch name")
+	}
+	return nil
 }
 
 func (m Model) handleUnlock() (tea.Model, tea.Cmd) {
@@ -479,16 +426,14 @@ func (m Model) confirmStashDrop() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	idx := stash.Index
-	m.confirmPrompt = fmt.Sprintf("Drop stash@{%d}? (y/n)", idx)
-	m.confirmAction = func() tea.Cmd {
+	m.modal = modal.OpenConfirm(fmt.Sprintf("Drop stash@{%d}? (y/n)", idx), func() tea.Cmd {
 		return func() tea.Msg {
 			if err := actions.DropStash(repoPath, idx); err != nil {
 				return ActionFailedMsg{RepoPath: repoPath, Err: fmt.Sprintf("failed to drop stash: %v", err)}
 			}
 			return StashDroppedMsg{RepoPath: repoPath}
 		}
-	}
-	m.overlay = ui.OverlayConfirm
+	})
 	return m, nil
 }
 
@@ -508,8 +453,7 @@ func (m Model) confirmBranchDelete() (tea.Model, tea.Cmd) {
 	}
 
 	branchName := row.Branch.Name
-	m.confirmPrompt = fmt.Sprintf("Delete branch %s? (y/n)", branchName)
-	m.confirmAction = func() tea.Cmd {
+	m.modal = modal.OpenConfirm(fmt.Sprintf("Delete branch %s? (y/n)", branchName), func() tea.Cmd {
 		return func() tea.Msg {
 			if err := actions.DeleteBranch(repoPath, branchName); err != nil {
 				return DeleteFailedMsg{
@@ -520,8 +464,7 @@ func (m Model) confirmBranchDelete() (tea.Model, tea.Cmd) {
 			}
 			return BranchDeletedMsg{RepoPath: repoPath}
 		}
-	}
-	m.overlay = ui.OverlayConfirm
+	})
 	return m, nil
 }
 
@@ -550,8 +493,7 @@ func (m Model) confirmWorktreeDelete() (tea.Model, tea.Cmd) {
 		branchName = ""
 	}
 
-	m.confirmPrompt = fmt.Sprintf("Remove worktree at %s? (y/n)", wtPath)
-	m.confirmAction = func() tea.Cmd {
+	m.modal = modal.OpenConfirm(fmt.Sprintf("Remove worktree at %s? (y/n)", wtPath), func() tea.Cmd {
 		return func() tea.Msg {
 			if err := actions.RemoveWorktree(repoPath, wtPath); err != nil {
 				return DeleteFailedMsg{
@@ -563,8 +505,7 @@ func (m Model) confirmWorktreeDelete() (tea.Model, tea.Cmd) {
 			}
 			return WorktreeRemovedMsg{RepoPath: repoPath, BranchName: branchName}
 		}
-	}
-	m.overlay = ui.OverlayConfirm
+	})
 	return m, nil
 }
 
@@ -591,32 +532,15 @@ func (m Model) confirmWorktreePrune() (tea.Model, tea.Cmd) {
 	if !ok2 {
 		return m, nil
 	}
-	m.confirmPrompt = "Prune stale worktrees? (y/n)"
-	m.confirmAction = func() tea.Cmd {
+	m.modal = modal.OpenConfirm("Prune stale worktrees? (y/n)", func() tea.Cmd {
 		return func() tea.Msg {
 			if err := actions.PruneWorktree(repoPath); err != nil {
 				return ActionFailedMsg{RepoPath: repoPath, Err: fmt.Sprintf("failed to prune worktrees: %v", err)}
 			}
 			return WorktreePrunedMsg{RepoPath: repoPath}
 		}
-	}
-	m.overlay = ui.OverlayConfirm
+	})
 	return m, nil
-}
-
-func (m Model) clearConfirm() Model {
-	m.overlay = ui.OverlayNone
-	m.confirmPrompt = ""
-	m.confirmAction = nil
-	m.confirmForce = false
-	return m
-}
-
-func (m Model) clearWorktreeInput() Model {
-	m.overlay = ui.OverlayNone
-	m.worktreeInput = ""
-	m.worktreeInputErr = ""
-	return m
 }
 
 // resetModeCursors zeroes the cursor and scroll positions for non-worktree

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brian-bell/wtui/actions"
 	"github.com/brian-bell/wtui/gitquery"
+	"github.com/brian-bell/wtui/model/modal"
 	"github.com/brian-bell/wtui/ui"
 )
 
@@ -23,15 +24,20 @@ type StashResultMsg struct {
 }
 
 type StashDiffResultMsg struct {
-	RepoPath string
-	Index    int
-	Diff     string
+	RepoPath    string
+	Index       int
+	Date        string
+	Message     string
+	DiffRequest uint64
+	Diff        string
 }
 
 type BranchDiffResultMsg struct {
-	RepoPath   string
-	BranchName string
-	Diff       string
+	RepoPath     string
+	BranchName   string
+	WorktreePath string
+	DiffRequest  uint64
+	Diff         string
 }
 
 type BranchDeletedMsg struct {
@@ -53,14 +59,16 @@ type CommitResultMsg struct {
 }
 
 type CommitDiffResultMsg struct {
-	RepoPath string
-	Hash     string
-	Diff     string
+	RepoPath    string
+	Hash        string
+	DiffRequest uint64
+	Diff        string
 }
 
 type WorktreeDiffResultMsg struct {
 	RepoPath     string
 	WorktreePath string
+	DiffRequest  uint64
 	Diff         string
 }
 
@@ -121,9 +129,10 @@ type ReflogResultMsg struct {
 }
 
 type ReflogDiffResultMsg struct {
-	RepoPath string
-	Hash     string
-	Diff     string
+	RepoPath    string
+	Hash        string
+	DiffRequest uint64
+	Diff        string
 }
 
 type ClipboardResultMsg struct {
@@ -198,8 +207,7 @@ func (m Model) handleWorktreeRemoved(msg WorktreeRemovedMsg) (tea.Model, tea.Cmd
 	}
 	repoPath := msg.RepoPath
 	branchName := msg.BranchName
-	m.confirmPrompt = fmt.Sprintf("Also delete branch %s? (y/n)", branchName)
-	m.confirmAction = func() tea.Cmd {
+	m.modal = modal.OpenConfirm(fmt.Sprintf("Also delete branch %s? (y/n)", branchName), func() tea.Cmd {
 		return func() tea.Msg {
 			if err := actions.DeleteBranch(repoPath, branchName); err != nil {
 				return DeleteFailedMsg{
@@ -211,8 +219,7 @@ func (m Model) handleWorktreeRemoved(msg WorktreeRemovedMsg) (tea.Model, tea.Cmd
 			}
 			return WorktreeDeleteCompletedMsg{RepoPath: repoPath}
 		}
-	}
-	m.overlay = ui.OverlayConfirm
+	})
 	return m, m.fetchWorktrees()
 }
 
@@ -282,13 +289,16 @@ func (m Model) handleWorktreeCreated(msg WorktreeCreatedMsg) (tea.Model, tea.Cmd
 
 func (m Model) handleWorktreeCreateFailed(msg WorktreeCreateFailedMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.overlay = ui.OverlayWorktreeInput
-		m.worktreeInput = msg.Input
+		errText := msg.Err
 		if msg.Err == "" {
-			m.worktreeInputErr = "Unable to create worktree"
-		} else {
-			m.worktreeInputErr = msg.Err
+			errText = "Unable to create worktree"
 		}
+		m.modal = modal.OpenInput(
+			"New worktree",
+			msg.Input,
+			validateWorktreeInput,
+			func(input string) tea.Cmd { return m.createWorktree(input) },
+		).SetInputError(errText)
 	}
 	return m
 }
@@ -330,7 +340,9 @@ func (m Model) handleStashResult(msg StashResultMsg) Model {
 
 func (m Model) handleStashDiffResult(msg StashDiffResultMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.overlayDiff = msg.Diff
+		if stash, ok := m.selectedStash(); ok && stashMatchesDiffResult(stash, msg) {
+			m.modal = m.modal.SetDiffForRequest(modal.DiffStash, msg.DiffRequest, msg.Diff)
+		}
 	}
 	return m
 }
@@ -338,7 +350,7 @@ func (m Model) handleStashDiffResult(msg StashDiffResultMsg) Model {
 func (m Model) handleWorktreeDiffResult(msg WorktreeDiffResultMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
 		if wt, ok := m.selectedWorktree(); ok && wt.Path == msg.WorktreePath {
-			m.overlayDiff = msg.Diff
+			m.modal = m.modal.SetDiffForRequest(modal.DiffWorktree, msg.DiffRequest, msg.Diff)
 		}
 	}
 	return m
@@ -346,8 +358,8 @@ func (m Model) handleWorktreeDiffResult(msg WorktreeDiffResultMsg) Model {
 
 func (m Model) handleBranchDiffResult(msg BranchDiffResultMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		if row, ok := m.selectedRow(); ok && row.Branch.Name == msg.BranchName {
-			m.overlayDiff = msg.Diff
+		if row, ok := m.selectedRow(); ok && branchMatchesDiffResult(row, msg) {
+			m.modal = m.modal.SetDiffForRequest(modal.DiffBranch, msg.DiffRequest, msg.Diff)
 		}
 	}
 	return m
@@ -372,14 +384,11 @@ func (m Model) handleBranchDeleted(msg BranchDeletedMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) handleDeleteFailed(msg DeleteFailedMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.confirmPrompt = fmt.Sprintf("Force delete %s? (y/n)", msg.Target)
-		m.confirmForce = true
-		m.overlay = ui.OverlayConfirm
 		successMsg := msg.SuccessMsg
 		repoPath := msg.RepoPath
 		target := msg.Target
 		forceAction := msg.ForceAction
-		m.confirmAction = func() tea.Cmd {
+		m.modal = modal.OpenForce(fmt.Sprintf("Force delete %s? (y/n)", msg.Target), func() tea.Cmd {
 			return func() tea.Msg {
 				if err := forceAction(); err != nil {
 					return ForceDeleteFailedMsg{
@@ -393,7 +402,7 @@ func (m Model) handleDeleteFailed(msg DeleteFailedMsg) Model {
 				}
 				return BranchDeletedMsg{RepoPath: repoPath}
 			}
-		}
+		})
 	}
 	return m
 }
@@ -442,7 +451,7 @@ func (m Model) handleReflogResult(msg ReflogResultMsg) Model {
 func (m Model) handleCommitDiffResult(msg CommitDiffResultMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
 		if commit, ok := m.selectedCommit(); ok && commit.Hash == msg.Hash {
-			m.overlayDiff = msg.Diff
+			m.modal = m.modal.SetDiffForRequest(modal.DiffCommit, msg.DiffRequest, msg.Diff)
 		}
 	}
 	return m
@@ -451,10 +460,30 @@ func (m Model) handleCommitDiffResult(msg CommitDiffResultMsg) Model {
 func (m Model) handleReflogDiffResult(msg ReflogDiffResultMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
 		if entry, ok := m.selectedReflog(); ok && entry.Hash == msg.Hash {
-			m.overlayDiff = msg.Diff
+			m.modal = m.modal.SetDiffForRequest(modal.DiffReflog, msg.DiffRequest, msg.Diff)
 		}
 	}
 	return m
+}
+
+func stashMatchesDiffResult(stash gitquery.Stash, msg StashDiffResultMsg) bool {
+	if stash.Index != msg.Index {
+		return false
+	}
+	if stash.Date != msg.Date {
+		return false
+	}
+	if stash.Message != msg.Message {
+		return false
+	}
+	return true
+}
+
+func branchMatchesDiffResult(row gitquery.BranchRow, msg BranchDiffResultMsg) bool {
+	if row.Branch.Name != msg.BranchName {
+		return false
+	}
+	return row.WorktreePath == msg.WorktreePath
 }
 
 func (m Model) handleCopyHash() (tea.Model, tea.Cmd) {

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -181,7 +181,15 @@ func TestModel_ViewOverlayShowsDiff(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	m, _ = update(m, model.StashDiffResultMsg{RepoPath: "/dev/alpha", Index: 0, Diff: "diff --git a/f.txt\n--- a/f.txt\n+++ b/f.txt"})
+	stash := testStashes()[0]
+	m, _ = update(m, model.StashDiffResultMsg{
+		RepoPath:    "/dev/alpha",
+		Index:       stash.Index,
+		Date:        stash.Date,
+		Message:     stash.Message,
+		DiffRequest: 1,
+		Diff:        "diff --git a/f.txt\n--- a/f.txt\n+++ b/f.txt",
+	})
 
 	view := m.View()
 	if !strings.Contains(view, "diff --git") {
@@ -520,6 +528,7 @@ func TestModel_ViewWorktreeDiffOverlayShowsDiff(t *testing.T) {
 	m, _ = update(m, model.WorktreeDiffResultMsg{
 		RepoPath:     "/dev/alpha",
 		WorktreePath: "/dev/alpha",
+		DiffRequest:  1,
 		Diff:         "diff --git a/f.txt\n--- a/f.txt\n+++ b/f.txt",
 	})
 
@@ -653,7 +662,7 @@ func TestModel_ViewReflogDiffOverlayShowsEmptyMessage(t *testing.T) {
 	})
 	// Open overlay and receive empty diff (e.g. checkout entry)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	m, _ = update(m, model.ReflogDiffResultMsg{RepoPath: "/dev/alpha", Hash: "abc1234", Diff: ""})
+	m, _ = update(m, model.ReflogDiffResultMsg{RepoPath: "/dev/alpha", Hash: "abc1234", DiffRequest: 1, Diff: ""})
 
 	view := m.View()
 	if !strings.Contains(view, "No changes at this reflog entry") {
@@ -671,7 +680,7 @@ func TestModel_ViewReflogDiffOverlayShowsDiff(t *testing.T) {
 		Reflogs:  testReflogs(),
 	})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	m, _ = update(m, model.ReflogDiffResultMsg{RepoPath: "/dev/alpha", Hash: "abc1234", Diff: "diff --git a/f.txt\n+added line"})
+	m, _ = update(m, model.ReflogDiffResultMsg{RepoPath: "/dev/alpha", Hash: "abc1234", DiffRequest: 1, Diff: "diff --git a/f.txt\n+added line"})
 
 	view := m.View()
 	if !strings.Contains(view, "diff --git") {


### PR DESCRIPTION
## Summary
- Replace scattered overlay, confirm, worktree input, and diff fields with a single `modal.Modal` value type.
- Route confirm, input, and diff overlay key handling through the modal state machine while preserving the existing UI render adapter.
- Carry exact async diff request identity through result messages so stale diff payloads cannot populate a newer or different modal.

## Implementation Notes
- Added `model/modal` with constructors for confirm, force confirm, input, and diff modals plus behavior-focused boundary tests.
- Added request ids for diff overlays and stricter branch/stash/worktree/commit/reflog identity checks before accepting async diff results.
- Kept destructive policy and chained confirmation policy in the host model, preserving locked/stale/root worktree safety boundaries.

## Verification
- `gofmt -l .`
- `go test ./model/modal ./model`
- `make test`
- `make build`
- Review-loop completed at 9/10.

Closes #76