### PR TITLE
Implement saved plan phase selection

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -468,6 +468,9 @@ type AgentLaunchContext struct {
 	ResumeSessionID  string
 	PlanID           string
 	PlanPath         string
+	PlanPhaseID      string
+	PlanPhaseTitle   string
+	PlanPhaseStatus  string
 	// InitialPrompt is appended as the trailing positional prompt argument.
 	InitialPrompt string
 }
@@ -503,6 +506,9 @@ func AgentLaunch(ctx AgentLaunchContext) (TerminalLaunchSpec, error) {
 		envVar{key: "WTUI_PLAN_STATE_ROOT", value: ctx.SessionStateRoot},
 		envVar{key: "WTUI_PLAN_ID", value: ctx.PlanID},
 		envVar{key: "WTUI_PLAN_PATH", value: ctx.PlanPath},
+		envVar{key: "WTUI_PLAN_PHASE_ID", value: ctx.PlanPhaseID},
+		envVar{key: "WTUI_PLAN_PHASE_TITLE", value: ctx.PlanPhaseTitle},
+		envVar{key: "WTUI_PLAN_PHASE_STATUS", value: ctx.PlanPhaseStatus},
 	)
 	return TerminalLaunchSpec{Cmd: cmd, Interactive: true}, nil
 }

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1628,6 +1628,32 @@ func TestAgentLaunchCodexAddsPlanEnvironmentAndPrompt(t *testing.T) {
 	}
 }
 
+func TestAgentLaunchAddsPlanPhaseEnvironment(t *testing.T) {
+	launch, err := actions.AgentLaunch(actions.AgentLaunchContext{
+		Command:         "codex",
+		WorktreePath:    "/repo/worktree",
+		PlanID:          "plan-1",
+		PlanPath:        "/state/wtui/sessions/v1/plans/plan-1/plan.md",
+		PlanPhaseID:     "p2",
+		PlanPhaseTitle:  "CLI subcommands",
+		PlanPhaseStatus: "pending",
+	})
+	if err != nil {
+		t.Fatalf("AgentLaunch returned error: %v", err)
+	}
+
+	env := envMap(launch.Cmd.Env)
+	for key, want := range map[string]string{
+		"WTUI_PLAN_PHASE_ID":     "p2",
+		"WTUI_PLAN_PHASE_TITLE":  "CLI subcommands",
+		"WTUI_PLAN_PHASE_STATUS": "pending",
+	} {
+		if env[key] != want {
+			t.Fatalf("%s = %q, want %q in env %#v", key, env[key], want, launch.Cmd.Env)
+		}
+	}
+}
+
 func TestAgentLaunchReplacesInheritedWTUIEnvironment(t *testing.T) {
 	t.Setenv("CUSTOM_KEEP", "still-here")
 	for _, key := range []string{
@@ -1641,6 +1667,9 @@ func TestAgentLaunchReplacesInheritedWTUIEnvironment(t *testing.T) {
 		"WTUI_PLAN_STATE_ROOT",
 		"WTUI_PLAN_ID",
 		"WTUI_PLAN_PATH",
+		"WTUI_PLAN_PHASE_ID",
+		"WTUI_PLAN_PHASE_TITLE",
+		"WTUI_PLAN_PHASE_STATUS",
 	} {
 		t.Setenv(key, "inherited-"+key)
 	}
@@ -1655,6 +1684,9 @@ func TestAgentLaunchReplacesInheritedWTUIEnvironment(t *testing.T) {
 		SessionStateRoot: "/state/wtui/sessions/v1",
 		PlanID:           "plan-2",
 		PlanPath:         "/state/wtui/sessions/v1/plans/plan-2/plan.md",
+		PlanPhaseID:      "p2",
+		PlanPhaseTitle:   "Launch environment",
+		PlanPhaseStatus:  "in_progress",
 	})
 	if err != nil {
 		t.Fatalf("AgentLaunch returned error: %v", err)
@@ -1671,6 +1703,9 @@ func TestAgentLaunchReplacesInheritedWTUIEnvironment(t *testing.T) {
 		"WTUI_PLAN_STATE_ROOT":    "/state/wtui/sessions/v1",
 		"WTUI_PLAN_ID":            "plan-2",
 		"WTUI_PLAN_PATH":          "/state/wtui/sessions/v1/plans/plan-2/plan.md",
+		"WTUI_PLAN_PHASE_ID":      "p2",
+		"WTUI_PLAN_PHASE_TITLE":   "Launch environment",
+		"WTUI_PLAN_PHASE_STATUS":  "in_progress",
 	} {
 		got, count := envEntryValue(launch.Cmd.Env, key)
 		if got != want || count != 1 {

--- a/model/model.go
+++ b/model/model.go
@@ -35,6 +35,7 @@ type Model struct {
 	sessions                  pane.Pane[sessions.SessionRecord]
 	plans                     pane.Pane[planstore.PlanRecord]
 	expandedPlanID            string
+	selectedPlanPhaseID       string
 	modal                     modal.Modal
 	diffRequestSeq            uint64
 	listRequestSeq            uint64
@@ -238,6 +239,7 @@ func (m Model) Plans() []planstore.PlanRecord {
 }
 func (m Model) PlanSelected() int               { return m.plans.SelectedIndex() }
 func (m Model) PlanScroll() int                 { return m.plans.Scroll() }
+func (m Model) SelectedPlanPhaseID() string     { return m.selectedPlanPhaseID }
 func (m Model) ReflogSelected() int             { return m.reflogs.SelectedIndex() }
 func (m Model) ReflogScroll() int               { return m.reflogs.Scroll() }
 func (m Model) Overlay() ui.OverlayState        { return m.overlayState() }
@@ -326,6 +328,7 @@ func (m Model) View() string {
 		PlanSelected:             planSelected,
 		PlanScroll:               planScroll,
 		ExpandedPlanID:           m.expandedPlanID,
+		SelectedPlanPhaseID:      m.selectedPlanPhaseID,
 		OverlayText:              modalView.Text,
 		TransientError:           m.visibleStatusText(),
 		TransientErrorFadeStep:   m.visibleStatusFadeStep(),
@@ -678,8 +681,40 @@ func (m Model) selectedPlanID() string {
 	return record.PlanID
 }
 
+func (m Model) selectedPlanPhase() (planstore.PlanPhase, bool) {
+	record, ok := m.selectedPlan()
+	if !ok || record.PlanID == "" || record.PlanID != m.expandedPlanID || m.selectedPlanPhaseID == "" {
+		return planstore.PlanPhase{}, false
+	}
+	for _, phase := range record.Phases {
+		if phase.PhaseID == m.selectedPlanPhaseID {
+			return phase, true
+		}
+	}
+	return planstore.PlanPhase{}, false
+}
+
+func (m Model) selectedPlanPhaseIndex() (int, bool) {
+	record, ok := m.selectedPlan()
+	if !ok || record.PlanID == "" || record.PlanID != m.expandedPlanID || m.selectedPlanPhaseID == "" {
+		return 0, false
+	}
+	for i, phase := range record.Phases {
+		if phase.PhaseID == m.selectedPlanPhaseID {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func (m Model) clearSelectedPlanPhase() Model {
+	m.selectedPlanPhaseID = ""
+	return m
+}
+
 func (m Model) setExpandedPlanID(planID string) Model {
 	m.expandedPlanID = planID
+	m.selectedPlanPhaseID = ""
 	m.plans = m.plans.SetItemHeight(planItemHeight(planID))
 	m = m.reflowPlans()
 	if planID == "" {
@@ -743,6 +778,86 @@ func (m Model) reflowExpandedPlan() Model {
 		m.plans = m.plans.ScrollBy(target-scroll, viewHeight, m.contentWidth())
 	}
 	return m
+}
+
+func (m Model) moveSelectedPlanPhase(delta int) (Model, bool) {
+	if m.mode != ui.ModePlans || m.expandedPlanID == "" || m.selectedPlanID() != m.expandedPlanID {
+		return m, false
+	}
+	record, ok := m.selectedPlan()
+	if !ok || len(record.Phases) == 0 {
+		return m, false
+	}
+
+	index, hasPhase := m.selectedPlanPhaseIndex()
+	if !hasPhase {
+		if delta > 0 {
+			m.selectedPlanPhaseID = record.Phases[0].PhaseID
+			return m.ensureSelectedPlanPhaseVisible(), true
+		}
+		return m, false
+	}
+
+	nextIndex := index + delta
+	if nextIndex < 0 {
+		m = m.clearSelectedPlanPhase()
+		return m.reflowExpandedPlan(), true
+	}
+	if nextIndex >= len(record.Phases) {
+		if m.plans.Len() <= 1 {
+			return m.ensureSelectedPlanPhaseVisible(), true
+		}
+		before := m.selectedPlanID()
+		m.plans = m.plans.Move(delta, m.contentHeightForMode(), m.contentWidth())
+		if after := m.selectedPlanID(); before != "" && after != before {
+			m = m.clearSelectedPlanPhase()
+			m = m.setExpandedPlanID("")
+		}
+		return m, true
+	}
+	m.selectedPlanPhaseID = record.Phases[nextIndex].PhaseID
+	return m.ensureSelectedPlanPhaseVisible(), true
+}
+
+func (m Model) ensureSelectedPlanPhaseVisible() Model {
+	index, ok := m.selectedPlanPhaseIndex()
+	if !ok {
+		return m.reflowExpandedPlan()
+	}
+	line, ok := m.selectedPlanVisualLine()
+	if !ok {
+		return m
+	}
+	line += 1 + index
+	viewHeight := m.planContentHeight()
+	if viewHeight <= 0 {
+		viewHeight = 1
+	}
+	scroll := m.PlanScroll()
+	target := scroll
+	if line < target {
+		target = line
+	}
+	if line >= target+viewHeight {
+		target = line - viewHeight + 1
+	}
+	if target != scroll {
+		m.plans = m.plans.ScrollBy(target-scroll, viewHeight, m.contentWidth())
+	}
+	return m
+}
+
+func (m Model) selectedPlanVisualLine() (int, bool) {
+	plans := m.filteredPlans()
+	selected := m.PlanSelected()
+	if selected < 0 || selected >= len(plans) {
+		return 0, false
+	}
+	line := 0
+	for i := 0; i < selected; i++ {
+		line += planVisualHeight(plans[i], m.expandedPlanID)
+	}
+	return line, true
 }
 
 func (m Model) isSelectedBranchDirtyWorktree() bool {

--- a/model/model.go
+++ b/model/model.go
@@ -909,6 +909,9 @@ func (m Model) reflowSessions() Model {
 
 func (m Model) reflowPlans() Model {
 	m.plans = m.plans.Reflow(m.planContentHeight(), m.contentWidth())
+	if m.selectedPlanPhaseID != "" {
+		return m.ensureSelectedPlanPhaseVisible()
+	}
 	return m
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -254,6 +254,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		}
 	case "tab":
 		m.activePane = 0
+		if m.mode == ui.ModePlans {
+			m = m.clearSelectedPlanPhase()
+		}
 	case "enter":
 		return m.handleEnter()
 	case "n":
@@ -329,6 +332,9 @@ func (m Model) moveCursor(delta int) Model {
 	case ui.ModeSessions:
 		m.sessions = m.sessions.Move(delta, h, w)
 	case ui.ModePlans:
+		if next, ok := m.moveSelectedPlanPhase(delta); ok {
+			return next
+		}
 		if m.canScrollExpandedPlan(delta, h) {
 			m.plans = m.plans.ScrollBy(delta, h, w)
 			return m
@@ -738,6 +744,12 @@ func (m Model) handleImplementPlan() (tea.Model, tea.Cmd) {
 		PlanPath:         planPath,
 		InitialPrompt:    implementationPrompt(plan, planPath),
 	}
+	if phase, ok := m.selectedPlanPhase(); ok {
+		ctx.PlanPhaseID = phase.PhaseID
+		ctx.PlanPhaseTitle = phase.Title
+		ctx.PlanPhaseStatus = phase.Status
+		ctx.InitialPrompt = implementationPromptForPhase(plan, planPath, phase)
+	}
 	return m.launchAgentWithContext(ctx)
 }
 
@@ -747,6 +759,22 @@ func implementationPrompt(plan planstore.PlanRecord, planPath string) string {
 		title = "(untitled)"
 	}
 	return fmt.Sprintf("Implement the saved wtui plan %q (ID: %s) at %s. Read the plan file, then begin implementation.", title, plan.PlanID, planPath)
+}
+
+func implementationPromptForPhase(plan planstore.PlanRecord, planPath string, phase planstore.PlanPhase) string {
+	title := plan.Title
+	if title == "" {
+		title = "(untitled)"
+	}
+	phaseTitle := phase.Title
+	if phaseTitle == "" {
+		phaseTitle = "(untitled)"
+	}
+	phaseStatus := phase.Status
+	if phaseStatus == "" {
+		phaseStatus = "(unknown)"
+	}
+	return fmt.Sprintf("Implement only the selected phase of the saved wtui plan %q (ID: %s) at %s. Selected phase: %s (%q), status %s. Read the plan file, then begin implementation of only that phase.", title, plan.PlanID, planPath, phase.PhaseID, phaseTitle, phaseStatus)
 }
 
 func (m Model) launchAgentAtPath(path string) (Model, tea.Cmd) {

--- a/model/model_plan_overlay_test.go
+++ b/model/model_plan_overlay_test.go
@@ -121,7 +121,7 @@ func TestModel_EnterOnExpandedPlanCollapsesPhases(t *testing.T) {
 	}
 }
 
-func TestModel_MovingToDifferentPlanCollapsesExpandedPhases(t *testing.T) {
+func TestModel_DownOnExpandedPlanSelectsFirstPhase(t *testing.T) {
 	m := model.New(testRepos())
 	m = plansInRightPane(t, m, []planstore.PlanRecord{
 		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Persist plans", Status: "draft",
@@ -132,9 +132,14 @@ func TestModel_MovingToDifferentPlanCollapsesExpandedPhases(t *testing.T) {
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
-	view := m.View()
-	if strings.Contains(view, "Tracer bullet") || strings.Contains(view, "Other phase") {
-		t.Fatalf("moving to another plan should collapse expanded phases:\n%s", view)
+	if got := m.PlanSelected(); got != 0 {
+		t.Fatalf("phase selection should keep selected plan, got %d", got)
+	}
+	if got := m.SelectedPlanPhaseID(); got != "p1" {
+		t.Fatalf("selected phase = %q, want p1", got)
+	}
+	if view := m.View(); !strings.Contains(view, "Tracer bullet") || strings.Contains(view, "Other phase") {
+		t.Fatalf("expanded selected plan should stay visible and not expand another plan:\n%s", view)
 	}
 }
 
@@ -203,12 +208,12 @@ func TestModel_ExpandedSinglePlanScrollsWithinManyPhases(t *testing.T) {
 	if got := m.PlanSelected(); got != 0 {
 		t.Fatalf("scrolling inside expanded single plan should not move selection, got %d", got)
 	}
-	if got := m.PlanScroll(); got != 3 {
-		t.Fatalf("expected expanded phase block to scroll to 3, got %d", got)
+	if got := m.PlanScroll(); got != 1 {
+		t.Fatalf("expected expanded phase block to scroll to 1, got %d", got)
 	}
 	view := m.View()
-	if !strings.Contains(view, "Phase 5") {
-		t.Fatalf("lower expanded phase should be reachable:\n%s", view)
+	if !strings.Contains(view, "Phase 3") {
+		t.Fatalf("selected expanded phase should be reachable:\n%s", view)
 	}
 	if strings.Contains(view, "Plan 1") {
 		t.Fatalf("scrolling within an oversized expanded plan should move past the plan row:\n%s", view)
@@ -248,7 +253,7 @@ func TestModel_TallExpandedPlanAtViewportBottomShowsFirstPhases(t *testing.T) {
 	}
 }
 
-func TestModel_ExpandedPlanMovesAndCollapsesAfterScrolledToBoundary(t *testing.T) {
+func TestModel_ExpandedPlanPhaseSelectionMovesToNextPlanAfterLastPhase(t *testing.T) {
 	m := model.New(testRepos())
 	m = plansInRightPaneAtSize(t, m, []planstore.PlanRecord{
 		{
@@ -265,12 +270,15 @@ func TestModel_ExpandedPlanMovesAndCollapsesAfterScrolledToBoundary(t *testing.T
 	}, 140, ui.BranchContentOverhead+4)
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 6; i++ {
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	}
 
 	if got := m.PlanSelected(); got != 1 {
-		t.Fatalf("expected movement to next plan after expanded boundary, got %d", got)
+		t.Fatalf("expected movement to next plan after last phase, got %d", got)
+	}
+	if got := m.SelectedPlanPhaseID(); got != "" {
+		t.Fatalf("phase selection should clear after moving to next plan, got %q", got)
 	}
 	view := m.View()
 	if strings.Contains(view, "Phase 5") {
@@ -278,6 +286,35 @@ func TestModel_ExpandedPlanMovesAndCollapsesAfterScrolledToBoundary(t *testing.T
 	}
 	if !strings.Contains(view, "Plan 2") {
 		t.Fatalf("next plan should be selected and visible:\n%s", view)
+	}
+}
+
+func TestModel_ExpandedSinglePlanKeepsLastPhaseSelectedAtBottomBoundary(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPaneAtSize(t, m, []planstore.PlanRecord{{
+		PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft",
+		Phases: []planstore.PlanPhase{
+			{PhaseID: "p1", Title: "Phase 1", Status: "completed", Order: 1},
+			{PhaseID: "p2", Title: "Phase 2", Status: "pending", Order: 2},
+		},
+	}}, 140, ui.BranchContentOverhead+4)
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.SelectedPlanPhaseID(); got != "p2" {
+		t.Fatalf("selected phase = %q, want p2", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.SelectedPlanPhaseID(); got != "p2" {
+		t.Fatalf("single-plan bottom boundary should keep last phase selected, got %q", got)
+	}
+	if got := m.PlanSelected(); got != 0 {
+		t.Fatalf("single-plan bottom boundary should keep selected plan, got %d", got)
+	}
+	if view := m.View(); !strings.Contains(view, "Phase 2") {
+		t.Fatalf("last selected phase should remain visible:\n%s", view)
 	}
 }
 
@@ -312,15 +349,81 @@ func TestModel_ExpandedPlanScrollsUpWithinManyPhases(t *testing.T) {
 	}
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
-	if got := m.PlanSelected(); got != 0 {
-		t.Fatalf("expected movement to previous plan after expanded top boundary, got %d", got)
+	if got := m.PlanSelected(); got != 1 {
+		t.Fatalf("returning from first phase should keep selected plan, got %d", got)
+	}
+	if got := m.SelectedPlanPhaseID(); got != "" {
+		t.Fatalf("phase selection should clear when returning to plan row, got %q", got)
 	}
 	view := m.View()
+	if !strings.Contains(view, "Phase 1") {
+		t.Fatalf("expanded phases should remain visible after returning to plan row:\n%s", view)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
+	if got := m.PlanSelected(); got != 0 {
+		t.Fatalf("expected movement to previous plan after returning to plan row, got %d", got)
+	}
+	view = m.View()
 	if strings.Contains(view, "Phase 1") {
 		t.Fatalf("moving to previous plan should collapse expanded phases:\n%s", view)
 	}
 	if !strings.Contains(view, "Plan 0") {
 		t.Fatalf("previous plan should be selected and visible:\n%s", view)
+	}
+}
+
+func TestModel_CollapsingExpandedPlanResumesPlanMovement(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPane(t, m, []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Phase 1", Status: "completed", Order: 1}}},
+		{PlanID: "plan-2", RepoPath: "/dev/alpha", Title: "Plan 2", Status: "draft"},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.SelectedPlanPhaseID(); got != "p1" {
+		t.Fatalf("selected phase = %q, want p1", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.PlanSelected(); got != 1 {
+		t.Fatalf("expected plan movement after collapse, got %d", got)
+	}
+	if got := m.SelectedPlanPhaseID(); got != "" {
+		t.Fatalf("selected phase should clear after collapse, got %q", got)
+	}
+	if view := m.View(); strings.Contains(view, "Phase 1") {
+		t.Fatalf("collapsed plan should not show phase rows:\n%s", view)
+	}
+}
+
+func TestModel_TabbingAwayFromPlansClearsSelectedPhase(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPane(t, m, []planstore.PlanRecord{
+		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft",
+			Phases: []planstore.PlanPhase{{PhaseID: "p1", Title: "Phase 1", Status: "completed", Order: 1}}},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.SelectedPlanPhaseID(); got != "p1" {
+		t.Fatalf("selected phase = %q, want p1", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if got := m.SelectedPlanPhaseID(); got != "" {
+		t.Fatalf("selected phase should clear when focus leaves plans pane, got %q", got)
+	}
+	if view := m.View(); !strings.Contains(view, "Phase 1") {
+		t.Fatalf("tabbing away should preserve phase expansion:\n%s", view)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if got := m.SelectedPlanPhaseID(); got != "" {
+		t.Fatalf("selected phase should not restore when focus returns, got %q", got)
 	}
 }
 

--- a/model/model_plan_overlay_test.go
+++ b/model/model_plan_overlay_test.go
@@ -220,6 +220,46 @@ func TestModel_ExpandedSinglePlanScrollsWithinManyPhases(t *testing.T) {
 	}
 }
 
+func TestModel_ReflowKeepsSelectedPlanPhaseVisible(t *testing.T) {
+	m := model.New(testRepos())
+	m = plansInRightPaneAtSize(t, m, []planstore.PlanRecord{{
+		PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft",
+		Phases: []planstore.PlanPhase{
+			{PhaseID: "p1", Title: "Phase 1", Status: "completed", Order: 1},
+			{PhaseID: "p2", Title: "Phase 2", Status: "completed", Order: 2},
+			{PhaseID: "p3", Title: "Phase 3", Status: "pending", Order: 3},
+			{PhaseID: "p4", Title: "Phase 4", Status: "pending", Order: 4},
+			{PhaseID: "p5", Title: "Phase 5", Status: "pending", Order: 5},
+		},
+	}}, 140, ui.BranchContentOverhead+4)
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	for i := 0; i < 5; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if got := m.SelectedPlanPhaseID(); got != "p5" {
+		t.Fatalf("selected phase = %q, want p5", got)
+	}
+	if got := m.PlanScroll(); got != 3 {
+		t.Fatalf("expected selected phase scroll before reflow to be 3, got %d", got)
+	}
+
+	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: ui.BranchContentOverhead + 4})
+	if got := m.SelectedPlanPhaseID(); got != "p5" {
+		t.Fatalf("selected phase after reflow = %q, want p5", got)
+	}
+	if got := m.PlanScroll(); got != 3 {
+		t.Fatalf("expected reflow to keep selected phase visible at scroll 3, got %d", got)
+	}
+	view := m.View()
+	if !strings.Contains(view, "Phase 5") {
+		t.Fatalf("selected phase should remain visible after reflow:\n%s", view)
+	}
+	if strings.Contains(view, "Plan 1") {
+		t.Fatalf("reflow should not snap back to the plan row while a phase is selected:\n%s", view)
+	}
+}
+
 func TestModel_TallExpandedPlanAtViewportBottomShowsFirstPhases(t *testing.T) {
 	m := model.New(testRepos())
 	records := []planstore.PlanRecord{

--- a/model/model_plan_test.go
+++ b/model/model_plan_test.go
@@ -173,6 +173,55 @@ func TestModel_IKeyLaunchesAgentFromSelectedPlan(t *testing.T) {
 	}
 }
 
+func TestModel_IKeyLaunchesAgentFromSelectedPlanPhase(t *testing.T) {
+	var got actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:     "codex",
+		SessionStateRoot: "/state/wtui/sessions/v1",
+		PlanMarkdownPath: func(planID string) (string, error) {
+			if planID != "plan-1" {
+				t.Fatalf("resolver planID = %q, want plan-1", planID)
+			}
+			return "/state/wtui/sessions/v1/plans/plan-1/plan.md", nil
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			got = ctx
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true"), Interactive: true}, nil
+		},
+	})
+	m = plansInRightPane(t, m, []planstore.PlanRecord{{
+		PlanID:       "plan-1",
+		Title:        "Implement plans",
+		Status:       "approved",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/plans",
+		Phases: []planstore.PlanPhase{
+			{PhaseID: "p1", Title: "Store tracer bullet", Status: "completed", Order: 1},
+			{PhaseID: "p2", Title: "CLI subcommands", Status: "pending", Order: 2},
+		},
+	}})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if gotPhase := m.SelectedPlanPhaseID(); gotPhase != "p2" {
+		t.Fatalf("selected phase = %q, want p2", gotPhase)
+	}
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd == nil {
+		t.Fatal("expected agent launch command")
+	}
+	if got.PlanPhaseID != "p2" || got.PlanPhaseTitle != "CLI subcommands" || got.PlanPhaseStatus != "pending" {
+		t.Fatalf("unexpected phase launch context: %#v", got)
+	}
+	prompt := strings.ToLower(got.InitialPrompt)
+	for _, want := range []string{"implement only", "selected phase", "p2", "cli subcommands", "pending", "read the plan file"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("phase prompt missing %q: %q", want, got.InitialPrompt)
+		}
+	}
+}
+
 func TestModel_IKeyNoOpsWithNoSelectedPlan(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: "codex"})
 	m = inRightPane(m)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -182,6 +182,7 @@ type RenderParams struct {
 	PlanSelected             int
 	PlanScroll               int
 	ExpandedPlanID           string
+	SelectedPlanPhaseID      string
 	OverlayText              string
 	TransientError           string
 	TransientErrorFadeStep   int
@@ -240,6 +241,8 @@ func Render(p RenderParams) string {
 	reflogSelected := p.Mode == ModeReflog && p.ReflogSelected >= 0 && p.ReflogSelected < len(p.Reflogs)
 	sessionSelected := p.Mode == ModeSessions && p.SessionSelected >= 0 && p.SessionSelected < len(p.Sessions)
 	planSelected := p.Mode == ModePlans && p.PlanSelected >= 0 && p.PlanSelected < len(p.Plans)
+	selectedPlanPhaseID := scopedSelectedPlanPhaseID(p, planSelected)
+	planPhaseSelected := selectedPlanPhaseID != ""
 	status := statusBarParams{
 		Width:                     p.Width,
 		Mode:                      p.Mode,
@@ -262,6 +265,7 @@ func Render(p RenderParams) string {
 		ReflogSelected:            reflogSelected,
 		SessionSelected:           sessionSelected,
 		PlanSelected:              planSelected,
+		PlanPhaseSelected:         planPhaseSelected,
 		TransientError:            p.TransientError,
 		TransientErrorFadeStep:    p.TransientErrorFadeStep,
 		SearchActive:              p.SearchActive,
@@ -330,6 +334,7 @@ func Render(p RenderParams) string {
 		reflogSel = -1
 		sessionSel = -1
 		planSel = -1
+		selectedPlanPhaseID = ""
 	}
 
 	var rightLines []string
@@ -347,7 +352,7 @@ func Render(p RenderParams) string {
 	case p.Mode == ModeSessions && len(p.Sessions) > 0:
 		rightLines = renderSessionPane(p.Sessions, sessionSel, p.SessionScroll, rightContentWidth, rightContentHeight)
 	case p.Mode == ModePlans && len(p.Plans) > 0:
-		rightLines = renderPlanPane(p.Plans, planSel, p.PlanScroll, rightContentWidth, rightContentHeight, p.ExpandedPlanID)
+		rightLines = renderPlanPane(p.Plans, planSel, p.PlanScroll, rightContentWidth, rightContentHeight, p.ExpandedPlanID, selectedPlanPhaseID)
 	default:
 		rightLines = renderPlaceholderPane(rightContentWidth, rightContentHeight, p.RightEmptyMessage)
 	}
@@ -375,6 +380,22 @@ func Render(p RenderParams) string {
 	content := lipgloss.JoinHorizontal(lipgloss.Top, panes...)
 
 	return content + "\n" + statusBar
+}
+
+func scopedSelectedPlanPhaseID(p RenderParams, planSelected bool) string {
+	if !planSelected || p.SelectedPlanPhaseID == "" {
+		return ""
+	}
+	plan := p.Plans[p.PlanSelected]
+	if p.ExpandedPlanID != plan.PlanID {
+		return ""
+	}
+	for _, phase := range plan.Phases {
+		if phase.PhaseID == p.SelectedPlanPhaseID {
+			return p.SelectedPlanPhaseID
+		}
+	}
+	return ""
 }
 
 // renderModeHeader produces the mode selector line shown at the top of the right pane.
@@ -461,6 +482,7 @@ type statusBarParams struct {
 	ReflogSelected            bool
 	SessionSelected           bool
 	PlanSelected              bool
+	PlanPhaseSelected         bool
 	TransientError            string
 	TransientErrorFadeStep    int
 	SearchActive              bool
@@ -757,10 +779,14 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 		}
 	case ModePlans:
 		if sp.ActivePane == 1 && sp.PlanSelected {
+			implementLabel := "implement"
+			if sp.PlanPhaseSelected {
+				implementLabel = "implement phase"
+			}
 			actions = append(actions,
 				shortcutHint{Key: "enter", Label: "phases"},
 				shortcutHint{Key: "o", Label: "open"},
-				shortcutHint{Key: "i", Label: "implement"},
+				shortcutHint{Key: "i", Label: implementLabel},
 				shortcutHint{Key: "y", Label: "copy path"},
 			)
 		}
@@ -1339,7 +1365,7 @@ const (
 	planUpdatedWidth = 10
 )
 
-func renderPlanPane(records []planstore.PlanRecord, selected, scroll, width, height int, expandedPlanID string) []string {
+func renderPlanPane(records []planstore.PlanRecord, selected, scroll, width, height int, expandedPlanID, selectedPhaseID string) []string {
 	if height <= 0 {
 		return nil
 	}
@@ -1360,7 +1386,7 @@ func renderPlanPane(records []planstore.PlanRecord, selected, scroll, width, hei
 			stashDateStyle.Render(fitSessionColumn(updated, planUpdatedWidth)),
 			stashMsgStyle.Render(record.Title),
 		)
-		if i == selected {
+		if i == selected && selectedPhaseID == "" {
 			selectedLine := truncateToWidth(formatPlanColumns(" > ",
 				record.Status,
 				record.Branch,
@@ -1372,13 +1398,13 @@ func renderPlanPane(records []planstore.PlanRecord, selected, scroll, width, hei
 		}
 		rows = append(rows, truncateToWidth(line, width))
 		if record.PlanID == expandedPlanID {
-			rows = append(rows, renderPlanPhaseRows(record, width)...)
+			rows = append(rows, renderPlanPhaseRows(record, width, selectedPhaseID)...)
 		}
 	}
 	return append([]string{header}, scrollAndPad(rows, scroll, rowHeight)...)
 }
 
-func renderPlanPhaseRows(record planstore.PlanRecord, width int) []string {
+func renderPlanPhaseRows(record planstore.PlanRecord, width int, selectedPhaseID string) []string {
 	if len(record.Phases) == 0 {
 		return []string{truncateToWidth("      No phases", width)}
 	}
@@ -1391,6 +1417,16 @@ func renderPlanPhaseRows(record planstore.PlanRecord, width int) []string {
 			"",
 			stashMsgStyle.Render(phase.Title),
 		)
+		if phase.PhaseID == selectedPhaseID {
+			selectedLine := truncateToWidth(formatPlanColumns(" > ",
+				phase.Status,
+				"",
+				"",
+				"",
+				phase.Title,
+			), width)
+			line = stashSelStyle.Width(width).Render(selectedLine)
+		}
 		rows = append(rows, truncateToWidth(line, width))
 	}
 	return rows

--- a/ui/ui_plan_test.go
+++ b/ui/ui_plan_test.go
@@ -95,6 +95,64 @@ func TestRender_PlansModeShowsPlanShortcut(t *testing.T) {
 	}
 }
 
+func TestRender_PlansModeShowsPhaseShortcutWhenPhaseSelected(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    120,
+		Height:   14,
+		Mode:     ModePlans,
+		Plans: []planstore.PlanRecord{{
+			PlanID: "plan-1",
+			Title:  "Persist plans",
+			Status: "draft",
+			Phases: []planstore.PlanPhase{
+				{PhaseID: "p1", Title: "Store", Status: "completed", Order: 1},
+			},
+		}},
+		ActivePane:          1,
+		PlanSelected:        0,
+		ExpandedPlanID:      "plan-1",
+		SelectedPlanPhaseID: "p1",
+	})
+	pane := shortcutPaneText(view)
+	if !strings.Contains(pane, "i      implement phase") {
+		t.Fatalf("selected phase shortcut should expose phase implementation:\n%s", view)
+	}
+	if strings.Contains(pane, "i      implement\n") {
+		t.Fatalf("selected phase shortcut should not expose whole-plan implementation:\n%s", view)
+	}
+}
+
+func TestRender_PlansModeIgnoresStaleSelectedPhaseForShortcut(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    120,
+		Height:   14,
+		Mode:     ModePlans,
+		Plans: []planstore.PlanRecord{{
+			PlanID: "plan-1",
+			Title:  "Persist plans",
+			Status: "draft",
+			Phases: []planstore.PlanPhase{
+				{PhaseID: "p1", Title: "Store", Status: "completed", Order: 1},
+			},
+		}},
+		ActivePane:          1,
+		PlanSelected:        0,
+		ExpandedPlanID:      "plan-1",
+		SelectedPlanPhaseID: "missing",
+	})
+	pane := shortcutPaneText(view)
+	if strings.Contains(pane, "i      implement phase") {
+		t.Fatalf("stale phase selection should not expose phase implementation:\n%s", view)
+	}
+	if !strings.Contains(pane, "i      implement") {
+		t.Fatalf("stale phase selection should fall back to whole-plan implementation:\n%s", view)
+	}
+}
+
 func TestRender_PlansModeOmitsPlanShortcutsWhenNoPlanSelected(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:      []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
@@ -151,6 +209,65 @@ func TestRender_PlansModeShowsExpandedPhasesForSelectedPlanOnly(t *testing.T) {
 	}
 	if strings.Contains(view, "Other phase") || strings.Contains(view, "blocked") {
 		t.Fatalf("only the selected expanded plan should show phase rows:\n%s", view)
+	}
+}
+
+func TestRender_PlansModeHighlightsSelectedPhaseRow(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModePlans,
+		Plans: []planstore.PlanRecord{{
+			PlanID: "plan-1",
+			Title:  "Persist plans",
+			Status: "in_progress",
+			Phases: []planstore.PlanPhase{
+				{PhaseID: "p1", Title: "Store", Status: "completed", Order: 1},
+				{PhaseID: "p2", Title: "CLI", Status: "pending", Order: 2},
+			},
+		}},
+		ActivePane:          1,
+		PlanSelected:        0,
+		ExpandedPlanID:      "plan-1",
+		SelectedPlanPhaseID: "p2",
+	})
+
+	if !strings.Contains(view, "> pending") || !strings.Contains(view, "CLI") {
+		t.Fatalf("selected phase row should be highlighted:\n%s", view)
+	}
+	if strings.Contains(view, "> in_progress") {
+		t.Fatalf("plan row should not be highlighted while a phase is selected:\n%s", view)
+	}
+}
+
+func TestRender_PlansModeIgnoresStaleSelectedPhaseForHighlight(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModePlans,
+		Plans: []planstore.PlanRecord{{
+			PlanID: "plan-1",
+			Title:  "Persist plans",
+			Status: "in_progress",
+			Phases: []planstore.PlanPhase{
+				{PhaseID: "p1", Title: "Store", Status: "completed", Order: 1},
+			},
+		}},
+		ActivePane:          1,
+		PlanSelected:        0,
+		ExpandedPlanID:      "plan-1",
+		SelectedPlanPhaseID: "missing",
+	})
+
+	if strings.Contains(view, "> completed") {
+		t.Fatalf("stale phase selection should not highlight phase rows:\n%s", view)
+	}
+	if !strings.Contains(view, "> in_progress") {
+		t.Fatalf("stale phase selection should leave plan row highlighted:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add selectable phase rows inside expanded saved plans in the plans pane.
- Launch agents with phase-specific plan context when `i` is pressed on a selected phase, while preserving whole-plan launch behavior from the plan row.
- Highlight selected phase rows and switch the shortcut label to `i implement phase` only when the selected phase is valid for the expanded plan.

## Implementation Notes
- Tracks a plan-scoped selected phase ID in the Bubble Tea model and clears it on focus/reset boundaries.
- Keeps expanded-plan navigation coherent across phase rows and adjacent plans.
- Extends `actions.AgentLaunchContext` and exported launch environment with `WTUI_PLAN_PHASE_ID`, `WTUI_PLAN_PHASE_TITLE`, and `WTUI_PLAN_PHASE_STATUS`.
- Adds model, actions, and UI coverage for phase launch context, env replacement, nested navigation, stale renderer state, and shortcut/highlight behavior.

## Verification
- `gofmt -l .`
- `make test`
- `make build`