### PR TITLE
Fix sessions table viewport and wtui env overrides

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -25,6 +25,11 @@ type commandSpec struct {
 	args []string
 }
 
+type envVar struct {
+	key   string
+	value string
+}
+
 type lookPathFunc func(string) (string, error)
 type getenvFunc func(string) string
 
@@ -212,11 +217,11 @@ func RunBootstrapHook(ctx BootstrapContext, hook BootstrapHook) error {
 
 	cmd := exec.CommandContext(commandCtx, scriptPath)
 	cmd.Dir = ctx.WorktreePath
-	cmd.Env = append(os.Environ(),
-		"WTUI_REPO_PATH="+ctx.RepoPath,
-		"WTUI_WORKTREE_PATH="+ctx.WorktreePath,
-		"WTUI_WORKTREE_REF="+ctx.Ref,
-		"WTUI_WORKTREE_CREATE_KIND="+ctx.Kind.String(),
+	cmd.Env = envWithOverrides(
+		envVar{key: "WTUI_REPO_PATH", value: ctx.RepoPath},
+		envVar{key: "WTUI_WORKTREE_PATH", value: ctx.WorktreePath},
+		envVar{key: "WTUI_WORKTREE_REF", value: ctx.Ref},
+		envVar{key: "WTUI_WORKTREE_CREATE_KIND", value: ctx.Kind.String()},
 	)
 	output := newTailBuffer(4096)
 	cmd.Stdout = output
@@ -480,17 +485,39 @@ func AgentLaunch(ctx AgentLaunchContext) (TerminalLaunchSpec, error) {
 	if commit == "" {
 		commit = ctx.Commit
 	}
-	cmd.Env = append(os.Environ(),
-		"WTUI_AGENT="+command,
-		"WTUI_LAUNCH_ID="+ctx.LaunchID,
-		"WTUI_REPO_PATH="+ctx.RepoPath,
-		"WTUI_WORKTREE_PATH="+ctx.WorktreePath,
-		"WTUI_BRANCH="+ctx.Branch,
-		"WTUI_COMMIT="+commit,
-		"WTUI_SESSION_STATE_ROOT="+ctx.SessionStateRoot,
-		"WTUI_PLAN_STATE_ROOT="+ctx.SessionStateRoot,
+	cmd.Env = envWithOverrides(
+		envVar{key: "WTUI_AGENT", value: command},
+		envVar{key: "WTUI_LAUNCH_ID", value: ctx.LaunchID},
+		envVar{key: "WTUI_REPO_PATH", value: ctx.RepoPath},
+		envVar{key: "WTUI_WORKTREE_PATH", value: ctx.WorktreePath},
+		envVar{key: "WTUI_BRANCH", value: ctx.Branch},
+		envVar{key: "WTUI_COMMIT", value: commit},
+		envVar{key: "WTUI_SESSION_STATE_ROOT", value: ctx.SessionStateRoot},
+		envVar{key: "WTUI_PLAN_STATE_ROOT", value: ctx.SessionStateRoot},
 	)
 	return TerminalLaunchSpec{Cmd: cmd, Interactive: true}, nil
+}
+
+func envWithOverrides(overrides ...envVar) []string {
+	overrideKeys := make(map[string]struct{}, len(overrides))
+	for _, item := range overrides {
+		overrideKeys[item.key] = struct{}{}
+	}
+
+	env := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, entry := range os.Environ() {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			if _, found := overrideKeys[key]; found {
+				continue
+			}
+		}
+		env = append(env, entry)
+	}
+	for _, item := range overrides {
+		env = append(env, item.key+"="+item.value)
+	}
+	return env
 }
 
 // ResolveWorktreeCommit returns HEAD for path, or "" when path is not a git

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1086,6 +1086,7 @@ printf "%s
 %s
 %s
 " "$WTUI_REPO_PATH" "$WTUI_WORKTREE_PATH" "$WTUI_WORKTREE_REF" "$WTUI_WORKTREE_CREATE_KIND" > env.txt
+env | awk -F= '/^WTUI_REPO_PATH=|^WTUI_WORKTREE_PATH=|^WTUI_WORKTREE_REF=|^WTUI_WORKTREE_CREATE_KIND=/ { count[$1]++ } END { for (key in count) print key "=" count[key] }' | sort > env-counts.txt
 `), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -1118,6 +1119,19 @@ printf "%s
 	want := strings.Join([]string{repoPath, worktreePath, "feature/one", "generic"}, "\n")
 	if strings.TrimSpace(string(env)) != want {
 		t.Fatalf("unexpected hook env:\n%s", env)
+	}
+	counts, err := os.ReadFile(filepath.Join(worktreePath, "env-counts.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCounts := strings.Join([]string{
+		"WTUI_REPO_PATH=1",
+		"WTUI_WORKTREE_CREATE_KIND=1",
+		"WTUI_WORKTREE_PATH=1",
+		"WTUI_WORKTREE_REF=1",
+	}, "\n")
+	if strings.TrimSpace(string(counts)) != wantCounts {
+		t.Fatalf("unexpected hook env counts:\n%s", counts)
 	}
 }
 
@@ -1588,6 +1602,7 @@ func TestAgentLaunchAddsSessionMetadataEnvironment(t *testing.T) {
 }
 
 func TestAgentLaunchReplacesInheritedWTUIEnvironment(t *testing.T) {
+	t.Setenv("CUSTOM_KEEP", "still-here")
 	for _, key := range []string{
 		"WTUI_AGENT",
 		"WTUI_LAUNCH_ID",
@@ -1628,6 +1643,9 @@ func TestAgentLaunchReplacesInheritedWTUIEnvironment(t *testing.T) {
 		if got != want || count != 1 {
 			t.Fatalf("%s appears %d time(s) with value %q, want exactly one %q in env %#v", key, count, got, want, launch.Cmd.Env)
 		}
+	}
+	if got := envMap(launch.Cmd.Env)["CUSTOM_KEEP"]; got != "still-here" {
+		t.Fatalf("CUSTOM_KEEP = %q, want unrelated env preserved in %#v", got, launch.Cmd.Env)
 	}
 }
 

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1064,6 +1064,14 @@ func TestRunBootstrapHook_RunsExecutableScriptInWorktree(t *testing.T) {
 	dir := t.TempDir()
 	repoPath := filepath.Join(dir, "repo")
 	worktreePath := filepath.Join(dir, "worktree")
+	for _, key := range []string{
+		"WTUI_REPO_PATH",
+		"WTUI_WORKTREE_PATH",
+		"WTUI_WORKTREE_REF",
+		"WTUI_WORKTREE_CREATE_KIND",
+	} {
+		t.Setenv(key, "inherited-"+key)
+	}
 	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -1579,6 +1587,50 @@ func TestAgentLaunchAddsSessionMetadataEnvironment(t *testing.T) {
 	}
 }
 
+func TestAgentLaunchReplacesInheritedWTUIEnvironment(t *testing.T) {
+	for _, key := range []string{
+		"WTUI_AGENT",
+		"WTUI_LAUNCH_ID",
+		"WTUI_REPO_PATH",
+		"WTUI_WORKTREE_PATH",
+		"WTUI_BRANCH",
+		"WTUI_COMMIT",
+		"WTUI_SESSION_STATE_ROOT",
+		"WTUI_PLAN_STATE_ROOT",
+	} {
+		t.Setenv(key, "inherited-"+key)
+	}
+
+	launch, err := actions.AgentLaunch(actions.AgentLaunchContext{
+		Command:          "codex",
+		LaunchID:         "launch-2",
+		RepoPath:         "/repo",
+		WorktreePath:     "/repo/worktree",
+		Branch:           "main",
+		Commit:           "ctx-commit",
+		SessionStateRoot: "/state/wtui/sessions/v1",
+	})
+	if err != nil {
+		t.Fatalf("AgentLaunch returned error: %v", err)
+	}
+
+	for key, want := range map[string]string{
+		"WTUI_AGENT":              "codex",
+		"WTUI_LAUNCH_ID":          "launch-2",
+		"WTUI_REPO_PATH":          "/repo",
+		"WTUI_WORKTREE_PATH":      "/repo/worktree",
+		"WTUI_BRANCH":             "main",
+		"WTUI_COMMIT":             "ctx-commit",
+		"WTUI_SESSION_STATE_ROOT": "/state/wtui/sessions/v1",
+		"WTUI_PLAN_STATE_ROOT":    "/state/wtui/sessions/v1",
+	} {
+		got, count := envEntryValue(launch.Cmd.Env, key)
+		if got != want || count != 1 {
+			t.Fatalf("%s appears %d time(s) with value %q, want exactly one %q in env %#v", key, count, got, want, launch.Cmd.Env)
+		}
+	}
+}
+
 func TestAgentLaunchResolvesMissingCommitFromWorktree(t *testing.T) {
 	repoPath := setupRepo(t)
 	wantCommit := strings.TrimSpace(runOutput(t, repoPath, "git", "rev-parse", "HEAD"))
@@ -1780,6 +1832,19 @@ func envMap(env []string) map[string]string {
 		}
 	}
 	return out
+}
+
+func envEntryValue(env []string, wantKey string) (string, int) {
+	var value string
+	var count int
+	for _, entry := range env {
+		key, entryValue, ok := strings.Cut(entry, "=")
+		if ok && key == wantKey {
+			value = entryValue
+			count++
+		}
+	}
+	return value, count
 }
 
 func TestAgentLaunch_RejectsMissingOrUnsupportedCommand(t *testing.T) {

--- a/model/model.go
+++ b/model/model.go
@@ -778,11 +778,7 @@ func (m Model) reflowReflogs() Model {
 }
 
 func (m Model) reflowSessions() Model {
-	contentHeight := m.height - ui.SessionContentOverhead
-	if contentHeight <= 0 {
-		contentHeight = 16
-	}
-	m.sessions = m.sessions.Reflow(contentHeight, m.contentWidth())
+	m.sessions = m.sessions.Reflow(m.sessionContentHeight(), m.contentWidth())
 	return m
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -778,7 +778,7 @@ func (m Model) reflowReflogs() Model {
 }
 
 func (m Model) reflowSessions() Model {
-	contentHeight := m.height - ui.BranchContentOverhead
+	contentHeight := m.height - ui.SessionContentOverhead
 	if contentHeight <= 0 {
 		contentHeight = 16
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -954,7 +954,15 @@ func (m Model) rightContentHeight() int {
 }
 
 func (m Model) planContentHeight() int {
-	height := m.rightContentHeight() - 1
+	height := m.height - ui.PlanContentOverhead
+	if height <= 0 {
+		return 1
+	}
+	return height
+}
+
+func (m Model) sessionContentHeight() int {
+	height := m.height - ui.SessionContentOverhead
 	if height <= 0 {
 		return 1
 	}
@@ -967,6 +975,8 @@ func (m Model) contentHeightForMode() int {
 		return m.worktreeContentHeight()
 	case ui.ModeStashes:
 		return m.stashContentHeight()
+	case ui.ModeSessions:
+		return m.sessionContentHeight()
 	case ui.ModePlans:
 		return m.planContentHeight()
 	default:

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/model"
+	"github.com/brian-bell/wtui/planstore"
+	"github.com/brian-bell/wtui/sessions"
 	"github.com/brian-bell/wtui/ui"
 )
 
@@ -107,6 +109,52 @@ func TestModel_ViewDistinguishesFilteredEmptyRepos(t *testing.T) {
 	}
 	if strings.Contains(view, "No selected repo") {
 		t.Fatal("filtered-empty repo view should not use generic no-selected-repo copy")
+	}
+}
+
+func TestModel_ViewKeepsSelectedSessionVisibleBelowTableHeader(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 100, Height: 8})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{
+		{Provider: sessions.ProviderCodex, SessionID: "codex-0", RepoPath: "/dev/alpha", Branch: "session-row-0"},
+		{Provider: sessions.ProviderCodex, SessionID: "codex-1", RepoPath: "/dev/alpha", Branch: "session-row-1"},
+		{Provider: sessions.ProviderCodex, SessionID: "codex-2", RepoPath: "/dev/alpha", Branch: "session-row-2"},
+	}, ListRequest: m.ListRequest(ui.ModeSessions)})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	view := m.View()
+	if !strings.Contains(view, "session-row-2") {
+		t.Fatalf("selected session should be visible below table header:\n%s", view)
+	}
+	if strings.Contains(view, "session-row-0") {
+		t.Fatalf("first session row should have scrolled off:\n%s", view)
+	}
+}
+
+func TestModel_ViewKeepsSelectedPlanVisibleBelowTableHeader(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 100, Height: 8})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
+	m, _ = update(m, model.PlanResultMsg{RepoPath: "/dev/alpha", Plans: []planstore.PlanRecord{
+		{PlanID: "plan-0", RepoPath: "/dev/alpha", Branch: "plan-row-0", Status: "draft", Title: "Plan zero"},
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Branch: "plan-row-1", Status: "draft", Title: "Plan one"},
+		{PlanID: "plan-2", RepoPath: "/dev/alpha", Branch: "plan-row-2", Status: "draft", Title: "Plan two"},
+	}, ListRequest: m.ListRequest(ui.ModePlans)})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	view := m.View()
+	if !strings.Contains(view, "plan-row-2") {
+		t.Fatalf("selected plan should be visible below table header:\n%s", view)
+	}
+	if strings.Contains(view, "plan-row-0") {
+		t.Fatalf("first plan row should have scrolled off:\n%s", view)
 	}
 }
 

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -135,7 +135,7 @@ func TestModel_ViewKeepsSelectedSessionVisibleBelowTableHeader(t *testing.T) {
 	}
 }
 
-func TestModel_ViewKeepsSelectedPlanVisibleBelowTableHeader(t *testing.T) {
+func TestModel_ViewKeepsExpandedSelectedPlanVisibleBelowTableHeader(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 100, Height: 8})
 	m = inRightPane(m)
@@ -143,15 +143,21 @@ func TestModel_ViewKeepsSelectedPlanVisibleBelowTableHeader(t *testing.T) {
 	m, _ = update(m, model.PlanResultMsg{RepoPath: "/dev/alpha", Plans: []planstore.PlanRecord{
 		{PlanID: "plan-0", RepoPath: "/dev/alpha", Branch: "plan-row-0", Status: "draft", Title: "Plan zero"},
 		{PlanID: "plan-1", RepoPath: "/dev/alpha", Branch: "plan-row-1", Status: "draft", Title: "Plan one"},
-		{PlanID: "plan-2", RepoPath: "/dev/alpha", Branch: "plan-row-2", Status: "draft", Title: "Plan two"},
+		{PlanID: "plan-2", RepoPath: "/dev/alpha", Branch: "plan-row-2", Status: "draft", Title: "Plan two", Phases: []planstore.PlanPhase{
+			{PhaseID: "p1", Title: "Bottom phase", Status: "phase-mark", Order: 1},
+		}},
 	}, ListRequest: m.ListRequest(ui.ModePlans)})
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 
 	view := m.View()
 	if !strings.Contains(view, "plan-row-2") {
 		t.Fatalf("selected plan should be visible below table header:\n%s", view)
+	}
+	if !strings.Contains(view, "phase-mark") {
+		t.Fatalf("expanded phase row should be visible below table header:\n%s", view)
 	}
 	if strings.Contains(view, "plan-row-0") {
 		t.Fatalf("first plan row should have scrolled off:\n%s", view)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -89,6 +89,18 @@ const WorktreeContentOverhead = BranchContentOverhead
 // right-pane chrome: status bar + borders + mode header).
 const StashContentOverhead = BranchContentOverhead
 
+// TableHeaderRows is the number of rows consumed by table headers inside
+// table-style right panes.
+const TableHeaderRows = 1
+
+// SessionContentOverhead is the number of rows consumed before session data
+// rows can render: right-pane chrome plus the sessions table header.
+const SessionContentOverhead = BranchContentOverhead + TableHeaderRows
+
+// PlanContentOverhead is the number of rows consumed before plan data rows can
+// render: right-pane chrome plus the plans table header.
+const PlanContentOverhead = BranchContentOverhead + TableHeaderRows
+
 // StashPrefixWidth is the visible width consumed by the stash line prefix:
 // indent/cursor (3) + date (10) + separator (2).
 const StashPrefixWidth = 15
@@ -1249,7 +1261,8 @@ func renderSessionPane(records []sessions.SessionRecord, selected, scroll, width
 		return nil
 	}
 	header := truncateToWidth(statusStyle.Render(formatSessionColumns("   ", "Provider", "Branch", "Worktree", "Status", "Summary")), width)
-	if height == 1 {
+	rowHeight := height - TableHeaderRows
+	if rowHeight <= 0 {
 		return []string{header}
 	}
 
@@ -1279,7 +1292,7 @@ func renderSessionPane(records []sessions.SessionRecord, selected, scroll, width
 		}
 		rows = append(rows, truncateToWidth(line, width))
 	}
-	return append([]string{header}, scrollAndPad(rows, scroll, height-1)...)
+	return append([]string{header}, scrollAndPad(rows, scroll, rowHeight)...)
 }
 
 const (
@@ -1320,7 +1333,8 @@ func renderPlanPane(records []planstore.PlanRecord, selected, scroll, width, hei
 		return nil
 	}
 	header := truncateToWidth(statusStyle.Render(formatPlanColumns("   ", "Status", "Branch", "Phase", "Updated", "Title")), width)
-	if height == 1 {
+	rowHeight := height - TableHeaderRows
+	if rowHeight <= 0 {
 		return []string{header}
 	}
 
@@ -1350,7 +1364,7 @@ func renderPlanPane(records []planstore.PlanRecord, selected, scroll, width, hei
 			rows = append(rows, renderPlanPhaseRows(record, width)...)
 		}
 	}
-	return append([]string{header}, scrollAndPad(rows, scroll, height-1)...)
+	return append([]string{header}, scrollAndPad(rows, scroll, rowHeight)...)
 }
 
 func renderPlanPhaseRows(record planstore.PlanRecord, width int) []string {


### PR DESCRIPTION
## Summary
- Fix sessions and plans row visibility by accounting for the table header in model viewport math.
- Keep the UI renderer and model in sync with explicit table/header overhead constants.
- Replace inherited `WTUI_*` values when launching agents or bootstrap hooks so child processes receive launch-specific metadata.

## Implementation
- Added `TableHeaderRows`, `SessionContentOverhead`, and `PlanContentOverhead` in the UI package and used them in table rendering.
- Updated sessions/plans reflow and cursor movement to use data-row viewport height.
- Added an env override helper for agent/bootstrap command construction that filters replaced keys out of `os.Environ()` before appending wtui metadata.
- Added regression coverage for short sessions/plans panes and inherited `WTUI_*` values.

## Verification
- `go test ./ui ./model ./actions`
- `make test`
- `make build`