### PR TITLE
Flow: add canonical wtui-flow agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,14 @@ The flow state root is resolved with this precedence: `--state-root` >
 `WTUI_FLOW_STATE_ROOT`, `WTUI_PLAN_STATE_ROOT`, or `WTUI_SESSION_STATE_ROOT`
 relocates the shared artifact root for sessions, plans, and flows.
 
+Flow-launched agents should use the canonical `wtui-flow` skill source at
+`agent-skills/wtui-flow/`. Install or symlink it beside
+`agent-skills/wtui-plan-persist/` in the user-level skill directory for your
+agent, such as `~/.codex/skills/wtui-flow` for Codex or the equivalent Claude
+skills directory. The skill activates when `WTUI_FLOW_ID` and
+`WTUI_FLOW_PHASE_ID` are present, reads the active flow before updates, and uses
+the implemented `wtui flow` and `wtui plan` commands for persistence.
+
 ## Configuration
 
 wtui reads an optional TOML config file before scanning repositories:

--- a/agent-skills/skill_docs_test.go
+++ b/agent-skills/skill_docs_test.go
@@ -1,0 +1,239 @@
+package agentskills
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestWtuiFlowSkillDocumentsAgentContract(t *testing.T) {
+	root := repoRoot(t)
+	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow", "SKILL.md"))
+
+	requireContainsAll(t, "skill metadata", skill, []string{
+		"name: wtui-flow",
+		"WTUI_FLOW_ID",
+		"WTUI_FLOW_PHASE_ID",
+	})
+	requireContainsAll(t, "flow commands", skill, []string{
+		"wtui flow read --flow-id",
+		"wtui flow phase set",
+		"wtui plan save",
+		"wtui plan phase set",
+		"wtui plan read",
+	})
+	requireContainsAll(t, "default phase playbooks", skill, []string{
+		"plan",
+		"plan-review",
+		"implementation",
+		"review-loop",
+		"pr-creation",
+		"autoreview",
+		"merge",
+	})
+	requireContainsAll(t, "agent-facing phase statuses", skill, []string{
+		"running",
+		"needs_attention",
+		"completed",
+		"blocked",
+		"skipped",
+		"ready",
+		"cannot set",
+	})
+	requireContainsAll(t, "flow outcomes and failure handling", skill, []string{
+		"--outcome",
+		"--summary",
+		"--notes",
+		"persistence failures",
+		"must not be treated as successful phase progression",
+	})
+}
+
+func TestWtuiFlowSkillMatchesImplementedFlowCLIContract(t *testing.T) {
+	root := repoRoot(t)
+	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow", "SKILL.md"))
+	flowCLI := readFile(t, filepath.Join(root, "cmd", "wtui", "flow.go"))
+	flowStore := readFile(t, filepath.Join(root, "flowstore", "store.go"))
+
+	if !strings.Contains(skill, "wtui flow phase set") || !strings.Contains(flowCLI, "runFlowPhaseSet") {
+		t.Fatal("skill and CLI should both expose flow phase set")
+	}
+	for _, flagName := range []string{
+		"flow-id",
+		"phase-id",
+		"status",
+		"outcome",
+		"summary",
+		"notes",
+		"state-root",
+	} {
+		if strings.Contains(skill, "--"+flagName) && !strings.Contains(flowCLI, `flags.String("`+flagName+`"`) {
+			t.Fatalf("skill documents --%s but flow CLI does not expose it", flagName)
+		}
+	}
+
+	for _, constant := range []string{
+		"PhaseRunning",
+		"PhaseNeedsAttention",
+		"PhaseCompleted",
+		"PhaseBlocked",
+		"PhaseSkipped",
+		"PhaseReady",
+		"StatusPending",
+		"StatusInProgress",
+		"StatusNeedsAttention",
+		"StatusBlocked",
+		"StatusCompleted",
+		"StatusMerged",
+		"StatusAbandoned",
+		"MergePending",
+		"MergeMerged",
+		"MergeBlocked",
+	} {
+		if !strings.Contains(flowStore, constant) {
+			t.Fatalf("flowstore contract missing %s", constant)
+		}
+	}
+
+	for _, unimplementedCommand := range []string{
+		"wtui flow phase add-child",
+		"wtui flow plan set",
+		"wtui flow pr set",
+		"wtui flow merge set",
+		"wtui flow session attach",
+		"wtui flow abandon",
+	} {
+		if hasRunnableCommandExample(skill, unimplementedCommand) {
+			t.Fatalf("skill includes a runnable example for unimplemented command %q", unimplementedCommand)
+		}
+	}
+}
+
+func TestWtuiFlowSkillKeepsPlanAndFlowStateRootsTogether(t *testing.T) {
+	root := repoRoot(t)
+	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow", "SKILL.md"))
+
+	requireContainsAll(t, "shared artifact root setup", skill, []string{
+		"WTUI_ARTIFACT_ROOT",
+		"WTUI_FLOW_STATE_ROOT",
+		"WTUI_PLAN_STATE_ROOT",
+		"WTUI_SESSION_STATE_ROOT",
+		"FLOW_STATE_ARGS",
+		"PLAN_STATE_ARGS",
+	})
+
+	for _, block := range fencedBashBlocks(skill) {
+		if strings.Contains(block, "wtui flow ") && !strings.Contains(block, `"${FLOW_STATE_ARGS[@]}"`) {
+			t.Fatalf("flow example missing FLOW_STATE_ARGS:\n%s", block)
+		}
+		if strings.Contains(block, "wtui plan ") && !strings.Contains(block, `"${PLAN_STATE_ARGS[@]}"`) {
+			t.Fatalf("plan example missing PLAN_STATE_ARGS:\n%s", block)
+		}
+	}
+}
+
+func TestWtuiFlowSkillPlanPhaseGuardsPersistenceFailures(t *testing.T) {
+	root := repoRoot(t)
+	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow", "SKILL.md"))
+
+	requireContainsAll(t, "plan persistence guards", skill, []string{
+		"if ! PLAN_ID=$(",
+		`--outcome "plan_save_failed"`,
+		`--outcome "plan_phase_save_failed"`,
+		`--outcome "plan_read_failed"`,
+		"exit 1",
+	})
+}
+
+func TestWtuiFlowSkillHandlesMissingPlanID(t *testing.T) {
+	root := repoRoot(t)
+	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow", "SKILL.md"))
+
+	requireContainsAll(t, "missing plan id guidance", skill, []string{
+		`if [ -z "$WTUI_PLAN_ID" ]`,
+		"missing_plan_id",
+		`if ! wtui plan read --plan-id "$WTUI_PLAN_ID" "${PLAN_STATE_ARGS[@]}"`,
+		"plan_review_read_failed",
+		`--status needs_attention`,
+		`wtui plan read --plan-id "$WTUI_PLAN_ID" "${PLAN_STATE_ARGS[@]}"`,
+	})
+}
+
+func TestWtuiFlowInstallationDocs(t *testing.T) {
+	root := repoRoot(t)
+	readme := readFile(t, filepath.Join(root, "README.md"))
+	configDocs := readFile(t, filepath.Join(root, "docs", "config.md"))
+
+	requireContainsAll(t, "README installation docs", readme, []string{
+		"agent-skills/wtui-flow/",
+		"wtui-flow",
+		"wtui-plan-persist",
+		"symlink",
+	})
+	requireContainsAll(t, "config installation docs", configDocs, []string{
+		"agent-skills/wtui-flow/",
+		"wtui-flow",
+		"wtui-plan-persist",
+		"symlink",
+	})
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), ".."))
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func requireContainsAll(t *testing.T, label, haystack string, needles []string) {
+	t.Helper()
+	normalized := strings.Join(strings.Fields(haystack), " ")
+	for _, needle := range needles {
+		if !strings.Contains(haystack, needle) && !strings.Contains(normalized, needle) {
+			t.Fatalf("%s missing %q", label, needle)
+		}
+	}
+}
+
+func hasRunnableCommandExample(markdown, command string) bool {
+	for _, block := range fencedBashBlocks(markdown) {
+		for _, line := range strings.Split(block, "\n") {
+			if strings.Contains(line, command) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fencedBashBlocks(markdown string) []string {
+	var blocks []string
+	var current []string
+	inBash := false
+	for _, line := range strings.Split(markdown, "\n") {
+		switch {
+		case strings.TrimSpace(line) == "```bash":
+			inBash = true
+			current = nil
+		case inBash && strings.TrimSpace(line) == "```":
+			blocks = append(blocks, strings.Join(current, "\n"))
+			inBash = false
+		case inBash:
+			current = append(current, line)
+		}
+	}
+	return blocks
+}

--- a/agent-skills/wtui-flow/SKILL.md
+++ b/agent-skills/wtui-flow/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: wtui-flow
+description: Participate in a wtui Flow phase by reading the active flow, using wtui plan/flow commands for persistence, and reporting any persistence failure instead of silently advancing workflow state.
+---
+
+# wtui Flow
+
+Use this skill whenever both `WTUI_FLOW_ID` and `WTUI_FLOW_PHASE_ID` are set.
+The persisted Flow record and the `wtui flow` CLI are the source of truth; this
+skill only explains how an agent should update them.
+
+## Start Every Phase
+
+Build reusable state-root arguments before running commands. `wtui flow` reads
+`WTUI_FLOW_STATE_ROOT`, but `wtui plan` does not; passing the same explicit root
+keeps Flow and plan artifacts together when a launch prompt provides a shared
+artifact root.
+
+```bash
+WTUI_ARTIFACT_ROOT="${WTUI_FLOW_STATE_ROOT:-${WTUI_PLAN_STATE_ROOT:-${WTUI_SESSION_STATE_ROOT:-}}}"
+FLOW_STATE_ARGS=()
+PLAN_STATE_ARGS=()
+if [ -n "$WTUI_ARTIFACT_ROOT" ]; then
+  FLOW_STATE_ARGS=(--state-root "$WTUI_ARTIFACT_ROOT")
+  PLAN_STATE_ARGS=(--state-root "$WTUI_ARTIFACT_ROOT")
+fi
+
+if ! wtui flow read --flow-id "$WTUI_FLOW_ID" "${FLOW_STATE_ARGS[@]}" >/dev/null; then
+  echo "wtui flow read failed; report the command error to the user." >&2
+  exit 1
+fi
+```
+
+Also use the launch metadata when present: `WTUI_FLOW_PHASE_ID`,
+`WTUI_PLAN_ID`, `WTUI_PLAN_PATH`, `WTUI_REPO_PATH`, `WTUI_WORKTREE_PATH`,
+`WTUI_BRANCH`, `WTUI_COMMIT`, `WTUI_SESSION_STATE_ROOT`, and
+`WTUI_PLAN_STATE_ROOT`.
+
+Agent-facing phase statuses are `running`, `needs_attention`, `completed`,
+`blocked`, and `skipped`. Agents cannot set `ready`; readiness is derived
+by wtui. Skipped phases require `--notes`, and restarting a blocked or
+needs-attention phase as `running` requires `--notes`.
+
+Use the current implemented phase update command:
+
+```bash
+wtui flow phase set \
+  --flow-id "$WTUI_FLOW_ID" \
+  --phase-id "$WTUI_FLOW_PHASE_ID" \
+  --status completed \
+  --outcome "approved" \
+  --summary "What changed and where the next phase should begin." \
+  --notes "Optional audit notes." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+## Persistence Failures
+
+If any `wtui flow` or `wtui plan` command exits non-zero, report the error to
+the user. These persistence failures must not be treated as successful phase
+progression. Do not say a phase advanced, a plan was saved, a PR was recorded,
+or a merge was recorded unless the corresponding command succeeded.
+
+The current Flow CLI exposes `create`, `list`, `read`, and `phase set`.
+Dedicated structured commands for child phases, plan links, PR metadata, and
+merge metadata are not part of the implemented contract yet. Until those
+commands exist, record the best available details in the current phase
+`--summary`, `--outcome`, and `--notes`, and explicitly tell the user that the
+richer metadata was not persisted as first-class Flow fields.
+
+## Plan Phase
+
+Goal: produce a saved wtui plan artifact.
+
+1. Read the flow.
+2. Save or update the plan through `wtui plan save`.
+3. Record plan progress with `wtui plan phase set` when the plan has phases.
+4. Complete or block the Flow phase with `wtui flow phase set`.
+
+```bash
+if ! PLAN_ID=$(printf '%s' "$PLAN_MARKDOWN" | wtui plan save \
+    --title "$FLOW_TITLE" \
+    --status approved \
+    --repo-path "$WTUI_REPO_PATH" \
+    --worktree-path "$WTUI_WORKTREE_PATH" \
+    --branch "$WTUI_BRANCH" \
+    "${PLAN_STATE_ARGS[@]}"); then
+  wtui flow phase set \
+    --flow-id "$WTUI_FLOW_ID" \
+    --phase-id plan \
+    --status blocked \
+    --outcome "plan_save_failed" \
+    --notes "wtui plan save failed; report the command error to the user." \
+    "${FLOW_STATE_ARGS[@]}"
+  exit 1
+fi
+
+if ! wtui plan phase set \
+    --plan-id "$PLAN_ID" \
+    --phase-id implementation \
+    --title "Implementation" \
+    --status pending \
+    --order 1 \
+    "${PLAN_STATE_ARGS[@]}"; then
+  wtui flow phase set \
+    --flow-id "$WTUI_FLOW_ID" \
+    --phase-id plan \
+    --status blocked \
+    --outcome "plan_phase_save_failed" \
+    --notes "wtui plan phase set failed for saved plan $PLAN_ID; report the command error to the user." \
+    "${FLOW_STATE_ARGS[@]}"
+  exit 1
+fi
+
+if ! wtui plan read --plan-id "$PLAN_ID" "${PLAN_STATE_ARGS[@]}" >/dev/null; then
+  wtui flow phase set \
+    --flow-id "$WTUI_FLOW_ID" \
+    --phase-id plan \
+    --status blocked \
+    --outcome "plan_read_failed" \
+    --notes "Saved plan $PLAN_ID could not be read back; report the command error to the user." \
+    "${FLOW_STATE_ARGS[@]}"
+  exit 1
+fi
+
+wtui flow phase set \
+  --flow-id "$WTUI_FLOW_ID" \
+  --phase-id plan \
+  --status completed \
+  --outcome "plan_saved" \
+  --summary "Saved plan $PLAN_ID." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+If plan persistence fails, mark the Flow phase `blocked` only if the blocking
+phase update itself succeeds; otherwise report both failures.
+
+## Plan Review Phase
+
+Goal: review the saved plan before implementation.
+
+Allowed outcomes are `approved`, `approved_with_concerns`,
+`changes_requested`, and `blocked`.
+
+Read the Flow first. Use `WTUI_PLAN_ID` when present. If it is absent, inspect
+the Plan phase summary or notes from the flow you just read; the current CLI
+does not expose a first-class plan link command yet. If you cannot recover a
+plan ID, mark Plan Review `needs_attention` or `blocked` instead of running
+`wtui plan read --plan-id ""`.
+
+```bash
+if ! wtui flow read --flow-id "$WTUI_FLOW_ID" "${FLOW_STATE_ARGS[@]}" >/dev/null; then
+  echo "wtui flow read failed; report the command error to the user." >&2
+  exit 1
+fi
+
+if [ -z "$WTUI_PLAN_ID" ]; then
+  wtui flow phase set \
+    --flow-id "$WTUI_FLOW_ID" \
+    --phase-id plan-review \
+    --status needs_attention \
+    --outcome "missing_plan_id" \
+    --notes "Plan Review needs the plan ID from the completed Plan phase." \
+    "${FLOW_STATE_ARGS[@]}"
+  exit 1
+fi
+
+if ! wtui plan read --plan-id "$WTUI_PLAN_ID" "${PLAN_STATE_ARGS[@]}" >/dev/null; then
+  wtui flow phase set \
+    --flow-id "$WTUI_FLOW_ID" \
+    --phase-id plan-review \
+    --status blocked \
+    --outcome "plan_review_read_failed" \
+    --notes "wtui plan read failed for $WTUI_PLAN_ID; report the command error to the user." \
+    "${FLOW_STATE_ARGS[@]}"
+  exit 1
+fi
+
+wtui flow phase set \
+  --flow-id "$WTUI_FLOW_ID" \
+  --phase-id plan-review \
+  --status completed \
+  --outcome "approved" \
+  --summary "Plan is ready for implementation." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+Use `--status needs_attention --outcome "changes_requested"` when the plan
+needs revision. Use `--status blocked --outcome "blocked" --notes "..."` when
+human input or an external dependency is required.
+
+## Implementation Phase
+
+Goal: implement the reviewed plan in the Flow worktree.
+
+Use `wtui plan read` when `WTUI_PLAN_ID` is available, then implement and verify
+the requested behavior. If the work splits into follow-up child phases, the
+current CLI cannot add child phases yet; record the child phase IDs and
+instructions in `--summary` or `--notes`, mark the phase `needs_attention` if
+the split needs user orchestration, and tell the user structured child phase
+persistence is not available in this CLI version.
+
+```bash
+wtui flow phase set \
+  --flow-id "$WTUI_FLOW_ID" \
+  --phase-id implementation \
+  --status completed \
+  --outcome "implemented" \
+  --summary "Implemented the accepted plan and verified the target tests." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+Use `blocked` for missing requirements or unavailable services. Use
+`needs_attention` for implementation concerns that should be reviewed before the
+workflow proceeds.
+
+## Review Loop Phase
+
+Goal: critique the implementation and drive revisions before PR creation.
+
+Run the requested review loop. Record `completed` when blocking findings are
+fixed, `needs_attention` when non-blocking concerns remain for the user, and
+`blocked` when the branch cannot be reviewed or fixed.
+
+```bash
+wtui flow phase set \
+  --flow-id "$WTUI_FLOW_ID" \
+  --phase-id review-loop \
+  --status completed \
+  --outcome "passed" \
+  --summary "Review loop passed after revisions." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+## PR Creation Phase
+
+Goal: commit, push, and open or update the pull request.
+
+After the PR exists, record the PR provider, number, URL, head branch, base
+branch, and status in the phase `--summary` or `--notes` because the current
+implemented CLI does not expose `wtui flow pr set`.
+
+```bash
+wtui flow phase set \
+  --flow-id "$WTUI_FLOW_ID" \
+  --phase-id pr-creation \
+  --status completed \
+  --outcome "pr_open" \
+  --summary "PR github#123 https://github.com/owner/repo/pull/123 head=branch base=main status=open." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+If a PR cannot be created, use `blocked` with notes explaining what failed.
+
+## Autoreview Phase
+
+Goal: perform a second-level review against the PR or pushed branch.
+
+Read the Flow first and verify PR metadata is present in the PR creation phase
+summary or notes. If it is missing, use `blocked` or `needs_attention` and say
+PR creation did not record enough metadata for autoreview.
+
+```bash
+wtui flow phase set \
+  --flow-id "$WTUI_FLOW_ID" \
+  --phase-id autoreview \
+  --status completed \
+  --outcome "passed" \
+  --summary "Autoreview passed; no blocking findings remain." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+## Merge Phase
+
+Goal: merge deliberately after review approval.
+
+Do not merge silently. After the explicit merge action succeeds, record merge
+status, commit, timestamp, and PR URL in `--summary` or `--notes` because the
+current implemented CLI does not expose `wtui flow merge set`.
+
+```bash
+wtui flow phase set \
+  --flow-id "$WTUI_FLOW_ID" \
+  --phase-id merge \
+  --status completed \
+  --outcome "merged" \
+  --summary "Merged PR github#123 at commit abc123 on 2026-06-07T00:00:00Z." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+If merge is unsafe, rejected, or waiting on CI, use `blocked` with notes.

--- a/docs/config.md
+++ b/docs/config.md
@@ -244,6 +244,15 @@ The flow state root is resolved as: `--state-root` >
 `WTUI_FLOW_STATE_ROOT` has highest precedence for the shared artifact root; if
 it is set, the TUI reads sessions, plans, and flows from that root.
 
+The canonical provider-agnostic Flow skill lives at
+`agent-skills/wtui-flow/`, beside `agent-skills/wtui-plan-persist/`. Install or
+symlink `wtui-flow` into the user-level skill directory for supported agents
+such as Codex or Claude; for Codex, a typical target is
+`~/.codex/skills/wtui-flow`. The skill activates when `WTUI_FLOW_ID` and
+`WTUI_FLOW_PHASE_ID` are present, reads the active flow with
+`wtui flow read --flow-id "$WTUI_FLOW_ID"`, and documents the implemented
+`wtui flow` / `wtui plan` commands for phase persistence.
+
 ### `[bootstrap]`
 
 Configures optional per-repo scripts that run after wtui successfully creates a


### PR DESCRIPTION
## Summary

- Add the canonical provider-agnostic `wtui-flow` skill under `agent-skills/wtui-flow/` with phase playbooks for Plan, Plan Review, Implementation, Review loop, PR creation, Autoreview, and Merge.
- Document installing/symlinking `wtui-flow` beside `wtui-plan-persist` in README/config docs.
- Add skill-content tests that guard env vars, implemented commands, phase statuses/outcomes, state-root usage, persistence failure behavior, and unsupported future flow commands.

Closes #109.

## TDD / Review Evidence

- RED: `go test ./agent-skills` failed while `agent-skills/wtui-flow/SKILL.md` and install docs were missing.
- GREEN: added the skill, docs, and content contract tests.
- Review loop: ran 5 loops (scores 7, 7, 7, 9, 9); fixed state-root propagation, missing-plan-ID handling, guarded plan persistence, guarded Plan Review reads, and unsupported-command detection.

## Verification

- `gofmt -l .`
- `make test`
- `make build`