### PR TITLE
Add bare repository worktree support

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -188,8 +188,16 @@ func ValidatePullRequestWorktreeInput(repoPath, input string) error {
 // worktrees: <repo>-worktrees/<branch-or-tag>.
 func DefaultWorktreePath(repoPath, ref string) string {
 	base := filepath.Base(repoPath)
+	if isBareRepo(repoPath) {
+		base = strings.TrimSuffix(base, ".git")
+	}
 	parent := filepath.Dir(repoPath)
 	return filepath.Join(parent, base+"-worktrees", sanitizePathPart(ref))
+}
+
+func isBareRepo(repoPath string) bool {
+	out, err := exec.Command("git", "-C", repoPath, "rev-parse", "--is-bare-repository").Output()
+	return err == nil && strings.TrimSpace(string(out)) == "true"
 }
 
 // DeleteBranch runs `git branch -d`.

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -118,6 +118,24 @@ func setupRemoteRepo(t *testing.T) (localPath, upstreamPath, branch string) {
 	return localPath, upstreamPath, branch
 }
 
+func setupBareRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "seed")
+	barePath := filepath.Join(dir, "project.git")
+
+	mustRun(t, dir, "git", "init", seedPath)
+	mustRun(t, seedPath, "git", "checkout", "-b", "main")
+	mustRun(t, seedPath, "git", "config", "user.email", "test@test.com")
+	mustRun(t, seedPath, "git", "config", "user.name", "Test")
+	mustRun(t, seedPath, "git", "commit", "--allow-empty", "-m", "init")
+	mustRun(t, dir, "git", "init", "--bare", barePath)
+	mustRun(t, seedPath, "git", "remote", "add", "origin", barePath)
+	mustRun(t, seedPath, "git", "push", "-u", "origin", "main")
+	mustRun(t, barePath, "git", "symbolic-ref", "HEAD", "refs/heads/main")
+	return barePath
+}
+
 func configureGitHubOrigin(t *testing.T, localPath, owner, repo string) {
 	t.Helper()
 	originPath := filepath.Join(filepath.Dir(localPath), "origin.git")
@@ -362,6 +380,16 @@ func TestDefaultWorktreePath(t *testing.T) {
 	}
 }
 
+func TestDefaultWorktreePath_BareRepoStripsDotGit(t *testing.T) {
+	repoPath := setupBareRepo(t)
+
+	path := actions.DefaultWorktreePath(repoPath, "feature/new")
+	expected := filepath.Join(filepath.Dir(repoPath), "project-worktrees", "feature-new")
+	if path != expected {
+		t.Fatalf("expected %q, got %q", expected, path)
+	}
+}
+
 func TestWorktreeSessionName(t *testing.T) {
 	tests := []struct {
 		path       string
@@ -464,6 +492,26 @@ func TestCreateWorktree_FromExistingBranch(t *testing.T) {
 	}
 }
 
+func TestCreateWorktree_FromBareRepoExistingBranch(t *testing.T) {
+	repoPath := setupBareRepo(t)
+
+	worktreePath, err := actions.CreateWorktree(repoPath, "main")
+	if err != nil {
+		t.Fatalf("CreateWorktree returned error: %v", err)
+	}
+
+	expectedPath := filepath.Join(filepath.Dir(repoPath), "project-worktrees", "main")
+	if worktreePath != expectedPath {
+		t.Fatalf("expected path %q, got %q", expectedPath, worktreePath)
+	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Fatalf("expected worktree directory to exist: %v", err)
+	}
+	if got := runOutput(t, worktreePath, "git", "branch", "--show-current"); got != "main" {
+		t.Fatalf("expected checked out branch main, got %q", got)
+	}
+}
+
 func TestCreateWorktree_FromNewBranchName(t *testing.T) {
 	repoPath := setupRepo(t)
 
@@ -479,6 +527,27 @@ func TestCreateWorktree_FromNewBranchName(t *testing.T) {
 	out, _ = exec.Command("git", "-C", repoPath, "branch", "--list", "feature/new").Output()
 	if !strings.Contains(string(out), "feature/new") {
 		t.Fatal("expected new branch to exist in repo")
+	}
+}
+
+func TestCreateWorktree_FromBareRepoNewBranch(t *testing.T) {
+	repoPath := setupBareRepo(t)
+
+	worktreePath, err := actions.CreateWorktree(repoPath, "feature/new")
+	if err != nil {
+		t.Fatalf("CreateWorktree returned error: %v", err)
+	}
+
+	expectedPath := filepath.Join(filepath.Dir(repoPath), "project-worktrees", "feature-new")
+	if worktreePath != expectedPath {
+		t.Fatalf("expected path %q, got %q", expectedPath, worktreePath)
+	}
+	if got := runOutput(t, worktreePath, "git", "branch", "--show-current"); got != "feature/new" {
+		t.Fatalf("expected checked out branch feature/new, got %q", got)
+	}
+	out := runOutput(t, repoPath, "git", "branch", "--list", "feature/new")
+	if !strings.Contains(out, "feature/new") {
+		t.Fatal("expected new branch to exist in bare repo")
 	}
 }
 
@@ -514,6 +583,42 @@ func TestCreatePullRequestWorktree_FromNumber(t *testing.T) {
 	}
 	if _, err := os.Stat(worktreePath); err != nil {
 		t.Fatalf("expected worktree directory to exist: %v", err)
+	}
+	if got := runOutput(t, worktreePath, "git", "branch", "--show-current"); got != "pr-123" {
+		t.Fatalf("expected branch pr-123, got %q", got)
+	}
+	if got := runOutput(t, worktreePath, "git", "rev-parse", "HEAD"); got != wantHead {
+		t.Fatalf("expected worktree HEAD %s, got %s", wantHead, got)
+	}
+}
+
+func TestCreatePullRequestWorktree_FromBareRepoNumber(t *testing.T) {
+	dir := t.TempDir()
+	upstreamPath := filepath.Join(dir, "upstream")
+	originPath := filepath.Join(dir, "origin.git")
+	localBarePath := filepath.Join(dir, "project.git")
+
+	mustRun(t, dir, "git", "init", upstreamPath)
+	mustRun(t, upstreamPath, "git", "checkout", "-b", "main")
+	mustRun(t, upstreamPath, "git", "config", "user.email", "test@test.com")
+	mustRun(t, upstreamPath, "git", "config", "user.name", "Test")
+	mustRun(t, upstreamPath, "git", "commit", "--allow-empty", "-m", "init")
+	mustRun(t, dir, "git", "init", "--bare", originPath)
+	mustRun(t, upstreamPath, "git", "remote", "add", "origin", originPath)
+	mustRun(t, upstreamPath, "git", "push", "-u", "origin", "main")
+	mustRun(t, upstreamPath, "git", "commit", "--allow-empty", "-m", "pr change")
+	wantHead := runOutput(t, upstreamPath, "git", "rev-parse", "HEAD")
+	mustRun(t, upstreamPath, "git", "push", "origin", "HEAD:refs/pull/123/head")
+	mustRun(t, dir, "git", "clone", "--bare", originPath, localBarePath)
+
+	worktreePath, err := actions.CreatePullRequestWorktree(localBarePath, "123")
+	if err != nil {
+		t.Fatalf("CreatePullRequestWorktree returned error: %v", err)
+	}
+
+	expectedPath := filepath.Join(dir, "project-worktrees", "pr-123")
+	if worktreePath != expectedPath {
+		t.Fatalf("expected path %q, got %q", expectedPath, worktreePath)
 	}
 	if got := runOutput(t, worktreePath, "git", "branch", "--show-current"); got != "pr-123" {
 		t.Fatalf("expected branch pr-123, got %q", got)

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -3,6 +3,7 @@ package gitquery
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 )
@@ -91,12 +92,14 @@ func FlattenBranches(branches []Branch) []BranchRow {
 	return rows
 }
 
-// ListWorktrees returns all worktrees for the given repo, with the main worktree first.
+// ListWorktrees returns non-bare worktree checkouts for the given repo.
+// A checkout whose path equals repoPath is marked as the root worktree.
 func ListWorktrees(repoPath string) ([]Worktree, error) {
 	return defaultQuery().ListWorktrees(repoPath)
 }
 
-// ListWorktrees returns all worktrees for the given repo, with the main worktree first.
+// ListWorktrees returns non-bare worktree checkouts for the given repo.
+// Bare roots are omitted, so a central bare repository can return zero rows.
 func (q *Querier) ListWorktrees(repoPath string) ([]Worktree, error) {
 	out, err := q.git.Run(repoPath, "worktree", "list", "--porcelain")
 	if err != nil {
@@ -104,7 +107,6 @@ func (q *Querier) ListWorktrees(repoPath string) ([]Worktree, error) {
 	}
 
 	var worktrees []Worktree
-	first := true
 	for _, wt := range ParseWorktreeList(out) {
 		if wt.IsBare {
 			continue
@@ -113,7 +115,7 @@ func (q *Querier) ListWorktrees(repoPath string) ([]Worktree, error) {
 		w := Worktree{
 			Path:       wt.Path,
 			Detached:   wt.Detached,
-			IsMain:     first,
+			IsMain:     samePath(wt.Path, repoPath),
 			Locked:     wt.Locked,
 			LockReason: wt.LockReason,
 		}
@@ -122,7 +124,6 @@ func (q *Querier) ListWorktrees(repoPath string) ([]Worktree, error) {
 		} else {
 			w.BranchName = wt.Branch
 		}
-		first = false
 		worktrees = append(worktrees, w)
 	}
 
@@ -389,7 +390,7 @@ func (q *Querier) branchAheadBehind(repoPath, branchName, upstream string) (int,
 func (q *Querier) rootWorktreeBranch(repoPath string, wtMap map[string][]string) string {
 	for branch, paths := range wtMap {
 		for _, path := range paths {
-			if path == repoPath {
+			if samePath(path, repoPath) {
 				return branch
 			}
 		}
@@ -466,6 +467,17 @@ func firstWorktreePath(paths []string) string {
 		return ""
 	}
 	return paths[0]
+}
+
+func samePath(a, b string) bool {
+	return canonicalPath(a) == canonicalPath(b)
+}
+
+func canonicalPath(path string) string {
+	if abs, err := filepath.Abs(path); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(path)
 }
 
 func (q *Querier) maybeGitCmd(dir string, args ...string) string {

--- a/gitquery/runner_test.go
+++ b/gitquery/runner_test.go
@@ -244,7 +244,7 @@ func TestQuerierListWorktrees_UsesInjectedRunnerForDirtyStatus(t *testing.T) {
 	f := &fakeRunner{
 		t: t,
 		run: map[string]fakeReply{
-			fakeKey("/repo", "worktree", "list", "--porcelain"): {
+			fakeKey(mainPath, "worktree", "list", "--porcelain"): {
 				out: "worktree " + mainPath + "\nHEAD abc123\nbranch refs/heads/main\n\nworktree " + dirtyPath + "\nHEAD def456\nbranch refs/heads/feature\n\nworktree " + stalePath + "\nHEAD 789abc\nbranch refs/heads/stale\n",
 			},
 			fakeKey(mainPath, "status", "--porcelain"): {},
@@ -257,7 +257,7 @@ func TestQuerierListWorktrees_UsesInjectedRunnerForDirtyStatus(t *testing.T) {
 		},
 	}
 
-	worktrees, err := gitquery.NewQuerier(f).ListWorktrees("/repo")
+	worktrees, err := gitquery.NewQuerier(f).ListWorktrees(mainPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -275,6 +275,121 @@ func TestQuerierListWorktrees_UsesInjectedRunnerForDirtyStatus(t *testing.T) {
 	}
 	if fakeCallContains(f.calls, stalePath+" | status --porcelain") {
 		t.Fatalf("stale worktree should not read dirty status; calls: %v", f.calls)
+	}
+}
+
+func TestQuerierListWorktrees_SkipsBareRootWithoutRootLabel(t *testing.T) {
+	worktreePath := t.TempDir()
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey("/dev/project.git", "worktree", "list", "--porcelain"): {
+				out: "worktree /dev/project.git\nbare\n\nworktree " + worktreePath + "\nHEAD abc123\nbranch refs/heads/feature\n",
+			},
+			fakeKey(worktreePath, "status", "--porcelain"): {},
+		},
+	}
+
+	worktrees, err := gitquery.NewQuerier(f).ListWorktrees("/dev/project.git")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(worktrees) != 1 {
+		t.Fatalf("expected one attached worktree, got %+v", worktrees)
+	}
+	if worktrees[0].Path != worktreePath {
+		t.Fatalf("expected worktree path %q, got %+v", worktreePath, worktrees[0])
+	}
+	if worktrees[0].BranchName != "feature" {
+		t.Fatalf("expected branch feature, got %+v", worktrees[0])
+	}
+	if worktrees[0].IsMain {
+		t.Fatalf("attached worktree from bare repo should not be marked root: %+v", worktrees[0])
+	}
+	if fakeCallContains(f.calls, "/dev/project.git | status --porcelain") {
+		t.Fatalf("bare root should not be checked for dirty status; calls: %v", f.calls)
+	}
+}
+
+func TestQuerierListWorktrees_BareRepoWithNoCheckoutsReturnsEmpty(t *testing.T) {
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey("/dev/project.git", "worktree", "list", "--porcelain"): {
+				out: "worktree /dev/project.git\nbare\n",
+			},
+		},
+	}
+
+	worktrees, err := gitquery.NewQuerier(f).ListWorktrees("/dev/project.git")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(worktrees) != 0 {
+		t.Fatalf("expected no worktrees, got %+v", worktrees)
+	}
+}
+
+func TestQuerierListWorktrees_RootLabelAllowsCleanedRepoPath(t *testing.T) {
+	mainPath := t.TempDir()
+	repoPath := mainPath + string(filepath.Separator)
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey(repoPath, "worktree", "list", "--porcelain"): {
+				out: "worktree " + mainPath + "\nHEAD abc123\nbranch refs/heads/main\n",
+			},
+			fakeKey(mainPath, "status", "--porcelain"): {},
+		},
+	}
+
+	worktrees, err := gitquery.NewQuerier(f).ListWorktrees(repoPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(worktrees) != 1 {
+		t.Fatalf("expected one worktree, got %+v", worktrees)
+	}
+	if !worktrees[0].IsMain {
+		t.Fatalf("expected cleaned repo path to match root worktree, got %+v", worktrees[0])
+	}
+}
+
+func TestQuerierListBranches_RootBranchAllowsCleanedRepoPath(t *testing.T) {
+	repoPath := "/repo/"
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey(repoPath, "for-each-ref", "--format=%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
+				out: "dev\trefs/heads/dev\t\t\nfeature\trefs/heads/feature\t\t\n",
+			},
+			fakeKey(repoPath, "worktree", "list", "--porcelain"): {
+				out: "worktree /repo\nHEAD abc123\nbranch refs/heads/dev\n",
+			},
+			fakeKey("/repo", "status", "--porcelain"): {},
+		},
+		ok: map[string]error{
+			fakeKey(repoPath, "merge-base", "--is-ancestor", "feature", "dev"): nil,
+		},
+	}
+
+	branches, err := gitquery.NewQuerier(f).ListBranches(repoPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dev := findBranch(branches, "dev")
+	if dev == nil {
+		t.Fatal("branch dev not found")
+	}
+	if dev.Merged {
+		t.Fatalf("root worktree branch should not be marked merged, got %+v", *dev)
+	}
+	feature := findBranch(branches, "feature")
+	if feature == nil {
+		t.Fatal("branch feature not found")
+	}
+	if !feature.Merged || feature.MergedInto != "dev" {
+		t.Fatalf("expected feature merged into root branch dev, got %+v", *feature)
 	}
 }
 

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brian-bell/wtui/actions"
 	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/model"
+	"github.com/brian-bell/wtui/scanner"
 	"github.com/brian-bell/wtui/ui"
 )
 
@@ -417,6 +418,36 @@ func TestModel_FKey_Worktree_FiresFetchCmd(t *testing.T) {
 	}
 }
 
+func TestModel_FKey_BareRepoWithoutWorktree_FiresFetchCmd(t *testing.T) {
+	repo := scanner.Repo{Path: "/dev/project.git", DisplayName: "project.git", IsBare: true}
+	m := model.New([]scanner.Repo{repo})
+	m = inRightPane(m)
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for fetch on bare repo without worktrees")
+	}
+	msg := cmd()
+	if _, ok := msg.(model.GitFetchFailedMsg); !ok {
+		t.Fatalf("expected GitFetchFailedMsg for nonexistent bare repo path, got %T", msg)
+	}
+}
+
+func TestModel_FKey_BareRepoBranchesWithoutSelection_FiresFetchCmd(t *testing.T) {
+	repo := scanner.Repo{Path: "/dev/project.git", DisplayName: "project.git", IsBare: true}
+	m := model.New([]scanner.Repo{repo})
+	m = inBranchesMode(m)
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd for branch-pane fetch on bare repo without rows")
+	}
+	msg := cmd()
+	if _, ok := msg.(model.GitFetchFailedMsg); !ok {
+		t.Fatalf("expected GitFetchFailedMsg for nonexistent bare repo path, got %T", msg)
+	}
+}
+
 func TestModel_ShiftFKey_Worktree_FiresPullCmd(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
@@ -461,6 +492,17 @@ func TestModel_ShiftFKey_NonWorktreeBranch_NoCmd(t *testing.T) {
 	}
 }
 
+func TestModel_ShiftFKey_BareRepoWithoutWorktree_NoCmd(t *testing.T) {
+	repo := scanner.Repo{Path: "/dev/project.git", DisplayName: "project.git", IsBare: true}
+	m := model.New([]scanner.Repo{repo})
+	m = inRightPane(m)
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'F'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for pull on bare repo without selected worktree, got %T", cmd)
+	}
+}
+
 func TestModel_FAndShiftFKeys_NonWorktreeAndBranchModes_NoCmd(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -484,6 +526,58 @@ func TestModel_FAndShiftFKeys_NonWorktreeAndBranchModes_NoCmd(t *testing.T) {
 				t.Fatalf("expected nil cmd for %q in mode %d, got %T", tc.key, tc.mode, cmd)
 			}
 		})
+	}
+}
+
+func TestModel_BareRepoCheckedOutBranchDeleteNoCmd(t *testing.T) {
+	repo := scanner.Repo{Path: "/dev/project.git", DisplayName: "project.git", IsBare: true}
+	m := model.New([]scanner.Repo{repo})
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{RepoPath: repo.Path, Branches: []gitquery.Branch{
+		{
+			Name:          "feature",
+			IsWorktree:    true,
+			WorktreePaths: []string{"/dev/project-worktrees/feature"},
+		},
+	}})
+	m = enableDestructive(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected no delete confirm for checked-out bare repo branch, got overlay %d", m.Overlay())
+	}
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for checked-out bare repo branch delete, got %T", cmd)
+	}
+}
+
+func TestModel_RootBranchDeleteAllowsCleanedRepoPath_NoCmd(t *testing.T) {
+	repo := scanner.Repo{Path: "/dev/project/", DisplayName: "project"}
+	m := model.New([]scanner.Repo{repo})
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{RepoPath: repo.Path, Branches: []gitquery.Branch{
+		{Name: "main", IsWorktree: true, WorktreePaths: []string{"/dev/project"}},
+	}})
+	m = enableDestructive(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected no delete confirm for cleaned root branch path, got overlay %d", m.Overlay())
+	}
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for cleaned root branch delete, got %T", cmd)
+	}
+}
+
+func TestModel_CKey_BareRepoHistory_NoCmd(t *testing.T) {
+	repo := scanner.Repo{Path: "/dev/project.git", DisplayName: "project.git", IsBare: true}
+	m := model.New([]scanner.Repo{repo})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for opening code from bare repo history, got %T", cmd)
 	}
 }
 

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -115,14 +115,18 @@ func (m Model) pullTargetPath() (string, string, bool) {
 // requires the selected branch to have a checked-out worktree, since a bare
 // branch has no working tree to pull into.
 func (m Model) gitTargetPath(forPull bool) (string, string, bool) {
-	repoPath, ok := m.currentRepoPath()
+	repo, ok := m.currentRepo()
 	if !ok {
 		return "", "", false
 	}
+	repoPath := repo.Path
 	switch m.mode {
 	case ui.ModeWorktrees:
 		wt, ok := m.selectedWorktree()
 		if !ok {
+			if forPull && repo.IsBare {
+				return "", "", false
+			}
 			return repoPath, repoPath, true
 		}
 		if wt.Stale {
@@ -132,6 +136,9 @@ func (m Model) gitTargetPath(forPull bool) (string, string, bool) {
 	case ui.ModeBranches:
 		row, ok := m.selectedRow()
 		if !ok {
+			if forPull && repo.IsBare {
+				return "", "", false
+			}
 			return repoPath, repoPath, true
 		}
 		if row.Stale {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -491,11 +491,11 @@ func (m Model) pathForOpenAction() (string, bool) {
 		return "", false
 	}
 	if m.mode == ui.ModeHistory {
-		path, ok := m.currentRepoPath()
-		if !ok {
+		repo, ok := m.currentRepo()
+		if !ok || repo.IsBare {
 			return "", false
 		}
-		return path, true
+		return repo.Path, true
 	}
 	if m.mode == ui.ModeBranches {
 		if row, ok := m.selectedRow(); ok && row.WorktreePath != "" {
@@ -603,7 +603,10 @@ func (m Model) confirmBranchDelete() (tea.Model, tea.Cmd) {
 	}
 
 	// Root branch cannot be deleted
-	if row.WorktreePath == repoPath {
+	if samePath(row.WorktreePath, repoPath) {
+		return m, nil
+	}
+	if repo, ok := m.currentRepo(); ok && repo.IsBare && row.WorktreePath != "" {
 		return m, nil
 	}
 

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -2,12 +2,14 @@ package model
 
 import (
 	"fmt"
+	"path/filepath"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/brian-bell/wtui/actions"
 	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/model/modal"
+	"github.com/brian-bell/wtui/scanner"
 	"github.com/brian-bell/wtui/ui"
 )
 
@@ -238,11 +240,19 @@ type ActionFailedMsg struct {
 // --- Message handlers ---
 
 func (m Model) currentRepoPath() (string, bool) {
-	repo, ok := m.repos.Selected()
+	repo, ok := m.currentRepo()
 	if !ok {
 		return "", false
 	}
 	return repo.Path, true
+}
+
+func (m Model) currentRepo() (scanner.Repo, bool) {
+	repo, ok := m.repos.Selected()
+	if !ok {
+		return scanner.Repo{}, false
+	}
+	return repo, true
 }
 
 func (m Model) isCurrentRepo(repoPath string) bool {
@@ -447,26 +457,8 @@ func (m Model) handleBranchResult(msg BranchResultMsg) Model {
 		return m
 	}
 	m = m.clearFetchListStatus(ui.ModeBranches)
-	allRows := gitquery.FlattenBranches(msg.Branches)
-	var filtered []gitquery.BranchRow
-	for _, row := range allRows {
-		if row.Branch.IsWorktree && row.WorktreePath != msg.RepoPath {
-			continue
-		}
-		filtered = append(filtered, row)
-	}
-	// Pin root worktree to position 0
-	for i, row := range filtered {
-		if row.WorktreePath == msg.RepoPath {
-			if i != 0 {
-				root := filtered[i]
-				copy(filtered[1:i+1], filtered[:i])
-				filtered[0] = root
-			}
-			break
-		}
-	}
-	m.rows = m.rows.SetItems(filtered)
+	repo, _ := m.currentRepo()
+	m.rows = m.rows.SetItems(branchRowsForRepo(repo, msg.Branches))
 	if m.pendingBranchSelection != "" {
 		pendingRef := "refs/heads/" + m.pendingBranchSelection
 		m.rows = m.rows.SelectFunc(func(row gitquery.BranchRow) bool {
@@ -476,6 +468,42 @@ func (m Model) handleBranchResult(msg BranchResultMsg) Model {
 	}
 	m = m.clampSelectionsAfterFilter()
 	return m
+}
+
+func branchRowsForRepo(repo scanner.Repo, branches []gitquery.Branch) []gitquery.BranchRow {
+	allRows := gitquery.FlattenBranches(branches)
+	filtered := make([]gitquery.BranchRow, 0, len(allRows))
+	for _, row := range allRows {
+		if !repo.IsBare && row.Branch.IsWorktree && !samePath(row.WorktreePath, repo.Path) {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+	for i, row := range filtered {
+		if !repo.IsBare && samePath(row.WorktreePath, repo.Path) {
+			if i != 0 {
+				root := filtered[i]
+				copy(filtered[1:i+1], filtered[:i])
+				filtered[0] = root
+			}
+			break
+		}
+	}
+	return filtered
+}
+
+func samePath(a, b string) bool {
+	if a == "" || b == "" {
+		return a == b
+	}
+	return canonicalPath(a) == canonicalPath(b)
+}
+
+func canonicalPath(path string) string {
+	if abs, err := filepath.Abs(path); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(path)
 }
 
 func (m Model) handleStashResult(msg StashResultMsg) Model {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -110,6 +110,103 @@ func TestModel_InitialSelection(t *testing.T) {
 	}
 }
 
+func TestModel_BareRepoShowsCheckedOutWorktreeBranches(t *testing.T) {
+	repo := scanner.Repo{Path: "/dev/project.git", DisplayName: "project.git", IsBare: true}
+	m := model.New([]scanner.Repo{repo})
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{RepoPath: repo.Path, Branches: []gitquery.Branch{
+		{Name: "main"},
+		{
+			Name:          "feature",
+			IsWorktree:    true,
+			WorktreePaths: []string{"/dev/project-worktrees/feature"},
+		},
+	}})
+
+	rows := m.Rows()
+	if len(rows) != 2 {
+		t.Fatalf("expected main and feature rows, got %+v", rows)
+	}
+	var sawMain, sawFeature bool
+	for _, row := range rows {
+		switch row.Branch.Name {
+		case "main":
+			sawMain = true
+		case "feature":
+			sawFeature = row.WorktreePath == "/dev/project-worktrees/feature"
+		}
+	}
+	if !sawMain || !sawFeature {
+		t.Fatalf("expected main and annotated feature rows, got %+v", rows)
+	}
+}
+
+func TestModel_BareRepoDoesNotPinRootBranch(t *testing.T) {
+	repo := scanner.Repo{Path: "/dev/project.git", DisplayName: "project.git", IsBare: true}
+	m := model.New([]scanner.Repo{repo})
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{RepoPath: repo.Path, Branches: []gitquery.Branch{
+		{Name: "alpha"},
+		{Name: "main"},
+		{
+			Name:          "zeta",
+			IsWorktree:    true,
+			WorktreePaths: []string{"/dev/project-worktrees/zeta"},
+		},
+	}})
+
+	rows := m.Rows()
+	if len(rows) != 3 {
+		t.Fatalf("expected all branches, got %+v", rows)
+	}
+	if rows[0].Branch.Name != "alpha" {
+		t.Fatalf("expected original branch order to remain unpinned, got %+v", rows)
+	}
+	for _, row := range rows {
+		if row.WorktreePath == repo.Path {
+			t.Fatalf("bare repo should not have a root branch row, got %+v", rows)
+		}
+	}
+}
+
+func TestModel_NormalRepoStillFiltersNonRootWorktreeBranches(t *testing.T) {
+	m := model.New([]scanner.Repo{{Path: "/dev/project", DisplayName: "project"}})
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/project", Branches: []gitquery.Branch{
+		{Name: "main", IsWorktree: true, WorktreePaths: []string{"/dev/project"}},
+		{Name: "feature", IsWorktree: true, WorktreePaths: []string{"/dev/project-worktrees/feature"}},
+		{Name: "topic"},
+	}})
+
+	rows := m.Rows()
+	if len(rows) != 2 {
+		t.Fatalf("expected root worktree branch plus topic, got %+v", rows)
+	}
+	if rows[0].Branch.Name != "main" || rows[0].WorktreePath != "/dev/project" {
+		t.Fatalf("expected root branch pinned first, got %+v", rows)
+	}
+	if rows[1].Branch.Name != "topic" {
+		t.Fatalf("expected non-worktree branch to remain, got %+v", rows)
+	}
+}
+
+func TestModel_NormalRepoRootBranchAllowsCleanedRepoPath(t *testing.T) {
+	m := model.New([]scanner.Repo{{Path: "/dev/project/", DisplayName: "project"}})
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/project/", Branches: []gitquery.Branch{
+		{Name: "main", IsWorktree: true, WorktreePaths: []string{"/dev/project"}},
+		{Name: "feature", IsWorktree: true, WorktreePaths: []string{"/dev/project-worktrees/feature"}},
+	}})
+
+	rows := m.Rows()
+	if len(rows) != 1 {
+		t.Fatalf("expected only root branch row, got %+v", rows)
+	}
+	if rows[0].Branch.Name != "main" || rows[0].WorktreePath != "/dev/project" {
+		t.Fatalf("expected cleaned root branch to remain, got %+v", rows)
+	}
+}
+
 func TestModel_DefaultModeIsWorktrees(t *testing.T) {
 	m := model.New(testRepos())
 	if m.Mode() != 1 {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -11,6 +11,7 @@ import (
 type Repo struct {
 	Path        string
 	DisplayName string
+	IsBare      bool
 }
 
 // ScanOptions configures the scanner.
@@ -57,10 +58,11 @@ func Scan(opts ScanOptions) ([]Repo, error) {
 
 		path := filepath.Join(root, entry.Name())
 
-		if isRepo(path) {
+		if isRepo, isBare := repoInfo(path); isRepo {
 			repos = append(repos, Repo{
 				Path:        path,
 				DisplayName: entry.Name(),
+				IsBare:      isBare,
 			})
 			continue
 		}
@@ -78,10 +80,11 @@ func Scan(opts ScanOptions) ([]Repo, error) {
 					continue
 				}
 				subPath := filepath.Join(path, sub.Name())
-				if isRepo(subPath) {
+				if isRepo, isBare := repoInfo(subPath); isRepo {
 					repos = append(repos, Repo{
 						Path:        subPath,
 						DisplayName: entry.Name() + "/" + sub.Name(),
+						IsBare:      isBare,
 					})
 				}
 			}
@@ -95,13 +98,84 @@ func Scan(opts ScanOptions) ([]Repo, error) {
 	return repos, nil
 }
 
-func isRepo(path string) bool {
-	// A repo has a ".git" entry that is either a directory (normal repo) or a
-	// regular file (a git worktree/submodule pointer). Bare repos (which have no
-	// ".git" entry at all) are intentionally not detected here.
+func repoInfo(path string) (isRepo bool, isBare bool) {
+	// A normal checkout has a ".git" entry that is either a directory or a
+	// regular file (a git worktree/submodule pointer).
 	info, err := os.Stat(filepath.Join(path, ".git"))
+	if err == nil {
+		return info.IsDir() || info.Mode().IsRegular(), false
+	}
+	if !os.IsNotExist(err) {
+		return false, false
+	}
+
+	if !isRegularFile(filepath.Join(path, "HEAD")) ||
+		!isDir(filepath.Join(path, "objects")) ||
+		!isDir(filepath.Join(path, "refs")) ||
+		!configHasCoreBare(filepath.Join(path, "config")) {
+		return false, false
+	}
+
+	head, err := os.ReadFile(filepath.Join(path, "HEAD"))
+	if err != nil {
+		return false, false
+	}
+	if !looksLikeGitHEAD(strings.TrimSpace(string(head))) {
+		return false, false
+	}
+	return true, true
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func isRegularFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+func looksLikeGitHEAD(head string) bool {
+	if strings.HasPrefix(head, "ref: refs/") {
+		return true
+	}
+	if len(head) != 40 {
+		return false
+	}
+	for _, r := range head {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+func configHasCoreBare(path string) bool {
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return false
 	}
-	return info.IsDir() || info.Mode().IsRegular()
+	inCore := false
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inCore = strings.EqualFold(strings.TrimSpace(strings.Trim(line, "[]")), "core")
+			continue
+		}
+		if !inCore {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(key), "bare") && strings.EqualFold(strings.TrimSpace(value), "true") {
+			return true
+		}
+	}
+	return false
 }

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -2,6 +2,7 @@ package scanner_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -11,6 +12,22 @@ import (
 func makeRepo(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Join(path, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func makeBareRepo(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(path, "objects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(path, "refs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "config"), []byte("[core]\n\tbare = true\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -33,6 +50,93 @@ func TestScan_DiscoversTopLevelRepo(t *testing.T) {
 	}
 	if repos[0].Path != repoDir {
 		t.Errorf("expected Path %q, got %q", repoDir, repos[0].Path)
+	}
+	if repos[0].IsBare {
+		t.Error("expected normal repo IsBare=false")
+	}
+}
+
+func TestScan_DiscoversTopLevelBareRepo(t *testing.T) {
+	root := t.TempDir()
+	repoDir := filepath.Join(root, "project.git")
+	makeBareRepo(t, repoDir)
+
+	repos, err := scanner.Scan(scanner.ScanOptions{Root: root})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+	if repos[0].Path != repoDir {
+		t.Errorf("expected Path %q, got %q", repoDir, repos[0].Path)
+	}
+	if repos[0].DisplayName != "project.git" {
+		t.Errorf("expected DisplayName %q, got %q", "project.git", repos[0].DisplayName)
+	}
+	if !repos[0].IsBare {
+		t.Error("expected bare repo IsBare=true")
+	}
+}
+
+func TestScan_DiscoversNestedBareRepo(t *testing.T) {
+	root := t.TempDir()
+	repoDir := filepath.Join(root, "org", "project.git")
+	makeBareRepo(t, repoDir)
+
+	repos, err := scanner.Scan(scanner.ScanOptions{Root: root})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+	if repos[0].DisplayName != "org/project.git" {
+		t.Errorf("expected DisplayName %q, got %q", "org/project.git", repos[0].DisplayName)
+	}
+	if !repos[0].IsBare {
+		t.Error("expected nested bare repo IsBare=true")
+	}
+}
+
+func TestScan_BareRepoCarriesIsBare(t *testing.T) {
+	root := t.TempDir()
+	repoDir := filepath.Join(root, "real.git")
+	if err := exec.Command("git", "init", "--bare", repoDir).Run(); err != nil {
+		t.Fatalf("git init --bare failed: %v", err)
+	}
+
+	repos, err := scanner.Scan(scanner.ScanOptions{Root: root})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+	if !repos[0].IsBare {
+		t.Fatalf("expected real bare repo IsBare=true, got %+v", repos[0])
+	}
+}
+
+func TestScan_DoesNotTreatRandomGitLikeDirectoryAsBare(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "project.git")
+	if err := os.MkdirAll(filepath.Join(dir, "objects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "refs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "HEAD"), []byte("not a ref\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := scanner.Scan(scanner.ScanOptions{Root: root})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repos) != 0 {
+		t.Fatalf("expected no repos, got %+v", repos)
 	}
 }
 
@@ -149,5 +253,8 @@ func TestScan_GitFileWorktreeDiscovered(t *testing.T) {
 	}
 	if repos[0].DisplayName != "wt-repo" {
 		t.Fatalf("expected DisplayName %q, got %q", "wt-repo", repos[0].DisplayName)
+	}
+	if repos[0].IsBare {
+		t.Error("expected git-file worktree IsBare=false")
 	}
 }


### PR DESCRIPTION
## Summary
- discover central bare repositories during scanning and preserve `.git` display names with `Repo.IsBare` metadata
- list attached worktrees without rendering bare roots or labeling the first checkout as root
- keep checked-out bare-repo branch rows visible while protecting pull/open/delete actions from bare repo paths
- use bare-friendly default worktree paths for normal and PR worktree creation

## Verification
- `gofmt -l .`
- `make test`
- `make build`

## Review loop
- loop 1: 8/10
- loop 2: 8/10
- loop 3: 8/10
