### PR TITLE
Move release snapshot out of PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,23 +28,3 @@ jobs:
 
       - name: Build
         run: make build
-
-  release-snapshot:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Build release snapshot
-        uses: goreleaser/goreleaser-action@v7
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --snapshot --clean --skip=publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,0 +1,30 @@
+name: Release Snapshot
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build release snapshot
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/release.md
+++ b/docs/release.md
@@ -28,8 +28,7 @@ HOMEBREW_TAP_GITHUB_TOKEN
 ## Cutting a Release
 
 1. Land the release changes on `main`.
-2. Wait for CI, including the `release-snapshot` job in
-   `.github/workflows/ci.yml`, to pass.
+2. Wait for CI and the `Release Snapshot` workflow to pass.
 3. Optional local check if GoReleaser is installed:
 
    ```bash


### PR DESCRIPTION
## Summary
- Remove the GoReleaser snapshot job from the PR-triggered CI workflow.
- Add a dedicated `Release Snapshot` workflow that runs on `push` to `main` and manual dispatch.
- Update release docs to point at the new workflow.

## Testing
- `gofmt` check passed.
- `make test` passed.
- `make build` passed.
- YAML parsing for the updated workflow files passed.