### PR TITLE
Add bootstrap hooks for worktree creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,12 @@ create a worktree without launching an agent. Enter an existing branch, tag, or
 new branch name; wtui creates it under a sibling `<repo>-worktrees/` directory
 and refreshes the list. Press `P` to create a review worktree from a GitHub PR
 number or URL; wtui fetches the PR head into `pr-<number>` and checks it out
-under the same sibling worktree directory. Press `f` to `git fetch --prune` and
-`F` to `git pull --ff-only` for the selected worktree. Locked worktrees cannot
-be deleted or pruned; press `u` to unlock one.
+under the same sibling worktree directory. If a matching `[bootstrap]` hook is
+configured, wtui runs it after successful worktree creation; hook failures keep
+the worktree, show a status error, and prevent automatic agent launch for `N`.
+Press `f` to `git fetch --prune` and `F` to `git pull --ff-only` for the
+selected worktree. Locked worktrees cannot be deleted or pruned; press `u` to
+unlock one.
 
 ### Branches view (mode 2)
 
@@ -168,11 +171,19 @@ max_depth = 2
 
 [agent]
 command = "codex"
+
+[bootstrap]
+timeout_seconds = 120
+
+[[bootstrap.hooks]]
+repo_path = "~/projects/wtui"
+script = ".wtui/bootstrap"
 ```
 
 `WORKTREE_ROOT` overrides `[scan].root` when both are set. See
-[docs/config.md](docs/config.md) for the full config reference, including parsed
-foundation fields for editor, terminal, provider, launch, and agent settings.
+[docs/config.md](docs/config.md) for the full config reference, including
+bootstrap hook settings and parsed foundation fields for editor, terminal,
+provider, launch, and agent settings.
 
 | Env var | Default | Description |
 |---------|---------|-------------|

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -11,6 +12,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 	"unicode"
 
 	"github.com/brian-bell/wtui/agent"
@@ -23,6 +26,37 @@ type commandSpec struct {
 
 type lookPathFunc func(string) (string, error)
 type getenvFunc func(string) string
+
+// BootstrapHook configures a script to run after a worktree is created.
+type BootstrapHook struct {
+	Script         string
+	TimeoutSeconds int
+}
+
+// WorktreeCreateKind identifies which create flow produced the worktree.
+type WorktreeCreateKind int
+
+const (
+	WorktreeCreateGeneric WorktreeCreateKind = iota
+	WorktreeCreatePullRequest
+)
+
+func (k WorktreeCreateKind) String() string {
+	switch k {
+	case WorktreeCreatePullRequest:
+		return "pull_request"
+	default:
+		return "generic"
+	}
+}
+
+// BootstrapContext describes the worktree creation that triggered a hook.
+type BootstrapContext struct {
+	RepoPath     string
+	WorktreePath string
+	Ref          string
+	Kind         WorktreeCreateKind
+}
 
 // RemoveWorktree runs `git worktree remove` for the given worktree path,
 // then prunes stale references to ensure the worktree no longer appears
@@ -76,6 +110,104 @@ func runGit(path string, args ...string) error {
 		return errors.New(msg)
 	}
 	return nil
+}
+
+// RunBootstrapHook executes a configured bootstrap script directly, with the
+// created worktree as its working directory.
+func RunBootstrapHook(ctx BootstrapContext, hook BootstrapHook) error {
+	scriptPath := hook.Script
+	if !filepath.IsAbs(scriptPath) {
+		scriptPath = filepath.Join(ctx.WorktreePath, scriptPath)
+	}
+	info, err := os.Stat(scriptPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("bootstrap hook not found: %s", scriptPath)
+		}
+		return fmt.Errorf("stat bootstrap hook %s: %w", scriptPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("bootstrap hook is not a regular file: %s", scriptPath)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("bootstrap hook is not executable: %s", scriptPath)
+	}
+
+	timeout := hook.TimeoutSeconds
+	if timeout == 0 {
+		timeout = 120
+	}
+	if timeout < 0 {
+		return fmt.Errorf("bootstrap hook timeout must be >= 0")
+	}
+	commandCtx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, scriptPath)
+	cmd.Dir = ctx.WorktreePath
+	cmd.Env = append(os.Environ(),
+		"WTUI_REPO_PATH="+ctx.RepoPath,
+		"WTUI_WORKTREE_PATH="+ctx.WorktreePath,
+		"WTUI_WORKTREE_REF="+ctx.Ref,
+		"WTUI_WORKTREE_CREATE_KIND="+ctx.Kind.String(),
+	)
+	output := newTailBuffer(4096)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	cmd.WaitDelay = 2 * time.Second
+	err = cmd.Run()
+	msg := output.String()
+	if commandCtx.Err() == context.DeadlineExceeded {
+		if msg != "" {
+			return fmt.Errorf("bootstrap hook %s timed out after %ds: %s", scriptPath, timeout, msg)
+		}
+		return fmt.Errorf("bootstrap hook %s timed out after %ds", scriptPath, timeout)
+	}
+	if err != nil {
+		if msg == "" {
+			return fmt.Errorf("bootstrap hook %s failed: %w", scriptPath, err)
+		}
+		return fmt.Errorf("bootstrap hook %s failed: %s", scriptPath, msg)
+	}
+	return nil
+}
+
+type tailBuffer struct {
+	mu        sync.Mutex
+	buf       []byte
+	limit     int
+	truncated bool
+}
+
+func newTailBuffer(limit int) *tailBuffer {
+	return &tailBuffer{limit: limit}
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = append(b.buf, p...)
+	if len(b.buf) > b.limit {
+		b.truncated = true
+		b.buf = append([]byte(nil), b.buf[len(b.buf)-b.limit:]...)
+		if idx := strings.IndexByte(string(b.buf), '\n'); idx >= 0 && idx+1 < len(b.buf) {
+			b.buf = append([]byte(nil), b.buf[idx+1:]...)
+		}
+	}
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	msg := strings.TrimSpace(string(b.buf))
+	if msg == "" {
+		return ""
+	}
+	if b.truncated {
+		return "... " + msg
+	}
+	return msg
 }
 
 // CreateWorktree creates a new worktree from an existing branch/tag/ref, or
@@ -182,6 +314,16 @@ func ValidatePullRequestWorktreeInput(repoPath, input string) error {
 		return err
 	}
 	return validatePullRequestRepo(repoPath, pr)
+}
+
+// NormalizePullRequestWorktreeRef returns the stable PR ref value wtui exposes
+// to post-create integrations.
+func NormalizePullRequestWorktreeRef(input string) (string, error) {
+	pr, err := parsePullRequestInput(input)
+	if err != nil {
+		return "", err
+	}
+	return strconv.Itoa(pr.Number), nil
 }
 
 // DefaultWorktreePath returns the conventional sibling path used for new

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -745,6 +745,176 @@ func TestCreateWorktree_RefStartingWithDashFails(t *testing.T) {
 	}
 }
 
+func TestRunBootstrapHook_RunsExecutableScriptInWorktree(t *testing.T) {
+	dir := t.TempDir()
+	repoPath := filepath.Join(dir, "repo")
+	worktreePath := filepath.Join(dir, "worktree")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(worktreePath, ".wtui", "bootstrap")
+	if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scriptPath, []byte(`#!/bin/sh
+pwd > cwd.txt
+printf "%s
+%s
+%s
+%s
+" "$WTUI_REPO_PATH" "$WTUI_WORKTREE_PATH" "$WTUI_WORKTREE_REF" "$WTUI_WORKTREE_CREATE_KIND" > env.txt
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := actions.RunBootstrapHook(actions.BootstrapContext{
+		RepoPath:     repoPath,
+		WorktreePath: worktreePath,
+		Ref:          "feature/one",
+		Kind:         actions.WorktreeCreateGeneric,
+	}, actions.BootstrapHook{Script: ".wtui/bootstrap", TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("RunBootstrapHook returned error: %v", err)
+	}
+
+	cwd, err := os.ReadFile(filepath.Join(worktreePath, "cwd.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	physicalWorktreePath, err := filepath.EvalSymlinks(worktreePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(cwd)) != physicalWorktreePath {
+		t.Fatalf("expected hook cwd %q, got %q", physicalWorktreePath, strings.TrimSpace(string(cwd)))
+	}
+	env, err := os.ReadFile(filepath.Join(worktreePath, "env.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.Join([]string{repoPath, worktreePath, "feature/one", "generic"}, "\n")
+	if strings.TrimSpace(string(env)) != want {
+		t.Fatalf("unexpected hook env:\n%s", env)
+	}
+}
+
+func TestRunBootstrapHook_AbsoluteScript(t *testing.T) {
+	dir := t.TempDir()
+	worktreePath := filepath.Join(dir, "worktree")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scriptPath := filepath.Join(dir, "bootstrap")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\ntouch absolute-ran\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := actions.RunBootstrapHook(actions.BootstrapContext{
+		RepoPath:     filepath.Join(dir, "repo"),
+		WorktreePath: worktreePath,
+		Ref:          "123",
+		Kind:         actions.WorktreeCreatePullRequest,
+	}, actions.BootstrapHook{Script: scriptPath, TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("RunBootstrapHook returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(worktreePath, "absolute-ran")); err != nil {
+		t.Fatalf("expected absolute hook to run in worktree: %v", err)
+	}
+}
+
+func TestRunBootstrapHook_ReportsScriptValidationErrors(t *testing.T) {
+	worktreePath := t.TempDir()
+	missingErr := actions.RunBootstrapHook(actions.BootstrapContext{
+		RepoPath:     "/repo",
+		WorktreePath: worktreePath,
+		Ref:          "feat",
+		Kind:         actions.WorktreeCreateGeneric,
+	}, actions.BootstrapHook{Script: ".wtui/missing", TimeoutSeconds: 5})
+	if missingErr == nil || !strings.Contains(missingErr.Error(), "bootstrap hook not found") {
+		t.Fatalf("expected missing hook error, got %v", missingErr)
+	}
+
+	scriptPath := filepath.Join(worktreePath, "bootstrap")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nexit 0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	execErr := actions.RunBootstrapHook(actions.BootstrapContext{
+		RepoPath:     "/repo",
+		WorktreePath: worktreePath,
+		Ref:          "feat",
+		Kind:         actions.WorktreeCreateGeneric,
+	}, actions.BootstrapHook{Script: "bootstrap", TimeoutSeconds: 5})
+	if execErr == nil || !strings.Contains(execErr.Error(), "bootstrap hook is not executable") {
+		t.Fatalf("expected executable-bit error, got %v", execErr)
+	}
+}
+
+func TestRunBootstrapHook_FailurePrefersScriptOutput(t *testing.T) {
+	worktreePath := t.TempDir()
+	scriptPath := filepath.Join(worktreePath, "bootstrap")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\necho first\necho useful failure >&2\nexit 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := actions.RunBootstrapHook(actions.BootstrapContext{
+		RepoPath:     "/repo",
+		WorktreePath: worktreePath,
+		Ref:          "feat",
+		Kind:         actions.WorktreeCreateGeneric,
+	}, actions.BootstrapHook{Script: "bootstrap", TimeoutSeconds: 5})
+	if err == nil {
+		t.Fatal("expected hook failure")
+	}
+	if !strings.Contains(err.Error(), "useful failure") {
+		t.Fatalf("expected script output, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), scriptPath) {
+		t.Fatalf("expected script path in error, got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "exit status") {
+		t.Fatalf("expected clean output without exit status, got %q", err.Error())
+	}
+}
+
+func TestRunBootstrapHook_Timeout(t *testing.T) {
+	worktreePath := t.TempDir()
+	scriptPath := filepath.Join(worktreePath, "bootstrap")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nsleep 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := actions.RunBootstrapHook(actions.BootstrapContext{
+		RepoPath:     "/repo",
+		WorktreePath: worktreePath,
+		Ref:          "feat",
+		Kind:         actions.WorktreeCreateGeneric,
+	}, actions.BootstrapHook{Script: "bootstrap", TimeoutSeconds: 1})
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+	if !strings.Contains(err.Error(), "timed out after 1s") {
+		t.Fatalf("expected timeout error, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), scriptPath) {
+		t.Fatalf("expected script path in timeout error, got %q", err.Error())
+	}
+}
+
+func TestNormalizePullRequestWorktreeRef(t *testing.T) {
+	for _, input := range []string{"123", "#123", "https://github.com/acme/project/pull/123/files"} {
+		t.Run(input, func(t *testing.T) {
+			ref, err := actions.NormalizePullRequestWorktreeRef(input)
+			if err != nil {
+				t.Fatalf("NormalizePullRequestWorktreeRef returned error: %v", err)
+			}
+			if ref != "123" {
+				t.Fatalf("expected normalized ref 123, got %q", ref)
+			}
+		})
+	}
+}
+
 func TestCreateBranch_FromHEAD(t *testing.T) {
 	repoPath := setupRepo(t)
 	head := runOutput(t, repoPath, "git", "rev-parse", "HEAD")

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/brian-bell/wtui/actions"
 	"github.com/brian-bell/wtui/config"
 	"github.com/brian-bell/wtui/internal/version"
 	"github.com/brian-bell/wtui/model"
@@ -92,11 +94,34 @@ func fillRunDeps(deps runDeps) runDeps {
 
 func startProgram(repos []scanner.Repo, cfg config.Config) error {
 	p := tea.NewProgram(model.NewWithOptions(repos, model.Options{
-		AgentCommand: cfg.Agent.Command,
+		AgentCommand:         cfg.Agent.Command,
+		BootstrapHookForRepo: bootstrapHookResolver(cfg),
+		RunBootstrapHook:     actions.RunBootstrapHook,
 		SaveAgentCommand: func(command string) error {
 			return config.SaveAgentCommand(command)
 		},
 	}), tea.WithAltScreen())
 	_, err := p.Run()
 	return err
+}
+
+func bootstrapHookResolver(cfg config.Config) func(string) (actions.BootstrapHook, bool) {
+	hooks := make(map[string]actions.BootstrapHook, len(cfg.Bootstrap.Hooks))
+	for _, hook := range cfg.Bootstrap.Hooks {
+		timeout := hook.TimeoutSeconds
+		if timeout == 0 {
+			timeout = cfg.Bootstrap.TimeoutSeconds
+		}
+		if timeout == 0 {
+			timeout = 120
+		}
+		hooks[filepath.Clean(hook.RepoPath)] = actions.BootstrapHook{
+			Script:         hook.Script,
+			TimeoutSeconds: timeout,
+		}
+	}
+	return func(repoPath string) (actions.BootstrapHook, bool) {
+		hook, ok := hooks[filepath.Clean(repoPath)]
+		return hook, ok
+	}
 }

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bytes"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/brian-bell/wtui/actions"
 	"github.com/brian-bell/wtui/config"
 	"github.com/brian-bell/wtui/internal/version"
 	"github.com/brian-bell/wtui/scanner"
@@ -140,5 +142,49 @@ func TestRun_PassesConfigToProgram(t *testing.T) {
 	}
 	if got.Agent.Command != "codex" {
 		t.Fatalf("expected agent config passed to program, got %q", got.Agent.Command)
+	}
+}
+
+func TestBootstrapHookResolverMatchesConfiguredRepoPath(t *testing.T) {
+	cfg := config.Config{
+		Bootstrap: config.BootstrapConfig{
+			TimeoutSeconds: 120,
+			Hooks: []config.BootstrapHookConfig{
+				{RepoPath: filepath.Clean("/dev/wtui/"), Script: ".wtui/bootstrap"},
+				{RepoPath: "/dev/client-api", Script: "/bin/bootstrap-client-api", TimeoutSeconds: 300},
+			},
+		},
+	}
+	resolve := bootstrapHookResolver(cfg)
+
+	hook, ok := resolve("/dev/wtui")
+	if !ok {
+		t.Fatal("expected hook for configured repo")
+	}
+	if hook != (actions.BootstrapHook{Script: ".wtui/bootstrap", TimeoutSeconds: 120}) {
+		t.Fatalf("unexpected hook: %#v", hook)
+	}
+
+	hook, ok = resolve("/dev/client-api")
+	if !ok {
+		t.Fatal("expected hook for second configured repo")
+	}
+	if hook.TimeoutSeconds != 300 {
+		t.Fatalf("expected per-hook timeout override 300, got %d", hook.TimeoutSeconds)
+	}
+}
+
+func TestBootstrapHookResolverDoesNotMatchDifferentRepoPath(t *testing.T) {
+	resolve := bootstrapHookResolver(config.Config{
+		Bootstrap: config.BootstrapConfig{
+			TimeoutSeconds: 120,
+			Hooks: []config.BootstrapHookConfig{
+				{RepoPath: "/dev/wtui", Script: ".wtui/bootstrap"},
+			},
+		},
+	})
+
+	if _, ok := resolve("/dev/wtui-other"); ok {
+		t.Fatal("expected non-matching repo to have no hook")
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -16,12 +16,13 @@ type homeDirFunc func() (string, error)
 
 // Config is wtui's parsed configuration file.
 type Config struct {
-	Scan     ScanConfig     `toml:"scan"`
-	Editor   EditorConfig   `toml:"editor"`
-	Terminal TerminalConfig `toml:"terminal"`
-	Provider ProviderConfig `toml:"provider"`
-	Launch   LaunchConfig   `toml:"launch"`
-	Agent    AgentConfig    `toml:"agent"`
+	Scan      ScanConfig      `toml:"scan"`
+	Editor    EditorConfig    `toml:"editor"`
+	Terminal  TerminalConfig  `toml:"terminal"`
+	Provider  ProviderConfig  `toml:"provider"`
+	Launch    LaunchConfig    `toml:"launch"`
+	Agent     AgentConfig     `toml:"agent"`
+	Bootstrap BootstrapConfig `toml:"bootstrap"`
 }
 
 // ScanConfig configures repository discovery.
@@ -53,6 +54,19 @@ type LaunchConfig struct {
 // AgentConfig stores the user's preferred interactive coding agent.
 type AgentConfig struct {
 	Command string `toml:"command"`
+}
+
+// BootstrapConfig configures optional scripts that run after worktree creation.
+type BootstrapConfig struct {
+	TimeoutSeconds int                   `toml:"timeout_seconds"`
+	Hooks          []BootstrapHookConfig `toml:"hooks"`
+}
+
+// BootstrapHookConfig maps one repository to its bootstrap script.
+type BootstrapHookConfig struct {
+	RepoPath       string `toml:"repo_path"`
+	Script         string `toml:"script"`
+	TimeoutSeconds int    `toml:"timeout_seconds"`
 }
 
 type loadOptions struct {
@@ -147,7 +161,48 @@ func parseConfigData(path string, data []byte, opts loadOptions) (Config, error)
 		}
 	}
 
+	if err := normalizeBootstrapConfig(path, &cfg.Bootstrap, opts); err != nil {
+		return Config{}, err
+	}
+
 	return cfg, nil
+}
+
+func normalizeBootstrapConfig(path string, cfg *BootstrapConfig, opts loadOptions) error {
+	if cfg.TimeoutSeconds < 0 {
+		return fmt.Errorf("parse config %s: bootstrap.timeout_seconds must be >= 0", path)
+	}
+	if cfg.TimeoutSeconds == 0 {
+		cfg.TimeoutSeconds = 120
+	}
+
+	for i := range cfg.Hooks {
+		hook := &cfg.Hooks[i]
+		hook.RepoPath = strings.TrimSpace(hook.RepoPath)
+		hook.Script = strings.TrimSpace(hook.Script)
+		if hook.RepoPath == "" {
+			return fmt.Errorf("parse config %s: bootstrap.hooks[%d].repo_path is required", path, i)
+		}
+		if hook.Script == "" {
+			return fmt.Errorf("parse config %s: bootstrap.hooks[%d].script is required", path, i)
+		}
+		if hook.TimeoutSeconds < 0 {
+			return fmt.Errorf("parse config %s: bootstrap.hooks[%d].timeout_seconds must be >= 0", path, i)
+		}
+
+		repoPath, err := expandHome(hook.RepoPath, opts.homeDir)
+		if err != nil {
+			return fmt.Errorf("expand bootstrap repo_path in config %s: %w", path, err)
+		}
+		hook.RepoPath = filepath.Clean(repoPath)
+
+		script, err := expandHome(hook.Script, opts.homeDir)
+		if err != nil {
+			return fmt.Errorf("expand bootstrap script in config %s: %w", path, err)
+		}
+		hook.Script = script
+	}
+	return nil
 }
 
 // DefaultPath returns the default config path:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,6 +42,18 @@ prefer_multiplexer = true
 
 [agent]
 command = "codex"
+
+[bootstrap]
+timeout_seconds = 180
+
+[[bootstrap.hooks]]
+repo_path = "~/wtui"
+script = ".wtui/bootstrap"
+
+[[bootstrap.hooks]]
+repo_path = "/dev/client-api/"
+script = "~/bin/bootstrap-client-api"
+timeout_seconds = 300
 `), 0o644)
 	if err != nil {
 		t.Fatal(err)
@@ -74,6 +86,123 @@ command = "codex"
 	}
 	if cfg.Agent.Command != "codex" {
 		t.Fatalf("expected agent command codex, got %q", cfg.Agent.Command)
+	}
+	if cfg.Bootstrap.TimeoutSeconds != 180 {
+		t.Fatalf("expected bootstrap timeout 180, got %d", cfg.Bootstrap.TimeoutSeconds)
+	}
+	if len(cfg.Bootstrap.Hooks) != 2 {
+		t.Fatalf("expected 2 bootstrap hooks, got %d", len(cfg.Bootstrap.Hooks))
+	}
+	if cfg.Bootstrap.Hooks[0].RepoPath != filepath.Join(home, "wtui") {
+		t.Fatalf("expected expanded repo path, got %q", cfg.Bootstrap.Hooks[0].RepoPath)
+	}
+	if cfg.Bootstrap.Hooks[0].Script != ".wtui/bootstrap" {
+		t.Fatalf("expected relative script preserved, got %q", cfg.Bootstrap.Hooks[0].Script)
+	}
+	if cfg.Bootstrap.Hooks[0].TimeoutSeconds != 0 {
+		t.Fatalf("expected hook timeout override omitted, got %d", cfg.Bootstrap.Hooks[0].TimeoutSeconds)
+	}
+	if cfg.Bootstrap.Hooks[1].RepoPath != filepath.Clean("/dev/client-api/") {
+		t.Fatalf("expected cleaned repo path, got %q", cfg.Bootstrap.Hooks[1].RepoPath)
+	}
+	if cfg.Bootstrap.Hooks[1].Script != filepath.Join(home, "bin", "bootstrap-client-api") {
+		t.Fatalf("expected expanded script path, got %q", cfg.Bootstrap.Hooks[1].Script)
+	}
+	if cfg.Bootstrap.Hooks[1].TimeoutSeconds != 300 {
+		t.Fatalf("expected per-hook timeout 300, got %d", cfg.Bootstrap.Hooks[1].TimeoutSeconds)
+	}
+}
+
+func TestLoadFrom_DefaultsBootstrapTimeout(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(`
+[bootstrap]
+
+[[bootstrap.hooks]]
+repo_path = "/dev/wtui"
+script = ".wtui/bootstrap"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+
+	if cfg.Bootstrap.TimeoutSeconds != 120 {
+		t.Fatalf("expected default bootstrap timeout 120, got %d", cfg.Bootstrap.TimeoutSeconds)
+	}
+}
+
+func TestLoadFrom_RejectsUnknownBootstrapFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[bootstrap]\ntimeout = 120\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := config.LoadFrom(path)
+	if err == nil {
+		t.Fatal("expected unknown bootstrap field error")
+	}
+	if !strings.Contains(err.Error(), "strict mode") {
+		t.Fatalf("expected strict decoder error, got %q", err.Error())
+	}
+}
+
+func TestLoadFrom_RejectsInvalidBootstrapHooks(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "missing repo path",
+			body: "[[bootstrap.hooks]]\nscript = \".wtui/bootstrap\"\n",
+			want: "repo_path",
+		},
+		{
+			name: "blank repo path",
+			body: "[[bootstrap.hooks]]\nrepo_path = \"   \"\nscript = \".wtui/bootstrap\"\n",
+			want: "repo_path",
+		},
+		{
+			name: "missing script",
+			body: "[[bootstrap.hooks]]\nrepo_path = \"/dev/wtui\"\n",
+			want: "script",
+		},
+		{
+			name: "blank script",
+			body: "[[bootstrap.hooks]]\nrepo_path = \"/dev/wtui\"\nscript = \"   \"\n",
+			want: "script",
+		},
+		{
+			name: "negative section timeout",
+			body: "[bootstrap]\ntimeout_seconds = -1\n",
+			want: "timeout_seconds",
+		},
+		{
+			name: "negative hook timeout",
+			body: "[[bootstrap.hooks]]\nrepo_path = \"/dev/wtui\"\nscript = \".wtui/bootstrap\"\ntimeout_seconds = -1\n",
+			want: "timeout_seconds",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(tc.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := config.LoadFrom(path)
+			if err == nil {
+				t.Fatal("expected invalid bootstrap config error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error to mention %q, got %q", tc.want, err.Error())
+			}
+		})
 	}
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,7 @@ exist:
 | Scan root | `WORKTREE_ROOT` | `[scan].root` | `~/dev` |
 | Terminal command | `TERMINAL` | none; `[terminal].command` is parsed but unused | platform fallback |
 | Coding agent | none | `[agent].command` | unset |
+| Bootstrap hook timeout | none | `[bootstrap].timeout_seconds` or hook override | `120` seconds |
 
 `[scan].root` supports `~` and `~/...` expansion. `WORKTREE_ROOT` is passed
 through as provided by the environment.
@@ -49,6 +50,18 @@ prefer_multiplexer = true
 
 [agent]
 command = "codex"
+
+[bootstrap]
+timeout_seconds = 120
+
+[[bootstrap.hooks]]
+repo_path = "~/dev/wtui"
+script = ".wtui/bootstrap"
+
+[[bootstrap.hooks]]
+repo_path = "~/dev/client-api"
+script = "~/bin/bootstrap-client-api"
+timeout_seconds = 300
 ```
 
 ## Sections
@@ -107,3 +120,32 @@ updates this value immediately, creating the config file if needed.
 | Key | Type | Description |
 |-----|------|-------------|
 | `command` | string | Supported values: `codex` or `claude`. |
+
+### `[bootstrap]`
+
+Configures optional per-repo scripts that run after wtui successfully creates a
+worktree with `n`, `P`, or `N`. Hooks are opt-in and are matched by configured
+repo path. wtui does not auto-discover scripts from scanned repositories.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `timeout_seconds` | integer | Default hook timeout. Omitted or `0` means `120`; negative values fail startup. |
+
+Add one `[[bootstrap.hooks]]` entry per repo:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `repo_path` | string | Required repo path to match. Supports `~` expansion. |
+| `script` | string | Required script path. Relative paths resolve from the newly created worktree; `~` paths are expanded. |
+| `timeout_seconds` | integer | Optional per-hook timeout override; negative values fail startup. |
+
+Bootstrap scripts execute directly, not through a shell. The script file must
+exist, be a regular file, and be executable. wtui sets the script working
+directory to the new worktree and appends these environment variables:
+`WTUI_REPO_PATH`, `WTUI_WORKTREE_PATH`, `WTUI_WORKTREE_REF`, and
+`WTUI_WORKTREE_CREATE_KIND`.
+
+If a hook fails, wtui keeps the created worktree and branch, refreshes the
+worktree list, and shows the hook error in the status bar. For `N`, a hook
+failure prevents automatic agent launch; the agent can still be launched
+manually afterward.

--- a/docs/roadmap-todo.md
+++ b/docs/roadmap-todo.md
@@ -23,7 +23,7 @@ clear.
 - [x] P1 - Branch creation from branches pane: complement worktree creation and make branch-first workflows smoother.
 - [ ] P2 - Worktree move/rename: wrap `git worktree move` for users who need to reorganize generated paths.
 - [ ] P2 - Bare repo support: detect bare repositories and support worktree creation/listing correctly for central bare repo workflows.
-- [ ] P2 - Bootstrap hooks: support an optional per-repo setup script after worktree creation for env files, dependency links, or setup commands.
+- [x] P2 - Bootstrap hooks: support an optional per-repo setup script after worktree creation for env files, dependency links, or setup commands.
 
 ## Phase 3: Multi-Repo Operations
 

--- a/model/model.go
+++ b/model/model.go
@@ -28,6 +28,8 @@ type Model struct {
 	modal                  modal.Modal
 	diffRequestSeq         uint64
 	listRequestSeq         uint64
+	worktreeCreateSeq      uint64
+	activeWorktreeCreate   uint64
 	listRequests           [listRequestSlots]uint64
 	activePane             int // 0=left (repos), 1=right (content)
 	destructive            bool
@@ -37,6 +39,8 @@ type Model struct {
 	agentCommand           string
 	saveAgent              func(string) error
 	launchAgent            func(string, string) (actions.TerminalLaunchSpec, error)
+	bootstrapHookForRepo   func(string) (actions.BootstrapHook, bool)
+	runBootstrapHook       func(actions.BootstrapContext, actions.BootstrapHook) error
 }
 
 type statusSource int
@@ -58,9 +62,11 @@ type statusError struct {
 // Options customizes production-only integrations while keeping New(repos)
 // simple for tests.
 type Options struct {
-	AgentCommand     string
-	SaveAgentCommand func(string) error
-	LaunchAgent      func(string, string) (actions.TerminalLaunchSpec, error)
+	AgentCommand         string
+	SaveAgentCommand     func(string) error
+	LaunchAgent          func(string, string) (actions.TerminalLaunchSpec, error)
+	BootstrapHookForRepo func(string) (actions.BootstrapHook, bool)
+	RunBootstrapHook     func(actions.BootstrapContext, actions.BootstrapHook) error
 }
 
 // New creates a Model from discovered repos.
@@ -78,17 +84,27 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if launchAgent == nil {
 		launchAgent = actions.AgentLaunch
 	}
+	bootstrapHookForRepo := opts.BootstrapHookForRepo
+	if bootstrapHookForRepo == nil {
+		bootstrapHookForRepo = func(string) (actions.BootstrapHook, bool) { return actions.BootstrapHook{}, false }
+	}
+	runBootstrapHook := opts.RunBootstrapHook
+	if runBootstrapHook == nil {
+		runBootstrapHook = actions.RunBootstrapHook
+	}
 	m := Model{
-		repos:        newRepoPane().SetItems(repos),
-		rows:         newBranchPane(),
-		stashes:      newStashPane(),
-		worktrees:    newWorktreePane(),
-		commits:      newCommitPane(),
-		reflogs:      newReflogPane(),
-		mode:         ui.ModeWorktrees,
-		agentCommand: agent.Normalize(opts.AgentCommand),
-		saveAgent:    saveAgent,
-		launchAgent:  launchAgent,
+		repos:                newRepoPane().SetItems(repos),
+		rows:                 newBranchPane(),
+		stashes:              newStashPane(),
+		worktrees:            newWorktreePane(),
+		commits:              newCommitPane(),
+		reflogs:              newReflogPane(),
+		mode:                 ui.ModeWorktrees,
+		agentCommand:         agent.Normalize(opts.AgentCommand),
+		saveAgent:            saveAgent,
+		launchAgent:          launchAgent,
+		bootstrapHookForRepo: bootstrapHookForRepo,
+		runBootstrapHook:     runBootstrapHook,
 	}
 	for mode := ui.ModeWorktrees; mode <= ui.ModeReflog; mode++ {
 		m.listRequestSeq++
@@ -382,6 +398,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleWorktreeCreated(msg)
 	case WorktreeCreateFailedMsg:
 		return m.handleWorktreeCreateFailed(msg), nil
+	case WorktreeBootstrapFailedMsg:
+		return m.handleWorktreeBootstrapFailed(msg)
 	case CommitResultMsg:
 		return m.handleCommitResult(msg), nil
 	case ReflogResultMsg:

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -61,6 +61,23 @@ func (m Model) nextListFetchRequest(mode ui.Mode) (Model, uint64) {
 	return m, request
 }
 
+func (m Model) nextWorktreeCreateRequest() (Model, uint64) {
+	m.worktreeCreateSeq++
+	m.activeWorktreeCreate = m.worktreeCreateSeq
+	return m, m.activeWorktreeCreate
+}
+
+func (m Model) isCurrentWorktreeCreateRequest(request uint64) bool {
+	return request == m.activeWorktreeCreate
+}
+
+func (m Model) clearWorktreeCreateRequest(request uint64) Model {
+	if request != 0 && request == m.activeWorktreeCreate {
+		m.activeWorktreeCreate = 0
+	}
+	return m
+}
+
 func (m Model) startFetchWorktrees() (Model, tea.Cmd) {
 	m, request := m.nextListFetchRequest(ui.ModeWorktrees)
 	return m, m.fetchWorktrees(request)
@@ -149,7 +166,7 @@ func (m Model) gitTargetPath(forPull bool) (string, string, bool) {
 	}
 }
 
-func (m Model) createWorktree(input string, launchAgent bool) tea.Cmd {
+func (m Model) createWorktree(input string, launchAgent bool, request uint64) tea.Cmd {
 	repoPath, ok := m.currentRepoPath()
 	if !ok {
 		return nil
@@ -157,9 +174,9 @@ func (m Model) createWorktree(input string, launchAgent bool) tea.Cmd {
 	return func() tea.Msg {
 		worktreePath, err := actions.CreateWorktree(repoPath, input)
 		if err != nil {
-			return WorktreeCreateFailedMsg{RepoPath: repoPath, Input: input, Err: err.Error(), LaunchAgent: launchAgent}
+			return WorktreeCreateFailedMsg{RepoPath: repoPath, Input: input, Err: err.Error(), LaunchAgent: launchAgent, Request: request}
 		}
-		return WorktreeCreatedMsg{RepoPath: repoPath, WorktreePath: worktreePath, LaunchAgent: launchAgent}
+		return m.finishWorktreeCreate(repoPath, worktreePath, input, actions.WorktreeCreateGeneric, launchAgent, request)
 	}
 }
 
@@ -202,7 +219,7 @@ func (m Model) selectedBranchStartPoint() string {
 	return "refs/heads/" + row.Branch.Name
 }
 
-func (m Model) createPullRequestWorktree(input string) tea.Cmd {
+func (m Model) createPullRequestWorktree(input string, request uint64) tea.Cmd {
 	repoPath, ok := m.currentRepoPath()
 	if !ok {
 		return nil
@@ -210,10 +227,31 @@ func (m Model) createPullRequestWorktree(input string) tea.Cmd {
 	return func() tea.Msg {
 		worktreePath, err := actions.CreatePullRequestWorktree(repoPath, input)
 		if err != nil {
-			return WorktreeCreateFailedMsg{RepoPath: repoPath, Input: input, Err: err.Error(), Kind: WorktreeCreatePullRequest}
+			return WorktreeCreateFailedMsg{RepoPath: repoPath, Input: input, Err: err.Error(), Kind: WorktreeCreatePullRequest, Request: request}
 		}
-		return WorktreeCreatedMsg{RepoPath: repoPath, WorktreePath: worktreePath}
+		ref, err := actions.NormalizePullRequestWorktreeRef(input)
+		if err != nil {
+			ref = input
+		}
+		return m.finishWorktreeCreate(repoPath, worktreePath, ref, actions.WorktreeCreatePullRequest, false, request)
 	}
+}
+
+func (m Model) finishWorktreeCreate(repoPath, worktreePath, ref string, kind actions.WorktreeCreateKind, launchAgent bool, request uint64) tea.Msg {
+	hook, ok := m.bootstrapHookForRepo(repoPath)
+	if !ok {
+		return WorktreeCreatedMsg{RepoPath: repoPath, WorktreePath: worktreePath, LaunchAgent: launchAgent, Request: request}
+	}
+	ctx := actions.BootstrapContext{
+		RepoPath:     repoPath,
+		WorktreePath: worktreePath,
+		Ref:          ref,
+		Kind:         kind,
+	}
+	if err := m.runBootstrapHook(ctx, hook); err != nil {
+		return WorktreeBootstrapFailedMsg{RepoPath: repoPath, WorktreePath: worktreePath, Err: err.Error(), LaunchAgent: launchAgent, Request: request}
+	}
+	return WorktreeCreatedMsg{RepoPath: repoPath, WorktreePath: worktreePath, LaunchAgent: launchAgent, BootstrapRan: true, Request: request}
 }
 
 func (m Model) fetchWorktrees(request uint64) tea.Cmd {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -16,7 +16,14 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	if m.modal.IsOpen() {
 		var cmd tea.Cmd
-		m.modal, _, cmd = m.modal.Update(msg)
+		view := m.modal.View()
+		var outcome modal.Outcome
+		m.modal, outcome, cmd = m.modal.Update(msg)
+		if outcome == modal.Accepted && cmd != nil && isWorktreeCreateInput(view) {
+			var request uint64
+			m, request = m.nextWorktreeCreateRequest()
+			cmd = tagWorktreeCreateRequest(cmd, request)
+		}
 		return m, cmd
 	}
 
@@ -64,6 +71,38 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleLeftPaneKey(key)
 	}
 	return m.handleRightPaneKey(key)
+}
+
+func isWorktreeCreateInput(view modal.View) bool {
+	if view.Kind != modal.Input {
+		return false
+	}
+	return view.Placeholder == ui.WorktreeInputPlaceholder || view.Placeholder == ui.PRWorktreeInputPlaceholder
+}
+
+func tagWorktreeCreateRequest(cmd tea.Cmd, request uint64) tea.Cmd {
+	return func() tea.Msg {
+		msg := cmd()
+		switch msg := msg.(type) {
+		case WorktreeCreatedMsg:
+			if msg.Request == 0 {
+				msg.Request = request
+			}
+			return msg
+		case WorktreeCreateFailedMsg:
+			if msg.Request == 0 {
+				msg.Request = request
+			}
+			return msg
+		case WorktreeBootstrapFailedMsg:
+			if msg.Request == 0 {
+				msg.Request = request
+			}
+			return msg
+		default:
+			return msg
+		}
+	}
 }
 
 func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -343,7 +382,7 @@ func (m Model) handleNewWorktree(launchAgent bool) (tea.Model, tea.Cmd) {
 		ui.WorktreeInputPlaceholder,
 		"",
 		validateWorktreeInput,
-		func(input string) tea.Cmd { return m.createWorktree(input, launchAgent) },
+		func(input string) tea.Cmd { return m.createWorktree(input, launchAgent, 0) },
 	)
 	return m, nil
 }
@@ -372,7 +411,7 @@ func (m Model) handleNewPullRequestWorktree() (tea.Model, tea.Cmd) {
 		ui.PRWorktreeInputPlaceholder,
 		"",
 		func(input string) error { return validatePullRequestWorktreeInput(repoPath, input) },
-		func(input string) tea.Cmd { return m.createPullRequestWorktree(input) },
+		func(input string) tea.Cmd { return m.createPullRequestWorktree(input, 0) },
 	)
 	return m, nil
 }

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -132,6 +132,8 @@ type WorktreeCreatedMsg struct {
 	RepoPath     string
 	WorktreePath string
 	LaunchAgent  bool
+	BootstrapRan bool
+	Request      uint64
 }
 
 type WorktreeCreateKind int
@@ -147,6 +149,15 @@ type WorktreeCreateFailedMsg struct {
 	Err         string
 	Kind        WorktreeCreateKind
 	LaunchAgent bool
+	Request     uint64
+}
+
+type WorktreeBootstrapFailedMsg struct {
+	RepoPath     string
+	WorktreePath string
+	Err          string
+	LaunchAgent  bool
+	Request      uint64
 }
 
 type ReflogResultMsg struct {
@@ -383,9 +394,10 @@ func (m Model) handleGitPullFailed(msg GitPullFailedMsg) Model {
 }
 
 func (m Model) handleWorktreeCreated(msg WorktreeCreatedMsg) (tea.Model, tea.Cmd) {
-	if !m.isCurrentRepo(msg.RepoPath) {
+	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentWorktreeCreateRequest(msg.Request) {
 		return m, nil
 	}
+	m = m.clearWorktreeCreateRequest(msg.Request)
 	m.mode = ui.ModeWorktrees
 	m.worktrees = m.worktrees.ResetSelection()
 	m, fetchCmd := m.startFetchWorktrees()
@@ -396,8 +408,26 @@ func (m Model) handleWorktreeCreated(msg WorktreeCreatedMsg) (tea.Model, tea.Cmd
 	return m, tea.Batch(fetchCmd, launchCmd)
 }
 
+func (m Model) handleWorktreeBootstrapFailed(msg WorktreeBootstrapFailedMsg) (tea.Model, tea.Cmd) {
+	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentWorktreeCreateRequest(msg.Request) {
+		return m, nil
+	}
+	m = m.clearWorktreeCreateRequest(msg.Request)
+	errText := msg.Err
+	if errText == "" {
+		errText = "bootstrap hook failed"
+	} else {
+		errText = "bootstrap hook failed: " + errText
+	}
+	m.mode = ui.ModeWorktrees
+	m.worktrees = m.worktrees.ResetSelection()
+	m = m.setStatus(statusGitMutation, errText)
+	return m.startFetchWorktrees()
+}
+
 func (m Model) handleWorktreeCreateFailed(msg WorktreeCreateFailedMsg) Model {
-	if m.isCurrentRepo(msg.RepoPath) {
+	if m.isCurrentRepo(msg.RepoPath) && m.isCurrentWorktreeCreateRequest(msg.Request) {
+		m = m.clearWorktreeCreateRequest(msg.Request)
 		errText := msg.Err
 		if msg.Err == "" {
 			errText = "Unable to create worktree"
@@ -405,12 +435,12 @@ func (m Model) handleWorktreeCreateFailed(msg WorktreeCreateFailedMsg) Model {
 		prompt := "New worktree"
 		placeholder := ui.WorktreeInputPlaceholder
 		validate := validateWorktreeInput
-		submit := func(input string) tea.Cmd { return m.createWorktree(input, msg.LaunchAgent) }
+		submit := func(input string) tea.Cmd { return m.createWorktree(input, msg.LaunchAgent, 0) }
 		if msg.Kind == WorktreeCreatePullRequest {
 			prompt = ui.PRWorktreePrompt
 			placeholder = ui.PRWorktreeInputPlaceholder
 			validate = func(input string) error { return validatePullRequestWorktreeInput(msg.RepoPath, input) }
-			submit = func(input string) tea.Cmd { return m.createPullRequestWorktree(input) }
+			submit = func(input string) tea.Cmd { return m.createPullRequestWorktree(input, 0) }
 		} else if msg.LaunchAgent {
 			prompt = "Create worktree and launch agent from"
 		}

--- a/model/model_realrepo_test.go
+++ b/model/model_realrepo_test.go
@@ -1,6 +1,7 @@
 package model_test
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -70,6 +71,36 @@ func setupModelRepoWithOptions(t *testing.T, opts model.Options) (model.Model, s
 	_, dir := setupModelRepo(t)
 	m := model.NewWithOptions([]scanner.Repo{{Path: dir, DisplayName: filepath.Base(dir)}}, opts)
 	return m, dir
+}
+
+func setupModelPullRequestRepoWithOptions(t *testing.T, opts model.Options) (model.Model, string) {
+	t.Helper()
+	dir := t.TempDir()
+	upstream := filepath.Join(dir, "upstream")
+	origin := filepath.Join(dir, "origin.git")
+	local := filepath.Join(dir, "local")
+	mustGit(t, dir, "init", upstream)
+	mustGit(t, upstream, "config", "user.email", "test@test.com")
+	mustGit(t, upstream, "config", "user.name", "Test")
+	writeFile(t, upstream, "README.md", "hello\n")
+	mustGit(t, upstream, "add", "README.md")
+	mustGit(t, upstream, "commit", "-m", "initial commit")
+	mustGit(t, dir, "init", "--bare", origin)
+	mustGit(t, upstream, "remote", "add", "origin", origin)
+	mustGit(t, upstream, "push", "-u", "origin", "HEAD")
+	mustGit(t, upstream, "checkout", "-b", "pr-head")
+	writeFile(t, upstream, "pr.txt", "review me\n")
+	mustGit(t, upstream, "add", "pr.txt")
+	mustGit(t, upstream, "commit", "-m", "pr change")
+	mustGit(t, upstream, "push", "origin", "HEAD:refs/pull/123/head")
+	mustGit(t, dir, "clone", origin, local)
+	if resolved, err := filepath.EvalSymlinks(local); err == nil {
+		local = resolved
+	}
+	mustGit(t, local, "config", "user.email", "test@test.com")
+	mustGit(t, local, "config", "user.name", "Test")
+	m := model.NewWithOptions([]scanner.Repo{{Path: local, DisplayName: filepath.Base(local)}}, opts)
+	return m, local
 }
 
 // TestModel_ModeFetchesProduceResultsAgainstRealRepo verifies that each mode's
@@ -344,13 +375,14 @@ func TestModel_CreateThenAgentLaunchAgainstRealRepo(t *testing.T) {
 	m, _ = update(m, m.Init()())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("agent-smoke")})
-	_, createCmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if createCmd == nil {
 		t.Fatal("expected create worktree command")
 	}
-	created, ok := createCmd().(model.WorktreeCreatedMsg)
+	msg := createCmd()
+	created, ok := msg.(model.WorktreeCreatedMsg)
 	if !ok {
-		t.Fatalf("expected WorktreeCreatedMsg, got %T", createCmd())
+		t.Fatalf("expected WorktreeCreatedMsg, got %T", msg)
 	}
 	if !created.LaunchAgent {
 		t.Fatal("expected created message to request agent launch")
@@ -380,6 +412,264 @@ func TestModel_CreateThenAgentLaunchAgainstRealRepo(t *testing.T) {
 	want := filepath.Join(filepath.Dir(dir), filepath.Base(dir)+"-worktrees", "agent-smoke")
 	if launchedPath != want {
 		t.Fatalf("expected launch from created worktree %q, got %q", want, launchedPath)
+	}
+}
+
+func TestModel_CreateWorktreeRunsBootstrapHookAgainstRealRepo(t *testing.T) {
+	var gotCtx actions.BootstrapContext
+	var gotHook actions.BootstrapHook
+	var m model.Model
+	var dir string
+	m, dir = setupModelRepoWithOptions(t, model.Options{
+		BootstrapHookForRepo: func(repoPath string) (actions.BootstrapHook, bool) {
+			if repoPath != dir {
+				t.Fatalf("expected hook lookup for %q, got %q", dir, repoPath)
+			}
+			return actions.BootstrapHook{Script: ".wtui/bootstrap", TimeoutSeconds: 7}, true
+		},
+		RunBootstrapHook: func(ctx actions.BootstrapContext, hook actions.BootstrapHook) error {
+			gotCtx = ctx
+			gotHook = hook
+			return nil
+		},
+	})
+
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("bootstrap-smoke")})
+	m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if createCmd == nil {
+		t.Fatal("expected create worktree command")
+	}
+	msg := createCmd()
+	created, ok := msg.(model.WorktreeCreatedMsg)
+	if !ok {
+		t.Fatalf("expected WorktreeCreatedMsg, got %T", msg)
+	}
+	if !created.BootstrapRan {
+		t.Fatal("expected created message to record bootstrap run")
+	}
+	wantPath := filepath.Join(filepath.Dir(dir), filepath.Base(dir)+"-worktrees", "bootstrap-smoke")
+	if gotCtx.RepoPath != dir || gotCtx.WorktreePath != wantPath || gotCtx.Ref != "bootstrap-smoke" || gotCtx.Kind != actions.WorktreeCreateGeneric {
+		t.Fatalf("unexpected bootstrap context: %#v", gotCtx)
+	}
+	if gotHook.Script != ".wtui/bootstrap" || gotHook.TimeoutSeconds != 7 {
+		t.Fatalf("unexpected bootstrap hook: %#v", gotHook)
+	}
+}
+
+func TestModel_CreateWorktreeWithoutHookPreservesCreatedMessageAgainstRealRepo(t *testing.T) {
+	m, _ := setupModelRepo(t)
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("no-hook")})
+	m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if createCmd == nil {
+		t.Fatal("expected create worktree command")
+	}
+	msg := createCmd()
+	created, ok := msg.(model.WorktreeCreatedMsg)
+	if !ok {
+		t.Fatalf("expected WorktreeCreatedMsg, got %T", msg)
+	}
+	if created.BootstrapRan {
+		t.Fatal("expected bootstrap to be skipped when no hook is configured")
+	}
+}
+
+func TestModel_BootstrapFailureRefreshesWorktreesAndShowsStatus(t *testing.T) {
+	m := inBranchesMode(model.New(testRepos()))
+	m, cmd := update(m, model.WorktreeBootstrapFailedMsg{
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/feat",
+		Err:          "setup failed",
+	})
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("expected mode worktrees after bootstrap failure, got %d", m.Mode())
+	}
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected input modal to stay closed, got overlay %d", m.Overlay())
+	}
+	if !strings.Contains(m.TransientError(), "bootstrap hook failed: setup failed") {
+		t.Fatalf("expected bootstrap error status, got %q", m.TransientError())
+	}
+	if cmd == nil {
+		t.Fatal("expected worktree refresh command")
+	}
+}
+
+func TestModel_StaleBootstrapFailureIsIgnored(t *testing.T) {
+	m := model.New(testRepos())
+	m, cmd := update(m, model.WorktreeBootstrapFailedMsg{
+		RepoPath:     "/dev/bravo",
+		WorktreePath: "/dev/bravo-worktrees/feat",
+		Err:          "setup failed",
+	})
+	if cmd != nil {
+		t.Fatal("expected stale bootstrap failure to be ignored")
+	}
+	if m.TransientError() != "" {
+		t.Fatalf("expected no status for stale bootstrap failure, got %q", m.TransientError())
+	}
+}
+
+func TestModel_StaleBootstrapFailureRequestIsIgnoredAfterNewerSubmit(t *testing.T) {
+	m := inWorktreesMode(model.New(testRepos()))
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("old")})
+	m, firstCmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("new")})
+	m, secondCmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if firstCmd == nil || secondCmd == nil {
+		t.Fatal("expected create commands")
+	}
+
+	m, cmd := update(m, model.WorktreeBootstrapFailedMsg{
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/old",
+		Err:          "old setup failed",
+		Request:      1,
+	})
+	if cmd != nil {
+		t.Fatal("expected stale bootstrap failure request to be ignored")
+	}
+	if m.TransientError() != "" {
+		t.Fatalf("expected no status for stale request, got %q", m.TransientError())
+	}
+}
+
+func TestModel_CancelledPromptDoesNotSupersedeInFlightCreate(t *testing.T) {
+	m := inWorktreesMode(model.New(testRepos()))
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("old")})
+	m, firstCmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if firstCmd == nil {
+		t.Fatal("expected create command")
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEsc})
+
+	msg := firstCmd()
+	m, _ = update(m, msg)
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("expected in-flight create failure to reopen input, got %d", m.Overlay())
+	}
+	if m.WorktreeInput() != "old" {
+		t.Fatalf("expected original input restored, got %q", m.WorktreeInput())
+	}
+}
+
+func TestModel_PullRequestWorktreeBootstrapFailureAgainstRealRepo(t *testing.T) {
+	var m model.Model
+	var dir string
+	m, dir = setupModelPullRequestRepoWithOptions(t, model.Options{
+		BootstrapHookForRepo: func(string) (actions.BootstrapHook, bool) {
+			return actions.BootstrapHook{Script: ".wtui/bootstrap", TimeoutSeconds: 5}, true
+		},
+		RunBootstrapHook: func(ctx actions.BootstrapContext, hook actions.BootstrapHook) error {
+			if ctx.Kind != actions.WorktreeCreatePullRequest || ctx.Ref != "123" || ctx.RepoPath != dir {
+				t.Fatalf("unexpected PR bootstrap context: %#v", ctx)
+			}
+			return errors.New("pr setup failed")
+		},
+	})
+
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'P'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("123")})
+	m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if createCmd == nil {
+		t.Fatal("expected create PR worktree command")
+	}
+	msg := createCmd()
+	failed, ok := msg.(model.WorktreeBootstrapFailedMsg)
+	if !ok {
+		t.Fatalf("expected WorktreeBootstrapFailedMsg, got %T", msg)
+	}
+	if failed.WorktreePath == "" || !strings.Contains(failed.Err, "pr setup failed") {
+		t.Fatalf("unexpected bootstrap failure message: %#v", failed)
+	}
+}
+
+func TestModel_CreateThenAgentLaunchWaitsForBootstrapHook(t *testing.T) {
+	var launchedPath string
+	hookRan := false
+	m, dir := setupModelRepoWithOptions(t, model.Options{
+		AgentCommand: "codex",
+		BootstrapHookForRepo: func(string) (actions.BootstrapHook, bool) {
+			return actions.BootstrapHook{Script: ".wtui/bootstrap", TimeoutSeconds: 5}, true
+		},
+		RunBootstrapHook: func(actions.BootstrapContext, actions.BootstrapHook) error {
+			hookRan = true
+			return nil
+		},
+		LaunchAgent: func(path, command string) (actions.TerminalLaunchSpec, error) {
+			if !hookRan {
+				t.Fatal("agent launched before bootstrap hook completed")
+			}
+			launchedPath = path
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+	})
+
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("agent-bootstrap")})
+	m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	msg := createCmd()
+	created, ok := msg.(model.WorktreeCreatedMsg)
+	if !ok {
+		t.Fatalf("expected WorktreeCreatedMsg, got %T", msg)
+	}
+	if !created.LaunchAgent || !created.BootstrapRan {
+		t.Fatalf("expected launch + bootstrap metadata, got %#v", created)
+	}
+	_, batchCmd := update(m, created)
+	if batchCmd == nil {
+		t.Fatal("expected launch command after successful bootstrap")
+	}
+	want := filepath.Join(filepath.Dir(dir), filepath.Base(dir)+"-worktrees", "agent-bootstrap")
+	if launchedPath != want {
+		t.Fatalf("expected launch from created worktree %q, got %q", want, launchedPath)
+	}
+	_ = batchCmd()
+}
+
+func TestModel_CreateThenAgentLaunchSkipsAgentWhenBootstrapFails(t *testing.T) {
+	launched := false
+	m, _ := setupModelRepoWithOptions(t, model.Options{
+		AgentCommand: "codex",
+		BootstrapHookForRepo: func(string) (actions.BootstrapHook, bool) {
+			return actions.BootstrapHook{Script: ".wtui/bootstrap", TimeoutSeconds: 5}, true
+		},
+		RunBootstrapHook: func(actions.BootstrapContext, actions.BootstrapHook) error {
+			return errors.New("setup failed")
+		},
+		LaunchAgent: func(path, command string) (actions.TerminalLaunchSpec, error) {
+			launched = true
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+	})
+
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("agent-bootstrap-fail")})
+	m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	msg := createCmd()
+	failed, ok := msg.(model.WorktreeBootstrapFailedMsg)
+	if !ok {
+		t.Fatalf("expected WorktreeBootstrapFailedMsg, got %T", msg)
+	}
+	if !failed.LaunchAgent {
+		t.Fatal("expected bootstrap failure to preserve original launch intent")
+	}
+	_, refreshCmd := update(m, failed)
+	if refreshCmd == nil {
+		t.Fatal("expected refresh command after bootstrap failure")
+	}
+	if launched {
+		t.Fatal("agent should not launch when bootstrap fails")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `[bootstrap]` config parsing for exact per-repo hook matching, default/per-hook timeouts, and path expansion
- run configured hooks after successful generic and PR worktree creation, with `N` launching the selected agent only after hook success
- add safe direct hook execution with executable validation, bounded output capture, timeout handling, and wtui-specific environment variables
- document bootstrap hook behavior and mark the roadmap item complete

## Verification
- `gofmt -l .`
- `make test`
- `make build`

## Review loop
- Loop 1: 8/10
- Loop 2: 8/10
- Loop 3: 8/10
- Loop 4: 8/10
