### PR TITLE
Clarify empty states for filtered results and fetch failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ The UI has two panes: repos on the left, content on the right. `tab` switches fo
 
 **Fuzzy filter:** Press `/` in the active pane to type-ahead filter repos or right-pane items. `enter` keeps the filter, `esc` clears it, `backspace` edits it.
 
+Empty panes explain why they are empty: no data for the selected repo, no fuzzy
+filter matches, or a load failure with details in the status bar.
+
 **Left pane (repos)**
 
 | Key | Action |

--- a/docs/roadmap-todo.md
+++ b/docs/roadmap-todo.md
@@ -10,7 +10,7 @@ features can build on.
 
 - [x] P0 - Git command error surfacing: surface async list/diff fetch failures in the status bar so empty panes are not confused with command failures.
 - [ ] P0 - Config file foundation: add `~/.config/wtui/config.toml` and load it early enough to support future scan, editor, terminal, provider, and launch settings.
-- [ ] P1 - Empty-state clarity: distinguish "nothing to show" from "command failed" and "repo has no matching filtered results."
+- [x] P1 - Empty-state clarity: distinguish "nothing to show" from "command failed" and "repo has no matching filtered results."
 - [x] P1 - Stale async result clarity: keep ignoring outdated async results, but make current command failures obvious when they belong to the selected repo/mode.
 
 ## Phase 2: Worktree Lifecycle Depth

--- a/docs/roadmap-todo.md
+++ b/docs/roadmap-todo.md
@@ -9,7 +9,7 @@ Goal: make failures visible and establish the configuration layer future
 features can build on.
 
 - [x] P0 - Git command error surfacing: surface async list/diff fetch failures in the status bar so empty panes are not confused with command failures.
-- [ ] P0 - Config file foundation: add `~/.config/wtui/config.toml` and load it early enough to support future scan, editor, terminal, provider, and launch settings.
+- [x] P0 - Config file foundation: add `~/.config/wtui/config.toml` and load it early enough to support future scan, editor, terminal, provider, and launch settings.
 - [x] P1 - Empty-state clarity: distinguish "nothing to show" from "command failed" and "repo has no matching filtered results."
 - [x] P1 - Stale async result clarity: keep ignoring outdated async results, but make current command failures obvious when they belong to the selected repo/mode.
 

--- a/model/model.go
+++ b/model/model.go
@@ -116,6 +116,8 @@ func (m Model) View() string {
 	stashes, stashSelected, stashScroll := m.stashes.View()
 	commits, commitSelected, commitScroll := m.commits.View()
 	reflogs, reflogSelected, reflogScroll := m.reflogs.View()
+	repoEmptyMessage := m.repoEmptyMessage(len(repos))
+	rightEmptyMessage := m.rightEmptyMessage(len(repos), len(worktrees), len(rows), len(stashes), len(commits), len(reflogs))
 	if len(repos) == 0 {
 		worktrees = nil
 		rows = nil
@@ -125,43 +127,140 @@ func (m Model) View() string {
 	}
 	modalView := m.modal.View()
 	return ui.Render(ui.RenderParams{
-		Repos:            repos,
-		Selected:         selected,
-		Width:            m.width,
-		Height:           m.height,
-		Mode:             m.mode,
-		Branches:         rows,
-		Stashes:          stashes,
-		BranchSelected:   branchSelected,
-		StashSelected:    stashSelected,
-		Overlay:          m.overlayState(),
-		OverlayDiff:      modalView.Diff,
-		OverlayScroll:    modalView.Scroll,
-		ConfirmPrompt:    modalView.Prompt,
-		ConfirmForce:     modalView.Force,
-		WorktreeInput:    modalView.Input,
-		WorktreeInputErr: modalView.InputErr,
-		BranchScroll:     branchScroll,
-		RepoScroll:       repoScroll,
-		StashScroll:      stashScroll,
-		ActivePane:       m.activePane,
-		Destructive:      m.destructive,
-		Worktrees:        worktrees,
-		WorktreeSelected: worktreeSelected,
-		WorktreeScroll:   worktreeScroll,
-		Commits:          commits,
-		CommitSelected:   commitSelected,
-		CommitScroll:     commitScroll,
-		Reflogs:          reflogs,
-		ReflogSelected:   reflogSelected,
-		ReflogScroll:     reflogScroll,
-		TransientError:   m.status.Text,
-		SearchActive:     m.searchActive,
-		RepoSearch:       m.repos.Query(),
-		ItemSearch:       m.activeItemPaneQuery(),
-		FetchAvailable:   m.canFetch(),
-		PullAvailable:    m.canPull(),
+		Repos:             repos,
+		Selected:          selected,
+		Width:             m.width,
+		Height:            m.height,
+		Mode:              m.mode,
+		Branches:          rows,
+		Stashes:           stashes,
+		BranchSelected:    branchSelected,
+		StashSelected:     stashSelected,
+		Overlay:           m.overlayState(),
+		OverlayDiff:       modalView.Diff,
+		OverlayScroll:     modalView.Scroll,
+		ConfirmPrompt:     modalView.Prompt,
+		ConfirmForce:      modalView.Force,
+		WorktreeInput:     modalView.Input,
+		WorktreeInputErr:  modalView.InputErr,
+		BranchScroll:      branchScroll,
+		RepoScroll:        repoScroll,
+		StashScroll:       stashScroll,
+		ActivePane:        m.activePane,
+		Destructive:       m.destructive,
+		Worktrees:         worktrees,
+		WorktreeSelected:  worktreeSelected,
+		WorktreeScroll:    worktreeScroll,
+		Commits:           commits,
+		CommitSelected:    commitSelected,
+		CommitScroll:      commitScroll,
+		Reflogs:           reflogs,
+		ReflogSelected:    reflogSelected,
+		ReflogScroll:      reflogScroll,
+		TransientError:    m.status.Text,
+		SearchActive:      m.searchActive,
+		RepoSearch:        m.repos.Query(),
+		ItemSearch:        m.activeItemPaneQuery(),
+		RepoEmptyMessage:  repoEmptyMessage,
+		RightEmptyMessage: rightEmptyMessage,
+		FetchAvailable:    m.canFetch(),
+		PullAvailable:     m.canPull(),
 	})
+}
+
+func (m Model) repoEmptyMessage(filteredRepos int) string {
+	if filteredRepos > 0 {
+		return ""
+	}
+	if m.repos.Query() != "" && m.repos.ItemCount() > 0 {
+		return "No repo results for " + m.repos.Query()
+	}
+	if m.repos.ItemCount() == 0 {
+		return "No repositories found"
+	}
+	return ""
+}
+
+func (m Model) rightEmptyMessage(filteredRepos, filteredWorktrees, filteredBranches, filteredStashes, filteredCommits, filteredReflogs int) string {
+	if filteredRepos == 0 {
+		return "No selected repo"
+	}
+	sourceCount, filteredCount := m.activeItemCounts(filteredWorktrees, filteredBranches, filteredStashes, filteredCommits, filteredReflogs)
+	if m.activeItemPaneQuery() != "" && sourceCount > 0 && filteredCount == 0 {
+		return "No " + modeResultName(m.mode) + " results for " + m.activeItemPaneQuery()
+	}
+	if m.status.Source == statusFetch && m.status.FetchKind == FetchList && m.status.Mode == m.mode {
+		return "Could not load " + modeDataName(m.mode) + "; see status bar"
+	}
+	return modeEmptyMessage(m.mode)
+}
+
+func (m Model) activeItemCounts(filteredWorktrees, filteredBranches, filteredStashes, filteredCommits, filteredReflogs int) (int, int) {
+	switch m.mode {
+	case ui.ModeWorktrees:
+		return m.worktrees.ItemCount(), filteredWorktrees
+	case ui.ModeBranches:
+		return m.rows.ItemCount(), filteredBranches
+	case ui.ModeStashes:
+		return m.stashes.ItemCount(), filteredStashes
+	case ui.ModeHistory:
+		return m.commits.ItemCount(), filteredCommits
+	case ui.ModeReflog:
+		return m.reflogs.ItemCount(), filteredReflogs
+	default:
+		return 0, 0
+	}
+}
+
+func modeDataName(mode ui.Mode) string {
+	switch mode {
+	case ui.ModeWorktrees:
+		return "worktrees"
+	case ui.ModeBranches:
+		return "branches"
+	case ui.ModeStashes:
+		return "stashes"
+	case ui.ModeHistory:
+		return "commits"
+	case ui.ModeReflog:
+		return "reflog"
+	default:
+		return "items"
+	}
+}
+
+func modeResultName(mode ui.Mode) string {
+	switch mode {
+	case ui.ModeWorktrees:
+		return "worktree"
+	case ui.ModeBranches:
+		return "branch"
+	case ui.ModeStashes:
+		return "stash"
+	case ui.ModeHistory:
+		return "commit"
+	case ui.ModeReflog:
+		return "reflog"
+	default:
+		return "item"
+	}
+}
+
+func modeEmptyMessage(mode ui.Mode) string {
+	switch mode {
+	case ui.ModeWorktrees:
+		return "No worktrees to show"
+	case ui.ModeBranches:
+		return "No branches to show"
+	case ui.ModeStashes:
+		return "No stashes"
+	case ui.ModeHistory:
+		return "No commits"
+	case ui.ModeReflog:
+		return "No reflog entries"
+	default:
+		return "nothing here yet"
+	}
 }
 
 func (m Model) overlayState() ui.OverlayState {

--- a/model/model.go
+++ b/model/model.go
@@ -172,17 +172,21 @@ func (m Model) repoEmptyMessage(filteredRepos int) string {
 	if filteredRepos > 0 {
 		return ""
 	}
-	if m.repos.Query() != "" && m.repos.ItemCount() > 0 {
+	itemCount := m.repos.ItemCount()
+	if m.repos.Query() != "" && itemCount > 0 {
 		return "No repo results for " + m.repos.Query()
 	}
-	if m.repos.ItemCount() == 0 {
+	if itemCount == 0 {
 		return "No repositories found"
 	}
-	return ""
+	return "No repo results"
 }
 
 func (m Model) rightEmptyMessage(filteredRepos, filteredWorktrees, filteredBranches, filteredStashes, filteredCommits, filteredReflogs int) string {
 	if filteredRepos == 0 {
+		if m.repos.Query() != "" && m.repos.ItemCount() > 0 {
+			return "No matching repo"
+		}
 		return "No selected repo"
 	}
 	sourceCount, filteredCount := m.activeItemCounts(filteredWorktrees, filteredBranches, filteredStashes, filteredCommits, filteredReflogs)

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -53,6 +53,16 @@ func TestModel_ViewContainsExpectedContent(t *testing.T) {
 	}
 }
 
+func TestModel_ViewNoReposShowsEmptyMessage(t *testing.T) {
+	m := model.New(nil)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+
+	view := m.View()
+	if !strings.Contains(view, "No repositories found") {
+		t.Fatalf("view with no repos should explain that no repositories were found, got:\n%s", view)
+	}
+}
+
 func TestModel_ViewWorktreesModeShowsPlaceholder(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: 24})
@@ -91,6 +101,12 @@ func TestModel_ViewDistinguishesFilteredEmptyRepos(t *testing.T) {
 	view := m.View()
 	if !strings.Contains(view, "No repo results for zzz") {
 		t.Fatalf("filtered repo pane should explain that the repo filter has no matches, got:\n%s", view)
+	}
+	if !strings.Contains(view, "No matching repo") {
+		t.Fatalf("right pane should explain that the repo filter leaves no selected repo, got:\n%s", view)
+	}
+	if strings.Contains(view, "No selected repo") {
+		t.Fatal("filtered-empty repo view should not use generic no-selected-repo copy")
 	}
 }
 

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -61,8 +61,8 @@ func TestModel_ViewWorktreesModeShowsPlaceholder(t *testing.T) {
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: branches})
 
 	view := m.View()
-	if !strings.Contains(view, "nothing here yet") {
-		t.Error("ModeWorktrees should show placeholder even when branch data is loaded")
+	if !strings.Contains(view, "No worktrees to show") {
+		t.Error("ModeWorktrees should show worktree-specific empty state even when branch data is loaded")
 	}
 	if strings.Contains(view, "main") {
 		t.Error("ModeWorktrees should NOT show branch data")
@@ -76,8 +76,110 @@ func TestModel_ViewStashesModeShowsPlaceholder(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 
 	view := m.View()
-	if !strings.Contains(view, "nothing here yet") {
-		t.Error("ModeStashes with no data should show placeholder")
+	if !strings.Contains(view, "No stashes") {
+		t.Error("ModeStashes with no data should show stash-specific empty state")
+	}
+}
+
+func TestModel_ViewDistinguishesFilteredEmptyRepos(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("zzz")})
+
+	view := m.View()
+	if !strings.Contains(view, "No repo results for zzz") {
+		t.Fatalf("filtered repo pane should explain that the repo filter has no matches, got:\n%s", view)
+	}
+}
+
+func TestModel_ViewDistinguishesFilteredEmptyItemsInEveryMode(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(model.Model) model.Model
+		want      string
+		notWanted string
+	}{
+		{
+			name: "worktrees",
+			setup: func(m model.Model) model.Model {
+				m = inRightPane(m)
+				m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+					{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+				}})
+				return m
+			},
+			want:      "No worktree results for zzz",
+			notWanted: "No worktrees to show",
+		},
+		{
+			name: "branches",
+			setup: func(m model.Model) model.Model {
+				m = inBranchesMode(m)
+				m, _ = update(m, model.BranchResultMsg{
+					RepoPath: "/dev/alpha",
+					Branches: []gitquery.Branch{
+						{Name: "main", HasUpstream: true},
+						{Name: "feature/auth", HasUpstream: true},
+					},
+				})
+				return m
+			},
+			want:      "No branch results for zzz",
+			notWanted: "No branches to show",
+		},
+		{
+			name: "stashes",
+			setup: func(m model.Model) model.Model {
+				m = inRightPane(m)
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+				m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()[:1]})
+				return m
+			},
+			want:      "No stash results for zzz",
+			notWanted: "No stashes",
+		},
+		{
+			name: "history",
+			setup: func(m model.Model) model.Model {
+				m = inRightPane(m)
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+				m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()[:1]})
+				return m
+			},
+			want:      "No commit results for zzz",
+			notWanted: "No commits",
+		},
+		{
+			name: "reflog",
+			setup: func(m model.Model) model.Model {
+				m = inRightPane(m)
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+				m, _ = update(m, model.ReflogResultMsg{RepoPath: "/dev/alpha", Reflogs: testReflogs()[:1]})
+				return m
+			},
+			want:      "No reflog results for zzz",
+			notWanted: "No reflog entries",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := model.New(testRepos())
+			m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+			m = tt.setup(m)
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("zzz")})
+
+			view := m.View()
+			if !strings.Contains(view, tt.want) {
+				t.Fatalf("filtered %s pane should explain that the filter has no matches, got:\n%s", tt.name, view)
+			}
+			if strings.Contains(view, tt.notWanted) {
+				t.Fatalf("filtered-empty %s pane should not look like an unfiltered empty pane", tt.name)
+			}
+		})
 	}
 }
 
@@ -283,8 +385,8 @@ func TestModel_ViewHistoryModeShowsPlaceholder(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 
 	view := m.View()
-	if !strings.Contains(view, "nothing here yet") {
-		t.Error("history mode with no commits should show placeholder")
+	if !strings.Contains(view, "No commits") {
+		t.Error("history mode with no commits should show history-specific empty state")
 	}
 }
 
@@ -652,6 +754,64 @@ func TestModel_ListFetchErrorShowsStatusWithoutClearingPane(t *testing.T) {
 	if !strings.Contains(view, "main") {
 		t.Error("list fetch failure should not clear existing pane data")
 	}
+	if strings.Contains(view, "Could not load worktrees; see status bar") {
+		t.Error("list fetch failure should not show a failure placeholder while existing pane data is visible")
+	}
+}
+
+func TestModel_ListFetchErrorOnEmptyPaneDoesNotLookLikeNoData(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inRightPane(m)
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath: "/dev/alpha",
+		Pane:     "worktrees",
+		Err:      "failed to load worktrees: boom",
+		Kind:     model.FetchList,
+		Mode:     ui.ModeWorktrees,
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "failed to load worktrees: boom") {
+		t.Error("view should show list fetch failure in status bar")
+	}
+	if !strings.Contains(view, "Could not load worktrees; see status bar") {
+		t.Fatalf("empty failed pane should direct the user to the status error, got:\n%s", view)
+	}
+	if strings.Contains(view, "No worktrees to show") {
+		t.Fatal("failed load should not look like successful empty data")
+	}
+}
+
+func TestModel_FilteredEmptyItemsTakePrecedenceOverListFetchErrorPlaceholder(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("zzz")})
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath: "/dev/alpha",
+		Pane:     "worktrees",
+		Err:      "failed to load worktrees: boom",
+		Kind:     model.FetchList,
+		Mode:     ui.ModeWorktrees,
+	})
+
+	view := m.View()
+	if !strings.Contains(view, "failed to load worktrees: boom") {
+		t.Error("status bar should still show the fetch failure")
+	}
+	if !strings.Contains(view, "No worktree results for zzz") {
+		t.Fatalf("filtered-empty message should explain the visible pane emptiness, got:\n%s", view)
+	}
+	if strings.Contains(view, "Could not load worktrees; see status bar") {
+		t.Fatal("filtered-empty pane should not be replaced by fetch-failure placeholder")
+	}
 }
 
 func TestModel_InitFetchUsesNonZeroListRequest(t *testing.T) {
@@ -952,7 +1112,7 @@ func TestModel_ViewReflogModeShowsPlaceholder(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
 
 	view := m.View()
-	if !strings.Contains(view, "nothing here yet") {
-		t.Error("reflog mode with no data should show placeholder")
+	if !strings.Contains(view, "No reflog entries") {
+		t.Error("reflog mode with no data should show reflog-specific empty state")
 	}
 }

--- a/model/pane/pane.go
+++ b/model/pane/pane.go
@@ -96,6 +96,11 @@ func (p Pane[T]) Len() int {
 	return len(p.filtered)
 }
 
+// ItemCount returns the number of source items before filtering.
+func (p Pane[T]) ItemCount() int {
+	return len(p.items)
+}
+
 // SelectedIndex returns the cursor position within the filtered view.
 func (p Pane[T]) SelectedIndex() int {
 	return p.selected

--- a/model/pane/pane_test.go
+++ b/model/pane/pane_test.go
@@ -128,6 +128,22 @@ func TestPaneSetQueryPreserveIndexKeepsCursorWhenPossible(t *testing.T) {
 	}
 }
 
+func TestPaneItemCountReportsSourceItemsWhenFilterHasNoMatches(t *testing.T) {
+	items := []testItem{
+		{name: "alpha"},
+		{name: "bravo"},
+	}
+	p := fixedTestPane(items).SetQuery("zzz")
+	filtered, _, _ := p.View()
+
+	if len(filtered) != 0 {
+		t.Fatalf("expected no filtered matches, got %#v", filtered)
+	}
+	if p.ItemCount() != 2 {
+		t.Fatalf("expected source item count 2, got %d", p.ItemCount())
+	}
+}
+
 func TestPaneMoveOnEmptyAndSingleItemLists(t *testing.T) {
 	var empty Pane[testItem]
 	empty = empty.Move(1, 2, 80)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -96,42 +96,44 @@ var (
 
 // RenderParams holds everything the renderer needs.
 type RenderParams struct {
-	Repos            []scanner.Repo
-	Selected         int
-	Width            int
-	Height           int
-	Mode             Mode
-	Branches         []gitquery.BranchRow
-	Stashes          []gitquery.Stash
-	BranchSelected   int
-	StashSelected    int
-	Overlay          OverlayState
-	OverlayDiff      string
-	OverlayScroll    int
-	ConfirmPrompt    string
-	ConfirmForce     bool
-	WorktreeInput    string
-	WorktreeInputErr string
-	BranchScroll     int
-	RepoScroll       int
-	StashScroll      int
-	ActivePane       int
-	Destructive      bool
-	Worktrees        []gitquery.Worktree
-	WorktreeSelected int
-	WorktreeScroll   int
-	Commits          []gitquery.Commit
-	CommitSelected   int
-	CommitScroll     int
-	Reflogs          []gitquery.ReflogEntry
-	ReflogSelected   int
-	ReflogScroll     int
-	TransientError   string
-	SearchActive     bool
-	RepoSearch       string
-	ItemSearch       string
-	FetchAvailable   bool
-	PullAvailable    bool
+	Repos             []scanner.Repo
+	Selected          int
+	Width             int
+	Height            int
+	Mode              Mode
+	Branches          []gitquery.BranchRow
+	Stashes           []gitquery.Stash
+	BranchSelected    int
+	StashSelected     int
+	Overlay           OverlayState
+	OverlayDiff       string
+	OverlayScroll     int
+	ConfirmPrompt     string
+	ConfirmForce      bool
+	WorktreeInput     string
+	WorktreeInputErr  string
+	BranchScroll      int
+	RepoScroll        int
+	StashScroll       int
+	ActivePane        int
+	Destructive       bool
+	Worktrees         []gitquery.Worktree
+	WorktreeSelected  int
+	WorktreeScroll    int
+	Commits           []gitquery.Commit
+	CommitSelected    int
+	CommitScroll      int
+	Reflogs           []gitquery.ReflogEntry
+	ReflogSelected    int
+	ReflogScroll      int
+	TransientError    string
+	SearchActive      bool
+	RepoSearch        string
+	ItemSearch        string
+	RepoEmptyMessage  string
+	RightEmptyMessage string
+	FetchAvailable    bool
+	PullAvailable     bool
 }
 
 // Render produces the full terminal view string.
@@ -191,7 +193,7 @@ func Render(p RenderParams) string {
 	leftContentWidth := LeftPaneWidth - 2 // left + right border
 	innerHeight := p.Height - 3           // status bar + top/bottom borders
 
-	leftLines := renderRepoList(p.Repos, p.Selected, p.RepoScroll, leftContentWidth, innerHeight)
+	leftLines := renderRepoList(p.Repos, p.Selected, p.RepoScroll, leftContentWidth, innerHeight, p.RepoEmptyMessage)
 	leftContent := strings.Join(leftLines, "\n")
 	leftPane := lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder()).
@@ -240,7 +242,7 @@ func Render(p RenderParams) string {
 	case p.Mode == ModeReflog && len(p.Reflogs) > 0:
 		rightLines = renderReflogPane(p.Reflogs, reflogSel, p.ReflogScroll, rightContentWidth, rightContentHeight)
 	default:
-		rightLines = renderPlaceholderPane(rightContentWidth, rightContentHeight)
+		rightLines = renderPlaceholderPane(rightContentWidth, rightContentHeight, p.RightEmptyMessage)
 	}
 
 	rightContent := modeHeader + "\n" + strings.Join(rightLines, "\n")
@@ -444,8 +446,18 @@ func renderStatusBarWithState(sp statusBarParams) string {
 	return statusStyle.Width(width).Render(hints)
 }
 
-func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int) []string {
+func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, emptyMessage string) []string {
+	if height <= 0 {
+		return nil
+	}
 	lines := make([]string, height)
+	if len(repos) == 0 && emptyMessage != "" {
+		lines[0] = renderPlaceholderLine(emptyMessage, width)
+		for i := 1; i < height; i++ {
+			lines[i] = strings.Repeat(" ", width)
+		}
+		return lines
+	}
 
 	for i := 0; i < height; i++ {
 		idx := scroll + i
@@ -855,14 +867,28 @@ func truncateReason(s string, max int) string {
 	return truncateToWidth(s, max-lipgloss.Width("…")) + "…"
 }
 
-func renderPlaceholderPane(width, height int) []string {
+func renderPlaceholderPane(width, height int, message string) []string {
+	if height <= 0 {
+		return nil
+	}
 	lines := make([]string, height)
-	placeholder := placeholderStyle.Render("nothing here yet")
+	if message == "" {
+		message = "nothing here yet"
+	}
 	mid := height / 2
+	lines[mid] = renderPlaceholderLine(message, width)
+	return lines
+}
+
+func renderPlaceholderLine(message string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	message = truncateToWidth(message, width)
+	placeholder := placeholderStyle.Render(message)
 	pad := (width - lipgloss.Width(placeholder)) / 2
 	if pad < 0 {
 		pad = 0
 	}
-	lines[mid] = strings.Repeat(" ", pad) + placeholder
-	return lines
+	return strings.Repeat(" ", pad) + placeholder
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -452,10 +452,10 @@ func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, e
 	}
 	lines := make([]string, height)
 	if len(repos) == 0 && emptyMessage != "" {
-		lines[0] = renderPlaceholderLine(emptyMessage, width)
-		for i := 1; i < height; i++ {
+		for i := range lines {
 			lines[i] = strings.Repeat(" ", width)
 		}
+		lines[height/2] = renderPlaceholderLine(emptyMessage, width)
 		return lines
 	}
 
@@ -873,6 +873,8 @@ func renderPlaceholderPane(width, height int, message string) []string {
 	}
 	lines := make([]string, height)
 	if message == "" {
+		// Keep a generic fallback for direct renderer callers; the model
+		// supplies mode-specific messages during normal application rendering.
 		message = "nothing here yet"
 	}
 	mid := height / 2

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1257,6 +1257,19 @@ func TestRender_EmptyStateMessagesFitPaneWidth(t *testing.T) {
 	}
 }
 
+func TestRepoList_EmptyMessageIsVerticallyCentered(t *testing.T) {
+	lines := renderRepoList(nil, 0, 0, 20, 5, "No repos")
+	for i, line := range lines {
+		hasMessage := strings.Contains(line, "No repos")
+		if i == 2 && !hasMessage {
+			t.Fatalf("expected empty message centered on line 2, got %#v", lines)
+		}
+		if i != 2 && hasMessage {
+			t.Fatalf("empty message should only appear on centered line, got line %d in %#v", i, lines)
+		}
+	}
+}
+
 // --- Reflog pane ---
 
 func TestReflogPane_ShowsEntryDetails(t *testing.T) {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -207,7 +207,7 @@ func TestRepoList_ScrollsWhenSelectionExceedsHeight(t *testing.T) {
 		{Path: "/e", DisplayName: "echo"},
 	}
 	// Height of 3 means only 3 visible at a time; scroll=2 shows repos 2-4
-	lines := renderRepoList(repos, 4, 2, LeftPaneWidth-2, 3)
+	lines := renderRepoList(repos, 4, 2, LeftPaneWidth-2, 3, "")
 	joined := strings.Join(lines, "\n")
 	if !strings.Contains(joined, "echo") {
 		t.Error("selected item 'echo' should be visible")
@@ -222,7 +222,7 @@ func TestRepoList_TruncatesLongNames(t *testing.T) {
 	repos := []scanner.Repo{
 		{Path: "/a", DisplayName: "this-is-a-very-long-repository-name-that-exceeds-width"},
 	}
-	lines := renderRepoList(repos, 0, 0, width, 3)
+	lines := renderRepoList(repos, 0, 0, width, 3, "")
 	for i, line := range lines {
 		if lipgloss.Width(line) > width {
 			t.Errorf("line %d width %d exceeds pane width %d", i, lipgloss.Width(line), width)
@@ -1195,6 +1195,65 @@ func TestRender_WorktreesModeShowsData(t *testing.T) {
 	}
 	if strings.Contains(view, "nothing here yet") {
 		t.Error("render should not show placeholder when worktree data exists")
+	}
+}
+
+func TestRender_UsesProvidedEmptyStateMessages(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:             []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:          0,
+		Width:             80,
+		Height:            10,
+		Mode:              ModeWorktrees,
+		RightEmptyMessage: "No worktrees to show",
+	})
+	if !strings.Contains(view, "No worktrees to show") {
+		t.Fatalf("render should show provided right-pane empty message, got:\n%s", view)
+	}
+	if strings.Contains(view, "nothing here yet") {
+		t.Fatal("render should not fall back to generic placeholder when an empty message is provided")
+	}
+
+	view = Render(RenderParams{
+		Width:            80,
+		Height:           10,
+		Mode:             ModeWorktrees,
+		RepoEmptyMessage: "No repo results for zzz",
+	})
+	if !strings.Contains(view, "No repo results for zzz") {
+		t.Fatalf("render should show provided repo empty message, got:\n%s", view)
+	}
+}
+
+func TestRender_EmptyStateMessagesDoNotPanicAtTinyHeights(t *testing.T) {
+	for _, height := range []int{1, 2, 3, 4} {
+		t.Run(fmt.Sprintf("height_%d", height), func(t *testing.T) {
+			_ = Render(RenderParams{
+				Width:             80,
+				Height:            height,
+				Mode:              ModeWorktrees,
+				RepoEmptyMessage:  "No repo results for zzz",
+				RightEmptyMessage: "No selected repo",
+			})
+		})
+	}
+}
+
+func TestRender_EmptyStateMessagesFitPaneWidth(t *testing.T) {
+	longMessage := "No repo results for " + strings.Repeat("z", 80)
+
+	repoLines := renderRepoList(nil, 0, 0, 12, 3, longMessage)
+	for i, line := range repoLines {
+		if lipgloss.Width(line) > 12 {
+			t.Fatalf("repo empty line %d width %d exceeds pane width 12: %q", i, lipgloss.Width(line), line)
+		}
+	}
+
+	rightLines := renderPlaceholderPane(16, 3, longMessage)
+	for i, line := range rightLines {
+		if lipgloss.Width(line) > 16 {
+			t.Fatalf("right empty line %d width %d exceeds pane width 16: %q", i, lipgloss.Width(line), line)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Distinguish empty states for repo lists and right-pane modes so the UI can show no-data, filtered-empty, and fetch-failure copy separately.
- Keep the model responsible for choosing the semantic empty message, while `ui` stays focused on rendering it.
- Add coverage for all right-pane modes, fetch-failure interactions, and tiny-terminal/long-query width safety.
- Update the README and mark the roadmap item complete.

## Testing
- Added and updated unit tests in `model`, `model/pane`, and `ui` for empty-state behavior, filtered results, fetch failures, and width/panic regressions.
- Local validation passed: `gofmt -l .`, `go test ./...`, and `make build`.