### PR TITLE
Surface async git fetch failures

### DIFF
--- a/docs/roadmap-todo.md
+++ b/docs/roadmap-todo.md
@@ -1,0 +1,83 @@
+# wtui Roadmap Todo
+
+This checklist is derived from `docs/product-roadmap.md`. Use it as the
+operational tracker for checking off roadmap work as it lands.
+
+## Phase 1: Error Surfacing and Config Foundation
+
+Goal: make failures visible and establish the configuration layer future
+features can build on.
+
+- [x] P0 - Git command error surfacing: surface async list/diff fetch failures in the status bar so empty panes are not confused with command failures.
+- [ ] P0 - Config file foundation: add `~/.config/wtui/config.toml` and load it early enough to support future scan, editor, terminal, provider, and launch settings.
+- [ ] P1 - Empty-state clarity: distinguish "nothing to show" from "command failed" and "repo has no matching filtered results."
+- [x] P1 - Stale async result clarity: keep ignoring outdated async results, but make current command failures obvious when they belong to the selected repo/mode.
+
+## Phase 2: Worktree Lifecycle Depth
+
+Goal: round out lifecycle operations while keeping the destructive boundary
+clear.
+
+- [ ] P1 - PR-based worktree creation: enter a PR number or URL, fetch the head branch, and create a worktree for review.
+- [ ] P1 - Branch creation from branches pane: complement worktree creation and make branch-first workflows smoother.
+- [ ] P1 - Coding-agent launch actions: launch Codex or Claude Code from a selected worktree or worktree branch, optionally after creating a new worktree or branch.
+- [ ] P2 - Worktree move/rename: wrap `git worktree move` for users who need to reorganize generated paths.
+- [ ] P2 - Bare repo support: detect bare repositories and support worktree creation/listing correctly for central bare repo workflows.
+- [ ] P2 - Bootstrap hooks: support an optional per-repo setup script after worktree creation for env files, dependency links, or setup commands.
+
+## Phase 3: Multi-Repo Operations
+
+Goal: make wtui more than a per-repo switcher while preserving safety and
+clarity.
+
+- [ ] P1 - Fetch all visible repos: extend the current fetch action across filtered repos with clear progress and failure reporting.
+- [ ] P1 - Prune stale worktrees across visible repos: require destructive mode and a confirmation summary.
+- [ ] P2 - Batch selection: enable scoped multi-repo actions without applying commands to the whole workspace accidentally.
+- [ ] P2 - Merged branch cleanup queue: group safe cleanup candidates across repos using the existing merged-branch indicators.
+- [ ] P2 - Operation log: provide a compact way to review successes, failures, and skipped items for multi-repo commands.
+
+## Phase 4: External Signals
+
+Goal: add context that helps users decide which worktree needs attention.
+
+- [ ] P2 - CI status per branch/worktree: show pass, fail, and running indicators for active branches.
+- [ ] P2 - GitHub/GitLab provider config: support PR creation, PR detection, and CI lookup without hardcoding one provider.
+- [ ] P3 - Worktree notes, labels, or tags: help users manage many parallel branches, especially for review or agent-driven work.
+- [ ] P3 - AI-agent session awareness: detect active coding-agent sessions in worktrees when reliable signals exist.
+- [ ] P3 - Desktop notifications: notify on long-running fetch, pull, or batch completion after the operation model is mature.
+
+## Phase 5: Release and Community Hygiene
+
+Goal: make the project easier to release, verify, and maintain once the product
+surface is stronger.
+
+- [ ] P1 - First tagged release validation: exercise a real `v0.1.0` tag and verify GitHub artifacts, checksums, Homebrew cask, and `go install`.
+- [ ] P1 - README/demo recording: show scan, filter, create worktree, diff, terminal launch, and cleanup.
+- [ ] P2 - Release notes and changelog habit: establish a predictable user-facing cadence for fixes and feature drops.
+- [ ] P2 - Issue templates and contribution notes: capture repo layout, OS, git version, terminal/multiplexer, and reproduction steps.
+
+## Phase 6: Configuration and Personal Workflow
+
+Goal: let users adapt wtui without changing source or environment wrappers.
+
+- [ ] P1 - Multiple scan roots: support developers who split work across `~/dev`, client folders, and sandbox folders.
+- [ ] P1 - Custom editor command: support Cursor, Zed, Neovim terminals, or arbitrary commands through config/env instead of hardcoding `code`.
+- [ ] P2 - Scan-depth/exclude controls: preserve zero-config defaults while letting large workspaces avoid slow or noisy directories.
+- [ ] P3 - Persisted UI defaults: remember default mode and possibly last selected repo without surprising statefulness.
+
+## Distribution Follow-Ups
+
+- [ ] P0 - Homebrew cask: keep this as the primary macOS install path.
+- [ ] P0 - GitHub Releases: verify artifacts and checksums on every release.
+- [ ] P0 - `go install`: keep documented as the source-friendly fallback.
+- [ ] P2 - AUR: consider after the first release proves stable.
+- [ ] P2 - Nix: consider a flake or nixpkgs path after release cadence settles.
+- [ ] P3 - Scoop/Windows: add only after validating terminal/editor behavior on Windows.
+
+## Launch Follow-Ups
+
+- [ ] Record a concrete workflow demo before launch.
+- [ ] Prepare a Hacker News "Show HN" post.
+- [ ] Prepare r/commandline, r/git, and r/golang posts with a concise workflow example.
+- [ ] Write a short blog post about multi-repo worktree state.
+- [ ] Submit to terminal tool directories after the release is installable.

--- a/model/model.go
+++ b/model/model.go
@@ -10,6 +10,8 @@ import (
 	"github.com/brian-bell/wtui/ui"
 )
 
+const listRequestSlots = int(ui.ModeReflog) + 1
+
 // Model is the bubbletea application model.
 type Model struct {
 	repos          pane.Pane[scanner.Repo]
@@ -23,10 +25,28 @@ type Model struct {
 	reflogs        pane.Pane[gitquery.ReflogEntry]
 	modal          modal.Modal
 	diffRequestSeq uint64
+	listRequestSeq uint64
+	listRequests   [listRequestSlots]uint64
 	activePane     int // 0=left (repos), 1=right (content)
 	destructive    bool
-	transientError string
+	status         statusError
 	searchActive   bool
+}
+
+type statusSource int
+
+const (
+	statusNone statusSource = iota
+	statusFetch
+	statusGitMutation
+	statusOther
+)
+
+type statusError struct {
+	Text      string
+	Source    statusSource
+	FetchKind FetchKind
+	Mode      ui.Mode
 }
 
 // New creates a Model from discovered repos.
@@ -39,6 +59,10 @@ func New(repos []scanner.Repo) Model {
 		commits:   newCommitPane(),
 		reflogs:   newReflogPane(),
 		mode:      ui.ModeWorktrees,
+	}
+	for mode := ui.ModeWorktrees; mode <= ui.ModeReflog; mode++ {
+		m.listRequestSeq++
+		m.listRequests[int(mode)] = m.listRequestSeq
 	}
 	return m
 }
@@ -75,10 +99,11 @@ func (m Model) RepoScroll() int                 { return m.repos.Scroll() }
 func (m Model) StashScroll() int                { return m.stashes.Scroll() }
 func (m Model) ActivePane() int                 { return m.activePane }
 func (m Model) Destructive() bool               { return m.destructive }
-func (m Model) TransientError() string          { return m.transientError }
+func (m Model) TransientError() string          { return m.status.Text }
 func (m Model) SearchActive() bool              { return m.searchActive }
 func (m Model) RepoSearch() string              { return m.repos.Query() }
 func (m Model) ItemSearch() string              { return m.activeItemPaneQuery() }
+func (m Model) ListRequest(mode ui.Mode) uint64 { return m.currentListRequest(mode) }
 
 func (m Model) Init() tea.Cmd {
 	return m.fetchForMode()
@@ -130,7 +155,7 @@ func (m Model) View() string {
 		Reflogs:          reflogs,
 		ReflogSelected:   reflogSelected,
 		ReflogScroll:     reflogScroll,
-		TransientError:   m.transientError,
+		TransientError:   m.status.Text,
 		SearchActive:     m.searchActive,
 		RepoSearch:       m.repos.Query(),
 		ItemSearch:       m.activeItemPaneQuery(),
@@ -227,12 +252,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleReflogDiffResult(msg), nil
 	case ClipboardResultMsg:
 		if msg.Err != "" {
-			m.transientError = msg.Err
+			m = m.setStatus(statusOther, msg.Err)
 		}
 		return m, nil
 	case TerminalResultMsg:
 		if msg.Err != "" {
-			m.transientError = msg.Err
+			m = m.setStatus(statusOther, msg.Err)
 		}
 		return m, nil
 	case DeleteFailedMsg:

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -114,6 +114,90 @@ func TestModel_WorktreeDiffResultStoresDiff(t *testing.T) {
 	}
 }
 
+func TestModel_WorktreeDiffFetchFailureCarriesIdentity(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/does-not-exist", BranchName: "main", Dirty: true},
+	}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.Overlay() != ui.OverlayWorktreeDiff {
+		t.Fatalf("expected OverlayWorktreeDiff, got %d", m.Overlay())
+	}
+	if cmd == nil {
+		t.Fatal("expected diff fetch command")
+	}
+	msg, ok := cmd().(model.FetchErrorMsg)
+	if !ok {
+		t.Fatalf("expected FetchErrorMsg, got %T", msg)
+	}
+	if msg.Kind != model.FetchWorktreeDiff {
+		t.Fatalf("expected FetchWorktreeDiff kind, got %d", msg.Kind)
+	}
+	if msg.DiffRequest != 1 {
+		t.Fatalf("expected diff request 1, got %d", msg.DiffRequest)
+	}
+	if msg.WorktreePath != "/dev/does-not-exist" {
+		t.Fatalf("expected worktree identity, got %q", msg.WorktreePath)
+	}
+}
+
+func TestModel_MatchingWorktreeDiffFetchFailureShowsStatusWithoutOverwritingOverlay(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", Dirty: true},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:     "/dev/alpha",
+		Err:          "failed to load diff: boom",
+		Kind:         model.FetchWorktreeDiff,
+		Mode:         ui.ModeWorktrees,
+		DiffRequest:  1,
+		WorktreePath: "/dev/alpha",
+	})
+
+	if m.Overlay() != ui.OverlayWorktreeDiff {
+		t.Fatalf("expected overlay to remain open, got %d", m.Overlay())
+	}
+	if m.OverlayDiff() != "" {
+		t.Fatalf("expected fetch failure not to overwrite overlay diff, got %q", m.OverlayDiff())
+	}
+	if !strings.Contains(m.View(), "failed to load diff: boom") {
+		t.Fatal("expected matching diff fetch failure in status bar")
+	}
+}
+
+func TestModel_StaleWorktreeDiffFetchFailureIgnored(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", Dirty: true},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})  // request 1
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEscape}) // close overlay
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})  // request 2
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:     "/dev/alpha",
+		Err:          "old diff failure",
+		Kind:         model.FetchWorktreeDiff,
+		Mode:         ui.ModeWorktrees,
+		DiffRequest:  1,
+		WorktreePath: "/dev/alpha",
+	})
+
+	if strings.Contains(m.View(), "old diff failure") {
+		t.Fatal("expected stale same-target diff failure to be ignored")
+	}
+	if m.OverlayDiff() != "" {
+		t.Fatalf("expected stale failure not to overwrite overlay diff, got %q", m.OverlayDiff())
+	}
+}
+
 func TestModel_StaleWorktreeDiffResultDiscarded(t *testing.T) {
 	m := model.New(testRepos())
 	m = selectBravo(m)
@@ -547,6 +631,62 @@ func TestModel_BranchDiffResultForWrongWorktreePathIgnored(t *testing.T) {
 	}
 }
 
+func TestModel_BranchDiffFetchFailureMatchesBranchAndWorktreePath(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{{
+			Name:          "feat",
+			IsWorktree:    true,
+			Dirty:         true,
+			WorktreePaths: []string{"/dev/alpha"},
+		}},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:    "/dev/alpha",
+		Err:         "branch diff failed",
+		Kind:        model.FetchBranchDiff,
+		Mode:        ui.ModeBranches,
+		DiffRequest: 1,
+		BranchName:  "feat",
+	})
+	if strings.Contains(m.View(), "branch diff failed") {
+		t.Fatal("missing worktree path branch diff failure should be ignored")
+	}
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:     "/dev/alpha",
+		Err:          "branch diff failed",
+		Kind:         model.FetchBranchDiff,
+		Mode:         ui.ModeBranches,
+		DiffRequest:  1,
+		BranchName:   "feat",
+		WorktreePath: "/dev/elsewhere",
+	})
+	if strings.Contains(m.View(), "branch diff failed") {
+		t.Fatal("wrong worktree path branch diff failure should be ignored")
+	}
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:     "/dev/alpha",
+		Err:          "branch diff failed",
+		Kind:         model.FetchBranchDiff,
+		Mode:         ui.ModeBranches,
+		DiffRequest:  1,
+		BranchName:   "feat",
+		WorktreePath: "/dev/alpha",
+	})
+	if !strings.Contains(m.View(), "branch diff failed") {
+		t.Fatal("matching branch diff failure should show in status bar")
+	}
+	if m.OverlayDiff() != "" {
+		t.Fatalf("branch diff failure should not overwrite overlay diff, got %q", m.OverlayDiff())
+	}
+}
+
 func TestModel_EnterDoesNothingForCleanBranch(t *testing.T) {
 	m := model.New(testRepos())
 	branches := []gitquery.Branch{
@@ -620,6 +760,50 @@ func TestModel_StaleCommitDiffResultDiscarded(t *testing.T) {
 	m, _ = update(m, model.CommitDiffResultMsg{RepoPath: "/dev/alpha", Hash: "abc1234", Diff: "stale"})
 	if m.OverlayDiff() != "" {
 		t.Errorf("expected stale commit diff discarded, got %q", m.OverlayDiff())
+	}
+}
+
+func TestModel_CommitDiffFetchFailureMatchesHashAndRequest(t *testing.T) {
+	m := modelInHistoryWithCommits()
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:    "/dev/alpha",
+		Err:         "commit diff failed",
+		Kind:        model.FetchCommitDiff,
+		Mode:        ui.ModeHistory,
+		DiffRequest: 1,
+		Hash:        "wrong",
+	})
+	if strings.Contains(m.View(), "commit diff failed") {
+		t.Fatal("wrong-hash commit diff failure should be ignored")
+	}
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:    "/dev/alpha",
+		Err:         "commit diff failed",
+		Kind:        model.FetchCommitDiff,
+		Mode:        ui.ModeHistory,
+		DiffRequest: 99,
+		Hash:        "abc1234",
+	})
+	if strings.Contains(m.View(), "commit diff failed") {
+		t.Fatal("wrong-request commit diff failure should be ignored")
+	}
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:    "/dev/alpha",
+		Err:         "commit diff failed",
+		Kind:        model.FetchCommitDiff,
+		Mode:        ui.ModeHistory,
+		DiffRequest: 1,
+		Hash:        "abc1234",
+	})
+	if !strings.Contains(m.View(), "commit diff failed") {
+		t.Fatal("matching commit diff failure should show in status bar")
+	}
+	if m.OverlayDiff() != "" {
+		t.Fatalf("commit diff failure should not overwrite overlay diff, got %q", m.OverlayDiff())
 	}
 }
 
@@ -825,6 +1009,61 @@ func TestModel_StaleStashDiffForChangedIdentityIgnored(t *testing.T) {
 	})
 	if m.OverlayDiff() != "new stash diff" {
 		t.Fatalf("expected matching stash identity diff stored, got %q", m.OverlayDiff())
+	}
+}
+
+func TestModel_StashDiffFetchFailureMatchesFullIdentity(t *testing.T) {
+	oldStash := gitquery.Stash{Index: 0, Date: "2026-03-18 10:00:00 -0700", Message: "old stash"}
+	newStash := gitquery.Stash{Index: 0, Date: "2026-03-19 10:00:00 -0700", Message: "new stash"}
+
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: []gitquery.Stash{oldStash}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: []gitquery.Stash{newStash}})
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:    "/dev/alpha",
+		Err:         "missing stash identity failed",
+		Kind:        model.FetchStashDiff,
+		Mode:        ui.ModeStashes,
+		DiffRequest: 1,
+		StashIndex:  newStash.Index,
+	})
+	if strings.Contains(m.View(), "missing stash identity failed") {
+		t.Fatal("missing stash date/message failure should be ignored")
+	}
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:     "/dev/alpha",
+		Err:          "old stash diff failed",
+		Kind:         model.FetchStashDiff,
+		Mode:         ui.ModeStashes,
+		DiffRequest:  1,
+		StashIndex:   oldStash.Index,
+		StashDate:    oldStash.Date,
+		StashMessage: oldStash.Message,
+	})
+	if strings.Contains(m.View(), "old stash diff failed") {
+		t.Fatal("stale stash identity failure should be ignored")
+	}
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:     "/dev/alpha",
+		Err:          "new stash diff failed",
+		Kind:         model.FetchStashDiff,
+		Mode:         ui.ModeStashes,
+		DiffRequest:  1,
+		StashIndex:   newStash.Index,
+		StashDate:    newStash.Date,
+		StashMessage: newStash.Message,
+	})
+	if !strings.Contains(m.View(), "new stash diff failed") {
+		t.Fatal("matching stash identity failure should show in status bar")
+	}
+	if m.OverlayDiff() != "" {
+		t.Fatalf("stash diff failure should not overwrite overlay diff, got %q", m.OverlayDiff())
 	}
 }
 
@@ -2103,6 +2342,50 @@ func TestModel_ReflogDiffResultWrongHashDiscarded(t *testing.T) {
 	m, _ = update(m, model.ReflogDiffResultMsg{RepoPath: "/dev/alpha", Hash: "wrong", Diff: "wrong diff"})
 	if m.OverlayDiff() != "" {
 		t.Errorf("expected wrong-hash reflog diff discarded, got %q", m.OverlayDiff())
+	}
+}
+
+func TestModel_ReflogDiffFetchFailureMatchesHashAndRequest(t *testing.T) {
+	m := modelInReflogWithEntries()
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:    "/dev/alpha",
+		Err:         "reflog diff failed",
+		Kind:        model.FetchReflogDiff,
+		Mode:        ui.ModeReflog,
+		DiffRequest: 1,
+		Hash:        "wrong",
+	})
+	if strings.Contains(m.View(), "reflog diff failed") {
+		t.Fatal("wrong-hash reflog diff failure should be ignored")
+	}
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:    "/dev/alpha",
+		Err:         "reflog diff failed",
+		Kind:        model.FetchReflogDiff,
+		Mode:        ui.ModeReflog,
+		DiffRequest: 99,
+		Hash:        "abc1234",
+	})
+	if strings.Contains(m.View(), "reflog diff failed") {
+		t.Fatal("wrong-request reflog diff failure should be ignored")
+	}
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:    "/dev/alpha",
+		Err:         "reflog diff failed",
+		Kind:        model.FetchReflogDiff,
+		Mode:        ui.ModeReflog,
+		DiffRequest: 1,
+		Hash:        "abc1234",
+	})
+	if !strings.Contains(m.View(), "reflog diff failed") {
+		t.Fatal("matching reflog diff failure should show in status bar")
+	}
+	if m.OverlayDiff() != "" {
+		t.Fatalf("reflog diff failure should not overwrite overlay diff, got %q", m.OverlayDiff())
 	}
 }
 

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -12,20 +12,78 @@ import (
 
 // --- Fetch commands ---
 
-func (m Model) fetchForMode() tea.Cmd {
+func (m Model) startFetchForMode() (Model, tea.Cmd) {
 	switch m.mode {
 	case ui.ModeWorktrees:
-		return m.fetchWorktrees()
+		return m.startFetchWorktrees()
 	case ui.ModeBranches:
-		return m.fetchBranches()
+		return m.startFetchBranches()
 	case ui.ModeStashes:
-		return m.fetchStashes()
+		return m.startFetchStashes()
 	case ui.ModeHistory:
-		return m.fetchCommits()
+		return m.startFetchCommits()
 	case ui.ModeReflog:
-		return m.fetchReflog()
+		return m.startFetchReflog()
+	}
+	return m, nil
+}
+
+func (m Model) fetchForMode() tea.Cmd {
+	request := m.currentListRequest(m.mode)
+	switch m.mode {
+	case ui.ModeWorktrees:
+		return m.fetchWorktrees(request)
+	case ui.ModeBranches:
+		return m.fetchBranches(request)
+	case ui.ModeStashes:
+		return m.fetchStashes(request)
+	case ui.ModeHistory:
+		return m.fetchCommits(request)
+	case ui.ModeReflog:
+		return m.fetchReflog(request)
 	}
 	return nil
+}
+
+func (m Model) currentListRequest(mode ui.Mode) uint64 {
+	if int(mode) < 0 || int(mode) >= len(m.listRequests) {
+		return 0
+	}
+	return m.listRequests[int(mode)]
+}
+
+func (m Model) nextListFetchRequest(mode ui.Mode) (Model, uint64) {
+	m.listRequestSeq++
+	request := m.listRequestSeq
+	if int(mode) >= 0 && int(mode) < len(m.listRequests) {
+		m.listRequests[int(mode)] = request
+	}
+	return m, request
+}
+
+func (m Model) startFetchWorktrees() (Model, tea.Cmd) {
+	m, request := m.nextListFetchRequest(ui.ModeWorktrees)
+	return m, m.fetchWorktrees(request)
+}
+
+func (m Model) startFetchBranches() (Model, tea.Cmd) {
+	m, request := m.nextListFetchRequest(ui.ModeBranches)
+	return m, m.fetchBranches(request)
+}
+
+func (m Model) startFetchStashes() (Model, tea.Cmd) {
+	m, request := m.nextListFetchRequest(ui.ModeStashes)
+	return m, m.fetchStashes(request)
+}
+
+func (m Model) startFetchCommits() (Model, tea.Cmd) {
+	m, request := m.nextListFetchRequest(ui.ModeHistory)
+	return m, m.fetchCommits(request)
+}
+
+func (m Model) startFetchReflog() (Model, tea.Cmd) {
+	m, request := m.nextListFetchRequest(ui.ModeReflog)
+	return m, m.fetchReflog(request)
 }
 
 func (m Model) canFetch() bool {
@@ -105,7 +163,7 @@ func (m Model) createWorktree(input string) tea.Cmd {
 	}
 }
 
-func (m Model) fetchWorktrees() tea.Cmd {
+func (m Model) fetchWorktrees(request uint64) tea.Cmd {
 	repoPath, ok := m.currentRepoPath()
 	if !ok {
 		return nil
@@ -113,13 +171,13 @@ func (m Model) fetchWorktrees() tea.Cmd {
 	return func() tea.Msg {
 		worktrees, err := gitquery.ListWorktrees(repoPath)
 		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "worktrees", Err: fmt.Sprintf("failed to load worktrees: %v", err)}
+			return FetchErrorMsg{RepoPath: repoPath, Pane: "worktrees", Err: fmt.Sprintf("failed to load worktrees: %v", err), Kind: FetchList, Mode: ui.ModeWorktrees, ListRequest: request}
 		}
-		return WorktreeResultMsg{RepoPath: repoPath, Worktrees: worktrees}
+		return WorktreeResultMsg{RepoPath: repoPath, Worktrees: worktrees, ListRequest: request}
 	}
 }
 
-func (m Model) fetchBranches() tea.Cmd {
+func (m Model) fetchBranches(request uint64) tea.Cmd {
 	repoPath, ok := m.currentRepoPath()
 	if !ok {
 		return nil
@@ -127,13 +185,13 @@ func (m Model) fetchBranches() tea.Cmd {
 	return func() tea.Msg {
 		branches, err := gitquery.ListBranches(repoPath)
 		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "branches", Err: fmt.Sprintf("failed to load branches: %v", err)}
+			return FetchErrorMsg{RepoPath: repoPath, Pane: "branches", Err: fmt.Sprintf("failed to load branches: %v", err), Kind: FetchList, Mode: ui.ModeBranches, ListRequest: request}
 		}
-		return BranchResultMsg{RepoPath: repoPath, Branches: branches}
+		return BranchResultMsg{RepoPath: repoPath, Branches: branches, ListRequest: request}
 	}
 }
 
-func (m Model) fetchStashes() tea.Cmd {
+func (m Model) fetchStashes(request uint64) tea.Cmd {
 	repoPath, ok := m.currentRepoPath()
 	if !ok {
 		return nil
@@ -141,9 +199,9 @@ func (m Model) fetchStashes() tea.Cmd {
 	return func() tea.Msg {
 		stashes, err := gitquery.ListStashes(repoPath)
 		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "stashes", Err: fmt.Sprintf("failed to load stashes: %v", err)}
+			return FetchErrorMsg{RepoPath: repoPath, Pane: "stashes", Err: fmt.Sprintf("failed to load stashes: %v", err), Kind: FetchList, Mode: ui.ModeStashes, ListRequest: request}
 		}
-		return StashResultMsg{RepoPath: repoPath, Stashes: stashes}
+		return StashResultMsg{RepoPath: repoPath, Stashes: stashes, ListRequest: request}
 	}
 }
 
@@ -166,7 +224,16 @@ func (m Model) fetchBranchDiff() tea.Cmd {
 	return func() tea.Msg {
 		diff, err := gitquery.BranchDiff(worktreePath)
 		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "branch diff", Err: fmt.Sprintf("failed to load diff: %v", err)}
+			return FetchErrorMsg{
+				RepoPath:     repoPath,
+				Pane:         "branch diff",
+				Err:          fmt.Sprintf("failed to load diff: %v", err),
+				Kind:         FetchBranchDiff,
+				Mode:         ui.ModeBranches,
+				DiffRequest:  diffRequest,
+				BranchName:   branchName,
+				WorktreePath: worktreePath,
+			}
 		}
 		return BranchDiffResultMsg{
 			RepoPath:     repoPath,
@@ -192,7 +259,15 @@ func (m Model) fetchWorktreeDiff() tea.Cmd {
 	return func() tea.Msg {
 		diff, err := gitquery.BranchDiff(worktreePath)
 		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "worktree diff", Err: fmt.Sprintf("failed to load diff: %v", err)}
+			return FetchErrorMsg{
+				RepoPath:     repoPath,
+				Pane:         "worktree diff",
+				Err:          fmt.Sprintf("failed to load diff: %v", err),
+				Kind:         FetchWorktreeDiff,
+				Mode:         ui.ModeWorktrees,
+				DiffRequest:  diffRequest,
+				WorktreePath: worktreePath,
+			}
 		}
 		return WorktreeDiffResultMsg{
 			RepoPath:     repoPath,
@@ -219,7 +294,17 @@ func (m Model) fetchStashDiff() tea.Cmd {
 	return func() tea.Msg {
 		diff, err := gitquery.StashDiff(repoPath, index)
 		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "stash diff", Err: fmt.Sprintf("failed to load diff: %v", err)}
+			return FetchErrorMsg{
+				RepoPath:     repoPath,
+				Pane:         "stash diff",
+				Err:          fmt.Sprintf("failed to load diff: %v", err),
+				Kind:         FetchStashDiff,
+				Mode:         ui.ModeStashes,
+				DiffRequest:  diffRequest,
+				StashIndex:   index,
+				StashDate:    stashDate,
+				StashMessage: stashMessage,
+			}
 		}
 		return StashDiffResultMsg{
 			RepoPath:    repoPath,
@@ -232,7 +317,7 @@ func (m Model) fetchStashDiff() tea.Cmd {
 	}
 }
 
-func (m Model) fetchCommits() tea.Cmd {
+func (m Model) fetchCommits(request uint64) tea.Cmd {
 	repoPath, ok := m.currentRepoPath()
 	if !ok {
 		return nil
@@ -240,13 +325,13 @@ func (m Model) fetchCommits() tea.Cmd {
 	return func() tea.Msg {
 		commits, err := gitquery.ListCommits(repoPath)
 		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "history", Err: fmt.Sprintf("failed to load commits: %v", err)}
+			return FetchErrorMsg{RepoPath: repoPath, Pane: "history", Err: fmt.Sprintf("failed to load commits: %v", err), Kind: FetchList, Mode: ui.ModeHistory, ListRequest: request}
 		}
-		return CommitResultMsg{RepoPath: repoPath, Commits: commits}
+		return CommitResultMsg{RepoPath: repoPath, Commits: commits, ListRequest: request}
 	}
 }
 
-func (m Model) fetchReflog() tea.Cmd {
+func (m Model) fetchReflog(request uint64) tea.Cmd {
 	repoPath, ok := m.currentRepoPath()
 	if !ok {
 		return nil
@@ -254,9 +339,9 @@ func (m Model) fetchReflog() tea.Cmd {
 	return func() tea.Msg {
 		reflogs, err := gitquery.ListReflog(repoPath)
 		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "reflog", Err: fmt.Sprintf("failed to load reflog: %v", err)}
+			return FetchErrorMsg{RepoPath: repoPath, Pane: "reflog", Err: fmt.Sprintf("failed to load reflog: %v", err), Kind: FetchList, Mode: ui.ModeReflog, ListRequest: request}
 		}
-		return ReflogResultMsg{RepoPath: repoPath, Reflogs: reflogs}
+		return ReflogResultMsg{RepoPath: repoPath, Reflogs: reflogs, ListRequest: request}
 	}
 }
 
@@ -274,7 +359,15 @@ func (m Model) fetchReflogDiff() tea.Cmd {
 	return func() tea.Msg {
 		diff, err := gitquery.ReflogDiff(repoPath, hash)
 		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "reflog diff", Err: fmt.Sprintf("failed to load diff: %v", err)}
+			return FetchErrorMsg{
+				RepoPath:    repoPath,
+				Pane:        "reflog diff",
+				Err:         fmt.Sprintf("failed to load diff: %v", err),
+				Kind:        FetchReflogDiff,
+				Mode:        ui.ModeReflog,
+				DiffRequest: diffRequest,
+				Hash:        hash,
+			}
 		}
 		return ReflogDiffResultMsg{RepoPath: repoPath, Hash: hash, DiffRequest: diffRequest, Diff: diff}
 	}
@@ -294,7 +387,15 @@ func (m Model) fetchCommitDiff() tea.Cmd {
 	return func() tea.Msg {
 		diff, err := gitquery.CommitDiff(repoPath, hash)
 		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "commit diff", Err: fmt.Sprintf("failed to load diff: %v", err)}
+			return FetchErrorMsg{
+				RepoPath:    repoPath,
+				Pane:        "commit diff",
+				Err:         fmt.Sprintf("failed to load diff: %v", err),
+				Kind:        FetchCommitDiff,
+				Mode:        ui.ModeHistory,
+				DiffRequest: diffRequest,
+				Hash:        hash,
+			}
 		}
 		return CommitDiffResultMsg{RepoPath: repoPath, Hash: hash, DiffRequest: diffRequest, Diff: diff}
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -19,7 +19,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
-	m.transientError = ""
+	m = m.clearAnyStatus()
 
 	if m.searchActive {
 		return m.handleSearchKey(msg)
@@ -43,7 +43,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if oldRepoPath != newRepoPath {
 				m = m.resetRightPaneCursors()
 				if ok {
-					return m, m.fetchForMode()
+					return m.startFetchForMode()
 				}
 			}
 		}
@@ -97,7 +97,7 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if oldRepoPath != newRepoPath {
 			m = m.resetRightPaneCursors()
 			if ok {
-				return m, m.fetchForMode()
+				return m.startFetchForMode()
 			}
 		}
 	}
@@ -114,13 +114,13 @@ func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 		if len(m.filteredRepos()) > 0 {
 			m.repos = m.repos.Move(-1, m.repoContentHeight(), ui.LeftPaneWidth-2)
 			m = m.resetRightPaneCursors()
-			return m, m.fetchForMode()
+			return m.startFetchForMode()
 		}
 	case "down", "j":
 		if len(m.filteredRepos()) > 0 {
 			m.repos = m.repos.Move(1, m.repoContentHeight(), ui.LeftPaneWidth-2)
 			m = m.resetRightPaneCursors()
-			return m, m.fetchForMode()
+			return m.startFetchForMode()
 		}
 	case "q", "ctrl+c", "esc":
 		return m, tea.Quit
@@ -138,43 +138,43 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode > ui.ModeWorktrees {
 			m.mode--
 			m = m.resetModeCursors()
-			return m, m.fetchForMode()
+			return m.startFetchForMode()
 		}
 	case "right", "l":
 		if m.mode < ui.ModeReflog {
 			m.mode++
 			m = m.resetModeCursors()
-			return m, m.fetchForMode()
+			return m.startFetchForMode()
 		}
 	case "1":
 		if m.mode != ui.ModeWorktrees {
 			m.mode = ui.ModeWorktrees
 			m = m.resetModeCursors()
-			return m, m.fetchWorktrees()
+			return m.startFetchWorktrees()
 		}
 	case "2":
 		if m.mode != ui.ModeBranches {
 			m.mode = ui.ModeBranches
 			m = m.resetModeCursors()
-			return m, m.fetchBranches()
+			return m.startFetchBranches()
 		}
 	case "3":
 		if m.mode != ui.ModeStashes {
 			m.mode = ui.ModeStashes
 			m = m.resetModeCursors()
-			return m, m.fetchStashes()
+			return m.startFetchStashes()
 		}
 	case "4":
 		if m.mode != ui.ModeHistory {
 			m.mode = ui.ModeHistory
 			m = m.resetModeCursors()
-			return m, m.fetchCommits()
+			return m.startFetchCommits()
 		}
 	case "5":
 		if m.mode != ui.ModeReflog {
 			m.mode = ui.ModeReflog
 			m = m.resetModeCursors()
-			return m, m.fetchReflog()
+			return m.startFetchReflog()
 		}
 	case "y":
 		return m.handleCopyHash()
@@ -391,7 +391,7 @@ func (m Model) handleOpenTerminal() (tea.Model, tea.Cmd) {
 	}
 	launch, err := actions.TerminalLaunch(path)
 	if err != nil {
-		m.transientError = err.Error()
+		m = m.setStatus(statusOther, err.Error())
 		return m, nil
 	}
 	if launch.Interactive {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -14,13 +14,15 @@ import (
 // --- Messages ---
 
 type BranchResultMsg struct {
-	RepoPath string
-	Branches []gitquery.Branch
+	RepoPath    string
+	Branches    []gitquery.Branch
+	ListRequest uint64
 }
 
 type StashResultMsg struct {
-	RepoPath string
-	Stashes  []gitquery.Stash
+	RepoPath    string
+	Stashes     []gitquery.Stash
+	ListRequest uint64
 }
 
 type StashDiffResultMsg struct {
@@ -49,13 +51,15 @@ type StashDroppedMsg struct {
 }
 
 type WorktreeResultMsg struct {
-	RepoPath  string
-	Worktrees []gitquery.Worktree
+	RepoPath    string
+	Worktrees   []gitquery.Worktree
+	ListRequest uint64
 }
 
 type CommitResultMsg struct {
-	RepoPath string
-	Commits  []gitquery.Commit
+	RepoPath    string
+	Commits     []gitquery.Commit
+	ListRequest uint64
 }
 
 type CommitDiffResultMsg struct {
@@ -124,8 +128,9 @@ type WorktreeCreateFailedMsg struct {
 }
 
 type ReflogResultMsg struct {
-	RepoPath string
-	Reflogs  []gitquery.ReflogEntry
+	RepoPath    string
+	Reflogs     []gitquery.ReflogEntry
+	ListRequest uint64
 }
 
 type ReflogDiffResultMsg struct {
@@ -157,12 +162,35 @@ type ForceDeleteFailedMsg struct {
 	Err      string
 }
 
+type FetchKind int
+
+const (
+	FetchUnknown FetchKind = iota
+	FetchList
+	FetchWorktreeDiff
+	FetchBranchDiff
+	FetchStashDiff
+	FetchCommitDiff
+	FetchReflogDiff
+)
+
 // FetchErrorMsg carries an error encountered while loading data for a pane,
-// so the failure can be surfaced instead of showing a blank pane.
+// so the failure can be surfaced instead of showing a blank pane. Pane is only
+// for display; Kind and target fields drive stale-result checks.
 type FetchErrorMsg struct {
-	RepoPath string
-	Pane     string
-	Err      string
+	RepoPath     string
+	Pane         string
+	Err          string
+	Kind         FetchKind
+	Mode         ui.Mode
+	ListRequest  uint64
+	DiffRequest  uint64
+	WorktreePath string
+	BranchName   string
+	StashIndex   int
+	StashDate    string
+	StashMessage string
+	Hash         string
 }
 
 // ActionFailedMsg carries an error from a destructive action (drop/prune)
@@ -187,11 +215,52 @@ func (m Model) isCurrentRepo(repoPath string) bool {
 	return ok && current == repoPath
 }
 
-func (m Model) handleWorktreeResult(msg WorktreeResultMsg) Model {
-	if m.isCurrentRepo(msg.RepoPath) {
-		m.worktrees = m.worktrees.SetItems(msg.Worktrees)
-		m = m.clampSelectionsAfterFilter()
+func (m Model) setStatus(source statusSource, text string) Model {
+	m.status = statusError{Text: text, Source: source}
+	return m
+}
+
+func (m Model) setFetchStatus(msg FetchErrorMsg) Model {
+	m.status = statusError{Text: msg.Err, Source: statusFetch, FetchKind: msg.Kind, Mode: msg.Mode}
+	return m
+}
+
+func (m Model) clearStatus(source statusSource) Model {
+	if m.status.Source == source {
+		m.status = statusError{}
 	}
+	return m
+}
+
+func (m Model) clearFetchListStatus(mode ui.Mode) Model {
+	if m.status.Source == statusFetch && m.status.FetchKind == FetchList && m.status.Mode == mode {
+		m.status = statusError{}
+	}
+	return m
+}
+
+func (m Model) isCurrentListRequest(mode ui.Mode, request uint64) bool {
+	if request == 0 {
+		return false
+	}
+	if int(mode) < 0 || int(mode) >= len(m.listRequests) {
+		return false
+	}
+	return m.listRequests[int(mode)] == request
+}
+
+func (m Model) clearAnyStatus() Model {
+	m.status = statusError{}
+	return m
+}
+
+func (m Model) handleWorktreeResult(msg WorktreeResultMsg) Model {
+	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeWorktrees, msg.ListRequest) {
+		return m
+	}
+	m = m.clearFetchListStatus(ui.ModeWorktrees)
+	m.worktrees = m.worktrees.SetItems(msg.Worktrees)
+	m = m.clampSelectionsAfterFilter()
 	return m
 }
 
@@ -203,7 +272,7 @@ func (m Model) handleWorktreeRemoved(msg WorktreeRemovedMsg) (tea.Model, tea.Cmd
 		m.worktrees = m.worktrees.Move(-1, m.worktreeContentHeight(), m.contentWidth())
 	}
 	if msg.BranchName == "" {
-		return m, m.fetchWorktrees()
+		return m.startFetchWorktrees()
 	}
 	repoPath := msg.RepoPath
 	branchName := msg.BranchName
@@ -220,7 +289,7 @@ func (m Model) handleWorktreeRemoved(msg WorktreeRemovedMsg) (tea.Model, tea.Cmd
 			return WorktreeDeleteCompletedMsg{RepoPath: repoPath}
 		}
 	})
-	return m, m.fetchWorktrees()
+	return m.startFetchWorktrees()
 }
 
 func (m Model) handleWorktreePruned(msg WorktreePrunedMsg) (tea.Model, tea.Cmd) {
@@ -228,52 +297,52 @@ func (m Model) handleWorktreePruned(msg WorktreePrunedMsg) (tea.Model, tea.Cmd) 
 		if m.WorktreeSelected() >= len(m.Worktrees())-1 && m.WorktreeSelected() > 0 {
 			m.worktrees = m.worktrees.Move(-1, m.worktreeContentHeight(), m.contentWidth())
 		}
-		return m, m.fetchWorktrees()
+		return m.startFetchWorktrees()
 	}
 	return m, nil
 }
 
 func (m Model) handleWorktreeUnlocked(msg WorktreeUnlockedMsg) (tea.Model, tea.Cmd) {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.transientError = ""
-		return m, m.fetchWorktrees()
+		m = m.clearStatus(statusOther)
+		return m.startFetchWorktrees()
 	}
 	return m, nil
 }
 
 func (m Model) handleWorktreeUnlockFailed(msg WorktreeUnlockFailedMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.transientError = msg.Err
+		m = m.setStatus(statusOther, msg.Err)
 	}
 	return m
 }
 
 func (m Model) handleGitFetched(msg GitFetchedMsg) (tea.Model, tea.Cmd) {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.transientError = ""
-		return m, m.fetchForMode()
+		m = m.clearStatus(statusGitMutation)
+		return m.startFetchForMode()
 	}
 	return m, nil
 }
 
 func (m Model) handleGitFetchFailed(msg GitFetchFailedMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.transientError = msg.Err
+		m = m.setStatus(statusGitMutation, msg.Err)
 	}
 	return m
 }
 
 func (m Model) handleGitPulled(msg GitPulledMsg) (tea.Model, tea.Cmd) {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.transientError = ""
-		return m, m.fetchForMode()
+		m = m.clearStatus(statusGitMutation)
+		return m.startFetchForMode()
 	}
 	return m, nil
 }
 
 func (m Model) handleGitPullFailed(msg GitPullFailedMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.transientError = msg.Err
+		m = m.setStatus(statusGitMutation, msg.Err)
 	}
 	return m
 }
@@ -284,7 +353,7 @@ func (m Model) handleWorktreeCreated(msg WorktreeCreatedMsg) (tea.Model, tea.Cmd
 	}
 	m.mode = ui.ModeWorktrees
 	m.worktrees = m.worktrees.ResetSelection()
-	return m, m.fetchWorktrees()
+	return m.startFetchWorktrees()
 }
 
 func (m Model) handleWorktreeCreateFailed(msg WorktreeCreateFailedMsg) Model {
@@ -304,37 +373,41 @@ func (m Model) handleWorktreeCreateFailed(msg WorktreeCreateFailedMsg) Model {
 }
 
 func (m Model) handleBranchResult(msg BranchResultMsg) Model {
-	if m.isCurrentRepo(msg.RepoPath) {
-		allRows := gitquery.FlattenBranches(msg.Branches)
-		var filtered []gitquery.BranchRow
-		for _, row := range allRows {
-			if row.Branch.IsWorktree && row.WorktreePath != msg.RepoPath {
-				continue
-			}
-			filtered = append(filtered, row)
-		}
-		// Pin root worktree to position 0
-		for i, row := range filtered {
-			if row.WorktreePath == msg.RepoPath {
-				if i != 0 {
-					root := filtered[i]
-					copy(filtered[1:i+1], filtered[:i])
-					filtered[0] = root
-				}
-				break
-			}
-		}
-		m.rows = m.rows.SetItems(filtered)
-		m = m.clampSelectionsAfterFilter()
+	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeBranches, msg.ListRequest) {
+		return m
 	}
+	m = m.clearFetchListStatus(ui.ModeBranches)
+	allRows := gitquery.FlattenBranches(msg.Branches)
+	var filtered []gitquery.BranchRow
+	for _, row := range allRows {
+		if row.Branch.IsWorktree && row.WorktreePath != msg.RepoPath {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	// Pin root worktree to position 0
+	for i, row := range filtered {
+		if row.WorktreePath == msg.RepoPath {
+			if i != 0 {
+				root := filtered[i]
+				copy(filtered[1:i+1], filtered[:i])
+				filtered[0] = root
+			}
+			break
+		}
+	}
+	m.rows = m.rows.SetItems(filtered)
+	m = m.clampSelectionsAfterFilter()
 	return m
 }
 
 func (m Model) handleStashResult(msg StashResultMsg) Model {
-	if m.isCurrentRepo(msg.RepoPath) {
-		m.stashes = m.stashes.SetItems(msg.Stashes)
-		m = m.clampSelectionsAfterFilter()
+	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeStashes, msg.ListRequest) {
+		return m
 	}
+	m = m.clearFetchListStatus(ui.ModeStashes)
+	m.stashes = m.stashes.SetItems(msg.Stashes)
+	m = m.clampSelectionsAfterFilter()
 	return m
 }
 
@@ -370,14 +443,14 @@ func (m Model) handleStashDropped(msg StashDroppedMsg) (tea.Model, tea.Cmd) {
 		if m.StashSelected() >= len(m.Stashes())-1 && m.StashSelected() > 0 {
 			m.stashes = m.stashes.Move(-1, m.stashContentHeight(), m.contentWidth())
 		}
-		return m, m.fetchStashes()
+		return m.startFetchStashes()
 	}
 	return m, nil
 }
 
 func (m Model) handleBranchDeleted(msg BranchDeletedMsg) (tea.Model, tea.Cmd) {
 	if m.isCurrentRepo(msg.RepoPath) {
-		return m, m.fetchBranches()
+		return m.startFetchBranches()
 	}
 	return m, nil
 }
@@ -410,41 +483,49 @@ func (m Model) handleDeleteFailed(msg DeleteFailedMsg) Model {
 func (m Model) handleForceDeleteFailed(msg ForceDeleteFailedMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
 		if msg.Err != "" {
-			m.transientError = msg.Err
+			m = m.setStatus(statusOther, msg.Err)
 		} else {
-			m.transientError = fmt.Sprintf("force delete %s failed", msg.Target)
+			m = m.setStatus(statusOther, fmt.Sprintf("force delete %s failed", msg.Target))
 		}
 	}
 	return m
 }
 
 func (m Model) handleFetchError(msg FetchErrorMsg) Model {
-	if m.isCurrentRepo(msg.RepoPath) {
-		m.transientError = msg.Err
+	if !m.isCurrentRepo(msg.RepoPath) {
+		return m
 	}
+	if !m.fetchErrorMatchesCurrentTarget(msg) {
+		return m
+	}
+	m = m.setFetchStatus(msg)
 	return m
 }
 
 func (m Model) handleActionFailed(msg ActionFailedMsg) Model {
 	if m.isCurrentRepo(msg.RepoPath) {
-		m.transientError = msg.Err
+		m = m.setStatus(statusOther, msg.Err)
 	}
 	return m
 }
 
 func (m Model) handleCommitResult(msg CommitResultMsg) Model {
-	if m.isCurrentRepo(msg.RepoPath) {
-		m.commits = m.commits.SetItems(msg.Commits)
-		m = m.clampSelectionsAfterFilter()
+	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeHistory, msg.ListRequest) {
+		return m
 	}
+	m = m.clearFetchListStatus(ui.ModeHistory)
+	m.commits = m.commits.SetItems(msg.Commits)
+	m = m.clampSelectionsAfterFilter()
 	return m
 }
 
 func (m Model) handleReflogResult(msg ReflogResultMsg) Model {
-	if m.isCurrentRepo(msg.RepoPath) {
-		m.reflogs = m.reflogs.SetItems(msg.Reflogs)
-		m = m.clampSelectionsAfterFilter()
+	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeReflog, msg.ListRequest) {
+		return m
 	}
+	m = m.clearFetchListStatus(ui.ModeReflog)
+	m.reflogs = m.reflogs.SetItems(msg.Reflogs)
+	m = m.clampSelectionsAfterFilter()
 	return m
 }
 
@@ -484,6 +565,67 @@ func branchMatchesDiffResult(row gitquery.BranchRow, msg BranchDiffResultMsg) bo
 		return false
 	}
 	return row.WorktreePath == msg.WorktreePath
+}
+
+func (m Model) fetchErrorMatchesCurrentTarget(msg FetchErrorMsg) bool {
+	switch msg.Kind {
+	case FetchUnknown:
+		return false
+	case FetchList:
+		return msg.Mode == m.mode && m.isCurrentListRequest(msg.Mode, msg.ListRequest)
+	case FetchWorktreeDiff:
+		if m.modal.View().Request != msg.DiffRequest {
+			return false
+		}
+		wt, ok := m.selectedWorktree()
+		return ok && wt.Path == msg.WorktreePath
+	case FetchBranchDiff:
+		if m.modal.View().Request != msg.DiffRequest {
+			return false
+		}
+		row, ok := m.selectedRow()
+		return ok && branchMatchesDiffError(row, msg)
+	case FetchStashDiff:
+		if m.modal.View().Request != msg.DiffRequest {
+			return false
+		}
+		stash, ok := m.selectedStash()
+		return ok && stashMatchesDiffError(stash, msg)
+	case FetchCommitDiff:
+		if m.modal.View().Request != msg.DiffRequest {
+			return false
+		}
+		commit, ok := m.selectedCommit()
+		return ok && commit.Hash == msg.Hash
+	case FetchReflogDiff:
+		if m.modal.View().Request != msg.DiffRequest {
+			return false
+		}
+		entry, ok := m.selectedReflog()
+		return ok && entry.Hash == msg.Hash
+	default:
+		return false
+	}
+}
+
+func branchMatchesDiffError(row gitquery.BranchRow, msg FetchErrorMsg) bool {
+	if row.Branch.Name != msg.BranchName {
+		return false
+	}
+	return msg.WorktreePath != "" && row.WorktreePath == msg.WorktreePath
+}
+
+func stashMatchesDiffError(stash gitquery.Stash, msg FetchErrorMsg) bool {
+	if stash.Index != msg.StashIndex {
+		return false
+	}
+	if msg.StashDate == "" || stash.Date != msg.StashDate {
+		return false
+	}
+	if msg.StashMessage == "" || stash.Message != msg.StashMessage {
+		return false
+	}
+	return true
 }
 
 func (m Model) handleCopyHash() (tea.Model, tea.Cmd) {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -33,8 +33,46 @@ func testStashes() []gitquery.Stash {
 
 // update sends a message and returns the concrete Model.
 func update(m model.Model, msg tea.Msg) (model.Model, tea.Cmd) {
+	msg = stampListRequest(m, msg)
 	tm, cmd := m.Update(msg)
 	return tm.(model.Model), cmd
+}
+
+func stampListRequest(m model.Model, msg tea.Msg) tea.Msg {
+	switch msg := msg.(type) {
+	case model.WorktreeResultMsg:
+		if msg.ListRequest == 0 {
+			msg.ListRequest = m.ListRequest(ui.ModeWorktrees)
+		}
+		return msg
+	case model.BranchResultMsg:
+		if msg.ListRequest == 0 {
+			msg.ListRequest = m.ListRequest(ui.ModeBranches)
+		}
+		return msg
+	case model.StashResultMsg:
+		if msg.ListRequest == 0 {
+			msg.ListRequest = m.ListRequest(ui.ModeStashes)
+		}
+		return msg
+	case model.CommitResultMsg:
+		if msg.ListRequest == 0 {
+			msg.ListRequest = m.ListRequest(ui.ModeHistory)
+		}
+		return msg
+	case model.ReflogResultMsg:
+		if msg.ListRequest == 0 {
+			msg.ListRequest = m.ListRequest(ui.ModeReflog)
+		}
+		return msg
+	case model.FetchErrorMsg:
+		if msg.Kind == model.FetchList && msg.ListRequest == 0 {
+			msg.ListRequest = m.ListRequest(msg.Mode)
+		}
+		return msg
+	default:
+		return msg
+	}
 }
 
 // inRightPane switches focus to the right pane.

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -629,6 +629,263 @@ func TestModel_ViewGitPullFailureClearsOnSuccess(t *testing.T) {
 	}
 }
 
+func TestModel_ListFetchErrorShowsStatusWithoutClearingPane(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+	}})
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath: "/dev/alpha",
+		Pane:     "worktrees",
+		Err:      "failed to load worktrees: boom",
+		Kind:     model.FetchList,
+		Mode:     ui.ModeWorktrees,
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "failed to load worktrees: boom") {
+		t.Error("view should show list fetch failure in status bar")
+	}
+	if !strings.Contains(view, "main") {
+		t.Error("list fetch failure should not clear existing pane data")
+	}
+}
+
+func TestModel_InitFetchUsesNonZeroListRequest(t *testing.T) {
+	m := model.New(testRepos())
+	msg := m.Init()()
+	fetchErr, ok := msg.(model.FetchErrorMsg)
+	if !ok {
+		t.Fatalf("expected fake repo init to return FetchErrorMsg, got %T", msg)
+	}
+	if fetchErr.ListRequest == 0 {
+		t.Fatal("initial fetch should carry a non-zero list request")
+	}
+}
+
+func TestModel_ZeroListRequestFetchErrorFailsClosed(t *testing.T) {
+	m := model.New(testRepos())
+	tm, _ := m.Update(model.FetchErrorMsg{
+		RepoPath:    "/dev/alpha",
+		Err:         "zero request failure",
+		Kind:        model.FetchList,
+		Mode:        ui.ModeWorktrees,
+		ListRequest: 0,
+	})
+	m = tm.(model.Model)
+
+	if strings.Contains(m.View(), "zero request failure") {
+		t.Fatal("zero-request list failure should be ignored")
+	}
+}
+
+func TestModel_ZeroListRequestResultFailsClosed(t *testing.T) {
+	m := model.New(testRepos())
+	tm, _ := m.Update(model.BranchResultMsg{
+		RepoPath:    "/dev/alpha",
+		Branches:    []gitquery.Branch{{Name: "zero-request-branch"}},
+		ListRequest: 0,
+	})
+	m = tm.(model.Model)
+
+	if strings.Contains(m.View(), "zero-request-branch") {
+		t.Fatal("zero-request list result should be ignored")
+	}
+}
+
+func TestModel_StaleListFetchErrorIgnored(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = selectBravo(m)
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath: "/dev/alpha",
+		Pane:     "worktrees",
+		Err:      "failed to load worktrees: stale",
+		Kind:     model.FetchList,
+		Mode:     ui.ModeWorktrees,
+	})
+
+	view := m.View()
+	if strings.Contains(view, "failed to load worktrees: stale") {
+		t.Error("stale list fetch failure should not show in status bar")
+	}
+}
+
+func TestModel_WrongModeListFetchErrorIgnored(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath: "/dev/alpha",
+		Pane:     "branches",
+		Err:      "failed to load branches: stale",
+		Kind:     model.FetchList,
+		Mode:     ui.ModeBranches,
+	})
+
+	if strings.Contains(m.View(), "failed to load branches: stale") {
+		t.Error("same-repo list failure from another mode should not show in status bar")
+	}
+}
+
+func TestModel_FetchErrorWithUnknownKindIgnored(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath: "/dev/alpha",
+		Pane:     "worktrees",
+		Err:      "missing kind",
+	})
+
+	if strings.Contains(m.View(), "missing kind") {
+		t.Error("fetch error without kind should fail closed")
+	}
+}
+
+func TestModel_ListSuccessClearsOnlyFetchStatus(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inRightPane(m)
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath: "/dev/alpha",
+		Err:      "failed to load worktrees: boom",
+		Kind:     model.FetchList,
+		Mode:     ui.ModeWorktrees,
+	})
+
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+	}})
+	if strings.Contains(m.View(), "failed to load worktrees: boom") {
+		t.Error("current list success should clear fetch status")
+	}
+
+	m, _ = update(m, model.WorktreeUnlockFailedMsg{RepoPath: "/dev/alpha", Err: "unlock failed"})
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+	}})
+	if !strings.Contains(m.View(), "unlock failed") {
+		t.Error("list success should not clear non-fetch status")
+	}
+}
+
+func TestModel_ListSuccessDoesNotClearDiffFetchStatus(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true, Dirty: true},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:     "/dev/alpha",
+		Err:          "diff failed",
+		Kind:         model.FetchWorktreeDiff,
+		Mode:         ui.ModeWorktrees,
+		DiffRequest:  1,
+		WorktreePath: "/dev/alpha",
+	})
+
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true, Dirty: true},
+	}})
+
+	if !strings.Contains(m.View(), "diff failed") {
+		t.Error("list success should not clear an active diff fetch failure")
+	}
+}
+
+func TestModel_OldListFetchErrorIgnoredAfterNewerListRequest(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inRightPane(m)
+
+	m, cmd := update(m, model.GitFetchedMsg{RepoPath: "/dev/alpha"})
+	if cmd == nil {
+		t.Fatal("expected first refresh command")
+	}
+	oldErr, ok := cmd().(model.FetchErrorMsg)
+	if !ok {
+		t.Fatalf("expected first refresh to fail against fake repo, got %T", cmd())
+	}
+
+	m, cmd = update(m, model.GitFetchedMsg{RepoPath: "/dev/alpha"})
+	if cmd == nil {
+		t.Fatal("expected second refresh command")
+	}
+	newErr, ok := cmd().(model.FetchErrorMsg)
+	if !ok {
+		t.Fatalf("expected second refresh to fail against fake repo, got %T", cmd())
+	}
+	if oldErr.ListRequest == newErr.ListRequest {
+		t.Fatal("expected refreshes to carry distinct list requests")
+	}
+
+	m, _ = update(m, model.WorktreeResultMsg{
+		RepoPath:    "/dev/alpha",
+		ListRequest: newErr.ListRequest,
+		Worktrees:   []gitquery.Worktree{{Path: "/dev/alpha", BranchName: "main", IsMain: true}},
+	})
+	m, _ = update(m, oldErr)
+
+	if strings.Contains(m.View(), oldErr.Err) {
+		t.Error("older same-mode list failure should be ignored after newer request succeeds")
+	}
+}
+
+func TestModel_WrongModeListSuccessDoesNotClearFetchStatus(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inRightPane(m)
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath: "/dev/alpha",
+		Err:      "worktree fetch failed",
+		Kind:     model.FetchList,
+		Mode:     ui.ModeWorktrees,
+	})
+
+	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: []gitquery.Branch{{Name: "main"}}})
+
+	if !strings.Contains(m.View(), "worktree fetch failed") {
+		t.Error("success for another list mode should not clear current fetch status")
+	}
+}
+
+func TestModel_NonModalKeyClearsStatusButModalKeyDoesNot(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m, _ = update(m, model.FetchErrorMsg{RepoPath: "/dev/alpha", Err: "fetch failed", Kind: model.FetchList, Mode: ui.ModeWorktrees})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if strings.Contains(m.View(), "fetch failed") {
+		t.Error("non-modal keypress should clear transient status")
+	}
+
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true, Dirty: true},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:     "/dev/alpha",
+		Err:          "diff failed",
+		Kind:         model.FetchWorktreeDiff,
+		Mode:         ui.ModeWorktrees,
+		DiffRequest:  1,
+		WorktreePath: "/dev/alpha",
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if !strings.Contains(m.View(), "diff failed") {
+		t.Error("modal keypress should not clear status by itself")
+	}
+}
+
 func TestModel_ViewReflogModeShowsReflogContent(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})


### PR DESCRIPTION
## Summary
- Surface async git list and diff failures in the status bar instead of leaving panes or overlays looking like valid empty results.
- Add request-aware list fetch tracking so stale same-repo/same-mode list results and errors are ignored.
- Add target-aware diff failure matching for worktree, branch, stash, commit, and reflog overlays while preserving existing stale success guards.
- Preserve transient status behavior for keypresses and source-aware clearing for git mutation/action errors.

## Verification
- `gofmt -l .`
- `make test`
- `make build`

## Notes
The shipped branch is based directly on `origin/main`; the earlier local implementation branch was based on an unpublished local modal-state-machine branch, so the final commit was cherry-picked onto a clean `main` base before push.