### PR TITLE
Show plan phases inline

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -661,6 +661,73 @@ func (m Model) selectedPlanID() string {
 	return record.PlanID
 }
 
+func (m Model) setExpandedPlanID(planID string) Model {
+	m.expandedPlanID = planID
+	m.plans = m.plans.SetItemHeight(planItemHeight(planID))
+	m = m.reflowPlans()
+	if planID == "" {
+		return m
+	}
+	return m.reflowExpandedPlan()
+}
+
+func (m Model) canScrollExpandedPlan(delta, viewHeight int) bool {
+	if m.expandedPlanID == "" || m.selectedPlanID() != m.expandedPlanID {
+		return false
+	}
+	if viewHeight <= 0 {
+		viewHeight = 1
+	}
+	plans := m.filteredPlans()
+	selected := m.PlanSelected()
+	if selected < 0 || selected >= len(plans) {
+		return false
+	}
+
+	line := 0
+	for i := 0; i < selected; i++ {
+		line += planVisualHeight(plans[i], m.expandedPlanID)
+	}
+	height := planVisualHeight(plans[selected], m.expandedPlanID)
+	scroll := m.PlanScroll()
+	if delta > 0 {
+		return line+height > scroll+viewHeight
+	}
+	if delta < 0 {
+		return scroll > line
+	}
+	return false
+}
+
+func (m Model) reflowExpandedPlan() Model {
+	plans := m.filteredPlans()
+	selected := m.PlanSelected()
+	if selected < 0 || selected >= len(plans) {
+		return m
+	}
+
+	viewHeight := m.planContentHeight()
+	line := 0
+	for i := 0; i < selected; i++ {
+		line += planVisualHeight(plans[i], m.expandedPlanID)
+	}
+	height := planVisualHeight(plans[selected], m.expandedPlanID)
+	scroll := m.PlanScroll()
+	target := scroll
+	if scroll > line {
+		target = line
+	}
+	if height <= viewHeight && line+height > target+viewHeight {
+		target = line + height - viewHeight
+	} else if height > viewHeight && line+1 >= target+viewHeight {
+		target = line
+	}
+	if target != scroll {
+		m.plans = m.plans.ScrollBy(target-scroll, viewHeight, m.contentWidth())
+	}
+	return m
+}
+
 func (m Model) isSelectedBranchDirtyWorktree() bool {
 	row, ok := m.selectedRow()
 	return ok && row.Branch.Dirty && row.Branch.IsWorktree
@@ -713,11 +780,7 @@ func (m Model) reflowSessions() Model {
 }
 
 func (m Model) reflowPlans() Model {
-	contentHeight := m.height - ui.BranchContentOverhead
-	if contentHeight <= 0 {
-		contentHeight = 16
-	}
-	m.plans = m.plans.Reflow(contentHeight, m.contentWidth())
+	m.plans = m.plans.Reflow(m.planContentHeight(), m.contentWidth())
 	return m
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -34,6 +34,7 @@ type Model struct {
 	reflogs                   pane.Pane[gitquery.ReflogEntry]
 	sessions                  pane.Pane[sessions.SessionRecord]
 	plans                     pane.Pane[planstore.PlanRecord]
+	expandedPlanID            string
 	modal                     modal.Modal
 	diffRequestSeq            uint64
 	listRequestSeq            uint64
@@ -307,6 +308,7 @@ func (m Model) View() string {
 		Plans:                    plans,
 		PlanSelected:             planSelected,
 		PlanScroll:               planScroll,
+		ExpandedPlanID:           m.expandedPlanID,
 		OverlayText:              modalView.Text,
 		TransientError:           m.visibleStatusText(),
 		TransientErrorFadeStep:   m.visibleStatusFadeStep(),
@@ -649,6 +651,14 @@ func (m Model) selectedPlan() (planstore.PlanRecord, bool) {
 		return planstore.PlanRecord{}, false
 	}
 	return m.plans.Selected()
+}
+
+func (m Model) selectedPlanID() string {
+	record, ok := m.selectedPlan()
+	if !ok {
+		return ""
+	}
+	return record.PlanID
 }
 
 func (m Model) isSelectedBranchDirtyWorktree() bool {

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -126,6 +126,7 @@ func (m Model) startFetchSessions() (Model, tea.Cmd) {
 
 func (m Model) startFetchPlans() (Model, tea.Cmd) {
 	m, request := m.nextListFetchRequest(ui.ModePlans)
+	m.expandedPlanID = ""
 	return m, m.fetchPlans(request)
 }
 

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -126,7 +126,7 @@ func (m Model) startFetchSessions() (Model, tea.Cmd) {
 
 func (m Model) startFetchPlans() (Model, tea.Cmd) {
 	m, request := m.nextListFetchRequest(ui.ModePlans)
-	m.expandedPlanID = ""
+	m = m.setExpandedPlanID("")
 	return m, m.fetchPlans(request)
 }
 

--- a/model/model_filter.go
+++ b/model/model_filter.go
@@ -104,6 +104,10 @@ func (m Model) setActiveSearchQuery(query string) Model {
 		return m.reflowRepos()
 	}
 
+	selectedPlanID := ""
+	if m.mode == ui.ModePlans {
+		selectedPlanID = m.selectedPlanID()
+	}
 	m.worktrees = m.worktrees.SetQueryPreserveIndex(query)
 	m.rows = m.rows.SetQueryPreserveIndex(query)
 	m.stashes = m.stashes.SetQueryPreserveIndex(query)
@@ -134,6 +138,9 @@ func (m Model) setActiveSearchQuery(query string) Model {
 	case ui.ModePlans:
 		m.plans = m.plans.SetQuery(query)
 		m = m.reflowPlans()
+		if selectedPlanID != "" && m.selectedPlanID() != selectedPlanID {
+			m.expandedPlanID = ""
+		}
 	}
 	return m
 }

--- a/model/model_filter.go
+++ b/model/model_filter.go
@@ -67,7 +67,23 @@ func newSessionPane() pane.Pane[sessions.SessionRecord] {
 }
 
 func newPlanPane() pane.Pane[planstore.PlanRecord] {
-	return pane.New(planSearchText, fixedHeight[planstore.PlanRecord])
+	return pane.New(planSearchText, planItemHeight(""))
+}
+
+func planItemHeight(expandedPlanID string) pane.ItemHeight[planstore.PlanRecord] {
+	return func(record planstore.PlanRecord, _ int) int {
+		return planVisualHeight(record, expandedPlanID)
+	}
+}
+
+func planVisualHeight(record planstore.PlanRecord, expandedPlanID string) int {
+	if expandedPlanID == "" || record.PlanID != expandedPlanID {
+		return 1
+	}
+	if len(record.Phases) == 0 {
+		return 2
+	}
+	return 1 + len(record.Phases)
 }
 
 func (m Model) activeSearchQuery() string {
@@ -104,10 +120,6 @@ func (m Model) setActiveSearchQuery(query string) Model {
 		return m.reflowRepos()
 	}
 
-	selectedPlanID := ""
-	if m.mode == ui.ModePlans {
-		selectedPlanID = m.selectedPlanID()
-	}
 	m.worktrees = m.worktrees.SetQueryPreserveIndex(query)
 	m.rows = m.rows.SetQueryPreserveIndex(query)
 	m.stashes = m.stashes.SetQueryPreserveIndex(query)
@@ -137,10 +149,7 @@ func (m Model) setActiveSearchQuery(query string) Model {
 		m = m.reflowSessions()
 	case ui.ModePlans:
 		m.plans = m.plans.SetQuery(query)
-		m = m.reflowPlans()
-		if selectedPlanID != "" && m.selectedPlanID() != selectedPlanID {
-			m.expandedPlanID = ""
-		}
+		m = m.setExpandedPlanID("")
 	}
 	return m
 }

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -310,7 +310,11 @@ func (m Model) moveCursor(delta int) Model {
 	case ui.ModeSessions:
 		m.sessions = m.sessions.Move(delta, h, w)
 	case ui.ModePlans:
+		before := m.selectedPlanID()
 		m.plans = m.plans.Move(delta, h, w)
+		if after := m.selectedPlanID(); before != "" && after != before {
+			m.expandedPlanID = ""
+		}
 	}
 	return m
 }
@@ -347,8 +351,14 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 		return m, m.fetchSessionTranscript()
 	}
 	if m.mode == ui.ModePlans && len(m.filteredPlans()) > 0 {
-		m = m.openPlanText()
-		return m, m.fetchPlanText()
+		if planID := m.selectedPlanID(); planID != "" {
+			if m.expandedPlanID == planID {
+				m.expandedPlanID = ""
+			} else {
+				m.expandedPlanID = planID
+			}
+		}
+		return m, nil
 	}
 	return m, nil
 }
@@ -856,6 +866,7 @@ func (m Model) resetModeCursors() Model {
 	m.reflogs = m.reflogs.ResetSelection()
 	m.sessions = m.sessions.ResetSelection()
 	m.plans = m.plans.ResetSelection()
+	m.expandedPlanID = ""
 	return m
 }
 
@@ -869,6 +880,7 @@ func (m Model) resetRightPaneCursors() Model {
 	m.reflogs = m.reflogs.SetItems(nil).ResetSelection()
 	m.sessions = m.sessions.SetItems(nil).ResetSelection()
 	m.plans = m.plans.SetItems(nil).ResetSelection()
+	m.expandedPlanID = ""
 	return m
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -252,6 +252,10 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModeWorktrees {
 			return m.handleNewPullRequestWorktree()
 		}
+	case "o":
+		if m.mode == ui.ModePlans {
+			return m.handleOpenPlanText()
+		}
 	case "m":
 		if m.mode == ui.ModeWorktrees {
 			return m.handleMoveWorktree()
@@ -310,10 +314,17 @@ func (m Model) moveCursor(delta int) Model {
 	case ui.ModeSessions:
 		m.sessions = m.sessions.Move(delta, h, w)
 	case ui.ModePlans:
+		if m.canScrollExpandedPlan(delta, h) {
+			m.plans = m.plans.ScrollBy(delta, h, w)
+			return m
+		}
+		if m.plans.Len() <= 1 {
+			return m
+		}
 		before := m.selectedPlanID()
 		m.plans = m.plans.Move(delta, h, w)
 		if after := m.selectedPlanID(); before != "" && after != before {
-			m.expandedPlanID = ""
+			m = m.setExpandedPlanID("")
 		}
 	}
 	return m
@@ -353,12 +364,20 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 	if m.mode == ui.ModePlans && len(m.filteredPlans()) > 0 {
 		if planID := m.selectedPlanID(); planID != "" {
 			if m.expandedPlanID == planID {
-				m.expandedPlanID = ""
+				m = m.setExpandedPlanID("")
 			} else {
-				m.expandedPlanID = planID
+				m = m.setExpandedPlanID(planID)
 			}
 		}
 		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) handleOpenPlanText() (tea.Model, tea.Cmd) {
+	if m.mode == ui.ModePlans && len(m.filteredPlans()) > 0 {
+		m = m.openPlanText()
+		return m, m.fetchPlanText()
 	}
 	return m, nil
 }
@@ -866,7 +885,7 @@ func (m Model) resetModeCursors() Model {
 	m.reflogs = m.reflogs.ResetSelection()
 	m.sessions = m.sessions.ResetSelection()
 	m.plans = m.plans.ResetSelection()
-	m.expandedPlanID = ""
+	m = m.setExpandedPlanID("")
 	return m
 }
 
@@ -880,7 +899,7 @@ func (m Model) resetRightPaneCursors() Model {
 	m.reflogs = m.reflogs.SetItems(nil).ResetSelection()
 	m.sessions = m.sessions.SetItems(nil).ResetSelection()
 	m.plans = m.plans.SetItems(nil).ResetSelection()
-	m.expandedPlanID = ""
+	m = m.setExpandedPlanID("")
 	return m
 }
 
@@ -900,12 +919,22 @@ func (m Model) rightContentHeight() int {
 	return height
 }
 
+func (m Model) planContentHeight() int {
+	height := m.rightContentHeight() - 1
+	if height <= 0 {
+		return 1
+	}
+	return height
+}
+
 func (m Model) contentHeightForMode() int {
 	switch m.mode {
 	case ui.ModeWorktrees:
 		return m.worktreeContentHeight()
 	case ui.ModeStashes:
 		return m.stashContentHeight()
+	case ui.ModePlans:
+		return m.planContentHeight()
 	default:
 		return m.rightContentHeight()
 	}

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -885,7 +885,7 @@ func (m Model) handlePlanResult(msg PlanResultMsg) Model {
 	}
 	m = m.clearFetchListStatus(ui.ModePlans)
 	m.plans = m.plans.SetItems(msg.Plans)
-	m.expandedPlanID = ""
+	m = m.setExpandedPlanID("")
 	m = m.clampSelectionsAfterFilter()
 	return m
 }

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -885,6 +885,7 @@ func (m Model) handlePlanResult(msg PlanResultMsg) Model {
 	}
 	m = m.clearFetchListStatus(ui.ModePlans)
 	m.plans = m.plans.SetItems(msg.Plans)
+	m.expandedPlanID = ""
 	m = m.clampSelectionsAfterFilter()
 	return m
 }

--- a/model/model_plan_overlay_test.go
+++ b/model/model_plan_overlay_test.go
@@ -13,7 +13,12 @@ import (
 
 func plansInRightPane(t *testing.T, m model.Model, records []planstore.PlanRecord) model.Model {
 	t.Helper()
-	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 18})
+	return plansInRightPaneAtSize(t, m, records, 140, 18)
+}
+
+func plansInRightPaneAtSize(t *testing.T, m model.Model, records []planstore.PlanRecord, width, height int) model.Model {
+	t.Helper()
+	m, _ = update(m, tea.WindowSizeMsg{Width: width, Height: height})
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
 	m, _ = update(m, model.PlanResultMsg{RepoPath: "/dev/alpha", Plans: records, ListRequest: m.ListRequest(ui.ModePlans)})
@@ -47,6 +52,36 @@ func TestModel_EnterOnPlanExpandsPhasesWithoutReadingPlan(t *testing.T) {
 	for _, want := range []string{"Tracer bullet", "completed"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expanded plan view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestModel_OKeyOnPlanOpensPlanText(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ReadPlan: func(planID string) (string, error) {
+			if planID != "plan-1" {
+				t.Fatalf("ReadPlan called with %q", planID)
+			}
+			return "# Persist plans\n\nfull body\n", nil
+		},
+	})
+	m = plansInRightPane(t, m, []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}}},
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	if cmd == nil {
+		t.Fatal("plans-mode o should return a plan read command")
+	}
+	if m.Overlay() != ui.OverlayPlanText {
+		t.Fatalf("expected plan text overlay, got %d", m.Overlay())
+	}
+	m, _ = update(m, cmd())
+	view := m.View()
+	for _, want := range []string{"# Persist plans", "full body"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("plan text overlay missing %q:\n%s", want, view)
 		}
 	}
 }
@@ -117,6 +152,178 @@ func TestModel_NoOpPlanMovementKeepsExpandedPhases(t *testing.T) {
 	}
 }
 
+func TestModel_ExpandedPlanAtViewportBottomScrollsPhasesIntoView(t *testing.T) {
+	m := model.New(testRepos())
+	records := []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft"},
+		{PlanID: "plan-2", RepoPath: "/dev/alpha", Title: "Plan 2", Status: "draft"},
+		{PlanID: "plan-3", RepoPath: "/dev/alpha", Title: "Plan 3", Status: "draft"},
+		{PlanID: "plan-4", RepoPath: "/dev/alpha", Title: "Plan 4", Status: "draft"},
+		{PlanID: "plan-5", RepoPath: "/dev/alpha", Title: "Plan 5", Status: "draft",
+			Phases: []planstore.PlanPhase{
+				{PhaseID: "p1", Title: "Bottom phase one", Status: "pending", Order: 1},
+				{PhaseID: "p2", Title: "Bottom phase two", Status: "completed", Order: 2},
+			}},
+	}
+	m = plansInRightPaneAtSize(t, m, records, 140, ui.BranchContentOverhead+4)
+	for i := 0; i < 4; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if got := m.PlanScroll(); got != 4 {
+		t.Fatalf("expanded bottom plan should scroll phase block into view, got scroll %d", got)
+	}
+	view := m.View()
+	for _, want := range []string{"Bottom phase one", "Bottom phase two"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expanded bottom plan missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestModel_ExpandedSinglePlanScrollsWithinManyPhases(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPaneAtSize(t, m, []planstore.PlanRecord{{
+		PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft",
+		Phases: []planstore.PlanPhase{
+			{PhaseID: "p1", Title: "Phase 1", Status: "completed", Order: 1},
+			{PhaseID: "p2", Title: "Phase 2", Status: "completed", Order: 2},
+			{PhaseID: "p3", Title: "Phase 3", Status: "pending", Order: 3},
+			{PhaseID: "p4", Title: "Phase 4", Status: "pending", Order: 4},
+			{PhaseID: "p5", Title: "Phase 5", Status: "pending", Order: 5},
+		},
+	}}, 140, ui.BranchContentOverhead+4)
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	for i := 0; i < 3; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+
+	if got := m.PlanSelected(); got != 0 {
+		t.Fatalf("scrolling inside expanded single plan should not move selection, got %d", got)
+	}
+	if got := m.PlanScroll(); got != 3 {
+		t.Fatalf("expected expanded phase block to scroll to 3, got %d", got)
+	}
+	view := m.View()
+	if !strings.Contains(view, "Phase 5") {
+		t.Fatalf("lower expanded phase should be reachable:\n%s", view)
+	}
+	if strings.Contains(view, "Plan 1") {
+		t.Fatalf("scrolling within an oversized expanded plan should move past the plan row:\n%s", view)
+	}
+}
+
+func TestModel_TallExpandedPlanAtViewportBottomShowsFirstPhases(t *testing.T) {
+	m := model.New(testRepos())
+	records := []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft"},
+		{PlanID: "plan-2", RepoPath: "/dev/alpha", Title: "Plan 2", Status: "draft"},
+		{PlanID: "plan-3", RepoPath: "/dev/alpha", Title: "Plan 3", Status: "draft"},
+		{PlanID: "plan-4", RepoPath: "/dev/alpha", Title: "Plan 4", Status: "draft"},
+		{PlanID: "plan-5", RepoPath: "/dev/alpha", Title: "Plan 5", Status: "draft",
+			Phases: []planstore.PlanPhase{
+				{PhaseID: "p1", Title: "Phase 1", Status: "completed", Order: 1},
+				{PhaseID: "p2", Title: "Phase 2", Status: "completed", Order: 2},
+				{PhaseID: "p3", Title: "Phase 3", Status: "pending", Order: 3},
+				{PhaseID: "p4", Title: "Phase 4", Status: "pending", Order: 4},
+				{PhaseID: "p5", Title: "Phase 5", Status: "pending", Order: 5},
+			}},
+	}
+	m = plansInRightPaneAtSize(t, m, records, 140, ui.BranchContentOverhead+4)
+	for i := 0; i < 4; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if got := m.PlanScroll(); got != 4 {
+		t.Fatalf("tall expanded bottom plan should move plan row to top, got scroll %d", got)
+	}
+	view := m.View()
+	for _, want := range []string{"Plan 5", "Phase 1", "Phase 2"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("tall expanded bottom plan should reveal initial phases, missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestModel_ExpandedPlanMovesAndCollapsesAfterScrolledToBoundary(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPaneAtSize(t, m, []planstore.PlanRecord{
+		{
+			PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft",
+			Phases: []planstore.PlanPhase{
+				{PhaseID: "p1", Title: "Phase 1", Status: "completed", Order: 1},
+				{PhaseID: "p2", Title: "Phase 2", Status: "completed", Order: 2},
+				{PhaseID: "p3", Title: "Phase 3", Status: "pending", Order: 3},
+				{PhaseID: "p4", Title: "Phase 4", Status: "pending", Order: 4},
+				{PhaseID: "p5", Title: "Phase 5", Status: "pending", Order: 5},
+			},
+		},
+		{PlanID: "plan-2", RepoPath: "/dev/alpha", Title: "Plan 2", Status: "draft"},
+	}, 140, ui.BranchContentOverhead+4)
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	for i := 0; i < 4; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+
+	if got := m.PlanSelected(); got != 1 {
+		t.Fatalf("expected movement to next plan after expanded boundary, got %d", got)
+	}
+	view := m.View()
+	if strings.Contains(view, "Phase 5") {
+		t.Fatalf("moving to next plan should collapse expanded phases:\n%s", view)
+	}
+	if !strings.Contains(view, "Plan 2") {
+		t.Fatalf("next plan should be selected and visible:\n%s", view)
+	}
+}
+
+func TestModel_ExpandedPlanScrollsUpWithinManyPhases(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPaneAtSize(t, m, []planstore.PlanRecord{
+		{PlanID: "plan-0", RepoPath: "/dev/alpha", Title: "Plan 0", Status: "draft"},
+		{
+			PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft",
+			Phases: []planstore.PlanPhase{
+				{PhaseID: "p1", Title: "Phase 1", Status: "completed", Order: 1},
+				{PhaseID: "p2", Title: "Phase 2", Status: "completed", Order: 2},
+				{PhaseID: "p3", Title: "Phase 3", Status: "pending", Order: 3},
+				{PhaseID: "p4", Title: "Phase 4", Status: "pending", Order: 4},
+				{PhaseID: "p5", Title: "Phase 5", Status: "pending", Order: 5},
+			},
+		},
+	}, 140, ui.BranchContentOverhead+4)
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	for i := 0; i < 2; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
+
+	if got := m.PlanSelected(); got != 1 {
+		t.Fatalf("scrolling up inside expanded plan should not move selection, got %d", got)
+	}
+	if got := m.PlanScroll(); got != 1 {
+		t.Fatalf("expected expanded phase block to scroll up to 1, got %d", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
+	if got := m.PlanSelected(); got != 0 {
+		t.Fatalf("expected movement to previous plan after expanded top boundary, got %d", got)
+	}
+	view := m.View()
+	if strings.Contains(view, "Phase 1") {
+		t.Fatalf("moving to previous plan should collapse expanded phases:\n%s", view)
+	}
+	if !strings.Contains(view, "Plan 0") {
+		t.Fatalf("previous plan should be selected and visible:\n%s", view)
+	}
+}
+
 func TestModel_PlanListReplacementClearsExpandedPhases(t *testing.T) {
 	m := model.New(testRepos())
 	m = plansInRightPane(t, m, []planstore.PlanRecord{
@@ -168,5 +375,22 @@ func TestModel_FilterSelectionChangeClearsExpandedPhases(t *testing.T) {
 	view := m.View()
 	if strings.Contains(view, "Tracer bullet") || strings.Contains(view, "Needle phase") {
 		t.Fatalf("filter changing selected plan should clear expanded phases:\n%s", view)
+	}
+}
+
+func TestModel_PlanFilterChangeClearsExpandedPhasesEvenWhenSelectionStays(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPane(t, m, []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}}},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	for _, r := range []rune("persist") {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	if strings.Contains(m.View(), "Tracer bullet") {
+		t.Fatalf("plan filtering should collapse expanded phases:\n%s", m.View())
 	}
 }

--- a/model/model_plan_overlay_test.go
+++ b/model/model_plan_overlay_test.go
@@ -1,7 +1,6 @@
 package model_test
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -14,63 +13,41 @@ import (
 
 func plansInRightPane(t *testing.T, m model.Model, records []planstore.PlanRecord) model.Model {
 	t.Helper()
+	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 18})
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
 	m, _ = update(m, model.PlanResultMsg{RepoPath: "/dev/alpha", Plans: records, ListRequest: m.ListRequest(ui.ModePlans)})
 	return m
 }
 
-func TestModel_EnterOnPlanOpensTextOverlay(t *testing.T) {
-	var gotPlanID string
+func TestModel_EnterOnPlanExpandsPhasesWithoutReadingPlan(t *testing.T) {
+	readCalled := false
 	m := model.NewWithOptions(testRepos(), model.Options{
 		ReadPlan: func(planID string) (string, error) {
-			gotPlanID = planID
+			readCalled = true
 			return "# Persist plans\n\nfull body\n", nil
 		},
 	})
 	m = plansInRightPane(t, m, []planstore.PlanRecord{
-		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft"},
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}}},
 	})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	if m.Overlay() != ui.OverlayPlanText {
-		t.Fatalf("expected OverlayPlanText, got %d", m.Overlay())
+	if cmd != nil {
+		t.Fatal("plans-mode enter should not return a plan read command")
 	}
-	if cmd == nil {
-		t.Fatal("expected plan read command")
+	if readCalled {
+		t.Fatal("plans-mode enter should not call ReadPlan")
 	}
-	msg, ok := cmd().(model.PlanReadResultMsg)
-	if !ok {
-		t.Fatalf("expected PlanReadResultMsg, got %T", msg)
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected no overlay, got %d", m.Overlay())
 	}
-	m, _ = update(m, msg)
-
-	if gotPlanID != "plan-1" {
-		t.Fatalf("reader got plan id %q, want plan-1", gotPlanID)
-	}
-	if got := m.OverlayText(); !strings.Contains(got, "# Persist plans") || !strings.Contains(got, "full body") {
-		t.Fatalf("unexpected plan overlay text: %q", got)
-	}
-}
-
-func TestModel_PlanReadErrorShowsStatus(t *testing.T) {
-	m := model.NewWithOptions(testRepos(), model.Options{
-		ReadPlan: func(string) (string, error) { return "", errors.New("missing plan file") },
-	})
-	m = plansInRightPane(t, m, []planstore.PlanRecord{
-		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft"},
-	})
-
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	if cmd == nil {
-		t.Fatal("expected plan read command")
-	}
-	m, _ = update(m, cmd())
-	if !strings.Contains(m.View(), "missing plan file") {
-		t.Fatalf("expected missing plan error in view:\n%s", m.View())
-	}
-	if m.OverlayText() != "" {
-		t.Fatalf("expected empty overlay text on error, got %q", m.OverlayText())
+	view := m.View()
+	for _, want := range []string{"Tracer bullet", "completed"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expanded plan view missing %q:\n%s", want, view)
+		}
 	}
 }
 
@@ -89,5 +66,107 @@ func TestModel_PlansFilterMatchesPlanAndPhaseFields(t *testing.T) {
 	got := m.Plans()
 	if len(got) != 1 || got[0].PlanID != "plan-1" {
 		t.Fatalf("filtered plans by phase title = %#v", got)
+	}
+}
+
+func TestModel_EnterOnExpandedPlanCollapsesPhases(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPane(t, m, []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}}},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatal("plans-mode second enter should not return a command")
+	}
+	if strings.Contains(m.View(), "Tracer bullet") {
+		t.Fatalf("second enter should collapse phases:\n%s", m.View())
+	}
+}
+
+func TestModel_MovingToDifferentPlanCollapsesExpandedPhases(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPane(t, m, []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}}},
+		{PlanID: "plan-2", RepoPath: "/dev/alpha", Title: "Other plan", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p2", Title: "Other phase", Status: "pending", Order: 1}}},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	view := m.View()
+	if strings.Contains(view, "Tracer bullet") || strings.Contains(view, "Other phase") {
+		t.Fatalf("moving to another plan should collapse expanded phases:\n%s", view)
+	}
+}
+
+func TestModel_NoOpPlanMovementKeepsExpandedPhases(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPane(t, m, []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}}},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if !strings.Contains(m.View(), "Tracer bullet") {
+		t.Fatalf("no-op movement should keep phases expanded:\n%s", m.View())
+	}
+}
+
+func TestModel_PlanListReplacementClearsExpandedPhases(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPane(t, m, []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}}},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, model.PlanResultMsg{RepoPath: "/dev/alpha", Plans: []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}}},
+	}, ListRequest: m.ListRequest(ui.ModePlans)})
+	if strings.Contains(m.View(), "Tracer bullet") {
+		t.Fatalf("plan replacement should clear expanded phases:\n%s", m.View())
+	}
+}
+
+func TestModel_PlanRefetchStartClearsExpandedPhases(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPane(t, m, []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}}},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, model.GitFetchedMsg{RepoPath: "/dev/alpha"})
+	if cmd == nil {
+		t.Fatal("expected plans refetch command")
+	}
+	if strings.Contains(m.View(), "Tracer bullet") {
+		t.Fatalf("plan refetch start should clear expanded phases:\n%s", m.View())
+	}
+}
+
+func TestModel_FilterSelectionChangeClearsExpandedPhases(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPane(t, m, []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}}},
+		{PlanID: "plan-2", RepoPath: "/dev/alpha", Title: "Needle plan", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p2", Title: "Needle phase", Status: "pending", Order: 1}}},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	for _, r := range []rune("needle") {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	view := m.View()
+	if strings.Contains(view, "Tracer bullet") || strings.Contains(view, "Needle phase") {
+		t.Fatalf("filter changing selected plan should clear expanded phases:\n%s", view)
 	}
 }

--- a/model/pane/pane.go
+++ b/model/pane/pane.go
@@ -63,6 +63,18 @@ func (p Pane[T]) Move(delta, viewHeight, viewWidth int) Pane[T] {
 	return p.Reflow(viewHeight, viewWidth)
 }
 
+// ScrollBy adjusts the visual-line scroll offset without changing selection.
+func (p Pane[T]) ScrollBy(delta, viewHeight, viewWidth int) Pane[T] {
+	p.scroll += delta
+	return p.clampScroll(viewHeight, viewWidth)
+}
+
+// SetItemHeight replaces the visual height function used for scrolling.
+func (p Pane[T]) SetItemHeight(height ItemHeight[T]) Pane[T] {
+	p.height = height
+	return p
+}
+
 // SelectFunc selects the first filtered item matching pred.
 func (p Pane[T]) SelectFunc(pred func(T) bool) Pane[T] {
 	for i, item := range p.filtered {

--- a/model/pane/pane_test.go
+++ b/model/pane/pane_test.go
@@ -195,6 +195,23 @@ func TestPaneVariableHeightScrollUsesVisualLines(t *testing.T) {
 	}
 }
 
+func TestPaneScrollByAndSetItemHeightClampToVisualBounds(t *testing.T) {
+	items := []testItem{{name: "expanded", lines: 1}}
+	p := fixedTestPane(items)
+	p = p.SetItemHeight(func(testItem, int) int {
+		return 4
+	})
+
+	p = p.ScrollBy(2, 3, 80)
+	_, selected, scroll := p.View()
+	if selected != 0 {
+		t.Fatalf("expected selection unchanged, got %d", selected)
+	}
+	if scroll != 1 {
+		t.Fatalf("expected scroll clamped to total lines minus viewport, got %d", scroll)
+	}
+}
+
 func TestPaneReflowClampsScrollAfterViewportShrink(t *testing.T) {
 	items := []testItem{
 		{name: "one", lines: 2},

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -169,6 +169,7 @@ type RenderParams struct {
 	Plans                    []planstore.PlanRecord
 	PlanSelected             int
 	PlanScroll               int
+	ExpandedPlanID           string
 	OverlayText              string
 	TransientError           string
 	TransientErrorFadeStep   int
@@ -334,7 +335,7 @@ func Render(p RenderParams) string {
 	case p.Mode == ModeSessions && len(p.Sessions) > 0:
 		rightLines = renderSessionPane(p.Sessions, sessionSel, p.SessionScroll, rightContentWidth, rightContentHeight)
 	case p.Mode == ModePlans && len(p.Plans) > 0:
-		rightLines = renderPlanPane(p.Plans, planSel, p.PlanScroll, rightContentWidth, rightContentHeight)
+		rightLines = renderPlanPane(p.Plans, planSel, p.PlanScroll, rightContentWidth, rightContentHeight, p.ExpandedPlanID)
 	default:
 		rightLines = renderPlaceholderPane(rightContentWidth, rightContentHeight, p.RightEmptyMessage)
 	}
@@ -738,7 +739,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 		}
 	case ModePlans:
 		if sp.ActivePane == 1 && sp.PlanSelected {
-			actions = append(actions, shortcutHint{Key: "enter", Label: "plan"})
+			actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
 		}
 	}
 	if sp.ActivePane == 1 && sp.Mode != ModeWorktrees && sp.Mode != ModeBranches {
@@ -1309,7 +1310,7 @@ const (
 	planUpdatedWidth = 10
 )
 
-func renderPlanPane(records []planstore.PlanRecord, selected, scroll, width, height int) []string {
+func renderPlanPane(records []planstore.PlanRecord, selected, scroll, width, height int, expandedPlanID string) []string {
 	if height <= 0 {
 		return nil
 	}
@@ -1340,8 +1341,29 @@ func renderPlanPane(records []planstore.PlanRecord, selected, scroll, width, hei
 			line = stashSelStyle.Width(width).Render(selectedLine)
 		}
 		rows = append(rows, truncateToWidth(line, width))
+		if i == selected && record.PlanID == expandedPlanID {
+			rows = append(rows, renderPlanPhaseRows(record, width)...)
+		}
 	}
 	return append([]string{header}, scrollAndPad(rows, scroll, height-1)...)
+}
+
+func renderPlanPhaseRows(record planstore.PlanRecord, width int) []string {
+	if len(record.Phases) == 0 {
+		return []string{truncateToWidth("      No phases", width)}
+	}
+	rows := make([]string, 0, len(record.Phases))
+	for _, phase := range record.Phases {
+		line := formatPlanColumns("      ",
+			statusStyle.Render(fitSessionColumn(phase.Status, planStatusWidth)),
+			"",
+			"",
+			"",
+			stashMsgStyle.Render(phase.Title),
+		)
+		rows = append(rows, truncateToWidth(line, width))
+	}
+	return rows
 }
 
 func formatPlanColumns(prefix, status, branch, phase, updated, title string) string {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -740,6 +740,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	case ModePlans:
 		if sp.ActivePane == 1 && sp.PlanSelected {
 			actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
+			actions = append(actions, shortcutHint{Key: "o", Label: "open"})
 		}
 	}
 	if sp.ActivePane == 1 && sp.Mode != ModeWorktrees && sp.Mode != ModeBranches {
@@ -1341,7 +1342,7 @@ func renderPlanPane(records []planstore.PlanRecord, selected, scroll, width, hei
 			line = stashSelStyle.Width(width).Render(selectedLine)
 		}
 		rows = append(rows, truncateToWidth(line, width))
-		if i == selected && record.PlanID == expandedPlanID {
+		if record.PlanID == expandedPlanID {
 			rows = append(rows, renderPlanPhaseRows(record, width)...)
 		}
 	}

--- a/ui/ui_plan_test.go
+++ b/ui/ui_plan_test.go
@@ -84,7 +84,8 @@ func TestRender_PlansModeShowsPlanShortcut(t *testing.T) {
 		ActivePane:   1,
 		PlanSelected: 0,
 	})
-	if !strings.Contains(shortcutPaneText(view), "enter  phases") {
+	pane := shortcutPaneText(view)
+	if !strings.Contains(pane, "enter  phases") || !strings.Contains(pane, "o      open") {
 		t.Fatalf("plans view should expose phases shortcut:\n%s", view)
 	}
 }
@@ -127,6 +128,31 @@ func TestRender_PlansModeShowsExpandedPhasesForSelectedPlanOnly(t *testing.T) {
 	}
 	if strings.Contains(view, "Other phase") || strings.Contains(view, "blocked") {
 		t.Fatalf("only the selected expanded plan should show phase rows:\n%s", view)
+	}
+}
+
+func TestRender_PlansModeKeepsExpandedPhasesWhenRightPaneInactive(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModePlans,
+		Plans: []planstore.PlanRecord{{
+			PlanID: "plan-1",
+			Title:  "Persist plans",
+			Status: "in_progress",
+			Phases: []planstore.PlanPhase{
+				{PhaseID: "p1", Title: "Store", Status: "completed", Order: 1},
+			},
+		}},
+		ActivePane:     0,
+		PlanSelected:   0,
+		ExpandedPlanID: "plan-1",
+	})
+
+	if !strings.Contains(view, "Store") || !strings.Contains(view, "completed") {
+		t.Fatalf("expanded phases should stay visible when focus leaves plans pane:\n%s", view)
 	}
 }
 

--- a/ui/ui_plan_test.go
+++ b/ui/ui_plan_test.go
@@ -84,8 +84,74 @@ func TestRender_PlansModeShowsPlanShortcut(t *testing.T) {
 		ActivePane:   1,
 		PlanSelected: 0,
 	})
-	if !strings.Contains(shortcutPaneText(view), "enter  plan") {
-		t.Fatalf("plans view should expose plan shortcut:\n%s", view)
+	if !strings.Contains(shortcutPaneText(view), "enter  phases") {
+		t.Fatalf("plans view should expose phases shortcut:\n%s", view)
+	}
+}
+
+func TestRender_PlansModeShowsExpandedPhasesForSelectedPlanOnly(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModePlans,
+		Plans: []planstore.PlanRecord{
+			{
+				PlanID: "plan-1",
+				Title:  "Persist plans",
+				Status: "in_progress",
+				Phases: []planstore.PlanPhase{
+					{PhaseID: "p1", Title: "Store", Status: "completed", Order: 1},
+					{PhaseID: "p2", Title: "CLI", Status: "pending", Order: 2},
+				},
+			},
+			{
+				PlanID: "plan-2",
+				Title:  "Other plan",
+				Status: "draft",
+				Phases: []planstore.PlanPhase{
+					{PhaseID: "p3", Title: "Other phase", Status: "blocked", Order: 1},
+				},
+			},
+		},
+		ActivePane:     1,
+		PlanSelected:   0,
+		ExpandedPlanID: "plan-1",
+	})
+
+	for _, want := range []string{"Store", "completed", "CLI", "pending"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expanded plan view missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "Other phase") || strings.Contains(view, "blocked") {
+		t.Fatalf("only the selected expanded plan should show phase rows:\n%s", view)
+	}
+}
+
+func TestRender_PlansModeShowsNoPhasesOnlyWhenExpanded(t *testing.T) {
+	params := RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    140,
+		Height:   10,
+		Mode:     ModePlans,
+		Plans: []planstore.PlanRecord{{
+			PlanID: "plan-1",
+			Title:  "Persist plans",
+			Status: "draft",
+		}},
+		ActivePane:   1,
+		PlanSelected: 0,
+	}
+
+	if view := Render(params); strings.Contains(view, "No phases") {
+		t.Fatalf("collapsed plan should not show no-phases fallback:\n%s", view)
+	}
+	params.ExpandedPlanID = "plan-1"
+	if view := Render(params); !strings.Contains(view, "No phases") {
+		t.Fatalf("expanded plan without phases should show fallback:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Change plans-mode `enter` to expand/collapse inline phase rows for the selected plan.
- Show each phase status and title in the plans pane, with a `No phases` fallback for expanded plans without recorded phases.
- Update the plans shortcut hint from `enter plan` to `enter phases`.

## Implementation Notes

- Tracks expansion by stable `PlanID` rather than selected index.
- Clears expanded phase rows when the selected plan changes, plans are refetched/replaced, repo/mode state resets, or filtering changes the selected plan.
- Keeps the existing plan text overlay plumbing in place, but plans-mode `enter` no longer opens it or calls `ReadPlan`.
- Adds model and UI regression coverage for toggling, collapse behavior, selected-only phase rendering, no-phase fallback, and avoiding the old read-overlay path.

## Verification

- `go test ./model ./ui`
- `gofmt -l .`
- `git diff --check`
- `make test`
- `make build`
