### PR TITLE
Add agent selection picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ filter matches, or a load failure with details in the status bar.
 | `↑`/`k` | Select previous repo |
 | `↓`/`j` | Select next repo |
 | `/` | Fuzzy filter repos |
-| `A` | Choose and persist the coding agent from a picker (`codex` or `claude`) |
+| `A` | Choose and persist the coding agent from a picker (`codex`, `codex-app`, or `claude`) |
 | `D` | Toggle destructive mode |
 | `f` | Fetch all currently visible repos with `--prune` |
 | `tab` | Switch focus to right pane |
@@ -81,7 +81,7 @@ filter matches, or a load failure with details in the status bar.
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
 | `m` | Move or rename a linked worktree (worktrees view) |
-| `A` | Choose and persist the coding agent from a picker (`codex` or `claude`) |
+| `A` | Choose and persist the coding agent from a picker (`codex`, `codex-app`, or `claude`) |
 | `a` | Launch the selected coding agent in the selected worktree |
 | `d` | Delete worktree/branch or drop stash — requires destructive mode |
 | `p` | Prune stale worktree — requires destructive mode (worktrees view) |
@@ -117,7 +117,7 @@ Each row shows the branch name (or `(detached)` for detached HEAD), status indic
 - `●` red: dirty — shows `N files +X/-Y` (lines added/deleted)
 - `✗` red: stale — worktree directory no longer exists
 
-Press `A` to choose `codex` or `claude` from a picker; wtui persists the choice to config.
+Press `A` to choose `codex`, `codex-app`, or `claude` from a picker; wtui persists the choice to config.
 Press `a` to launch the selected agent in the current non-stale worktree, or
 `N` to create a worktree and launch the agent there immediately. Press `n` to
 create a worktree without launching an agent. Enter an existing branch, tag, or

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ filter matches, or a load failure with details in the status bar.
 | `↑`/`k` | Select previous repo |
 | `↓`/`j` | Select next repo |
 | `/` | Fuzzy filter repos |
-| `A` | Choose and persist the coding agent (`codex`, `codex-app`, or `claude`) |
+| `A` | Choose and persist the coding agent from a picker (`codex` or `claude`) |
 | `D` | Toggle destructive mode |
 | `f` | Fetch all currently visible repos with `--prune` |
 | `tab` | Switch focus to right pane |
@@ -81,7 +81,7 @@ filter matches, or a load failure with details in the status bar.
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
 | `m` | Move or rename a linked worktree (worktrees view) |
-| `A` | Choose and persist the coding agent (`codex`, `codex-app`, or `claude`) |
+| `A` | Choose and persist the coding agent from a picker (`codex` or `claude`) |
 | `a` | Launch the selected coding agent in the selected worktree |
 | `d` | Delete worktree/branch or drop stash — requires destructive mode |
 | `p` | Prune stale worktree — requires destructive mode (worktrees view) |
@@ -117,7 +117,7 @@ Each row shows the branch name (or `(detached)` for detached HEAD), status indic
 - `●` red: dirty — shows `N files +X/-Y` (lines added/deleted)
 - `✗` red: stale — worktree directory no longer exists
 
-Press `A` to choose `codex`, `codex-app`, or `claude`; wtui persists the choice to config.
+Press `A` to choose `codex` or `claude` from a picker; wtui persists the choice to config.
 Press `a` to launch the selected agent in the current non-stale worktree, or
 `N` to create a worktree and launch the agent there immediately. Press `n` to
 create a worktree without launching an agent. Enter an existing branch, tag, or

--- a/docs/config.md
+++ b/docs/config.md
@@ -127,12 +127,12 @@ Parsed for future launch behavior.
 ### `[agent]`
 
 Stores the selected coding agent for interactive launches. Pressing `A` in wtui
-opens an agent picker for `codex` or `claude` and updates this value
-immediately, creating the config file if needed.
+opens an agent picker for `codex`, `codex-app`, or `claude` and updates this
+value immediately, creating the config file if needed.
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `command` | string | Supported values: `codex`, `codex-app`, or `claude`; the in-app picker offers `codex` and `claude`. |
+| `command` | string | Supported values: `codex`, `codex-app`, or `claude`. |
 | `plan_prompt` | string | Optional one-line template for the editable instructions opened by `i` in the plans pane. Supports `{title}`, `{plan_id}`, `{plan_path}`, `{repo_path}`, and `{worktree_path}`. Unknown placeholders remain literal. Blank or omitted uses the built-in prompt. |
 
 ### `[sessions]`

--- a/docs/config.md
+++ b/docs/config.md
@@ -127,11 +127,12 @@ Parsed for future launch behavior.
 ### `[agent]`
 
 Stores the selected coding agent for interactive launches. Pressing `A` in wtui
-updates this value immediately, creating the config file if needed.
+opens an agent picker for `codex` or `claude` and updates this value
+immediately, creating the config file if needed.
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `command` | string | Supported values: `codex`, `codex-app`, or `claude`. |
+| `command` | string | Supported values: `codex`, `codex-app`, or `claude`; the in-app picker offers `codex` and `claude`. |
 | `plan_prompt` | string | Optional one-line template for the editable instructions opened by `i` in the plans pane. Supports `{title}`, `{plan_id}`, `{plan_path}`, `{repo_path}`, and `{worktree_path}`. Unknown placeholders remain literal. Blank or omitted uses the built-in prompt. |
 
 ### `[sessions]`

--- a/model/modal/modal.go
+++ b/model/modal/modal.go
@@ -12,6 +12,7 @@ const (
 	None Kind = iota
 	Confirm
 	Input
+	Select
 	Diff
 	Text
 )
@@ -36,6 +37,11 @@ const (
 	Cancelled
 )
 
+type SelectItem struct {
+	Label string
+	Value string
+}
+
 // Modal is the single in-process state machine for transient modal UI. Its
 // zero value is closed.
 type Modal struct {
@@ -48,6 +54,8 @@ type Modal struct {
 	inputErr    string
 	validate    func(string) error
 	submit      func(string) tea.Cmd
+	selectItems []SelectItem
+	selectIndex int
 	diffKind    DiffKind
 	diff        string
 	text        string
@@ -62,6 +70,8 @@ type View struct {
 	Force       bool
 	Input       string
 	InputErr    string
+	SelectItems []SelectItem
+	SelectIndex int
 	DiffKind    DiffKind
 	Diff        string
 	Text        string
@@ -84,6 +94,20 @@ func OpenInput(prompt, placeholder, initial string, validate func(string) error,
 		placeholder: placeholder,
 		input:       initial,
 		validate:    validate,
+		submit:      submit,
+	}
+}
+
+func OpenSelect(prompt string, items []SelectItem, selectedIndex int, submit func(string) tea.Cmd) Modal {
+	if selectedIndex < 0 || selectedIndex >= len(items) {
+		selectedIndex = 0
+	}
+	copiedItems := append([]SelectItem(nil), items...)
+	return Modal{
+		kind:        Select,
+		prompt:      prompt,
+		selectItems: copiedItems,
+		selectIndex: selectedIndex,
 		submit:      submit,
 	}
 }
@@ -146,6 +170,8 @@ func (m Modal) View() View {
 		Force:       m.force,
 		Input:       m.input,
 		InputErr:    m.inputErr,
+		SelectItems: append([]SelectItem(nil), m.selectItems...),
+		SelectIndex: m.selectIndex,
 		DiffKind:    m.diffKind,
 		Diff:        m.diff,
 		Text:        m.text,
@@ -160,6 +186,8 @@ func (m Modal) Update(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 		return m.updateConfirm(msg)
 	case Input:
 		return m.updateInput(msg)
+	case Select:
+		return m.updateSelect(msg)
 	case Diff:
 		return m.updateDiff(msg)
 	case Text:
@@ -225,6 +253,48 @@ func (m Modal) updateInput(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 		}
 		return m, Consumed, nil
 	}
+}
+
+func (m Modal) updateSelect(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		if len(m.selectItems) == 0 {
+			return Modal{}, Accepted, nil
+		}
+		cmd := deferSubmit(m.submit, m.selectItems[m.selectIndex].Value)
+		if cmd == nil {
+			return Modal{}, Accepted, nil
+		}
+		return Modal{}, Accepted, cmd
+	case "esc", "ctrl+c":
+		return Modal{}, Cancelled, nil
+	case "down", "j":
+		m.selectIndex = nextSelectIndex(m.selectIndex, len(m.selectItems))
+		return m, Consumed, nil
+	case "up", "k":
+		m.selectIndex = previousSelectIndex(m.selectIndex, len(m.selectItems))
+		return m, Consumed, nil
+	default:
+		return m, Consumed, nil
+	}
+}
+
+func nextSelectIndex(index, length int) int {
+	if length == 0 {
+		return 0
+	}
+	return (index + 1) % length
+}
+
+func previousSelectIndex(index, length int) int {
+	if length == 0 {
+		return 0
+	}
+	index--
+	if index < 0 {
+		return length - 1
+	}
+	return index
 }
 
 func deferAction(action func() tea.Cmd) tea.Cmd {

--- a/model/modal/modal_test.go
+++ b/model/modal/modal_test.go
@@ -172,6 +172,131 @@ func TestInputInvalidSubmitStaysOpenWithError(t *testing.T) {
 	}
 }
 
+func TestSelectSnapshotsPromptItemsAndInitialSelection(t *testing.T) {
+	items := []modal.SelectItem{
+		{Label: "Codex", Value: "codex"},
+		{Label: "Claude", Value: "claude"},
+	}
+
+	view := modal.OpenSelect("Choose agent", items, 1, nil).View()
+
+	if view.Kind != modal.Select {
+		t.Fatalf("expected Select kind, got %v", view.Kind)
+	}
+	if view.Prompt != "Choose agent" {
+		t.Fatalf("expected prompt snapshot, got %q", view.Prompt)
+	}
+	if !reflect.DeepEqual(view.SelectItems, items) {
+		t.Fatalf("expected select items %#v, got %#v", items, view.SelectItems)
+	}
+	if view.SelectIndex != 1 {
+		t.Fatalf("expected selected index 1, got %d", view.SelectIndex)
+	}
+}
+
+func TestSelectMovesWithWrapping(t *testing.T) {
+	m := modal.OpenSelect("Choose agent", []modal.SelectItem{
+		{Label: "codex", Value: "codex"},
+		{Label: "claude", Value: "claude"},
+	}, 0, nil)
+
+	m, out, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if out != modal.Consumed {
+		t.Fatalf("expected Consumed for down, got %v", out)
+	}
+	if got := m.View().SelectIndex; got != 1 {
+		t.Fatalf("down selected index = %d, want 1", got)
+	}
+
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.View().SelectIndex; got != 0 {
+		t.Fatalf("down should wrap to 0, got %d", got)
+	}
+
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if got := m.View().SelectIndex; got != 1 {
+		t.Fatalf("up should wrap to 1, got %d", got)
+	}
+}
+
+func TestSelectMovesWithJKAliases(t *testing.T) {
+	m := modal.OpenSelect("Choose agent", []modal.SelectItem{
+		{Label: "codex", Value: "codex"},
+		{Label: "claude", Value: "claude"},
+	}, 0, nil)
+
+	m, out, _ := m.Update(keyRunes("j"))
+	if out != modal.Consumed {
+		t.Fatalf("expected Consumed for j, got %v", out)
+	}
+	if got := m.View().SelectIndex; got != 1 {
+		t.Fatalf("j selected index = %d, want 1", got)
+	}
+
+	m, out, _ = m.Update(keyRunes("k"))
+	if out != modal.Consumed {
+		t.Fatalf("expected Consumed for k, got %v", out)
+	}
+	if got := m.View().SelectIndex; got != 0 {
+		t.Fatalf("k selected index = %d, want 0", got)
+	}
+}
+
+func TestSelectEnterSubmitsSelectedValueAndCloses(t *testing.T) {
+	var submitted string
+	m := modal.OpenSelect("Choose agent", []modal.SelectItem{
+		{Label: "codex", Value: "codex"},
+		{Label: "claude", Value: "claude"},
+	}, 1, func(value string) tea.Cmd {
+		submitted = value
+		return func() tea.Msg { return sentinelMsg("saved") }
+	})
+
+	next, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if out != modal.Accepted {
+		t.Fatalf("expected Accepted, got %v", out)
+	}
+	if next.IsOpen() {
+		t.Fatal("expected select modal closed after enter")
+	}
+	if cmd == nil {
+		t.Fatal("expected submit command")
+	}
+	if submitted != "" {
+		t.Fatalf("expected submit deferred until command runs, got %q", submitted)
+	}
+	if got := cmd(); got != sentinelMsg("saved") {
+		t.Fatalf("expected sentinel message, got %T %[1]v", got)
+	}
+	if submitted != "claude" {
+		t.Fatalf("expected submitted value %q, got %q", "claude", submitted)
+	}
+}
+
+func TestSelectCancelClosesWithoutSubmit(t *testing.T) {
+	for _, key := range []tea.KeyMsg{{Type: tea.KeyEscape}, {Type: tea.KeyCtrlC}} {
+		m := modal.OpenSelect("Choose agent", []modal.SelectItem{
+			{Label: "codex", Value: "codex"},
+		}, 0, func(string) tea.Cmd {
+			t.Fatal("cancel must not invoke submit")
+			return nil
+		})
+
+		next, out, cmd := m.Update(key)
+
+		if out != modal.Cancelled {
+			t.Fatalf("expected Cancelled for %q, got %v", key.String(), out)
+		}
+		if next.IsOpen() {
+			t.Fatalf("expected modal closed for %q", key.String())
+		}
+		if cmd != nil {
+			t.Fatalf("expected nil command for %q, got %T", key.String(), cmd)
+		}
+	}
+}
+
 func TestDiffScrollsClampsAndCloses(t *testing.T) {
 	m := modal.OpenDiff(modal.DiffWorktree, "line 1\nline 2")
 

--- a/model/model.go
+++ b/model/model.go
@@ -393,6 +393,9 @@ func (m Model) View() string {
 		WorktreeInputPlaceholder: modalView.Placeholder,
 		WorktreeInput:            modalView.Input,
 		WorktreeInputErr:         modalView.InputErr,
+		SelectPrompt:             modalView.Prompt,
+		SelectItems:              uiSelectItems(modalView.SelectItems),
+		SelectSelected:           modalView.SelectIndex,
 		BranchScroll:             branchScroll,
 		RepoScroll:               repoScroll,
 		StashScroll:              stashScroll,
@@ -565,6 +568,8 @@ func (m Model) overlayState() ui.OverlayState {
 		return ui.OverlayConfirm
 	case modal.Input:
 		return ui.OverlayWorktreeInput
+	case modal.Select:
+		return ui.OverlayAgentSelect
 	case modal.Diff:
 		switch view.DiffKind {
 		case modal.DiffStash:
@@ -584,6 +589,17 @@ func (m Model) overlayState() ui.OverlayState {
 		return ui.OverlayPlanText
 	}
 	return ui.OverlayNone
+}
+
+func uiSelectItems(items []modal.SelectItem) []ui.SelectItem {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]ui.SelectItem, len(items))
+	for i, item := range items {
+		out[i] = ui.SelectItem{Label: item.Label, Value: item.Value}
+	}
+	return out
 }
 
 func (m Model) openPlanText() Model {

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3119,7 +3119,7 @@ func TestModel_NewWithOptionsStoresCodexAppAgent(t *testing.T) {
 	}
 }
 
-func TestModel_ShiftAOpensAgentInputFromBothPanes(t *testing.T) {
+func TestModel_ShiftAOpensAgentSelectFromBothPanes(t *testing.T) {
 	for _, setup := range []struct {
 		name string
 		fn   func(model.Model) model.Model
@@ -3130,20 +3130,51 @@ func TestModel_ShiftAOpensAgentInputFromBothPanes(t *testing.T) {
 		t.Run(setup.name, func(t *testing.T) {
 			m := setup.fn(model.New(testRepos()))
 			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
-			if m.Overlay() != ui.OverlayWorktreeInput {
-				t.Fatalf("expected agent input overlay, got %d", m.Overlay())
+			if m.Overlay() != ui.OverlayAgentSelect {
+				t.Fatalf("expected agent select overlay, got %d", m.Overlay())
 			}
-			if !strings.Contains(m.View(), "codex, codex-app, or claude") {
-				t.Fatalf("expected agent prompt in view")
+			view := m.View()
+			for _, want := range []string{"Choose interactive helper", "codex", "claude"} {
+				if !strings.Contains(view, want) {
+					t.Fatalf("expected agent select view to contain %q", want)
+				}
 			}
 			if cmd != nil {
-				t.Fatalf("expected nil cmd opening agent input, got %T", cmd)
+				t.Fatalf("expected nil cmd opening agent select, got %T", cmd)
 			}
 		})
 	}
 }
 
-func TestModel_AgentInputSavesAndSetsCodex(t *testing.T) {
+func TestModel_ShiftAAgentSelectPreselectsCurrentAgent(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		agent     string
+		wantCodex bool
+	}{
+		{name: "unset", wantCodex: true},
+		{name: "invalid", agent: "codex-app", wantCodex: true},
+		{name: "claude", agent: "claude", wantCodex: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: tt.agent})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+			view := m.View()
+
+			if tt.wantCodex {
+				if !strings.Contains(view, "> codex") {
+					t.Fatalf("expected codex selected in view:\n%s", view)
+				}
+				return
+			}
+			if !strings.Contains(view, "> claude") {
+				t.Fatalf("expected claude selected in view:\n%s", view)
+			}
+		})
+	}
+}
+
+func TestModel_AgentSelectSavesAndSetsCodex(t *testing.T) {
 	var saved string
 	m := model.NewWithOptions(testRepos(), model.Options{
 		SaveAgentCommand: func(command string) error {
@@ -3152,7 +3183,6 @@ func TestModel_AgentInputSavesAndSetsCodex(t *testing.T) {
 		},
 	})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("codex")})
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if m.Overlay() != ui.OverlayNone {
 		t.Fatalf("expected overlay closed, got %d", m.Overlay())
@@ -3169,10 +3199,10 @@ func TestModel_AgentInputSavesAndSetsCodex(t *testing.T) {
 	}
 }
 
-func TestModel_AgentInputSavesAndSetsClaude(t *testing.T) {
+func TestModel_AgentSelectDownSavesAndSetsClaude(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("claude")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd == nil {
 		t.Fatal("expected save-agent command")
@@ -3183,7 +3213,7 @@ func TestModel_AgentInputSavesAndSetsClaude(t *testing.T) {
 	}
 }
 
-func TestModel_AgentInputSavesAndSetsCodexApp(t *testing.T) {
+func TestModel_AgentSelectUpWrapSavesAndSetsClaude(t *testing.T) {
 	var saved string
 	m := model.NewWithOptions(testRepos(), model.Options{
 		SaveAgentCommand: func(command string) error {
@@ -3192,17 +3222,43 @@ func TestModel_AgentInputSavesAndSetsCodexApp(t *testing.T) {
 		},
 	})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(" CoDeX-App ")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd == nil {
 		t.Fatal("expected save-agent command")
 	}
 	m, _ = update(m, cmd())
-	if saved != "codex-app" {
-		t.Fatalf("expected saved codex-app, got %q", saved)
+	if saved != "claude" {
+		t.Fatalf("expected saved claude, got %q", saved)
 	}
-	if m.AgentCommand() != "codex-app" {
-		t.Fatalf("expected session agent codex-app, got %q", m.AgentCommand())
+	if m.AgentCommand() != "claude" {
+		t.Fatalf("expected session agent claude, got %q", m.AgentCommand())
+	}
+}
+
+func TestModel_AgentSelectEscCancelsWithoutSaving(t *testing.T) {
+	saveCalled := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "claude",
+		SaveAgentCommand: func(string) error {
+			saveCalled = true
+			return nil
+		},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEscape})
+
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected overlay closed, got %d", m.Overlay())
+	}
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for cancel, got %T", cmd)
+	}
+	if saveCalled {
+		t.Fatal("cancel should not call SaveAgentCommand")
+	}
+	if m.AgentCommand() != "claude" {
+		t.Fatalf("expected agent unchanged, got %q", m.AgentCommand())
 	}
 }
 
@@ -3211,7 +3267,6 @@ func TestModel_AgentSaveFailureKeepsSessionChoiceAndShowsStatus(t *testing.T) {
 		SaveAgentCommand: func(string) error { return errors.New("disk full") },
 	})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("codex")})
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd == nil {
 		t.Fatal("expected save-agent command")

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3134,7 +3134,7 @@ func TestModel_ShiftAOpensAgentSelectFromBothPanes(t *testing.T) {
 				t.Fatalf("expected agent select overlay, got %d", m.Overlay())
 			}
 			view := m.View()
-			for _, want := range []string{"Choose interactive helper", "codex", "claude"} {
+			for _, want := range []string{"Choose interactive helper", "codex", "codex-app", "claude"} {
 				if !strings.Contains(view, want) {
 					t.Fatalf("expected agent select view to contain %q", want)
 				}
@@ -3148,27 +3148,22 @@ func TestModel_ShiftAOpensAgentSelectFromBothPanes(t *testing.T) {
 
 func TestModel_ShiftAAgentSelectPreselectsCurrentAgent(t *testing.T) {
 	for _, tt := range []struct {
-		name      string
-		agent     string
-		wantCodex bool
+		name         string
+		agent        string
+		wantSelected string
 	}{
-		{name: "unset", wantCodex: true},
-		{name: "invalid", agent: "codex-app", wantCodex: true},
-		{name: "claude", agent: "claude", wantCodex: false},
+		{name: "unset", wantSelected: "codex"},
+		{name: "invalid", agent: "unsupported", wantSelected: "codex"},
+		{name: "codex-app", agent: "codex-app", wantSelected: "codex-app"},
+		{name: "claude", agent: "claude", wantSelected: "claude"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: tt.agent})
 			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
 			view := m.View()
 
-			if tt.wantCodex {
-				if !strings.Contains(view, "> codex") {
-					t.Fatalf("expected codex selected in view:\n%s", view)
-				}
-				return
-			}
-			if !strings.Contains(view, "> claude") {
-				t.Fatalf("expected claude selected in view:\n%s", view)
+			if !strings.Contains(view, "> "+tt.wantSelected) {
+				t.Fatalf("expected %s selected in view:\n%s", tt.wantSelected, view)
 			}
 		})
 	}
@@ -3203,6 +3198,7 @@ func TestModel_AgentSelectDownSavesAndSetsClaude(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd == nil {
 		t.Fatal("expected save-agent command")
@@ -3210,6 +3206,29 @@ func TestModel_AgentSelectDownSavesAndSetsClaude(t *testing.T) {
 	m, _ = update(m, cmd())
 	if m.AgentCommand() != "claude" {
 		t.Fatalf("expected session agent claude, got %q", m.AgentCommand())
+	}
+}
+
+func TestModel_AgentSelectDownSavesAndSetsCodexApp(t *testing.T) {
+	var saved string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SaveAgentCommand: func(command string) error {
+			saved = command
+			return nil
+		},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected save-agent command")
+	}
+	m, _ = update(m, cmd())
+	if saved != "codex-app" {
+		t.Fatalf("expected saved codex-app, got %q", saved)
+	}
+	if m.AgentCommand() != "codex-app" {
+		t.Fatalf("expected session agent codex-app, got %q", m.AgentCommand())
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -496,14 +496,17 @@ func (m Model) handleSetAgent() (tea.Model, tea.Cmd) {
 func agentSelectItems() []modal.SelectItem {
 	return []modal.SelectItem{
 		{Label: agent.CommandCodex, Value: agent.CommandCodex},
+		{Label: agent.CommandCodexApp, Value: agent.CommandCodexApp},
 		{Label: agent.CommandClaude, Value: agent.CommandClaude},
 	}
 }
 
 func selectedAgentIndex(command string) int {
 	switch agent.Normalize(command) {
-	case agent.CommandClaude:
+	case agent.CommandCodexApp:
 		return 1
+	case agent.CommandClaude:
+		return 2
 	default:
 		return 0
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -484,18 +484,29 @@ func (m Model) handleDelete() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleSetAgent() (tea.Model, tea.Cmd) {
-	m.modal = modal.OpenInput(
-		"Set agent ("+ui.AgentInputPlaceholder+")",
-		ui.AgentInputPlaceholder,
-		m.agentCommand,
-		validateAgentInput,
-		func(input string) tea.Cmd { return m.setAgent(agent.Normalize(input)) },
+	m.modal = modal.OpenSelect(
+		"Choose interactive helper",
+		agentSelectItems(),
+		selectedAgentIndex(m.agentCommand),
+		func(value string) tea.Cmd { return m.setAgent(agent.Normalize(value)) },
 	)
 	return m, nil
 }
 
-func validateAgentInput(input string) error {
-	return agent.Validate(input)
+func agentSelectItems() []modal.SelectItem {
+	return []modal.SelectItem{
+		{Label: agent.CommandCodex, Value: agent.CommandCodex},
+		{Label: agent.CommandClaude, Value: agent.CommandClaude},
+	}
+}
+
+func selectedAgentIndex(command string) int {
+	switch agent.Normalize(command) {
+	case agent.CommandClaude:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func (m Model) setAgent(command string) tea.Cmd {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -29,6 +29,7 @@ const (
 	OverlaySessionTranscript
 	OverlayPlanText
 	OverlayWorktreeInput
+	OverlayAgentSelect
 )
 
 const BranchPrompt = "New branch"
@@ -45,7 +46,12 @@ const FlowBaseRefInputPlaceholder = "optional base ref"
 const WorktreeMoveInputPlaceholder = "new path or sibling name"
 const BranchInputPlaceholder = "branch name"
 const PRWorktreeInputPlaceholder = "PR number or URL"
-const AgentInputPlaceholder = "codex, codex-app, or claude"
+const AgentInputPlaceholder = "codex or claude"
+
+type SelectItem struct {
+	Label string
+	Value string
+}
 
 // Mode represents the active right-pane view. The model owns the application
 // state, but the renderer needs the same typed value (and the model imports ui,
@@ -180,6 +186,9 @@ type RenderParams struct {
 	WorktreeInputPlaceholder string
 	WorktreeInput            string
 	WorktreeInputErr         string
+	SelectPrompt             string
+	SelectItems              []SelectItem
+	SelectSelected           int
 	BranchScroll             int
 	RepoScroll               int
 	StashScroll              int
@@ -598,6 +607,8 @@ func renderStatusBarWithState(sp statusBarParams) string {
 			return statusStyle.Width(width).Render("  enter: launch  esc: cancel  backspace: delete")
 		}
 		return statusStyle.Width(width).Render("  enter: create/set  esc: cancel  backspace: delete")
+	case overlay == OverlayAgentSelect:
+		return statusStyle.Width(width).Render("  up/down select  enter: confirm  esc: cancel")
 	case overlay != OverlayNone:
 		return statusStyle.Width(width).Render("  ↑/↓ scroll  esc: close")
 	}
@@ -1722,6 +1733,10 @@ func renderOverlay(p RenderParams) string {
 		lines := renderWorktreeInputDialog(p.WorktreeInputPrompt, p.WorktreeInputPlaceholder, p.WorktreeInput, p.WorktreeInputErr, p.Width, contentHeight)
 		return strings.Join(lines, "\n") + "\n" + statusBar
 	}
+	if p.Overlay == OverlayAgentSelect {
+		lines := renderSelectDialog(p.SelectPrompt, p.SelectItems, p.SelectSelected, p.Width, contentHeight)
+		return strings.Join(lines, "\n") + "\n" + statusBar
+	}
 	if p.Overlay == OverlayPlanText {
 		lines := renderPlainTextOverlay(p.OverlayText, p.OverlayScroll, p.Width, contentHeight)
 		return strings.Join(lines, "\n") + "\n" + statusBar
@@ -1784,6 +1799,44 @@ func renderConfirmDialog(prompt string, force bool, width, height int) []string 
 			style = dirtyRedStyle.Bold(true)
 		}
 		lines[mid] = strings.Repeat(" ", pad) + style.Render(prompt)
+	}
+	return lines
+}
+
+func renderSelectDialog(prompt string, items []SelectItem, selected int, width, height int) []string {
+	lines := make([]string, height)
+	if height <= 0 {
+		return lines
+	}
+	if prompt == "" {
+		prompt = "Choose"
+	}
+	if selected < 0 || selected >= len(items) {
+		selected = 0
+	}
+
+	blockHeight := len(items) + 1
+	start := (height - blockHeight) / 2
+	if start < 0 {
+		start = 0
+	}
+	if start < len(lines) {
+		lines[start] = centeredLine(activeModeStyle.Render(prompt), width)
+	}
+	for i, item := range items {
+		row := start + 1 + i
+		if row >= len(lines) {
+			break
+		}
+		label := item.Label
+		if label == "" {
+			label = item.Value
+		}
+		line := "  " + label
+		if i == selected {
+			line = selectedStyle.Render("> " + label)
+		}
+		lines[row] = centeredLine(line, width)
 	}
 	return lines
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -46,7 +46,7 @@ const FlowBaseRefInputPlaceholder = "optional base ref"
 const WorktreeMoveInputPlaceholder = "new path or sibling name"
 const BranchInputPlaceholder = "branch name"
 const PRWorktreeInputPlaceholder = "PR number or URL"
-const AgentInputPlaceholder = "codex or claude"
+const AgentInputPlaceholder = "codex, codex-app, or claude"
 
 type SelectItem struct {
 	Label string

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1974,11 +1974,11 @@ func TestRender_AgentSelectDialogShowsPromptItemsAndSelection(t *testing.T) {
 		Mode:           1,
 		Overlay:        OverlayAgentSelect,
 		SelectPrompt:   "Choose interactive helper",
-		SelectItems:    []SelectItem{{Label: "codex", Value: "codex"}, {Label: "claude", Value: "claude"}},
-		SelectSelected: 1,
+		SelectItems:    []SelectItem{{Label: "codex", Value: "codex"}, {Label: "codex-app", Value: "codex-app"}, {Label: "claude", Value: "claude"}},
+		SelectSelected: 2,
 	})
 	stripped := ansi.Strip(view)
-	for _, want := range []string{"Choose interactive helper", "codex", "claude"} {
+	for _, want := range []string{"Choose interactive helper", "codex", "codex-app", "claude"} {
 		if !strings.Contains(stripped, want) {
 			t.Fatalf("agent select dialog should show %q:\n%s", want, stripped)
 		}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -521,6 +521,18 @@ func TestStatusBar_WorktreeInputOverlayShowsInputHints(t *testing.T) {
 	}
 }
 
+func TestStatusBar_AgentSelectOverlayShowsSelectHints(t *testing.T) {
+	bar := RenderStatusBar(120, 1, OverlayAgentSelect, 1, false, false, false)
+	for _, hint := range []string{"up/down select", "enter: confirm", "esc: cancel"} {
+		if !strings.Contains(bar, hint) {
+			t.Errorf("expected hint %q in agent select overlay bar %q", hint, bar)
+		}
+	}
+	if strings.Contains(bar, "backspace: delete") {
+		t.Fatalf("agent select status should not show text-input hint: %q", bar)
+	}
+}
+
 func TestStatusBar_LaunchInstructionsOverlayShowsLaunchHint(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:                    []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
@@ -1954,21 +1966,25 @@ func TestRender_PullRequestWorktreeInputDialogShowsPromptAndPlaceholder(t *testi
 	}
 }
 
-func TestRender_AgentInputDialogUsesExplicitPlaceholder(t *testing.T) {
+func TestRender_AgentSelectDialogShowsPromptItemsAndSelection(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:                    []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:                    80,
-		Height:                   24,
-		Mode:                     1,
-		Overlay:                  OverlayWorktreeInput,
-		WorktreeInputPrompt:      "Choose interactive helper",
-		WorktreeInputPlaceholder: AgentInputPlaceholder,
+		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:          80,
+		Height:         24,
+		Mode:           1,
+		Overlay:        OverlayAgentSelect,
+		SelectPrompt:   "Choose interactive helper",
+		SelectItems:    []SelectItem{{Label: "codex", Value: "codex"}, {Label: "claude", Value: "claude"}},
+		SelectSelected: 1,
 	})
-	if !strings.Contains(view, "Choose interactive helper:") {
-		t.Error("agent input dialog should show caller-provided prompt")
+	stripped := ansi.Strip(view)
+	for _, want := range []string{"Choose interactive helper", "codex", "claude"} {
+		if !strings.Contains(stripped, want) {
+			t.Fatalf("agent select dialog should show %q:\n%s", want, stripped)
+		}
 	}
-	if !strings.Contains(view, AgentInputPlaceholder) {
-		t.Error("agent input dialog should show caller-provided placeholder")
+	if !strings.Contains(stripped, "> claude") {
+		t.Fatalf("agent select dialog should mark selected choice:\n%s", stripped)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the typed Shift+A agent command input with a fixed codex/claude select modal
- add generic modal select state and wire it through model render params and UI overlay rendering
- update agent picker docs and cover modal, model, and UI behavior with tests

## Verification
- go test ./model/modal
- go test ./model -run 'Agent|ShiftA'
- go test ./ui -run 'Agent|StatusBar.*Overlay'
- gofmt -l .
- env -u WTUI_FLOW_STATE_ROOT -u WTUI_PLAN_STATE_ROOT -u WTUI_SESSION_STATE_ROOT -u WTUI_PLAN_ID -u WTUI_PLAN_PATH -u WTUI_AGENT -u WTUI_BRANCH -u WTUI_COMMIT -u WTUI_LAUNCH_ID -u WTUI_REPO_PATH -u WTUI_WORKTREE_PATH make test
- env -u WTUI_FLOW_STATE_ROOT -u WTUI_PLAN_STATE_ROOT -u WTUI_SESSION_STATE_ROOT -u WTUI_PLAN_ID -u WTUI_PLAN_PATH -u WTUI_AGENT -u WTUI_BRANCH -u WTUI_COMMIT -u WTUI_LAUNCH_ID -u WTUI_REPO_PATH -u WTUI_WORKTREE_PATH make build

## Review loop
- pass 1: 9/10, added j/k alias coverage
- pass 2: 9/10, no blocking issues