### PR TITLE
Tame session summary rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ filter matches, or a load failure with details in the status bar.
 | `F` | Pull with `--ff-only` (worktrees, and branches with a checked-out worktree) |
 | `t` | Open or attach to a tmux/Zellij session for the worktree |
 | `c` | Open VSCode at worktree path |
-| `y` | Copy hash to clipboard (history/reflog view) |
+| `y` | Copy hash to clipboard (history/reflog view) or selected agent session ID (sessions view) |
 | `r` | Resume selected agent session (sessions view) |
-| `s` | Copy selected agent session ID (sessions view) |
+| `s` | Show selected agent session summary (sessions view) |
 | `D` | Toggle destructive mode |
 | `tab` | Switch focus to left pane |
 | `q`/`esc` | Close overlay or quit |
@@ -171,8 +171,8 @@ Browse captured Claude Code and Codex sessions associated with the selected
 repo. Rows show provider, branch, worktree, status, and summary. Use `/` to
 filter sessions by provider, session ID, launch ID, branch, worktree, model,
 status, or summary. Press `enter` to open the normalized transcript overlay,
-`r` to resume the selected provider session, or `s` to copy the raw provider
-session ID.
+`s` to show the selected summary, `r` to resume the selected provider session,
+or `y` to copy the raw provider session ID.
 
 Session data is stored under the user state directory by default:
 `$XDG_STATE_HOME/wtui/sessions/v1`, or

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3521,7 +3521,63 @@ func TestModel_EnterOnSessionOpensTranscriptOverlay(t *testing.T) {
 	}
 }
 
-func TestModel_SKeyCopiesSelectedSessionID(t *testing.T) {
+func TestModel_SKeyShowsSelectedSessionSummary(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{
+		{Provider: sessions.ProviderCodex, SessionID: "codex-1", RepoPath: "/dev/alpha", Summary: "first line\nsecond line\nthird line"},
+	}, ListRequest: m.ListRequest(ui.ModeSessions)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if cmd != nil {
+		t.Fatalf("expected summary overlay to open without command, got %T", cmd)
+	}
+	if m.Overlay() != ui.OverlayPlanText {
+		t.Fatalf("expected text overlay for session summary, got %d", m.Overlay())
+	}
+	if got := m.OverlayText(); got != "first line\nsecond line\nthird line" {
+		t.Fatalf("summary overlay text = %q", got)
+	}
+}
+
+func TestModel_SKeyEmptySessionSummaryShowsFallback(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{
+		{Provider: sessions.ProviderCodex, SessionID: "codex-1", RepoPath: "/dev/alpha"},
+	}, ListRequest: m.ListRequest(ui.ModeSessions)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if cmd != nil {
+		t.Fatalf("expected summary overlay to open without command, got %T", cmd)
+	}
+	if got := m.OverlayText(); got != "No summary" {
+		t.Fatalf("empty summary overlay text = %q", got)
+	}
+}
+
+func TestModel_SKeySessionSummaryNoOpsOutsideSessionSelection(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{})
+	m = inRightPane(m)
+
+	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}}); cmd != nil {
+		t.Fatalf("expected s outside sessions to no-op, got %T", cmd)
+	}
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected no overlay outside sessions, got %d", m.Overlay())
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}}); cmd != nil {
+		t.Fatalf("expected s with no selected session to no-op, got %T", cmd)
+	}
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected no overlay without selected session, got %d", m.Overlay())
+	}
+}
+
+func TestModel_YKeyCopiesSelectedSessionID(t *testing.T) {
 	var copied []string
 	m := model.NewWithOptions(testRepos(), model.Options{
 		CopyToClipboard: func(text string) error {
@@ -3535,7 +3591,7 @@ func TestModel_SKeyCopiesSelectedSessionID(t *testing.T) {
 		{Provider: sessions.ProviderCodex, SessionID: "raw-codex-session-1", RepoPath: "/dev/alpha"},
 	}, ListRequest: m.ListRequest(ui.ModeSessions)})
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if cmd == nil {
 		t.Fatal("expected copy session id command")
 	}
@@ -3549,7 +3605,7 @@ func TestModel_SKeyCopiesSelectedSessionID(t *testing.T) {
 	}
 }
 
-func TestModel_SKeySessionCopyNoOpsOutsideSessionSelection(t *testing.T) {
+func TestModel_YKeySessionCopyNoOpsOutsideSessionSelection(t *testing.T) {
 	var copied []string
 	m := model.NewWithOptions(testRepos(), model.Options{
 		CopyToClipboard: func(text string) error {
@@ -3559,19 +3615,19 @@ func TestModel_SKeySessionCopyNoOpsOutsideSessionSelection(t *testing.T) {
 	})
 	m = inRightPane(m)
 
-	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}}); cmd != nil {
-		t.Fatalf("expected s outside sessions to no-op, got %T", cmd)
+	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}); cmd != nil {
+		t.Fatalf("expected y outside copyable modes to no-op, got %T", cmd)
 	}
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
-	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}}); cmd != nil {
-		t.Fatalf("expected s with no selected session to no-op, got %T", cmd)
+	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}); cmd != nil {
+		t.Fatalf("expected y with no selected session to no-op, got %T", cmd)
 	}
 	if len(copied) != 0 {
 		t.Fatalf("expected no clipboard calls, got %#v", copied)
 	}
 }
 
-func TestModel_SKeySessionCopyErrorShowsStatus(t *testing.T) {
+func TestModel_YKeySessionCopyErrorShowsStatus(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		CopyToClipboard: func(string) error {
 			return errors.New("clipboard unavailable")
@@ -3583,13 +3639,36 @@ func TestModel_SKeySessionCopyErrorShowsStatus(t *testing.T) {
 		{Provider: sessions.ProviderCodex, SessionID: "codex-1", RepoPath: "/dev/alpha"},
 	}, ListRequest: m.ListRequest(ui.ModeSessions)})
 
-	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if cmd == nil {
 		t.Fatal("expected copy command")
 	}
 	m, _ = update(m, cmd())
 	if !strings.Contains(m.View(), "clipboard unavailable") {
 		t.Fatal("expected clipboard error in status bar")
+	}
+}
+
+func TestModel_SessionScrollAccountsForTwoLineSummaries(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{})
+	m = inRightPane(m)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 180, Height: ui.BranchContentOverhead + 3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{
+		{Provider: sessions.ProviderCodex, SessionID: "codex-1", RepoPath: "/dev/alpha", Branch: "one", Summary: "one first\none second"},
+		{Provider: sessions.ProviderCodex, SessionID: "codex-2", RepoPath: "/dev/alpha", Branch: "two", Summary: "two first\ntwo second"},
+		{Provider: sessions.ProviderCodex, SessionID: "codex-3", RepoPath: "/dev/alpha", Branch: "three", Summary: "three only"},
+	}, ListRequest: m.ListRequest(ui.ModeSessions)})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	view := m.View()
+	if !strings.Contains(view, "> codex     three") {
+		t.Fatalf("expected selected third session to stay visible:\n%s", view)
+	}
+	if strings.Contains(view, "one first") {
+		t.Fatalf("expected first two-line session to scroll offscreen:\n%s", view)
 	}
 }
 

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3649,7 +3649,7 @@ func TestModel_YKeySessionCopyErrorShowsStatus(t *testing.T) {
 	}
 }
 
-func TestModel_SessionScrollAccountsForTwoLineSummaries(t *testing.T) {
+func TestModel_SessionScrollTreatsMultilineSummariesAsOneRow(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{})
 	m = inRightPane(m)
 	m, _ = update(m, tea.WindowSizeMsg{Width: 180, Height: ui.BranchContentOverhead + 3})
@@ -3668,7 +3668,10 @@ func TestModel_SessionScrollAccountsForTwoLineSummaries(t *testing.T) {
 		t.Fatalf("expected selected third session to stay visible:\n%s", view)
 	}
 	if strings.Contains(view, "one first") {
-		t.Fatalf("expected first two-line session to scroll offscreen:\n%s", view)
+		t.Fatalf("expected first session row to scroll offscreen:\n%s", view)
+	}
+	if !strings.Contains(view, "two first two second") {
+		t.Fatalf("expected multiline summaries to collapse whitespace within one row:\n%s", view)
 	}
 }
 

--- a/model/model_filter.go
+++ b/model/model_filter.go
@@ -63,7 +63,9 @@ func newReflogPane() pane.Pane[gitquery.ReflogEntry] {
 }
 
 func newSessionPane() pane.Pane[sessions.SessionRecord] {
-	return pane.New(sessionSearchText, fixedHeight[sessions.SessionRecord])
+	return pane.New(sessionSearchText, func(record sessions.SessionRecord, _ int) int {
+		return ui.SessionLineCount(record.Summary)
+	})
 }
 
 func newPlanPane() pane.Pane[planstore.PlanRecord] {

--- a/model/model_filter.go
+++ b/model/model_filter.go
@@ -63,9 +63,7 @@ func newReflogPane() pane.Pane[gitquery.ReflogEntry] {
 }
 
 func newSessionPane() pane.Pane[sessions.SessionRecord] {
-	return pane.New(sessionSearchText, func(record sessions.SessionRecord, _ int) int {
-		return ui.SessionLineCount(record.Summary)
-	})
+	return pane.New(sessionSearchText, fixedHeight[sessions.SessionRecord])
 }
 
 func newPlanPane() pane.Pane[planstore.PlanRecord] {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -240,9 +240,12 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModePlans {
 			return m.handleCopyPlanPath()
 		}
+		if m.mode == ui.ModeSessions {
+			return m.handleCopySessionID()
+		}
 		return m.handleCopyHash()
 	case "s":
-		return m.handleCopySessionID()
+		return m.handleShowSessionSummary()
 	case "r":
 		return m.handleResumeSession()
 	case "i":

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -1078,4 +1079,20 @@ func (m Model) handleCopyPlanPath() (tea.Model, tea.Cmd) {
 		}
 		return ClipboardResultMsg{}
 	}
+}
+
+func (m Model) handleShowSessionSummary() (tea.Model, tea.Cmd) {
+	if m.mode != ui.ModeSessions {
+		return m, nil
+	}
+	record, ok := m.selectedSession()
+	if !ok {
+		return m, nil
+	}
+	summary := record.Summary
+	if strings.TrimSpace(summary) == "" {
+		summary = "No summary"
+	}
+	m.modal = modal.OpenText(summary)
+	return m, nil
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1282,13 +1282,13 @@ func renderSessionPane(records []sessions.SessionRecord, selected, scroll, width
 		if worktree == "." || worktree == string(filepath.Separator) {
 			worktree = ""
 		}
-		summaryFirst, summaryRest, hasSummaryRest := sessionSummaryDisplayLines(record.Summary)
+		summary := sessionSummaryDisplayText(record.Summary)
 		line := formatSessionColumns("   ",
 			diffHdrStyle.Render(fitSessionColumn(provider, sessionProviderWidth)),
 			branchStyle.Render(fitSessionColumn(record.Branch, sessionBranchWidth)),
 			stashDateStyle.Render(fitSessionColumn(worktree, sessionWorktreeWidth)),
 			statusStyle.Render(fitSessionColumn(record.Status, sessionStatusWidth)),
-			stashMsgStyle.Render(summaryFirst),
+			stashMsgStyle.Render(summary),
 		)
 		if i == selected {
 			selectedLine := truncateToWidth(formatSessionColumns(" > ",
@@ -1296,40 +1296,17 @@ func renderSessionPane(records []sessions.SessionRecord, selected, scroll, width
 				record.Branch,
 				worktree,
 				record.Status,
-				summaryFirst,
+				summary,
 			), width)
 			line = stashSelStyle.Width(width).Render(selectedLine)
 		}
 		rows = append(rows, truncateToWidth(line, width))
-		if hasSummaryRest {
-			continuation := truncateToWidth(formatSessionColumns("   ", "", "", "", "", stashMsgStyle.Render(summaryRest)), width)
-			if i == selected {
-				continuation = stashSelStyle.Width(width).Render(truncateToWidth(formatSessionColumns("   ", "", "", "", "", summaryRest), width))
-			}
-			rows = append(rows, continuation)
-		}
 	}
 	return append([]string{header}, scrollAndPad(rows, scroll, rowHeight)...)
 }
 
-// SessionLineCount returns the capped number of visual lines a session row
-// occupies in the sessions table.
-func SessionLineCount(summary string) int {
-	if _, _, hasRest := sessionSummaryDisplayLines(summary); hasRest {
-		return 2
-	}
-	return 1
-}
-
-func sessionSummaryDisplayLines(summary string) (string, string, bool) {
-	first, rest, ok := strings.Cut(summary, "\n")
-	first = strings.TrimSuffix(first, "\r")
-	if !ok {
-		return first, "", false
-	}
-	next, _, _ := strings.Cut(rest, "\n")
-	next = strings.TrimSuffix(next, "\r")
-	return first, next, true
+func sessionSummaryDisplayText(summary string) string {
+	return strings.Join(strings.Fields(summary), " ")
 }
 
 const (

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -556,7 +556,8 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 	title := shortcutTitleStyle.Render("Shortcuts") + "  " + shortcutModeStyle.Render(modeShortcutTitle(sp.Mode))
 	lines = append(lines, ansi.Truncate(" "+title, width, ""))
 	compact := height <= 3
-	if !compact {
+	tight := height <= 7
+	if !compact && !tight {
 		lines = append(lines, strings.Repeat(" ", width))
 	}
 	sectionCount := 0
@@ -567,7 +568,7 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 			continue
 		}
 		if !compact {
-			if sectionCount > 0 {
+			if sectionCount > 0 && !tight {
 				lines = append(lines, strings.Repeat(" ", width))
 			}
 			lines = append(lines, truncateToWidth(" "+shortcutGroupStyle.Render(section.Title), width))
@@ -618,10 +619,6 @@ func sidebarShortcutHints(hints []shortcutHint) []shortcutHint {
 				continue
 			case hint.Key == "t" && next.Key == "c":
 				grouped = append(grouped, shortcutHint{Key: "t/c", Label: hint.Label + " / " + next.Label, Warning: hint.Warning || next.Warning})
-				i++
-				continue
-			case hint.Key == "s" && next.Key == "y":
-				grouped = append(grouped, shortcutHint{Key: "s/y", Label: hint.Label + " / " + next.Label, Warning: hint.Warning || next.Warning})
 				i++
 				continue
 			}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -620,6 +620,10 @@ func sidebarShortcutHints(hints []shortcutHint) []shortcutHint {
 				grouped = append(grouped, shortcutHint{Key: "t/c", Label: hint.Label + " / " + next.Label, Warning: hint.Warning || next.Warning})
 				i++
 				continue
+			case hint.Key == "s" && next.Key == "y":
+				grouped = append(grouped, shortcutHint{Key: "s/y", Label: hint.Label + " / " + next.Label, Warning: hint.Warning || next.Warning})
+				i++
+				continue
 			}
 		}
 		grouped = append(grouped, hint)
@@ -750,7 +754,8 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 			actions = append(actions,
 				shortcutHint{Key: "enter", Label: "transcript"},
 				shortcutHint{Key: "r", Label: "resume"},
-				shortcutHint{Key: "s", Label: "copy id"},
+				shortcutHint{Key: "s", Label: "summary"},
+				shortcutHint{Key: "y", Label: "copy id"},
 			)
 		}
 	case ModePlans:
@@ -1277,12 +1282,13 @@ func renderSessionPane(records []sessions.SessionRecord, selected, scroll, width
 		if worktree == "." || worktree == string(filepath.Separator) {
 			worktree = ""
 		}
+		summaryFirst, summaryRest, hasSummaryRest := sessionSummaryDisplayLines(record.Summary)
 		line := formatSessionColumns("   ",
 			diffHdrStyle.Render(fitSessionColumn(provider, sessionProviderWidth)),
 			branchStyle.Render(fitSessionColumn(record.Branch, sessionBranchWidth)),
 			stashDateStyle.Render(fitSessionColumn(worktree, sessionWorktreeWidth)),
 			statusStyle.Render(fitSessionColumn(record.Status, sessionStatusWidth)),
-			stashMsgStyle.Render(record.Summary),
+			stashMsgStyle.Render(summaryFirst),
 		)
 		if i == selected {
 			selectedLine := truncateToWidth(formatSessionColumns(" > ",
@@ -1290,13 +1296,40 @@ func renderSessionPane(records []sessions.SessionRecord, selected, scroll, width
 				record.Branch,
 				worktree,
 				record.Status,
-				record.Summary,
+				summaryFirst,
 			), width)
 			line = stashSelStyle.Width(width).Render(selectedLine)
 		}
 		rows = append(rows, truncateToWidth(line, width))
+		if hasSummaryRest {
+			continuation := truncateToWidth(formatSessionColumns("   ", "", "", "", "", stashMsgStyle.Render(summaryRest)), width)
+			if i == selected {
+				continuation = stashSelStyle.Width(width).Render(truncateToWidth(formatSessionColumns("   ", "", "", "", "", summaryRest), width))
+			}
+			rows = append(rows, continuation)
+		}
 	}
 	return append([]string{header}, scrollAndPad(rows, scroll, rowHeight)...)
+}
+
+// SessionLineCount returns the capped number of visual lines a session row
+// occupies in the sessions table.
+func SessionLineCount(summary string) int {
+	if _, _, hasRest := sessionSummaryDisplayLines(summary); hasRest {
+		return 2
+	}
+	return 1
+}
+
+func sessionSummaryDisplayLines(summary string) (string, string, bool) {
+	first, rest, ok := strings.Cut(summary, "\n")
+	first = strings.TrimSuffix(first, "\r")
+	if !ok {
+		return first, "", false
+	}
+	next, _, _ := strings.Cut(rest, "\n")
+	next = strings.TrimSuffix(next, "\r")
+	return first, next, true
 }
 
 const (

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -181,7 +181,7 @@ func TestRender_SessionsModeShowsHeaderAndRows(t *testing.T) {
 	}
 }
 
-func TestRender_SessionsModeTruncatesSummaryToOneDownwardContinuation(t *testing.T) {
+func TestRender_SessionsModeKeepsSummaryOnOneLine(t *testing.T) {
 	params := RenderParams{
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
 		Selected: 0,
@@ -203,7 +203,7 @@ func TestRender_SessionsModeTruncatesSummaryToOneDownwardContinuation(t *testing
 				Status:    "ended",
 				RepoPath:  "/dev/wtui",
 				Branch:    "selected",
-				Summary:   "selected first line",
+				Summary:   "selected first line\n\nselected third line",
 			},
 			{
 				Provider:  sessions.ProviderClaude,
@@ -219,67 +219,54 @@ func TestRender_SessionsModeTruncatesSummaryToOneDownwardContinuation(t *testing
 	}
 
 	baseline := strippedLines(Render(params))
-	params.Sessions[1].Summary = "selected first line\nselected second line\nselected third line"
 	view := Render(params)
 	lines := strippedLines(view)
 
 	baselineAbove := lineIndexContaining(baseline, "above summary")
 	above := lineIndexContaining(lines, "above summary")
 	row := lineIndexContaining(lines, "selected first line")
-	continuation := lineIndexContaining(lines, "selected second line")
 	below := lineIndexContaining(lines, "below summary")
 
 	if above != baselineAbove {
-		t.Fatalf("summary continuation should not force preceding content up, above row index=%d baseline=%d:\n%s", above, baselineAbove, view)
+		t.Fatalf("summary should not force preceding content up, above row index=%d baseline=%d:\n%s", above, baselineAbove, view)
 	}
-	if row < 0 || continuation != row+1 {
-		t.Fatalf("summary continuation should render directly below selected row, row=%d continuation=%d:\n%s", row, continuation, view)
+	if row < 0 || below != row+1 {
+		t.Fatalf("summary should occupy only the selected row, row=%d below=%d:\n%s", row, below, view)
 	}
-	if below != continuation+1 {
-		t.Fatalf("rows after the expanded summary should move down after the continuation, below=%d continuation=%d:\n%s", below, continuation, view)
-	}
-	if strings.Contains(ansi.Strip(view), "selected third line") {
-		t.Fatalf("sessions view should omit summary text after one continuation line:\n%s", view)
+	if !strings.Contains(lines[row], "selected first line selected third line") {
+		t.Fatalf("summary whitespace should collapse onto one display row:\n%s", view)
 	}
 }
 
-func TestRender_SessionsModeCountsBlankSummaryContinuation(t *testing.T) {
-	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
-		Selected: 0,
-		Width:    180,
-		Height:   12,
-		Mode:     ModeSessions,
-		Sessions: []sessions.SessionRecord{
-			{
-				Provider:  sessions.ProviderCodex,
-				SessionID: "codex-selected",
-				Status:    "ended",
-				RepoPath:  "/dev/wtui",
-				Branch:    "selected",
-				Summary:   "selected first line\n\nselected third line",
-			},
-			{
-				Provider:  sessions.ProviderClaude,
-				SessionID: "claude-below",
-				Status:    "ended",
-				RepoPath:  "/dev/wtui",
-				Branch:    "below",
-				Summary:   "below summary",
-			},
-		},
-		ActivePane:      1,
-		SessionSelected: 0,
-	})
-	lines := strippedLines(view)
-	row := lineIndexContaining(lines, "selected first line")
-	below := lineIndexContaining(lines, "below summary")
-
-	if row < 0 || below != row+2 {
-		t.Fatalf("blank second summary line should still reserve one downward continuation row, row=%d below=%d:\n%s", row, below, view)
+func TestRender_SessionsModeTruncatesSummaryToPaneWidth(t *testing.T) {
+	const rightContentWidth = 58
+	lines := renderSessionPane([]sessions.SessionRecord{{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "codex-selected",
+		Status:    "ended",
+		RepoPath:  "/dev/wtui",
+		Branch:    "selected",
+		Summary:   "selected first line " + strings.Repeat("very long summary ", 20),
+	}}, 0, 0, rightContentWidth, 4)
+	row := ""
+	for _, line := range lines {
+		stripped := ansi.Strip(line)
+		if strings.Contains(stripped, "selected") {
+			row = stripped
+			break
+		}
 	}
-	if strings.Contains(ansi.Strip(view), "selected third line") {
-		t.Fatalf("sessions view should omit summary text after one continuation line:\n%s", view)
+
+	if row == "" {
+		t.Fatalf("expected session row in view:\n%s", strings.Join(lines, "\n"))
+	}
+	if lipgloss.Width(row) > rightContentWidth {
+		t.Fatalf("session row width = %d, want <= %d:\n%s", lipgloss.Width(row), rightContentWidth, strings.Join(lines, "\n"))
+	}
+	for _, line := range lines {
+		if strings.Contains(line, "very long summary very long summary very long summary very long summary") {
+			t.Fatalf("summary should be truncated to pane width, got overlong visible text:\n%s", strings.Join(lines, "\n"))
+		}
 	}
 }
 

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -181,6 +181,108 @@ func TestRender_SessionsModeShowsHeaderAndRows(t *testing.T) {
 	}
 }
 
+func TestRender_SessionsModeTruncatesSummaryToOneDownwardContinuation(t *testing.T) {
+	params := RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModeSessions,
+		Sessions: []sessions.SessionRecord{
+			{
+				Provider:  sessions.ProviderCodex,
+				SessionID: "codex-above",
+				Status:    "ended",
+				RepoPath:  "/dev/wtui",
+				Branch:    "above",
+				Summary:   "above summary",
+			},
+			{
+				Provider:  sessions.ProviderCodex,
+				SessionID: "codex-selected",
+				Status:    "ended",
+				RepoPath:  "/dev/wtui",
+				Branch:    "selected",
+				Summary:   "selected first line",
+			},
+			{
+				Provider:  sessions.ProviderClaude,
+				SessionID: "claude-below",
+				Status:    "ended",
+				RepoPath:  "/dev/wtui",
+				Branch:    "below",
+				Summary:   "below summary",
+			},
+		},
+		ActivePane:      1,
+		SessionSelected: 1,
+	}
+
+	baseline := strippedLines(Render(params))
+	params.Sessions[1].Summary = "selected first line\nselected second line\nselected third line"
+	view := Render(params)
+	lines := strippedLines(view)
+
+	baselineAbove := lineIndexContaining(baseline, "above summary")
+	above := lineIndexContaining(lines, "above summary")
+	row := lineIndexContaining(lines, "selected first line")
+	continuation := lineIndexContaining(lines, "selected second line")
+	below := lineIndexContaining(lines, "below summary")
+
+	if above != baselineAbove {
+		t.Fatalf("summary continuation should not force preceding content up, above row index=%d baseline=%d:\n%s", above, baselineAbove, view)
+	}
+	if row < 0 || continuation != row+1 {
+		t.Fatalf("summary continuation should render directly below selected row, row=%d continuation=%d:\n%s", row, continuation, view)
+	}
+	if below != continuation+1 {
+		t.Fatalf("rows after the expanded summary should move down after the continuation, below=%d continuation=%d:\n%s", below, continuation, view)
+	}
+	if strings.Contains(ansi.Strip(view), "selected third line") {
+		t.Fatalf("sessions view should omit summary text after one continuation line:\n%s", view)
+	}
+}
+
+func TestRender_SessionsModeCountsBlankSummaryContinuation(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModeSessions,
+		Sessions: []sessions.SessionRecord{
+			{
+				Provider:  sessions.ProviderCodex,
+				SessionID: "codex-selected",
+				Status:    "ended",
+				RepoPath:  "/dev/wtui",
+				Branch:    "selected",
+				Summary:   "selected first line\n\nselected third line",
+			},
+			{
+				Provider:  sessions.ProviderClaude,
+				SessionID: "claude-below",
+				Status:    "ended",
+				RepoPath:  "/dev/wtui",
+				Branch:    "below",
+				Summary:   "below summary",
+			},
+		},
+		ActivePane:      1,
+		SessionSelected: 0,
+	})
+	lines := strippedLines(view)
+	row := lineIndexContaining(lines, "selected first line")
+	below := lineIndexContaining(lines, "below summary")
+
+	if row < 0 || below != row+2 {
+		t.Fatalf("blank second summary line should still reserve one downward continuation row, row=%d below=%d:\n%s", row, below, view)
+	}
+	if strings.Contains(ansi.Strip(view), "selected third line") {
+		t.Fatalf("sessions view should omit summary text after one continuation line:\n%s", view)
+	}
+}
+
 func lineContaining(view, needle string) string {
 	for _, line := range strings.Split(view, "\n") {
 		stripped := ansi.Strip(line)
@@ -189,6 +291,23 @@ func lineContaining(view, needle string) string {
 		}
 	}
 	return ""
+}
+
+func strippedLines(view string) []string {
+	lines := strings.Split(view, "\n")
+	for i, line := range lines {
+		lines[i] = ansi.Strip(line)
+	}
+	return lines
+}
+
+func lineIndexContaining(lines []string, needle string) int {
+	for i, line := range lines {
+		if strings.Contains(line, needle) {
+			return i
+		}
+	}
+	return -1
 }
 
 func shortcutPaneLines(view string) []string {
@@ -264,10 +383,13 @@ func TestRender_SessionsModeShowsSelectedSessionShortcuts(t *testing.T) {
 		SessionSelected: 0,
 	})
 	pane := shortcutPaneText(view)
-	for _, want := range []string{"enter  transcript", "r      resume", "s      copy id"} {
+	for _, want := range []string{"enter  transcript", "r      resume", "s/y    summary / copy id"} {
 		if !strings.Contains(pane, want) {
 			t.Fatalf("sessions view should expose selected session shortcut %q:\n%s", want, pane)
 		}
+	}
+	if strings.Contains(pane, "s      copy id") {
+		t.Fatalf("sessions view should not expose old copy-id shortcut:\n%s", pane)
 	}
 }
 
@@ -288,7 +410,7 @@ func TestRender_SessionsModeHidesSessionActionsWithoutSelection(t *testing.T) {
 		SessionSelected: -1,
 	})
 	pane := shortcutPaneText(view)
-	for _, hidden := range []string{"enter  transcript", "r      resume", "s      copy id"} {
+	for _, hidden := range []string{"enter  transcript", "r      resume", "s/y    summary / copy id", "s      summary", "y      copy id", "s      copy id"} {
 		if strings.Contains(pane, hidden) {
 			t.Fatalf("sessions view should hide %q without selected session:\n%s", hidden, pane)
 		}
@@ -818,7 +940,7 @@ func TestRender_ShortSessionPaneKeepsSelectedSessionActions(t *testing.T) {
 		SessionSelected: 0,
 	})
 	pane := shortcutPaneText(view)
-	for _, want := range []string{"enter  transcript", "r      resume", "s      copy id", shortcutOverflowMarker} {
+	for _, want := range []string{"enter  transcript", "r      resume", "s/y    summary / copy id", shortcutOverflowMarker} {
 		if !strings.Contains(pane, want) {
 			t.Fatalf("short session shortcut pane should keep selected session action %q, got:\n%s", want, pane)
 		}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -370,7 +370,7 @@ func TestRender_SessionsModeShowsSelectedSessionShortcuts(t *testing.T) {
 		SessionSelected: 0,
 	})
 	pane := shortcutPaneText(view)
-	for _, want := range []string{"enter  transcript", "r      resume", "s/y    summary / copy id"} {
+	for _, want := range []string{"enter  transcript", "r      resume", "s      summary", "y      copy id"} {
 		if !strings.Contains(pane, want) {
 			t.Fatalf("sessions view should expose selected session shortcut %q:\n%s", want, pane)
 		}
@@ -397,7 +397,7 @@ func TestRender_SessionsModeHidesSessionActionsWithoutSelection(t *testing.T) {
 		SessionSelected: -1,
 	})
 	pane := shortcutPaneText(view)
-	for _, hidden := range []string{"enter  transcript", "r      resume", "s/y    summary / copy id", "s      summary", "y      copy id", "s      copy id"} {
+	for _, hidden := range []string{"enter  transcript", "r      resume", "s      summary", "y      copy id", "s      copy id"} {
 		if strings.Contains(pane, hidden) {
 			t.Fatalf("sessions view should hide %q without selected session:\n%s", hidden, pane)
 		}
@@ -927,7 +927,7 @@ func TestRender_ShortSessionPaneKeepsSelectedSessionActions(t *testing.T) {
 		SessionSelected: 0,
 	})
 	pane := shortcutPaneText(view)
-	for _, want := range []string{"enter  transcript", "r      resume", "s/y    summary / copy id", shortcutOverflowMarker} {
+	for _, want := range []string{"enter  transcript", "r      resume", "s      summary", "y      copy id", shortcutOverflowMarker} {
 		if !strings.Contains(pane, want) {
 			t.Fatalf("short session shortcut pane should keep selected session action %q, got:\n%s", want, pane)
 		}


### PR DESCRIPTION
## Summary
- limit sessions table summaries to the main row plus one downward continuation line
- add `s` to open the full selected session summary and move session-id copy to `y`
- group the compact shortcut hint as `s/y summary / copy id` and account for the sessions header in pane scrolling

## Implementation
- split session summary rendering into first line plus one continuation line, including blank second lines
- update the session pane height function so scrolling matches the capped renderer
- preserve existing `y` behavior for history/reflog hash copy and latest main's plan-path copy behavior
- add UI/model coverage for downward continuation, blank continuation rows, compact hints, summary overlay, session-id copy, and session scrolling

## Verification
- `gofmt -l .`
- `make test`
- `make build`