### PR TITLE
Polish shortcut sidebar rendering

### DIFF
--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -288,8 +288,8 @@ func TestModel_ViewStatusBarShowsKeyHints(t *testing.T) {
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 
 	view := m.View()
-	if !strings.Contains(view, "tab: pane") {
-		t.Error("status bar should contain 'tab: pane' hint")
+	if !strings.Contains(view, "tab    pane") {
+		t.Error("view should contain 'tab    pane' shortcut")
 	}
 }
 
@@ -360,8 +360,8 @@ func TestModel_StatusBarStashesModeShowsDropHint(t *testing.T) {
 	m, _ = update(m, model.StashResultMsg{RepoPath: "/dev/alpha", Stashes: testStashes()[:1]})
 
 	view := m.View()
-	if !strings.Contains(view, "d: drop") {
-		t.Error("stashes status bar should mention 'd: drop' in destructive mode")
+	if !strings.Contains(view, "d      drop") {
+		t.Error("stashes view should mention 'd      drop' in destructive mode")
 	}
 }
 
@@ -396,8 +396,8 @@ func TestModel_ViewReadOnlyShowsDestructiveModeHint(t *testing.T) {
 	m = inBranchesMode(m)
 
 	view := m.View()
-	if !strings.Contains(view, "D: destructive mode") {
-		t.Error("read-only mode should show 'D: destructive mode' hint")
+	if !strings.Contains(view, "D      destructive mode") {
+		t.Error("read-only mode should show 'D      destructive mode' hint")
 	}
 }
 
@@ -414,8 +414,8 @@ func TestModel_ViewDestructiveModeShowsDeleteHint(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 
 	view := m.View()
-	if !strings.Contains(view, "d: delete") {
-		t.Error("destructive mode should show 'd: delete'")
+	if !strings.Contains(view, "d      delete") {
+		t.Error("destructive mode should show 'd      delete'")
 	}
 }
 
@@ -455,17 +455,14 @@ func TestModel_StatusBarHistoryModeShowsHistoryKeys(t *testing.T) {
 	m, _ = update(m, model.CommitResultMsg{RepoPath: "/dev/alpha", Commits: testCommits()[:1]})
 
 	view := m.View()
-	if !strings.Contains(view, "enter: diff") {
-		t.Error("mode 3 status bar should mention 'enter: diff'")
+	if !strings.Contains(view, "enter  diff") {
+		t.Error("mode 3 view should mention 'enter  diff'")
 	}
-	if !strings.Contains(view, "y: copy hash") {
-		t.Error("mode 3 status bar should mention 'y: copy hash'")
+	if !strings.Contains(view, "y      copy hash") {
+		t.Error("mode 3 view should mention 'y      copy hash'")
 	}
-	if !strings.Contains(view, "t: terminal") {
-		t.Error("mode 3 status bar should mention 't: terminal'")
-	}
-	if !strings.Contains(view, "c: code") {
-		t.Error("mode 3 status bar should mention 'c: code'")
+	if !strings.Contains(view, "t/c    terminal / code") {
+		t.Error("mode 3 view should mention 't/c    terminal / code'")
 	}
 }
 
@@ -476,8 +473,8 @@ func TestModel_ViewDestructiveModeHidesDestructiveHint(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 
 	view := m.View()
-	if strings.Contains(view, "D: destructive mode") {
-		t.Error("destructive mode should NOT show 'D: destructive mode' hint")
+	if strings.Contains(view, "D      destructive mode") {
+		t.Error("destructive mode should NOT show 'D      destructive mode' hint")
 	}
 }
 
@@ -495,11 +492,11 @@ func TestModel_ViewWorktreesModeDestructiveShowsDeleteHint(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
 	view := m.View()
-	if !strings.Contains(view, "d: delete") {
-		t.Error("worktrees mode destructive non-stale should show 'd: delete'")
+	if !strings.Contains(view, "d      delete") {
+		t.Error("worktrees mode destructive non-stale should show 'd      delete'")
 	}
-	if strings.Contains(view, "p: prune") {
-		t.Error("worktrees mode destructive non-stale should NOT show 'p: prune'")
+	if strings.Contains(view, "p      prune") {
+		t.Error("worktrees mode destructive non-stale should NOT show 'p      prune'")
 	}
 }
 
@@ -527,8 +524,8 @@ func TestModel_ViewWorktreesModeLockedShowsUnlockHint(t *testing.T) {
 	}})
 
 	view := m.View()
-	if !strings.Contains(view, "u: unlock") {
-		t.Error("locked worktree should show 'u: unlock'")
+	if !strings.Contains(view, "u      unlock") {
+		t.Error("locked worktree should show 'u      unlock'")
 	}
 }
 
@@ -553,7 +550,7 @@ func TestModel_ViewWorktreesModeShowsMoveHintForMovableWorktree(t *testing.T) {
 			m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
 			view := m.View()
-			if !strings.Contains(view, "m: move") {
+			if !strings.Contains(view, "m      move") {
 				t.Fatalf("movable %s worktree should show move hint, got:\n%s", tt.name, view)
 			}
 		})
@@ -578,7 +575,7 @@ func TestModel_ViewWorktreesModeHidesMoveHintForIneligibleWorktrees(t *testing.T
 			m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{tt.worktree}})
 
 			view := m.View()
-			if strings.Contains(view, "m: move") {
+			if strings.Contains(view, "m      move") {
 				t.Fatalf("%s worktree should not show move hint, got:\n%s", tt.name, view)
 			}
 		})
@@ -613,7 +610,7 @@ func TestModel_ViewWorktreesModeLockedStaleHidesDeleteAndPruneHints(t *testing.T
 	}})
 
 	view := m.View()
-	for _, hint := range []string{"d: delete", "p: prune"} {
+	for _, hint := range []string{"d      delete", "p      prune"} {
 		if strings.Contains(view, hint) {
 			t.Errorf("locked stale worktree should not show %q", hint)
 		}
@@ -631,11 +628,11 @@ func TestModel_ViewWorktreesModeDestructiveStaleShowsPruneHint(t *testing.T) {
 	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: wts})
 
 	view := m.View()
-	if !strings.Contains(view, "p: prune") {
-		t.Error("worktrees mode destructive stale should show 'p: prune'")
+	if !strings.Contains(view, "p      prune") {
+		t.Error("worktrees mode destructive stale should show 'p      prune'")
 	}
-	if strings.Contains(view, "d: delete") {
-		t.Error("worktrees mode destructive stale should NOT show 'd: delete'")
+	if strings.Contains(view, "d      delete") {
+		t.Error("worktrees mode destructive stale should NOT show 'd      delete'")
 	}
 }
 
@@ -650,11 +647,11 @@ func TestModel_ViewWorktreesModeReadOnlyShowsDestructiveHint(t *testing.T) {
 	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: wts})
 
 	view := m.View()
-	if !strings.Contains(view, "D: destructive mode") {
-		t.Error("worktrees mode read-only should show 'D: destructive mode'")
+	if !strings.Contains(view, "D      destructive mode") {
+		t.Error("worktrees mode read-only should show 'D      destructive mode'")
 	}
-	if strings.Contains(view, "d: delete") {
-		t.Error("worktrees mode read-only should NOT show 'd: delete'")
+	if strings.Contains(view, "d      delete") {
+		t.Error("worktrees mode read-only should NOT show 'd      delete'")
 	}
 }
 
@@ -689,7 +686,7 @@ func TestModel_ViewWorktreesDirtyShowsDiffHint(t *testing.T) {
 	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: wts})
 
 	view := m.View()
-	for _, hint := range []string{"enter: diff", "t: terminal", "c: code"} {
+	for _, hint := range []string{"enter  diff", "t/c    terminal / code"} {
 		if !strings.Contains(view, hint) {
 			t.Errorf("view should show %q for dirty worktree", hint)
 		}
@@ -706,11 +703,11 @@ func TestModel_ViewWorktreesCleanHidesEnterDiff(t *testing.T) {
 	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: wts})
 
 	view := m.View()
-	if strings.Contains(view, "enter: diff") {
-		t.Error("view should NOT show 'enter: diff' for clean worktree")
+	if strings.Contains(view, "enter  diff") {
+		t.Error("view should NOT show 'enter  diff' for clean worktree")
 	}
-	if !strings.Contains(view, "t: terminal") {
-		t.Error("view should show 't: terminal' for clean worktree")
+	if !strings.Contains(view, "t/c    terminal / code") {
+		t.Error("view should show 't/c    terminal / code' for clean worktree")
 	}
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -107,6 +107,7 @@ var (
 	activeModeStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)               // 15 = bright white
 	inactiveModeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
 	shortcutTitleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)               // 15 = bright white
+	shortcutModeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)               // 12 = bright blue
 	shortcutGroupStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Bold(true)               // 14 = bright cyan
 	shortcutKeyStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)               // 12 = bright blue
 	shortcutTextStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("250"))                         // 250 = light gray
@@ -524,9 +525,10 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 		return ""
 	}
 	lines := make([]string, 0)
-	title := fmt.Sprintf("Shortcuts  %s", modeShortcutTitle(sp.Mode))
-	lines = append(lines, truncateToWidth(" "+shortcutTitleStyle.Render(title), width))
+	title := shortcutTitleStyle.Render("Shortcuts") + "  " + shortcutModeStyle.Render(modeShortcutTitle(sp.Mode))
+	lines = append(lines, ansi.Truncate(" "+title, width, ""))
 	compact := height <= 3
+	sectionCount := 0
 
 	for _, section := range shortcutSections(sp) {
 		hints := sidebarShortcutHints(section.Hints)
@@ -534,11 +536,15 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 			continue
 		}
 		if !compact {
+			if sectionCount > 0 {
+				lines = append(lines, strings.Repeat(" ", width))
+			}
 			lines = append(lines, truncateToWidth(" "+shortcutGroupStyle.Render(section.Title), width))
 		}
 		for _, hint := range hints {
 			lines = append(lines, renderShortcutPaneHint(hint, width))
 		}
+		sectionCount++
 	}
 
 	if len(lines) > height {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -566,7 +566,7 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 
 func renderShortcutPaneHint(hint shortcutHint, width int) string {
 	if hint.Key == "merged" && hint.Label == "merged" {
-		return truncateToWidth(" "+shortcutTextStyle.Render(hint.Label), width)
+		return ansi.Truncate(" "+shortcutTextStyle.Render(hint.Label), width, "")
 	}
 	keyStyle := shortcutKeyStyle
 	if hint.Warning {
@@ -574,7 +574,7 @@ func renderShortcutPaneHint(hint shortcutHint, width int) string {
 	}
 	key := padShortcutKey(keyStyle.Render(hint.Key), shortcutKeyColumnWidth)
 	label := shortcutTextStyle.Render(hint.Label)
-	return truncateToWidth(" "+key+" "+label, width)
+	return ansi.Truncate(" "+key+" "+label, width, "")
 }
 
 func sidebarShortcutHints(hints []shortcutHint) []shortcutHint {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -528,6 +528,9 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 	title := shortcutTitleStyle.Render("Shortcuts") + "  " + shortcutModeStyle.Render(modeShortcutTitle(sp.Mode))
 	lines = append(lines, ansi.Truncate(" "+title, width, ""))
 	compact := height <= 3
+	if !compact {
+		lines = append(lines, strings.Repeat(" ", width))
+	}
 	sectionCount := 0
 
 	for _, section := range shortcutSections(sp) {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/scanner"
@@ -56,6 +57,11 @@ const LeftPaneWidth = 30
 // shortcut rail, including its left and right borders.
 const ShortcutPaneWidth = 28
 
+const (
+	shortcutKeyColumnWidth = 6
+	shortcutOverflowMarker = "..."
+)
+
 // MinContentPaneWidth keeps the primary item pane useful before the shortcut
 // rail is shown. Narrow terminals continue using footer hints instead.
 const MinContentPaneWidth = 48
@@ -103,7 +109,7 @@ var (
 	shortcutTitleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)               // 15 = bright white
 	shortcutGroupStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Bold(true)               // 14 = bright cyan
 	shortcutKeyStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)               // 12 = bright blue
-	shortcutTextStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))                          // 15 = bright white
+	shortcutTextStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("250"))                         // 250 = light gray
 	stashDateStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
 	stashMsgStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))                          // 15 = bright white
 	stashSelStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true).Reverse(true) // 15 = bright white
@@ -244,7 +250,8 @@ func Render(p RenderParams) string {
 		AgentAvailable:            p.AgentAvailable,
 		NewAgent:                  p.NewAgentAvailable,
 	}
-	showShortcutPane := !hasActiveStatusQuery(status) && shouldRenderShortcutPane(p.Width, p.Height, status)
+	innerHeight := p.Height - 3 // status bar + top/bottom borders
+	showShortcutPane := !hasActiveStatusQuery(status) && shouldRenderShortcutPane(p.Width, innerHeight, status)
 	statusBar := renderFooterStatusBar(status, !showShortcutPane)
 
 	// Border colors based on active pane
@@ -264,8 +271,6 @@ func Render(p RenderParams) string {
 	}
 
 	leftContentWidth := LeftPaneWidth - 2 // left + right border
-	innerHeight := p.Height - 3           // status bar + top/bottom borders
-
 	leftLines := renderRepoList(p.Repos, p.Selected, p.RepoScroll, leftContentWidth, innerHeight, p.RepoEmptyMessage)
 	leftContent := strings.Join(leftLines, "\n")
 	leftPane := lipgloss.NewStyle().
@@ -367,7 +372,7 @@ func renderModeHeader(mode Mode, width int) string {
 			parts = append(parts, inactiveModeStyle.Render(fmt.Sprintf(" %d %s", m.key, m.name)))
 		}
 	}
-	line := " " + strings.Join(parts, " ")
+	line := ansi.Truncate(" "+strings.Join(parts, " "), width, "")
 	separator := strings.Repeat("─", width)
 	return line + "\n" + separator
 }
@@ -455,7 +460,7 @@ func shouldRenderShortcutPane(width, height int, sp statusBarParams) bool {
 	if width < LeftPaneWidth+ShortcutPaneWidth+MinContentPaneWidth {
 		return false
 	}
-	return shortcutPaneLineCount(shortcutSections(sp)) <= height-3
+	return height >= 3
 }
 
 func renderFooterStatusBar(sp statusBarParams, includeHints bool) string {
@@ -518,34 +523,31 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 	if height <= 0 {
 		return ""
 	}
-	lines := make([]string, 0, height)
+	lines := make([]string, 0)
 	title := fmt.Sprintf("Shortcuts  %s", modeShortcutTitle(sp.Mode))
 	lines = append(lines, truncateToWidth(" "+shortcutTitleStyle.Render(title), width))
+	compact := height <= 3
 
 	for _, section := range shortcutSections(sp) {
-		if len(section.Hints) == 0 {
+		hints := sidebarShortcutHints(section.Hints)
+		if len(hints) == 0 {
 			continue
 		}
-		if len(lines) < height {
+		if !compact {
 			lines = append(lines, truncateToWidth(" "+shortcutGroupStyle.Render(section.Title), width))
 		}
-		for _, hint := range section.Hints {
-			if len(lines) >= height {
-				break
-			}
-			keyStyle := shortcutKeyStyle
-			if hint.Warning {
-				keyStyle = dirtyRedStyle.Bold(true)
-			}
-			key := keyStyle.Render(hint.Key + shortcutSeparator(hint))
-			label := shortcutTextStyle.Render(hint.Label)
-			lines = append(lines, truncateToWidth(" "+key+" "+label, width))
-		}
-		if len(lines) >= height {
-			break
+		for _, hint := range hints {
+			lines = append(lines, renderShortcutPaneHint(hint, width))
 		}
 	}
 
+	if len(lines) > height {
+		if height == 1 {
+			lines = []string{truncateToWidth(" "+statusStyle.Render(shortcutOverflowMarker), width)}
+		} else {
+			lines = append(lines[:height-1], truncateToWidth(" "+statusStyle.Render(shortcutOverflowMarker), width))
+		}
+	}
 	for len(lines) < height {
 		lines = append(lines, strings.Repeat(" ", width))
 	}
@@ -553,33 +555,55 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 	return strings.Join(lines, "\n")
 }
 
-func shortcutPaneLineCount(sections []shortcutSection) int {
-	lines := 1 // title
-	for _, section := range sections {
-		if len(section.Hints) == 0 {
-			continue
-		}
-		lines += 1 + len(section.Hints)
+func renderShortcutPaneHint(hint shortcutHint, width int) string {
+	if hint.Key == "merged" && hint.Label == "merged" {
+		return truncateToWidth(" "+shortcutTextStyle.Render(hint.Label), width)
 	}
-	return lines
+	keyStyle := shortcutKeyStyle
+	if hint.Warning {
+		keyStyle = dirtyRedStyle.Bold(true)
+	}
+	key := padShortcutKey(keyStyle.Render(hint.Key), shortcutKeyColumnWidth)
+	label := shortcutTextStyle.Render(hint.Label)
+	return truncateToWidth(" "+key+" "+label, width)
+}
+
+func sidebarShortcutHints(hints []shortcutHint) []shortcutHint {
+	grouped := make([]shortcutHint, 0, len(hints))
+	for i := 0; i < len(hints); i++ {
+		hint := hints[i]
+		if i+1 < len(hints) {
+			next := hints[i+1]
+			switch {
+			case hint.Key == "f" && next.Key == "F":
+				grouped = append(grouped, shortcutHint{Key: "f/F", Label: hint.Label + " / " + next.Label, Warning: hint.Warning || next.Warning})
+				i++
+				continue
+			case hint.Key == "t" && next.Key == "c":
+				grouped = append(grouped, shortcutHint{Key: "t/c", Label: hint.Label + " / " + next.Label, Warning: hint.Warning || next.Warning})
+				i++
+				continue
+			}
+		}
+		grouped = append(grouped, hint)
+	}
+	return grouped
+}
+
+func padShortcutKey(key string, width int) string {
+	padding := width - lipgloss.Width(key)
+	if padding <= 0 {
+		return key
+	}
+	return key + strings.Repeat(" ", padding)
 }
 
 func shortcutSections(sp statusBarParams) []shortcutSection {
 	navigation := []shortcutHint{{Key: "↑/↓", Label: "select", Inline: true}}
-
-	sections := []shortcutSection{
-		{
-			Title: "Global",
-			Hints: []shortcutHint{
-				{Key: "tab", Label: "pane"},
-				{Key: "q/esc", Label: "quit"},
-				{Key: "A", Label: "set agent"},
-			},
-		},
-		{
-			Title: "Navigate",
-			Hints: navigation,
-		},
+	global := []shortcutHint{
+		{Key: "tab", Label: "pane"},
+		{Key: "q/esc", Label: "quit"},
+		{Key: "A", Label: "set agent"},
 	}
 
 	var actions []shortcutHint
@@ -700,9 +724,14 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	if !sp.Destructive && (sp.Mode == ModeWorktrees || sp.Mode == ModeBranches || sp.Mode == ModeStashes) {
 		actions = append([]shortcutHint{{Key: "D", Label: "destructive mode"}}, actions...)
 	}
+	var sections []shortcutSection
 	if len(actions) > 0 {
 		sections = append(sections, shortcutSection{Title: "Actions", Hints: actions})
 	}
+	sections = append(sections,
+		shortcutSection{Title: "Navigate", Hints: navigation},
+		shortcutSection{Title: "Global", Hints: global},
+	)
 	if sp.Mode == ModeBranches {
 		sections = append(sections, shortcutSection{
 			Title: "Legend",
@@ -732,7 +761,7 @@ func renderFooterShortcuts(sp statusBarParams, sections []shortcutSection) strin
 		}
 		return renderFooterLegend(legend)
 	}
-	return "  " + renderFooterHintList(sections)
+	return "  " + renderFooterHintList(footerSectionOrder(sections))
 }
 
 func transientStatusStyle(fadeStep int) lipgloss.Style {
@@ -861,6 +890,23 @@ func branchFooterSectionOrder(sections []shortcutSection) []shortcutSection {
 	}
 	for _, section := range sections {
 		if section.Title != "Global" && section.Title != "Safety" && section.Title != "Actions" {
+			ordered = append(ordered, section)
+		}
+	}
+	return ordered
+}
+
+func footerSectionOrder(sections []shortcutSection) []shortcutSection {
+	ordered := make([]shortcutSection, 0, len(sections))
+	for _, title := range []string{"Global", "Navigate", "Actions", "Legend"} {
+		for _, section := range sections {
+			if section.Title == title {
+				ordered = append(ordered, section)
+			}
+		}
+	}
+	for _, section := range sections {
+		if section.Title != "Global" && section.Title != "Navigate" && section.Title != "Actions" && section.Title != "Legend" {
 			ordered = append(ordered, section)
 		}
 	}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -192,7 +192,7 @@ func lineContaining(view, needle string) string {
 }
 
 func shortcutPaneLines(view string) []string {
-	var start int
+	start := -1
 	for _, line := range strings.Split(view, "\n") {
 		stripped := ansi.Strip(line)
 		if idx := strings.Index(stripped, "Shortcuts"); idx >= 0 {
@@ -200,7 +200,7 @@ func shortcutPaneLines(view string) []string {
 			break
 		}
 	}
-	if start == 0 {
+	if start < 0 {
 		return nil
 	}
 
@@ -654,6 +654,26 @@ func TestRender_ShortcutPaneStylesModeTitleSeparately(t *testing.T) {
 	want := shortcutTitleStyle.Render("Shortcuts") + "  " + shortcutModeStyle.Render("Worktrees")
 	if !strings.Contains(pane, want) {
 		t.Fatalf("shortcut pane title should style mode separately, got %q want fragment %q", pane, want)
+	}
+}
+
+func TestSidebarShortcutHintsGroupsOnlyAdjacentPairs(t *testing.T) {
+	grouped := sidebarShortcutHints([]shortcutHint{
+		{Key: "f", Label: "fetch"},
+		{Key: "F", Label: "pull"},
+		{Key: "t", Label: "terminal"},
+		{Key: "x", Label: "extra"},
+		{Key: "c", Label: "code"},
+	})
+
+	want := []shortcutHint{
+		{Key: "f/F", Label: "fetch / pull"},
+		{Key: "t", Label: "terminal"},
+		{Key: "x", Label: "extra"},
+		{Key: "c", Label: "code"},
+	}
+	if fmt.Sprint(grouped) != fmt.Sprint(want) {
+		t.Fatalf("sidebar grouping should only combine adjacent key pairs, got %#v want %#v", grouped, want)
 	}
 }
 

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -319,7 +319,7 @@ func TestRender_WorktreesModeShowsAgentHints(t *testing.T) {
 		Repos:             []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
 		Selected:          0,
 		Width:             140,
-		Height:            18,
+		Height:            20,
 		Mode:              1,
 		ActivePane:        1,
 		Worktrees:         []gitquery.Worktree{{Path: "/a", BranchName: "main", IsMain: true}},
@@ -618,6 +618,37 @@ func TestRender_ShortcutPanePrioritizesActions(t *testing.T) {
 	}
 }
 
+func TestRender_ShortcutPaneSeparatesSectionsWithBlankRows(t *testing.T) {
+	sp := statusBarParams{
+		Mode:                     ModeWorktrees,
+		ActivePane:               1,
+		RepoSelected:             true,
+		WorktreeSelected:         true,
+		WorktreeOpenableSelected: true,
+		FetchAvailable:           true,
+		PullAvailable:            true,
+	}
+
+	lines := strings.Split(ansi.Strip(renderShortcutPane(sp, 26, 18)), "\n")
+	for i, line := range lines {
+		if strings.Contains(line, "Navigate") {
+			if i == 0 || strings.TrimSpace(lines[i-1]) != "" {
+				t.Fatalf("shortcut pane should leave a blank row before Navigate, got:\n%s", strings.Join(lines, "\n"))
+			}
+			return
+		}
+	}
+	t.Fatalf("shortcut pane should include Navigate section, got:\n%s", strings.Join(lines, "\n"))
+}
+
+func TestRender_ShortcutPaneStylesModeTitleSeparately(t *testing.T) {
+	pane := renderShortcutPane(statusBarParams{Mode: ModeWorktrees}, 26, 6)
+	want := shortcutTitleStyle.Render("Shortcuts") + "  " + shortcutModeStyle.Render("Worktrees")
+	if !strings.Contains(pane, want) {
+		t.Fatalf("shortcut pane title should style mode separately, got %q want fragment %q", pane, want)
+	}
+}
+
 func TestRender_ShortcutPaneGroupsRelatedRows(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:                 []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
@@ -799,7 +830,7 @@ func TestRender_BranchShortcutPaneKeepsLegend(t *testing.T) {
 		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
 		Selected: 0,
 		Width:    160,
-		Height:   24,
+		Height:   26,
 		Mode:     ModeBranches,
 		Branches: []gitquery.BranchRow{
 			{Branch: gitquery.Branch{Name: "feature", HasUpstream: false, Dirty: true, IsWorktree: true}, WorktreePath: "/a-feature"},

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -108,7 +108,7 @@ func TestRender_BranchesModeShowsPullWhenAvailable(t *testing.T) {
 		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
 		Selected: 0,
 		Width:    180,
-		Height:   10,
+		Height:   16,
 		Mode:     2,
 		Branches: []gitquery.BranchRow{
 			{Branch: gitquery.Branch{Name: "main", IsWorktree: true}, WorktreePath: "/a"},
@@ -630,6 +630,14 @@ func TestRender_ShortcutPaneSeparatesSectionsWithBlankRows(t *testing.T) {
 	}
 
 	lines := strings.Split(ansi.Strip(renderShortcutPane(sp, 26, 18)), "\n")
+	for i, line := range lines {
+		if strings.Contains(line, "Actions") {
+			if i == 0 || strings.TrimSpace(lines[i-1]) != "" {
+				t.Fatalf("shortcut pane should leave a blank row below the title, got:\n%s", strings.Join(lines, "\n"))
+			}
+			break
+		}
+	}
 	for i, line := range lines {
 		if strings.Contains(line, "Navigate") {
 			if i == 0 || strings.TrimSpace(lines[i-1]) != "" {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -117,10 +117,9 @@ func TestRender_BranchesModeShowsPullWhenAvailable(t *testing.T) {
 		FetchAvailable: true,
 		PullAvailable:  true,
 	})
-	for _, hint := range []string{"f: fetch", "F: pull"} {
-		if !strings.Contains(view, hint) {
-			t.Errorf("branches render should contain %q when available", hint)
-		}
+	pane := shortcutPaneText(view)
+	if !strings.Contains(pane, "f/F") || !strings.Contains(pane, "fetch / pull") {
+		t.Errorf("branches render should contain grouped fetch/pull shortcut, got:\n%s", pane)
 	}
 }
 
@@ -134,7 +133,7 @@ func TestRender_LeftPaneShowsFetchVisibleWhenReposExist(t *testing.T) {
 		ActivePane:            0,
 		FetchVisibleAvailable: true,
 	})
-	if !strings.Contains(view, "f: fetch visible") {
+	if !strings.Contains(shortcutPaneText(view), "f      fetch visible") {
 		t.Fatalf("left-pane render should expose fetch-visible hint, got:\n%s", view)
 	}
 }
@@ -192,6 +191,37 @@ func lineContaining(view, needle string) string {
 	return ""
 }
 
+func shortcutPaneLines(view string) []string {
+	var start int
+	for _, line := range strings.Split(view, "\n") {
+		stripped := ansi.Strip(line)
+		if idx := strings.Index(stripped, "Shortcuts"); idx >= 0 {
+			start = idx
+			break
+		}
+	}
+	if start == 0 {
+		return nil
+	}
+
+	var lines []string
+	for _, line := range strings.Split(view, "\n") {
+		stripped := ansi.Strip(line)
+		if len(stripped) <= start {
+			continue
+		}
+		text := strings.Trim(stripped[start:], " │")
+		if text != "" {
+			lines = append(lines, text)
+		}
+	}
+	return lines
+}
+
+func shortcutPaneText(view string) string {
+	return strings.Join(shortcutPaneLines(view), "\n")
+}
+
 func TestRender_SessionsModeEmptyMessages(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
@@ -233,7 +263,7 @@ func TestRender_SessionsModeShowsTranscriptShortcut(t *testing.T) {
 		ActivePane:      1,
 		SessionSelected: 0,
 	})
-	if !strings.Contains(view, "enter: transcript") {
+	if !strings.Contains(shortcutPaneText(view), "enter  transcript") {
 		t.Fatalf("sessions view should expose transcript shortcut:\n%s", view)
 	}
 }
@@ -248,7 +278,7 @@ func TestRender_LeftPaneShortcutPaneShowsFetchVisibleWhenReposExist(t *testing.T
 		ActivePane:            0,
 		FetchVisibleAvailable: true,
 	})
-	if !strings.Contains(view, "f: fetch visible") {
+	if !strings.Contains(shortcutPaneText(view), "f      fetch visible") {
 		t.Fatalf("left-pane shortcut pane should expose fetch-visible hint, got:\n%s", view)
 	}
 }
@@ -289,15 +319,16 @@ func TestRender_WorktreesModeShowsAgentHints(t *testing.T) {
 		Repos:             []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
 		Selected:          0,
 		Width:             140,
-		Height:            10,
+		Height:            18,
 		Mode:              1,
 		ActivePane:        1,
 		Worktrees:         []gitquery.Worktree{{Path: "/a", BranchName: "main", IsMain: true}},
 		AgentAvailable:    true,
 		NewAgentAvailable: true,
 	})
-	for _, hint := range []string{"A: set agent", "a: agent", "N: new+agent"} {
-		if !strings.Contains(view, hint) {
+	pane := shortcutPaneText(view)
+	for _, hint := range []string{"A      set agent", "a      agent", "N      new+agent"} {
+		if !strings.Contains(pane, hint) {
 			t.Fatalf("expected worktrees view to contain %q, got %q", hint, view)
 		}
 	}
@@ -308,14 +339,15 @@ func TestRender_StaleWorktreeShowsSetAgentHint(t *testing.T) {
 		Repos:             []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
 		Selected:          0,
 		Width:             140,
-		Height:            10,
+		Height:            16,
 		Mode:              1,
 		ActivePane:        1,
 		Worktrees:         []gitquery.Worktree{{Path: "/gone", BranchName: "gone", Stale: true}},
 		NewAgentAvailable: true,
 	})
-	for _, hint := range []string{"A: set agent", "N: new+agent"} {
-		if !strings.Contains(view, hint) {
+	pane := shortcutPaneText(view)
+	for _, hint := range []string{"A      set agent", "N      new+agent"} {
+		if !strings.Contains(pane, hint) {
 			t.Fatalf("expected stale worktree view to contain %q, got %q", hint, view)
 		}
 	}
@@ -326,20 +358,20 @@ func TestRender_BranchesModeShowsAgentHintOnlyWhenTargetAvailable(t *testing.T) 
 		Repos:      []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
 		Selected:   0,
 		Width:      140,
-		Height:     10,
+		Height:     18,
 		Mode:       2,
 		ActivePane: 1,
 		Branches:   []gitquery.BranchRow{{Branch: gitquery.Branch{Name: "feat"}}},
 	}
 	view := Render(params)
-	if strings.Contains(view, "a: agent") {
+	if strings.Contains(shortcutPaneText(view), "a      agent") {
 		t.Fatalf("bare branch should not show agent hint, got %q", view)
 	}
 
 	params.AgentAvailable = true
 	params.Branches = []gitquery.BranchRow{{Branch: gitquery.Branch{Name: "main", IsWorktree: true}, WorktreePath: "/a"}}
 	view = Render(params)
-	if !strings.Contains(view, "a: agent") {
+	if !strings.Contains(shortcutPaneText(view), "a      agent") {
 		t.Fatalf("checked-out branch should show agent hint, got %q", view)
 	}
 }
@@ -451,7 +483,7 @@ func TestRender_WideLayoutReplacesFooterHints(t *testing.T) {
 	if strings.Contains(footer, "tab: pane") || strings.Contains(footer, "q/esc: quit") {
 		t.Fatalf("wide render footer should not carry shortcut hints, got %q", footer)
 	}
-	if !strings.Contains(view, "tab:") || !strings.Contains(view, "pane") {
+	if !strings.Contains(shortcutPaneText(view), "tab    pane") {
 		t.Fatal("wide render should still expose global shortcuts in the shortcut pane")
 	}
 }
@@ -475,7 +507,7 @@ func TestRender_NarrowLayoutKeepsFooterHints(t *testing.T) {
 	}
 }
 
-func TestRender_ShortWideLayoutFallsBackToFooterHints(t *testing.T) {
+func TestRender_ShortWideLayoutKeepsClippedShortcutPane(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
 		Selected: 0,
@@ -491,14 +523,237 @@ func TestRender_ShortWideLayoutFallsBackToFooterHints(t *testing.T) {
 		PullAvailable:    true,
 	})
 
-	if strings.Contains(view, "Shortcuts") {
-		t.Fatal("wide but short render should not replace footer hints with a truncated shortcut pane")
+	if !strings.Contains(view, "Shortcuts") {
+		t.Fatal("wide but short render should keep a clipped shortcut pane")
+	}
+	if !strings.Contains(view, "new worktree") {
+		t.Fatalf("short wide shortcut pane should keep high-priority actions, got:\n%s", view)
 	}
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	for _, want := range []string{"tab: pane", "n: new worktree", "F: pull", "c: code"} {
-		if !strings.Contains(footer, want) {
-			t.Fatalf("short wide footer should retain %q, got %q", want, footer)
+	for _, forbidden := range []string{"tab: pane", "n: new worktree", "F: pull", "c: code"} {
+		if strings.Contains(footer, forbidden) {
+			t.Fatalf("short wide footer should not carry shortcut hint %q, got %q", forbidden, footer)
+		}
+	}
+}
+
+func TestRender_ShortcutPaneUsesUsableHeightGate(t *testing.T) {
+	params := RenderParams{
+		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected: 0,
+		Width:    120,
+		Mode:     ModeWorktrees,
+		Worktrees: []gitquery.Worktree{
+			{Path: "/a", BranchName: "main", IsMain: true},
+		},
+		WorktreeSelected: 0,
+		ActivePane:       1,
+	}
+
+	params.Height = 5 // two usable pane rows after borders/status.
+	if view := Render(params); strings.Contains(view, "Shortcuts") {
+		t.Fatalf("shortcut pane should stay hidden below three usable rows, got:\n%s", view)
+	}
+
+	params.Height = 6 // three usable pane rows after borders/status.
+	view := Render(params)
+	if !strings.Contains(view, "Shortcuts") || !strings.Contains(shortcutPaneText(view), shortcutOverflowMarker) {
+		t.Fatalf("shortcut pane should render and clip at three usable rows, got:\n%s", view)
+	}
+	if got := len(strings.Split(view, "\n")); got != params.Height {
+		t.Fatalf("shortcut pane render should not exceed terminal height, got %d lines want %d:\n%s", got, params.Height, view)
+	}
+}
+
+func TestRenderShortcutPane_ClipsOverflowAtEdgeHeights(t *testing.T) {
+	sp := statusBarParams{
+		Mode:                      ModeWorktrees,
+		ActivePane:                1,
+		RepoSelected:              true,
+		WorktreeSelected:          true,
+		WorktreeOpenableSelected:  true,
+		WorktreeDeletableSelected: true,
+		FetchAvailable:            true,
+		PullAvailable:             true,
+	}
+
+	if got := ansi.Strip(renderShortcutPane(sp, 26, 1)); strings.TrimSpace(got) != shortcutOverflowMarker {
+		t.Fatalf("height 1 should render only overflow marker, got %q", got)
+	}
+	if got := ansi.Strip(renderShortcutPane(sp, 26, 2)); !strings.Contains(got, "Shortcuts") || !strings.Contains(got, shortcutOverflowMarker) {
+		t.Fatalf("height 2 should render title plus overflow marker, got %q", got)
+	}
+	if got := ansi.Strip(renderShortcutPane(sp, 26, 3)); !strings.Contains(got, "D      destructive mode") || !strings.Contains(got, shortcutOverflowMarker) {
+		t.Fatalf("height 3 should render first shortcut plus overflow marker, got %q", got)
+	}
+}
+
+func TestRender_ShortcutPanePrioritizesActions(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected: 0,
+		Width:    120,
+		Height:   18,
+		Mode:     ModeWorktrees,
+		Worktrees: []gitquery.Worktree{
+			{Path: "/a", BranchName: "main", IsMain: true},
+		},
+		WorktreeSelected: 0,
+		ActivePane:       1,
+		FetchAvailable:   true,
+		PullAvailable:    true,
+	})
+	pane := shortcutPaneText(view)
+	actions := strings.Index(pane, "Actions")
+	navigate := strings.Index(pane, "Navigate")
+	global := strings.Index(pane, "Global")
+	newWorktree := strings.Index(pane, "new worktree")
+	tabPane := strings.Index(pane, "tab    pane")
+	if actions < 0 || navigate < 0 || global < 0 || !(actions < navigate && navigate < global) {
+		t.Fatalf("shortcut pane should order Actions, Navigate, Global, got:\n%s", pane)
+	}
+	if newWorktree < 0 || tabPane < 0 || newWorktree > tabPane {
+		t.Fatalf("shortcut pane should show contextual actions before global hints, got:\n%s", pane)
+	}
+}
+
+func TestRender_ShortcutPaneGroupsRelatedRows(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:                 []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:              0,
+		Width:                 140,
+		Height:                18,
+		Mode:                  ModeWorktrees,
+		Worktrees:             []gitquery.Worktree{{Path: "/a-worktrees/feat", BranchName: "feat"}},
+		WorktreeSelected:      0,
+		ActivePane:            1,
+		FetchAvailable:        true,
+		PullAvailable:         true,
+		WorktreeMoveAvailable: true,
+	})
+	lines := shortcutPaneLines(view)
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{"f/F    fetch / pull", "t/c    terminal / code"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("shortcut pane should include grouped row %q, got:\n%s", want, joined)
+		}
+	}
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "f      fetch") || strings.HasPrefix(trimmed, "F      pull") ||
+			strings.HasPrefix(trimmed, "t      terminal") || strings.HasPrefix(trimmed, "c      code") {
+			t.Fatalf("shortcut pane should not include ungrouped related row %q:\n%s", line, joined)
+		}
+	}
+}
+
+func TestRender_ShortcutPaneAlignsLabels(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:          []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:       0,
+		Width:          140,
+		Height:         18,
+		Mode:           ModeWorktrees,
+		Worktrees:      []gitquery.Worktree{{Path: "/a-worktrees/feat", BranchName: "feat"}},
+		ActivePane:     1,
+		FetchAvailable: true,
+		PullAvailable:  true,
+	})
+	pane := shortcutPaneText(view)
+	rows := []struct {
+		key   string
+		label string
+	}{
+		{key: "n", label: "new worktree"},
+		{key: "P", label: "PR"},
+		{key: "f/F", label: "fetch / pull"},
+		{key: "t/c", label: "terminal / code"},
+	}
+
+	labelColumn := -1
+	for _, row := range rows {
+		line := lineContaining(pane, row.label)
+		if line == "" || !strings.HasPrefix(strings.TrimSpace(line), row.key) {
+			t.Fatalf("missing shortcut row %s %s in:\n%s", row.key, row.label, pane)
+		}
+		column := strings.Index(line, row.label)
+		if labelColumn == -1 {
+			labelColumn = column
+			continue
+		}
+		if column != labelColumn {
+			t.Fatalf("label %q starts at column %d, want %d in:\n%s", row.label, column, labelColumn, pane)
+		}
+	}
+}
+
+func TestRender_ShortBranchPaneClipsLegendAfterActions(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected: 0,
+		Width:    160,
+		Height:   12,
+		Mode:     ModeBranches,
+		Branches: []gitquery.BranchRow{
+			{Branch: gitquery.Branch{Name: "feature", HasUpstream: false, Dirty: true, IsWorktree: true}, WorktreePath: "/a-feature"},
+		},
+		BranchSelected: 0,
+		ActivePane:     1,
+		Destructive:    true,
+		FetchAvailable: true,
+		PullAvailable:  true,
+	})
+	pane := shortcutPaneText(view)
+	for _, want := range []string{"Actions", "n      new branch", "enter  diff", shortcutOverflowMarker} {
+		if !strings.Contains(pane, want) {
+			t.Fatalf("short branch shortcut pane should keep action %q, got:\n%s", want, pane)
+		}
+	}
+	if strings.Contains(pane, "Legend") {
+		t.Fatalf("short branch shortcut pane should clip lower-priority legend first, got:\n%s", pane)
+	}
+}
+
+func TestRender_ShortSessionPaneKeepsTranscriptAction(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    120,
+		Height:   8,
+		Mode:     ModeSessions,
+		Sessions: []sessions.SessionRecord{{
+			Provider:  sessions.ProviderCodex,
+			SessionID: "codex-session-1",
+			Status:    "ended",
+			RepoPath:  "/dev/wtui",
+		}},
+		ActivePane:      1,
+		SessionSelected: 0,
+	})
+	pane := shortcutPaneText(view)
+	if !strings.Contains(pane, "enter  transcript") || !strings.Contains(pane, shortcutOverflowMarker) {
+		t.Fatalf("short session shortcut pane should keep transcript action and clip, got:\n%s", pane)
+	}
+}
+
+func TestRender_ShortLeftPaneOmitsRightPaneActions(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:                 []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:              0,
+		Width:                 120,
+		Height:                8,
+		Mode:                  ModeHistory,
+		ActivePane:            0,
+		FetchVisibleAvailable: true,
+	})
+	pane := shortcutPaneText(view)
+	if !strings.Contains(pane, "f      fetch visible") {
+		t.Fatalf("short left-pane shortcut pane should keep left-pane action, got:\n%s", pane)
+	}
+	for _, forbidden := range []string{"enter  diff", "y      copy hash", "t/c    terminal / code"} {
+		if strings.Contains(pane, forbidden) {
+			t.Fatalf("short left-pane shortcut pane should omit right-pane action %q, got:\n%s", forbidden, pane)
 		}
 	}
 }
@@ -559,10 +814,14 @@ func TestRender_BranchShortcutPaneKeepsLegend(t *testing.T) {
 	if !strings.Contains(view, "Shortcuts") {
 		t.Fatal("branch wide render should use shortcut pane when the full shortcut list fits")
 	}
-	for _, want := range []string{"Legend", "clean", "ahead/behind", "dirty", "no upstream", "merged", "d: delete", "F: pull"} {
-		if !strings.Contains(view, want) {
+	pane := shortcutPaneText(view)
+	for _, want := range []string{"Legend", "clean", "ahead/behind", "dirty", "no upstream", "merged", "d      delete", "f/F    fetch / pull"} {
+		if !strings.Contains(pane, want) {
 			t.Fatalf("branch shortcut pane should include %q, got:\n%s", want, view)
 		}
+	}
+	if strings.Contains(pane, "merged merged") {
+		t.Fatalf("branch shortcut pane should render merged legend once, got:\n%s", pane)
 	}
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
@@ -688,7 +947,7 @@ func TestRender_WorktreeRootOmitsDeleteHint(t *testing.T) {
 	if !strings.Contains(view, "Shortcuts") {
 		t.Fatal("wide worktree render should use shortcut pane")
 	}
-	if strings.Contains(view, "d: delete") {
+	if strings.Contains(shortcutPaneText(view), "d      delete") {
 		t.Fatalf("root worktree should not advertise delete, got:\n%s", view)
 	}
 }
@@ -739,7 +998,7 @@ func TestRender_WorktreeMoveHintAvailability(t *testing.T) {
 				ActivePane:            1,
 				WorktreeMoveAvailable: tt.canMove,
 			})
-			hasMove := strings.Contains(view, "m: move")
+			hasMove := strings.Contains(shortcutPaneText(view), "m      move")
 			if hasMove != tt.wantMove {
 				t.Fatalf("move hint visibility mismatch, want %v got %v:\n%s", tt.wantMove, hasMove, view)
 			}
@@ -783,10 +1042,10 @@ func TestRender_BranchShortcutPaneShowsDiffButOmitsRootDelete(t *testing.T) {
 		Destructive:    true,
 	})
 
-	if !strings.Contains(view, "enter: diff") {
+	if !strings.Contains(shortcutPaneText(view), "enter  diff") {
 		t.Fatalf("dirty branch worktree should advertise diff action, got:\n%s", view)
 	}
-	if strings.Contains(view, "d: delete") {
+	if strings.Contains(shortcutPaneText(view), "d      delete") {
 		t.Fatalf("root branch should not advertise delete action, got:\n%s", view)
 	}
 }
@@ -808,8 +1067,8 @@ func TestRender_BranchWithoutWorktreeOmitsOpenHints(t *testing.T) {
 	if !strings.Contains(view, "Shortcuts") {
 		t.Fatal("wide branch render should use shortcut pane")
 	}
-	for _, forbidden := range []string{"t: terminal", "c: code"} {
-		if strings.Contains(view, forbidden) {
+	for _, forbidden := range []string{"t/c    terminal / code", "t      terminal", "c      code"} {
+		if strings.Contains(shortcutPaneText(view), forbidden) {
 			t.Fatalf("non-worktree branch should not advertise %q, got:\n%s", forbidden, view)
 		}
 	}
@@ -896,8 +1155,9 @@ func TestRender_NonWorktreeModesShowSyncHintsWhenAvailable(t *testing.T) {
 			if !strings.Contains(view, "Shortcuts") {
 				t.Fatal("wide render should use shortcut pane")
 			}
-			for _, want := range []string{"f: fetch", "F: pull"} {
-				if !strings.Contains(view, want) {
+			pane := shortcutPaneText(view)
+			for _, want := range []string{"f/F    fetch / pull"} {
+				if !strings.Contains(pane, want) {
 					t.Fatalf("%s render should include %q when available, got:\n%s", tt.name, want, view)
 				}
 			}


### PR DESCRIPTION
## Summary
- Keep the shortcut sidebar visible in wide layouts when there is enough usable height, clipping lower-priority content with `...` instead of falling back to footer hints
- Prioritize contextual actions above navigation/global/legend content in the sidebar
- Align sidebar shortcut rows, group related `f/F` and `t/c` actions, and keep footer shortcut formatting/order separate
- Add UI and model-view coverage for clipping, grouping, alignment, branch legend behavior, session actions, and short left-pane states

## Verification
- `go test ./ui ./model`
- `make test`
- `gofmt -l .`
- `make build`
- `git diff --check`