### PR TITLE
Fix plan repo metadata for linked worktrees

### DIFF
--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -29,6 +29,7 @@ func main() {
 type runDeps struct {
 	loadConfig   func() (config.Config, error)
 	getenv       func(string) string
+	getwd        func() (string, error)
 	scan         func(scanner.ScanOptions) ([]scanner.Repo, error)
 	startProgram func([]scanner.Repo, config.Config) error
 	stdin        io.Reader
@@ -89,6 +90,9 @@ func fillRunDeps(deps runDeps) runDeps {
 	}
 	if deps.getenv == nil {
 		deps.getenv = os.Getenv
+	}
+	if deps.getwd == nil {
+		deps.getwd = os.Getwd
 	}
 	if deps.scan == nil {
 		deps.scan = scanner.Scan

--- a/cmd/wtui/plan.go
+++ b/cmd/wtui/plan.go
@@ -242,8 +242,8 @@ func shouldResolvePlanGitMetadata(store *planstore.Store, record planstore.PlanR
 	if record.PlanID == "" {
 		return true
 	}
-	hasIncomingMetadata := record.RepoPath != "" || record.WorktreePath != "" || record.Branch != "" || record.Commit != ""
-	return hasIncomingMetadata || !store.HasPlan(record.PlanID)
+	hasIncomingLocation := record.RepoPath != "" || record.WorktreePath != ""
+	return hasIncomingLocation || !store.HasPlan(record.PlanID)
 }
 
 func resolvePlanGitMetadata(record *planstore.PlanRecord, deps runDeps) {

--- a/cmd/wtui/plan.go
+++ b/cmd/wtui/plan.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/brian-bell/wtui/planstore"
@@ -108,6 +110,7 @@ func runPlanSave(args []string, deps runDeps) error {
 		Branch:       fallbackEnv(*branch, "WTUI_BRANCH", deps),
 		Commit:       fallbackEnv(*commit, "WTUI_COMMIT", deps),
 	}
+	resolvePlanGitMetadata(&record, deps)
 	savedID, err := store.Save(record)
 	if err != nil {
 		return err
@@ -223,4 +226,145 @@ func fallbackEnv(value, key string, deps runDeps) string {
 		return value
 	}
 	return deps.getenv(key)
+}
+
+type planGitMetadata struct {
+	RepoPath     string
+	WorktreePath string
+	Branch       string
+	Commit       string
+	Linked       bool
+}
+
+func resolvePlanGitMetadata(record *planstore.PlanRecord, deps runDeps) {
+	cwd, err := deps.getwd()
+	if err != nil {
+		cwd = ""
+	}
+	candidate := record.WorktreePath
+	if candidate == "" {
+		candidate = record.RepoPath
+	}
+	if candidate == "" {
+		candidate = cwd
+	}
+	if meta, ok := resolvePlanGitMetadataAt(candidate); ok {
+		applyPlanGitMetadata(record, meta)
+	}
+}
+
+func applyPlanGitMetadata(record *planstore.PlanRecord, meta planGitMetadata) {
+	if record.RepoPath == "" {
+		record.RepoPath = meta.RepoPath
+	} else if meta.Linked && meta.RepoPath != "" && samePlanPath(record.RepoPath, meta.WorktreePath) {
+		record.RepoPath = meta.RepoPath
+	}
+	if record.WorktreePath == "" {
+		record.WorktreePath = meta.WorktreePath
+	}
+	if record.Branch == "" {
+		record.Branch = meta.Branch
+	}
+	if record.Commit == "" {
+		record.Commit = meta.Commit
+	}
+}
+
+func samePlanPath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+func resolvePlanGitMetadataAt(cwd string) (planGitMetadata, bool) {
+	if cwd == "" {
+		return planGitMetadata{}, false
+	}
+	worktreePath, _ := planGitOutput(cwd, "rev-parse", "--show-toplevel")
+	commonDir, _ := planGitOutput(cwd, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	gitDir, _ := planGitOutput(cwd, "rev-parse", "--path-format=absolute", "--git-dir")
+	if worktreePath == "" && commonDir == "" && gitDir == "" {
+		return planGitMetadata{}, false
+	}
+	isBare := false
+	if out, err := planGitOutput(cwd, "rev-parse", "--is-bare-repository"); err == nil {
+		isBare = out == "true"
+	}
+	commonDirIsBare := false
+	if commonDir != "" {
+		if out, err := planGitOutput(commonDir, "rev-parse", "--is-bare-repository"); err == nil {
+			commonDirIsBare = out == "true"
+		}
+	}
+	linked := planIsLinkedWorktreeGitDir(gitDir, commonDir)
+	repoPath := planRepoPathFromGitMetadata(worktreePath, gitDir, commonDir, isBare, commonDirIsBare)
+	branch, _ := planGitOutput(cwd, "branch", "--show-current")
+	commit, _ := planGitOutput(cwd, "rev-parse", "HEAD")
+	return planGitMetadata{
+		RepoPath:     repoPath,
+		WorktreePath: worktreePath,
+		Branch:       branch,
+		Commit:       commit,
+		Linked:       linked,
+	}, true
+}
+
+func planRepoPathFromGitMetadata(worktreePath, gitDir, commonDir string, isBare, commonDirIsBare bool) string {
+	if isBare {
+		if commonDir != "" {
+			return filepath.Clean(commonDir)
+		}
+		if gitDir == "" {
+			return ""
+		}
+		return filepath.Clean(gitDir)
+	}
+	if commonDir != "" && gitDir != "" && planIsLinkedWorktreeGitDir(gitDir, commonDir) {
+		if commonDirIsBare {
+			return filepath.Clean(commonDir)
+		}
+		if filepath.Base(filepath.Clean(commonDir)) != ".git" {
+			return worktreePath
+		}
+		return planRepoPathFromGitCommonDir(commonDir)
+	}
+	if worktreePath != "" {
+		return worktreePath
+	}
+	if commonDir != "" {
+		return planRepoPathFromGitCommonDir(commonDir)
+	}
+	if gitDir == "" {
+		return ""
+	}
+	return planRepoPathFromGitCommonDir(gitDir)
+}
+
+func planIsLinkedWorktreeGitDir(gitDir, commonDir string) bool {
+	if gitDir == "" || commonDir == "" {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Join(filepath.Clean(commonDir), "worktrees"), filepath.Clean(gitDir))
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func planRepoPathFromGitCommonDir(commonDir string) string {
+	commonDir = filepath.Clean(commonDir)
+	if filepath.Base(commonDir) == ".git" {
+		return filepath.Dir(commonDir)
+	}
+	return commonDir
+}
+
+func planGitOutput(cwd string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", cwd}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }

--- a/cmd/wtui/plan.go
+++ b/cmd/wtui/plan.go
@@ -110,7 +110,9 @@ func runPlanSave(args []string, deps runDeps) error {
 		Branch:       fallbackEnv(*branch, "WTUI_BRANCH", deps),
 		Commit:       fallbackEnv(*commit, "WTUI_COMMIT", deps),
 	}
-	resolvePlanGitMetadata(&record, deps)
+	if shouldResolvePlanGitMetadata(store, record) {
+		resolvePlanGitMetadata(&record, deps)
+	}
 	savedID, err := store.Save(record)
 	if err != nil {
 		return err
@@ -234,6 +236,14 @@ type planGitMetadata struct {
 	Branch       string
 	Commit       string
 	Linked       bool
+}
+
+func shouldResolvePlanGitMetadata(store *planstore.Store, record planstore.PlanRecord) bool {
+	if record.PlanID == "" {
+		return true
+	}
+	hasIncomingMetadata := record.RepoPath != "" || record.WorktreePath != "" || record.Branch != "" || record.Commit != ""
+	return hasIncomingMetadata || !store.HasPlan(record.PlanID)
 }
 
 func resolvePlanGitMetadata(record *planstore.PlanRecord, deps runDeps) {

--- a/cmd/wtui/plan_test.go
+++ b/cmd/wtui/plan_test.go
@@ -267,6 +267,53 @@ func TestRunPlanSaveExplicitRepoPathDoesNotUseUnrelatedCWDMetadata(t *testing.T)
 	}
 }
 
+func TestRunPlanSaveUpdatePreservesExistingGitMetadataWhenOmitted(t *testing.T) {
+	stateRoot := t.TempDir()
+	repoDir, worktreeDir := makeLinkedWorktree(t)
+	otherRepoDir, otherWorktreeDir := makeLinkedWorktree(t)
+	var stdout bytes.Buffer
+
+	err := run([]string{"wtui", "plan", "save", "--title", "Original", "--plan-id", "p", "--state-root", stateRoot},
+		noScanDeps(t, runDeps{
+			getwd:  func() (string, error) { return worktreeDir, nil },
+			stdin:  strings.NewReader("first body"),
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("first run returned error: %v", err)
+	}
+
+	stdout.Reset()
+	err = run([]string{"wtui", "plan", "save", "--title", "Updated", "--plan-id", "p", "--state-root", stateRoot},
+		noScanDeps(t, runDeps{
+			getwd:  func() (string, error) { return otherWorktreeDir, nil },
+			stdin:  strings.NewReader("second body"),
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("second run returned error: %v", err)
+	}
+
+	record := readPlanRecord(t, stateRoot, "p")
+	if record.Title != "Updated" {
+		t.Fatalf("title = %q, want Updated", record.Title)
+	}
+	if record.RepoPath != repoDir || record.WorktreePath != worktreeDir {
+		t.Fatalf("git metadata should stay on original checkout, got repo=%q worktree=%q; want repo=%q worktree=%q",
+			record.RepoPath, record.WorktreePath, repoDir, worktreeDir)
+	}
+	if record.RepoPath == otherRepoDir || record.WorktreePath == otherWorktreeDir {
+		t.Fatalf("git metadata was overwritten by update cwd: %#v", record)
+	}
+	md, err := os.ReadFile(filepath.Join(stateRoot, "plans", "p", "plan.md"))
+	if err != nil {
+		t.Fatalf("read plan.md: %v", err)
+	}
+	if string(md) != "second body" {
+		t.Fatalf("plan.md = %q, want second body", md)
+	}
+}
+
 func TestRunPlanListJSON(t *testing.T) {
 	root := t.TempDir()
 	mustRun(t, []string{"wtui", "plan", "save", "--title", "Alpha", "--plan-id", "alpha", "--state-root", root, "--repo-path", "/repo"}, "alpha body")

--- a/cmd/wtui/plan_test.go
+++ b/cmd/wtui/plan_test.go
@@ -314,6 +314,77 @@ func TestRunPlanSaveUpdatePreservesExistingGitMetadataWhenOmitted(t *testing.T) 
 	}
 }
 
+func TestRunPlanSaveUpdateWithBranchOnlyPreservesOmittedGitMetadata(t *testing.T) {
+	stateRoot := t.TempDir()
+	repoDir, worktreeDir := makeLinkedWorktree(t)
+	otherRepoDir, otherWorktreeDir := makeLinkedWorktree(t)
+	var stdout bytes.Buffer
+
+	err := run([]string{"wtui", "plan", "save", "--title", "Original", "--plan-id", "p", "--state-root", stateRoot},
+		noScanDeps(t, runDeps{
+			getwd:  func() (string, error) { return worktreeDir, nil },
+			stdin:  strings.NewReader("first body"),
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("first run returned error: %v", err)
+	}
+	original := readPlanRecord(t, stateRoot, "p")
+
+	stdout.Reset()
+	err = run([]string{"wtui", "plan", "save", "--title", "Updated", "--plan-id", "p", "--state-root", stateRoot, "--branch", "manual-branch"},
+		noScanDeps(t, runDeps{
+			getwd:  func() (string, error) { return otherWorktreeDir, nil },
+			stdin:  strings.NewReader("second body"),
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("second run returned error: %v", err)
+	}
+
+	record := readPlanRecord(t, stateRoot, "p")
+	if record.Branch != "manual-branch" {
+		t.Fatalf("branch = %q, want manual-branch", record.Branch)
+	}
+	if record.RepoPath != repoDir || record.WorktreePath != worktreeDir || record.Commit != original.Commit {
+		t.Fatalf("omitted git metadata should stay original, got repo=%q worktree=%q commit=%q; want repo=%q worktree=%q commit=%q",
+			record.RepoPath, record.WorktreePath, record.Commit, repoDir, worktreeDir, original.Commit)
+	}
+	if record.RepoPath == otherRepoDir || record.WorktreePath == otherWorktreeDir {
+		t.Fatalf("omitted git metadata was overwritten by update cwd: %#v", record)
+	}
+}
+
+func TestRunPlanSaveFromBareRepoUsesBareRepoPath(t *testing.T) {
+	stateRoot := t.TempDir()
+	bareDir, commit := makeBareRepo(t)
+	var stdout bytes.Buffer
+
+	err := run([]string{"wtui", "plan", "save", "--title", "P", "--plan-id", "p", "--state-root", stateRoot},
+		noScanDeps(t, runDeps{
+			getwd:  func() (string, error) { return bareDir, nil },
+			stdin:  strings.NewReader("body"),
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	record := readPlanRecord(t, stateRoot, "p")
+	if record.RepoPath != bareDir {
+		t.Fatalf("repo_path = %q, want bare repo %q", record.RepoPath, bareDir)
+	}
+	if record.WorktreePath != "" {
+		t.Fatalf("worktree_path = %q, want empty for bare repo", record.WorktreePath)
+	}
+	if record.Branch != "main" {
+		t.Fatalf("branch = %q, want main", record.Branch)
+	}
+	if record.Commit != commit {
+		t.Fatalf("commit = %q, want %q", record.Commit, commit)
+	}
+}
+
 func TestRunPlanListJSON(t *testing.T) {
 	root := t.TempDir()
 	mustRun(t, []string{"wtui", "plan", "save", "--title", "Alpha", "--plan-id", "alpha", "--state-root", root, "--repo-path", "/repo"}, "alpha body")
@@ -397,6 +468,24 @@ func makeLinkedWorktree(t *testing.T) (repoDir, worktreeDir string) {
 	return mustRealPath(t, repoDir), mustRealPath(t, worktreeDir)
 }
 
+func makeBareRepo(t *testing.T) (bareDir, commit string) {
+	t.Helper()
+	root := t.TempDir()
+	repoDir := filepath.Join(root, "project")
+	bareDir = filepath.Join(root, "project.git")
+	mustGit(t, root, "init", repoDir)
+	mustGit(t, repoDir, "config", "user.email", "test@example.com")
+	mustGit(t, repoDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repoDir, "add", "README.md")
+	mustGit(t, repoDir, "commit", "-m", "initial")
+	mustGit(t, repoDir, "branch", "-M", "main")
+	mustGit(t, root, "clone", "--bare", repoDir, bareDir)
+	return mustRealPath(t, bareDir), gitOutput(t, bareDir, "rev-parse", "HEAD")
+}
+
 func mustGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -404,6 +493,17 @@ func mustGit(t *testing.T, dir string, args ...string) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v failed: %v\n%s", args, err, out)
 	}
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func readPlanRecord(t *testing.T, root, planID string) planstore.PlanRecord {

--- a/cmd/wtui/plan_test.go
+++ b/cmd/wtui/plan_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/brian-bell/wtui/config"
+	"github.com/brian-bell/wtui/planstore"
 	"github.com/brian-bell/wtui/scanner"
 )
 
@@ -180,6 +182,91 @@ func TestRunPlanSaveFillsMetadataFromEnv(t *testing.T) {
 	}
 }
 
+func TestRunPlanSaveFromLinkedWorktreeUsesRootRepoPath(t *testing.T) {
+	stateRoot := t.TempDir()
+	repoDir, worktreeDir := makeLinkedWorktree(t)
+	var stdout bytes.Buffer
+
+	err := run([]string{"wtui", "plan", "save", "--title", "P", "--plan-id", "p", "--state-root", stateRoot},
+		noScanDeps(t, runDeps{
+			getwd:  func() (string, error) { return worktreeDir, nil },
+			stdin:  strings.NewReader("body"),
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	record := readPlanRecord(t, stateRoot, "p")
+	if record.RepoPath != repoDir {
+		t.Fatalf("repo_path = %q, want root repo %q", record.RepoPath, repoDir)
+	}
+	if record.WorktreePath != worktreeDir {
+		t.Fatalf("worktree_path = %q, want linked worktree %q", record.WorktreePath, worktreeDir)
+	}
+	if record.Branch != "feature/plan" {
+		t.Fatalf("branch = %q, want feature/plan", record.Branch)
+	}
+	if record.Commit == "" {
+		t.Fatal("expected commit metadata from linked worktree")
+	}
+}
+
+func TestRunPlanSaveNormalizesLinkedWorktreeRepoPathFromEnv(t *testing.T) {
+	stateRoot := t.TempDir()
+	repoDir, worktreeDir := makeLinkedWorktree(t)
+	var stdout bytes.Buffer
+
+	err := run([]string{"wtui", "plan", "save", "--title", "P", "--plan-id", "p", "--state-root", stateRoot},
+		noScanDeps(t, runDeps{
+			getenv: func(key string) string {
+				switch key {
+				case "WTUI_REPO_PATH", "WTUI_WORKTREE_PATH":
+					return worktreeDir
+				}
+				return ""
+			},
+			getwd:  func() (string, error) { return worktreeDir, nil },
+			stdin:  strings.NewReader("body"),
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	record := readPlanRecord(t, stateRoot, "p")
+	if record.RepoPath != repoDir {
+		t.Fatalf("repo_path = %q, want root repo %q", record.RepoPath, repoDir)
+	}
+	if record.WorktreePath != worktreeDir {
+		t.Fatalf("worktree_path = %q, want linked worktree %q", record.WorktreePath, worktreeDir)
+	}
+}
+
+func TestRunPlanSaveExplicitRepoPathDoesNotUseUnrelatedCWDMetadata(t *testing.T) {
+	stateRoot := t.TempDir()
+	_, worktreeDir := makeLinkedWorktree(t)
+	var stdout bytes.Buffer
+
+	err := run([]string{"wtui", "plan", "save", "--title", "P", "--plan-id", "p", "--state-root", stateRoot, "--repo-path", "/repo"},
+		noScanDeps(t, runDeps{
+			getwd:  func() (string, error) { return worktreeDir, nil },
+			stdin:  strings.NewReader("body"),
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	record := readPlanRecord(t, stateRoot, "p")
+	if record.RepoPath != "/repo" {
+		t.Fatalf("repo_path = %q, want explicit /repo", record.RepoPath)
+	}
+	if record.WorktreePath != "" || record.Branch != "" || record.Commit != "" {
+		t.Fatalf("explicit unrelated repo should not use cwd metadata: %#v", record)
+	}
+}
+
 func TestRunPlanListJSON(t *testing.T) {
 	root := t.TempDir()
 	mustRun(t, []string{"wtui", "plan", "save", "--title", "Alpha", "--plan-id", "alpha", "--state-root", root, "--repo-path", "/repo"}, "alpha body")
@@ -244,4 +331,52 @@ func mustRun(t *testing.T, args []string, stdin string) {
 	if err != nil {
 		t.Fatalf("run(%v) error = %v", args, err)
 	}
+}
+
+func makeLinkedWorktree(t *testing.T) (repoDir, worktreeDir string) {
+	t.Helper()
+	root := t.TempDir()
+	repoDir = filepath.Join(root, "project")
+	worktreeDir = filepath.Join(root, "project-worktrees", "feature-plan")
+	mustGit(t, root, "init", repoDir)
+	mustGit(t, repoDir, "config", "user.email", "test@example.com")
+	mustGit(t, repoDir, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repoDir, "add", "README.md")
+	mustGit(t, repoDir, "commit", "-m", "initial")
+	mustGit(t, repoDir, "worktree", "add", "-b", "feature/plan", worktreeDir)
+	return mustRealPath(t, repoDir), mustRealPath(t, worktreeDir)
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func readPlanRecord(t *testing.T, root, planID string) planstore.PlanRecord {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "plans", planID, "meta.json"))
+	if err != nil {
+		t.Fatalf("read meta.json: %v", err)
+	}
+	var record planstore.PlanRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatalf("decode meta.json: %v\n%s", err, data)
+	}
+	return record
+}
+
+func mustRealPath(t *testing.T, path string) string {
+	t.Helper()
+	realPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("resolve real path %q: %v", path, err)
+	}
+	return realPath
 }

--- a/planstore/store.go
+++ b/planstore/store.go
@@ -156,6 +156,12 @@ func (s *Store) Root() string {
 	return s.root
 }
 
+// HasPlan reports whether a valid plan record already exists.
+func (s *Store) HasPlan(planID string) bool {
+	_, ok := s.readRecord(planID)
+	return ok
+}
+
 // Save writes a plan record and returns its plan ID. When a plan with the same
 // ID already exists, Markdown and Title are always replaced from the incoming
 // record (both are required), while Status, Source, Summary, phases,


### PR DESCRIPTION
## Summary
- Resolve git metadata during `wtui plan save` so saves from linked worktree directories attach to the root repo.
- Preserve the linked checkout as `worktree_path` while normalizing bad linked-worktree `WTUI_REPO_PATH` values.
- Avoid leaking unrelated cwd metadata when callers explicitly pass a different repo path.

## Testing
- `go test ./...`