### PR TITLE
Flow: validate phase updates

### DIFF
--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -15,7 +15,7 @@ import (
 // the artifact root but must never scan repositories or start the TUI.
 func runFlow(args []string, deps runDeps) error {
 	if len(args) < 3 {
-		return fmt.Errorf("usage: wtui flow <create|list|read> [flags]")
+		return fmt.Errorf("usage: wtui flow <create|list|read|phase> [flags]")
 	}
 	switch args[2] {
 	case "create":
@@ -24,6 +24,8 @@ func runFlow(args []string, deps runDeps) error {
 		return runFlowList(args[3:], deps)
 	case "read":
 		return runFlowRead(args[3:], deps)
+	case "phase":
+		return runFlowPhase(args[3:], deps)
 	default:
 		return fmt.Errorf("unknown flow subcommand %q", args[2])
 	}
@@ -147,6 +149,60 @@ func runFlowRead(args []string, deps runDeps) error {
 		return err
 	}
 	record, err := store.Read(*flowID)
+	if err != nil {
+		return err
+	}
+	return writeFlowJSON(deps.stdout, record)
+}
+
+func runFlowPhase(args []string, deps runDeps) error {
+	if len(args) < 1 || args[0] != "set" {
+		return fmt.Errorf("usage: wtui flow phase set [flags]")
+	}
+	return runFlowPhaseSet(args[1:], deps)
+}
+
+func runFlowPhaseSet(args []string, deps runDeps) error {
+	flags := flag.NewFlagSet("flow phase set", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flowID := flags.String("flow-id", "", "flow id")
+	phaseID := flags.String("phase-id", "", "phase id")
+	status := flags.String("status", "", "phase status")
+	outcome := flags.String("outcome", "", "phase outcome")
+	summary := flags.String("summary", "", "phase summary")
+	notes := flags.String("notes", "", "phase notes")
+	stateRoot := flags.String("state-root", "", "artifact state root")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *flowID == "" {
+		return fmt.Errorf("flow phase set requires --flow-id")
+	}
+	if *phaseID == "" {
+		return fmt.Errorf("flow phase set requires --phase-id")
+	}
+	if *status == "" {
+		return fmt.Errorf("flow phase set requires --status")
+	}
+	switch *status {
+	case flowstore.PhaseCompleted, flowstore.PhaseNeedsAttention, flowstore.PhaseBlocked, flowstore.PhaseSkipped:
+	case flowstore.PhaseReady:
+		return fmt.Errorf("cannot set phase status to ready; readiness is derived")
+	default:
+		return fmt.Errorf("unsupported agent-facing phase status %q", *status)
+	}
+	store, err := newFlowStore(*stateRoot, deps)
+	if err != nil {
+		return err
+	}
+	record, err := store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  *flowID,
+		PhaseID: *phaseID,
+		Status:  *status,
+		Outcome: *outcome,
+		Notes:   *notes,
+		Summary: *summary,
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -185,7 +185,7 @@ func runFlowPhaseSet(args []string, deps runDeps) error {
 		return fmt.Errorf("flow phase set requires --status")
 	}
 	switch *status {
-	case flowstore.PhaseCompleted, flowstore.PhaseNeedsAttention, flowstore.PhaseBlocked, flowstore.PhaseSkipped:
+	case flowstore.PhaseRunning, flowstore.PhaseCompleted, flowstore.PhaseNeedsAttention, flowstore.PhaseBlocked, flowstore.PhaseSkipped:
 	case flowstore.PhaseReady:
 		return fmt.Errorf("cannot set phase status to ready; readiness is derived")
 	default:

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -117,6 +117,7 @@ func TestRunFlowPhaseSetUpdatesAgentFacingStatus(t *testing.T) {
 		notes    string
 		wantFlow string
 	}{
+		{name: "running", status: flowstore.PhaseRunning, wantFlow: flowstore.StatusInProgress},
 		{name: "completed", status: flowstore.PhaseCompleted, wantFlow: flowstore.StatusInProgress},
 		{name: "needs attention", status: flowstore.PhaseNeedsAttention, wantFlow: flowstore.StatusNeedsAttention},
 		{name: "blocked", status: flowstore.PhaseBlocked, wantFlow: flowstore.StatusBlocked},
@@ -159,6 +160,57 @@ func TestRunFlowPhaseSetUpdatesAgentFacingStatus(t *testing.T) {
 	}
 }
 
+func TestRunFlowPhaseSetRestartsBlockedPhaseWithNotes(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	created := mustRunFlow(t, []string{"wtui", "flow", "create", "--title", "Restart Blocked", "--instructions", "phase it", "--repo-path", repoPath, "--json", "--state-root", root})
+
+	err := run([]string{
+		"wtui", "flow", "phase", "set",
+		"--flow-id", created.FlowID,
+		"--phase-id", "plan",
+		"--status", flowstore.PhaseBlocked,
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
+	if err != nil {
+		t.Fatalf("set blocked returned error: %v", err)
+	}
+
+	err = run([]string{
+		"wtui", "flow", "phase", "set",
+		"--flow-id", created.FlowID,
+		"--phase-id", "plan",
+		"--status", flowstore.PhaseRunning,
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
+	if err == nil || !strings.Contains(err.Error(), "restarting blocked phase requires notes") {
+		t.Fatalf("restart without notes error = %v, want notes requirement", err)
+	}
+
+	var stdout bytes.Buffer
+	err = run([]string{
+		"wtui", "flow", "phase", "set",
+		"--flow-id", created.FlowID,
+		"--phase-id", "plan",
+		"--status", flowstore.PhaseRunning,
+		"--notes", "Unblocked after user confirmed scope.",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: &stdout}))
+	if err != nil {
+		t.Fatalf("restart with notes returned error: %v", err)
+	}
+	var updated flowstore.FlowRecord
+	if err := json.Unmarshal(stdout.Bytes(), &updated); err != nil {
+		t.Fatalf("output is not JSON record: %v\n%s", err, stdout.String())
+	}
+	if updated.Phases[0].Status != flowstore.PhaseRunning {
+		t.Fatalf("phase status = %q, want running", updated.Phases[0].Status)
+	}
+	if updated.Phases[0].Notes != "Unblocked after user confirmed scope." {
+		t.Fatalf("phase notes = %q", updated.Phases[0].Notes)
+	}
+}
+
 func TestRunFlowPhaseSetRejectsUnsupportedStatuses(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")
@@ -170,7 +222,6 @@ func TestRunFlowPhaseSetRejectsUnsupportedStatuses(t *testing.T) {
 		want   string
 	}{
 		{name: "ready", status: flowstore.PhaseReady, want: "cannot set phase status to ready"},
-		{name: "running", status: flowstore.PhaseRunning, want: "unsupported agent-facing phase status"},
 		{name: "bogus", status: "done", want: "unsupported agent-facing phase status"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -109,6 +109,114 @@ func TestRunFlowReadPrintsJSONRecord(t *testing.T) {
 	}
 }
 
+func TestRunFlowPhaseSetUpdatesAgentFacingStatus(t *testing.T) {
+	root := t.TempDir()
+	for _, tc := range []struct {
+		name     string
+		status   string
+		notes    string
+		wantFlow string
+	}{
+		{name: "completed", status: flowstore.PhaseCompleted, wantFlow: flowstore.StatusInProgress},
+		{name: "needs attention", status: flowstore.PhaseNeedsAttention, wantFlow: flowstore.StatusNeedsAttention},
+		{name: "blocked", status: flowstore.PhaseBlocked, wantFlow: flowstore.StatusBlocked},
+		{name: "skipped", status: flowstore.PhaseSkipped, notes: "Existing plan is approved.", wantFlow: flowstore.StatusInProgress},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repoPath := filepath.Join(root, "repo-"+tc.name)
+			created := mustRunFlow(t, []string{"wtui", "flow", "create", "--title", tc.name, "--instructions", "phase it", "--repo-path", repoPath, "--json", "--state-root", root})
+
+			args := []string{
+				"wtui", "flow", "phase", "set",
+				"--flow-id", created.FlowID,
+				"--phase-id", "plan",
+				"--status", tc.status,
+				"--summary", "Phase updated.",
+				"--state-root", root,
+			}
+			if tc.notes != "" {
+				args = append(args, "--notes", tc.notes)
+			}
+			var stdout bytes.Buffer
+			err := run(args, noScanDeps(t, runDeps{stdout: &stdout}))
+			if err != nil {
+				t.Fatalf("run returned error: %v", err)
+			}
+			var updated flowstore.FlowRecord
+			if err := json.Unmarshal(stdout.Bytes(), &updated); err != nil {
+				t.Fatalf("output is not JSON record: %v\n%s", err, stdout.String())
+			}
+			if updated.Phases[0].Status != tc.status || updated.Phases[0].Summary != "Phase updated." {
+				t.Fatalf("updated phase = %#v", updated.Phases[0])
+			}
+			if tc.notes != "" && updated.Phases[0].Notes != tc.notes {
+				t.Fatalf("phase notes = %q, want %q", updated.Phases[0].Notes, tc.notes)
+			}
+			if updated.Status != tc.wantFlow {
+				t.Fatalf("flow status = %q, want %q", updated.Status, tc.wantFlow)
+			}
+		})
+	}
+}
+
+func TestRunFlowPhaseSetRejectsUnsupportedStatuses(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	created := mustRunFlow(t, []string{"wtui", "flow", "create", "--title", "Reject Status", "--instructions", "phase it", "--repo-path", repoPath, "--json", "--state-root", root})
+
+	for _, tc := range []struct {
+		name   string
+		status string
+		want   string
+	}{
+		{name: "ready", status: flowstore.PhaseReady, want: "cannot set phase status to ready"},
+		{name: "running", status: flowstore.PhaseRunning, want: "unsupported agent-facing phase status"},
+		{name: "bogus", status: "done", want: "unsupported agent-facing phase status"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := run([]string{
+				"wtui", "flow", "phase", "set",
+				"--flow-id", created.FlowID,
+				"--phase-id", "plan",
+				"--status", tc.status,
+				"--state-root", root,
+			}, noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("run error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunFlowPhaseSetRejectsSkippedWithoutNotes(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	created := mustRunFlow(t, []string{"wtui", "flow", "create", "--title", "Reject Skip", "--instructions", "phase it", "--repo-path", repoPath, "--json", "--state-root", root})
+
+	err := run([]string{
+		"wtui", "flow", "phase", "set",
+		"--flow-id", created.FlowID,
+		"--phase-id", "plan",
+		"--status", flowstore.PhaseSkipped,
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
+	if err == nil || !strings.Contains(err.Error(), "skipped phase requires notes") {
+		t.Fatalf("run error = %v, want skipped notes error", err)
+	}
+
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	read, err := store.Read(created.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.Phases[0].Status != flowstore.PhaseReady {
+		t.Fatalf("phase status after rejected skip = %q, want ready", read.Phases[0].Status)
+	}
+}
+
 func TestRunFlowCreateStateRootPrecedence(t *testing.T) {
 	flowRoot := t.TempDir()
 	planRoot := t.TempDir()

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -311,18 +312,40 @@ func (s *Store) SetPhase(update PhaseUpdate) (FlowRecord, error) {
 
 func (s *Store) acquireFlowLock(flowID string) (func(), error) {
 	lockPath := filepath.Join(s.flowDir(flowID), ".update.lock")
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, filePerm)
+	if err != nil {
+		return nil, fmt.Errorf("open flow lock: %w", err)
+	}
 	deadline := time.Now().Add(s.lockTimeout)
 	for {
-		file, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, filePerm)
+		err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
 		if err == nil {
-			_, _ = fmt.Fprintf(file, "%d\n", os.Getpid())
-			_ = file.Close()
-			return func() { _ = os.Remove(lockPath) }, nil
+			if err := file.Truncate(0); err != nil {
+				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				_ = file.Close()
+				return nil, fmt.Errorf("truncate flow lock: %w", err)
+			}
+			if _, err := file.Seek(0, 0); err != nil {
+				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				_ = file.Close()
+				return nil, fmt.Errorf("seek flow lock: %w", err)
+			}
+			if _, err := fmt.Fprintf(file, "%d\n", os.Getpid()); err != nil {
+				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				_ = file.Close()
+				return nil, fmt.Errorf("write flow lock: %w", err)
+			}
+			return func() {
+				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				_ = file.Close()
+			}, nil
 		}
-		if !os.IsExist(err) {
+		if err != syscall.EWOULDBLOCK && err != syscall.EAGAIN {
+			_ = file.Close()
 			return nil, fmt.Errorf("acquire flow lock: %w", err)
 		}
 		if !time.Now().Before(deadline) {
+			_ = file.Close()
 			return nil, fmt.Errorf("timed out waiting for flow lock %q", flowID)
 		}
 		time.Sleep(5 * time.Millisecond)

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -23,6 +23,7 @@ const (
 
 const maxSlugLength = 48
 const maxIDCollisionAttempts = 1000
+const defaultLockTimeout = 5 * time.Second
 
 var flowIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
 
@@ -54,14 +55,16 @@ const (
 
 // Store reads and writes flow records under an artifact root.
 type Store struct {
-	root string
-	now  func() time.Time
+	root        string
+	now         func() time.Time
+	lockTimeout time.Duration
 }
 
 // StoreOptions configures a Store.
 type StoreOptions struct {
-	Root string
-	Now  func() time.Time
+	Root        string
+	Now         func() time.Time
+	LockTimeout time.Duration
 }
 
 // FlowPhase is one phase in the persisted Flow pipeline.
@@ -135,6 +138,16 @@ type FlowFilter struct {
 	RepoPath string
 }
 
+// PhaseUpdate describes one persisted phase status update.
+type PhaseUpdate struct {
+	FlowID  string
+	PhaseID string
+	Status  string
+	Outcome string
+	Notes   string
+	Summary string
+}
+
 // NewStore creates a Store rooted at an absolute artifact root.
 func NewStore(opts StoreOptions) (*Store, error) {
 	root := opts.Root
@@ -161,7 +174,11 @@ func NewStore(opts StoreOptions) (*Store, error) {
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
 	}
-	return &Store{root: root, now: now}, nil
+	lockTimeout := opts.LockTimeout
+	if lockTimeout <= 0 {
+		lockTimeout = defaultLockTimeout
+	}
+	return &Store{root: root, now: now, lockTimeout: lockTimeout}, nil
 }
 
 // DefaultRoot returns the default artifact root, matching sessions and plans.
@@ -236,6 +253,82 @@ func (s *Store) Read(flowID string) (FlowRecord, error) {
 	return record, nil
 }
 
+// SetPhase validates and persists one phase update on an existing flow.
+func (s *Store) SetPhase(update PhaseUpdate) (FlowRecord, error) {
+	if err := validateFlowID(update.FlowID); err != nil {
+		return FlowRecord{}, err
+	}
+	if _, err := os.Stat(s.flowDir(update.FlowID)); os.IsNotExist(err) {
+		return FlowRecord{}, fmt.Errorf("flow %q not found", update.FlowID)
+	} else if err != nil {
+		return FlowRecord{}, fmt.Errorf("stat flow %q: %w", update.FlowID, err)
+	}
+	release, err := s.acquireFlowLock(update.FlowID)
+	if err != nil {
+		return FlowRecord{}, err
+	}
+	defer release()
+	record, ok := s.readRecord(update.FlowID)
+	if !ok {
+		return FlowRecord{}, fmt.Errorf("flow %q not found", update.FlowID)
+	}
+	phaseIndex := -1
+	for i, phase := range record.Phases {
+		if phase.PhaseID == update.PhaseID {
+			phaseIndex = i
+			break
+		}
+	}
+	if phaseIndex < 0 {
+		return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
+	}
+
+	now := s.now()
+	phase := record.Phases[phaseIndex]
+	if err := validatePhaseUpdate(phase, update); err != nil {
+		return FlowRecord{}, err
+	}
+	phase.Status = update.Status
+	if update.Outcome != "" {
+		phase.Outcome = update.Outcome
+	}
+	if update.Notes != "" {
+		phase.Notes = update.Notes
+	}
+	if update.Summary != "" {
+		phase.Summary = update.Summary
+	}
+	phase.UpdatedAt = now
+	record.Phases[phaseIndex] = phase
+	record.UpdatedAt = now
+	record = refreshPhaseReadiness(record, now)
+	record.Status = DeriveStatus(record)
+	if err := s.write(record); err != nil {
+		return FlowRecord{}, err
+	}
+	return record, nil
+}
+
+func (s *Store) acquireFlowLock(flowID string) (func(), error) {
+	lockPath := filepath.Join(s.flowDir(flowID), ".update.lock")
+	deadline := time.Now().Add(s.lockTimeout)
+	for {
+		file, err := os.OpenFile(lockPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, filePerm)
+		if err == nil {
+			_, _ = fmt.Fprintf(file, "%d\n", os.Getpid())
+			_ = file.Close()
+			return func() { _ = os.Remove(lockPath) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, fmt.Errorf("acquire flow lock: %w", err)
+		}
+		if !time.Now().Before(deadline) {
+			return nil, fmt.Errorf("timed out waiting for flow lock %q", flowID)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 // List returns records matching filter, sorted by UpdatedAt descending.
 func (s *Store) List(filter FlowFilter) ([]FlowRecord, error) {
 	root := filepath.Join(s.root, "flows")
@@ -263,6 +356,76 @@ func (s *Store) List(filter FlowFilter) ([]FlowRecord, error) {
 		return records[i].UpdatedAt.After(records[j].UpdatedAt)
 	})
 	return records, nil
+}
+
+func validatePhaseUpdate(current FlowPhase, update PhaseUpdate) error {
+	if strings.TrimSpace(update.Status) == "" {
+		return fmt.Errorf("phase status is required")
+	}
+	switch update.Status {
+	case PhaseRunning, PhaseNeedsAttention, PhaseCompleted, PhaseBlocked, PhaseSkipped:
+	case PhaseReady:
+		return fmt.Errorf("cannot set phase status to ready; readiness is derived")
+	default:
+		return fmt.Errorf("invalid phase status %q", update.Status)
+	}
+	if update.Status == PhaseSkipped && strings.TrimSpace(update.Notes) == "" {
+		return fmt.Errorf("skipped phase requires notes")
+	}
+	if current.Status == update.Status {
+		return nil
+	}
+	switch current.Status {
+	case PhaseReady:
+		switch update.Status {
+		case PhaseRunning, PhaseCompleted, PhaseNeedsAttention, PhaseBlocked, PhaseSkipped:
+			return nil
+		}
+	case PhaseRunning:
+		switch update.Status {
+		case PhaseCompleted, PhaseNeedsAttention, PhaseBlocked, PhaseSkipped:
+			return nil
+		}
+	case PhaseNeedsAttention, PhaseBlocked:
+		switch update.Status {
+		case PhaseRunning, PhaseSkipped:
+			if update.Status == PhaseRunning && strings.TrimSpace(update.Notes) == "" {
+				return fmt.Errorf("restarting %s phase requires notes", current.Status)
+			}
+			return nil
+		}
+	case PhaseCompleted, PhaseSkipped:
+		if update.Status == PhaseRunning {
+			return nil
+		}
+	case PhasePending:
+		if update.Status == PhaseSkipped {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid phase transition %s -> %s", current.Status, update.Status)
+}
+
+func refreshPhaseReadiness(record FlowRecord, now time.Time) FlowRecord {
+	predecessorsSatisfied := true
+	for i := range record.Phases {
+		phase := record.Phases[i]
+		if phase.Status == PhasePending || phase.Status == PhaseReady {
+			nextStatus := PhasePending
+			if predecessorsSatisfied {
+				nextStatus = PhaseReady
+			}
+			if phase.Status != nextStatus {
+				phase.Status = nextStatus
+				phase.UpdatedAt = now
+				record.Phases[i] = phase
+			}
+		}
+		if phase.Status != PhaseCompleted && phase.Status != PhaseSkipped {
+			predecessorsSatisfied = false
+		}
+	}
+	return record
 }
 
 // DeriveStatus computes the flow-level status from phase and merge state.

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -450,7 +451,16 @@ func TestStoreSetPhaseReportsLockTimeout(t *testing.T) {
 		t.Fatalf("Create() error = %v", err)
 	}
 	lockPath := filepath.Join(root, "flows", record.FlowID, ".update.lock")
-	if err := os.WriteFile(lockPath, []byte("held"), 0o600); err != nil {
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	defer lockFile.Close()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatalf("flock lock file: %v", err)
+	}
+	defer syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	if _, err := lockFile.WriteString("held\n"); err != nil {
 		t.Fatalf("write lock file: %v", err)
 	}
 
@@ -461,6 +471,45 @@ func TestStoreSetPhaseReportsLockTimeout(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "timed out waiting for flow lock") {
 		t.Fatalf("SetPhase() error = %v, want lock timeout", err)
+	}
+}
+
+func TestStoreSetPhaseIgnoresAbandonedLockMarker(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Stale lock",
+		Instructions: "recover phase updates",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	lockPath := filepath.Join(root, "flows", record.FlowID, ".update.lock")
+	if err := os.WriteFile(lockPath, []byte("not a live lock\n"), 0o600); err != nil {
+		t.Fatalf("write lock file: %v", err)
+	}
+
+	updated, err := store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "plan",
+		Status:  flowstore.PhaseRunning,
+	})
+	if err != nil {
+		t.Fatalf("SetPhase() error = %v", err)
+	}
+	if updated.Phases[0].Status != flowstore.PhaseRunning {
+		t.Fatalf("phase status = %q, want running", updated.Phases[0].Status)
+	}
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("read lock file: %v", err)
+	}
+	if !strings.Contains(string(lockData), "\n") || strings.Contains(string(lockData), "not a live lock") {
+		t.Fatalf("lock marker was not refreshed: %q", lockData)
 	}
 }
 

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -227,6 +228,360 @@ func TestStoreListFiltersSortsAndSkipsBadRecords(t *testing.T) {
 	}
 	if records[0].FlowID != newer.FlowID || records[1].FlowID != older.FlowID {
 		t.Fatalf("List() order = %#v, want updated_at desc", records)
+	}
+}
+
+func TestStoreSetPhasePersistsUpdateAndDerivesStatus(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	times := []time.Time{
+		time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 7, 12, 0, 1, 0, time.UTC),
+		time.Date(2026, 6, 7, 12, 0, 2, 0, time.UTC),
+		time.Date(2026, 6, 7, 12, 0, 3, 0, time.UTC),
+		time.Date(2026, 6, 7, 12, 0, 4, 0, time.UTC),
+	}
+	i := 0
+	store, err := flowstore.NewStore(flowstore.StoreOptions{
+		Root: root,
+		Now: func() time.Time {
+			tm := times[i]
+			i++
+			return tm
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Phase updates",
+		Instructions: "exercise phase set",
+		RepoPath:     repoPath,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	running, err := store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "plan",
+		Status:  flowstore.PhaseRunning,
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(running) error = %v", err)
+	}
+	if running.Status != flowstore.StatusInProgress {
+		t.Fatalf("running flow status = %q, want in_progress", running.Status)
+	}
+	if running.Phases[0].Status != flowstore.PhaseRunning || running.Phases[0].UpdatedAt != times[2] {
+		t.Fatalf("running phase = %#v, want running at %s", running.Phases[0], times[2])
+	}
+
+	completed, err := store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "plan",
+		Status:  flowstore.PhaseCompleted,
+		Summary: "Plan saved and reviewed.",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(completed) error = %v", err)
+	}
+	if completed.Status != flowstore.StatusInProgress {
+		t.Fatalf("completed first phase flow status = %q, want in_progress", completed.Status)
+	}
+	if completed.UpdatedAt != times[3] {
+		t.Fatalf("flow UpdatedAt = %s, want %s", completed.UpdatedAt, times[3])
+	}
+	if completed.Phases[0].Status != flowstore.PhaseCompleted || completed.Phases[0].Summary != "Plan saved and reviewed." {
+		t.Fatalf("completed phase = %#v", completed.Phases[0])
+	}
+	if completed.Phases[1].Status != flowstore.PhaseReady {
+		t.Fatalf("next phase status = %q, want ready", completed.Phases[1].Status)
+	}
+
+	repeated, err := store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "plan",
+		Status:  flowstore.PhaseCompleted,
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(repeated completed) error = %v", err)
+	}
+	if repeated.Phases[0].Summary != "Plan saved and reviewed." {
+		t.Fatalf("repeated update should preserve summary, got %#v", repeated.Phases[0])
+	}
+
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.Status != completed.Status || read.Phases[0].Status != flowstore.PhaseCompleted || read.Phases[1].Status != flowstore.PhaseReady {
+		t.Fatalf("persisted record = %#v, want completed plan and ready next phase", read)
+	}
+}
+
+func TestStoreSetPhaseRejectsInvalidTransitions(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Validate transitions",
+		Instructions: "reject invalid updates",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		update flowstore.PhaseUpdate
+		want   string
+	}{
+		{
+			name:   "invalid status",
+			update: flowstore.PhaseUpdate{FlowID: record.FlowID, PhaseID: "plan", Status: "done"},
+			want:   "invalid phase status",
+		},
+		{
+			name:   "force ready",
+			update: flowstore.PhaseUpdate{FlowID: record.FlowID, PhaseID: "plan", Status: flowstore.PhaseReady},
+			want:   "cannot set phase status to ready",
+		},
+		{
+			name:   "pending to completed",
+			update: flowstore.PhaseUpdate{FlowID: record.FlowID, PhaseID: "plan-review", Status: flowstore.PhaseCompleted},
+			want:   "invalid phase transition",
+		},
+		{
+			name:   "skipped without notes",
+			update: flowstore.PhaseUpdate{FlowID: record.FlowID, PhaseID: "plan-review", Status: flowstore.PhaseSkipped},
+			want:   "skipped phase requires notes",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := store.SetPhase(tc.update)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("SetPhase() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestStoreSetPhaseAllowsSkippedWithNotesAndIdempotentUpdates(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Skip and repeat",
+		Instructions: "exercise idempotency",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	skipped, err := store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "plan",
+		Status:  flowstore.PhaseSkipped,
+		Notes:   "Existing plan already approved.",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(skipped) error = %v", err)
+	}
+	if skipped.Phases[0].Status != flowstore.PhaseSkipped || skipped.Phases[0].Notes != "Existing plan already approved." {
+		t.Fatalf("skipped phase = %#v", skipped.Phases[0])
+	}
+	if skipped.Phases[1].Status != flowstore.PhaseReady {
+		t.Fatalf("next phase status = %q, want ready", skipped.Phases[1].Status)
+	}
+
+	repeated, err := store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "plan",
+		Status:  flowstore.PhaseSkipped,
+		Notes:   "Existing plan already approved.",
+		Summary: "No new plan needed.",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(repeated skipped) error = %v", err)
+	}
+	if len(repeated.Phases) != len(record.Phases) {
+		t.Fatalf("phase count = %d, want %d", len(repeated.Phases), len(record.Phases))
+	}
+	if repeated.Phases[0].Summary != "No new plan needed." || repeated.Phases[1].Status != flowstore.PhaseReady {
+		t.Fatalf("repeated update record = %#v", repeated)
+	}
+
+	pendingSkipped, err := store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "implementation",
+		Status:  flowstore.PhaseSkipped,
+		Notes:   "Implementation is covered by the existing branch.",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(pending skipped) error = %v", err)
+	}
+	if pendingSkipped.Phases[2].Status != flowstore.PhaseSkipped || pendingSkipped.Phases[2].Notes != "Implementation is covered by the existing branch." {
+		t.Fatalf("pending skipped phase = %#v", pendingSkipped.Phases[2])
+	}
+}
+
+func TestStoreSetPhaseReportsLockTimeout(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{
+		Root:        root,
+		LockTimeout: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Lock timeout",
+		Instructions: "hold the update lock",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	lockPath := filepath.Join(root, "flows", record.FlowID, ".update.lock")
+	if err := os.WriteFile(lockPath, []byte("held"), 0o600); err != nil {
+		t.Fatalf("write lock file: %v", err)
+	}
+
+	_, err = store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "plan",
+		Status:  flowstore.PhaseRunning,
+	})
+	if err == nil || !strings.Contains(err.Error(), "timed out waiting for flow lock") {
+		t.Fatalf("SetPhase() error = %v, want lock timeout", err)
+	}
+}
+
+func TestStoreSetPhaseConcurrentUpdatesDoNotOverwriteEachOther(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	record, err := store.Create(flowstore.FlowRecord{
+		FlowID:       "concurrent-flow",
+		Title:        "Concurrent updates",
+		Instructions: "preserve both mutations",
+		RepoPath:     filepath.Join(root, "repo"),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "plan", Title: "Plan", Kind: "plan", Status: flowstore.PhaseRunning, Order: 1, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "implementation", Title: "Implementation", Kind: "implementation", Status: flowstore.PhaseRunning, Order: 2, CreatedAt: now, UpdatedAt: now},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, err := store.SetPhase(flowstore.PhaseUpdate{
+			FlowID:  record.FlowID,
+			PhaseID: "plan",
+			Status:  flowstore.PhaseCompleted,
+			Summary: "Plan complete.",
+		})
+		errs <- err
+	}()
+	go func() {
+		defer wg.Done()
+		_, err := store.SetPhase(flowstore.PhaseUpdate{
+			FlowID:  record.FlowID,
+			PhaseID: "implementation",
+			Status:  flowstore.PhaseBlocked,
+			Notes:   "Needs human input.",
+		})
+		errs <- err
+	}()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("SetPhase() error = %v", err)
+		}
+	}
+
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.Phases[0].Status != flowstore.PhaseCompleted || read.Phases[0].Summary != "Plan complete." {
+		t.Fatalf("plan phase after concurrent updates = %#v", read.Phases[0])
+	}
+	if read.Phases[1].Status != flowstore.PhaseBlocked || read.Phases[1].Notes != "Needs human input." {
+		t.Fatalf("implementation phase after concurrent updates = %#v", read.Phases[1])
+	}
+	if read.Status != flowstore.StatusBlocked {
+		t.Fatalf("flow status = %q, want blocked", read.Status)
+	}
+}
+
+func TestStoreSetPhaseChildPhasesGateDownstreamReadiness(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	record, err := store.Create(flowstore.FlowRecord{
+		FlowID:       "child-gate-flow",
+		Title:        "Child gate",
+		Instructions: "child phases gate downstream",
+		RepoPath:     filepath.Join(root, "repo"),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning, Order: 1, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "implementation-followup", ParentPhaseID: "implementation", Title: "Follow-up", Status: flowstore.PhasePending, Order: 2, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhasePending, Order: 3, CreatedAt: now, UpdatedAt: now},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	updated, err := store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "implementation",
+		Status:  flowstore.PhaseCompleted,
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(implementation completed) error = %v", err)
+	}
+	if updated.Phases[1].Status != flowstore.PhaseReady {
+		t.Fatalf("child phase status = %q, want ready", updated.Phases[1].Status)
+	}
+	if updated.Phases[2].Status != flowstore.PhasePending {
+		t.Fatalf("downstream phase status = %q, want pending while child is not done", updated.Phases[2].Status)
+	}
+
+	updated, err = store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "implementation-followup",
+		Status:  flowstore.PhaseCompleted,
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(child completed) error = %v", err)
+	}
+	if updated.Phases[2].Status != flowstore.PhaseReady {
+		t.Fatalf("downstream phase status = %q, want ready after child completion", updated.Phases[2].Status)
 	}
 }
 

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -40,6 +40,61 @@ func TestRender_FlowsModeShowsHeaderAndRows(t *testing.T) {
 	}
 }
 
+func TestRender_FlowsModeShowsUpdatedPhaseDrivenStates(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{
+			{
+				FlowID: "blocked-flow",
+				Title:  "Blocked implementation",
+				Status: flowstore.StatusBlocked,
+				Branch: "flow/blocked",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "plan", Status: flowstore.PhaseCompleted},
+					{PhaseID: "implementation", Status: flowstore.PhaseBlocked},
+				},
+			},
+			{
+				FlowID: "attention-flow",
+				Title:  "Needs review input",
+				Status: flowstore.StatusNeedsAttention,
+				Branch: "flow/needs-attention",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "plan", Status: flowstore.PhaseCompleted},
+					{PhaseID: "review-loop", Status: flowstore.PhaseNeedsAttention},
+				},
+			},
+			{
+				FlowID: "completed-flow",
+				Title:  "Completed flow",
+				Status: flowstore.StatusCompleted,
+				Branch: "flow/completed",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "plan", Status: flowstore.PhaseCompleted},
+					{PhaseID: "review-loop", Status: flowstore.PhaseSkipped},
+				},
+			},
+		},
+		ActivePane:   1,
+		FlowSelected: 0,
+	})
+
+	for _, want := range []string{
+		"blocked", "flow/blocked", "Blocked implementation",
+		"needs_attention", "flow/needs-attention", "Needs review input",
+		"completed", "flow/completed", "Completed flow",
+		"1/2", "2/2",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("updated flows view missing %q:\n%s", want, view)
+		}
+	}
+}
+
 func TestFlowPhaseProgressShowsDashWhenNoPhases(t *testing.T) {
 	got := flowPhaseProgress(flowstore.FlowRecord{})
 	if got != "-" {


### PR DESCRIPTION
## Summary

- Add `flowstore.SetPhase` for validated Flow phase updates with derived readiness/status and per-flow lock/reload/write serialization.
- Add `wtui flow phase set` for agent-facing phase statuses (`completed`, `needs_attention`, `blocked`, `skipped`) while rejecting forced `ready`, unsupported statuses, invalid transitions, and skipped phases without notes.
- Cover updated Flow mode rendering for blocked, needs-attention, and completed records.

## Review loop

- Loop 1: 7/10; fixed the CLI/store lifecycle gap so fresh ready phases can be updated through the public agent-facing command.
- Loop 2: 8/10; also preserved optional phase metadata on partial updates, added CLI skipped-without-notes coverage, updated usage text, and made child phases gate downstream readiness.

## Verification

- `gofmt -l .`
- `make test`
- `make build`

Fixes #108