### PR TITLE
Add config file foundation for startup and scan settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,9 @@ gofmt -l .          # formatting check used by CI
 
 `wtui` is a Go Bubble Tea TUI for managing git worktrees across repositories.
 
-- `cmd/wtui/main.go` parses `--version`/`-v`, reads `WORKTREE_ROOT`, and wires `scanner.Scan()` into the Bubble Tea program.
-- `scanner/` discovers repos under `WORKTREE_ROOT` or `~/dev` (up to 2 levels deep), excluding `*-worktrees`.
+- `cmd/wtui/main.go` parses `--version`/`-v`, loads config, applies `WORKTREE_ROOT`, and wires `scanner.Scan()` into the Bubble Tea program.
+- `config/` loads optional TOML from `$XDG_CONFIG_HOME/wtui/config.toml` or `~/.config/wtui/config.toml`; missing config is non-fatal, unreadable or malformed existing config is startup-fatal, and parsed future fields include editor, terminal, provider, and launch settings.
+- `scanner/` discovers repos under `WORKTREE_ROOT`, `[scan].root`, or `~/dev` (default up to 2 levels deep, configurable down with `[scan].max_depth`), excluding `*-worktrees`.
 - `gitquery/` shells out to git for worktrees, branches, stashes, history, reflog, and diffs; `parse.go` holds the pure parsing split out from execution, and `runner.go` defines the `Runner` seam (the git CLI adapter) wrapped by a `Querier`. Package-level functions delegate to a default `Querier`; `NewQuerier(runner)` injects a fake `Runner` for tests.
 - `actions/` performs git mutations (create/remove/prune/unlock worktree, delete branch, drop stash, fetch `--prune`, pull `--ff-only`) plus clipboard, VS Code, and tmux/Zellij terminal launching.
 - `model/` owns Bubble Tea state, key handling, fuzzy filtering, overlays, confirmations, and async result handling (split across `model.go`, `model_keys.go`, `model_fetch.go`, `model_messages.go`, `model_filter.go`). Each list (repos, branches, stashes, worktrees, commits, reflog) is a generic value-type `pane.Pane[T]` from `model/pane/` that owns its own filtering, selection, and scroll, and overlay state (confirmations, input prompts, diffs) is consolidated into a typed `modal.Modal` from `model/modal/`.
@@ -28,5 +29,6 @@ gofmt -l .          # formatting check used by CI
 - Destructive actions are gated by destructive mode in the model; preserve that safety boundary.
 - Locked worktrees should not be deleted or pruned; unlock is a separate action.
 - Branch lists hide non-root worktree branches; the root branch stays pinned at the top.
-- `WORKTREE_ROOT` overrides the scan root (default `~/dev`); `TERMINAL` overrides the terminal launched by `t` outside tmux/Zellij.
+- `WORKTREE_ROOT` overrides `[scan].root`, which falls back to `~/dev`; `TERMINAL` overrides the terminal launched by `t` outside tmux/Zellij.
+- `[scan].root` supports `~` expansion; parsed editor/terminal/provider/launch config fields are foundation only until their behavior is wired in.
 - CI expects `gofmt`, `make test`, and `make build` to pass.

--- a/README.md
+++ b/README.md
@@ -127,9 +127,28 @@ Browse HEAD reflog entries (up to 50) for the selected repo. Each row shows the 
 
 ## Configuration
 
+wtui reads an optional TOML config file before scanning repositories:
+
+```text
+$XDG_CONFIG_HOME/wtui/config.toml
+~/.config/wtui/config.toml
+```
+
+Example:
+
+```toml
+[scan]
+root = "~/projects"
+max_depth = 2
+```
+
+`WORKTREE_ROOT` overrides `[scan].root` when both are set. See
+[docs/config.md](docs/config.md) for the full config reference, including parsed
+foundation fields for editor, terminal, provider, and launch settings.
+
 | Env var | Default | Description |
 |---------|---------|-------------|
-| `WORKTREE_ROOT` | `~/dev` | Root directory to scan for git repos (up to 2 levels deep) |
+| `WORKTREE_ROOT` | `[scan].root` or `~/dev` | Root directory to scan for git repos; depth defaults to 2 and can be reduced with `[scan].max_depth` |
 | `TERMINAL` | unset | Terminal command to use when `t` opens a worktree outside tmux/Zellij |
 
 ## Development

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -3,36 +3,95 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/brian-bell/wtui/config"
 	"github.com/brian-bell/wtui/internal/version"
 	"github.com/brian-bell/wtui/model"
 	"github.com/brian-bell/wtui/scanner"
 )
 
 func main() {
-	versionFlag := flag.Bool("version", false, "print version and exit")
-	flag.BoolVar(versionFlag, "v", false, "print version and exit")
-	flag.Parse()
+	if err := run(os.Args, runDeps{}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+type runDeps struct {
+	loadConfig   func() (config.Config, error)
+	getenv       func(string) string
+	scan         func(scanner.ScanOptions) ([]scanner.Repo, error)
+	startProgram func([]scanner.Repo) error
+	stdout       io.Writer
+}
+
+func run(args []string, deps runDeps) error {
+	deps = fillRunDeps(deps)
+
+	flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	versionFlag := flags.Bool("version", false, "print version and exit")
+	flags.BoolVar(versionFlag, "v", false, "print version and exit")
+	if err := flags.Parse(args[1:]); err != nil {
+		return err
+	}
 
 	if *versionFlag {
-		fmt.Println(version.String())
-		return
+		fmt.Fprintln(deps.stdout, version.String())
+		return nil
 	}
 
-	root := os.Getenv("WORKTREE_ROOT")
-
-	repos, err := scanner.Scan(scanner.ScanOptions{Root: root})
+	cfg, err := deps.loadConfig()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error scanning repos: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("error loading config: %w", err)
 	}
 
-	p := tea.NewProgram(model.New(repos), tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+	root := cfg.Scan.Root
+	if envRoot := deps.getenv("WORKTREE_ROOT"); envRoot != "" {
+		root = envRoot
 	}
+
+	repos, err := deps.scan(scanner.ScanOptions{
+		Root:     root,
+		MaxDepth: cfg.Scan.MaxDepth,
+	})
+	if err != nil {
+		return fmt.Errorf("error scanning repos: %w", err)
+	}
+
+	if err := deps.startProgram(repos); err != nil {
+		return fmt.Errorf("error: %w", err)
+	}
+	return nil
+}
+
+func fillRunDeps(deps runDeps) runDeps {
+	if deps.loadConfig == nil {
+		deps.loadConfig = func() (config.Config, error) {
+			return config.Load()
+		}
+	}
+	if deps.getenv == nil {
+		deps.getenv = os.Getenv
+	}
+	if deps.scan == nil {
+		deps.scan = scanner.Scan
+	}
+	if deps.startProgram == nil {
+		deps.startProgram = startProgram
+	}
+	if deps.stdout == nil {
+		deps.stdout = os.Stdout
+	}
+	return deps
+}
+
+func startProgram(repos []scanner.Repo) error {
+	p := tea.NewProgram(model.New(repos), tea.WithAltScreen())
+	_, err := p.Run()
+	return err
 }

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/brian-bell/wtui/config"
+	"github.com/brian-bell/wtui/internal/version"
+	"github.com/brian-bell/wtui/scanner"
+)
+
+func TestRun_VersionBypassesConfigAndScan(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "--version"}, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for --version")
+			return config.Config{}, nil
+		},
+		scan: func(scanner.ScanOptions) ([]scanner.Repo, error) {
+			t.Fatal("scan should not run for --version")
+			return nil, nil
+		},
+		startProgram: func([]scanner.Repo) error {
+			t.Fatal("program should not start for --version")
+			return nil
+		},
+		stdout: &stdout,
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	if strings.TrimSpace(stdout.String()) != version.String() {
+		t.Fatalf("expected version output %q, got %q", version.String(), stdout.String())
+	}
+}
+
+func TestRun_LoadsConfigBeforeScanning(t *testing.T) {
+	var got scanner.ScanOptions
+	err := run([]string{"wtui"}, runDeps{
+		loadConfig: func() (config.Config, error) {
+			return config.Config{
+				Scan: config.ScanConfig{
+					Root:     "/from/config",
+					MaxDepth: 1,
+				},
+			}, nil
+		},
+		getenv: func(string) string { return "" },
+		scan: func(opts scanner.ScanOptions) ([]scanner.Repo, error) {
+			got = opts
+			return []scanner.Repo{{Path: "/repo", DisplayName: "repo"}}, nil
+		},
+		startProgram: func([]scanner.Repo) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	if got.Root != "/from/config" {
+		t.Fatalf("expected config scan root, got %q", got.Root)
+	}
+	if got.MaxDepth != 1 {
+		t.Fatalf("expected config max depth 1, got %d", got.MaxDepth)
+	}
+}
+
+func TestRun_WorktreeRootEnvOverridesConfigRoot(t *testing.T) {
+	var got scanner.ScanOptions
+	err := run([]string{"wtui"}, runDeps{
+		loadConfig: func() (config.Config, error) {
+			return config.Config{
+				Scan: config.ScanConfig{Root: "/from/config", MaxDepth: 1},
+			}, nil
+		},
+		getenv: func(key string) string {
+			if key == "WORKTREE_ROOT" {
+				return "/from/env"
+			}
+			return ""
+		},
+		scan: func(opts scanner.ScanOptions) ([]scanner.Repo, error) {
+			got = opts
+			return nil, nil
+		},
+		startProgram: func([]scanner.Repo) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	if got.Root != "/from/env" {
+		t.Fatalf("expected WORKTREE_ROOT to override config root, got %q", got.Root)
+	}
+	if got.MaxDepth != 1 {
+		t.Fatalf("expected config max depth to remain 1, got %d", got.MaxDepth)
+	}
+}
+
+func TestRun_ConfigErrorStopsBeforeScan(t *testing.T) {
+	scanned := false
+	err := run([]string{"wtui"}, runDeps{
+		loadConfig: func() (config.Config, error) {
+			return config.Config{}, errors.New("bad config")
+		},
+		getenv: func(string) string { return "" },
+		scan: func(scanner.ScanOptions) ([]scanner.Repo, error) {
+			scanned = true
+			return nil, nil
+		},
+		startProgram: func([]scanner.Repo) error { return nil },
+	})
+	if err == nil {
+		t.Fatal("expected config error")
+	}
+	if scanned {
+		t.Fatal("scan should not run when config fails")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,183 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+type getenvFunc func(string) string
+type homeDirFunc func() (string, error)
+
+// Config is wtui's parsed configuration file.
+type Config struct {
+	Scan     ScanConfig     `toml:"scan"`
+	Editor   EditorConfig   `toml:"editor"`
+	Terminal TerminalConfig `toml:"terminal"`
+	Provider ProviderConfig `toml:"provider"`
+	Launch   LaunchConfig   `toml:"launch"`
+}
+
+// ScanConfig configures repository discovery.
+type ScanConfig struct {
+	Root     string `toml:"root"`
+	MaxDepth int    `toml:"max_depth"`
+}
+
+// EditorConfig is parsed now so editor behavior can be wired in later.
+type EditorConfig struct {
+	Command string `toml:"command"`
+}
+
+// TerminalConfig is parsed now so terminal behavior can be wired in later.
+type TerminalConfig struct {
+	Command string `toml:"command"`
+}
+
+// ProviderConfig is parsed now so provider-specific behavior can be wired in later.
+type ProviderConfig struct {
+	Name string `toml:"name"`
+}
+
+// LaunchConfig is parsed now so launch behavior can be wired in later.
+type LaunchConfig struct {
+	PreferMultiplexer bool `toml:"prefer_multiplexer"`
+}
+
+type loadOptions struct {
+	getenv  getenvFunc
+	homeDir homeDirFunc
+}
+
+// Option customizes config loading. It is primarily useful in tests.
+type Option func(*loadOptions)
+
+// WithGetenv overrides environment lookup during config loading.
+func WithGetenv(getenv func(string) string) Option {
+	return func(opts *loadOptions) {
+		opts.getenv = getenv
+	}
+}
+
+// WithHomeDir overrides home directory lookup during config loading.
+func WithHomeDir(homeDir func() (string, error)) Option {
+	return func(opts *loadOptions) {
+		opts.homeDir = homeDir
+	}
+}
+
+// Load reads wtui's default config file.
+func Load(options ...Option) (Config, error) {
+	opts := defaultOptions(options...)
+	paths, err := defaultPaths(opts)
+	if err != nil {
+		return Config{}, err
+	}
+	for _, path := range paths {
+		cfg, found, err := loadPath(path, opts)
+		if err != nil {
+			return Config{}, err
+		}
+		if found {
+			return cfg, nil
+		}
+	}
+	return Config{}, nil
+}
+
+// LoadFrom reads a config file from path. Missing files are allowed and return
+// the default empty config.
+func LoadFrom(path string, options ...Option) (Config, error) {
+	opts := defaultOptions(options...)
+	cfg, _, err := loadPath(path, opts)
+	return cfg, err
+}
+
+func loadPath(path string, opts loadOptions) (Config, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Config{}, false, nil
+		}
+		return Config{}, false, fmt.Errorf("read config %s: %w", path, err)
+	}
+
+	var cfg Config
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return Config{}, true, fmt.Errorf("parse config %s: %w", path, err)
+	}
+
+	if cfg.Scan.MaxDepth < 0 {
+		return Config{}, true, fmt.Errorf("parse config %s: scan.max_depth must be >= 0", path)
+	}
+
+	if cfg.Scan.Root != "" {
+		root, err := expandHome(cfg.Scan.Root, opts.homeDir)
+		if err != nil {
+			return Config{}, true, fmt.Errorf("expand scan root in config %s: %w", path, err)
+		}
+		cfg.Scan.Root = root
+	}
+
+	return cfg, true, nil
+}
+
+// DefaultPath returns the default config path:
+// $XDG_CONFIG_HOME/wtui/config.toml, or ~/.config/wtui/config.toml.
+func DefaultPath(options ...Option) (string, error) {
+	opts := defaultOptions(options...)
+	paths, err := defaultPaths(opts)
+	if err != nil {
+		return "", err
+	}
+	return paths[0], nil
+}
+
+func defaultPaths(opts loadOptions) ([]string, error) {
+	var paths []string
+	if xdg := opts.getenv("XDG_CONFIG_HOME"); xdg != "" {
+		paths = append(paths, filepath.Join(xdg, "wtui", "config.toml"))
+	}
+
+	home, err := opts.homeDir()
+	if err != nil {
+		if len(paths) > 0 {
+			return paths, nil
+		}
+		return nil, err
+	}
+	homePath := filepath.Join(home, ".config", "wtui", "config.toml")
+	if len(paths) == 0 || paths[len(paths)-1] != homePath {
+		paths = append(paths, homePath)
+	}
+	return paths, nil
+}
+
+func defaultOptions(options ...Option) loadOptions {
+	opts := loadOptions{
+		getenv:  os.Getenv,
+		homeDir: os.UserHomeDir,
+	}
+	for _, option := range options {
+		option(&opts)
+	}
+	return opts
+}
+
+func expandHome(path string, homeDir homeDirFunc) (string, error) {
+	switch {
+	case path == "~":
+		return homeDir()
+	case strings.HasPrefix(path, "~/"):
+		home, err := homeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, path[2:]), nil
+	default:
+		return path, nil
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -106,18 +107,20 @@ func loadPath(path string, opts loadOptions) (Config, bool, error) {
 	}
 
 	var cfg Config
-	if err := toml.Unmarshal(data, &cfg); err != nil {
-		return Config{}, true, fmt.Errorf("parse config %s: %w", path, err)
+	decoder := toml.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cfg); err != nil {
+		return Config{}, false, fmt.Errorf("parse config %s: %w", path, err)
 	}
 
 	if cfg.Scan.MaxDepth < 0 {
-		return Config{}, true, fmt.Errorf("parse config %s: scan.max_depth must be >= 0", path)
+		return Config{}, false, fmt.Errorf("parse config %s: scan.max_depth must be >= 0", path)
 	}
 
 	if cfg.Scan.Root != "" {
 		root, err := expandHome(cfg.Scan.Root, opts.homeDir)
 		if err != nil {
-			return Config{}, true, fmt.Errorf("expand scan root in config %s: %w", path, err)
+			return Config{}, false, fmt.Errorf("expand scan root in config %s: %w", path, err)
 		}
 		cfg.Scan.Root = root
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -86,6 +86,24 @@ func TestLoadFrom_ReportsMalformedConfigWithPath(t *testing.T) {
 	}
 }
 
+func TestLoadFrom_RejectsUnknownFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[scan]\nroto = \"~/src\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := config.LoadFrom(path)
+	if err == nil {
+		t.Fatal("expected unknown field error")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("expected error to include path %q, got %q", path, err.Error())
+	}
+	if !strings.Contains(err.Error(), "strict mode") {
+		t.Fatalf("expected strict decoder error, got %q", err.Error())
+	}
+}
+
 func TestLoadFrom_ReportsUnreadableConfigWithPath(t *testing.T) {
 	path := t.TempDir()
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,225 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brian-bell/wtui/config"
+)
+
+func TestLoadFrom_AllowsMissingConfig(t *testing.T) {
+	cfg, err := config.LoadFrom(filepath.Join(t.TempDir(), "missing.toml"))
+	if err != nil {
+		t.Fatalf("LoadFrom returned error for missing config: %v", err)
+	}
+
+	if cfg.Scan.Root != "" {
+		t.Fatalf("expected empty scan root, got %q", cfg.Scan.Root)
+	}
+}
+
+func TestLoadFrom_ParsesConfigSections(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	err := os.WriteFile(path, []byte(`
+[scan]
+root = "~/src"
+max_depth = 1
+
+[editor]
+command = "code"
+
+[terminal]
+command = "wezterm start"
+
+[provider]
+name = "github"
+
+[launch]
+prefer_multiplexer = true
+`), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.LoadFrom(path, config.WithHomeDir(func() (string, error) {
+		return home, nil
+	}))
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+
+	if cfg.Scan.Root != filepath.Join(home, "src") {
+		t.Fatalf("expected expanded scan root, got %q", cfg.Scan.Root)
+	}
+	if cfg.Scan.MaxDepth != 1 {
+		t.Fatalf("expected max depth 1, got %d", cfg.Scan.MaxDepth)
+	}
+	if cfg.Editor.Command != "code" {
+		t.Fatalf("expected editor command code, got %q", cfg.Editor.Command)
+	}
+	if cfg.Terminal.Command != "wezterm start" {
+		t.Fatalf("expected terminal command, got %q", cfg.Terminal.Command)
+	}
+	if cfg.Provider.Name != "github" {
+		t.Fatalf("expected provider github, got %q", cfg.Provider.Name)
+	}
+	if !cfg.Launch.PreferMultiplexer {
+		t.Fatal("expected launch prefer_multiplexer to parse true")
+	}
+}
+
+func TestLoadFrom_ReportsMalformedConfigWithPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[scan\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := config.LoadFrom(path)
+	if err == nil {
+		t.Fatal("expected malformed config error")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("expected error to include path %q, got %q", path, err.Error())
+	}
+}
+
+func TestLoadFrom_ReportsUnreadableConfigWithPath(t *testing.T) {
+	path := t.TempDir()
+
+	_, err := config.LoadFrom(path)
+	if err == nil {
+		t.Fatal("expected unreadable config error")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("expected error to include path %q, got %q", path, err.Error())
+	}
+	if !strings.Contains(err.Error(), "read config") {
+		t.Fatalf("expected read config error, got %q", err.Error())
+	}
+}
+
+func TestLoadFrom_RejectsNegativeMaxDepth(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[scan]\nmax_depth = -1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := config.LoadFrom(path)
+	if err == nil {
+		t.Fatal("expected negative max_depth error")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("expected error to include path %q, got %q", path, err.Error())
+	}
+	if !strings.Contains(err.Error(), "max_depth") {
+		t.Fatalf("expected error to mention max_depth, got %q", err.Error())
+	}
+}
+
+func TestLoad_StopsAtMalformedXDGConfig(t *testing.T) {
+	xdg := t.TempDir()
+	home := t.TempDir()
+	xdgConfig := filepath.Join(xdg, "wtui", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(xdgConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(xdgConfig, []byte("[scan\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	homeConfig := filepath.Join(home, ".config", "wtui", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(homeConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(homeConfig, []byte("[scan]\nroot = \"/home-config\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := config.Load(
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return home, nil
+		}),
+	)
+	if err == nil {
+		t.Fatal("expected malformed XDG config error")
+	}
+	if !strings.Contains(err.Error(), xdgConfig) {
+		t.Fatalf("expected error to include XDG config path %q, got %q", xdgConfig, err.Error())
+	}
+}
+
+func TestLoad_FallsBackToHomeConfigWhenXDGConfigIsMissing(t *testing.T) {
+	xdg := t.TempDir()
+	home := t.TempDir()
+	homeConfig := filepath.Join(home, ".config", "wtui", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(homeConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(homeConfig, []byte("[scan]\nroot = \"/home-config\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return home, nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.Scan.Root != "/home-config" {
+		t.Fatalf("expected home config fallback, got root %q", cfg.Scan.Root)
+	}
+}
+
+func TestDefaultPath_UsesXDGConfigHome(t *testing.T) {
+	path, err := config.DefaultPath(
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return "/xdg"
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return "/home/user", nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("DefaultPath returned error: %v", err)
+	}
+
+	if path != filepath.Join("/xdg", "wtui", "config.toml") {
+		t.Fatalf("unexpected config path %q", path)
+	}
+}
+
+func TestDefaultPath_FallsBackToHomeConfig(t *testing.T) {
+	path, err := config.DefaultPath(
+		config.WithGetenv(func(string) string { return "" }),
+		config.WithHomeDir(func() (string, error) {
+			return "/home/user", nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("DefaultPath returned error: %v", err)
+	}
+
+	if path != filepath.Join("/home/user", ".config", "wtui", "config.toml") {
+		t.Fatalf("unexpected config path %q", path)
+	}
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,96 @@
+# wtui Configuration
+
+wtui reads an optional TOML config file before scanning repositories.
+
+## Config Path
+
+wtui looks for config in this order:
+
+1. `$XDG_CONFIG_HOME/wtui/config.toml`
+2. `~/.config/wtui/config.toml`
+
+The file is optional. If it does not exist, wtui starts with built-in defaults.
+If a config file exists but cannot be read or parsed, startup fails before
+repository scanning. wtui only falls through to the next path when the earlier
+path does not exist.
+
+## Precedence
+
+Environment variables remain the highest-precedence settings where they already
+exist:
+
+| Setting | Highest precedence | Config fallback | Built-in default |
+|---------|--------------------|-----------------|------------------|
+| Scan root | `WORKTREE_ROOT` | `[scan].root` | `~/dev` |
+| Terminal command | `TERMINAL` | none; `[terminal].command` is parsed but unused | platform fallback |
+
+`[scan].root` supports `~` and `~/...` expansion. `WORKTREE_ROOT` is passed
+through as provided by the environment.
+
+## Example
+
+```toml
+[scan]
+root = "~/dev"
+max_depth = 2
+
+[editor]
+command = "code"
+
+[terminal]
+command = "wezterm start"
+
+[provider]
+name = "github"
+
+[launch]
+prefer_multiplexer = true
+```
+
+## Sections
+
+### `[scan]`
+
+Controls repository discovery.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `root` | string | Directory to scan for git repositories. |
+| `max_depth` | integer | Scan depth below `root`; `1` scans immediate children, `2` also scans one level deeper. |
+
+When `max_depth` is omitted or set to `0`, wtui uses the scanner default of `2`.
+Values greater than `2` behave like `2`.
+
+### `[editor]`
+
+Parsed for future editor-launch settings. The current editor action still opens
+VS Code with `code`.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `command` | string | Future editor command setting. |
+
+### `[terminal]`
+
+Parsed for future terminal-launch settings. The current terminal action still
+uses tmux/Zellij detection, then `TERMINAL`, then platform fallbacks.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `command` | string | Future terminal command setting. |
+
+### `[provider]`
+
+Parsed for future provider-specific features.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `name` | string | Future provider name, such as `github`. |
+
+### `[launch]`
+
+Parsed for future launch behavior.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `prefer_multiplexer` | boolean | Future launch preference for tmux/Zellij behavior. |

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/pelletier/go-toml/v2 v2.3.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
+github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=


### PR DESCRIPTION
## Summary
- Add an optional TOML config loader at `~/.config/wtui/config.toml` with XDG support and early startup loading.
- Wire config into `cmd/wtui` so scan settings load before repository discovery, while `WORKTREE_ROOT` still overrides the configured scan root.
- Add typed foundation fields for future editor, terminal, provider, and launch settings without changing their runtime behavior yet.
- Update README, AGENTS.md, and add `docs/config.md` to document config path, precedence, and the active vs parsed-only settings split.

## Testing
- Added unit coverage for missing config, malformed/unreadable config, path fallback, `~` expansion, negative `max_depth`, startup precedence, and `--version` bypass behavior.
- Ran formatting checks, `make test`, and `make build` successfully.