### PR TITLE
Add visible repo batch fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ filter matches, or a load failure with details in the status bar.
 | `/` | Fuzzy filter repos |
 | `A` | Choose and persist the coding agent (`codex` or `claude`) |
 | `D` | Toggle destructive mode |
+| `f` | Fetch all currently visible repos with `--prune` |
 | `tab` | Switch focus to right pane |
 | `q`/`esc` | Quit |
 
@@ -95,6 +96,10 @@ filter matches, or a load failure with details in the status bar.
 | `q`/`esc` | Close overlay or quit |
 
 The right pane header shows the active mode. Press `1`–`5` or use arrow keys to switch between worktrees, branches, stashes, history, and reflog.
+
+When the left repo pane is focused, press `f` to run `git fetch --prune` for
+the currently visible repos. Repo filtering limits the batch to the filtered
+list captured when the key is pressed.
 
 ### Worktrees view (mode 1)
 

--- a/docs/roadmap-todo.md
+++ b/docs/roadmap-todo.md
@@ -30,7 +30,7 @@ clear.
 Goal: make wtui more than a per-repo switcher while preserving safety and
 clarity.
 
-- [ ] P1 - Fetch all visible repos: extend the current fetch action across filtered repos with clear progress and failure reporting.
+- [x] P1 - Fetch all visible repos: extend the current fetch action across filtered repos with clear progress and failure reporting.
 - [ ] P1 - Prune stale worktrees across visible repos: require destructive mode and a confirmation summary.
 - [ ] P2 - Batch selection: enable scoped multi-repo actions without applying commands to the whole workspace accidentally.
 - [ ] P2 - Merged branch cleanup queue: group safe cleanup candidates across repos using the existing merged-branch indicators.

--- a/model/model.go
+++ b/model/model.go
@@ -16,35 +16,36 @@ const listRequestSlots = int(ui.ModeReflog) + 1
 
 // Model is the bubbletea application model.
 type Model struct {
-	repos                    pane.Pane[scanner.Repo]
-	width                    int
-	height                   int
-	mode                     ui.Mode
-	rows                     pane.Pane[gitquery.BranchRow]
-	stashes                  pane.Pane[gitquery.Stash]
-	worktrees                pane.Pane[gitquery.Worktree]
-	commits                  pane.Pane[gitquery.Commit]
-	reflogs                  pane.Pane[gitquery.ReflogEntry]
-	modal                    modal.Modal
-	diffRequestSeq           uint64
-	listRequestSeq           uint64
-	worktreeCreateSeq        uint64
-	activeWorktreeCreate     uint64
-	listRequests             [listRequestSlots]uint64
-	activePane               int // 0=left (repos), 1=right (content)
-	destructive              bool
-	status                   statusError
-	visibleRepoFetchSeq      uint64
-	visibleRepoFetch         visibleRepoFetchState
-	searchActive             bool
-	pendingBranchSelection   string
-	pendingWorktreeSelection string
-	agentCommand             string
-	fetchRepo                func(string) error
-	saveAgent                func(string) error
-	launchAgent              func(string, string) (actions.TerminalLaunchSpec, error)
-	bootstrapHookForRepo     func(string) (actions.BootstrapHook, bool)
-	runBootstrapHook         func(actions.BootstrapContext, actions.BootstrapHook) error
+	repos                     pane.Pane[scanner.Repo]
+	width                     int
+	height                    int
+	mode                      ui.Mode
+	rows                      pane.Pane[gitquery.BranchRow]
+	stashes                   pane.Pane[gitquery.Stash]
+	worktrees                 pane.Pane[gitquery.Worktree]
+	commits                   pane.Pane[gitquery.Commit]
+	reflogs                   pane.Pane[gitquery.ReflogEntry]
+	modal                     modal.Modal
+	diffRequestSeq            uint64
+	listRequestSeq            uint64
+	worktreeCreateSeq         uint64
+	activeWorktreeCreate      uint64
+	listRequests              [listRequestSlots]uint64
+	activePane                int // 0=left (repos), 1=right (content)
+	destructive               bool
+	status                    statusError
+	visibleRepoFetchSeq       uint64
+	visibleRepoFetchStatusSeq uint64
+	visibleRepoFetch          visibleRepoFetchState
+	searchActive              bool
+	pendingBranchSelection    string
+	pendingWorktreeSelection  string
+	agentCommand              string
+	fetchRepo                 func(string) error
+	saveAgent                 func(string) error
+	launchAgent               func(string, string) (actions.TerminalLaunchSpec, error)
+	bootstrapHookForRepo      func(string) (actions.BootstrapHook, bool)
+	runBootstrapHook          func(actions.BootstrapContext, actions.BootstrapHook) error
 }
 
 type statusSource int
@@ -414,6 +415,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleGitFetchFailed(msg), nil
 	case VisibleRepoFetchResultMsg:
 		return m.handleVisibleRepoFetchResult(msg)
+	case VisibleRepoFetchStatusExpiredMsg:
+		return m.handleVisibleRepoFetchStatusExpired(msg), nil
 	case GitPulledMsg:
 		return m.handleGitPulled(msg)
 	case GitPullFailedMsg:

--- a/model/model.go
+++ b/model/model.go
@@ -34,10 +34,13 @@ type Model struct {
 	activePane               int // 0=left (repos), 1=right (content)
 	destructive              bool
 	status                   statusError
+	visibleRepoFetchSeq      uint64
+	visibleRepoFetch         visibleRepoFetchState
 	searchActive             bool
 	pendingBranchSelection   string
 	pendingWorktreeSelection string
 	agentCommand             string
+	fetchRepo                func(string) error
 	saveAgent                func(string) error
 	launchAgent              func(string, string) (actions.TerminalLaunchSpec, error)
 	bootstrapHookForRepo     func(string) (actions.BootstrapHook, bool)
@@ -60,10 +63,21 @@ type statusError struct {
 	Mode      ui.Mode
 }
 
+type visibleRepoFetchState struct {
+	Request       uint64
+	Total         int
+	Completed     int
+	Successes     int
+	FailureNames  []string
+	FailureCount  int
+	CapturedPaths map[string]struct{}
+}
+
 // Options customizes production-only integrations while keeping New(repos)
 // simple for tests.
 type Options struct {
 	AgentCommand         string
+	FetchRepo            func(string) error
 	SaveAgentCommand     func(string) error
 	LaunchAgent          func(string, string) (actions.TerminalLaunchSpec, error)
 	BootstrapHookForRepo func(string) (actions.BootstrapHook, bool)
@@ -80,6 +94,10 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	saveAgent := opts.SaveAgentCommand
 	if saveAgent == nil {
 		saveAgent = func(string) error { return nil }
+	}
+	fetchRepo := opts.FetchRepo
+	if fetchRepo == nil {
+		fetchRepo = actions.Fetch
 	}
 	launchAgent := opts.LaunchAgent
 	if launchAgent == nil {
@@ -102,6 +120,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		reflogs:              newReflogPane(),
 		mode:                 ui.ModeWorktrees,
 		agentCommand:         agent.Normalize(opts.AgentCommand),
+		fetchRepo:            fetchRepo,
 		saveAgent:            saveAgent,
 		launchAgent:          launchAgent,
 		bootstrapHookForRepo: bootstrapHookForRepo,
@@ -146,7 +165,7 @@ func (m Model) RepoScroll() int                 { return m.repos.Scroll() }
 func (m Model) StashScroll() int                { return m.stashes.Scroll() }
 func (m Model) ActivePane() int                 { return m.activePane }
 func (m Model) Destructive() bool               { return m.destructive }
-func (m Model) TransientError() string          { return m.status.Text }
+func (m Model) TransientError() string          { return m.visibleStatusText() }
 func (m Model) SearchActive() bool              { return m.searchActive }
 func (m Model) RepoSearch() string              { return m.repos.Query() }
 func (m Model) ItemSearch() string              { return m.activeItemPaneQuery() }
@@ -207,13 +226,14 @@ func (m Model) View() string {
 		Reflogs:                  reflogs,
 		ReflogSelected:           reflogSelected,
 		ReflogScroll:             reflogScroll,
-		TransientError:           m.status.Text,
+		TransientError:           m.visibleStatusText(),
 		SearchActive:             m.searchActive,
 		RepoSearch:               m.repos.Query(),
 		ItemSearch:               m.activeItemPaneQuery(),
 		RepoEmptyMessage:         repoEmptyMessage,
 		RightEmptyMessage:        rightEmptyMessage,
 		FetchAvailable:           m.canFetch(),
+		FetchVisibleAvailable:    m.canFetchVisibleRepos(),
 		PullAvailable:            m.canPull(),
 		WorktreeMoveAvailable:    m.canMoveWorktree(),
 		AgentAvailable:           m.canLaunchAgent(),
@@ -392,6 +412,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleGitFetched(msg)
 	case GitFetchFailedMsg:
 		return m.handleGitFetchFailed(msg), nil
+	case VisibleRepoFetchResultMsg:
+		return m.handleVisibleRepoFetchResult(msg)
 	case GitPulledMsg:
 		return m.handleGitPulled(msg)
 	case GitPullFailedMsg:

--- a/model/model.go
+++ b/model/model.go
@@ -62,6 +62,7 @@ type statusError struct {
 	Source    statusSource
 	FetchKind FetchKind
 	Mode      ui.Mode
+	FadeStep  int
 }
 
 type visibleRepoFetchState struct {
@@ -167,6 +168,7 @@ func (m Model) StashScroll() int                { return m.stashes.Scroll() }
 func (m Model) ActivePane() int                 { return m.activePane }
 func (m Model) Destructive() bool               { return m.destructive }
 func (m Model) TransientError() string          { return m.visibleStatusText() }
+func (m Model) TransientErrorFadeStep() int     { return m.visibleStatusFadeStep() }
 func (m Model) SearchActive() bool              { return m.searchActive }
 func (m Model) RepoSearch() string              { return m.repos.Query() }
 func (m Model) ItemSearch() string              { return m.activeItemPaneQuery() }
@@ -228,6 +230,7 @@ func (m Model) View() string {
 		ReflogSelected:           reflogSelected,
 		ReflogScroll:             reflogScroll,
 		TransientError:           m.visibleStatusText(),
+		TransientErrorFadeStep:   m.visibleStatusFadeStep(),
 		SearchActive:             m.searchActive,
 		RepoSearch:               m.repos.Query(),
 		ItemSearch:               m.activeItemPaneQuery(),
@@ -415,6 +418,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleGitFetchFailed(msg), nil
 	case VisibleRepoFetchResultMsg:
 		return m.handleVisibleRepoFetchResult(msg)
+	case VisibleRepoFetchStatusFadeMsg:
+		return m.handleVisibleRepoFetchStatusFade(msg), nil
 	case VisibleRepoFetchStatusExpiredMsg:
 		return m.handleVisibleRepoFetchStatusExpired(msg), nil
 	case GitPulledMsg:

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -796,6 +796,50 @@ func TestModel_VisibleRepoFetchFinalStatusExpires(t *testing.T) {
 	}
 }
 
+func TestModel_VisibleRepoFetchFinalStatusFadesBeforeExpiry(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(string) error { return nil },
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	for _, msg := range runBatchCmd(t, cmd) {
+		m, _ = update(m, msg)
+	}
+	if m.TransientErrorFadeStep() != 0 {
+		t.Fatalf("expected fresh status to start unfaded, got step %d", m.TransientErrorFadeStep())
+	}
+
+	m, _ = update(m, model.VisibleRepoFetchStatusFadeMsg{Request: 1, Text: "Fetched 3 visible repos", Step: 1})
+	if m.TransientErrorFadeStep() != 1 {
+		t.Fatalf("expected fade step 1, got %d", m.TransientErrorFadeStep())
+	}
+	if !strings.Contains(m.View(), "Fetched 3 visible repos") {
+		t.Fatalf("fade should keep status visible, got:\n%s", m.View())
+	}
+
+	m, _ = update(m, model.VisibleRepoFetchStatusFadeMsg{Request: 1, Text: "Fetched 3 visible repos", Step: 2})
+	if m.TransientErrorFadeStep() != 2 {
+		t.Fatalf("expected fade step 2, got %d", m.TransientErrorFadeStep())
+	}
+}
+
+func TestModel_VisibleRepoFetchFinalStatusStillClearsOnKeypress(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(string) error { return nil },
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	for _, msg := range runBatchCmd(t, cmd) {
+		m, _ = update(m, msg)
+	}
+	m, _ = update(m, model.VisibleRepoFetchStatusFadeMsg{Request: 1, Text: "Fetched 3 visible repos", Step: 1})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if strings.Contains(m.View(), "Fetched 3 visible repos") {
+		t.Fatalf("expected keypress to clear faded status immediately, got:\n%s", m.View())
+	}
+}
+
 func TestModel_VisibleRepoFetchStatusExpiryDoesNotClearNewerStatus(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		FetchRepo: func(string) error { return nil },

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -777,6 +777,43 @@ func TestModel_VisibleRepoFetchProgressSuccessAndRefresh(t *testing.T) {
 	}
 }
 
+func TestModel_VisibleRepoFetchFinalStatusExpires(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(string) error { return nil },
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	for _, msg := range runBatchCmd(t, cmd) {
+		m, _ = update(m, msg)
+	}
+	if !strings.Contains(m.View(), "Fetched 3 visible repos") {
+		t.Fatalf("expected final success status before expiry, got:\n%s", m.View())
+	}
+
+	m, _ = update(m, model.VisibleRepoFetchStatusExpiredMsg{Request: 1, Text: "Fetched 3 visible repos"})
+	if strings.Contains(m.View(), "Fetched 3 visible repos") {
+		t.Fatalf("expected final success status to expire, got:\n%s", m.View())
+	}
+}
+
+func TestModel_VisibleRepoFetchStatusExpiryDoesNotClearNewerStatus(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(string) error { return nil },
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	for _, msg := range runBatchCmd(t, cmd) {
+		m, _ = update(m, msg)
+	}
+	m, _ = update(m, model.GitFetchFailedMsg{RepoPath: "/dev/alpha", Err: "fetch failed: newer"})
+
+	m, _ = update(m, model.VisibleRepoFetchStatusExpiredMsg{Request: 1, Text: "Fetched 3 visible repos"})
+	view := m.View()
+	if !strings.Contains(view, "fetch failed: newer") {
+		t.Fatalf("expiry should not clear a newer git status, got:\n%s", view)
+	}
+}
+
 func TestModel_VisibleRepoFetchPartialFailureSummaryIsCapped(t *testing.T) {
 	repos := []scanner.Repo{
 		{Path: "/dev/alpha", DisplayName: "alpha"},
@@ -840,10 +877,7 @@ func TestModel_VisibleRepoFetchRefreshesOnlyIfCurrentSelectionWasCaptured(t *tes
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
-	m, cmd = update(m, msgs[0])
-	if cmd != nil {
-		t.Fatal("batch completion should not refresh when current selection was not captured")
-	}
+	m, _ = update(m, msgs[0])
 	if !strings.Contains(m.View(), "Fetched 1 visible repos") {
 		t.Fatalf("expected final success status, got:\n%s", m.View())
 	}

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -698,7 +698,7 @@ func TestModel_LeftPaneFKeyFetchesFilteredReposOnly(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected batch fetch command")
 	}
-	if !strings.Contains(m.View(), "Fetching 0/1 visible repos...") {
+	if !strings.Contains(m.View(), "Fetching 0/1 visible repo...") {
 		t.Fatalf("expected initial batch fetch status, got:\n%s", m.View())
 	}
 
@@ -730,6 +730,24 @@ func TestModel_LeftPaneFKeyWithNoVisibleReposShowsStatus(t *testing.T) {
 	}
 	if !strings.Contains(m.View(), "No visible repos to fetch") {
 		t.Fatalf("expected no-visible-repos status, got:\n%s", m.View())
+	}
+}
+
+func TestModel_LeftPaneFKeyDuringVisibleRepoFetchDoesNotStartAnotherBatch(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(string) error { return nil },
+	})
+
+	m, firstCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if firstCmd == nil {
+		t.Fatal("expected first batch fetch command")
+	}
+	m, secondCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if secondCmd != nil {
+		t.Fatal("expected no command when batch fetch is already in progress")
+	}
+	if !strings.Contains(m.View(), "Fetching 0/3 visible repos...") {
+		t.Fatalf("expected original batch progress to remain visible, got:\n%s", m.View())
 	}
 }
 
@@ -892,16 +910,14 @@ func TestModel_VisibleRepoFetchStaleResultIgnoredByRequest(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		FetchRepo: func(string) error { return nil },
 	})
-	m, oldCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
-	oldMsg := runBatchCmd(t, oldCmd)[0]
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 
-	m, cmd := update(m, oldMsg)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m, cmd := update(m, model.VisibleRepoFetchResultMsg{Request: 999, RepoPath: "/dev/alpha"})
 	if cmd != nil {
 		t.Fatal("stale batch result should not trigger refresh")
 	}
 	if !strings.Contains(m.View(), "Fetching 0/3 visible repos...") {
-		t.Fatalf("stale result should not advance newer batch progress, got:\n%s", m.View())
+		t.Fatalf("stale result should not advance batch progress, got:\n%s", m.View())
 	}
 }
 
@@ -922,7 +938,7 @@ func TestModel_VisibleRepoFetchRefreshesOnlyIfCurrentSelectionWasCaptured(t *tes
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
 	m, _ = update(m, msgs[0])
-	if !strings.Contains(m.View(), "Fetched 1 visible repos") {
+	if !strings.Contains(m.View(), "Fetched 1 visible repo") {
 		t.Fatalf("expected final success status, got:\n%s", m.View())
 	}
 }

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -2,6 +2,7 @@ package model_test
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -681,6 +682,217 @@ func TestModel_FKey_BareRepoBranchesWithoutSelection_FiresFetchCmd(t *testing.T)
 	}
 }
 
+func TestModel_LeftPaneFKeyFetchesFilteredReposOnly(t *testing.T) {
+	var fetched []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(path string) error {
+			fetched = append(fetched, path)
+			return nil
+		},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("bravo")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if cmd == nil {
+		t.Fatal("expected batch fetch command")
+	}
+	if !strings.Contains(m.View(), "Fetching 0/1 visible repos...") {
+		t.Fatalf("expected initial batch fetch status, got:\n%s", m.View())
+	}
+
+	msgs := runBatchCmd(t, cmd)
+	if len(msgs) != 1 {
+		t.Fatalf("expected one fetch result, got %d", len(msgs))
+	}
+	if len(fetched) != 1 || fetched[0] != "/dev/bravo" {
+		t.Fatalf("expected only filtered repo to be fetched, got %v", fetched)
+	}
+	result, ok := msgs[0].(model.VisibleRepoFetchResultMsg)
+	if !ok {
+		t.Fatalf("expected VisibleRepoFetchResultMsg, got %T", msgs[0])
+	}
+	if result.RepoPath != "/dev/bravo" || result.DisplayName != "bravo" || result.Err != "" {
+		t.Fatalf("unexpected fetch result: %#v", result)
+	}
+}
+
+func TestModel_LeftPaneFKeyWithNoVisibleReposShowsStatus(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("missing")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if cmd != nil {
+		t.Fatal("expected no command when no repos are visible")
+	}
+	if !strings.Contains(m.View(), "No visible repos to fetch") {
+		t.Fatalf("expected no-visible-repos status, got:\n%s", m.View())
+	}
+}
+
+func TestModel_VisibleRepoFetchProgressSurvivesOrdinaryKeypress(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(string) error { return nil },
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	msgs := runBatchCmd(t, cmd)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if !strings.Contains(m.View(), "Fetching 0/3 visible repos...") {
+		t.Fatalf("active progress should survive ordinary keypress, got:\n%s", m.View())
+	}
+	m, _ = update(m, msgs[0])
+	if !strings.Contains(m.View(), "Fetching 1/3 visible repos...") {
+		t.Fatalf("active progress should continue after result, got:\n%s", m.View())
+	}
+}
+
+func TestModel_VisibleRepoFetchProgressSuccessAndRefresh(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(string) error { return nil },
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	msgs := runBatchCmd(t, cmd)
+	for i, msg := range msgs {
+		m, cmd = update(m, msg)
+		if i < len(msgs)-1 {
+			want := fmt.Sprintf("Fetching %d/3 visible repos...", i+1)
+			if !strings.Contains(m.View(), want) {
+				t.Fatalf("expected progress %q, got:\n%s", want, m.View())
+			}
+			if cmd != nil {
+				t.Fatal("did not expect refresh before batch completion")
+			}
+		}
+	}
+	if !strings.Contains(m.View(), "Fetched 3 visible repos") {
+		t.Fatalf("expected final success status, got:\n%s", m.View())
+	}
+	if cmd == nil {
+		t.Fatal("expected one selected-repo refresh when batch completes")
+	}
+}
+
+func TestModel_VisibleRepoFetchPartialFailureSummaryIsCapped(t *testing.T) {
+	repos := []scanner.Repo{
+		{Path: "/dev/alpha", DisplayName: "alpha"},
+		{Path: "/dev/bravo", DisplayName: "bravo"},
+		{Path: "/dev/charlie", DisplayName: "charlie"},
+		{Path: "/dev/delta", DisplayName: "delta"},
+		{Path: "/dev/echo", DisplayName: "echo"},
+	}
+	m := model.NewWithOptions(repos, model.Options{
+		FetchRepo: func(path string) error {
+			if path == "/dev/alpha" {
+				return nil
+			}
+			return errors.New("nope")
+		},
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	for _, msg := range runBatchCmd(t, cmd) {
+		m, cmd = update(m, msg)
+	}
+	view := m.View()
+	if !strings.Contains(view, "Fetched 1/5 visible repos; failed: bravo, charlie, delta +1 more") {
+		t.Fatalf("expected capped failure summary, got:\n%s", view)
+	}
+	if cmd == nil {
+		t.Fatal("expected refresh for current selected repo after completion")
+	}
+}
+
+func TestModel_VisibleRepoFetchStaleResultIgnoredByRequest(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(string) error { return nil },
+	})
+	m, oldCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	oldMsg := runBatchCmd(t, oldCmd)[0]
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+
+	m, cmd := update(m, oldMsg)
+	if cmd != nil {
+		t.Fatal("stale batch result should not trigger refresh")
+	}
+	if !strings.Contains(m.View(), "Fetching 0/3 visible repos...") {
+		t.Fatalf("stale result should not advance newer batch progress, got:\n%s", m.View())
+	}
+}
+
+func TestModel_VisibleRepoFetchRefreshesOnlyIfCurrentSelectionWasCaptured(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(string) error { return nil },
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("bravo")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	msgs := runBatchCmd(t, cmd)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlU})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	m, cmd = update(m, msgs[0])
+	if cmd != nil {
+		t.Fatal("batch completion should not refresh when current selection was not captured")
+	}
+	if !strings.Contains(m.View(), "Fetched 1 visible repos") {
+		t.Fatalf("expected final success status, got:\n%s", m.View())
+	}
+}
+
+func TestModel_VisibleRepoFetchRefreshesChangedSelectionInsideCapturedBatch(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(string) error { return nil },
+	})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	msgs := runBatchCmd(t, cmd)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	for _, msg := range msgs {
+		m, cmd = update(m, msg)
+	}
+	if cmd == nil {
+		t.Fatal("expected refresh when changed selection is part of captured batch")
+	}
+	if !strings.Contains(m.View(), "Fetched 3 visible repos") {
+		t.Fatalf("expected final success status, got:\n%s", m.View())
+	}
+}
+
+func TestModel_RightPaneFetchUsesInjectedFetchRepo(t *testing.T) {
+	var fetched []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FetchRepo: func(path string) error {
+			fetched = append(fetched, path)
+			return nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+	}})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if cmd == nil {
+		t.Fatal("expected fetch command")
+	}
+	if msg := cmd(); msg != (model.GitFetchedMsg{RepoPath: "/dev/alpha"}) {
+		t.Fatalf("expected GitFetchedMsg, got %#v", msg)
+	}
+	if len(fetched) != 1 || fetched[0] != "/dev/alpha" {
+		t.Fatalf("expected injected fetch for selected worktree path, got %v", fetched)
+	}
+}
+
 func TestModel_ShiftFKey_Worktree_FiresPullCmd(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
@@ -852,6 +1064,23 @@ func TestModel_StaleGitPullFailedMsgIgnored(t *testing.T) {
 	if strings.Contains(m.View(), "pull failed") {
 		t.Fatal("expected stale pull failure to be ignored")
 	}
+}
+
+func runBatchCmd(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected command")
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		return []tea.Msg{msg}
+	}
+	msgs := make([]tea.Msg, 0, len(batch))
+	for _, subcmd := range batch {
+		msgs = append(msgs, subcmd())
+	}
+	return msgs
 }
 
 // --- Branch diff (enter key) ---

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -16,6 +16,7 @@ import (
 
 const visibleRepoFetchFailureNameLimit = 3
 const visibleRepoFetchStatusTTL = 3 * time.Second
+const visibleRepoFetchFadeStepDuration = 1 * time.Second
 
 func (m Model) startFetchForMode() (Model, tea.Cmd) {
 	switch m.mode {
@@ -176,6 +177,12 @@ func (m Model) visibleRepoFetchFinalStatusText() string {
 func expireVisibleRepoFetchStatus(request uint64, text string) tea.Cmd {
 	return tea.Tick(visibleRepoFetchStatusTTL, func(time.Time) tea.Msg {
 		return VisibleRepoFetchStatusExpiredMsg{Request: request, Text: text}
+	})
+}
+
+func fadeVisibleRepoFetchStatus(request uint64, text string, step int) tea.Cmd {
+	return tea.Tick(time.Duration(step)*visibleRepoFetchFadeStepDuration, func(time.Time) tea.Msg {
+		return VisibleRepoFetchStatusFadeMsg{Request: request, Text: text, Step: step}
 	})
 }
 

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -110,6 +110,10 @@ func (m Model) startFetchReflog() (Model, tea.Cmd) {
 }
 
 func (m Model) startFetchVisibleRepos() (Model, tea.Cmd) {
+	if m.visibleRepoFetch.Request != 0 {
+		return m, nil
+	}
+
 	repos := m.filteredRepos()
 	if len(repos) == 0 {
 		m.visibleRepoFetch = visibleRepoFetchState{}
@@ -158,20 +162,27 @@ func (m Model) canFetchVisibleRepos() bool {
 }
 
 func (m Model) visibleRepoFetchProgressText() string {
-	return fmt.Sprintf("Fetching %d/%d visible repos...", m.visibleRepoFetch.Completed, m.visibleRepoFetch.Total)
+	return fmt.Sprintf("Fetching %d/%d visible %s...", m.visibleRepoFetch.Completed, m.visibleRepoFetch.Total, visibleRepoNoun(m.visibleRepoFetch.Total))
 }
 
 func (m Model) visibleRepoFetchFinalStatusText() string {
 	total := m.visibleRepoFetch.Total
 	if m.visibleRepoFetch.FailureCount == 0 {
-		return fmt.Sprintf("Fetched %d visible repos", total)
+		return fmt.Sprintf("Fetched %d visible %s", total, visibleRepoNoun(total))
 	}
 	failed := strings.Join(m.visibleRepoFetch.FailureNames, ", ")
 	remaining := m.visibleRepoFetch.FailureCount - len(m.visibleRepoFetch.FailureNames)
 	if remaining > 0 {
 		failed = fmt.Sprintf("%s +%d more", failed, remaining)
 	}
-	return fmt.Sprintf("Fetched %d/%d visible repos; failed: %s", m.visibleRepoFetch.Successes, total, failed)
+	return fmt.Sprintf("Fetched %d/%d visible %s; failed: %s", m.visibleRepoFetch.Successes, total, visibleRepoNoun(total), failed)
+}
+
+func visibleRepoNoun(count int) string {
+	if count == 1 {
+		return "repo"
+	}
+	return "repos"
 }
 
 func expireVisibleRepoFetchStatus(request uint64, text string) tea.Cmd {

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -11,6 +12,8 @@ import (
 )
 
 // --- Fetch commands ---
+
+const visibleRepoFetchFailureNameLimit = 3
 
 func (m Model) startFetchForMode() (Model, tea.Cmd) {
 	switch m.mode {
@@ -103,12 +106,69 @@ func (m Model) startFetchReflog() (Model, tea.Cmd) {
 	return m, m.fetchReflog(request)
 }
 
+func (m Model) startFetchVisibleRepos() (Model, tea.Cmd) {
+	repos := m.filteredRepos()
+	if len(repos) == 0 {
+		m.visibleRepoFetch = visibleRepoFetchState{}
+		m = m.setStatus(statusGitMutation, "No visible repos to fetch")
+		return m, nil
+	}
+
+	m.visibleRepoFetchSeq++
+	request := m.visibleRepoFetchSeq
+	capturedPaths := make(map[string]struct{}, len(repos))
+	cmds := make([]tea.Cmd, 0, len(repos))
+	for _, repo := range repos {
+		repo := repo
+		capturedPaths[repo.Path] = struct{}{}
+		cmds = append(cmds, func() tea.Msg {
+			errText := ""
+			if err := m.fetchRepo(repo.Path); err != nil {
+				errText = fmt.Sprintf("fetch failed: %v", err)
+			}
+			return VisibleRepoFetchResultMsg{
+				Request:     request,
+				RepoPath:    repo.Path,
+				DisplayName: repo.DisplayName,
+				Err:         errText,
+			}
+		})
+	}
+	m.visibleRepoFetch = visibleRepoFetchState{
+		Request:       request,
+		Total:         len(repos),
+		CapturedPaths: capturedPaths,
+	}
+	return m, tea.Batch(cmds...)
+}
+
 func (m Model) canFetch() bool {
 	if m.activePane != 1 {
 		return false
 	}
 	_, _, ok := m.fetchTargetPath()
 	return ok
+}
+
+func (m Model) canFetchVisibleRepos() bool {
+	return m.activePane == 0 && len(m.filteredRepos()) > 0
+}
+
+func (m Model) visibleRepoFetchProgressText() string {
+	return fmt.Sprintf("Fetching %d/%d visible repos...", m.visibleRepoFetch.Completed, m.visibleRepoFetch.Total)
+}
+
+func (m Model) visibleRepoFetchFinalStatusText() string {
+	total := m.visibleRepoFetch.Total
+	if m.visibleRepoFetch.FailureCount == 0 {
+		return fmt.Sprintf("Fetched %d visible repos", total)
+	}
+	failed := strings.Join(m.visibleRepoFetch.FailureNames, ", ")
+	remaining := m.visibleRepoFetch.FailureCount - len(m.visibleRepoFetch.FailureNames)
+	if remaining > 0 {
+		failed = fmt.Sprintf("%s +%d more", failed, remaining)
+	}
+	return fmt.Sprintf("Fetched %d/%d visible repos; failed: %s", m.visibleRepoFetch.Successes, total, failed)
 }
 
 func (m Model) canPull() bool {

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -14,6 +15,7 @@ import (
 // --- Fetch commands ---
 
 const visibleRepoFetchFailureNameLimit = 3
+const visibleRepoFetchStatusTTL = 3 * time.Second
 
 func (m Model) startFetchForMode() (Model, tea.Cmd) {
 	switch m.mode {
@@ -169,6 +171,12 @@ func (m Model) visibleRepoFetchFinalStatusText() string {
 		failed = fmt.Sprintf("%s +%d more", failed, remaining)
 	}
 	return fmt.Sprintf("Fetched %d/%d visible repos; failed: %s", m.visibleRepoFetch.Successes, total, failed)
+}
+
+func expireVisibleRepoFetchStatus(request uint64, text string) tea.Cmd {
+	return tea.Tick(visibleRepoFetchStatusTTL, func(time.Time) tea.Msg {
+		return VisibleRepoFetchStatusExpiredMsg{Request: request, Text: text}
+	})
 }
 
 func (m Model) canPull() bool {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -167,6 +167,8 @@ func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 			m = m.resetRightPaneCursors()
 			return m.startFetchForMode()
 		}
+	case "f":
+		return m.startFetchVisibleRepos()
 	case "q", "ctrl+c", "esc":
 		return m, tea.Quit
 	}
@@ -501,7 +503,7 @@ func (m Model) handleFetch() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, func() tea.Msg {
-		if err := actions.Fetch(path); err != nil {
+		if err := m.fetchRepo(path); err != nil {
 			return GitFetchFailedMsg{RepoPath: repoPath, Err: fmt.Sprintf("fetch failed: %v", err)}
 		}
 		return GitFetchedMsg{RepoPath: repoPath}

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -121,6 +121,13 @@ type GitFetchFailedMsg struct {
 	Err      string
 }
 
+type VisibleRepoFetchResultMsg struct {
+	Request     uint64
+	RepoPath    string
+	DisplayName string
+	Err         string
+}
+
 type GitPulledMsg struct {
 	RepoPath string
 }
@@ -323,6 +330,13 @@ func (m Model) clearAnyStatus() Model {
 	return m
 }
 
+func (m Model) visibleStatusText() string {
+	if m.visibleRepoFetch.Request != 0 {
+		return m.visibleRepoFetchProgressText()
+	}
+	return m.status.Text
+}
+
 func (m Model) handleWorktreeResult(msg WorktreeResultMsg) Model {
 	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeWorktrees, msg.ListRequest) {
 		return m
@@ -406,6 +420,38 @@ func (m Model) handleGitFetchFailed(msg GitFetchFailedMsg) Model {
 		m = m.setStatus(statusGitMutation, msg.Err)
 	}
 	return m
+}
+
+func (m Model) handleVisibleRepoFetchResult(msg VisibleRepoFetchResultMsg) (tea.Model, tea.Cmd) {
+	if msg.Request == 0 || msg.Request != m.visibleRepoFetch.Request {
+		return m, nil
+	}
+	if msg.Err == "" {
+		m.visibleRepoFetch.Successes++
+	} else {
+		m.visibleRepoFetch.FailureCount++
+		if len(m.visibleRepoFetch.FailureNames) < visibleRepoFetchFailureNameLimit {
+			name := msg.DisplayName
+			if name == "" {
+				name = msg.RepoPath
+			}
+			m.visibleRepoFetch.FailureNames = append(m.visibleRepoFetch.FailureNames, name)
+		}
+	}
+	m.visibleRepoFetch.Completed++
+	if m.visibleRepoFetch.Completed < m.visibleRepoFetch.Total {
+		return m, nil
+	}
+
+	currentPath, currentOK := m.currentRepoPath()
+	_, shouldRefresh := m.visibleRepoFetch.CapturedPaths[currentPath]
+	finalStatus := m.visibleRepoFetchFinalStatusText()
+	m.visibleRepoFetch = visibleRepoFetchState{}
+	m = m.setStatus(statusGitMutation, finalStatus)
+	if currentOK && shouldRefresh {
+		return m.startFetchForMode()
+	}
+	return m, nil
 }
 
 func (m Model) handleGitPulled(msg GitPulledMsg) (tea.Model, tea.Cmd) {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -343,6 +343,8 @@ func (m Model) clearAnyStatus() Model {
 
 func (m Model) visibleStatusText() string {
 	if m.visibleRepoFetch.Request != 0 {
+		// In-flight batch fetch progress owns the transient status line until
+		// the batch completes; later statuses replace the final batch summary.
 		return m.visibleRepoFetchProgressText()
 	}
 	return m.status.Text

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -128,6 +128,11 @@ type VisibleRepoFetchResultMsg struct {
 	Err         string
 }
 
+type VisibleRepoFetchStatusExpiredMsg struct {
+	Request uint64
+	Text    string
+}
+
 type GitPulledMsg struct {
 	RepoPath string
 }
@@ -447,11 +452,26 @@ func (m Model) handleVisibleRepoFetchResult(msg VisibleRepoFetchResultMsg) (tea.
 	_, shouldRefresh := m.visibleRepoFetch.CapturedPaths[currentPath]
 	finalStatus := m.visibleRepoFetchFinalStatusText()
 	m.visibleRepoFetch = visibleRepoFetchState{}
+	m.visibleRepoFetchStatusSeq++
+	statusRequest := m.visibleRepoFetchStatusSeq
 	m = m.setStatus(statusGitMutation, finalStatus)
+	expireCmd := expireVisibleRepoFetchStatus(statusRequest, finalStatus)
 	if currentOK && shouldRefresh {
-		return m.startFetchForMode()
+		var fetchCmd tea.Cmd
+		m, fetchCmd = m.startFetchForMode()
+		return m, tea.Batch(fetchCmd, expireCmd)
 	}
-	return m, nil
+	return m, expireCmd
+}
+
+func (m Model) handleVisibleRepoFetchStatusExpired(msg VisibleRepoFetchStatusExpiredMsg) Model {
+	if msg.Request == 0 || msg.Request != m.visibleRepoFetchStatusSeq {
+		return m
+	}
+	if m.status.Source == statusGitMutation && m.status.Text == msg.Text {
+		m.status = statusError{}
+	}
+	return m
 }
 
 func (m Model) handleGitPulled(msg GitPulledMsg) (tea.Model, tea.Cmd) {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -128,6 +128,12 @@ type VisibleRepoFetchResultMsg struct {
 	Err         string
 }
 
+type VisibleRepoFetchStatusFadeMsg struct {
+	Request uint64
+	Text    string
+	Step    int
+}
+
 type VisibleRepoFetchStatusExpiredMsg struct {
 	Request uint64
 	Text    string
@@ -342,6 +348,13 @@ func (m Model) visibleStatusText() string {
 	return m.status.Text
 }
 
+func (m Model) visibleStatusFadeStep() int {
+	if m.visibleRepoFetch.Request != 0 {
+		return 0
+	}
+	return m.status.FadeStep
+}
+
 func (m Model) handleWorktreeResult(msg WorktreeResultMsg) Model {
 	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeWorktrees, msg.ListRequest) {
 		return m
@@ -455,13 +468,27 @@ func (m Model) handleVisibleRepoFetchResult(msg VisibleRepoFetchResultMsg) (tea.
 	m.visibleRepoFetchStatusSeq++
 	statusRequest := m.visibleRepoFetchStatusSeq
 	m = m.setStatus(statusGitMutation, finalStatus)
-	expireCmd := expireVisibleRepoFetchStatus(statusRequest, finalStatus)
+	statusCmds := []tea.Cmd{
+		fadeVisibleRepoFetchStatus(statusRequest, finalStatus, 1),
+		fadeVisibleRepoFetchStatus(statusRequest, finalStatus, 2),
+		expireVisibleRepoFetchStatus(statusRequest, finalStatus),
+	}
 	if currentOK && shouldRefresh {
 		var fetchCmd tea.Cmd
 		m, fetchCmd = m.startFetchForMode()
-		return m, tea.Batch(fetchCmd, expireCmd)
+		statusCmds = append([]tea.Cmd{fetchCmd}, statusCmds...)
 	}
-	return m, expireCmd
+	return m, tea.Batch(statusCmds...)
+}
+
+func (m Model) handleVisibleRepoFetchStatusFade(msg VisibleRepoFetchStatusFadeMsg) Model {
+	if msg.Request == 0 || msg.Request != m.visibleRepoFetchStatusSeq {
+		return m
+	}
+	if m.status.Source == statusGitMutation && m.status.Text == msg.Text {
+		m.status.FadeStep = msg.Step
+	}
+	return m
 }
 
 func (m Model) handleVisibleRepoFetchStatusExpired(msg VisibleRepoFetchStatusExpiredMsg) Model {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -156,6 +156,7 @@ type RenderParams struct {
 	RepoEmptyMessage         string
 	RightEmptyMessage        string
 	FetchAvailable           bool
+	FetchVisibleAvailable    bool
 	PullAvailable            bool
 	WorktreeMoveAvailable    bool
 	AgentAvailable           bool
@@ -227,6 +228,7 @@ func Render(p RenderParams) string {
 		RepoSearch:                p.RepoSearch,
 		ItemSearch:                p.ItemSearch,
 		FetchAvailable:            p.FetchAvailable,
+		FetchVisibleAvailable:     p.FetchVisibleAvailable,
 		PullAvailable:             p.PullAvailable,
 		AgentAvailable:            p.AgentAvailable,
 		NewAgent:                  p.NewAgentAvailable,
@@ -413,6 +415,7 @@ type statusBarParams struct {
 	RepoSearch                string
 	ItemSearch                string
 	FetchAvailable            bool
+	FetchVisibleAvailable     bool
 	PullAvailable             bool
 	AgentAvailable            bool
 	NewAgent                  bool
@@ -566,6 +569,9 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	}
 
 	var actions []shortcutHint
+	if sp.ActivePane == 0 && sp.FetchVisibleAvailable {
+		actions = append(actions, shortcutHint{Key: "f", Label: "fetch visible"})
+	}
 	switch sp.Mode {
 	case ModeWorktrees:
 		if sp.ActivePane == 1 && sp.RepoSelected && !sp.StaleSelected {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -150,6 +150,7 @@ type RenderParams struct {
 	ReflogSelected           int
 	ReflogScroll             int
 	TransientError           string
+	TransientErrorFadeStep   int
 	SearchActive             bool
 	RepoSearch               string
 	ItemSearch               string
@@ -224,6 +225,7 @@ func Render(p RenderParams) string {
 		CommitSelected:            commitSelected,
 		ReflogSelected:            reflogSelected,
 		TransientError:            p.TransientError,
+		TransientErrorFadeStep:    p.TransientErrorFadeStep,
 		SearchActive:              p.SearchActive,
 		RepoSearch:                p.RepoSearch,
 		ItemSearch:                p.ItemSearch,
@@ -411,6 +413,7 @@ type statusBarParams struct {
 	CommitSelected            bool
 	ReflogSelected            bool
 	TransientError            string
+	TransientErrorFadeStep    int
 	SearchActive              bool
 	RepoSearch                string
 	ItemSearch                string
@@ -472,7 +475,7 @@ func renderStatusBarWithState(sp statusBarParams) string {
 	itemSearch := sp.ItemSearch
 
 	if transientError != "" {
-		return statusStyle.Width(width).Render("  " + dirtyRedStyle.Render(transientError))
+		return statusStyle.Width(width).Render("  " + transientStatusStyle(sp.TransientErrorFadeStep).Render(transientError))
 	}
 
 	label := "items"
@@ -715,6 +718,17 @@ func renderFooterShortcuts(sp statusBarParams, sections []shortcutSection) strin
 		return renderFooterLegend(legend)
 	}
 	return "  " + renderFooterHintList(sections)
+}
+
+func transientStatusStyle(fadeStep int) lipgloss.Style {
+	switch fadeStep {
+	case 1:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	case 2:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
+	default:
+		return dirtyRedStyle
+	}
 }
 
 func renderWorktreeFooterShortcuts(sp statusBarParams, sections []shortcutSection) string {
@@ -1177,19 +1191,20 @@ func renderWorktreePane(worktrees []gitquery.Worktree, selected, scroll, width, 
 
 func renderOverlay(p RenderParams) string {
 	statusBar := renderStatusBarWithState(statusBarParams{
-		Width:          p.Width,
-		Mode:           p.Mode,
-		Overlay:        p.Overlay,
-		ActivePane:     p.ActivePane,
-		Destructive:    p.Destructive,
-		TransientError: p.TransientError,
-		SearchActive:   p.SearchActive,
-		RepoSearch:     p.RepoSearch,
-		ItemSearch:     p.ItemSearch,
-		FetchAvailable: p.FetchAvailable,
-		PullAvailable:  p.PullAvailable,
-		AgentAvailable: p.AgentAvailable,
-		NewAgent:       p.NewAgentAvailable,
+		Width:                  p.Width,
+		Mode:                   p.Mode,
+		Overlay:                p.Overlay,
+		ActivePane:             p.ActivePane,
+		Destructive:            p.Destructive,
+		TransientError:         p.TransientError,
+		TransientErrorFadeStep: p.TransientErrorFadeStep,
+		SearchActive:           p.SearchActive,
+		RepoSearch:             p.RepoSearch,
+		ItemSearch:             p.ItemSearch,
+		FetchAvailable:         p.FetchAvailable,
+		PullAvailable:          p.PullAvailable,
+		AgentAvailable:         p.AgentAvailable,
+		NewAgent:               p.NewAgentAvailable,
 	})
 	contentHeight := p.Height - 1
 

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -122,6 +122,48 @@ func TestRender_BranchesModeShowsPullWhenAvailable(t *testing.T) {
 	}
 }
 
+func TestRender_LeftPaneShowsFetchVisibleWhenReposExist(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:                 []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:              0,
+		Width:                 120,
+		Height:                10,
+		Mode:                  1,
+		ActivePane:            0,
+		FetchVisibleAvailable: true,
+	})
+	if !strings.Contains(view, "f: fetch visible") {
+		t.Fatalf("left-pane render should expose fetch-visible hint, got:\n%s", view)
+	}
+}
+
+func TestRender_LeftPaneShortcutPaneShowsFetchVisibleWhenReposExist(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:                 []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:              0,
+		Width:                 120,
+		Height:                24,
+		Mode:                  1,
+		ActivePane:            0,
+		FetchVisibleAvailable: true,
+	})
+	if !strings.Contains(view, "f: fetch visible") {
+		t.Fatalf("left-pane shortcut pane should expose fetch-visible hint, got:\n%s", view)
+	}
+}
+
+func TestRender_LeftPaneHidesFetchVisibleWhenNoReposVisible(t *testing.T) {
+	view := Render(RenderParams{
+		Width:      120,
+		Height:     10,
+		Mode:       1,
+		ActivePane: 0,
+	})
+	if strings.Contains(view, "f: fetch visible") {
+		t.Fatalf("empty left-pane render should hide fetch-visible hint, got:\n%s", view)
+	}
+}
+
 func TestStatusBar_WorktreesModeShowsNewWorktreeHint(t *testing.T) {
 	bar := RenderStatusBar(120, 1, 0, 1, false, false, false)
 	if !strings.Contains(bar, "n: new worktree") {


### PR DESCRIPTION
## Summary
- add a left-pane `f` action that fetches every currently visible/filtered repo with `git fetch --prune`
- track batch progress with request IDs so stale results are ignored and active progress survives ordinary keypresses
- report final success/failure counts with capped failing repo names and refresh the current repo view when it was included in the batch
- document the new left-pane shortcut and mark the Phase 3 roadmap item complete

## Testing
- `go test ./model ./ui`
- `go test ./...`
- `gofmt -l .`
- `make build`