### PR TITLE
Add worktree move workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ filter matches, or a load failure with details in the status bar.
 | `n` | Create a new worktree in worktrees view, or a new branch in branches view |
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
+| `m` | Move or rename a linked worktree (worktrees view) |
 | `A` | Choose and persist the coding agent (`codex` or `claude`) |
 | `a` | Launch the selected coding agent in the selected worktree |
 | `d` | Delete worktree/branch or drop stash — requires destructive mode |
@@ -113,8 +114,10 @@ new branch name; wtui creates it under a sibling `<repo>-worktrees/` directory
 and refreshes the list. Press `P` to create a review worktree from a GitHub PR
 number or URL; wtui fetches the PR head into `pr-<number>` and checks it out
 under the same sibling worktree directory. Press `f` to `git fetch --prune` and
-`F` to `git pull --ff-only` for the selected worktree. Locked worktrees cannot
-be deleted or pruned; press `u` to unlock one.
+`F` to `git pull --ff-only` for the selected worktree. Press `m` on a linked
+non-stale, unlocked worktree to move it to an absolute path or rename it with a
+sibling-relative destination; dirty local changes move with the worktree.
+Locked worktrees cannot be moved, deleted, or pruned; press `u` to unlock one.
 
 ### Branches view (mode 2)
 

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -55,6 +55,72 @@ func UnlockWorktree(repoPath, worktreePath string) error {
 	return exec.Command("git", "-C", repoPath, "worktree", "unlock", worktreePath).Run()
 }
 
+// MoveWorktree runs `git worktree move` for a linked worktree and returns the
+// resolved destination path on success.
+func MoveWorktree(repoPath, worktreePath, destination string) (string, error) {
+	finalPath, err := resolveWorktreeMoveDestination(worktreePath, destination)
+	if err != nil {
+		return "", err
+	}
+	if filepath.Clean(worktreePath) == finalPath {
+		return "", fmt.Errorf("worktree destination must be different")
+	}
+	if _, err := os.Stat(finalPath); err == nil {
+		return "", fmt.Errorf("worktree destination already exists: %s", finalPath)
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	cleanupParent, err := createWorktreeMoveDestinationParent(finalPath)
+	if err != nil {
+		return "", err
+	}
+	if err := runGit(repoPath, "worktree", "move", "--", worktreePath, finalPath); err != nil {
+		cleanupParent()
+		return "", err
+	}
+	return finalPath, nil
+}
+
+func createWorktreeMoveDestinationParent(finalPath string) (func(), error) {
+	parent := filepath.Dir(finalPath)
+	var created []string
+	for dir := parent; ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(dir); err == nil {
+			break
+		} else if os.IsNotExist(err) {
+			created = append(created, dir)
+		} else {
+			return nil, err
+		}
+		if next := filepath.Dir(dir); next == dir {
+			break
+		}
+	}
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return nil, err
+	}
+	return func() {
+		for _, dir := range created {
+			_ = os.Remove(dir)
+		}
+	}, nil
+}
+
+func resolveWorktreeMoveDestination(worktreePath, input string) (string, error) {
+	worktreePath = strings.TrimSpace(worktreePath)
+	if worktreePath == "" {
+		return "", fmt.Errorf("worktree path cannot be empty")
+	}
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", fmt.Errorf("worktree destination cannot be empty")
+	}
+	if filepath.IsAbs(input) {
+		return filepath.Clean(input), nil
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(worktreePath), input)), nil
+}
+
 // Fetch runs `git fetch --prune` for the given repo or worktree path.
 func Fetch(path string) error {
 	return runGit(path, "fetch", "--prune")

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -74,9 +74,219 @@ func TestRemoveWorktree_Error(t *testing.T) {
 	}
 }
 
+func TestMoveWorktree(t *testing.T) {
+	repoPath := setupRepo(t)
+	worktreePath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feat")
+	newPath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feat-renamed")
+	mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "feat")
+
+	got, err := actions.MoveWorktree(repoPath, worktreePath, newPath)
+	if err != nil {
+		t.Fatalf("MoveWorktree returned error: %v", err)
+	}
+	if got != newPath {
+		t.Fatalf("expected returned path %q, got %q", newPath, got)
+	}
+	if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+		t.Fatalf("expected old worktree path to be gone, stat err=%v", err)
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("expected new worktree path to exist: %v", err)
+	}
+	out := runOutput(t, repoPath, "git", "worktree", "list", "--porcelain")
+	if !strings.Contains(out, "worktree "+newPath) {
+		t.Fatalf("expected worktree list to contain new path, got:\n%s", out)
+	}
+	if strings.Contains(out, "worktree "+worktreePath+"\n") {
+		t.Fatalf("expected worktree list not to contain old path, got:\n%s", out)
+	}
+	branch := runOutput(t, newPath, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	if branch != "feat" {
+		t.Fatalf("expected moved worktree to remain on feat, got %q", branch)
+	}
+}
+
+func TestMoveWorktree_DirtyWorktreeMovesWithLocalChanges(t *testing.T) {
+	repoPath := setupRepo(t)
+	worktreePath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feat")
+	newPath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feat-renamed")
+	mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "feat")
+	if err := os.WriteFile(filepath.Join(worktreePath, "dirty.txt"), []byte("dirty"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := actions.MoveWorktree(repoPath, worktreePath, newPath)
+	if err != nil {
+		t.Fatalf("MoveWorktree returned error for dirty worktree: %v", err)
+	}
+	if got != newPath {
+		t.Fatalf("expected returned path %q, got %q", newPath, got)
+	}
+	if contents, err := os.ReadFile(filepath.Join(newPath, "dirty.txt")); err != nil {
+		t.Fatalf("expected dirty file to move with worktree: %v", err)
+	} else if string(contents) != "dirty" {
+		t.Fatalf("expected dirty contents preserved, got %q", contents)
+	}
+}
+
+func TestMoveWorktree_ResolvesDestinations(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantPath    func(root string) string
+		wantParents bool
+	}{
+		{
+			name:  "bare relative destination",
+			input: "feat-renamed",
+			wantPath: func(root string) string {
+				return filepath.Join(root, "repo-worktrees", "feat-renamed")
+			},
+		},
+		{
+			name:  "nested relative destination creates parents",
+			input: filepath.Join("team", "feat-renamed"),
+			wantPath: func(root string) string {
+				return filepath.Join(root, "repo-worktrees", "team", "feat-renamed")
+			},
+			wantParents: true,
+		},
+		{
+			name:  "absolute destination",
+			input: "ABS",
+			wantPath: func(root string) string {
+				return filepath.Join(root, "elsewhere", "feat-renamed")
+			},
+			wantParents: true,
+		},
+		{
+			name:  "path with spaces",
+			input: "feat renamed",
+			wantPath: func(root string) string {
+				return filepath.Join(root, "repo-worktrees", "feat renamed")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoPath := setupRepo(t)
+			root := filepath.Dir(repoPath)
+			worktreePath := filepath.Join(root, "repo-worktrees", "feat")
+			mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "feat")
+			input := tt.input
+			wantPath := tt.wantPath(root)
+			if input == "ABS" {
+				input = wantPath
+			}
+
+			got, err := actions.MoveWorktree(repoPath, worktreePath, input)
+			if err != nil {
+				t.Fatalf("MoveWorktree returned error: %v", err)
+			}
+			if got != wantPath {
+				t.Fatalf("expected resolved path %q, got %q", wantPath, got)
+			}
+			if _, err := os.Stat(wantPath); err != nil {
+				t.Fatalf("expected destination to exist: %v", err)
+			}
+			if tt.wantParents {
+				if _, err := os.Stat(filepath.Dir(wantPath)); err != nil {
+					t.Fatalf("expected destination parent to exist: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestMoveWorktree_Failures(t *testing.T) {
+	t.Run("empty destination", func(t *testing.T) {
+		if _, err := actions.MoveWorktree("/repo", "/repo-wt", ""); err == nil {
+			t.Fatal("expected empty destination error")
+		}
+	})
+
+	t.Run("whitespace destination", func(t *testing.T) {
+		if _, err := actions.MoveWorktree("/repo", "/repo-wt", "   "); err == nil {
+			t.Fatal("expected whitespace destination error")
+		}
+	})
+
+	t.Run("empty worktree path", func(t *testing.T) {
+		if _, err := actions.MoveWorktree("/repo", "", "new"); err == nil {
+			t.Fatal("expected empty worktree path error")
+		}
+	})
+
+	t.Run("same destination", func(t *testing.T) {
+		repoPath := setupRepo(t)
+		worktreePath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feat")
+		mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "feat")
+		if _, err := actions.MoveWorktree(repoPath, worktreePath, worktreePath); err == nil {
+			t.Fatal("expected same destination error")
+		}
+	})
+
+	t.Run("destination already exists", func(t *testing.T) {
+		repoPath := setupRepo(t)
+		worktreePath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feat")
+		newPath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "existing")
+		mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "feat")
+		if err := os.MkdirAll(newPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := actions.MoveWorktree(repoPath, worktreePath, newPath); err == nil {
+			t.Fatal("expected existing destination error")
+		}
+	})
+
+	t.Run("locked worktree", func(t *testing.T) {
+		repoPath := setupRepo(t)
+		worktreePath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feat")
+		newPath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feat-renamed")
+		mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "feat")
+		mustRun(t, repoPath, "git", "worktree", "lock", "--reason", "busy", worktreePath)
+		if _, err := actions.MoveWorktree(repoPath, worktreePath, newPath); err == nil {
+			t.Fatal("expected locked worktree error")
+		} else if strings.Contains(err.Error(), "exit status") {
+			t.Fatalf("expected clean git error, got %q", err.Error())
+		}
+	})
+
+	t.Run("failed move cleans created parent directories", func(t *testing.T) {
+		repoPath := setupRepo(t)
+		worktreePath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feat")
+		newPath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "team", "feat-renamed")
+		mustRun(t, repoPath, "git", "worktree", "add", worktreePath, "-b", "feat")
+		mustRun(t, repoPath, "git", "worktree", "lock", "--reason", "busy", worktreePath)
+		if _, err := actions.MoveWorktree(repoPath, worktreePath, newPath); err == nil {
+			t.Fatal("expected locked worktree error")
+		}
+		if _, err := os.Stat(filepath.Dir(newPath)); !os.IsNotExist(err) {
+			t.Fatalf("expected created destination parent to be cleaned up, stat err=%v", err)
+		}
+		if _, err := os.Stat(filepath.Dir(worktreePath)); err != nil {
+			t.Fatalf("expected existing worktree parent to remain: %v", err)
+		}
+	})
+
+	t.Run("main worktree", func(t *testing.T) {
+		repoPath := setupRepo(t)
+		newPath := filepath.Join(filepath.Dir(repoPath), "repo-renamed")
+		if _, err := actions.MoveWorktree(repoPath, repoPath, newPath); err == nil {
+			t.Fatal("expected main worktree error")
+		} else if strings.Contains(err.Error(), "exit status") {
+			t.Fatalf("expected clean git error, got %q", err.Error())
+		}
+	})
+}
+
 func setupRepo(t *testing.T) (repoPath string) {
 	t.Helper()
 	dir := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
 	repoPath = filepath.Join(dir, "repo")
 	mustRun(t, dir, "git", "init", repoPath)
 	mustRun(t, repoPath, "git", "config", "user.email", "test@test.com")

--- a/docs/roadmap-todo.md
+++ b/docs/roadmap-todo.md
@@ -21,7 +21,7 @@ clear.
 - [x] P1 - PR-based worktree creation: enter a PR number or URL, fetch the head branch, and create a worktree for review.
 - [x] P1 - Coding-agent launch actions: launch Codex or Claude Code from a selected worktree or worktree branch, optionally after creating a new worktree or branch.
 - [x] P1 - Branch creation from branches pane: complement worktree creation and make branch-first workflows smoother.
-- [ ] P2 - Worktree move/rename: wrap `git worktree move` for users who need to reorganize generated paths.
+- [x] P2 - Worktree move/rename: wrap `git worktree move` for users who need to reorganize generated paths.
 - [ ] P2 - Bare repo support: detect bare repositories and support worktree creation/listing correctly for central bare repo workflows.
 - [ ] P2 - Bootstrap hooks: support an optional per-repo setup script after worktree creation for env files, dependency links, or setup commands.
 

--- a/model/model.go
+++ b/model/model.go
@@ -16,27 +16,28 @@ const listRequestSlots = int(ui.ModeReflog) + 1
 
 // Model is the bubbletea application model.
 type Model struct {
-	repos                  pane.Pane[scanner.Repo]
-	width                  int
-	height                 int
-	mode                   ui.Mode
-	rows                   pane.Pane[gitquery.BranchRow]
-	stashes                pane.Pane[gitquery.Stash]
-	worktrees              pane.Pane[gitquery.Worktree]
-	commits                pane.Pane[gitquery.Commit]
-	reflogs                pane.Pane[gitquery.ReflogEntry]
-	modal                  modal.Modal
-	diffRequestSeq         uint64
-	listRequestSeq         uint64
-	listRequests           [listRequestSlots]uint64
-	activePane             int // 0=left (repos), 1=right (content)
-	destructive            bool
-	status                 statusError
-	searchActive           bool
-	pendingBranchSelection string
-	agentCommand           string
-	saveAgent              func(string) error
-	launchAgent            func(string, string) (actions.TerminalLaunchSpec, error)
+	repos                    pane.Pane[scanner.Repo]
+	width                    int
+	height                   int
+	mode                     ui.Mode
+	rows                     pane.Pane[gitquery.BranchRow]
+	stashes                  pane.Pane[gitquery.Stash]
+	worktrees                pane.Pane[gitquery.Worktree]
+	commits                  pane.Pane[gitquery.Commit]
+	reflogs                  pane.Pane[gitquery.ReflogEntry]
+	modal                    modal.Modal
+	diffRequestSeq           uint64
+	listRequestSeq           uint64
+	listRequests             [listRequestSlots]uint64
+	activePane               int // 0=left (repos), 1=right (content)
+	destructive              bool
+	status                   statusError
+	searchActive             bool
+	pendingBranchSelection   string
+	pendingWorktreeSelection string
+	agentCommand             string
+	saveAgent                func(string) error
+	launchAgent              func(string, string) (actions.TerminalLaunchSpec, error)
 }
 
 type statusSource int
@@ -198,6 +199,7 @@ func (m Model) View() string {
 		RightEmptyMessage:        rightEmptyMessage,
 		FetchAvailable:           m.canFetch(),
 		PullAvailable:            m.canPull(),
+		WorktreeMoveAvailable:    m.canMoveWorktree(),
 		AgentAvailable:           m.canLaunchAgent(),
 		NewAgentAvailable:        m.canCreateAndLaunchAgent(),
 	})
@@ -382,6 +384,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleWorktreeCreated(msg)
 	case WorktreeCreateFailedMsg:
 		return m.handleWorktreeCreateFailed(msg), nil
+	case WorktreeMovedMsg:
+		return m.handleWorktreeMoved(msg)
+	case WorktreeMoveFailedMsg:
+		return m.handleWorktreeMoveFailed(msg), nil
 	case CommitResultMsg:
 		return m.handleCommitResult(msg), nil
 	case ReflogResultMsg:

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -98,6 +98,239 @@ func TestModel_EnterOnEmptyWorktreeListIsNoOp(t *testing.T) {
 	}
 }
 
+func TestModel_MoveWorktreeOpensInputForMovableLinkedWorktree(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+		{Path: "/dev/alpha-worktrees/feat", BranchName: "feat"},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	if cmd != nil {
+		t.Fatal("expected opening move input to return no command")
+	}
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("expected OverlayWorktreeInput, got %d", m.Overlay())
+	}
+	if m.ConfirmPrompt() != ui.WorktreeMovePrompt {
+		t.Fatalf("expected move prompt %q, got %q", ui.WorktreeMovePrompt, m.ConfirmPrompt())
+	}
+	if !strings.Contains(m.View(), ui.WorktreeMoveInputPlaceholder) {
+		t.Fatalf("expected move placeholder in view, got:\n%s", m.View())
+	}
+	if m.WorktreeInput() != "" {
+		t.Fatalf("expected empty initial move input, got %q", m.WorktreeInput())
+	}
+}
+
+func TestModel_MoveWorktreeInputNoOpsWhenUnavailable(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(model.Model) model.Model
+		wantOverlay ui.OverlayState
+	}{
+		{
+			name: "main worktree",
+			setup: func(m model.Model) model.Model {
+				m = inRightPane(m)
+				m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+					{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+				}})
+				return m
+			},
+		},
+		{
+			name: "stale worktree",
+			setup: func(m model.Model) model.Model {
+				m = inRightPane(m)
+				m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+					{Path: "/dev/alpha-worktrees/feat", BranchName: "feat", Stale: true},
+				}})
+				return m
+			},
+		},
+		{
+			name: "locked worktree",
+			setup: func(m model.Model) model.Model {
+				m = inRightPane(m)
+				m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+					{Path: "/dev/alpha-worktrees/feat", BranchName: "feat", Locked: true},
+				}})
+				return m
+			},
+		},
+		{
+			name: "dirty worktree is movable",
+			setup: func(m model.Model) model.Model {
+				m = inRightPane(m)
+				m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+					{Path: "/dev/alpha-worktrees/feat", BranchName: "feat", Dirty: true},
+				}})
+				return m
+			},
+			wantOverlay: ui.OverlayWorktreeInput,
+		},
+		{
+			name: "empty list",
+			setup: func(m model.Model) model.Model {
+				return inRightPane(m)
+			},
+		},
+		{
+			name: "left pane",
+			setup: func(m model.Model) model.Model {
+				m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+					{Path: "/dev/alpha-worktrees/feat", BranchName: "feat"},
+				}})
+				return m
+			},
+		},
+		{
+			name: "non-worktrees mode",
+			setup: func(m model.Model) model.Model {
+				return inBranchesMode(m)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.setup(model.New(testRepos()))
+			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+			if cmd != nil {
+				t.Fatal("expected no command")
+			}
+			if m.Overlay() != tt.wantOverlay {
+				t.Fatalf("expected overlay %d, got %d", tt.wantOverlay, m.Overlay())
+			}
+		})
+	}
+}
+
+func TestModel_MoveWorktreeSubmitReturnsCommandAndFailureReopensInput(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	oldPath := "/dev/alpha-worktrees/feat"
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: oldPath, BranchName: "feat"},
+	}})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feat-renamed")})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected move overlay to close on submit, got %d", m.Overlay())
+	}
+	if cmd == nil {
+		t.Fatal("expected move command")
+	}
+	msg, ok := cmd().(model.WorktreeMoveFailedMsg)
+	if !ok {
+		t.Fatalf("expected WorktreeMoveFailedMsg, got %T", msg)
+	}
+	if msg.RepoPath != "/dev/alpha" || msg.OldPath != oldPath || msg.Input != "feat-renamed" || msg.Err == "" {
+		t.Fatalf("unexpected failure message: %+v", msg)
+	}
+
+	m, _ = update(m, msg)
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("expected move input to reopen, got %d", m.Overlay())
+	}
+	if m.WorktreeInput() != "feat-renamed" {
+		t.Fatalf("expected original input preserved, got %q", m.WorktreeInput())
+	}
+	if m.WorktreeInputErr() == "" {
+		t.Fatal("expected move error to be shown")
+	}
+}
+
+func TestModel_StaleWorktreeMoveFailureIgnored(t *testing.T) {
+	m := model.New(testRepos())
+	m = selectBravo(m)
+	m, _ = update(m, model.WorktreeMoveFailedMsg{
+		RepoPath: "/dev/alpha",
+		OldPath:  "/dev/alpha-worktrees/feat",
+		Input:    "feat-renamed",
+		Err:      "boom",
+	})
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected stale move failure to be ignored, got overlay %d", m.Overlay())
+	}
+}
+
+func TestModel_WorktreeMovedRefreshesAndSelectsMovedPath(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+		{Path: "/dev/alpha-worktrees/feat", BranchName: "feat"},
+	}})
+
+	m, cmd := update(m, model.WorktreeMovedMsg{
+		RepoPath: "/dev/alpha",
+		OldPath:  "/dev/alpha-worktrees/feat",
+		NewPath:  "/dev/alpha-worktrees/feat-renamed",
+	})
+	if cmd == nil {
+		t.Fatal("expected worktree refresh command after move")
+	}
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+		{Path: "/dev/alpha-worktrees/feat-renamed", BranchName: "feat"},
+	}})
+	if m.WorktreeSelected() != 1 {
+		t.Fatalf("expected moved worktree selected, got index %d", m.WorktreeSelected())
+	}
+}
+
+func TestModel_StaleWorktreeMovedIgnored(t *testing.T) {
+	m := model.New(testRepos())
+	m = selectBravo(m)
+	m, cmd := update(m, model.WorktreeMovedMsg{
+		RepoPath: "/dev/alpha",
+		OldPath:  "/dev/alpha-worktrees/feat",
+		NewPath:  "/dev/alpha-worktrees/feat-renamed",
+	})
+	if cmd != nil {
+		t.Fatal("expected stale move success to return no command")
+	}
+	if m.WorktreeSelected() != 0 {
+		t.Fatalf("expected selection unchanged, got %d", m.WorktreeSelected())
+	}
+}
+
+func TestModel_WorktreeMovePendingSelectionClampsWhenPathMissing(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+		{Path: "/dev/alpha-worktrees/feat", BranchName: "feat"},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	m, _ = update(m, model.WorktreeMovedMsg{
+		RepoPath: "/dev/alpha",
+		OldPath:  "/dev/alpha-worktrees/feat",
+		NewPath:  "/dev/alpha-worktrees/feat-renamed",
+	})
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+	}})
+	if m.WorktreeSelected() != 0 {
+		t.Fatalf("expected selection to clamp when moved path is missing, got %d", m.WorktreeSelected())
+	}
+
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+		{Path: "/dev/alpha-worktrees/feat-renamed", BranchName: "feat"},
+	}})
+	if m.WorktreeSelected() != 0 {
+		t.Fatalf("expected missing-path pending selection to be cleared, got %d", m.WorktreeSelected())
+	}
+}
+
 func TestModel_WorktreeDiffResultStoresDiff(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -216,6 +216,20 @@ func (m Model) createPullRequestWorktree(input string) tea.Cmd {
 	}
 }
 
+func (m Model) moveWorktree(oldPath, input string) tea.Cmd {
+	repoPath, ok := m.currentRepoPath()
+	if !ok {
+		return nil
+	}
+	return func() tea.Msg {
+		newPath, err := actions.MoveWorktree(repoPath, oldPath, input)
+		if err != nil {
+			return WorktreeMoveFailedMsg{RepoPath: repoPath, OldPath: oldPath, Input: input, Err: err.Error()}
+		}
+		return WorktreeMovedMsg{RepoPath: repoPath, OldPath: oldPath, NewPath: newPath}
+	}
+}
+
 func (m Model) fetchWorktrees(request uint64) tea.Cmd {
 	repoPath, ok := m.currentRepoPath()
 	if !ok {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brian-bell/wtui/actions"
 	"github.com/brian-bell/wtui/agent"
+	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/model/modal"
 	"github.com/brian-bell/wtui/ui"
 )
@@ -197,6 +198,10 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 	case "P":
 		if m.mode == ui.ModeWorktrees {
 			return m.handleNewPullRequestWorktree()
+		}
+	case "m":
+		if m.mode == ui.ModeWorktrees {
+			return m.handleMoveWorktree()
 		}
 	case "N":
 		if m.mode == ui.ModeWorktrees {
@@ -393,6 +398,41 @@ func validateBranchInput(input string) error {
 
 func validatePullRequestWorktreeInput(repoPath, input string) error {
 	return actions.ValidatePullRequestWorktreeInput(repoPath, input)
+}
+
+func (m Model) handleMoveWorktree() (tea.Model, tea.Cmd) {
+	wt, ok := m.selectedWorktree()
+	if !ok || !canMoveWorktree(wt) {
+		return m, nil
+	}
+	oldPath := wt.Path
+	m.modal = modal.OpenInput(
+		ui.WorktreeMovePrompt,
+		ui.WorktreeMoveInputPlaceholder,
+		"",
+		validateWorktreeMoveInput,
+		func(input string) tea.Cmd { return m.moveWorktree(oldPath, input) },
+	)
+	return m, nil
+}
+
+func validateWorktreeMoveInput(input string) error {
+	if input == "" {
+		return fmt.Errorf("enter a new path or sibling name")
+	}
+	return nil
+}
+
+func canMoveWorktree(wt gitquery.Worktree) bool {
+	return !wt.IsMain && !wt.Stale && !wt.Locked
+}
+
+func (m Model) canMoveWorktree() bool {
+	if m.activePane != 1 || m.mode != ui.ModeWorktrees {
+		return false
+	}
+	wt, ok := m.selectedWorktree()
+	return ok && canMoveWorktree(wt)
 }
 
 func (m Model) handleUnlock() (tea.Model, tea.Cmd) {
@@ -712,6 +752,7 @@ func (m Model) resetModeCursors() Model {
 
 func (m Model) resetRightPaneCursors() Model {
 	m.pendingBranchSelection = ""
+	m.pendingWorktreeSelection = ""
 	m.rows = m.rows.SetItems(nil).ResetSelection()
 	m.stashes = m.stashes.SetItems(nil).ResetSelection()
 	m.worktrees = m.worktrees.SetItems(nil).ResetSelection()

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -134,6 +134,19 @@ type WorktreeCreatedMsg struct {
 	LaunchAgent  bool
 }
 
+type WorktreeMovedMsg struct {
+	RepoPath string
+	OldPath  string
+	NewPath  string
+}
+
+type WorktreeMoveFailedMsg struct {
+	RepoPath string
+	OldPath  string
+	Input    string
+	Err      string
+}
+
 type WorktreeCreateKind int
 
 const (
@@ -295,6 +308,13 @@ func (m Model) handleWorktreeResult(msg WorktreeResultMsg) Model {
 	}
 	m = m.clearFetchListStatus(ui.ModeWorktrees)
 	m.worktrees = m.worktrees.SetItems(msg.Worktrees)
+	if m.pendingWorktreeSelection != "" {
+		pendingPath := m.pendingWorktreeSelection
+		m.worktrees = m.worktrees.SelectFunc(func(wt gitquery.Worktree) bool {
+			return wt.Path == pendingPath
+		})
+		m.pendingWorktreeSelection = ""
+	}
 	m = m.clampSelectionsAfterFilter()
 	return m
 }
@@ -420,6 +440,33 @@ func (m Model) handleWorktreeCreateFailed(msg WorktreeCreateFailedMsg) Model {
 			msg.Input,
 			validate,
 			submit,
+		).SetInputError(errText)
+	}
+	return m
+}
+
+func (m Model) handleWorktreeMoved(msg WorktreeMovedMsg) (tea.Model, tea.Cmd) {
+	if !m.isCurrentRepo(msg.RepoPath) {
+		return m, nil
+	}
+	m.pendingWorktreeSelection = msg.NewPath
+	m = m.clearStatus(statusOther)
+	return m.startFetchWorktrees()
+}
+
+func (m Model) handleWorktreeMoveFailed(msg WorktreeMoveFailedMsg) Model {
+	if m.isCurrentRepo(msg.RepoPath) {
+		errText := msg.Err
+		if errText == "" {
+			errText = "Unable to move worktree"
+		}
+		oldPath := msg.OldPath
+		m.modal = modal.OpenInput(
+			ui.WorktreeMovePrompt,
+			ui.WorktreeMoveInputPlaceholder,
+			msg.Input,
+			validateWorktreeMoveInput,
+			func(input string) tea.Cmd { return m.moveWorktree(oldPath, input) },
 		).SetInputError(errText)
 	}
 	return m

--- a/model/model_realrepo_test.go
+++ b/model/model_realrepo_test.go
@@ -218,6 +218,49 @@ func TestModel_CreateBranchFromSelectedBranchAgainstRealRepo(t *testing.T) {
 	}
 }
 
+func TestModel_MoveWorktreeAgainstRealRepo(t *testing.T) {
+	m, dir := setupModelRepo(t)
+	root := filepath.Dir(dir)
+	oldPath := filepath.Join(root, "repo-worktrees", "feat")
+	newPath := filepath.Join(root, "repo-worktrees", "feat-renamed")
+	mustGit(t, dir, "worktree", "add", oldPath, "-b", "feat")
+
+	m = inRightPane(m)
+	m, _ = update(m, m.Init()())
+	if len(m.Worktrees()) != 2 {
+		t.Fatalf("expected root and linked worktree, got %+v", m.Worktrees())
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feat-renamed")})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected move command")
+	}
+	moved, ok := cmd().(model.WorktreeMovedMsg)
+	if !ok {
+		t.Fatalf("expected WorktreeMovedMsg, got %T", cmd())
+	}
+	if moved.OldPath != oldPath || moved.NewPath != newPath {
+		t.Fatalf("unexpected move message: %+v", moved)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("expected old worktree path removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("expected new worktree path to exist: %v", err)
+	}
+
+	m, cmd = update(m, moved)
+	if cmd == nil {
+		t.Fatal("expected refresh command after move")
+	}
+	m, _ = update(m, cmd())
+	if got := m.Worktrees()[m.WorktreeSelected()].Path; got != newPath {
+		t.Fatalf("expected moved worktree selected at %q, got %q", newPath, got)
+	}
+}
+
 func TestModel_StashDiffPayloadAgainstRealRepo(t *testing.T) {
 	m, dir := setupModelRepo(t)
 	writeFile(t, dir, "README.md", "hello\nstashed\n")

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -515,6 +515,77 @@ func TestModel_ViewWorktreesModeLockedShowsUnlockHint(t *testing.T) {
 	}
 }
 
+func TestModel_ViewWorktreesModeShowsMoveHintForMovableWorktree(t *testing.T) {
+	tests := []struct {
+		name     string
+		worktree gitquery.Worktree
+	}{
+		{"clean", gitquery.Worktree{Path: "/dev/alpha-worktrees/feat", BranchName: "feat"}},
+		{"dirty", gitquery.Worktree{Path: "/dev/alpha-worktrees/feat", BranchName: "feat", Dirty: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := model.New(testRepos())
+			m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+			m = inRightPane(m)
+			m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+				{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+				tt.worktree,
+			}})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+			view := m.View()
+			if !strings.Contains(view, "m: move") {
+				t.Fatalf("movable %s worktree should show move hint, got:\n%s", tt.name, view)
+			}
+		})
+	}
+}
+
+func TestModel_ViewWorktreesModeHidesMoveHintForIneligibleWorktrees(t *testing.T) {
+	tests := []struct {
+		name     string
+		worktree gitquery.Worktree
+	}{
+		{"main", gitquery.Worktree{Path: "/dev/alpha", BranchName: "main", IsMain: true}},
+		{"stale", gitquery.Worktree{Path: "/dev/alpha-worktrees/feat", BranchName: "feat", Stale: true}},
+		{"locked", gitquery.Worktree{Path: "/dev/alpha-worktrees/feat", BranchName: "feat", Locked: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := model.New(testRepos())
+			m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+			m = inRightPane(m)
+			m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{tt.worktree}})
+
+			view := m.View()
+			if strings.Contains(view, "m: move") {
+				t.Fatalf("%s worktree should not show move hint, got:\n%s", tt.name, view)
+			}
+		})
+	}
+}
+
+func TestModel_ViewWorktreeMoveInputShowsPromptAndPlaceholder(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha-worktrees/feat", BranchName: "feat"},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+
+	view := m.View()
+	if !strings.Contains(view, "Move worktree to:") {
+		t.Fatalf("move input should show prompt, got:\n%s", view)
+	}
+	if !strings.Contains(view, ui.WorktreeMoveInputPlaceholder) {
+		t.Fatalf("move input should show placeholder, got:\n%s", view)
+	}
+}
+
 func TestModel_ViewWorktreesModeLockedStaleHidesDeleteAndPruneHints(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -25,8 +25,10 @@ const (
 )
 
 const BranchPrompt = "New branch"
+const WorktreeMovePrompt = "Move worktree to"
 const PRWorktreePrompt = "PR worktree"
 const WorktreeInputPlaceholder = "branch, tag, or new branch name"
+const WorktreeMoveInputPlaceholder = "new path or sibling name"
 const BranchInputPlaceholder = "branch name"
 const PRWorktreeInputPlaceholder = "PR number or URL"
 const AgentInputPlaceholder = "codex or claude"
@@ -155,6 +157,7 @@ type RenderParams struct {
 	RightEmptyMessage        string
 	FetchAvailable           bool
 	PullAvailable            bool
+	WorktreeMoveAvailable    bool
 	AgentAvailable           bool
 	NewAgentAvailable        bool
 }
@@ -178,7 +181,7 @@ func Render(p RenderParams) string {
 		repoPath = p.Repos[p.Selected].Path
 	}
 
-	var worktreeSelected, staleSelected, dirtySelected, lockedSelected, worktreeDeletableSelected, worktreeOpenableSelected bool
+	var worktreeSelected, staleSelected, dirtySelected, lockedSelected, worktreeDeletableSelected, worktreeOpenableSelected, worktreeMoveSelected bool
 	if p.Mode == ModeWorktrees && p.WorktreeSelected >= 0 && p.WorktreeSelected < len(p.Worktrees) {
 		worktreeSelected = true
 		wt := p.Worktrees[p.WorktreeSelected]
@@ -187,6 +190,7 @@ func Render(p RenderParams) string {
 		lockedSelected = wt.Locked
 		worktreeDeletableSelected = !wt.IsMain && !wt.Stale && !wt.Locked
 		worktreeOpenableSelected = !wt.Stale
+		worktreeMoveSelected = p.WorktreeMoveAvailable
 	}
 	var branchDirtySelected, branchDeletableSelected, branchOpenableSelected bool
 	if p.Mode == ModeBranches && p.BranchSelected >= 0 && p.BranchSelected < len(p.Branches) {
@@ -211,6 +215,7 @@ func Render(p RenderParams) string {
 		LockedSelected:            lockedSelected,
 		WorktreeDeletableSelected: worktreeDeletableSelected,
 		WorktreeOpenableSelected:  worktreeOpenableSelected,
+		WorktreeMoveSelected:      worktreeMoveSelected,
 		BranchDirtySelected:       branchDirtySelected,
 		BranchDeletableSelected:   branchDeletableSelected,
 		BranchOpenableSelected:    branchOpenableSelected,
@@ -396,6 +401,7 @@ type statusBarParams struct {
 	LockedSelected            bool
 	WorktreeDeletableSelected bool
 	WorktreeOpenableSelected  bool
+	WorktreeMoveSelected      bool
 	BranchDirtySelected       bool
 	BranchDeletableSelected   bool
 	BranchOpenableSelected    bool
@@ -571,6 +577,9 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 			if sp.DirtySelected {
 				actions = append(actions, shortcutHint{Key: "enter", Label: "diff"})
 			}
+			if sp.WorktreeMoveSelected {
+				actions = append(actions, shortcutHint{Key: "m", Label: "move"})
+			}
 			if sp.Destructive && sp.WorktreeDeletableSelected {
 				actions = append(actions, shortcutHint{Key: "d", Label: "delete", Warning: true})
 			}
@@ -734,7 +743,7 @@ func renderWorktreeFooterShortcuts(sp statusBarParams, sections []shortcutSectio
 			parts = candidate
 		}
 	}
-	for _, key := range []string{"n", "N", "d", "p", "u", "enter", "f", "F"} {
+	for _, key := range []string{"n", "N", "m", "d", "p", "u", "enter", "f", "F"} {
 		if hint, ok := findShortcutHint(hints, key); ok {
 			parts = append(parts, renderFooterHint(hint))
 		}
@@ -761,7 +770,7 @@ func renderWorktreeFooterShortcuts(sp statusBarParams, sections []shortcutSectio
 
 func worktreeFooterParts(hints []shortcutHint, includeDestructiveMode bool) []string {
 	var parts []string
-	keys := []string{"n", "N", "d", "p", "u", "enter", "f", "F"}
+	keys := []string{"n", "N", "m", "d", "p", "u", "enter", "f", "F"}
 	if includeDestructiveMode {
 		keys = append([]string{"D"}, keys...)
 	}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -529,6 +529,81 @@ func TestRender_WorktreeRootOmitsDeleteHint(t *testing.T) {
 	}
 }
 
+func TestRender_WorktreeMoveHintAvailability(t *testing.T) {
+	tests := []struct {
+		name     string
+		worktree gitquery.Worktree
+		canMove  bool
+		wantMove bool
+	}{
+		{
+			name:     "movable linked worktree",
+			worktree: gitquery.Worktree{Path: "/a-worktrees/feat", BranchName: "feat"},
+			canMove:  true,
+			wantMove: true,
+		},
+		{
+			name:     "dirty linked worktree",
+			worktree: gitquery.Worktree{Path: "/a-worktrees/feat", BranchName: "feat", Dirty: true},
+			canMove:  true,
+			wantMove: true,
+		},
+		{
+			name:     "main worktree",
+			worktree: gitquery.Worktree{Path: "/a", BranchName: "main", IsMain: true},
+		},
+		{
+			name:     "stale worktree",
+			worktree: gitquery.Worktree{Path: "/a-worktrees/feat", BranchName: "feat", Stale: true},
+		},
+		{
+			name:     "locked worktree",
+			worktree: gitquery.Worktree{Path: "/a-worktrees/feat", BranchName: "feat", Locked: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view := Render(RenderParams{
+				Repos:                 []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+				Selected:              0,
+				Width:                 120,
+				Height:                18,
+				Mode:                  ModeWorktrees,
+				Worktrees:             []gitquery.Worktree{tt.worktree},
+				WorktreeSelected:      0,
+				ActivePane:            1,
+				WorktreeMoveAvailable: tt.canMove,
+			})
+			hasMove := strings.Contains(view, "m: move")
+			if hasMove != tt.wantMove {
+				t.Fatalf("move hint visibility mismatch, want %v got %v:\n%s", tt.wantMove, hasMove, view)
+			}
+		})
+	}
+}
+
+func TestRender_NarrowWorktreeFooterIncludesMoveWhenAvailable(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:                 []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:              0,
+		Width:                 100,
+		Height:                18,
+		Mode:                  ModeWorktrees,
+		Worktrees:             []gitquery.Worktree{{Path: "/a-worktrees/feat", BranchName: "feat"}},
+		WorktreeSelected:      0,
+		ActivePane:            1,
+		WorktreeMoveAvailable: true,
+	})
+	if strings.Contains(view, "Shortcuts") {
+		t.Fatal("narrow render should keep shortcuts in footer")
+	}
+	footer := strings.Split(view, "\n")[len(strings.Split(view, "\n"))-1]
+	if !strings.Contains(footer, "m: move") {
+		t.Fatalf("narrow footer should include move hint, got %q", footer)
+	}
+}
+
 func TestRender_BranchShortcutPaneShowsDiffButOmitsRootDelete(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
@@ -1179,6 +1254,24 @@ func TestRender_WorktreeInputDialogShowsPlaceholder(t *testing.T) {
 	})
 	if !strings.Contains(view, "branch, tag, or new branch name") {
 		t.Error("worktree input dialog should show placeholder when input is empty")
+	}
+}
+
+func TestRender_WorktreeMoveInputDialogShowsPromptAndPlaceholder(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:                    []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:                    80,
+		Height:                   24,
+		Mode:                     1,
+		Overlay:                  OverlayWorktreeInput,
+		WorktreeInputPrompt:      WorktreeMovePrompt,
+		WorktreeInputPlaceholder: WorktreeMoveInputPlaceholder,
+	})
+	if !strings.Contains(view, "Move worktree to:") {
+		t.Error("move input dialog should show move prompt")
+	}
+	if !strings.Contains(view, WorktreeMoveInputPlaceholder) {
+		t.Error("move input dialog should show move placeholder")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an actions.MoveWorktree API around git worktree move with destination resolution, parent creation, and cleanup on failure
- add a worktrees-pane m shortcut that prompts for a new path/name, runs the move, refreshes, and reselects the moved worktree when present
- update shortcut rendering, README docs, and roadmap status for worktree move/rename

## Verification
- gofmt -l .
- make test
- make build

## Review loop
- Loop 1: 8/10
- Loop 2: 8/10
- Loop 3: 9/10