### PR TITLE
Launch Codex.app from wtui

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -468,16 +468,23 @@ type AgentLaunchContext struct {
 	ResumeSessionID  string
 	PlanID           string
 	PlanPath         string
-	// InitialPrompt is appended as the trailing positional prompt argument.
+	// InitialPrompt is passed to providers when they support a launch-time prompt.
 	InitialPrompt string
 }
 
 // AgentLaunch returns a safe, direct command for launching a supported coding
 // agent in path.
 func AgentLaunch(ctx AgentLaunchContext) (TerminalLaunchSpec, error) {
+	return agentLaunch(ctx, runtime.GOOS)
+}
+
+func agentLaunch(ctx AgentLaunchContext, goos string) (TerminalLaunchSpec, error) {
 	command := agent.Normalize(ctx.Command)
 	if err := agent.Validate(command); err != nil {
 		return TerminalLaunchSpec{}, err
+	}
+	if command == agent.CommandCodexApp {
+		return codexAppLaunch(ctx, goos)
 	}
 	args := agentLaunchArgs(command, ctx.ResumeSessionID)
 	if ctx.InitialPrompt != "" {
@@ -505,6 +512,58 @@ func AgentLaunch(ctx AgentLaunchContext) (TerminalLaunchSpec, error) {
 		envVar{key: "WTUI_PLAN_PATH", value: ctx.PlanPath},
 	)
 	return TerminalLaunchSpec{Cmd: cmd, Interactive: true}, nil
+}
+
+func codexAppLaunch(ctx AgentLaunchContext, goos string) (TerminalLaunchSpec, error) {
+	if goos != "darwin" {
+		return TerminalLaunchSpec{}, fmt.Errorf("codex-app launch is only supported on macOS")
+	}
+	launchURL, err := codexAppLaunchURL(ctx)
+	if err != nil {
+		return TerminalLaunchSpec{}, err
+	}
+	cmd := exec.Command("open", launchURL)
+	cmd.Env = envWithoutPrefix("WTUI_")
+	return TerminalLaunchSpec{Cmd: cmd}, nil
+}
+
+func codexAppLaunchURL(ctx AgentLaunchContext) (string, error) {
+	if ctx.ResumeSessionID != "" {
+		return "codex://threads/" + url.PathEscape(ctx.ResumeSessionID), nil
+	}
+
+	path := ctx.WorkingDir
+	if path == "" {
+		path = ctx.WorktreePath
+	}
+	if path == "" {
+		return "", fmt.Errorf("codex-app launch requires a worktree path or working directory")
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("codex-app launch path must be absolute: %s", path)
+	}
+
+	values := []string{"path=" + codexAppQueryEscape(path)}
+	if ctx.InitialPrompt != "" {
+		values = append(values, "prompt="+codexAppQueryEscape(ctx.InitialPrompt))
+	}
+	return "codex://threads/new?" + strings.Join(values, "&"), nil
+}
+
+func codexAppQueryEscape(value string) string {
+	return strings.ReplaceAll(url.QueryEscape(value), "+", "%20")
+}
+
+func envWithoutPrefix(prefix string) []string {
+	env := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && strings.HasPrefix(key, prefix) {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return env
 }
 
 func envWithOverrides(overrides ...envVar) []string {

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -544,10 +544,71 @@ func codexAppLaunchURL(ctx AgentLaunchContext) (string, error) {
 	}
 
 	values := []string{"path=" + codexAppQueryEscape(path)}
-	if ctx.InitialPrompt != "" {
-		values = append(values, "prompt="+codexAppQueryEscape(ctx.InitialPrompt))
+	if prompt := codexAppLaunchPrompt(ctx); prompt != "" {
+		values = append(values, "prompt="+codexAppQueryEscape(prompt))
 	}
 	return "codex://threads/new?" + strings.Join(values, "&"), nil
+}
+
+func codexAppLaunchPrompt(ctx AgentLaunchContext) string {
+	if ctx.InitialPrompt == "" {
+		return ""
+	}
+	metadata := codexAppLaunchMetadata(ctx)
+	if metadata == "" {
+		return ctx.InitialPrompt
+	}
+	return ctx.InitialPrompt + "\n\n" + metadata
+}
+
+func codexAppLaunchMetadata(ctx AgentLaunchContext) string {
+	if ctx.LaunchID == "" &&
+		ctx.RepoPath == "" &&
+		ctx.Branch == "" &&
+		ctx.Commit == "" &&
+		ctx.SessionStateRoot == "" &&
+		ctx.PlanID == "" &&
+		ctx.PlanPath == "" {
+		return ""
+	}
+
+	items := []envVar{
+		{key: "WTUI_AGENT", value: agent.CommandCodexApp},
+		{key: "WTUI_LAUNCH_ID", value: ctx.LaunchID},
+		{key: "WTUI_REPO_PATH", value: ctx.RepoPath},
+		{key: "WTUI_WORKTREE_PATH", value: ctx.WorktreePath},
+		{key: "WTUI_BRANCH", value: ctx.Branch},
+		{key: "WTUI_COMMIT", value: ctx.Commit},
+		{key: "WTUI_SESSION_STATE_ROOT", value: ctx.SessionStateRoot},
+		{key: "WTUI_PLAN_STATE_ROOT", value: ctx.SessionStateRoot},
+		{key: "WTUI_PLAN_ID", value: ctx.PlanID},
+		{key: "WTUI_PLAN_PATH", value: ctx.PlanPath},
+	}
+
+	var kept []envVar
+	for _, item := range items {
+		if item.value != "" {
+			kept = append(kept, item)
+		}
+	}
+	if len(kept) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("wtui launch metadata (Codex App launches do not inherit WTUI_* environment from macOS open):")
+	for _, item := range kept {
+		b.WriteString("\n- ")
+		b.WriteString(item.key)
+		b.WriteString("=")
+		b.WriteString(shellQuote(item.value))
+	}
+	if ctx.SessionStateRoot != "" {
+		b.WriteString("\nWhen running wtui plan commands for this launch, pass `--state-root ")
+		b.WriteString(shellQuote(ctx.SessionStateRoot))
+		b.WriteString("` or export WTUI_PLAN_STATE_ROOT/WTUI_SESSION_STATE_ROOT with that value.")
+	}
+	return b.String()
 }
 
 func codexAppQueryEscape(value string) string {

--- a/actions/agent_launch_internal_test.go
+++ b/actions/agent_launch_internal_test.go
@@ -75,6 +75,48 @@ func TestCodexAppLaunchUsesWorkingDirForNewThreadPath(t *testing.T) {
 	}
 }
 
+func TestCodexAppLaunchPromptIncludesWTUIMetadata(t *testing.T) {
+	t.Setenv("WTUI_PLAN_STATE_ROOT", "/inherited/state")
+	launch, err := agentLaunch(AgentLaunchContext{
+		Command:          "codex-app",
+		LaunchID:         "launch-1",
+		RepoPath:         "/repo",
+		WorktreePath:     "/repo/work'tree$(bad)",
+		Branch:           "feature/$(echo pwned)",
+		Commit:           "abcdef",
+		SessionStateRoot: "/state/wtui/sessions/v1",
+		PlanID:           "plan-1",
+		PlanPath:         "/state/wtui/sessions/v1/plans/plan-1/plan.md",
+		InitialPrompt:    "Read the plan and begin implementation.",
+	}, "darwin")
+	if err != nil {
+		t.Fatalf("agentLaunch returned error: %v", err)
+	}
+	assertNoWTUIEnv(t, launch.Cmd.Environ())
+
+	gotURL, err := url.Parse(launch.Cmd.Args[1])
+	if err != nil {
+		t.Fatalf("parse launch URL: %v", err)
+	}
+	prompt := gotURL.Query().Get("prompt")
+	for _, want := range []string{
+		"Read the plan and begin implementation.",
+		"WTUI_LAUNCH_ID=" + shellQuote("launch-1"),
+		"WTUI_REPO_PATH=" + shellQuote("/repo"),
+		"WTUI_WORKTREE_PATH=" + shellQuote("/repo/work'tree$(bad)"),
+		"WTUI_BRANCH=" + shellQuote("feature/$(echo pwned)"),
+		"WTUI_SESSION_STATE_ROOT=" + shellQuote("/state/wtui/sessions/v1"),
+		"WTUI_PLAN_STATE_ROOT=" + shellQuote("/state/wtui/sessions/v1"),
+		"WTUI_PLAN_ID=" + shellQuote("plan-1"),
+		"WTUI_PLAN_PATH=" + shellQuote("/state/wtui/sessions/v1/plans/plan-1/plan.md"),
+		"--state-root " + shellQuote("/state/wtui/sessions/v1"),
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
 func TestCodexAppLaunchOpensResumeDeepLink(t *testing.T) {
 	t.Setenv("WTUI_SESSION_STATE_ROOT", "/inherited/state")
 	launch, err := agentLaunch(AgentLaunchContext{

--- a/actions/agent_launch_internal_test.go
+++ b/actions/agent_launch_internal_test.go
@@ -2,6 +2,9 @@ package actions
 
 import (
 	"encoding/json"
+	"net/url"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -25,5 +28,108 @@ func TestClaudeSessionHookSettingsEncodesJSONString(t *testing.T) {
 	}
 	if got := decoded.Hooks.SessionEnd[0].Hooks[0].Command; got != hookCommand {
 		t.Fatalf("command = %q, want %q", got, hookCommand)
+	}
+}
+
+func TestCodexAppLaunchOpensNewThreadDeepLink(t *testing.T) {
+	t.Setenv("WTUI_LAUNCH_ID", "inherited-launch")
+	launch, err := agentLaunch(AgentLaunchContext{
+		Command:       "codex-app",
+		WorktreePath:  "/repo/work tree+plus",
+		InitialPrompt: "Read the plan & begin + ship.",
+	}, "darwin")
+	if err != nil {
+		t.Fatalf("agentLaunch returned error: %v", err)
+	}
+	if launch.Interactive {
+		t.Fatal("expected codex-app launch to be non-interactive")
+	}
+	if launch.Cmd.Dir != "" {
+		t.Fatalf("expected open command to have no working dir, got %q", launch.Cmd.Dir)
+	}
+	assertNoWTUIEnv(t, launch.Cmd.Environ())
+	if !reflect.DeepEqual(launch.Cmd.Args, []string{"open", "codex://threads/new?path=%2Frepo%2Fwork%20tree%2Bplus&prompt=Read%20the%20plan%20%26%20begin%20%2B%20ship."}) {
+		t.Fatalf("unexpected codex-app args: %#v", launch.Cmd.Args)
+	}
+}
+
+func TestCodexAppLaunchUsesWorkingDirForNewThreadPath(t *testing.T) {
+	launch, err := agentLaunch(AgentLaunchContext{
+		Command:      "codex-app",
+		WorktreePath: "/repo/worktree",
+		WorkingDir:   "/repo/worktree/subdir",
+	}, "darwin")
+	if err != nil {
+		t.Fatalf("agentLaunch returned error: %v", err)
+	}
+
+	gotURL, err := url.Parse(launch.Cmd.Args[1])
+	if err != nil {
+		t.Fatalf("parse launch URL: %v", err)
+	}
+	if got := gotURL.Query().Get("path"); got != "/repo/worktree/subdir" {
+		t.Fatalf("path query = %q, want working dir", got)
+	}
+	if got := gotURL.Query().Get("prompt"); got != "" {
+		t.Fatalf("prompt query = %q, want empty", got)
+	}
+}
+
+func TestCodexAppLaunchOpensResumeDeepLink(t *testing.T) {
+	t.Setenv("WTUI_SESSION_STATE_ROOT", "/inherited/state")
+	launch, err := agentLaunch(AgentLaunchContext{
+		Command:          "codex-app",
+		WorktreePath:     "/repo/worktree",
+		InitialPrompt:    "ignored for resume",
+		ResumeSessionID:  "9a0c8d4e-1111-2222-3333-abcdefabcdef",
+		SessionStateRoot: "/state/wtui/sessions/v1",
+	}, "darwin")
+	if err != nil {
+		t.Fatalf("agentLaunch returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(launch.Cmd.Args, []string{"open", "codex://threads/9a0c8d4e-1111-2222-3333-abcdefabcdef"}) {
+		t.Fatalf("unexpected codex-app resume args: %#v", launch.Cmd.Args)
+	}
+	assertNoWTUIEnv(t, launch.Cmd.Environ())
+}
+
+func TestCodexAppLaunchRejectsMissingNewThreadPath(t *testing.T) {
+	_, err := agentLaunch(AgentLaunchContext{Command: "codex-app"}, "darwin")
+	if err == nil {
+		t.Fatal("expected missing path error")
+	}
+	if !strings.Contains(err.Error(), "requires a worktree path or working directory") {
+		t.Fatalf("unexpected missing path error: %v", err)
+	}
+}
+
+func TestCodexAppLaunchRejectsRelativeNewThreadPath(t *testing.T) {
+	_, err := agentLaunch(AgentLaunchContext{Command: "codex-app", WorktreePath: "relative/path"}, "darwin")
+	if err == nil {
+		t.Fatal("expected relative path error")
+	}
+	if !strings.Contains(err.Error(), "path must be absolute") {
+		t.Fatalf("unexpected relative path error: %v", err)
+	}
+}
+
+func TestCodexAppLaunchRejectsUnsupportedPlatform(t *testing.T) {
+	_, err := agentLaunch(AgentLaunchContext{Command: "codex-app", WorktreePath: "/repo/worktree"}, "linux")
+	if err == nil {
+		t.Fatal("expected unsupported platform error")
+	}
+	if !strings.Contains(err.Error(), "only supported on macOS") {
+		t.Fatalf("unexpected unsupported platform error: %v", err)
+	}
+}
+
+func assertNoWTUIEnv(t *testing.T, env []string) {
+	t.Helper()
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && strings.HasPrefix(key, "WTUI_") {
+			t.Fatalf("expected codex-app open command to scrub WTUI env, found %q in %#v", key, env)
+		}
 	}
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	CommandCodex  = "codex"
-	CommandClaude = "claude"
+	CommandCodex    = "codex"
+	CommandCodexApp = "codex-app"
+	CommandClaude   = "claude"
 )
 
 func Normalize(command string) string {
@@ -16,7 +17,7 @@ func Normalize(command string) string {
 
 func Supported(command string) bool {
 	switch Normalize(command) {
-	case CommandCodex, CommandClaude:
+	case CommandCodex, CommandCodexApp, CommandClaude:
 		return true
 	default:
 		return false
@@ -28,7 +29,7 @@ func Validate(command string) error {
 		return fmt.Errorf("agent is not set")
 	}
 	if !Supported(command) {
-		return fmt.Errorf("unsupported agent %q; choose codex or claude", command)
+		return fmt.Errorf("unsupported agent %q; choose codex, codex-app, or claude", command)
 	}
 	return nil
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,0 +1,39 @@
+package agent_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/brian-bell/wtui/agent"
+)
+
+func TestNormalizeSupportsCodexApp(t *testing.T) {
+	if got := agent.Normalize("  CoDeX-App  "); got != agent.CommandCodexApp {
+		t.Fatalf("Normalize = %q, want %q", got, agent.CommandCodexApp)
+	}
+}
+
+func TestSupportedIncludesCodexApp(t *testing.T) {
+	for _, command := range []string{agent.CommandCodex, agent.CommandCodexApp, agent.CommandClaude} {
+		t.Run(command, func(t *testing.T) {
+			if !agent.Supported(command) {
+				t.Fatalf("expected %q to be supported", command)
+			}
+			if err := agent.Validate(command); err != nil {
+				t.Fatalf("Validate(%q) returned error: %v", command, err)
+			}
+		})
+	}
+}
+
+func TestValidateUnsupportedAgentMentionsCodexApp(t *testing.T) {
+	err := agent.Validate("vim")
+	if err == nil {
+		t.Fatal("expected unsupported agent error")
+	}
+	for _, want := range []string{"codex", "codex-app", "claude"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error %q to mention %q", err.Error(), want)
+		}
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -283,6 +283,56 @@ func TestSaveAgentCommand_CreatesMissingConfig(t *testing.T) {
 	}
 }
 
+func TestLoadFrom_AcceptsCodexAppAgent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[agent]\ncommand = \" CoDeX-App \"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if cfg.Agent.Command != "codex-app" {
+		t.Fatalf("expected normalized agent codex-app, got %q", cfg.Agent.Command)
+	}
+}
+
+func TestSaveAgentCommand_WritesCodexApp(t *testing.T) {
+	xdg := t.TempDir()
+	err := config.SaveAgentCommand("codex-app",
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return t.TempDir(), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("SaveAgentCommand returned error: %v", err)
+	}
+
+	path := filepath.Join(xdg, "wtui", "config.toml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `command = "codex-app"`) {
+		t.Fatalf("expected codex-app command in saved config, got:\n%s", raw)
+	}
+
+	cfg, err := config.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if cfg.Agent.Command != "codex-app" {
+		t.Fatalf("expected saved agent codex-app, got %q", cfg.Agent.Command)
+	}
+}
+
 func TestSaveAgentCommand_PreservesExistingParsedSettings(t *testing.T) {
 	xdg := t.TempDir()
 	home := t.TempDir()

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3112,6 +3112,13 @@ func TestModel_NewWithOptionsStoresAgent(t *testing.T) {
 	}
 }
 
+func TestModel_NewWithOptionsStoresCodexAppAgent(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: " CoDeX-App "})
+	if m.AgentCommand() != "codex-app" {
+		t.Fatalf("expected configured agent codex-app, got %q", m.AgentCommand())
+	}
+}
+
 func TestModel_ShiftAOpensAgentInputFromBothPanes(t *testing.T) {
 	for _, setup := range []struct {
 		name string
@@ -3126,7 +3133,7 @@ func TestModel_ShiftAOpensAgentInputFromBothPanes(t *testing.T) {
 			if m.Overlay() != ui.OverlayWorktreeInput {
 				t.Fatalf("expected agent input overlay, got %d", m.Overlay())
 			}
-			if !strings.Contains(m.View(), "codex or claude") {
+			if !strings.Contains(m.View(), "codex, codex-app, or claude") {
 				t.Fatalf("expected agent prompt in view")
 			}
 			if cmd != nil {
@@ -3176,6 +3183,29 @@ func TestModel_AgentInputSavesAndSetsClaude(t *testing.T) {
 	}
 }
 
+func TestModel_AgentInputSavesAndSetsCodexApp(t *testing.T) {
+	var saved string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SaveAgentCommand: func(command string) error {
+			saved = command
+			return nil
+		},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(" CoDeX-App ")})
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected save-agent command")
+	}
+	m, _ = update(m, cmd())
+	if saved != "codex-app" {
+		t.Fatalf("expected saved codex-app, got %q", saved)
+	}
+	if m.AgentCommand() != "codex-app" {
+		t.Fatalf("expected session agent codex-app, got %q", m.AgentCommand())
+	}
+}
+
 func TestModel_AgentSaveFailureKeepsSessionChoiceAndShowsStatus(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		SaveAgentCommand: func(string) error { return errors.New("disk full") },
@@ -3216,6 +3246,33 @@ func TestModel_AKeyLaunchesAgentFromWorktree(t *testing.T) {
 	}
 	if gotPath != "/dev/alpha" || gotCommand != "codex" {
 		t.Fatalf("expected launch /dev/alpha with codex, got path=%q command=%q", gotPath, gotCommand)
+	}
+}
+
+func TestModel_AKeyLaunchesCodexAppFromWorktree(t *testing.T) {
+	var got actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex-app",
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			got = ctx
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", Commit: "abc123", IsMain: true},
+	}, ListRequest: m.ListRequest(ui.ModeWorktrees)})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd == nil {
+		t.Fatal("expected agent launch command")
+	}
+	if got.Command != "codex-app" ||
+		got.RepoPath != "/dev/alpha" ||
+		got.WorktreePath != "/dev/alpha" ||
+		got.Branch != "main" ||
+		got.Commit != "abc123" {
+		t.Fatalf("unexpected codex-app launch context: %#v", got)
 	}
 }
 
@@ -3751,6 +3808,69 @@ func TestModel_RKeyResumesSessionFromCWDWhenWorktreePathMissing(t *testing.T) {
 
 	if got.Command != "codex" || got.ResumeSessionID != "codex-session-1" || got.WorktreePath != "" || got.WorkingDir != "/dev/alpha/subdir" {
 		t.Fatalf("unexpected cwd fallback resume context: %#v", got)
+	}
+}
+
+func TestModel_RKeyUsesCodexAppPreferenceForCodexSessionResume(t *testing.T) {
+	var got actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex-app",
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			got = ctx
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{
+		{Provider: sessions.ProviderCodex, SessionID: "9a0c8d4e-1111-2222-3333-abcdefabcdef", RepoPath: "/dev/alpha"},
+	}, ListRequest: m.ListRequest(ui.ModeSessions)})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("expected codex-app resume command")
+	}
+	_ = cmd()
+
+	if got.Command != "codex-app" ||
+		got.ResumeSessionID != "9a0c8d4e-1111-2222-3333-abcdefabcdef" ||
+		got.WorktreePath != "" ||
+		got.WorkingDir != "" {
+		t.Fatalf("unexpected codex-app resume context: %#v", got)
+	}
+}
+
+func TestModel_RKeyKeepsClaudeProviderWhenCodexAppPreferenceSelected(t *testing.T) {
+	var got actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex-app",
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			got = ctx
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{
+		{
+			Provider:     sessions.ProviderClaude,
+			SessionID:    "claude-session-1",
+			RepoPath:     "/dev/alpha",
+			WorktreePath: "/dev/alpha-worktrees/docs",
+		},
+	}, ListRequest: m.ListRequest(ui.ModeSessions)})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("expected claude resume command")
+	}
+	_ = cmd()
+
+	if got.Command != "claude" ||
+		got.ResumeSessionID != "claude-session-1" ||
+		got.WorktreePath != "/dev/alpha-worktrees/docs" ||
+		got.WorkingDir != "/dev/alpha-worktrees/docs" {
+		t.Fatalf("unexpected claude resume context with codex-app preference: %#v", got)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/model/modal"
 	"github.com/brian-bell/wtui/planstore"
+	"github.com/brian-bell/wtui/sessions"
 	"github.com/brian-bell/wtui/ui"
 )
 
@@ -418,7 +419,7 @@ func (m Model) handleDelete() (tea.Model, tea.Cmd) {
 
 func (m Model) handleSetAgent() (tea.Model, tea.Cmd) {
 	m.modal = modal.OpenInput(
-		"Set agent (codex or claude)",
+		"Set agent ("+ui.AgentInputPlaceholder+")",
 		ui.AgentInputPlaceholder,
 		m.agentCommand,
 		validateAgentInput,
@@ -445,7 +446,7 @@ func (m Model) handleNewWorktree(launchAgent bool) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if launchAgent && m.agentCommand == "" {
-		m = m.setStatus(statusOther, "Press A to choose codex or claude before launching an agent")
+		m = m.setStatus(statusOther, "Press A to choose "+ui.AgentInputPlaceholder+" before launching an agent")
 		return m, nil
 	}
 	prompt := "Create worktree from"
@@ -660,7 +661,7 @@ func (m Model) handleOpenAgent() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if m.agentCommand == "" {
-		m = m.setStatus(statusOther, "Press A to choose codex or claude before launching an agent")
+		m = m.setStatus(statusOther, "Press A to choose "+ui.AgentInputPlaceholder+" before launching an agent")
 		return m, nil
 	}
 	return m.launchAgentAtPath(path)
@@ -674,16 +675,20 @@ func (m Model) handleResumeSession() (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
+	command := string(record.Provider)
+	if record.Provider == sessions.ProviderCodex && agent.Normalize(m.agentCommand) == agent.CommandCodexApp {
+		command = agent.CommandCodexApp
+	}
 	workingDir := record.CWD
 	if workingDir == "" {
 		workingDir = record.WorktreePath
 	}
-	if workingDir == "" {
+	if workingDir == "" && command != agent.CommandCodexApp {
 		m = m.setStatus(statusOther, "Session has no worktree path or cwd to resume from")
 		return m, nil
 	}
 	ctx := actions.AgentLaunchContext{
-		Command:          string(record.Provider),
+		Command:          command,
 		LaunchID:         newLaunchID(),
 		RepoPath:         record.RepoPath,
 		WorktreePath:     record.WorktreePath,
@@ -706,7 +711,7 @@ func (m Model) handleImplementPlan() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if m.agentCommand == "" {
-		m = m.setStatus(statusOther, "Press A to choose codex or claude before launching an agent")
+		m = m.setStatus(statusOther, "Press A to choose "+ui.AgentInputPlaceholder+" before launching an agent")
 		return m, nil
 	}
 	planPath, err := m.planMarkdownPath(plan.PlanID)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -37,7 +37,7 @@ const WorktreeInputPlaceholder = "branch, tag, or new branch name"
 const WorktreeMoveInputPlaceholder = "new path or sibling name"
 const BranchInputPlaceholder = "branch name"
 const PRWorktreeInputPlaceholder = "PR number or URL"
-const AgentInputPlaceholder = "codex or claude"
+const AgentInputPlaceholder = "codex, codex-app, or claude"
 
 // Mode represents the active right-pane view. The model owns the application
 // state, but the renderer needs the same typed value (and the model imports ui,


### PR DESCRIPTION
## Summary
- Add `codex-app` as a supported wtui agent selection alongside `codex` and `claude`.
- Launch Codex.app on macOS through `codex://` deep links for new threads and resumed Codex sessions.
- Keep CLI `codex` and `claude` launch behavior on the existing hook/env path.

## Implementation
- Builds non-interactive `open codex://...` launch specs for `codex-app`, with RFC3986-style query escaping and clear non-macOS / missing-path errors.
- Scrubs inherited `WTUI_*` environment variables from app deep-link launches while preserving wtui metadata injection for subprocess-based agents.
- Wires `codex-app` through agent validation, config save/load tests, the agent input overlay, worktree launches, and Codex session resume. Claude session resume remains provider-specific even when `codex-app` is selected.

## Verification
- `gofmt -l .`
- `go test ./agent ./config ./actions ./model ./ui`
- `make test`
- `make build`
- Ran a two-pass review loop: first pass 7/10, final pass 9/10 after fixes.