### PR TITLE
Add editable plan launch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ filter matches, or a load failure with details in the status bar.
 | `↑`/`k` | Select previous repo |
 | `↓`/`j` | Select next repo |
 | `/` | Fuzzy filter repos |
-| `A` | Choose and persist the coding agent (`codex` or `claude`) |
+| `A` | Choose and persist the coding agent (`codex`, `codex-app`, or `claude`) |
 | `D` | Toggle destructive mode |
 | `f` | Fetch all currently visible repos with `--prune` |
 | `tab` | Switch focus to right pane |
@@ -190,7 +190,9 @@ Browse saved agent plans for the selected repo. Rows show status, branch, phase
 progress (`completed/total`), the updated date, and the title. Use `/` to filter
 plans by title, summary, status, branch, worktree basename, provider, session
 ID, launch ID, and phase titles/statuses. Press `enter` to open the plan
-Markdown in a plain-text overlay.
+Markdown in a plain-text overlay. Press `i` to edit the launch instructions for
+the selected plan, then `enter` to launch the selected agent or `esc` to cancel;
+blank instructions are rejected.
 
 Plans are persisted explicitly by agents through the `wtui plan` CLI rather than
 captured from hooks. Plans share the agent-artifact root with sessions: they are
@@ -218,15 +220,17 @@ wtui plan read --plan-id "$PLAN_ID"          # prints Markdown only
 
 The plan state root is resolved with this precedence: `--state-root` >
 `WTUI_PLAN_STATE_ROOT` > `WTUI_SESSION_STATE_ROOT` > `[sessions].root` > the user
-state default. Agents launched by wtui get `WTUI_PLAN_STATE_ROOT` and
+state default. CLI-launched agents get `WTUI_PLAN_STATE_ROOT` and
 `WTUI_SESSION_STATE_ROOT` set to the same resolved root. Omitted metadata is
 filled from `WTUI_AGENT`, `WTUI_LAUNCH_ID`, `WTUI_REPO_PATH`,
-`WTUI_WORKTREE_PATH`, `WTUI_BRANCH`, and `WTUI_COMMIT`. The `wtui-plan-persist`
-skill instructs agents on when and how to save plans. Its canonical source
-lives in `agent-skills/wtui-plan-persist/`, which is intentionally outside
-Codex and Claude's repo auto-discovery directories so it can be symlinked into
-user-level skill dirs for use across repos. v1 has no TUI plan editing or
-deletion.
+`WTUI_WORKTREE_PATH`, `WTUI_BRANCH`, and `WTUI_COMMIT`. `codex-app` launches use
+macOS `open`, so they do not inherit `WTUI_*`; wtui includes equivalent metadata
+in the launch prompt, and agents should pass the listed `--state-root` when
+running `wtui plan` commands. The `wtui-plan-persist` skill instructs agents on
+when and how to save plans. Its canonical source lives in
+`agent-skills/wtui-plan-persist/`, which is intentionally outside Codex and
+Claude's repo auto-discovery directories so it can be symlinked into user-level
+skill dirs for use across repos. v1 has no TUI plan editing or deletion.
 
 ## Configuration
 
@@ -246,6 +250,7 @@ max_depth = 2
 
 [agent]
 command = "codex"
+plan_prompt = "Implement the saved wtui plan {title} (ID: {plan_id}) at {plan_path}. Read the plan file, then begin implementation."
 
 [sessions]
 root = "~/.local/state/wtui/sessions/v1"
@@ -259,10 +264,11 @@ repo_path = "~/projects/wtui"
 script = ".wtui/bootstrap"
 ```
 
-`WORKTREE_ROOT` overrides `[scan].root` when both are set. See
-[docs/config.md](docs/config.md) for the full config reference, including
-sessions storage, bootstrap hook settings, and parsed foundation fields for
-editor, terminal, provider, launch, and agent settings.
+`WORKTREE_ROOT` overrides `[scan].root` when both are set. `[agent].plan_prompt`
+customizes the editable instructions shown before launching an agent from the
+plans pane. See [docs/config.md](docs/config.md) for the full config reference,
+including sessions storage, bootstrap hook settings, and parsed foundation
+fields for editor, terminal, provider, launch, and agent settings.
 
 | Env var | Default | Description |
 |---------|---------|-------------|
@@ -273,10 +279,12 @@ editor, terminal, provider, launch, and agent settings.
 
 ### Agent session hooks
 
-Agents launched from wtui with `a`, `N`, or session resume `r` are wired
+CLI agents launched from wtui with `a`, `N`, or session resume `r` are wired
 automatically: wtui passes Claude Code or Codex a session-end hook that calls
 the current wtui binary, and it includes `WTUI_*` metadata so hook records can
-be associated with the repo, worktree, branch, and launch.
+be associated with the repo, worktree, branch, and launch. `codex-app` opens via
+macOS deep link instead; wtui scrubs inherited `WTUI_*` from `open` and includes
+launch metadata in the prompt when a prompt is provided.
 
 For manual agent sessions that are not launched by wtui, configure Claude Code
 or Codex hooks to call wtui:

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -570,6 +570,7 @@ func codexAppLaunchPrompt(ctx AgentLaunchContext) string {
 func codexAppLaunchMetadata(ctx AgentLaunchContext) string {
 	if ctx.LaunchID == "" &&
 		ctx.RepoPath == "" &&
+		ctx.WorktreePath == "" &&
 		ctx.Branch == "" &&
 		ctx.Commit == "" &&
 		ctx.SessionStateRoot == "" &&

--- a/actions/agent_launch_internal_test.go
+++ b/actions/agent_launch_internal_test.go
@@ -48,8 +48,28 @@ func TestCodexAppLaunchOpensNewThreadDeepLink(t *testing.T) {
 		t.Fatalf("expected open command to have no working dir, got %q", launch.Cmd.Dir)
 	}
 	assertNoWTUIEnv(t, launch.Cmd.Environ())
-	if !reflect.DeepEqual(launch.Cmd.Args, []string{"open", "codex://threads/new?path=%2Frepo%2Fwork%20tree%2Bplus&prompt=Read%20the%20plan%20%26%20begin%20%2B%20ship."}) {
+	if !reflect.DeepEqual(launch.Cmd.Args[:1], []string{"open"}) {
 		t.Fatalf("unexpected codex-app args: %#v", launch.Cmd.Args)
+	}
+	gotURL, err := url.Parse(launch.Cmd.Args[1])
+	if err != nil {
+		t.Fatalf("parse launch URL: %v", err)
+	}
+	if got := gotURL.Query().Get("path"); got != "/repo/work tree+plus" {
+		t.Fatalf("path query = %q, want worktree path", got)
+	}
+	prompt := gotURL.Query().Get("prompt")
+	for _, want := range []string{
+		"Read the plan & begin + ship.",
+		"WTUI_AGENT=" + shellQuote("codex-app"),
+		"WTUI_WORKTREE_PATH=" + shellQuote("/repo/work tree+plus"),
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "inherited-launch") {
+		t.Fatalf("prompt leaked inherited WTUI_LAUNCH_ID:\n%s", prompt)
 	}
 }
 

--- a/agent-skills/wtui-plan-persist/SKILL.md
+++ b/agent-skills/wtui-plan-persist/SKILL.md
@@ -46,10 +46,13 @@ only when you supply them, and otherwise preserves the stored values plus
 `created_at` and recorded phases. So a body-only revise keeps the existing
 status; pass `--status` whenever the lifecycle changes.
 
-When wtui launched the agent it exports `WTUI_AGENT`, `WTUI_LAUNCH_ID`,
+When wtui launched a CLI agent it exports `WTUI_AGENT`, `WTUI_LAUNCH_ID`,
 `WTUI_REPO_PATH`, `WTUI_WORKTREE_PATH`, `WTUI_BRANCH`, and `WTUI_COMMIT`; the CLI
 fills omitted metadata from those automatically, so you usually only need
-`--title` (and `--plan-id` for edits).
+`--title` (and `--plan-id` for edits). `codex-app` launches are different because
+wtui opens a macOS deep link and `WTUI_*` is not inherited. In that case, use the
+metadata block in the launch prompt: pass the listed `--state-root` to `wtui plan`
+commands or export the listed vars before running them.
 
 ## How to record phases
 

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -171,12 +171,13 @@ func startProgram(repos []scanner.Repo, cfg config.Config) error {
 		return err
 	}
 	p := tea.NewProgram(model.NewWithOptions(repos, model.Options{
-		AgentCommand:     cfg.Agent.Command,
-		SessionStateRoot: sessionStore.Root(),
-		ListSessions:     sessionStore.List,
-		ReadTranscript:   sessionStore.ReadTranscript,
-		ListPlans:        planStore.List,
-		ReadPlan:         planStore.ReadPlan,
+		AgentCommand:       cfg.Agent.Command,
+		PlanPromptTemplate: cfg.Agent.PlanPrompt,
+		SessionStateRoot:   sessionStore.Root(),
+		ListSessions:       sessionStore.List,
+		ReadTranscript:     sessionStore.ReadTranscript,
+		ListPlans:          planStore.List,
+		ReadPlan:           planStore.ReadPlan,
 		FinalizeAgentSession: func(ctx actions.AgentLaunchContext) error {
 			return sessionStore.MarkLaunchEnded(ctx.LaunchID, time.Now().UTC())
 		},

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -127,7 +127,10 @@ func TestRun_PassesConfigToProgram(t *testing.T) {
 	var got config.Config
 	err := run([]string{"wtui"}, runDeps{
 		loadConfig: func() (config.Config, error) {
-			return config.Config{Agent: config.AgentConfig{Command: "codex"}}, nil
+			return config.Config{Agent: config.AgentConfig{
+				Command:    "codex",
+				PlanPrompt: "Implement {title}",
+			}}, nil
 		},
 		getenv: func(string) string { return "" },
 		scan: func(scanner.ScanOptions) ([]scanner.Repo, error) {
@@ -143,6 +146,9 @@ func TestRun_PassesConfigToProgram(t *testing.T) {
 	}
 	if got.Agent.Command != "codex" {
 		t.Fatalf("expected agent config passed to program, got %q", got.Agent.Command)
+	}
+	if got.Agent.PlanPrompt != "Implement {title}" {
+		t.Fatalf("expected agent plan prompt passed to program, got %q", got.Agent.PlanPrompt)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -54,7 +54,8 @@ type LaunchConfig struct {
 
 // AgentConfig stores the user's preferred interactive coding agent.
 type AgentConfig struct {
-	Command string `toml:"command"`
+	Command    string `toml:"command"`
+	PlanPrompt string `toml:"plan_prompt"`
 }
 
 // SessionsConfig controls agent-session capture storage.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,6 +42,7 @@ prefer_multiplexer = true
 
 [agent]
 command = "codex"
+plan_prompt = "Implement {title} from {plan_path}"
 
 [sessions]
 root = "~/state/wtui/sessions"
@@ -90,6 +91,9 @@ timeout_seconds = 300
 	}
 	if cfg.Agent.Command != "codex" {
 		t.Fatalf("expected agent command codex, got %q", cfg.Agent.Command)
+	}
+	if cfg.Agent.PlanPrompt != "Implement {title} from {plan_path}" {
+		t.Fatalf("expected agent plan prompt to parse, got %q", cfg.Agent.PlanPrompt)
 	}
 	if cfg.Sessions.Root != filepath.Join(home, "state", "wtui", "sessions") {
 		t.Fatalf("expected expanded sessions root, got %q", cfg.Sessions.Root)

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,7 @@ exist:
 | Scan root | `WORKTREE_ROOT` | `[scan].root` | `~/dev` |
 | Terminal command | `TERMINAL` | none; `[terminal].command` is parsed but unused | platform fallback |
 | Coding agent | none | `[agent].command` | unset |
+| Plan launch prompt | none | `[agent].plan_prompt` | built-in plan implementation prompt |
 | Sessions root | `WTUI_SESSION_STATE_ROOT` for hooks | `[sessions].root` | `$XDG_STATE_HOME/wtui/sessions/v1` or `~/.local/state/wtui/sessions/v1` |
 | Plan state root | `--state-root` > `WTUI_PLAN_STATE_ROOT` > `WTUI_SESSION_STATE_ROOT` | `[sessions].root` | same as sessions root (`<root>/plans/...`) |
 | Bootstrap hook timeout | none | `[bootstrap].timeout_seconds` or hook override | `120` seconds |
@@ -54,6 +55,7 @@ prefer_multiplexer = true
 
 [agent]
 command = "codex"
+plan_prompt = "Implement the saved wtui plan {title} (ID: {plan_id}) at {plan_path}. Read the plan file, then begin implementation."
 
 [sessions]
 root = "~/.local/state/wtui/sessions/v1"
@@ -127,7 +129,8 @@ updates this value immediately, creating the config file if needed.
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `command` | string | Supported values: `codex` or `claude`. |
+| `command` | string | Supported values: `codex`, `codex-app`, or `claude`. |
+| `plan_prompt` | string | Optional one-line template for the editable instructions opened by `i` in the plans pane. Supports `{title}`, `{plan_id}`, `{plan_path}`, `{repo_path}`, and `{worktree_path}`. Unknown placeholders remain literal. Blank or omitted uses the built-in prompt. |
 
 ### `[sessions]`
 
@@ -187,10 +190,13 @@ The plan state root is resolved as: `--state-root` > `WTUI_PLAN_STATE_ROOT` >
 `wtui plan` commands may load config to resolve the root but never scan repos or
 start the TUI. Omitted metadata is filled from `WTUI_AGENT` (provider),
 `WTUI_LAUNCH_ID`, `WTUI_REPO_PATH`, `WTUI_WORKTREE_PATH`, `WTUI_BRANCH`, and
-`WTUI_COMMIT`. wtui does not infer git metadata in v1. The
-`wtui-plan-persist` skill instructs agents on when and how to save plans; its
-canonical source lives in `agent-skills/wtui-plan-persist/` for symlinking into
-user-level Codex/Claude skill directories.
+`WTUI_COMMIT`. `codex-app` launches do not inherit `WTUI_*` because wtui opens a
+macOS deep link; use the metadata block in the launch prompt to pass
+`--state-root` or export the listed vars before running `wtui plan`. wtui does
+not infer git metadata in v1. The `wtui-plan-persist` skill instructs agents on
+when and how to save plans; its canonical source lives in
+`agent-skills/wtui-plan-persist/` for symlinking into user-level Codex/Claude
+skill directories.
 
 ### `[bootstrap]`
 
@@ -290,10 +296,13 @@ Codex hook example:
 }
 ```
 
-When wtui launches or resumes an agent session, it appends these environment
+When wtui launches or resumes a CLI agent session, it appends these environment
 variables:
 `WTUI_AGENT`, `WTUI_LAUNCH_ID`, `WTUI_REPO_PATH`, `WTUI_WORKTREE_PATH`,
 `WTUI_BRANCH`, `WTUI_COMMIT`, and `WTUI_SESSION_STATE_ROOT`.
+`codex-app` launches are the exception: wtui opens a macOS deep link, scrubs
+inherited `WTUI_*` from `open`, and includes launch metadata in the prompt when a
+prompt is provided.
 
 Session resume uses the stored provider session ID. Codex resumes with
 `codex ... resume <session-id>` and Claude Code resumes with

--- a/model/model.go
+++ b/model/model.go
@@ -52,6 +52,7 @@ type Model struct {
 	pendingBranchSelection    string
 	pendingWorktreeSelection  string
 	agentCommand              string
+	planPromptTemplate        string
 	fetchRepo                 func(string) error
 	listSessions              func(sessions.SessionFilter) ([]sessions.SessionRecord, error)
 	readTranscript            func(sessions.Provider, string) ([]sessions.TranscriptEvent, error)
@@ -98,6 +99,7 @@ type visibleRepoFetchState struct {
 // simple for tests.
 type Options struct {
 	AgentCommand         string
+	PlanPromptTemplate   string
 	FetchRepo            func(string) error
 	ListSessions         func(sessions.SessionFilter) ([]sessions.SessionRecord, error)
 	ReadTranscript       func(sessions.Provider, string) ([]sessions.TranscriptEvent, error)
@@ -182,6 +184,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		plans:                newPlanPane(),
 		mode:                 ui.ModeWorktrees,
 		agentCommand:         agent.Normalize(opts.AgentCommand),
+		planPromptTemplate:   opts.PlanPromptTemplate,
 		fetchRepo:            fetchRepo,
 		listSessions:         listSessions,
 		readTranscript:       readTranscript,
@@ -595,6 +598,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleAgentSet(msg), nil
 	case AgentSetFailedMsg:
 		return m.handleAgentSetFailed(msg), nil
+	case PlanLaunchRequestedMsg:
+		return m.launchAgentWithContext(msg.LaunchContext)
 	case AgentResultMsg:
 		resultErr := msg.Err
 		if msg.LaunchContext.LaunchID != "" {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -708,22 +709,41 @@ func (m Model) handleResumeSession() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleImplementPlan() (tea.Model, tea.Cmd) {
+	ctx, ok, next := m.planLaunchContext()
+	if !ok {
+		return next, nil
+	}
+	m = next
+	m.modal = modal.OpenInput(
+		ui.LaunchInstructionsPrompt,
+		"launch instructions",
+		ctx.InitialPrompt,
+		validatePlanLaunchInput,
+		func(input string) tea.Cmd {
+			ctx.InitialPrompt = input
+			return func() tea.Msg { return PlanLaunchRequestedMsg{LaunchContext: ctx} }
+		},
+	)
+	return m, nil
+}
+
+func (m Model) planLaunchContext() (actions.AgentLaunchContext, bool, Model) {
 	repoPath, repoOK := m.currentRepoPath()
 	plan, ok := m.selectedPlan()
 	if !ok {
 		if !repoOK {
 			m = m.setStatus(statusOther, "Cannot determine launch path for this plan")
 		}
-		return m, nil
+		return actions.AgentLaunchContext{}, false, m
 	}
 	if m.agentCommand == "" {
 		m = m.setStatus(statusOther, "Press A to choose "+ui.AgentInputPlaceholder+" before launching an agent")
-		return m, nil
+		return actions.AgentLaunchContext{}, false, m
 	}
 	planPath, err := m.planMarkdownPath(plan.PlanID)
 	if err != nil {
 		m = m.setStatus(statusOther, err.Error())
-		return m, nil
+		return actions.AgentLaunchContext{}, false, m
 	}
 	if plan.RepoPath != "" {
 		repoPath = plan.RepoPath
@@ -737,17 +757,19 @@ func (m Model) handleImplementPlan() (tea.Model, tea.Cmd) {
 	}
 	if launchPath == "" {
 		m = m.setStatus(statusOther, "Cannot determine launch path for this plan")
-		return m, nil
+		return actions.AgentLaunchContext{}, false, m
 	}
 	ctx := actions.AgentLaunchContext{
 		Command:          m.agentCommand,
 		LaunchID:         newLaunchID(),
 		RepoPath:         repoPath,
 		WorktreePath:     launchPath,
+		Branch:           plan.Branch,
+		Commit:           plan.Commit,
 		SessionStateRoot: m.sessionStateRoot,
 		PlanID:           plan.PlanID,
 		PlanPath:         planPath,
-		InitialPrompt:    implementationPrompt(plan, planPath),
+		InitialPrompt:    m.implementationPrompt(plan, planPath, repoPath, launchPath),
 	}
 	if phase, ok := m.selectedPlanPhase(); ok {
 		ctx.PlanPhaseID = phase.PhaseID
@@ -755,10 +777,36 @@ func (m Model) handleImplementPlan() (tea.Model, tea.Cmd) {
 		ctx.PlanPhaseStatus = phase.Status
 		ctx.InitialPrompt = implementationPromptForPhase(plan, planPath, phase)
 	}
-	return m.launchAgentWithContext(ctx)
+	return ctx, true, m
 }
 
-func implementationPrompt(plan planstore.PlanRecord, planPath string) string {
+func validatePlanLaunchInput(input string) error {
+	if input == "" {
+		return fmt.Errorf("enter launch instructions")
+	}
+	return nil
+}
+
+func (m Model) implementationPrompt(plan planstore.PlanRecord, planPath, repoPath, worktreePath string) string {
+	template := m.planPromptTemplate
+	if strings.TrimSpace(template) == "" {
+		return defaultImplementationPrompt(plan, planPath)
+	}
+	title := plan.Title
+	if title == "" {
+		title = "(untitled)"
+	}
+	replacer := strings.NewReplacer(
+		"{title}", title,
+		"{plan_id}", plan.PlanID,
+		"{plan_path}", planPath,
+		"{repo_path}", repoPath,
+		"{worktree_path}", worktreePath,
+	)
+	return replacer.Replace(template)
+}
+
+func defaultImplementationPrompt(plan planstore.PlanRecord, planPath string) string {
 	title := plan.Title
 	if title == "" {
 		title = "(untitled)"

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -259,6 +259,10 @@ type AgentResultMsg struct {
 	Err           string
 }
 
+type PlanLaunchRequestedMsg struct {
+	LaunchContext actions.AgentLaunchContext
+}
+
 type DeleteFailedMsg struct {
 	RepoPath    string
 	Target      string       // display name (branch name or worktree path)

--- a/model/model_plan_test.go
+++ b/model/model_plan_test.go
@@ -124,7 +124,104 @@ func TestModel_PlanListErrorShowsStatus(t *testing.T) {
 	}
 }
 
-func TestModel_IKeyLaunchesAgentFromSelectedPlan(t *testing.T) {
+func TestModel_IKeyOpensPlanLaunchInstructionsInput(t *testing.T) {
+	var launched bool
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:     "codex",
+		SessionStateRoot: "/state/wtui/sessions/v1",
+		PlanMarkdownPath: func(planID string) (string, error) {
+			if planID != "plan-1" {
+				t.Fatalf("resolver planID = %q, want plan-1", planID)
+			}
+			return "/state/wtui/sessions/v1/plans/plan-1/plan.md", nil
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launched = true
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true"), Interactive: true}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
+	m, _ = update(m, model.PlanResultMsg{RepoPath: "/dev/alpha", Plans: []planstore.PlanRecord{{
+		PlanID:       "plan-1",
+		Title:        "Implement plans",
+		Status:       "approved",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/plans",
+		Branch:       "feature/plans",
+		Commit:       "abc123",
+	}}, ListRequest: m.ListRequest(ui.ModePlans)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd opening launch instructions, got %T", cmd)
+	}
+	if launched {
+		t.Fatal("opening launch instructions must not launch the agent")
+	}
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("expected launch instructions input overlay, got %d", m.Overlay())
+	}
+	if !strings.Contains(m.View(), "Launch instructions") {
+		t.Fatalf("expected launch instructions prompt in view:\n%s", m.View())
+	}
+	prompt := strings.ToLower(m.WorktreeInput())
+	for _, want := range []string{"implement plans", "plan-1", "/state/wtui/sessions/v1/plans/plan-1/plan.md", "read the plan file", "begin implementation"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("initial prompt missing %q: %q", want, m.WorktreeInput())
+		}
+	}
+}
+
+func TestModel_PlanPromptTemplateReplacesSupportedPlaceholders(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:       "codex",
+		PlanPromptTemplate: "Do {title} ({plan_id}) from {plan_path} in {repo_path} at {worktree_path}; keep {unknown}",
+		PlanMarkdownPath:   func(string) (string, error) { return "/state/plans/plan-1/plan.md", nil },
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
+	m, _ = update(m, model.PlanResultMsg{RepoPath: "/dev/alpha", Plans: []planstore.PlanRecord{{
+		PlanID:       "plan-1",
+		Title:        "Implement plans",
+		Status:       "approved",
+		RepoPath:     "/dev/plan-repo",
+		WorktreePath: "/dev/plan-worktree",
+	}}, ListRequest: m.ListRequest(ui.ModePlans)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd opening launch instructions, got %T", cmd)
+	}
+	want := "Do Implement plans (plan-1) from /state/plans/plan-1/plan.md in /dev/plan-repo at /dev/plan-worktree; keep {unknown}"
+	if m.WorktreeInput() != want {
+		t.Fatalf("launch instructions = %q, want %q", m.WorktreeInput(), want)
+	}
+}
+
+func TestModel_PlanPromptTemplateBlankFallsBackToDefault(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:       "codex",
+		PlanPromptTemplate: "   ",
+		PlanMarkdownPath:   func(string) (string, error) { return "/state/plans/plan-1/plan.md", nil },
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
+	m, _ = update(m, model.PlanResultMsg{RepoPath: "/dev/alpha", Plans: []planstore.PlanRecord{
+		{PlanID: "plan-1", Title: "Implement plans", Status: "approved", RepoPath: "/dev/alpha"},
+	}, ListRequest: m.ListRequest(ui.ModePlans)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd opening launch instructions, got %T", cmd)
+	}
+	want := `Implement the saved wtui plan "Implement plans" (ID: plan-1) at /state/plans/plan-1/plan.md. Read the plan file, then begin implementation.`
+	if m.WorktreeInput() != want {
+		t.Fatalf("default launch instructions = %q, want %q", m.WorktreeInput(), want)
+	}
+}
+
+func TestModel_PlanLaunchInstructionsSubmitLaunchesAgent(t *testing.T) {
 	var got actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand:     "codex",
@@ -148,28 +245,94 @@ func TestModel_IKeyLaunchesAgentFromSelectedPlan(t *testing.T) {
 		Status:       "approved",
 		RepoPath:     "/dev/alpha",
 		WorktreePath: "/dev/alpha-worktrees/plans",
+		Branch:       "feature/plans",
+		Commit:       "abc123",
 	}}, ListRequest: m.ListRequest(ui.ModePlans)})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlU})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Custom launch instructions")})
 
-	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd == nil {
+		t.Fatal("expected submit command")
+	}
+	if got.Command != "" {
+		t.Fatalf("submit command should defer launch until handled, got %#v", got)
+	}
+	m, launchCmd := update(m, cmd())
+	if launchCmd == nil {
 		t.Fatal("expected agent launch command")
+	}
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected launch instructions overlay closed, got %d", m.Overlay())
 	}
 	if got.Command != "codex" ||
 		got.RepoPath != "/dev/alpha" ||
 		got.WorktreePath != "/dev/alpha-worktrees/plans" ||
+		got.Branch != "feature/plans" ||
+		got.Commit != "abc123" ||
 		got.SessionStateRoot != "/state/wtui/sessions/v1" ||
 		got.PlanID != "plan-1" ||
-		got.PlanPath != "/state/wtui/sessions/v1/plans/plan-1/plan.md" {
+		got.PlanPath != "/state/wtui/sessions/v1/plans/plan-1/plan.md" ||
+		got.InitialPrompt != "Custom launch instructions" {
 		t.Fatalf("unexpected launch context: %#v", got)
 	}
 	if got.LaunchID == "" {
 		t.Fatalf("expected launch ID in context: %#v", got)
 	}
-	prompt := strings.ToLower(got.InitialPrompt)
-	for _, want := range []string{"implement plans", "plan-1", "/state/wtui/sessions/v1/plans/plan-1/plan.md", "read the plan file", "begin implementation"} {
-		if !strings.Contains(prompt, want) {
-			t.Fatalf("initial prompt missing %q: %q", want, got.InitialPrompt)
-		}
+}
+
+func TestModel_PlanLaunchInstructionsEscCancels(t *testing.T) {
+	var launched bool
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:     "codex",
+		PlanMarkdownPath: func(string) (string, error) { return "/state/plans/plan-1/plan.md", nil },
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launched = true
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true"), Interactive: true}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
+	m, _ = update(m, model.PlanResultMsg{RepoPath: "/dev/alpha", Plans: []planstore.PlanRecord{
+		{PlanID: "plan-1", Title: "Implement plans", Status: "approved", RepoPath: "/dev/alpha"},
+	}, ListRequest: m.ListRequest(ui.ModePlans)})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd cancelling launch instructions, got %T", cmd)
+	}
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected overlay closed, got %d", m.Overlay())
+	}
+	if launched {
+		t.Fatal("cancelled launch instructions must not launch agent")
+	}
+}
+
+func TestModel_PlanLaunchInstructionsRejectsBlankSubmit(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:     "codex",
+		PlanMarkdownPath: func(string) (string, error) { return "/state/plans/plan-1/plan.md", nil },
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
+	m, _ = update(m, model.PlanResultMsg{RepoPath: "/dev/alpha", Plans: []planstore.PlanRecord{
+		{PlanID: "plan-1", Title: "Implement plans", Status: "approved", RepoPath: "/dev/alpha"},
+	}, ListRequest: m.ListRequest(ui.ModePlans)})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlU})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for blank launch instructions, got %T", cmd)
+	}
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("expected input overlay to remain, got %d", m.Overlay())
+	}
+	if m.WorktreeInputErr() != "enter launch instructions" {
+		t.Fatalf("expected launch instructions error, got %q", m.WorktreeInputErr())
 	}
 }
 
@@ -207,16 +370,34 @@ func TestModel_IKeyLaunchesAgentFromSelectedPlanPhase(t *testing.T) {
 	if gotPhase := m.SelectedPlanPhaseID(); gotPhase != "p2" {
 		t.Fatalf("selected phase = %q, want p2", gotPhase)
 	}
-	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd opening launch instructions, got %T", cmd)
+	}
+	if got.Command != "" {
+		t.Fatalf("opening launch instructions should defer launch, got %#v", got)
+	}
+	prompt := strings.ToLower(m.WorktreeInput())
+	for _, want := range []string{"implement only", "selected phase", "p2", "cli subcommands", "pending", "read the plan file"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("phase prompt missing %q: %q", want, m.WorktreeInput())
+		}
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd == nil {
+		t.Fatal("expected submit command")
+	}
+	_, launchCmd := update(m, cmd())
+	if launchCmd == nil {
 		t.Fatal("expected agent launch command")
 	}
 	if got.PlanPhaseID != "p2" || got.PlanPhaseTitle != "CLI subcommands" || got.PlanPhaseStatus != "pending" {
 		t.Fatalf("unexpected phase launch context: %#v", got)
 	}
-	prompt := strings.ToLower(got.InitialPrompt)
+	launchPrompt := strings.ToLower(got.InitialPrompt)
 	for _, want := range []string{"implement only", "selected phase", "p2", "cli subcommands", "pending", "read the plan file"} {
-		if !strings.Contains(prompt, want) {
+		if !strings.Contains(launchPrompt, want) {
 			t.Fatalf("phase prompt missing %q: %q", want, got.InitialPrompt)
 		}
 	}
@@ -285,8 +466,16 @@ func TestModel_IKeyLaunchPathFallsBackFromPlanRepoToSelectedRepo(t *testing.T) {
 			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
 			m, _ = update(m, model.PlanResultMsg{RepoPath: "/dev/alpha", Plans: []planstore.PlanRecord{tc.plan}, ListRequest: m.ListRequest(ui.ModePlans)})
 
-			_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+			if cmd != nil {
+				t.Fatalf("expected nil cmd opening launch instructions, got %T", cmd)
+			}
+			m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 			if cmd == nil {
+				t.Fatal("expected submit command")
+			}
+			_, launchCmd := update(m, cmd())
+			if launchCmd == nil {
 				t.Fatal("expected launch command")
 			}
 			if got.RepoPath != tc.wantRepo || got.WorktreePath != tc.wantPath {
@@ -352,7 +541,15 @@ func TestModel_IKeyLaunchErrorShowsStatus(t *testing.T) {
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
 	if cmd != nil {
-		t.Fatalf("expected nil cmd on launch error, got %T", cmd)
+		t.Fatalf("expected nil cmd opening launch instructions, got %T", cmd)
+	}
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected submit command")
+	}
+	m, launchCmd := update(m, cmd())
+	if launchCmd != nil {
+		t.Fatalf("expected nil cmd on launch error, got %T", launchCmd)
 	}
 	if !strings.Contains(m.View(), "agent unavailable") {
 		t.Fatal("expected launch error in status")

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -31,6 +31,7 @@ const (
 )
 
 const BranchPrompt = "New branch"
+const LaunchInstructionsPrompt = "Launch instructions"
 const WorktreeMovePrompt = "Move worktree to"
 const PRWorktreePrompt = "PR worktree"
 const WorktreeInputPlaceholder = "branch, tag, or new branch name"
@@ -63,6 +64,12 @@ const ShortcutPaneWidth = 28
 const (
 	shortcutKeyColumnWidth = 6
 	shortcutOverflowMarker = "..."
+)
+
+const (
+	launchInstructionsMaxWidth = 72
+	launchInstructionsMinWidth = 32
+	launchInstructionsMaxLines = 6
 )
 
 // MinContentPaneWidth keeps the primary item pane useful before the shortcut
@@ -247,6 +254,7 @@ func Render(p RenderParams) string {
 		Width:                     p.Width,
 		Mode:                      p.Mode,
 		Overlay:                   p.Overlay,
+		WorktreeInputPrompt:       p.WorktreeInputPrompt,
 		ActivePane:                p.ActivePane,
 		Destructive:               p.Destructive,
 		RepoSelected:              repoPath != "",
@@ -464,6 +472,7 @@ type statusBarParams struct {
 	Width                     int
 	Mode                      Mode
 	Overlay                   OverlayState
+	WorktreeInputPrompt       string
 	ActivePane                int
 	Destructive               bool
 	RepoSelected              bool
@@ -562,6 +571,9 @@ func renderStatusBarWithState(sp statusBarParams) string {
 	case overlay == OverlayConfirm:
 		return statusStyle.Width(width).Render("  y: confirm  n/esc: cancel")
 	case overlay == OverlayWorktreeInput:
+		if sp.WorktreeInputPrompt == LaunchInstructionsPrompt {
+			return statusStyle.Width(width).Render("  enter: launch  esc: cancel  backspace: delete")
+		}
 		return statusStyle.Width(width).Render("  enter: create/set  esc: cancel  backspace: delete")
 	case overlay != OverlayNone:
 		return statusStyle.Width(width).Render("  ↑/↓ scroll  esc: close")
@@ -1537,6 +1549,7 @@ func renderOverlay(p RenderParams) string {
 		Width:                  p.Width,
 		Mode:                   p.Mode,
 		Overlay:                p.Overlay,
+		WorktreeInputPrompt:    p.WorktreeInputPrompt,
 		ActivePane:             p.ActivePane,
 		Destructive:            p.Destructive,
 		TransientError:         p.TransientError,
@@ -1627,6 +1640,10 @@ func renderConfirmDialog(prompt string, force bool, width, height int) []string 
 }
 
 func renderWorktreeInputDialog(promptText, placeholder, input, errText string, width, height int) []string {
+	if promptText == LaunchInstructionsPrompt {
+		return renderLaunchInstructionsDialog(promptText, placeholder, input, errText, width, height)
+	}
+
 	lines := make([]string, height)
 	mid := height / 2
 	if mid >= len(lines) {
@@ -1654,6 +1671,159 @@ func renderWorktreeInputDialog(promptText, placeholder, input, errText string, w
 
 	if errText != "" && mid+1 < len(lines) {
 		lines[mid+1] = centeredLine(dirtyRedStyle.Render(errText), width)
+	}
+	return lines
+}
+
+func renderLaunchInstructionsDialog(promptText, placeholder, input, errText string, width, height int) []string {
+	lines := make([]string, height)
+	if width <= 0 || height <= 0 {
+		return lines
+	}
+	if placeholder == "" {
+		placeholder = "launch instructions"
+	}
+
+	panelWidth := width - 4
+	if panelWidth > launchInstructionsMaxWidth {
+		panelWidth = launchInstructionsMaxWidth
+	}
+	if panelWidth < launchInstructionsMinWidth {
+		panelWidth = width
+	}
+	if panelWidth < 4 {
+		panelWidth = width
+	}
+	contentWidth := panelWidth - 4 // border plus one-space left/right padding
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+
+	value := input
+	placeholderVisible := false
+	if value == "" {
+		value = placeholder
+		placeholderVisible = true
+	}
+	wrapWidth := contentWidth - lipgloss.Width("█")
+	if wrapWidth < 1 {
+		wrapWidth = 1
+	}
+	bodyLines := wrapPlainText(value, wrapWidth)
+	if len(bodyLines) > launchInstructionsMaxLines {
+		bodyLines = compactLaunchInstructionLines(bodyLines, launchInstructionsMaxLines)
+	}
+
+	content := []string{activeModeStyle.Render(promptText), ""}
+	for i, line := range bodyLines {
+		if placeholderVisible {
+			line = placeholderStyle.Render(line)
+		}
+		if i == len(bodyLines)-1 {
+			line += activeModeStyle.Render("█")
+		}
+		content = append(content, line)
+	}
+	if errText != "" {
+		content = append(content, "")
+		for _, line := range wrapPlainText(errText, contentWidth) {
+			content = append(content, dirtyRedStyle.Render(line))
+		}
+	}
+
+	for i, line := range content {
+		content[i] = " " + fitSessionColumn(line, contentWidth) + " "
+	}
+	panel := lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("12")).
+		Width(contentWidth + 2).
+		Render(strings.Join(content, "\n"))
+	panelLines := strings.Split(panel, "\n")
+	top := (height - len(panelLines)) / 2
+	if top < 0 {
+		top = 0
+	}
+	for i, line := range panelLines {
+		row := top + i
+		if row >= len(lines) {
+			break
+		}
+		lines[row] = centeredLine(line, width)
+	}
+	return lines
+}
+
+func compactLaunchInstructionLines(lines []string, maxLines int) []string {
+	if maxLines <= 0 || len(lines) <= maxLines {
+		return lines
+	}
+	if maxLines == 1 {
+		return []string{shortcutOverflowMarker}
+	}
+	if maxLines == 2 {
+		return []string{lines[0], shortcutOverflowMarker}
+	}
+	headCount := (maxLines - 1) / 2
+	tailCount := maxLines - headCount - 1
+	compact := make([]string, 0, maxLines)
+	compact = append(compact, lines[:headCount]...)
+	compact = append(compact, shortcutOverflowMarker)
+	compact = append(compact, lines[len(lines)-tailCount:]...)
+	return compact
+}
+
+func wrapPlainText(s string, maxWidth int) []string {
+	if maxWidth <= 0 {
+		return []string{""}
+	}
+	if s == "" {
+		return []string{""}
+	}
+
+	var lines []string
+	for _, paragraph := range strings.Split(s, "\n") {
+		words := strings.Fields(paragraph)
+		if len(words) == 0 {
+			lines = append(lines, "")
+			continue
+		}
+
+		current := ""
+		for _, word := range words {
+			for word != "" {
+				if current == "" {
+					if lipgloss.Width(word) <= maxWidth {
+						current = word
+						word = ""
+						continue
+					}
+					head, rest := splitAtWidth(word, maxWidth)
+					if head == "" {
+						runes := []rune(word)
+						head = string(runes[:1])
+						rest = string(runes[1:])
+					}
+					lines = append(lines, head)
+					word = rest
+					continue
+				}
+				candidate := current + " " + word
+				if lipgloss.Width(candidate) <= maxWidth {
+					current = candidate
+					word = ""
+					continue
+				}
+				lines = append(lines, current)
+				current = ""
+			}
+		}
+		if current != "" {
+			lines = append(lines, current)
+		}
+	}
+	if len(lines) == 0 {
+		return []string{""}
 	}
 	return lines
 }

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -521,6 +521,28 @@ func TestStatusBar_WorktreeInputOverlayShowsInputHints(t *testing.T) {
 	}
 }
 
+func TestStatusBar_LaunchInstructionsOverlayShowsLaunchHint(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:                    []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:                    120,
+		Height:                   12,
+		Mode:                     ModePlans,
+		Overlay:                  OverlayWorktreeInput,
+		WorktreeInputPrompt:      LaunchInstructionsPrompt,
+		WorktreeInputPlaceholder: "launch instructions",
+		WorktreeInput:            "Implement the selected plan",
+	})
+	status := strings.Split(view, "\n")[11]
+	for _, hint := range []string{"enter: launch", "esc: cancel", "backspace: delete"} {
+		if !strings.Contains(status, hint) {
+			t.Errorf("expected hint %q in launch overlay bar %q", hint, status)
+		}
+	}
+	if strings.Contains(status, "enter: create") {
+		t.Fatalf("launch instructions status should not show create hint: %q", status)
+	}
+}
+
 func TestStatusBar_KeyHintSpacingIs2(t *testing.T) {
 	bar := RenderStatusBar(160, 2, 0, 1, true, false, false)
 	for _, pair := range [][2]string{
@@ -1947,6 +1969,83 @@ func TestRender_AgentInputDialogUsesExplicitPlaceholder(t *testing.T) {
 	}
 	if !strings.Contains(view, AgentInputPlaceholder) {
 		t.Error("agent input dialog should show caller-provided placeholder")
+	}
+}
+
+func TestRender_LaunchInstructionsInputDialogWrapsInCompactPanel(t *testing.T) {
+	longInput := `Implement the saved wtui plan "Persist custom launch instructions" at /state/wtui/plans/plan-1/plan.md. Read the plan file, then begin implementation.`
+	view := Render(RenderParams{
+		Repos:                    []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:                    120,
+		Height:                   24,
+		Mode:                     ModePlans,
+		Overlay:                  OverlayWorktreeInput,
+		WorktreeInputPrompt:      LaunchInstructionsPrompt,
+		WorktreeInputPlaceholder: "launch instructions",
+		WorktreeInput:            longInput,
+	})
+
+	if !strings.Contains(view, LaunchInstructionsPrompt) {
+		t.Fatalf("launch instructions dialog should show prompt:\n%s", view)
+	}
+	if strings.Contains(view, longInput) {
+		t.Fatalf("launch instructions should wrap instead of rendering on one line:\n%s", view)
+	}
+	for _, want := range []string{"Implement the saved wtui plan", "Read the plan file", "then begin"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("wrapped launch instructions missing %q:\n%s", want, view)
+		}
+	}
+
+	lines := strings.Split(view, "\n")
+	for i, line := range lines[:len(lines)-1] {
+		trimmed := strings.TrimLeft(ansi.Strip(line), " ")
+		if trimmed == "" {
+			continue
+		}
+		if got := lipgloss.Width(trimmed); got > launchInstructionsMaxWidth {
+			t.Fatalf("modal line %d width = %d, want <= %d: %q", i, got, launchInstructionsMaxWidth, trimmed)
+		}
+	}
+}
+
+func TestRender_LaunchInstructionsInputDialogMarksOverflow(t *testing.T) {
+	longInput := strings.Join([]string{
+		"Start with the saved wtui plan title and repository path.",
+		"Keep this middle instruction one.",
+		"Keep this middle instruction two.",
+		"Keep this middle instruction three.",
+		"Keep this middle instruction four.",
+		"Finish by launching the selected agent with the edited instructions.",
+	}, " ")
+	view := Render(RenderParams{
+		Repos:                    []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:                    52,
+		Height:                   20,
+		Mode:                     ModePlans,
+		Overlay:                  OverlayWorktreeInput,
+		WorktreeInputPrompt:      LaunchInstructionsPrompt,
+		WorktreeInputPlaceholder: "launch instructions",
+		WorktreeInput:            longInput,
+	})
+
+	for _, want := range []string{"Start with the saved", shortcutOverflowMarker, "Finish by launching"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("overflowed launch instructions missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "middle instruction three") {
+		t.Fatalf("overflowed launch instructions should compact middle content:\n%s", view)
+	}
+	lines := strings.Split(view, "\n")
+	for i, line := range lines[:len(lines)-1] {
+		trimmed := strings.TrimLeft(ansi.Strip(line), " ")
+		if trimmed == "" {
+			continue
+		}
+		if got := lipgloss.Width(trimmed); got > 52 {
+			t.Fatalf("modal line %d width = %d, want <= terminal width: %q", i, got, trimmed)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds an editable launch-instructions prompt before starting an agent from the saved plans pane. Pressing `i` now opens the generated instructions, allows edits, rejects blank submissions, and launches only after submitting the prompt.

## Implementation

- Adds `[agent].plan_prompt` as an optional template for plan launch instructions, with placeholders for plan title, ID, plan path, repo path, and worktree path.
- Wires the prompt template through startup config into the model and preserves saved plan branch/commit plus selected phase metadata in launch contexts.
- Adds a compact multiline TUI dialog for launch instructions, including prompt-specific status hints and overflow marking for long text.
- Extends Codex App deep-link prompts with wtui launch metadata because macOS `open` does not inherit `WTUI_*` environment variables.
- Updates README, config docs, and the `wtui-plan-persist` skill for the editable launch flow and the `codex-app` environment exception.

## Verification

- `gofmt -l .`
- `git diff --check --cached`
- `make test`
- `make build`
