### PR TITLE
[codex] Restore shortcut pane after repo filter

### DIFF
--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -110,6 +110,23 @@ func TestModel_ViewDistinguishesFilteredEmptyRepos(t *testing.T) {
 	}
 }
 
+func TestModel_ViewRestoresShortcutPaneAfterKeepingRepoFilter(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("alp")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	view := m.View()
+	if !strings.Contains(view, "Shortcuts") {
+		t.Fatalf("kept repo filter should restore shortcut pane, got:\n%s", view)
+	}
+	if !strings.Contains(view, "filtered repos: alp") {
+		t.Fatalf("kept repo filter should keep filter footer, got:\n%s", view)
+	}
+}
+
 func TestModel_ViewDistinguishesFilteredEmptyItemsInEveryMode(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -458,11 +458,7 @@ func renderFooterStatusBar(sp statusBarParams, includeHints bool) string {
 }
 
 func hasActiveStatusQuery(sp statusBarParams) bool {
-	query := sp.ItemSearch
-	if sp.ActivePane == 0 {
-		query = sp.RepoSearch
-	}
-	return sp.SearchActive || query != ""
+	return sp.SearchActive
 }
 
 func renderStatusBarWithState(sp statusBarParams) string {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -492,7 +492,7 @@ func TestRender_SearchActiveSuppressesShortcutPane(t *testing.T) {
 	}
 }
 
-func TestRender_FilteredStateSuppressesShortcutPane(t *testing.T) {
+func TestRender_FilteredItemStateKeepsShortcutPane(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:      []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
 		Selected:   0,
@@ -503,13 +503,34 @@ func TestRender_FilteredStateSuppressesShortcutPane(t *testing.T) {
 		ItemSearch: "feat",
 	})
 
-	if strings.Contains(view, "Shortcuts") {
-		t.Fatal("filtered state should suppress normal shortcut pane")
+	if !strings.Contains(view, "Shortcuts") {
+		t.Fatal("filtered item state should keep normal shortcut pane")
 	}
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
 	if !strings.Contains(footer, "filtered items: feat") || !strings.Contains(footer, "esc: clear") {
 		t.Fatalf("filtered footer should show filter controls, got %q", footer)
+	}
+}
+
+func TestRender_FilteredRepoStateKeepsShortcutPane(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:      []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:   0,
+		Width:      120,
+		Height:     18,
+		Mode:       ModeWorktrees,
+		ActivePane: 0,
+		RepoSearch: "alp",
+	})
+
+	if !strings.Contains(view, "Shortcuts") {
+		t.Fatal("filtered repo state should keep normal shortcut pane")
+	}
+	lines := strings.Split(view, "\n")
+	footer := lines[len(lines)-1]
+	if !strings.Contains(footer, "filtered repos: alp") || !strings.Contains(footer, "esc: clear") {
+		t.Fatalf("filtered repo footer should show filter controls, got %q", footer)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the wide-layout shortcut pane disappearing after keeping a repo or item filter.

## Root Cause

The renderer treated any persisted filter query as an active status query. That was correct while the search editor was open, but after pressing enter to keep a repo filter, the saved query kept suppressing the right shortcut pane indefinitely.

## Changes

- Only suppress the shortcut pane while search input is actively open.
- Keep the filtered footer message visible for persisted filters.
- Add renderer coverage for persisted repo and item filters.
- Add a model-level regression test for keeping a repo filter with enter.

## Validation

- `gofmt -l .`
- `make test`
- `make build`