### PR TITLE
Add right-side shortcut pane

### DIFF
--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -323,6 +323,7 @@ func TestModel_StatusBarStashesModeShowsStashKeys(t *testing.T) {
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // stashes
+	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()[:1]})
 
 	view := m.View()
 	if !strings.Contains(view, "enter") {
@@ -339,6 +340,7 @@ func TestModel_StatusBarStashesModeShowsDropHint(t *testing.T) {
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}}) // enable destructive
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // stashes
+	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()[:1]})
 
 	view := m.View()
 	if !strings.Contains(view, "d: drop") {
@@ -386,6 +388,12 @@ func TestModel_ViewDestructiveModeShowsDeleteHint(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{
+		RepoPath: "/dev/alpha",
+		Branches: []gitquery.Branch{
+			{Name: "feature", HasUpstream: true},
+		},
+	})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 
 	view := m.View()
@@ -427,6 +435,7 @@ func TestModel_StatusBarHistoryModeShowsHistoryKeys(t *testing.T) {
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()[:1]})
 
 	view := m.View()
 	if !strings.Contains(view, "enter: diff") {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -413,11 +413,10 @@ type statusBarParams struct {
 }
 
 type shortcutHint struct {
-	Key      string
-	Label    string
-	Warning  bool
-	Inline   bool
-	PaneOnly bool
+	Key     string
+	Label   string
+	Warning bool
+	Inline  bool
 }
 
 type shortcutSection struct {
@@ -716,6 +715,8 @@ func renderWorktreeFooterShortcuts(sp statusBarParams, sections []shortcutSectio
 	requiredWithDestructive := worktreeFooterParts(hints, true)
 	if hint, ok := findShortcutHint(hints, "A"); ok {
 		candidate := append(append([]string{}, parts...), renderFooterHint(hint))
+		// When agent actions are visible, keep A by making room from the D
+		// toggle first; otherwise preserve D ahead of lower-priority A.
 		if sp.AgentAvailable || sp.NewAgent {
 			if footerPartsFit(sp.Width, candidate, append([]string{renderFooterHint(shortcutHint{Key: "↑/↓", Label: "select", Inline: true})}, required...)...) {
 				parts = candidate
@@ -861,9 +862,6 @@ func renderFooterHintList(sections []shortcutSection) string {
 	var parts []string
 	for _, section := range sections {
 		for _, hint := range section.Hints {
-			if hint.PaneOnly {
-				continue
-			}
 			parts = append(parts, renderFooterHint(hint))
 		}
 	}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -41,6 +41,14 @@ const (
 
 const LeftPaneWidth = 30
 
+// ShortcutPaneWidth is the total width reserved for the right-hand keyboard
+// shortcut rail, including its left and right borders.
+const ShortcutPaneWidth = 28
+
+// MinContentPaneWidth keeps the primary item pane useful before the shortcut
+// rail is shown. Narrow terminals continue using footer hints instead.
+const MinContentPaneWidth = 48
+
 // RepoContentOverhead is the number of rows consumed by chrome around the
 // repo list: status bar (1) + top/bottom borders (2).
 const RepoContentOverhead = 3
@@ -72,28 +80,32 @@ const StashPrefixWidth = 15
 //	14  = bright cyan    15  = bright white   238 = dark gray
 //	241 = medium gray
 var (
-	repoStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))                          // 10 = bright green
-	selectedStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true).Reverse(true) // 10 = bright green
-	placeholderStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Italic(true)            // 241 = medium gray
-	statusStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
-	branchStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)               // 15 = bright white
-	cleanStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))                          // 10 = bright green
-	commitStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
-	activeModeStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)               // 15 = bright white
-	inactiveModeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
-	stashDateStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
-	stashMsgStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))                          // 15 = bright white
-	stashSelStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true).Reverse(true) // 15 = bright white
-	branchSelStyle    = lipgloss.NewStyle().Bold(true).Reverse(true)
-	rootStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("12")) // 12 = bright blue
-	lockedStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("14")) // 14 = bright cyan
-	noUpstreamStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))  // 5 = magenta
-	aheadBehindStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("11")) // 11 = bright yellow
-	mergedStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))  // 6 = cyan
-	dirtyRedStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))  // 9 = bright red
-	diffAddStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("10")) // 10 = bright green
-	diffDelStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))  // 9 = bright red
-	diffHdrStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("14")) // 14 = bright cyan
+	repoStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))                          // 10 = bright green
+	selectedStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true).Reverse(true) // 10 = bright green
+	placeholderStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Italic(true)            // 241 = medium gray
+	statusStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
+	branchStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)               // 15 = bright white
+	cleanStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))                          // 10 = bright green
+	commitStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
+	activeModeStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)               // 15 = bright white
+	inactiveModeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
+	shortcutTitleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)               // 15 = bright white
+	shortcutGroupStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Bold(true)               // 14 = bright cyan
+	shortcutKeyStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)               // 12 = bright blue
+	shortcutTextStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))                          // 15 = bright white
+	stashDateStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
+	stashMsgStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))                          // 15 = bright white
+	stashSelStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true).Reverse(true) // 15 = bright white
+	branchSelStyle     = lipgloss.NewStyle().Bold(true).Reverse(true)
+	rootStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("12")) // 12 = bright blue
+	lockedStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("14")) // 14 = bright cyan
+	noUpstreamStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))  // 5 = magenta
+	aheadBehindStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("11")) // 11 = bright yellow
+	mergedStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))  // 6 = cyan
+	dirtyRedStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))  // 9 = bright red
+	diffAddStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("10")) // 10 = bright green
+	diffDelStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))  // 9 = bright red
+	diffHdrStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("14")) // 14 = bright cyan
 )
 
 // RenderParams holds everything the renderer needs.
@@ -153,29 +165,59 @@ func Render(p RenderParams) string {
 		return renderOverlay(p)
 	}
 
-	var staleSelected, dirtySelected, lockedSelected bool
+	var repoPath string
+	if p.Selected >= 0 && p.Selected < len(p.Repos) {
+		repoPath = p.Repos[p.Selected].Path
+	}
+
+	var worktreeSelected, staleSelected, dirtySelected, lockedSelected, worktreeDeletableSelected, worktreeOpenableSelected bool
 	if p.Mode == ModeWorktrees && p.WorktreeSelected >= 0 && p.WorktreeSelected < len(p.Worktrees) {
+		worktreeSelected = true
 		wt := p.Worktrees[p.WorktreeSelected]
 		staleSelected = wt.Stale
 		dirtySelected = wt.Dirty
 		lockedSelected = wt.Locked
+		worktreeDeletableSelected = !wt.IsMain && !wt.Stale && !wt.Locked
+		worktreeOpenableSelected = !wt.Stale
 	}
-	statusBar := renderStatusBarWithState(statusBarParams{
-		Width:          p.Width,
-		Mode:           p.Mode,
-		Overlay:        p.Overlay,
-		ActivePane:     p.ActivePane,
-		Destructive:    p.Destructive,
-		StaleSelected:  staleSelected,
-		DirtySelected:  dirtySelected,
-		LockedSelected: lockedSelected,
-		TransientError: p.TransientError,
-		SearchActive:   p.SearchActive,
-		RepoSearch:     p.RepoSearch,
-		ItemSearch:     p.ItemSearch,
-		FetchAvailable: p.FetchAvailable,
-		PullAvailable:  p.PullAvailable,
-	})
+	var branchDirtySelected, branchDeletableSelected, branchOpenableSelected bool
+	if p.Mode == ModeBranches && p.BranchSelected >= 0 && p.BranchSelected < len(p.Branches) {
+		row := p.Branches[p.BranchSelected]
+		branchDirtySelected = row.Branch.Dirty && row.Branch.IsWorktree
+		branchDeletableSelected = row.WorktreePath != repoPath
+		branchOpenableSelected = row.WorktreePath != ""
+	}
+	stashSelected := p.Mode == ModeStashes && p.StashSelected >= 0 && p.StashSelected < len(p.Stashes)
+	commitSelected := p.Mode == ModeHistory && p.CommitSelected >= 0 && p.CommitSelected < len(p.Commits)
+	reflogSelected := p.Mode == ModeReflog && p.ReflogSelected >= 0 && p.ReflogSelected < len(p.Reflogs)
+	status := statusBarParams{
+		Width:                     p.Width,
+		Mode:                      p.Mode,
+		Overlay:                   p.Overlay,
+		ActivePane:                p.ActivePane,
+		Destructive:               p.Destructive,
+		RepoSelected:              repoPath != "",
+		WorktreeSelected:          worktreeSelected,
+		StaleSelected:             staleSelected,
+		DirtySelected:             dirtySelected,
+		LockedSelected:            lockedSelected,
+		WorktreeDeletableSelected: worktreeDeletableSelected,
+		WorktreeOpenableSelected:  worktreeOpenableSelected,
+		BranchDirtySelected:       branchDirtySelected,
+		BranchDeletableSelected:   branchDeletableSelected,
+		BranchOpenableSelected:    branchOpenableSelected,
+		StashSelected:             stashSelected,
+		CommitSelected:            commitSelected,
+		ReflogSelected:            reflogSelected,
+		TransientError:            p.TransientError,
+		SearchActive:              p.SearchActive,
+		RepoSearch:                p.RepoSearch,
+		ItemSearch:                p.ItemSearch,
+		FetchAvailable:            p.FetchAvailable,
+		PullAvailable:             p.PullAvailable,
+	}
+	showShortcutPane := !hasActiveStatusQuery(status) && shouldRenderShortcutPane(p.Width, p.Height, status)
+	statusBar := renderFooterStatusBar(status, !showShortcutPane)
 
 	// Border colors based on active pane
 	activeBorderColor := lipgloss.Color("12")
@@ -206,17 +248,15 @@ func Render(p RenderParams) string {
 		Render(leftContent)
 
 	rightContentWidth := p.Width - LeftPaneWidth - 2 // left + right border
+	if showShortcutPane {
+		rightContentWidth = p.Width - LeftPaneWidth - ShortcutPaneWidth - 2
+	}
 	if rightContentWidth < 0 {
 		rightContentWidth = 0
 	}
 
 	modeHeader := renderModeHeader(p.Mode, rightContentWidth)
 	rightContentHeight := p.Height - BranchContentOverhead
-
-	var repoPath string
-	if p.Selected < len(p.Repos) {
-		repoPath = p.Repos[p.Selected].Path
-	}
 
 	// Hide cursor in right pane when left pane is active
 	branchSel := p.BranchSelected
@@ -256,7 +296,19 @@ func Render(p RenderParams) string {
 		Height(innerHeight).
 		Render(rightContent)
 
-	content := lipgloss.JoinHorizontal(lipgloss.Top, leftPane, rightPane)
+	panes := []string{leftPane, rightPane}
+	if showShortcutPane {
+		shortcutContentWidth := ShortcutPaneWidth - 2
+		shortcutPane := lipgloss.NewStyle().
+			Border(lipgloss.NormalBorder()).
+			BorderForeground(inactiveBorderColor).
+			Width(shortcutContentWidth).
+			Height(innerHeight).
+			Render(renderShortcutPane(status, shortcutContentWidth, innerHeight))
+		panes = append(panes, shortcutPane)
+	}
+
+	content := lipgloss.JoinHorizontal(lipgloss.Top, panes...)
 
 	return content + "\n" + statusBar
 }
@@ -296,52 +348,106 @@ func RenderStatusBar(width int, mode Mode, overlay OverlayState, activePane int,
 		pullAvailable = false
 	}
 	return renderStatusBarWithState(statusBarParams{
-		Width:          width,
-		Mode:           mode,
-		Overlay:        overlay,
-		ActivePane:     activePane,
-		Destructive:    destructive,
-		StaleSelected:  staleSelected,
-		DirtySelected:  dirtySelected,
-		FetchAvailable: fetchAvailable,
-		PullAvailable:  pullAvailable,
+		Width:                     width,
+		Mode:                      mode,
+		Overlay:                   overlay,
+		ActivePane:                activePane,
+		Destructive:               destructive,
+		RepoSelected:              true,
+		WorktreeSelected:          mode == ModeWorktrees,
+		StaleSelected:             staleSelected,
+		DirtySelected:             dirtySelected,
+		WorktreeDeletableSelected: activePane == 1 && mode == ModeWorktrees && !staleSelected,
+		WorktreeOpenableSelected:  activePane == 1 && mode == ModeWorktrees && !staleSelected,
+		BranchDeletableSelected:   activePane == 1 && mode == ModeBranches,
+		BranchOpenableSelected:    activePane == 1 && mode == ModeBranches,
+		StashSelected:             activePane == 1 && mode == ModeStashes,
+		CommitSelected:            activePane == 1 && mode == ModeHistory,
+		ReflogSelected:            activePane == 1 && mode == ModeReflog,
+		FetchAvailable:            fetchAvailable,
+		PullAvailable:             pullAvailable,
 	})
 }
 
 // statusBarParams groups the many fields the status-bar renderer needs,
 // avoiding a long and error-prone positional parameter list.
 type statusBarParams struct {
-	Width          int
-	Mode           Mode
-	Overlay        OverlayState
-	ActivePane     int
-	Destructive    bool
-	StaleSelected  bool
-	DirtySelected  bool
-	LockedSelected bool
-	TransientError string
-	SearchActive   bool
-	RepoSearch     string
-	ItemSearch     string
-	FetchAvailable bool
-	PullAvailable  bool
+	Width                     int
+	Mode                      Mode
+	Overlay                   OverlayState
+	ActivePane                int
+	Destructive               bool
+	RepoSelected              bool
+	WorktreeSelected          bool
+	StaleSelected             bool
+	DirtySelected             bool
+	LockedSelected            bool
+	WorktreeDeletableSelected bool
+	WorktreeOpenableSelected  bool
+	BranchDirtySelected       bool
+	BranchDeletableSelected   bool
+	BranchOpenableSelected    bool
+	StashSelected             bool
+	CommitSelected            bool
+	ReflogSelected            bool
+	TransientError            string
+	SearchActive              bool
+	RepoSearch                string
+	ItemSearch                string
+	FetchAvailable            bool
+	PullAvailable             bool
+}
+
+type shortcutHint struct {
+	Key      string
+	Label    string
+	Warning  bool
+	Inline   bool
+	PaneOnly bool
+}
+
+type shortcutSection struct {
+	Title string
+	Hints []shortcutHint
+}
+
+func shouldRenderShortcutPane(width, height int, sp statusBarParams) bool {
+	if width < LeftPaneWidth+ShortcutPaneWidth+MinContentPaneWidth {
+		return false
+	}
+	return shortcutPaneLineCount(shortcutSections(sp)) <= height-3
+}
+
+func renderFooterStatusBar(sp statusBarParams, includeHints bool) string {
+	if includeHints {
+		return renderStatusBarWithState(sp)
+	}
+	query := sp.ItemSearch
+	if sp.ActivePane == 0 {
+		query = sp.RepoSearch
+	}
+	if sp.TransientError != "" || sp.SearchActive || query != "" {
+		return renderStatusBarWithState(sp)
+	}
+	return statusStyle.Width(sp.Width).Render("")
+}
+
+func hasActiveStatusQuery(sp statusBarParams) bool {
+	query := sp.ItemSearch
+	if sp.ActivePane == 0 {
+		query = sp.RepoSearch
+	}
+	return sp.SearchActive || query != ""
 }
 
 func renderStatusBarWithState(sp statusBarParams) string {
 	width := sp.Width
-	mode := sp.Mode
 	overlay := sp.Overlay
 	activePane := sp.ActivePane
-	destructive := sp.Destructive
-	staleSelected := sp.StaleSelected
-	dirtySelected := sp.DirtySelected
-	lockedSelected := sp.LockedSelected
 	transientError := sp.TransientError
 	searchActive := sp.SearchActive
 	repoSearch := sp.RepoSearch
 	itemSearch := sp.ItemSearch
-	fetchAvailable := sp.FetchAvailable
-	pullAvailable := sp.PullAvailable
 
 	if transientError != "" {
 		return statusStyle.Width(width).Render("  " + dirtyRedStyle.Render(transientError))
@@ -360,94 +466,391 @@ func renderStatusBarWithState(sp statusBarParams) string {
 		return statusStyle.Width(width).Render(fmt.Sprintf("  filtered %s: %s  /: edit  esc: clear", label, query))
 	}
 
-	var hints string
 	switch {
 	case overlay == OverlayConfirm:
-		hints = "  y: confirm  n/esc: cancel"
+		return statusStyle.Width(width).Render("  y: confirm  n/esc: cancel")
 	case overlay == OverlayWorktreeInput:
-		hints = "  enter: create  esc: cancel  backspace: delete"
+		return statusStyle.Width(width).Render("  enter: create  esc: cancel  backspace: delete")
 	case overlay != OverlayNone:
-		hints = "  ↑/↓ scroll  esc: close"
-	case mode == ModeReflog:
-		hints = "  tab: pane  q/esc: quit  ↑/↓ select  enter: diff  y: copy hash"
-		if fetchAvailable {
-			hints += "  f: fetch"
-		}
-		if pullAvailable {
-			hints += "  F: pull"
-		}
-	case mode == ModeHistory:
-		hints = "  tab: pane  q/esc: quit  ↑/↓ select  enter: diff  y: copy hash  t: terminal  c: code"
-		if fetchAvailable {
-			hints += "  f: fetch"
-		}
-		if pullAvailable {
-			hints += "  F: pull"
-		}
-	case mode == ModeStashes:
-		hints = "  tab: pane  q/esc: quit  ↑/↓ select  enter: diff"
-		if destructive {
-			hints += "  " + dirtyRedStyle.Render("d: drop")
-		} else {
-			hints += "  D: destructive mode"
-		}
-		if fetchAvailable {
-			hints += "  f: fetch"
-		}
-		if pullAvailable {
-			hints += "  F: pull"
-		}
-	case mode == ModeBranches:
-		keys := "  |  tab: pane  q/esc: quit"
-		if !destructive {
-			keys += "  D: destructive mode"
-		}
-		if activePane == 1 {
-			keys += "  t: terminal  c: code"
-			if destructive {
-				keys += "  " + dirtyRedStyle.Render("d: delete")
-			}
-			if fetchAvailable {
-				keys += "  f: fetch"
-			}
-			if pullAvailable {
-				keys += "  F: pull"
-			}
-		}
-		hints = " " + cleanStyle.Render("✔") + " clean  " + aheadBehindStyle.Render("●") + " ahead/behind  " + dirtyRedStyle.Render("●") + " dirty  " + noUpstreamStyle.Render("●") + " no upstream  " + mergedStyle.Render("merged") + keys
-	case mode == ModeWorktrees:
-		hints = "  tab: pane  q/esc: quit  ↑/↓ select"
-		if !destructive {
-			hints += "  D: destructive mode"
-		}
-		if activePane == 1 && !staleSelected {
-			hints += "  n: new worktree"
-			if lockedSelected {
-				hints += "  u: unlock"
-			}
-			if destructive && !lockedSelected {
-				hints += "  " + dirtyRedStyle.Render("d: delete")
-			}
-			if dirtySelected {
-				hints += "  enter: diff"
-			}
-			if fetchAvailable {
-				hints += "  f: fetch"
-			}
-			if pullAvailable {
-				hints += "  F: pull"
-			}
-			hints += "  t: terminal c: code"
-			hints += " P: PR"
-		}
-		if activePane == 1 && staleSelected && destructive && !lockedSelected {
-			hints += "  " + dirtyRedStyle.Render("p: prune")
-		}
-	default:
-		hints = "  tab: pane  q/esc: quit  ↑/↓ select"
+		return statusStyle.Width(width).Render("  ↑/↓ scroll  esc: close")
 	}
 
-	return statusStyle.Width(width).Render(hints)
+	return statusStyle.Width(width).Render(renderFooterShortcuts(sp, shortcutSections(sp)))
+}
+
+func renderShortcutPane(sp statusBarParams, width, height int) string {
+	if height <= 0 {
+		return ""
+	}
+	lines := make([]string, 0, height)
+	title := fmt.Sprintf("Shortcuts  %s", modeShortcutTitle(sp.Mode))
+	lines = append(lines, truncateToWidth(" "+shortcutTitleStyle.Render(title), width))
+
+	for _, section := range shortcutSections(sp) {
+		if len(section.Hints) == 0 {
+			continue
+		}
+		if len(lines) < height {
+			lines = append(lines, truncateToWidth(" "+shortcutGroupStyle.Render(section.Title), width))
+		}
+		for _, hint := range section.Hints {
+			if len(lines) >= height {
+				break
+			}
+			keyStyle := shortcutKeyStyle
+			if hint.Warning {
+				keyStyle = dirtyRedStyle.Bold(true)
+			}
+			key := keyStyle.Render(hint.Key + shortcutSeparator(hint))
+			label := shortcutTextStyle.Render(hint.Label)
+			lines = append(lines, truncateToWidth(" "+key+" "+label, width))
+		}
+		if len(lines) >= height {
+			break
+		}
+	}
+
+	for len(lines) < height {
+		lines = append(lines, strings.Repeat(" ", width))
+	}
+	truncateLines(lines, width)
+	return strings.Join(lines, "\n")
+}
+
+func shortcutPaneLineCount(sections []shortcutSection) int {
+	lines := 1 // title
+	for _, section := range sections {
+		if len(section.Hints) == 0 {
+			continue
+		}
+		lines += 1 + len(section.Hints)
+	}
+	return lines
+}
+
+func shortcutSections(sp statusBarParams) []shortcutSection {
+	navigation := []shortcutHint{{Key: "↑/↓", Label: "select", Inline: true}}
+	if sp.ActivePane == 1 {
+		navigation = append(navigation, shortcutHint{Key: "1-5", Label: "switch views", PaneOnly: true})
+	}
+
+	sections := []shortcutSection{
+		{
+			Title: "Global",
+			Hints: []shortcutHint{
+				{Key: "tab", Label: "pane"},
+				{Key: "q/esc", Label: "quit"},
+			},
+		},
+		{
+			Title: "Navigate",
+			Hints: navigation,
+		},
+	}
+
+	var actions []shortcutHint
+	switch sp.Mode {
+	case ModeWorktrees:
+		if sp.ActivePane == 1 && sp.RepoSelected && !sp.StaleSelected {
+			actions = append(actions, shortcutHint{Key: "n", Label: "new worktree"})
+			actions = append(actions, shortcutHint{Key: "P", Label: "PR"})
+			if sp.DirtySelected {
+				actions = append(actions, shortcutHint{Key: "enter", Label: "diff"})
+			}
+			if sp.Destructive && sp.WorktreeDeletableSelected {
+				actions = append(actions, shortcutHint{Key: "d", Label: "delete", Warning: true})
+			}
+			if sp.FetchAvailable {
+				actions = append(actions, shortcutHint{Key: "f", Label: "fetch"})
+			}
+			if sp.PullAvailable {
+				actions = append(actions, shortcutHint{Key: "F", Label: "pull"})
+			}
+			if sp.WorktreeOpenableSelected {
+				actions = append(actions,
+					shortcutHint{Key: "t", Label: "terminal"},
+					shortcutHint{Key: "c", Label: "code"},
+				)
+			}
+		}
+		if sp.ActivePane == 1 && sp.StaleSelected && sp.Destructive && sp.WorktreeSelected && !sp.LockedSelected {
+			actions = append(actions, shortcutHint{Key: "p", Label: "prune", Warning: true})
+		}
+		if sp.ActivePane == 1 && sp.WorktreeSelected && sp.LockedSelected {
+			actions = append(actions, shortcutHint{Key: "u", Label: "unlock"})
+		}
+	case ModeBranches:
+		if sp.ActivePane == 1 {
+			if sp.BranchDirtySelected {
+				actions = append(actions, shortcutHint{Key: "enter", Label: "diff"})
+			}
+			if sp.BranchOpenableSelected {
+				actions = append(actions,
+					shortcutHint{Key: "t", Label: "terminal"},
+					shortcutHint{Key: "c", Label: "code"},
+				)
+			}
+			if sp.Destructive && sp.BranchDeletableSelected {
+				actions = append(actions, shortcutHint{Key: "d", Label: "delete", Warning: true})
+			}
+			if sp.FetchAvailable {
+				actions = append(actions, shortcutHint{Key: "f", Label: "fetch"})
+			}
+			if sp.PullAvailable {
+				actions = append(actions, shortcutHint{Key: "F", Label: "pull"})
+			}
+		}
+	case ModeStashes:
+		if sp.ActivePane == 1 && sp.StashSelected {
+			actions = append(actions, shortcutHint{Key: "enter", Label: "diff"})
+			if sp.Destructive {
+				actions = append(actions, shortcutHint{Key: "d", Label: "drop", Warning: true})
+			}
+		}
+	case ModeHistory:
+		if sp.ActivePane == 1 {
+			if sp.CommitSelected {
+				actions = append(actions,
+					shortcutHint{Key: "enter", Label: "diff"},
+					shortcutHint{Key: "y", Label: "copy hash"},
+				)
+			}
+			if sp.RepoSelected {
+				actions = append(actions,
+					shortcutHint{Key: "t", Label: "terminal"},
+					shortcutHint{Key: "c", Label: "code"},
+				)
+			}
+		}
+	case ModeReflog:
+		if sp.ActivePane == 1 && sp.ReflogSelected {
+			actions = append(actions,
+				shortcutHint{Key: "enter", Label: "diff"},
+				shortcutHint{Key: "y", Label: "copy hash"},
+			)
+		}
+	}
+	if sp.ActivePane == 1 && sp.Mode != ModeWorktrees && sp.Mode != ModeBranches {
+		if sp.FetchAvailable {
+			actions = append(actions, shortcutHint{Key: "f", Label: "fetch"})
+		}
+		if sp.PullAvailable {
+			actions = append(actions, shortcutHint{Key: "F", Label: "pull"})
+		}
+	}
+	if !sp.Destructive && (sp.Mode == ModeWorktrees || sp.Mode == ModeBranches || sp.Mode == ModeStashes) {
+		actions = append([]shortcutHint{{Key: "D", Label: "destructive mode"}}, actions...)
+	}
+	if len(actions) > 0 {
+		sections = append(sections, shortcutSection{Title: "Actions", Hints: actions})
+	}
+	if sp.Mode == ModeBranches {
+		sections = append(sections, shortcutSection{
+			Title: "Legend",
+			Hints: []shortcutHint{
+				{Key: "✔", Label: "clean"},
+				{Key: "●", Label: "ahead/behind"},
+				{Key: "●", Label: "dirty", Warning: true},
+				{Key: "●", Label: "no upstream"},
+				{Key: "merged", Label: "merged"},
+			},
+		})
+	}
+	return sections
+}
+
+func renderFooterShortcuts(sp statusBarParams, sections []shortcutSection) string {
+	if sp.Mode == ModeWorktrees {
+		return renderWorktreeFooterShortcuts(sp, sections)
+	}
+	if sp.Mode == ModeBranches {
+		legend, rest := splitLegendSection(sections)
+		rest = withoutSection(rest, "Navigate")
+		rest = branchFooterSectionOrder(rest)
+		keys := renderFooterHintList(rest)
+		if keys != "" {
+			return renderFooterLegend(legend) + "  |  " + keys
+		}
+		return renderFooterLegend(legend)
+	}
+	return "  " + renderFooterHintList(sections)
+}
+
+func renderWorktreeFooterShortcuts(sp statusBarParams, sections []shortcutSection) string {
+	hints := flattenShortcutHints(sections)
+	parts := []string{}
+	for _, key := range []string{"tab", "q/esc", "↑/↓"} {
+		if hint, ok := findShortcutHint(hints, key); ok {
+			parts = append(parts, renderFooterHint(hint))
+		}
+	}
+	for _, key := range []string{"D", "n", "d", "p", "u", "enter", "f", "F"} {
+		if hint, ok := findShortcutHint(hints, key); ok {
+			if key == "D" && sp.DirtySelected && !footerPartsFit(sp.Width, append(parts, renderFooterHint(hint)), "t: terminal c: code") {
+				continue
+			}
+			parts = append(parts, renderFooterHint(hint))
+		}
+	}
+
+	open := ""
+	if _, ok := findShortcutHint(hints, "t"); ok {
+		if _, ok := findShortcutHint(hints, "c"); ok {
+			open = "t: terminal c: code"
+		}
+	}
+	if open != "" {
+		parts = append(parts, open)
+	}
+	if hint, ok := findShortcutHint(hints, "P"); ok {
+		candidate := append(append([]string{}, parts...), renderFooterHint(hint))
+		if footerPartsFit(sp.Width, candidate) {
+			parts = candidate
+		}
+	}
+
+	return "  " + strings.Join(parts, " ")
+}
+
+func footerPartsFit(width int, parts []string, extra ...string) bool {
+	all := append(append([]string{}, parts...), extra...)
+	return lipgloss.Width("  "+strings.Join(all, " ")) <= width
+}
+
+func flattenShortcutHints(sections []shortcutSection) []shortcutHint {
+	var hints []shortcutHint
+	for _, section := range sections {
+		hints = append(hints, section.Hints...)
+	}
+	return hints
+}
+
+func findShortcutHint(hints []shortcutHint, key string) (shortcutHint, bool) {
+	for _, hint := range hints {
+		if hint.Key == key {
+			return hint, true
+		}
+	}
+	return shortcutHint{}, false
+}
+
+func branchFooterSectionOrder(sections []shortcutSection) []shortcutSection {
+	ordered := make([]shortcutSection, 0, len(sections))
+	for _, title := range []string{"Global", "Safety", "Actions"} {
+		for _, section := range sections {
+			if section.Title == title {
+				ordered = append(ordered, section)
+			}
+		}
+	}
+	for _, section := range sections {
+		if section.Title != "Global" && section.Title != "Safety" && section.Title != "Actions" {
+			ordered = append(ordered, section)
+		}
+	}
+	return ordered
+}
+
+func withoutSection(sections []shortcutSection, title string) []shortcutSection {
+	filtered := make([]shortcutSection, 0, len(sections))
+	for _, section := range sections {
+		if section.Title == title {
+			continue
+		}
+		filtered = append(filtered, section)
+	}
+	return filtered
+}
+
+func splitLegendSection(sections []shortcutSection) ([]shortcutHint, []shortcutSection) {
+	rest := make([]shortcutSection, 0, len(sections))
+	var legend []shortcutHint
+	for _, section := range sections {
+		if section.Title == "Legend" {
+			legend = section.Hints
+			continue
+		}
+		rest = append(rest, section)
+	}
+	return legend, rest
+}
+
+func renderFooterLegend(hints []shortcutHint) string {
+	if len(hints) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(hints))
+	for _, hint := range hints {
+		parts = append(parts, renderFooterHint(hint))
+	}
+	return " " + strings.Join(parts, "  ")
+}
+
+func renderFooterHintList(sections []shortcutSection) string {
+	var parts []string
+	for _, section := range sections {
+		for _, hint := range section.Hints {
+			if hint.PaneOnly {
+				continue
+			}
+			parts = append(parts, renderFooterHint(hint))
+		}
+	}
+	return strings.Join(parts, "  ")
+}
+
+func renderFooterHint(hint shortcutHint) string {
+	switch hint.Key {
+	case "✔":
+		return cleanStyle.Render("✔") + " " + hint.Label
+	case "●":
+		return styledDotForLabel(hint.Label) + " " + hint.Label
+	case "merged":
+		return mergedStyle.Render("merged")
+	}
+
+	text := hint.Key + shortcutSeparator(hint) + " " + hint.Label
+	if hint.Warning {
+		return dirtyRedStyle.Render(text)
+	}
+	return text
+}
+
+func styledDotForLabel(label string) string {
+	switch label {
+	case "ahead/behind":
+		return aheadBehindStyle.Render("●")
+	case "dirty":
+		return dirtyRedStyle.Render("●")
+	case "no upstream":
+		return noUpstreamStyle.Render("●")
+	default:
+		return shortcutKeyStyle.Render("●")
+	}
+}
+
+func shortcutSeparator(hint shortcutHint) string {
+	if hint.Inline {
+		return ""
+	}
+	return ":"
+}
+
+func modeShortcutTitle(mode Mode) string {
+	switch mode {
+	case ModeWorktrees:
+		return "Worktrees"
+	case ModeBranches:
+		return "Branches"
+	case ModeStashes:
+		return "Stashes"
+	case ModeHistory:
+		return "History"
+	case ModeReflog:
+		return "Reflog"
+	default:
+		return "Items"
+	}
 }
 
 func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, emptyMessage string) []string {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -201,6 +201,402 @@ func TestRender_ModeHeaderInRightPane(t *testing.T) {
 	}
 }
 
+func TestRender_WideLayoutShowsShortcutPane(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected: 0,
+		Width:    120,
+		Height:   18,
+		Mode:     ModeWorktrees,
+		Worktrees: []gitquery.Worktree{
+			{Path: "/a", BranchName: "main", IsMain: true},
+		},
+		WorktreeSelected: 0,
+		ActivePane:       1,
+		FetchAvailable:   true,
+		PullAvailable:    true,
+	})
+
+	for _, want := range []string{"Shortcuts", "Worktrees", "Global", "Navigate", "Actions", "n", "new worktree", "F", "pull"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("wide render should include shortcut pane text %q", want)
+		}
+	}
+}
+
+func TestRender_WideLayoutReplacesFooterHints(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:      []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:   0,
+		Width:      120,
+		Height:     18,
+		Mode:       ModeWorktrees,
+		ActivePane: 1,
+	})
+
+	lines := strings.Split(view, "\n")
+	footer := lines[len(lines)-1]
+	if strings.Contains(footer, "tab: pane") || strings.Contains(footer, "q/esc: quit") {
+		t.Fatalf("wide render footer should not carry shortcut hints, got %q", footer)
+	}
+	if !strings.Contains(view, "tab:") || !strings.Contains(view, "pane") {
+		t.Fatal("wide render should still expose global shortcuts in the shortcut pane")
+	}
+}
+
+func TestRender_NarrowLayoutKeepsFooterHints(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected: 0,
+		Width:    80,
+		Height:   18,
+		Mode:     ModeWorktrees,
+	})
+
+	lines := strings.Split(view, "\n")
+	footer := lines[len(lines)-1]
+	if !strings.Contains(footer, "tab: pane") {
+		t.Fatalf("narrow render should keep footer hints, got %q", footer)
+	}
+	if strings.Contains(view, "Shortcuts") {
+		t.Fatal("narrow render should not reserve a shortcut pane")
+	}
+}
+
+func TestRender_ShortWideLayoutFallsBackToFooterHints(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected: 0,
+		Width:    120,
+		Height:   12,
+		Mode:     ModeWorktrees,
+		Worktrees: []gitquery.Worktree{
+			{Path: "/a", BranchName: "main", IsMain: true},
+		},
+		WorktreeSelected: 0,
+		ActivePane:       1,
+		FetchAvailable:   true,
+		PullAvailable:    true,
+	})
+
+	if strings.Contains(view, "Shortcuts") {
+		t.Fatal("wide but short render should not replace footer hints with a truncated shortcut pane")
+	}
+	lines := strings.Split(view, "\n")
+	footer := lines[len(lines)-1]
+	for _, want := range []string{"tab: pane", "n: new worktree", "F: pull", "c: code"} {
+		if !strings.Contains(footer, want) {
+			t.Fatalf("short wide footer should retain %q, got %q", want, footer)
+		}
+	}
+}
+
+func TestRender_HistoryShortcutPaneOmitsDestructiveMode(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:      []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:   0,
+		Width:      120,
+		Height:     18,
+		Mode:       ModeHistory,
+		ActivePane: 1,
+	})
+
+	if !strings.Contains(view, "Shortcuts") {
+		t.Fatal("history wide render should use shortcut pane")
+	}
+	if strings.Contains(view, "D: destructive mode") {
+		t.Fatal("history shortcut pane should not advertise destructive mode")
+	}
+}
+
+func TestRender_LeftPaneShortcutPaneOmitsModeNumberHint(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:      []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:   0,
+		Width:      120,
+		Height:     18,
+		Mode:       ModeWorktrees,
+		ActivePane: 0,
+	})
+
+	if !strings.Contains(view, "Shortcuts") {
+		t.Fatal("wide render should use shortcut pane")
+	}
+	if strings.Contains(view, "1-5: switch views") {
+		t.Fatal("left-pane shortcut pane should not advertise right-pane-only mode number keys")
+	}
+}
+
+func TestRender_BranchShortcutPaneKeepsLegend(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected: 0,
+		Width:    160,
+		Height:   24,
+		Mode:     ModeBranches,
+		Branches: []gitquery.BranchRow{
+			{Branch: gitquery.Branch{Name: "feature", HasUpstream: false, Dirty: true, IsWorktree: true}, WorktreePath: "/a-feature"},
+		},
+		BranchSelected: 0,
+		ActivePane:     1,
+		Destructive:    true,
+		FetchAvailable: true,
+		PullAvailable:  true,
+	})
+
+	if !strings.Contains(view, "Shortcuts") {
+		t.Fatal("branch wide render should use shortcut pane when the full shortcut list fits")
+	}
+	for _, want := range []string{"Legend", "clean", "ahead/behind", "dirty", "no upstream", "merged", "d: delete", "F: pull"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("branch shortcut pane should include %q, got:\n%s", want, view)
+		}
+	}
+	lines := strings.Split(view, "\n")
+	footer := lines[len(lines)-1]
+	if strings.Contains(footer, "tab: pane") || strings.Contains(footer, "no upstream") {
+		t.Fatalf("branch wide footer should not duplicate shortcut or legend hints, got %q", footer)
+	}
+}
+
+func TestRender_SearchActiveSuppressesShortcutPane(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:        []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:     0,
+		Width:        120,
+		Height:       18,
+		Mode:         ModeWorktrees,
+		ActivePane:   1,
+		SearchActive: true,
+		ItemSearch:   "feat",
+	})
+
+	if strings.Contains(view, "Shortcuts") {
+		t.Fatal("active search should suppress normal shortcut pane")
+	}
+	lines := strings.Split(view, "\n")
+	footer := lines[len(lines)-1]
+	if !strings.Contains(footer, "/ items: feat") || !strings.Contains(footer, "enter: keep") {
+		t.Fatalf("active search footer should show search controls, got %q", footer)
+	}
+}
+
+func TestRender_FilteredStateSuppressesShortcutPane(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:      []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:   0,
+		Width:      120,
+		Height:     18,
+		Mode:       ModeWorktrees,
+		ActivePane: 1,
+		ItemSearch: "feat",
+	})
+
+	if strings.Contains(view, "Shortcuts") {
+		t.Fatal("filtered state should suppress normal shortcut pane")
+	}
+	lines := strings.Split(view, "\n")
+	footer := lines[len(lines)-1]
+	if !strings.Contains(footer, "filtered items: feat") || !strings.Contains(footer, "esc: clear") {
+		t.Fatalf("filtered footer should show filter controls, got %q", footer)
+	}
+}
+
+func TestRender_LeftPaneOmitsRightPaneActions(t *testing.T) {
+	tests := []struct {
+		name      string
+		mode      Mode
+		forbidden []string
+	}{
+		{name: "stashes", mode: ModeStashes, forbidden: []string{"enter: diff", "d: drop"}},
+		{name: "history", mode: ModeHistory, forbidden: []string{"enter: diff", "y: copy hash", "t: terminal", "c: code"}},
+		{name: "reflog", mode: ModeReflog, forbidden: []string{"enter: diff", "y: copy hash"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view := Render(RenderParams{
+				Repos:       []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+				Selected:    0,
+				Width:       120,
+				Height:      18,
+				Mode:        tt.mode,
+				ActivePane:  0,
+				Destructive: true,
+			})
+
+			if !strings.Contains(view, "Shortcuts") {
+				t.Fatal("wide left-pane render should still show global/navigation shortcuts")
+			}
+			for _, forbidden := range tt.forbidden {
+				if strings.Contains(view, forbidden) {
+					t.Fatalf("left-pane %s render should not advertise %q, got:\n%s", tt.name, forbidden, view)
+				}
+			}
+		})
+	}
+}
+
+func TestRender_WorktreeRootOmitsDeleteHint(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected: 0,
+		Width:    120,
+		Height:   18,
+		Mode:     ModeWorktrees,
+		Worktrees: []gitquery.Worktree{
+			{Path: "/a", BranchName: "main", IsMain: true},
+		},
+		WorktreeSelected: 0,
+		ActivePane:       1,
+		Destructive:      true,
+	})
+
+	if !strings.Contains(view, "Shortcuts") {
+		t.Fatal("wide worktree render should use shortcut pane")
+	}
+	if strings.Contains(view, "d: delete") {
+		t.Fatalf("root worktree should not advertise delete, got:\n%s", view)
+	}
+}
+
+func TestRender_BranchShortcutPaneShowsDiffButOmitsRootDelete(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected: 0,
+		Width:    160,
+		Height:   24,
+		Mode:     ModeBranches,
+		Branches: []gitquery.BranchRow{
+			{Branch: gitquery.Branch{Name: "main", HasUpstream: true, Dirty: true, IsWorktree: true}, WorktreePath: "/a"},
+		},
+		BranchSelected: 0,
+		ActivePane:     1,
+		Destructive:    true,
+	})
+
+	if !strings.Contains(view, "enter: diff") {
+		t.Fatalf("dirty branch worktree should advertise diff action, got:\n%s", view)
+	}
+	if strings.Contains(view, "d: delete") {
+		t.Fatalf("root branch should not advertise delete action, got:\n%s", view)
+	}
+}
+
+func TestRender_BranchWithoutWorktreeOmitsOpenHints(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected: 0,
+		Width:    160,
+		Height:   24,
+		Mode:     ModeBranches,
+		Branches: []gitquery.BranchRow{
+			{Branch: gitquery.Branch{Name: "feature", HasUpstream: true}},
+		},
+		BranchSelected: 0,
+		ActivePane:     1,
+	})
+
+	if !strings.Contains(view, "Shortcuts") {
+		t.Fatal("wide branch render should use shortcut pane")
+	}
+	for _, forbidden := range []string{"t: terminal", "c: code"} {
+		if strings.Contains(view, forbidden) {
+			t.Fatalf("non-worktree branch should not advertise %q, got:\n%s", forbidden, view)
+		}
+	}
+}
+
+func TestRender_EmptyItemPanesOmitItemActions(t *testing.T) {
+	tests := []struct {
+		name      string
+		mode      Mode
+		forbidden []string
+	}{
+		{name: "stashes", mode: ModeStashes, forbidden: []string{"enter: diff", "d: drop"}},
+		{name: "history", mode: ModeHistory, forbidden: []string{"enter: diff", "y: copy hash"}},
+		{name: "reflog", mode: ModeReflog, forbidden: []string{"enter: diff", "y: copy hash"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view := Render(RenderParams{
+				Repos:       []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+				Selected:    0,
+				Width:       120,
+				Height:      18,
+				Mode:        tt.mode,
+				ActivePane:  1,
+				Destructive: true,
+			})
+
+			if !strings.Contains(view, "Shortcuts") {
+				t.Fatal("wide empty-pane render should still show global/navigation shortcuts")
+			}
+			for _, forbidden := range tt.forbidden {
+				if strings.Contains(view, forbidden) {
+					t.Fatalf("empty %s render should not advertise %q, got:\n%s", tt.name, forbidden, view)
+				}
+			}
+		})
+	}
+}
+
+func TestRender_NonWorktreeModesShowSyncHintsWhenAvailable(t *testing.T) {
+	tests := []struct {
+		name   string
+		params RenderParams
+	}{
+		{
+			name: "stashes",
+			params: RenderParams{
+				Mode:          ModeStashes,
+				Stashes:       []gitquery.Stash{{Index: 0, Date: "2026-01-01", Message: "wip"}},
+				StashSelected: 0,
+			},
+		},
+		{
+			name: "history",
+			params: RenderParams{
+				Mode:           ModeHistory,
+				Commits:        []gitquery.Commit{{Hash: "abc1234", Author: "alice", Date: "today", Subject: "commit"}},
+				CommitSelected: 0,
+			},
+		},
+		{
+			name: "reflog",
+			params: RenderParams{
+				Mode:           ModeReflog,
+				Reflogs:        []gitquery.ReflogEntry{{Hash: "abc1234", Selector: "HEAD@{0}", Date: "today", Subject: "checkout"}},
+				ReflogSelected: 0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := tt.params
+			params.Repos = []scanner.Repo{{Path: "/a", DisplayName: "alpha"}}
+			params.Selected = 0
+			params.Width = 120
+			params.Height = 18
+			params.ActivePane = 1
+			params.FetchAvailable = true
+			params.PullAvailable = true
+
+			view := Render(params)
+			if !strings.Contains(view, "Shortcuts") {
+				t.Fatal("wide render should use shortcut pane")
+			}
+			for _, want := range []string{"f: fetch", "F: pull"} {
+				if !strings.Contains(view, want) {
+					t.Fatalf("%s render should include %q when available, got:\n%s", tt.name, want, view)
+				}
+			}
+		})
+	}
+}
+
 func TestRepoList_ScrollsWhenSelectionExceedsHeight(t *testing.T) {
 	repos := []scanner.Repo{
 		{Path: "/a", DisplayName: "alpha"},


### PR DESCRIPTION
## Summary
- move normal keyboard shortcut hints into a right-side shortcut pane on wide TUI layouts
- keep footer hints for narrow/short layouts and reserve the bottom bar for status, search/filter, and overlay controls
- state-gate shortcut hints so the UI avoids advertising no-op actions for root/stale/locked worktrees, non-worktree branches, empty item panes, and filtered/search states

## Implementation
- add a shared structured shortcut model used by both the right pane and compact footer fallback
- reserve a 28-column shortcut rail only when the full shortcut list fits without squeezing the main content below the minimum content width
- preserve the new PR-worktree shortcut from main and compact the legacy worktree footer fallback so it remains one line

## Verification
- make test
- make build
- git diff --check
