### PR TITLE
[codex] Add branch creation from branches pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ filter matches, or a load failure with details in the status bar.
 | `1`/`2`/`3`/`4`/`5` | Switch to worktrees / branches / stashes / history / reflog |
 | `←`/`h`/`→`/`l` | Cycle through modes |
 | `enter` | View diff (dirty worktree, dirty branch, stash, commit, or reflog entry) |
-| `n` | Create a new worktree from a branch, tag, or new branch name |
+| `n` | Create a new worktree in worktrees view, or a new branch in branches view |
 | `d` | Delete worktree/branch or drop stash — requires destructive mode |
 | `p` | Prune stale worktree — requires destructive mode (worktrees view) |
 | `u` | Unlock a locked worktree (worktrees view) |
@@ -114,7 +114,7 @@ Status indicators stack on each branch:
 - `●` purple: no upstream or upstream gone
 - `merged` cyan: branch is fully merged into the cleanup branch (`main` or `master`)
 
-Branches ahead of upstream show up to 5 unpushed commit messages, with overflow count. When the root branch is dirty, `enter` opens a full-screen diff overlay. `t` opens or attaches to a tmux/Zellij session and `c` opens VSCode at the worktree path (root branch only). `f` runs `git fetch --prune`, and `F` runs `git pull --ff-only` for branches that have a checked-out worktree. `d` deletes non-worktree branches, with a force-retry prompt on failure. Deletion requires destructive mode to be enabled first (`D`).
+Branches ahead of upstream show up to 5 unpushed commit messages, with overflow count. Press `n` to create a new branch from the selected branch, without checking it out or creating a worktree. When the root branch is dirty, `enter` opens a full-screen diff overlay. `t` opens or attaches to a tmux/Zellij session and `c` opens VSCode at the worktree path (root branch only). `f` runs `git fetch --prune`, and `F` runs `git pull --ff-only` for branches that have a checked-out worktree. `d` deletes non-worktree branches, with a force-retry prompt on failure. Deletion requires destructive mode to be enabled first (`D`).
 
 ### Stashes view (mode 3)
 

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -110,6 +110,25 @@ func CreateWorktree(repoPath, ref string) (string, error) {
 	return worktreePath, nil
 }
 
+// CreateBranch creates a new branch without checking it out. When startPoint is
+// empty, git creates the branch at HEAD.
+func CreateBranch(repoPath, name, startPoint string) error {
+	name = strings.TrimSpace(name)
+	startPoint = strings.TrimSpace(startPoint)
+	if name == "" {
+		return fmt.Errorf("branch name cannot be empty")
+	}
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf("branch name cannot start with -: %q", name)
+	}
+
+	args := []string{"branch", "--", name}
+	if startPoint != "" {
+		args = append(args, startPoint)
+	}
+	return runGit(repoPath, args...)
+}
+
 // DefaultWorktreePath returns the conventional sibling path used for new
 // worktrees: <repo>-worktrees/<branch-or-tag>.
 func DefaultWorktreePath(repoPath, ref string) string {

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -496,6 +496,90 @@ func TestCreateWorktree_RefStartingWithDashFails(t *testing.T) {
 	}
 }
 
+func TestCreateBranch_FromHEAD(t *testing.T) {
+	repoPath := setupRepo(t)
+	head := runOutput(t, repoPath, "git", "rev-parse", "HEAD")
+	initial := runOutput(t, repoPath, "git", "branch", "--show-current")
+
+	if err := actions.CreateBranch(repoPath, "feature/one", ""); err != nil {
+		t.Fatalf("CreateBranch returned error: %v", err)
+	}
+
+	got := runOutput(t, repoPath, "git", "rev-parse", "feature/one")
+	if got != head {
+		t.Fatalf("expected feature/one at HEAD %s, got %s", head, got)
+	}
+	current := runOutput(t, repoPath, "git", "branch", "--show-current")
+	if current != initial {
+		t.Fatalf("expected current branch to remain %s, got %q", initial, current)
+	}
+}
+
+func TestCreateBranch_FromStartPoint(t *testing.T) {
+	repoPath := setupRepo(t)
+	initial := runOutput(t, repoPath, "git", "branch", "--show-current")
+	mustRun(t, repoPath, "git", "branch", "base")
+	mustRun(t, repoPath, "git", "checkout", "base")
+	mustRun(t, repoPath, "git", "commit", "--allow-empty", "-m", "base change")
+	base := runOutput(t, repoPath, "git", "rev-parse", "base")
+	mustRun(t, repoPath, "git", "checkout", initial)
+
+	if err := actions.CreateBranch(repoPath, "feature/from-base", "base"); err != nil {
+		t.Fatalf("CreateBranch returned error: %v", err)
+	}
+
+	got := runOutput(t, repoPath, "git", "rev-parse", "feature/from-base")
+	if got != base {
+		t.Fatalf("expected feature/from-base at base %s, got %s", base, got)
+	}
+	current := runOutput(t, repoPath, "git", "branch", "--show-current")
+	if current != initial {
+		t.Fatalf("expected current branch to remain %s, got %q", initial, current)
+	}
+}
+
+func TestCreateBranch_InvalidInputFails(t *testing.T) {
+	repoPath := setupRepo(t)
+	for _, input := range []string{"", "  ", "--bad"} {
+		t.Run(input, func(t *testing.T) {
+			if err := actions.CreateBranch(repoPath, input, ""); err == nil {
+				t.Fatal("expected invalid branch name to fail")
+			}
+		})
+	}
+}
+
+func TestCreateBranch_GitValidationErrorsAreReadable(t *testing.T) {
+	repoPath := setupRepo(t)
+	mustRun(t, repoPath, "git", "branch", "existing")
+
+	for _, input := range []string{"existing", "bad name"} {
+		t.Run(input, func(t *testing.T) {
+			err := actions.CreateBranch(repoPath, input, "")
+			if err == nil {
+				t.Fatal("expected branch creation to fail")
+			}
+			if strings.Contains(err.Error(), "exit status") {
+				t.Fatalf("expected clean git error without exit status, got %q", err.Error())
+			}
+		})
+	}
+}
+
+func TestCreateBranch_StartPointStartingWithDashIsTreatedAsRef(t *testing.T) {
+	repoPath := setupRepo(t)
+	err := actions.CreateBranch(repoPath, "feature/from-dash", "--bad")
+	if err == nil {
+		t.Fatal("expected invalid start point to fail")
+	}
+	if strings.Contains(err.Error(), "exit status") {
+		t.Fatalf("expected clean git error without exit status, got %q", err.Error())
+	}
+	if out := runOutput(t, repoPath, "git", "branch", "--list", "feature/from-dash"); out != "" {
+		t.Fatalf("expected branch not to be created, got %q", out)
+	}
+}
+
 func TestUnlockWorktree(t *testing.T) {
 	repoPath := setupRepo(t)
 	worktreePath := filepath.Join(filepath.Dir(repoPath), "wt-unlock")

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -23,6 +23,8 @@ are already implemented and should be treated as the baseline product:
   drop, or prune actions are exposed.
 - Worktree creation from an existing branch, tag, ref, or new branch name using
   `n`, with new checkouts placed under `<repo>-worktrees/<ref>`.
+- Branch creation from the branches pane using `n`, creating from the selected
+  branch without checking out or creating a worktree.
 - Worktree deletion followed by an optional associated branch deletion prompt.
 - Stale worktree pruning, with locked worktrees protected from delete/prune and
   unlock exposed as a separate `u` action.

--- a/docs/roadmap-todo.md
+++ b/docs/roadmap-todo.md
@@ -19,7 +19,7 @@ Goal: round out lifecycle operations while keeping the destructive boundary
 clear.
 
 - [ ] P1 - PR-based worktree creation: enter a PR number or URL, fetch the head branch, and create a worktree for review.
-- [ ] P1 - Branch creation from branches pane: complement worktree creation and make branch-first workflows smoother.
+- [x] P1 - Branch creation from branches pane: complement worktree creation and make branch-first workflows smoother.
 - [ ] P1 - Coding-agent launch actions: launch Codex or Claude Code from a selected worktree or worktree branch, optionally after creating a new worktree or branch.
 - [ ] P2 - Worktree move/rename: wrap `git worktree move` for users who need to reorganize generated paths.
 - [ ] P2 - Bare repo support: detect bare repositories and support worktree creation/listing correctly for central bare repo workflows.

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -48,6 +48,7 @@ type Worktree struct {
 // Branch represents a local git branch with its status.
 type Branch struct {
 	Name          string
+	FullRef       string
 	HasUpstream   bool
 	UpstreamGone  bool
 	Ahead         int
@@ -275,7 +276,7 @@ func (q *Querier) StashDiff(repoPath string, index int) (string, error) {
 	return out, nil
 }
 
-const refFormat = "%(refname:short)\t%(upstream)\t%(upstream:track)"
+const refFormat = "%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)"
 
 // ListBranches returns all local branches sorted alphabetically by name.
 func ListBranches(repoPath string) ([]Branch, error) {

--- a/gitquery/parse.go
+++ b/gitquery/parse.go
@@ -5,17 +5,25 @@ import (
 	"strings"
 )
 
-// ParseBranchLine parses one line of git for-each-ref --format=%(refname:short)\t%(upstream)\t%(upstream:track).
+// ParseBranchLine parses one line of git for-each-ref output for a local branch.
 // Returns the branch (with Name, HasUpstream, UpstreamGone populated) and the upstream ref string.
 func ParseBranchLine(line string) (Branch, string) {
-	parts := strings.SplitN(line, "\t", 3)
+	parts := strings.SplitN(line, "\t", 4)
 	b := Branch{Name: parts[0]}
 
+	upstreamIndex := 1
+	trackIndex := 2
+	if len(parts) > 1 && strings.HasPrefix(parts[1], "refs/heads/") {
+		b.FullRef = parts[1]
+		upstreamIndex = 2
+		trackIndex = 3
+	}
+
 	var upstream string
-	if len(parts) > 1 && parts[1] != "" {
+	if len(parts) > upstreamIndex && parts[upstreamIndex] != "" {
 		b.HasUpstream = true
-		upstream = parts[1]
-		if len(parts) > 2 && strings.Contains(parts[2], "gone") {
+		upstream = parts[upstreamIndex]
+		if len(parts) > trackIndex && strings.Contains(parts[trackIndex], "gone") {
 			b.UpstreamGone = true
 		}
 	}

--- a/gitquery/parse_test.go
+++ b/gitquery/parse_test.go
@@ -229,6 +229,25 @@ func TestParseBranchLine_WithUpstream(t *testing.T) {
 	}
 }
 
+func TestParseBranchLine_WithFullRef(t *testing.T) {
+	line := "heads/base\trefs/heads/base\trefs/remotes/origin/base\t"
+
+	b, upstream := gitquery.ParseBranchLine(line)
+
+	if b.Name != "heads/base" {
+		t.Errorf("expected Name %q, got %q", "heads/base", b.Name)
+	}
+	if b.FullRef != "refs/heads/base" {
+		t.Errorf("expected FullRef %q, got %q", "refs/heads/base", b.FullRef)
+	}
+	if !b.HasUpstream {
+		t.Error("expected HasUpstream = true")
+	}
+	if upstream != "refs/remotes/origin/base" {
+		t.Errorf("expected upstream %q, got %q", "refs/remotes/origin/base", upstream)
+	}
+}
+
 func TestParseBranchLine_UpstreamGone(t *testing.T) {
 	line := "old-feature\trefs/remotes/origin/old-feature\t[gone]"
 

--- a/gitquery/runner_test.go
+++ b/gitquery/runner_test.go
@@ -58,7 +58,7 @@ func TestQuerierListBranches_AheadBehindFailureLeavesCountsZero(t *testing.T) {
 	f := &fakeRunner{
 		t: t,
 		run: map[string]fakeReply{
-			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
+			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
 				out: "feature\trefs/remotes/origin/feature\t[ahead 3]\nmain\t\t\n",
 			},
 			fakeKey("/repo", "worktree", "list", "--porcelain"): {
@@ -99,7 +99,7 @@ func TestQuerierListBranches_ForEachRefFailureIsFatal(t *testing.T) {
 	f := &fakeRunner{
 		t: t,
 		run: map[string]fakeReply{
-			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
+			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
 				err: wantErr,
 			},
 		},
@@ -122,7 +122,7 @@ func TestQuerierListBranches_UnpushedCommitsOnlyReadForAheadBranches(t *testing.
 	f := &fakeRunner{
 		t: t,
 		run: map[string]fakeReply{
-			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
+			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
 				out: "behind\trefs/remotes/origin/behind\t[behind 1]\nfeature\trefs/remotes/origin/feature\t[ahead 2]\nmain\t\t\n",
 			},
 			fakeKey("/repo", "worktree", "list", "--porcelain"): {
@@ -170,7 +170,7 @@ func TestQuerierListBranches_DirtyStatusFailureIsBestEffort(t *testing.T) {
 	f := &fakeRunner{
 		t: t,
 		run: map[string]fakeReply{
-			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
+			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
 				out: "feature\t\t\nmain\t\t\n",
 			},
 			fakeKey("/repo", "worktree", "list", "--porcelain"): {
@@ -207,7 +207,7 @@ func TestQuerierListBranches_OkProbeMarksMergedBranches(t *testing.T) {
 	f := &fakeRunner{
 		t: t,
 		run: map[string]fakeReply{
-			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
+			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
 				out: "feature\t\t\nmain\t\t\n",
 			},
 			fakeKey("/repo", "worktree", "list", "--porcelain"): {

--- a/model/model.go
+++ b/model/model.go
@@ -14,23 +14,24 @@ const listRequestSlots = int(ui.ModeReflog) + 1
 
 // Model is the bubbletea application model.
 type Model struct {
-	repos          pane.Pane[scanner.Repo]
-	width          int
-	height         int
-	mode           ui.Mode
-	rows           pane.Pane[gitquery.BranchRow]
-	stashes        pane.Pane[gitquery.Stash]
-	worktrees      pane.Pane[gitquery.Worktree]
-	commits        pane.Pane[gitquery.Commit]
-	reflogs        pane.Pane[gitquery.ReflogEntry]
-	modal          modal.Modal
-	diffRequestSeq uint64
-	listRequestSeq uint64
-	listRequests   [listRequestSlots]uint64
-	activePane     int // 0=left (repos), 1=right (content)
-	destructive    bool
-	status         statusError
-	searchActive   bool
+	repos                  pane.Pane[scanner.Repo]
+	width                  int
+	height                 int
+	mode                   ui.Mode
+	rows                   pane.Pane[gitquery.BranchRow]
+	stashes                pane.Pane[gitquery.Stash]
+	worktrees              pane.Pane[gitquery.Worktree]
+	commits                pane.Pane[gitquery.Commit]
+	reflogs                pane.Pane[gitquery.ReflogEntry]
+	modal                  modal.Modal
+	diffRequestSeq         uint64
+	listRequestSeq         uint64
+	listRequests           [listRequestSlots]uint64
+	activePane             int // 0=left (repos), 1=right (content)
+	destructive            bool
+	status                 statusError
+	searchActive           bool
+	pendingBranchSelection string
 }
 
 type statusSource int
@@ -127,44 +128,45 @@ func (m Model) View() string {
 	}
 	modalView := m.modal.View()
 	return ui.Render(ui.RenderParams{
-		Repos:             repos,
-		Selected:          selected,
-		Width:             m.width,
-		Height:            m.height,
-		Mode:              m.mode,
-		Branches:          rows,
-		Stashes:           stashes,
-		BranchSelected:    branchSelected,
-		StashSelected:     stashSelected,
-		Overlay:           m.overlayState(),
-		OverlayDiff:       modalView.Diff,
-		OverlayScroll:     modalView.Scroll,
-		ConfirmPrompt:     modalView.Prompt,
-		ConfirmForce:      modalView.Force,
-		WorktreeInput:     modalView.Input,
-		WorktreeInputErr:  modalView.InputErr,
-		BranchScroll:      branchScroll,
-		RepoScroll:        repoScroll,
-		StashScroll:       stashScroll,
-		ActivePane:        m.activePane,
-		Destructive:       m.destructive,
-		Worktrees:         worktrees,
-		WorktreeSelected:  worktreeSelected,
-		WorktreeScroll:    worktreeScroll,
-		Commits:           commits,
-		CommitSelected:    commitSelected,
-		CommitScroll:      commitScroll,
-		Reflogs:           reflogs,
-		ReflogSelected:    reflogSelected,
-		ReflogScroll:      reflogScroll,
-		TransientError:    m.status.Text,
-		SearchActive:      m.searchActive,
-		RepoSearch:        m.repos.Query(),
-		ItemSearch:        m.activeItemPaneQuery(),
-		RepoEmptyMessage:  repoEmptyMessage,
-		RightEmptyMessage: rightEmptyMessage,
-		FetchAvailable:    m.canFetch(),
-		PullAvailable:     m.canPull(),
+		Repos:               repos,
+		Selected:            selected,
+		Width:               m.width,
+		Height:              m.height,
+		Mode:                m.mode,
+		Branches:            rows,
+		Stashes:             stashes,
+		BranchSelected:      branchSelected,
+		StashSelected:       stashSelected,
+		Overlay:             m.overlayState(),
+		OverlayDiff:         modalView.Diff,
+		OverlayScroll:       modalView.Scroll,
+		ConfirmPrompt:       modalView.Prompt,
+		ConfirmForce:        modalView.Force,
+		WorktreeInputPrompt: modalView.Prompt,
+		WorktreeInput:       modalView.Input,
+		WorktreeInputErr:    modalView.InputErr,
+		BranchScroll:        branchScroll,
+		RepoScroll:          repoScroll,
+		StashScroll:         stashScroll,
+		ActivePane:          m.activePane,
+		Destructive:         m.destructive,
+		Worktrees:           worktrees,
+		WorktreeSelected:    worktreeSelected,
+		WorktreeScroll:      worktreeScroll,
+		Commits:             commits,
+		CommitSelected:      commitSelected,
+		CommitScroll:        commitScroll,
+		Reflogs:             reflogs,
+		ReflogSelected:      reflogSelected,
+		ReflogScroll:        reflogScroll,
+		TransientError:      m.status.Text,
+		SearchActive:        m.searchActive,
+		RepoSearch:          m.repos.Query(),
+		ItemSearch:          m.activeItemPaneQuery(),
+		RepoEmptyMessage:    repoEmptyMessage,
+		RightEmptyMessage:   rightEmptyMessage,
+		FetchAvailable:      m.canFetch(),
+		PullAvailable:       m.canPull(),
 	})
 }
 
@@ -319,6 +321,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleStashDropped(msg)
 	case BranchDeletedMsg:
 		return m.handleBranchDeleted(msg)
+	case BranchCreatedMsg:
+		return m.handleBranchCreated(msg)
+	case BranchCreateFailedMsg:
+		return m.handleBranchCreateFailed(msg), nil
 	case WorktreeResultMsg:
 		return m.handleWorktreeResult(msg), nil
 	case WorktreeRemovedMsg:

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -2087,6 +2087,26 @@ func TestModel_BranchCreatedSelectsNewBranchByFullRef(t *testing.T) {
 	}
 }
 
+func TestModel_BranchCreatedPendingSelectionClearsOnRepoSwitch(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchCreatedMsg{RepoPath: "/dev/alpha", Name: "feature/one"})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})  // left pane
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown}) // repo bravo
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/bravo",
+		Branches: []gitquery.Branch{
+			{Name: "main"},
+			{Name: "feature/one"},
+		},
+	})
+
+	if m.BranchSelected() != 0 {
+		t.Fatalf("expected repo switch to clear pending branch selection, got index %d", m.BranchSelected())
+	}
+}
+
 // --- Confirmation dialog + delete ---
 
 // enableDestructive presses Shift+D to enter destructive mode.

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -1544,13 +1544,12 @@ func TestModel_NKeyOpensWorktreeInput(t *testing.T) {
 	}
 }
 
-func TestModel_NKeyNoOpOutsideWorktreesMode(t *testing.T) {
+func TestModel_NKeyNoOpOutsideCreationModes(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		key  rune
 		mode ui.Mode
 	}{
-		{name: "branches", key: '2', mode: ui.ModeBranches},
 		{name: "stashes", key: '3', mode: ui.ModeStashes},
 		{name: "history", key: '4', mode: ui.ModeHistory},
 		{name: "reflog", key: '5', mode: ui.ModeReflog},
@@ -1690,6 +1689,258 @@ func TestModel_WorktreeCreateFailedUsesFallbackError(t *testing.T) {
 	}
 	if m.WorktreeInputErr() != "Unable to create worktree" {
 		t.Errorf("expected fallback error, got %q", m.WorktreeInputErr())
+	}
+}
+
+// --- Branch creation ---
+
+func TestModel_NKeyInBranchesModeOpensBranchInput(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Errorf("expected OverlayWorktreeInput, got %d", m.Overlay())
+	}
+	if m.WorktreeInput() != "" {
+		t.Errorf("expected empty branch input, got %q", m.WorktreeInput())
+	}
+	if !strings.Contains(m.View(), "Create branch:") {
+		t.Errorf("expected branch prompt in view, got %q", m.View())
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd opening input, got %T", cmd)
+	}
+}
+
+func TestModel_NKeyInBranchesModeWithNoRepoIsNoOp(t *testing.T) {
+	m := model.New(nil)
+	m = inBranchesMode(m)
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if m.Overlay() != ui.OverlayNone {
+		t.Errorf("expected OverlayNone, got %d", m.Overlay())
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd, got %T", cmd)
+	}
+}
+
+func TestModel_BranchInputEnterRequiresText(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Errorf("expected input overlay to remain, got %d", m.Overlay())
+	}
+	if m.WorktreeInputErr() == "" {
+		t.Fatal("expected validation error")
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd for empty input, got %T", cmd)
+	}
+}
+
+func TestModel_BranchInputEnterCreatesBranch(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feature/one")})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.Overlay() != ui.OverlayNone {
+		t.Errorf("expected overlay closed, got %d", m.Overlay())
+	}
+	if cmd == nil {
+		t.Fatal("expected create branch cmd")
+	}
+	msg := cmd()
+	if _, ok := msg.(model.BranchCreateFailedMsg); !ok {
+		t.Fatalf("expected BranchCreateFailedMsg from fake repo, got %T", msg)
+	}
+}
+
+func TestModel_BranchInputUsesSelectedBranchAsStartPoint(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{
+			{Name: "main"},
+			{Name: "base"},
+		},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feature/from-base")})
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected create branch cmd")
+	}
+	msg, ok := cmd().(model.BranchCreateFailedMsg)
+	if !ok {
+		t.Fatalf("expected BranchCreateFailedMsg from fake repo, got %T", msg)
+	}
+	if msg.StartPoint != "refs/heads/base" {
+		t.Fatalf("expected start point refs/heads/base, got %q", msg.StartPoint)
+	}
+}
+
+func TestModel_BranchInputUsesFullRefForHeadsPrefixedBranch(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{
+			{Name: "main", FullRef: "refs/heads/main"},
+			{Name: "heads/base", FullRef: "refs/heads/heads/base"},
+		},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feature/from-heads-base")})
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected create branch cmd")
+	}
+	msg, ok := cmd().(model.BranchCreateFailedMsg)
+	if !ok {
+		t.Fatalf("expected BranchCreateFailedMsg from fake repo, got %T", msg)
+	}
+	if msg.StartPoint != "refs/heads/heads/base" {
+		t.Fatalf("expected start point refs/heads/heads/base, got %q", msg.StartPoint)
+	}
+}
+
+func TestModel_BranchCreatedRefetchesBranches(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, cmd := update(m, model.BranchCreatedMsg{RepoPath: "/dev/alpha", Name: "feature/one"})
+	if m.Mode() != ui.ModeBranches {
+		t.Errorf("expected mode branches after create, got %d", m.Mode())
+	}
+	if cmd == nil {
+		t.Fatal("expected fetchBranches cmd after create")
+	}
+}
+
+func TestModel_BranchCreateFailedReopensBranchInput(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, model.BranchCreateFailedMsg{RepoPath: "/dev/alpha", Input: "feature/one", Err: "boom"})
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Errorf("expected OverlayWorktreeInput, got %d", m.Overlay())
+	}
+	if m.WorktreeInput() != "feature/one" {
+		t.Errorf("expected input restored, got %q", m.WorktreeInput())
+	}
+	if m.WorktreeInputErr() != "boom" {
+		t.Errorf("expected error restored, got %q", m.WorktreeInputErr())
+	}
+	if !strings.Contains(m.View(), "Create branch:") {
+		t.Errorf("expected branch prompt in view, got %q", m.View())
+	}
+}
+
+func TestModel_BranchCreateFailedRetryPreservesStartPoint(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{
+			{Name: "main"},
+			{Name: "base"},
+		},
+	})
+	m, _ = update(m, model.BranchCreateFailedMsg{
+		RepoPath:   "/dev/alpha",
+		Input:      "bad name",
+		Err:        "bad branch name",
+		StartPoint: "refs/heads/base",
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlU})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feature/from-base")})
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected retry create branch cmd")
+	}
+	msg, ok := cmd().(model.BranchCreateFailedMsg)
+	if !ok {
+		t.Fatalf("expected BranchCreateFailedMsg from fake repo, got %T", msg)
+	}
+	if msg.StartPoint != "refs/heads/base" {
+		t.Fatalf("expected retry to preserve start point refs/heads/base, got %q", msg.StartPoint)
+	}
+}
+
+func TestModel_BranchCreateFailedUsesFallbackError(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, model.BranchCreateFailedMsg{RepoPath: "/dev/alpha", Input: "feature/one"})
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Errorf("expected OverlayWorktreeInput, got %d", m.Overlay())
+	}
+	if m.WorktreeInputErr() != "Unable to create branch" {
+		t.Errorf("expected fallback error, got %q", m.WorktreeInputErr())
+	}
+}
+
+func TestModel_BranchCreatedClearsFilterBeforeSelectingNewBranch(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{
+			{Name: "main"},
+			{Name: "base"},
+		},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("base")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, _ = update(m, model.BranchCreatedMsg{RepoPath: "/dev/alpha", Name: "feature/one"})
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{
+			{Name: "main"},
+			{Name: "base"},
+			{Name: "feature/one"},
+		},
+	})
+	if m.ItemSearch() != "" {
+		t.Fatalf("expected branch filter cleared after create, got %q", m.ItemSearch())
+	}
+	if m.BranchSelected() != 2 {
+		t.Fatalf("expected new branch selected at index 2, got %d", m.BranchSelected())
+	}
+}
+
+func TestModel_BranchCreatedSelectsNewBranchAfterRefresh(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchCreatedMsg{RepoPath: "/dev/alpha", Name: "feature/one"})
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{
+			{Name: "main"},
+			{Name: "feature/one"},
+		},
+	})
+	if m.BranchSelected() != 1 {
+		t.Fatalf("expected new branch selected at index 1, got %d", m.BranchSelected())
+	}
+}
+
+func TestModel_BranchCreatedSelectsNewBranchByFullRef(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchCreatedMsg{RepoPath: "/dev/alpha", Name: "base"})
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{
+			{Name: "main", FullRef: "refs/heads/main"},
+			{Name: "heads/base", FullRef: "refs/heads/base"},
+		},
+	})
+	if m.BranchSelected() != 1 {
+		t.Fatalf("expected new branch selected by full ref at index 1, got %d", m.BranchSelected())
 	}
 }
 

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -163,6 +163,45 @@ func (m Model) createWorktree(input string) tea.Cmd {
 	}
 }
 
+func (m Model) createBranch(input string) tea.Cmd {
+	repoPath, ok := m.currentRepoPath()
+	if !ok {
+		return nil
+	}
+	return m.createBranchCommand(repoPath, input, m.selectedBranchStartPoint())
+}
+
+func (m Model) createBranchFromStartPoint(input, startPoint string) tea.Cmd {
+	repoPath, ok := m.currentRepoPath()
+	if !ok {
+		return nil
+	}
+	return m.createBranchCommand(repoPath, input, startPoint)
+}
+
+func (m Model) createBranchCommand(repoPath, input, startPoint string) tea.Cmd {
+	return func() tea.Msg {
+		if err := actions.CreateBranch(repoPath, input, startPoint); err != nil {
+			return BranchCreateFailedMsg{RepoPath: repoPath, Input: input, Err: err.Error(), StartPoint: startPoint}
+		}
+		return BranchCreatedMsg{RepoPath: repoPath, Name: input}
+	}
+}
+
+func (m Model) selectedBranchStartPoint() string {
+	if m.mode != ui.ModeBranches {
+		return ""
+	}
+	row, ok := m.selectedRow()
+	if !ok || row.Branch.Name == "(detached)" {
+		return ""
+	}
+	if row.Branch.FullRef != "" {
+		return row.Branch.FullRef
+	}
+	return "refs/heads/" + row.Branch.Name
+}
+
 func (m Model) fetchWorktrees(request uint64) tea.Cmd {
 	repoPath, ok := m.currentRepoPath()
 	if !ok {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -186,6 +186,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModeWorktrees {
 			return m.handleNewWorktree()
 		}
+		if m.mode == ui.ModeBranches {
+			return m.handleNewBranch()
+		}
 	case "d":
 		return m.handleDelete()
 	case "p":
@@ -297,9 +300,29 @@ func (m Model) handleNewWorktree() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m Model) handleNewBranch() (tea.Model, tea.Cmd) {
+	if _, ok := m.currentRepoPath(); !ok {
+		return m, nil
+	}
+	m.modal = modal.OpenInput(
+		ui.BranchPrompt,
+		"",
+		validateBranchInput,
+		func(input string) tea.Cmd { return m.createBranch(input) },
+	)
+	return m, nil
+}
+
 func validateWorktreeInput(input string) error {
 	if input == "" {
 		return fmt.Errorf("Enter a branch, tag, or new branch name")
+	}
+	return nil
+}
+
+func validateBranchInput(input string) error {
+	if input == "" {
+		return fmt.Errorf("Enter a branch name")
 	}
 	return nil
 }

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -601,6 +601,7 @@ func (m Model) resetModeCursors() Model {
 }
 
 func (m Model) resetRightPaneCursors() Model {
+	m.pendingBranchSelection = ""
 	m.rows = m.rows.SetItems(nil).ResetSelection()
 	m.stashes = m.stashes.SetItems(nil).ResetSelection()
 	m.worktrees = m.worktrees.SetItems(nil).ResetSelection()

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -46,6 +46,18 @@ type BranchDeletedMsg struct {
 	RepoPath string
 }
 
+type BranchCreatedMsg struct {
+	RepoPath string
+	Name     string
+}
+
+type BranchCreateFailedMsg struct {
+	RepoPath   string
+	Input      string
+	Err        string
+	StartPoint string
+}
+
 type StashDroppedMsg struct {
 	RepoPath string
 }
@@ -397,6 +409,13 @@ func (m Model) handleBranchResult(msg BranchResultMsg) Model {
 		}
 	}
 	m.rows = m.rows.SetItems(filtered)
+	if m.pendingBranchSelection != "" {
+		pendingRef := "refs/heads/" + m.pendingBranchSelection
+		m.rows = m.rows.SelectFunc(func(row gitquery.BranchRow) bool {
+			return row.Branch.Name == m.pendingBranchSelection || row.Branch.FullRef == pendingRef
+		})
+		m.pendingBranchSelection = ""
+	}
 	m = m.clampSelectionsAfterFilter()
 	return m
 }
@@ -453,6 +472,32 @@ func (m Model) handleBranchDeleted(msg BranchDeletedMsg) (tea.Model, tea.Cmd) {
 		return m.startFetchBranches()
 	}
 	return m, nil
+}
+
+func (m Model) handleBranchCreated(msg BranchCreatedMsg) (tea.Model, tea.Cmd) {
+	if m.isCurrentRepo(msg.RepoPath) {
+		m.mode = ui.ModeBranches
+		m.rows = m.rows.SetQuery("")
+		m.pendingBranchSelection = msg.Name
+		return m.startFetchBranches()
+	}
+	return m, nil
+}
+
+func (m Model) handleBranchCreateFailed(msg BranchCreateFailedMsg) Model {
+	if m.isCurrentRepo(msg.RepoPath) {
+		errText := msg.Err
+		if msg.Err == "" {
+			errText = "Unable to create branch"
+		}
+		m.modal = modal.OpenInput(
+			ui.BranchPrompt,
+			msg.Input,
+			validateBranchInput,
+			func(input string) tea.Cmd { return m.createBranchFromStartPoint(input, msg.StartPoint) },
+		).SetInputError(errText)
+	}
+	return m
 }
 
 func (m Model) handleDeleteFailed(msg DeleteFailedMsg) Model {

--- a/model/model_realrepo_test.go
+++ b/model/model_realrepo_test.go
@@ -157,6 +157,59 @@ func TestModel_BranchDiffPayloadAgainstRealRepo(t *testing.T) {
 	}
 }
 
+func TestModel_CreateBranchFromSelectedBranchAgainstRealRepo(t *testing.T) {
+	m, dir := setupModelRepo(t)
+	initial := gitOut(t, dir, "rev-parse", "--abbrev-ref", "HEAD")
+	mustGit(t, dir, "checkout", "-b", "base")
+	writeFile(t, dir, "base.txt", "base\n")
+	mustGit(t, dir, "add", "base.txt")
+	mustGit(t, dir, "commit", "-m", "base commit")
+	baseHead := gitOut(t, dir, "rev-parse", "base")
+	mustGit(t, dir, "checkout", initial)
+	mustGit(t, dir, "tag", "base", initial)
+
+	m = inRightPane(m)
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	if cmd == nil {
+		t.Fatal("expected branches fetch cmd")
+	}
+	m, _ = update(m, cmd())
+	baseIndex := -1
+	for i, row := range m.Rows() {
+		if row.Branch.Name == "base" || row.Branch.Name == "heads/base" {
+			baseIndex = i
+			break
+		}
+	}
+	if baseIndex == -1 {
+		t.Fatalf("expected base branch in rows: %+v", m.Rows())
+	}
+	for i := 0; i < baseIndex; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feature/from-base")})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected create branch cmd")
+	}
+	msg := cmd()
+	if _, ok := msg.(model.BranchCreatedMsg); !ok {
+		t.Fatalf("expected BranchCreatedMsg, got %T", msg)
+	}
+	got := gitOut(t, dir, "rev-parse", "feature/from-base")
+	if got != baseHead {
+		t.Fatalf("expected feature/from-base at base %s, got %s", baseHead, got)
+	}
+	if current := gitOut(t, dir, "rev-parse", "--abbrev-ref", "HEAD"); current != initial {
+		t.Fatalf("expected current branch to remain %s, got %s", initial, current)
+	}
+	if m.Mode() != ui.ModeBranches {
+		t.Fatalf("expected mode branches, got %d", m.Mode())
+	}
+}
+
 func TestModel_StashDiffPayloadAgainstRealRepo(t *testing.T) {
 	m, dir := setupModelRepo(t)
 	writeFile(t, dir, "README.md", "hello\nstashed\n")

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -24,6 +24,8 @@ const (
 	OverlayWorktreeInput
 )
 
+const BranchPrompt = "New branch"
+
 // Mode represents the active right-pane view. The model owns the application
 // state, but the renderer needs the same typed value (and the model imports ui,
 // not the other way around), so the type lives here to avoid an import cycle.
@@ -96,44 +98,45 @@ var (
 
 // RenderParams holds everything the renderer needs.
 type RenderParams struct {
-	Repos             []scanner.Repo
-	Selected          int
-	Width             int
-	Height            int
-	Mode              Mode
-	Branches          []gitquery.BranchRow
-	Stashes           []gitquery.Stash
-	BranchSelected    int
-	StashSelected     int
-	Overlay           OverlayState
-	OverlayDiff       string
-	OverlayScroll     int
-	ConfirmPrompt     string
-	ConfirmForce      bool
-	WorktreeInput     string
-	WorktreeInputErr  string
-	BranchScroll      int
-	RepoScroll        int
-	StashScroll       int
-	ActivePane        int
-	Destructive       bool
-	Worktrees         []gitquery.Worktree
-	WorktreeSelected  int
-	WorktreeScroll    int
-	Commits           []gitquery.Commit
-	CommitSelected    int
-	CommitScroll      int
-	Reflogs           []gitquery.ReflogEntry
-	ReflogSelected    int
-	ReflogScroll      int
-	TransientError    string
-	SearchActive      bool
-	RepoSearch        string
-	ItemSearch        string
-	RepoEmptyMessage  string
-	RightEmptyMessage string
-	FetchAvailable    bool
-	PullAvailable     bool
+	Repos               []scanner.Repo
+	Selected            int
+	Width               int
+	Height              int
+	Mode                Mode
+	Branches            []gitquery.BranchRow
+	Stashes             []gitquery.Stash
+	BranchSelected      int
+	StashSelected       int
+	Overlay             OverlayState
+	OverlayDiff         string
+	OverlayScroll       int
+	ConfirmPrompt       string
+	ConfirmForce        bool
+	WorktreeInputPrompt string
+	WorktreeInput       string
+	WorktreeInputErr    string
+	BranchScroll        int
+	RepoScroll          int
+	StashScroll         int
+	ActivePane          int
+	Destructive         bool
+	Worktrees           []gitquery.Worktree
+	WorktreeSelected    int
+	WorktreeScroll      int
+	Commits             []gitquery.Commit
+	CommitSelected      int
+	CommitScroll        int
+	Reflogs             []gitquery.ReflogEntry
+	ReflogSelected      int
+	ReflogScroll        int
+	TransientError      string
+	SearchActive        bool
+	RepoSearch          string
+	ItemSearch          string
+	RepoEmptyMessage    string
+	RightEmptyMessage   string
+	FetchAvailable      bool
+	PullAvailable       bool
 }
 
 // Render produces the full terminal view string.
@@ -400,7 +403,7 @@ func renderStatusBarWithState(sp statusBarParams) string {
 			keys += "  D: destructive mode"
 		}
 		if activePane == 1 {
-			keys += "  t: terminal  c: code"
+			keys += "  n: new branch  t: terminal  c: code"
 			if destructive {
 				keys += "  " + dirtyRedStyle.Render("d: delete")
 			}
@@ -706,7 +709,7 @@ func renderOverlay(p RenderParams) string {
 		return strings.Join(lines, "\n") + "\n" + statusBar
 	}
 	if p.Overlay == OverlayWorktreeInput {
-		lines := renderWorktreeInputDialog(p.WorktreeInput, p.WorktreeInputErr, p.Width, contentHeight)
+		lines := renderWorktreeInputDialog(p.WorktreeInputPrompt, p.WorktreeInput, p.WorktreeInputErr, p.Width, contentHeight)
 		return strings.Join(lines, "\n") + "\n" + statusBar
 	}
 
@@ -771,7 +774,7 @@ func renderConfirmDialog(prompt string, force bool, width, height int) []string 
 	return lines
 }
 
-func renderWorktreeInputDialog(input, errText string, width, height int) []string {
+func renderWorktreeInputDialog(prompt, input, errText string, width, height int) []string {
 	lines := make([]string, height)
 	mid := height / 2
 	if mid >= len(lines) {
@@ -779,12 +782,17 @@ func renderWorktreeInputDialog(input, errText string, width, height int) []strin
 	}
 
 	label := "Create worktree from: "
+	placeholder := "branch, tag, or new branch name"
+	if prompt == BranchPrompt {
+		label = "Create branch: "
+		placeholder = "branch name"
+	}
 	value := input
 	if value == "" {
-		value = placeholderStyle.Render("branch, tag, or new branch name")
+		value = placeholderStyle.Render(placeholder)
 	}
-	prompt := label + value + activeModeStyle.Render("█")
-	lines[mid] = centeredLine(prompt, width)
+	line := label + value + activeModeStyle.Render("█")
+	lines[mid] = centeredLine(line, width)
 
 	if errText != "" && mid+1 < len(lines) {
 		lines[mid+1] = centeredLine(dirtyRedStyle.Render(errText), width)

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -91,7 +91,7 @@ func TestStatusBar_ActionHintsHiddenWhenLeftPaneActive(t *testing.T) {
 
 func TestStatusBar_ActionHintsShownWhenRightPaneActive(t *testing.T) {
 	bar := RenderStatusBar(160, 2, 0, 1, true, false, false) // activePane=1 (right)
-	for _, hint := range []string{"f: fetch", "t: terminal", "c: code", "d: delete"} {
+	for _, hint := range []string{"n: new branch", "f: fetch", "t: terminal", "c: code", "d: delete"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("hint %q should be shown when right pane is active", hint)
 		}
@@ -709,6 +709,23 @@ func TestRender_WorktreeInputDialogShowsPlaceholder(t *testing.T) {
 	})
 	if !strings.Contains(view, "branch, tag, or new branch name") {
 		t.Error("worktree input dialog should show placeholder when input is empty")
+	}
+}
+
+func TestRender_BranchInputDialogShowsPromptAndPlaceholder(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:               []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:               80,
+		Height:              24,
+		Mode:                2,
+		Overlay:             OverlayWorktreeInput,
+		WorktreeInputPrompt: BranchPrompt,
+	})
+	if !strings.Contains(view, "Create branch:") {
+		t.Error("branch input dialog should show branch-specific prompt")
+	}
+	if !strings.Contains(view, "branch name") {
+		t.Error("branch input dialog should show branch-specific placeholder")
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `actions.CreateBranch` for creating local branches without checkout or worktree creation
- wire `n` in the branches pane to a branch-specific input prompt, success refresh, failure retry, and new-branch selection
- carry full branch refs from `gitquery` so selected branch start points are unambiguous when tags collide with branch names
- update key hints, README, roadmap current state, and roadmap todo

## Validation

- `gofmt -l .`
- `make test`
- `make build`
- review-loop completed 4 passes; final reviewer score: 9/10

## Notes

Untracked local `plans/` files were intentionally left out of this PR.
