### PR TITLE
Let wtui Codex launches inherit user settings

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -825,11 +825,10 @@ func envWithOverrides(overrides ...envVar) []string {
 }
 
 func agentEnvironment(command string, overrides ...envVar) []string {
-	filter := keepEnvVar
 	if command == agent.CommandCodex {
-		filter = keepCodexChildEnvVar
+		return envWithOverridesMatching(keepCodexChildEnvVar, overrides...)
 	}
-	return envWithOverridesMatching(filter, overrides...)
+	return envWithOverridesMatching(nil, overrides...)
 }
 
 func envWithOverridesMatching(keep func(string) bool, overrides ...envVar) []string {
@@ -857,11 +856,10 @@ func envWithOverridesMatching(keep func(string) bool, overrides ...envVar) []str
 	return env
 }
 
-func keepEnvVar(string) bool {
-	return true
-}
-
 func keepCodexChildEnvVar(key string) bool {
+	// These are known parent Codex runtime/session markers. A wtui launch
+	// should start a fresh interactive Codex CLI that reads user config; other
+	// CODEX_* variables are intentionally preserved for user config/auth.
 	switch key {
 	case "CODEX_CI", "CODEX_SANDBOX", "CODEX_SHELL", "CODEX_THREAD_ID":
 		return false

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -699,7 +699,7 @@ func agentCommandSpec(ctx AgentLaunchContext) (*exec.Cmd, []envVar, error) {
 		{key: "WTUI_FLOW_ID", value: ctx.FlowID},
 		{key: "WTUI_FLOW_PHASE_ID", value: ctx.FlowPhaseID},
 	}
-	cmd.Env = envWithOverrides(overrides...)
+	cmd.Env = agentEnvironment(command, overrides...)
 	return cmd, overrides, nil
 }
 
@@ -821,6 +821,18 @@ func envWithoutPrefix(prefix string) []string {
 }
 
 func envWithOverrides(overrides ...envVar) []string {
+	return envWithOverridesMatching(nil, overrides...)
+}
+
+func agentEnvironment(command string, overrides ...envVar) []string {
+	filter := keepEnvVar
+	if command == agent.CommandCodex {
+		filter = keepCodexChildEnvVar
+	}
+	return envWithOverridesMatching(filter, overrides...)
+}
+
+func envWithOverridesMatching(keep func(string) bool, overrides ...envVar) []string {
 	overrideKeys := make(map[string]struct{}, len(overrides))
 	for _, item := range overrides {
 		overrideKeys[item.key] = struct{}{}
@@ -833,6 +845,9 @@ func envWithOverrides(overrides ...envVar) []string {
 			if _, found := overrideKeys[key]; found {
 				continue
 			}
+			if keep != nil && !keep(key) {
+				continue
+			}
 		}
 		env = append(env, entry)
 	}
@@ -840,6 +855,19 @@ func envWithOverrides(overrides ...envVar) []string {
 		env = append(env, item.key+"="+item.value)
 	}
 	return env
+}
+
+func keepEnvVar(string) bool {
+	return true
+}
+
+func keepCodexChildEnvVar(key string) bool {
+	switch key {
+	case "CODEX_CI", "CODEX_SANDBOX", "CODEX_SHELL", "CODEX_THREAD_ID":
+		return false
+	}
+	return !strings.HasPrefix(key, "CODEX_INTERNAL_") &&
+		!strings.HasPrefix(key, "CODEX_SANDBOX_")
 }
 
 // ResolveWorktreeCommit returns HEAD for path, or "" when path is not a git

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1794,6 +1794,73 @@ func TestAgentCommandReplacesInheritedWTUIEnvironment(t *testing.T) {
 	}
 }
 
+func TestAgentCommandCodexScrubsParentRuntimeEnvironment(t *testing.T) {
+	for key, value := range map[string]string{
+		"CODEX_CI":                           "1",
+		"CODEX_HOME":                         "/user/codex-home",
+		"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop",
+		"CODEX_SANDBOX":                      "restricted",
+		"CODEX_SANDBOX_MODE":                 "workspace-write",
+		"CODEX_SHELL":                        "1",
+		"CODEX_THREAD_ID":                    "parent-thread",
+		"OPENAI_API_KEY":                     "api-key",
+	} {
+		t.Setenv(key, value)
+	}
+
+	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
+		Command:      "codex",
+		LaunchID:     "launch-1",
+		RepoPath:     "/repo",
+		WorktreePath: "/repo/worktree",
+	})
+	if err != nil {
+		t.Fatalf("AgentCommand returned error: %v", err)
+	}
+
+	env := envMap(cmd.Env)
+	for _, key := range []string{
+		"CODEX_CI",
+		"CODEX_INTERNAL_ORIGINATOR_OVERRIDE",
+		"CODEX_SANDBOX",
+		"CODEX_SANDBOX_MODE",
+		"CODEX_SHELL",
+		"CODEX_THREAD_ID",
+	} {
+		if _, found := env[key]; found {
+			t.Fatalf("codex child env should scrub %s, got %#v", key, cmd.Env)
+		}
+	}
+	for key, want := range map[string]string{
+		"CODEX_HOME":     "/user/codex-home",
+		"OPENAI_API_KEY": "api-key",
+		"WTUI_AGENT":     "codex",
+		"WTUI_LAUNCH_ID": "launch-1",
+	} {
+		if env[key] != want {
+			t.Fatalf("%s = %q, want %q in env %#v", key, env[key], want, cmd.Env)
+		}
+	}
+}
+
+func TestAgentCommandClaudeKeepsCodexEnvironment(t *testing.T) {
+	t.Setenv("CODEX_THREAD_ID", "parent-thread")
+
+	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
+		Command:      "claude",
+		LaunchID:     "launch-1",
+		RepoPath:     "/repo",
+		WorktreePath: "/repo/worktree",
+	})
+	if err != nil {
+		t.Fatalf("AgentCommand returned error: %v", err)
+	}
+
+	if got := envMap(cmd.Env)["CODEX_THREAD_ID"]; got != "parent-thread" {
+		t.Fatalf("CODEX_THREAD_ID = %q, want inherited parent-thread in %#v", got, cmd.Env)
+	}
+}
+
 func TestAgentCommandClaudeAddsPromptAsFinalArg(t *testing.T) {
 	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
 		Command:       "claude",

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1803,7 +1803,10 @@ func TestAgentCommandCodexScrubsParentRuntimeEnvironment(t *testing.T) {
 		"CODEX_SANDBOX_MODE":                 "workspace-write",
 		"CODEX_SHELL":                        "1",
 		"CODEX_THREAD_ID":                    "parent-thread",
+		"CODEX_USER_SETTING":                 "keep-me",
+		"HOME":                               "/home/user",
 		"OPENAI_API_KEY":                     "api-key",
+		"PATH":                               "/user/bin:/bin",
 	} {
 		t.Setenv(key, value)
 	}
@@ -1832,10 +1835,13 @@ func TestAgentCommandCodexScrubsParentRuntimeEnvironment(t *testing.T) {
 		}
 	}
 	for key, want := range map[string]string{
-		"CODEX_HOME":     "/user/codex-home",
-		"OPENAI_API_KEY": "api-key",
-		"WTUI_AGENT":     "codex",
-		"WTUI_LAUNCH_ID": "launch-1",
+		"CODEX_HOME":         "/user/codex-home",
+		"CODEX_USER_SETTING": "keep-me",
+		"HOME":               "/home/user",
+		"OPENAI_API_KEY":     "api-key",
+		"PATH":               "/user/bin:/bin",
+		"WTUI_AGENT":         "codex",
+		"WTUI_LAUNCH_ID":     "launch-1",
 	} {
 		if env[key] != want {
 			t.Fatalf("%s = %q, want %q in env %#v", key, env[key], want, cmd.Env)
@@ -1844,7 +1850,16 @@ func TestAgentCommandCodexScrubsParentRuntimeEnvironment(t *testing.T) {
 }
 
 func TestAgentCommandClaudeKeepsCodexEnvironment(t *testing.T) {
-	t.Setenv("CODEX_THREAD_ID", "parent-thread")
+	for key, value := range map[string]string{
+		"CODEX_CI":                           "1",
+		"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop",
+		"CODEX_SANDBOX":                      "restricted",
+		"CODEX_SANDBOX_MODE":                 "workspace-write",
+		"CODEX_SHELL":                        "1",
+		"CODEX_THREAD_ID":                    "parent-thread",
+	} {
+		t.Setenv(key, value)
+	}
 
 	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
 		Command:      "claude",
@@ -1856,8 +1871,18 @@ func TestAgentCommandClaudeKeepsCodexEnvironment(t *testing.T) {
 		t.Fatalf("AgentCommand returned error: %v", err)
 	}
 
-	if got := envMap(cmd.Env)["CODEX_THREAD_ID"]; got != "parent-thread" {
-		t.Fatalf("CODEX_THREAD_ID = %q, want inherited parent-thread in %#v", got, cmd.Env)
+	env := envMap(cmd.Env)
+	for key, want := range map[string]string{
+		"CODEX_CI":                           "1",
+		"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop",
+		"CODEX_SANDBOX":                      "restricted",
+		"CODEX_SANDBOX_MODE":                 "workspace-write",
+		"CODEX_SHELL":                        "1",
+		"CODEX_THREAD_ID":                    "parent-thread",
+	} {
+		if env[key] != want {
+			t.Fatalf("%s = %q, want inherited %q in %#v", key, env[key], want, cmd.Env)
+		}
 	}
 }
 

--- a/actions/agent_launch_internal_test.go
+++ b/actions/agent_launch_internal_test.go
@@ -414,6 +414,17 @@ func TestClaudeSessionHookSettingsEncodesJSONString(t *testing.T) {
 }
 
 func TestCodexAppLaunchOpensNewThreadDeepLink(t *testing.T) {
+	for key, value := range map[string]string{
+		"CODEX_CI":                           "1",
+		"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop",
+		"CODEX_SANDBOX":                      "restricted",
+		"CODEX_SANDBOX_MODE":                 "workspace-write",
+		"CODEX_SHELL":                        "1",
+		"CODEX_THREAD_ID":                    "parent-thread",
+		"CODEX_USER_SETTING":                 "keep-me",
+	} {
+		t.Setenv(key, value)
+	}
 	t.Setenv("WTUI_LAUNCH_ID", "inherited-launch")
 	launch, err := agentLaunch(AgentLaunchContext{
 		Command:       "codex-app",
@@ -430,6 +441,20 @@ func TestCodexAppLaunchOpensNewThreadDeepLink(t *testing.T) {
 		t.Fatalf("expected open command to have no working dir, got %q", launch.Cmd.Dir)
 	}
 	assertNoWTUIEnv(t, launch.Cmd.Environ())
+	env := envMapInternal(launch.Cmd.Environ())
+	for key, want := range map[string]string{
+		"CODEX_CI":                           "1",
+		"CODEX_INTERNAL_ORIGINATOR_OVERRIDE": "Codex Desktop",
+		"CODEX_SANDBOX":                      "restricted",
+		"CODEX_SANDBOX_MODE":                 "workspace-write",
+		"CODEX_SHELL":                        "1",
+		"CODEX_THREAD_ID":                    "parent-thread",
+		"CODEX_USER_SETTING":                 "keep-me",
+	} {
+		if env[key] != want {
+			t.Fatalf("%s = %q, want inherited %q in %#v", key, env[key], want, launch.Cmd.Environ())
+		}
+	}
 	if !reflect.DeepEqual(launch.Cmd.Args[:1], []string{"open"}) {
 		t.Fatalf("unexpected codex-app args: %#v", launch.Cmd.Args)
 	}
@@ -670,4 +695,15 @@ func assertNoWTUIEnv(t *testing.T, env []string) {
 			t.Fatalf("expected codex-app open command to scrub WTUI env, found %q in %#v", key, env)
 		}
 	}
+}
+
+func envMapInternal(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			out[key] = value
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## Summary
- Scrub parent Codex runtime markers before wtui starts a child `codex` CLI session.
- Preserve user-level Codex/auth environment such as `CODEX_HOME`, `HOME`, `PATH`, and `OPENAI_API_KEY` so launched sessions read normal user settings.
- Add regression tests for the Codex-specific environment scrub while confirming Claude launch environment behavior is unchanged.

## Why
wtui can be launched from inside a Codex session. In that case, child Codex launches inherited parent runtime markers such as `CODEX_THREAD_ID`, `CODEX_SHELL`, `CODEX_CI`, and sandbox-related env, making them behave like nested sessions instead of fresh user-level Codex CLI sessions.

## Verification
- `make test`
- `make build`
- `gofmt -l .`

## Caveat
This makes wtui inherit the effective user Codex config cleanly; Full Access still depends on the user-level Codex config/profile declaring that mode.