### PR TITLE
Remove dead gitquery helpers

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -425,9 +425,7 @@ func parsePullRequestInput(input string) (pullRequestInput, error) {
 	if strings.HasPrefix(input, "-") {
 		return pullRequestInput{}, fmt.Errorf("PR number or URL cannot start with -: %q", input)
 	}
-	if strings.HasPrefix(input, "#") {
-		input = strings.TrimPrefix(input, "#")
-	}
+	input = strings.TrimPrefix(input, "#")
 	if number, ok := parsePositiveInt(input); ok {
 		return pullRequestInput{Number: number}, nil
 	}

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -144,13 +144,6 @@ func (q *Querier) ListWorktrees(repoPath string) ([]Worktree, error) {
 // readDirtyStatus inspects a worktree path and reports how many files are
 // changed along with the number of lines added and deleted relative to HEAD.
 // A path with no changes yields zero counts and a nil error.
-func readDirtyStatus(path string) (files, added, deleted int, err error) {
-	return defaultQuery().readDirtyStatus(path)
-}
-
-// readDirtyStatus inspects a worktree path and reports how many files are
-// changed along with the number of lines added and deleted relative to HEAD.
-// A path with no changes yields zero counts and a nil error.
 func (q *Querier) readDirtyStatus(path string) (files, added, deleted int, err error) {
 	statusOut, err := q.git.Run(path, "status", "--porcelain")
 	if err != nil {
@@ -168,10 +161,6 @@ func (q *Querier) readDirtyStatus(path string) (files, added, deleted int, err e
 	}
 	added, deleted = ParseNumstat(diffOut)
 	return files, added, deleted, nil
-}
-
-func populateWorktreeDirtyStatus(wt *Worktree) {
-	defaultQuery().populateWorktreeDirtyStatus(wt)
 }
 
 func (q *Querier) populateWorktreeDirtyStatus(wt *Worktree) {
@@ -365,11 +354,6 @@ func (q *Querier) BranchDiff(worktreePath string) (string, error) {
 }
 
 // branchWorktreeMap returns a map of branch name -> worktree paths and detached worktree paths.
-func branchWorktreeMap(repoPath string) (map[string][]string, []string, error) {
-	return defaultQuery().branchWorktreeMap(repoPath)
-}
-
-// branchWorktreeMap returns a map of branch name -> worktree paths and detached worktree paths.
 func (q *Querier) branchWorktreeMap(repoPath string) (map[string][]string, []string, error) {
 	out, err := q.git.Run(repoPath, "worktree", "list", "--porcelain")
 	if err != nil {
@@ -393,10 +377,6 @@ func (q *Querier) branchWorktreeMap(repoPath string) (map[string][]string, []str
 	return m, detachedPaths, nil
 }
 
-func branchAheadBehind(repoPath, branchName, upstream string) (int, int, error) {
-	return defaultQuery().branchAheadBehind(repoPath, branchName, upstream)
-}
-
 func (q *Querier) branchAheadBehind(repoPath, branchName, upstream string) (int, int, error) {
 	out, err := q.git.Run(repoPath, "rev-list", "--count", "--left-right", branchName+"..."+upstream)
 	if err != nil {
@@ -404,10 +384,6 @@ func (q *Querier) branchAheadBehind(repoPath, branchName, upstream string) (int,
 	}
 	ahead, behind := ParseAheadBehind(out)
 	return ahead, behind, nil
-}
-
-func rootWorktreeBranch(repoPath string, wtMap map[string][]string) string {
-	return defaultQuery().rootWorktreeBranch(repoPath, wtMap)
 }
 
 func (q *Querier) rootWorktreeBranch(repoPath string, wtMap map[string][]string) string {
@@ -419,10 +395,6 @@ func (q *Querier) rootWorktreeBranch(repoPath string, wtMap map[string][]string)
 		}
 	}
 	return strings.TrimSpace(q.maybeGitCmd(repoPath, "branch", "--show-current"))
-}
-
-func defaultCleanupBranch(repoPath string, branchLines []string, fallback string) string {
-	return defaultQuery().defaultCleanupBranch(repoPath, branchLines, fallback)
 }
 
 func (q *Querier) defaultCleanupBranch(repoPath string, branchLines []string, fallback string) string {
@@ -451,16 +423,8 @@ func (q *Querier) defaultCleanupBranch(repoPath string, branchLines []string, fa
 	return ""
 }
 
-func branchMergedInto(repoPath, branchName, cleanupBranch string) bool {
-	return defaultQuery().branchMergedInto(repoPath, branchName, cleanupBranch)
-}
-
 func (q *Querier) branchMergedInto(repoPath, branchName, cleanupBranch string) bool {
 	return q.git.Ok(repoPath, "merge-base", "--is-ancestor", branchName, cleanupBranch) == nil
-}
-
-func unpushedCommits(repoPath, branchName, upstream string) []string {
-	return defaultQuery().unpushedCommits(repoPath, branchName, upstream)
 }
 
 func (q *Querier) unpushedCommits(repoPath, branchName, upstream string) []string {
@@ -469,10 +433,6 @@ func (q *Querier) unpushedCommits(repoPath, branchName, upstream string) []strin
 		return nil
 	}
 	return splitLines(out)
-}
-
-func populateDirtyStatus(b *Branch, paths []string) {
-	defaultQuery().populateDirtyStatus(b, paths)
 }
 
 func (q *Querier) populateDirtyStatus(b *Branch, paths []string) {
@@ -506,10 +466,6 @@ func firstWorktreePath(paths []string) string {
 		return ""
 	}
 	return paths[0]
-}
-
-func maybeGitCmd(dir string, args ...string) string {
-	return defaultQuery().maybeGitCmd(dir, args...)
 }
 
 func (q *Querier) maybeGitCmd(dir string, args ...string) string {

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -1475,7 +1475,7 @@ func TestModel_WorktreePrunedRefetchesWorktrees(t *testing.T) {
 		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
 		{Path: "/dev/gone", BranchName: "stale", Stale: true},
 	}})
-	m, cmd := update(m, model.WorktreePrunedMsg{RepoPath: "/dev/alpha"})
+	_, cmd := update(m, model.WorktreePrunedMsg{RepoPath: "/dev/alpha"})
 	if cmd == nil {
 		t.Fatal("expected fetchWorktrees cmd after prune, got nil")
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -379,14 +379,14 @@ func (m Model) handleNewPullRequestWorktree() (tea.Model, tea.Cmd) {
 
 func validateWorktreeInput(input string) error {
 	if input == "" {
-		return fmt.Errorf("Enter a branch, tag, or new branch name")
+		return fmt.Errorf("enter a branch, tag, or new branch name")
 	}
 	return nil
 }
 
 func validateBranchInput(input string) error {
 	if input == "" {
-		return fmt.Errorf("Enter a branch name")
+		return fmt.Errorf("enter a branch name")
 	}
 	return nil
 }

--- a/model/model_realrepo_test.go
+++ b/model/model_realrepo_test.go
@@ -67,8 +67,8 @@ func setupModelRepo(t *testing.T) (model.Model, string) {
 
 func setupModelRepoWithOptions(t *testing.T, opts model.Options) (model.Model, string) {
 	t.Helper()
-	m, dir := setupModelRepo(t)
-	m = model.NewWithOptions([]scanner.Repo{{Path: dir, DisplayName: filepath.Base(dir)}}, opts)
+	_, dir := setupModelRepo(t)
+	m := model.NewWithOptions([]scanner.Repo{{Path: dir, DisplayName: filepath.Base(dir)}}, opts)
 	return m, dir
 }
 

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -270,7 +270,7 @@ func TestModel_EmptyReposNoPanic(t *testing.T) {
 	m := model.New(nil)
 	_ = m.View()
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
+	_, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
 }
 
 func TestModel_QuitKeys(t *testing.T) {
@@ -655,7 +655,7 @@ func TestModel_RightPaneSearchIsSharedAcrossModesAndEscapeClearsIt(t *testing.T)
 	}})
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
-	for _, r := range []rune("work") {
+	for _, r := range "work" {
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 	}
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -695,7 +695,7 @@ func TestModel_RightPaneFilterAppliesToAsyncReplacement(t *testing.T) {
 	}})
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
-	for _, r := range []rune("api") {
+	for _, r := range "api" {
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 	}
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: []gitquery.Branch{

--- a/model/pane/pane.go
+++ b/model/pane/pane.go
@@ -228,9 +228,8 @@ func fuzzyMatch(query, target string) bool {
 
 func fuzzyMatchRunes(query, target string) bool {
 	q := []rune(strings.ToLower(query))
-	t := []rune(strings.ToLower(target))
 	next := 0
-	for _, r := range t {
+	for _, r := range strings.ToLower(target) {
 		if next < len(q) && q[next] == r {
 			next++
 		}


### PR DESCRIPTION
## Summary
- Remove unused package-level gitquery delegate helpers left behind by the Querier refactor.
- Keep the live Querier methods and exported package APIs intact.
- Clean related analyzer findings: dead test assignments, unnecessary rune conversions, lowercase error strings, and a no-op-safe TrimPrefix simplification.

## Verification
- `go run golang.org/x/tools/cmd/deadcode@latest -test ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `make build`