### PR TITLE
Add Codex autoreview ship workflow

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,47 @@
+name: Codex
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number. Defaults to the most recently updated open PR.
+        required: false
+        type: string
+      instructions:
+        description: Optional instructions for the ship workflow.
+        required: false
+        type: string
+      autoreview_parallel_tests:
+        description: Optional test command Codex should run as part of the autoreview gate.
+        required: false
+        type: string
+      codex_version:
+        description: Optional @openai/codex version for openai/codex-action.
+        required: false
+        type: string
+
+jobs:
+  autoreview_ship:
+    if: |
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && (contains(github.event.comment.body, '@codex') || contains(github.event.comment.body, '@autoreview')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && (contains(github.event.comment.body, '@codex') || contains(github.event.comment.body, '@autoreview')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && (contains(github.event.review.body, '@codex') || contains(github.event.review.body, '@autoreview')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      github.event_name == 'workflow_dispatch'
+    uses: brian-bell/skills/.github/workflows/autoreview-ship.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+    secrets: inherit
+    with:
+      pr_number: ${{ github.event.inputs.pr_number || '' }}
+      instructions: ${{ github.event.inputs.instructions || '' }}
+      autoreview_parallel_tests: ${{ github.event.inputs.autoreview_parallel_tests || '' }}
+      codex_version: ${{ github.event.inputs.codex_version || '' }}


### PR DESCRIPTION
## Summary
- Add a Codex GitHub Actions caller workflow for the reusable autoreview ship workflow in brian-bell/skills.
- Enable trusted PR comments/reviews containing @codex or @autoreview to run autoreview first, then ship when the gate passes.
- Add workflow_dispatch inputs for PR number, instructions, autoreview parallel tests, and Codex version overrides.

## Safety
- Comment and review triggers are gated to OWNER, MEMBER, or COLLABORATOR author associations.
- The reusable workflow receives inherited secrets and the write permissions it needs to update PRs.

## Verification
- Parsed .github/workflows/codex.yml with Ruby YAML.
- Ran actionlint on .github/workflows/codex.yml.
- Ran the local autoreview helper with actionlint as the parallel test; it reported no accepted/actionable findings.