### PR TITLE
Add Clear Dark UI theme

### DIFF
--- a/ui/theme.go
+++ b/ui/theme.go
@@ -1,0 +1,141 @@
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+type themePalette struct {
+	bg          lipgloss.Color
+	fg          lipgloss.Color
+	fgStrong    lipgloss.Color
+	muted       lipgloss.Color
+	borderMuted lipgloss.Color
+	focus       lipgloss.Color
+	info        lipgloss.Color
+	success     lipgloss.Color
+	warning     lipgloss.Color
+	danger      lipgloss.Color
+	special     lipgloss.Color
+	selectionBg lipgloss.Color
+	selectionFg lipgloss.Color
+}
+
+type themeStyles struct {
+	palette           themePalette
+	repo              lipgloss.Style
+	selected          lipgloss.Style
+	placeholder       lipgloss.Style
+	status            lipgloss.Style
+	branch            lipgloss.Style
+	clean             lipgloss.Style
+	commit            lipgloss.Style
+	activeMode        lipgloss.Style
+	inactiveMode      lipgloss.Style
+	shortcutTitle     lipgloss.Style
+	shortcutMode      lipgloss.Style
+	shortcutGroup     lipgloss.Style
+	shortcutKey       lipgloss.Style
+	shortcutText      lipgloss.Style
+	stashDate         lipgloss.Style
+	stashMsg          lipgloss.Style
+	stashSelected     lipgloss.Style
+	branchSelected    lipgloss.Style
+	root              lipgloss.Style
+	locked            lipgloss.Style
+	noUpstream        lipgloss.Style
+	aheadBehind       lipgloss.Style
+	merged            lipgloss.Style
+	dirty             lipgloss.Style
+	diffAdd           lipgloss.Style
+	diffDel           lipgloss.Style
+	diffHeader        lipgloss.Style
+	activeBorder      lipgloss.Color
+	inactiveBorder    lipgloss.Color
+	destructiveBorder lipgloss.Color
+}
+
+var clearDarkPalette = themePalette{
+	bg:          lipgloss.Color("#191D27"),
+	fg:          lipgloss.Color("#E0E0E0"),
+	fgStrong:    lipgloss.Color("#E5EFF5"),
+	muted:       lipgloss.Color("#465C6D"),
+	borderMuted: lipgloss.Color("#35424C"),
+	focus:       lipgloss.Color("#67B5ED"),
+	info:        lipgloss.Color("#84DDE0"),
+	success:     lipgloss.Color("#79BE7E"),
+	warning:     lipgloss.Color("#E5C872"),
+	danger:      lipgloss.Color("#DF6C5A"),
+	special:     lipgloss.Color("#D389E5"),
+	selectionBg: lipgloss.Color("#273D4C"),
+	selectionFg: lipgloss.Color("#E5EFF5"),
+}
+
+var clearDarkTheme = newThemeStyles(clearDarkPalette)
+
+func newThemeStyles(p themePalette) themeStyles {
+	selected := lipgloss.NewStyle().
+		Foreground(p.selectionFg).
+		Background(p.selectionBg).
+		Bold(true)
+	return themeStyles{
+		palette:           p,
+		repo:              lipgloss.NewStyle().Foreground(p.success),
+		selected:          selected,
+		placeholder:       lipgloss.NewStyle().Foreground(p.muted).Italic(true),
+		status:            lipgloss.NewStyle().Foreground(p.muted),
+		branch:            lipgloss.NewStyle().Foreground(p.fgStrong).Bold(true),
+		clean:             lipgloss.NewStyle().Foreground(p.success),
+		commit:            lipgloss.NewStyle().Foreground(p.muted),
+		activeMode:        lipgloss.NewStyle().Foreground(p.focus).Bold(true),
+		inactiveMode:      lipgloss.NewStyle().Foreground(p.muted),
+		shortcutTitle:     lipgloss.NewStyle().Foreground(p.fgStrong).Bold(true),
+		shortcutMode:      lipgloss.NewStyle().Foreground(p.focus).Bold(true),
+		shortcutGroup:     lipgloss.NewStyle().Foreground(p.info).Bold(true),
+		shortcutKey:       lipgloss.NewStyle().Foreground(p.focus).Bold(true),
+		shortcutText:      lipgloss.NewStyle().Foreground(p.fg),
+		stashDate:         lipgloss.NewStyle().Foreground(p.muted),
+		stashMsg:          lipgloss.NewStyle().Foreground(p.fgStrong),
+		stashSelected:     selected,
+		branchSelected:    selected,
+		root:              lipgloss.NewStyle().Foreground(p.focus),
+		locked:            lipgloss.NewStyle().Foreground(p.info),
+		noUpstream:        lipgloss.NewStyle().Foreground(p.special),
+		aheadBehind:       lipgloss.NewStyle().Foreground(p.warning),
+		merged:            lipgloss.NewStyle().Foreground(p.info),
+		dirty:             lipgloss.NewStyle().Foreground(p.danger),
+		diffAdd:           lipgloss.NewStyle().Foreground(p.success),
+		diffDel:           lipgloss.NewStyle().Foreground(p.danger),
+		diffHeader:        lipgloss.NewStyle().Foreground(p.info),
+		activeBorder:      p.focus,
+		inactiveBorder:    p.borderMuted,
+		destructiveBorder: p.danger,
+	}
+}
+
+var (
+	repoStyle          = clearDarkTheme.repo
+	selectedStyle      = clearDarkTheme.selected
+	placeholderStyle   = clearDarkTheme.placeholder
+	statusStyle        = clearDarkTheme.status
+	branchStyle        = clearDarkTheme.branch
+	cleanStyle         = clearDarkTheme.clean
+	commitStyle        = clearDarkTheme.commit
+	activeModeStyle    = clearDarkTheme.activeMode
+	inactiveModeStyle  = clearDarkTheme.inactiveMode
+	shortcutTitleStyle = clearDarkTheme.shortcutTitle
+	shortcutModeStyle  = clearDarkTheme.shortcutMode
+	shortcutGroupStyle = clearDarkTheme.shortcutGroup
+	shortcutKeyStyle   = clearDarkTheme.shortcutKey
+	shortcutTextStyle  = clearDarkTheme.shortcutText
+	stashDateStyle     = clearDarkTheme.stashDate
+	stashMsgStyle      = clearDarkTheme.stashMsg
+	stashSelStyle      = clearDarkTheme.stashSelected
+	branchSelStyle     = clearDarkTheme.branchSelected
+	rootStyle          = clearDarkTheme.root
+	lockedStyle        = clearDarkTheme.locked
+	noUpstreamStyle    = clearDarkTheme.noUpstream
+	aheadBehindStyle   = clearDarkTheme.aheadBehind
+	mergedStyle        = clearDarkTheme.merged
+	dirtyRedStyle      = clearDarkTheme.dirty
+	diffAddStyle       = clearDarkTheme.diffAdd
+	diffDelStyle       = clearDarkTheme.diffDel
+	diffHdrStyle       = clearDarkTheme.diffHeader
+)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1185,8 +1185,7 @@ func renderBranchPaneSelected(rows []gitquery.BranchRow, selected, scroll, width
 
 		line := "   " + branch + indicators + locationLabel
 		if i == selected {
-			selectedLine := truncateToWidth(" > "+strings.TrimPrefix(ansi.Strip(line), "   "), width)
-			line = branchSelStyle.Width(width).Render(selectedLine)
+			line = renderSelectedBranchRow(row, repoPath, width)
 		}
 		content = append(content, line)
 
@@ -1206,6 +1205,40 @@ func renderBranchPaneSelected(rows []gitquery.BranchRow, selected, scroll, width
 
 	truncateLines(content, width)
 	return scrollAndPad(content, scroll, height)
+}
+
+func renderSelectedBranchRow(row gitquery.BranchRow, repoPath string, width int) string {
+	b := row.Branch
+	line := selectedStyle.Render(" > ") + selectedSegment(branchStyle, b.Name)
+
+	var indicators string
+	if b.Ahead > 0 || b.Behind > 0 {
+		indicators += selectedSegment(aheadBehindStyle, " ●")
+		indicators += selectedStyle.Render(fmt.Sprintf(" +%d/-%d", b.Ahead, b.Behind))
+	}
+	if b.Dirty {
+		indicators += renderSelectedDirtyIndicator(b.FilesChanged, b.LinesAdded, b.LinesDeleted)
+	}
+	if !b.HasUpstream || b.UpstreamGone {
+		indicators += selectedSegment(noUpstreamStyle, " ●")
+	}
+	if b.Merged {
+		indicators += selectedSegment(mergedStyle, " merged")
+	}
+	if indicators == "" {
+		indicators = selectedSegment(cleanStyle, " ✔")
+	}
+	line += indicators
+
+	if row.WorktreePath != "" {
+		line += selectedStyle.Render(" ")
+		if repoPath != "" && row.WorktreePath == repoPath {
+			line += selectedSegment(rootStyle, "[root]")
+		} else {
+			line += selectedSegment(commitStyle, fmt.Sprintf("[%s]", row.WorktreePath))
+		}
+	}
+	return renderSelectedRow(line, width)
 }
 
 // StashLineCount returns the number of visual lines a stash entry occupies
@@ -1786,14 +1819,48 @@ func renderWorktreePane(worktrees []gitquery.Worktree, selected, scroll, width, 
 
 		line := "   " + name + indicators + rootLabel + path
 		if i == selected {
-			selectedLine := truncateToWidth(" > "+strings.TrimPrefix(ansi.Strip(line), "   "), width)
-			line = branchSelStyle.Width(width).Render(selectedLine)
+			line = renderSelectedWorktreeRow(wt, width)
 		}
 		content = append(content, line)
 	}
 
 	truncateLines(content, width)
 	return scrollAndPad(content, scroll, height)
+}
+
+func renderSelectedWorktreeRow(wt gitquery.Worktree, width int) string {
+	name := wt.BranchName
+	if wt.Detached {
+		name = "(detached)"
+	}
+	line := selectedStyle.Render(" > ") + selectedSegment(branchStyle, name)
+
+	if wt.Locked {
+		line += renderSelectedLockedIndicator(wt.LockReason)
+		if !wt.Stale {
+			if wt.Dirty {
+				line += renderSelectedDirtyIndicator(wt.FilesChanged, wt.LinesAdded, wt.LinesDeleted)
+			} else {
+				line += selectedSegment(cleanStyle, " ✔")
+			}
+		}
+	} else if wt.Stale {
+		line += selectedSegment(dirtyRedStyle, " ✗")
+		line += selectedStyle.Render(" ")
+		line += selectedSegment(dirtyRedStyle, "stale")
+	} else if wt.Dirty {
+		line += renderSelectedDirtyIndicator(wt.FilesChanged, wt.LinesAdded, wt.LinesDeleted)
+	} else {
+		line += selectedSegment(cleanStyle, " ✔")
+	}
+
+	if wt.IsMain {
+		line += selectedStyle.Render(" ")
+		line += selectedSegment(rootStyle, "[root]")
+	}
+	line += selectedStyle.Render(" ")
+	line += selectedSegment(commitStyle, wt.Path)
+	return renderSelectedRow(line, width)
 }
 
 func renderOverlay(p RenderParams) string {
@@ -2135,12 +2202,7 @@ func truncateToWidth(s string, maxWidth int) string {
 	if lipgloss.Width(s) <= maxWidth {
 		return s
 	}
-	// Strip ANSI, truncate runes, re-measure. Crude but correct for our use.
-	runes := []rune(s)
-	for len(runes) > 0 && lipgloss.Width(string(runes)) > maxWidth {
-		runes = runes[:len(runes)-1]
-	}
-	return string(runes)
+	return ansi.Truncate(s, maxWidth, "")
 }
 
 // scrollAndPad applies a scroll offset to content and returns a zero-padded
@@ -2172,6 +2234,15 @@ func renderDirtyIndicator(filesChanged, linesAdded, linesDeleted int) string {
 	return s
 }
 
+func renderSelectedDirtyIndicator(filesChanged, linesAdded, linesDeleted int) string {
+	s := selectedSegment(dirtyRedStyle, " ●")
+	s += selectedStyle.Render(fmt.Sprintf(" %d files ", filesChanged))
+	s += selectedSegment(diffAddStyle, fmt.Sprintf("+%d", linesAdded))
+	s += selectedStyle.Render("/")
+	s += selectedSegment(diffDelStyle, fmt.Sprintf("-%d", linesDeleted))
+	return s
+}
+
 // MaxLockReasonWidth caps the visible width of a lock reason in the worktree
 // pane so a long reason cannot push the path off the end of the line.
 const MaxLockReasonWidth = 40
@@ -2182,6 +2253,29 @@ func renderLockedIndicator(reason string) string {
 		s += " " + lockedStyle.Render(truncateReason(reason, MaxLockReasonWidth))
 	}
 	return s
+}
+
+func renderSelectedLockedIndicator(reason string) string {
+	s := selectedSegment(lockedStyle, " 🔒")
+	s += selectedStyle.Render(" ")
+	s += selectedSegment(lockedStyle, "locked")
+	if reason != "" {
+		s += selectedStyle.Render(" ")
+		s += selectedSegment(lockedStyle, truncateReason(reason, MaxLockReasonWidth))
+	}
+	return s
+}
+
+func selectedSegment(style lipgloss.Style, text string) string {
+	return style.Background(clearDarkTheme.palette.selectionBg).Bold(true).Render(text)
+}
+
+func renderSelectedRow(line string, width int) string {
+	line = truncateToWidth(line, width)
+	if padding := width - lipgloss.Width(line); padding > 0 {
+		line += selectedStyle.Render(strings.Repeat(" ", padding))
+	}
+	return line
 }
 
 func truncateReason(s string, max int) string {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -130,42 +130,6 @@ const FlowContentOverhead = BranchContentOverhead + TableHeaderRows
 // indent/cursor (3) + date (10) + separator (2).
 const StashPrefixWidth = 15
 
-// ANSI palette codes used below (8-/16-color + 256-color grays):
-//
-//	5   = magenta        6   = cyan          9   = bright red
-//	10  = bright green   11  = bright yellow  12  = bright blue
-//	14  = bright cyan    15  = bright white   238 = dark gray
-//	241 = medium gray
-var (
-	repoStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))                          // 10 = bright green
-	selectedStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true).Reverse(true) // 10 = bright green
-	placeholderStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Italic(true)            // 241 = medium gray
-	statusStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
-	branchStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)               // 15 = bright white
-	cleanStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))                          // 10 = bright green
-	commitStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
-	activeModeStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)               // 15 = bright white
-	inactiveModeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
-	shortcutTitleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true)               // 15 = bright white
-	shortcutModeStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)               // 12 = bright blue
-	shortcutGroupStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Bold(true)               // 14 = bright cyan
-	shortcutKeyStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("12")).Bold(true)               // 12 = bright blue
-	shortcutTextStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("250"))                         // 250 = light gray
-	stashDateStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))                         // 241 = medium gray
-	stashMsgStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))                          // 15 = bright white
-	stashSelStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Bold(true).Reverse(true) // 15 = bright white
-	branchSelStyle     = lipgloss.NewStyle().Bold(true).Reverse(true)
-	rootStyle          = lipgloss.NewStyle().Foreground(lipgloss.Color("12")) // 12 = bright blue
-	lockedStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("14")) // 14 = bright cyan
-	noUpstreamStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))  // 5 = magenta
-	aheadBehindStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("11")) // 11 = bright yellow
-	mergedStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))  // 6 = cyan
-	dirtyRedStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))  // 9 = bright red
-	diffAddStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("10")) // 10 = bright green
-	diffDelStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))  // 9 = bright red
-	diffHdrStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("14")) // 14 = bright cyan
-)
-
 // RenderParams holds everything the renderer needs.
 type RenderParams struct {
 	Repos                    []scanner.Repo
@@ -316,10 +280,10 @@ func Render(p RenderParams) string {
 	showShortcutPane := !hasActiveStatusQuery(status) && shouldRenderShortcutPane(p.Width, innerHeight, status)
 	statusBar := renderFooterStatusBar(status, !showShortcutPane)
 
-	// Border colors based on active pane
-	activeBorderColor := lipgloss.Color("12")
-	inactiveBorderColor := lipgloss.Color("238")
-	destructiveBorderColor := lipgloss.Color("9")
+	// Border colors based on active pane.
+	activeBorderColor := clearDarkTheme.activeBorder
+	inactiveBorderColor := clearDarkTheme.inactiveBorder
+	destructiveBorderColor := clearDarkTheme.destructiveBorder
 
 	leftBorderColor := inactiveBorderColor
 	rightBorderColor := inactiveBorderColor
@@ -902,9 +866,9 @@ func renderFooterShortcuts(sp statusBarParams, sections []shortcutSection) strin
 func transientStatusStyle(fadeStep int) lipgloss.Style {
 	switch fadeStep {
 	case 1:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+		return lipgloss.NewStyle().Foreground(clearDarkTheme.palette.muted)
 	case 2:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
+		return lipgloss.NewStyle().Foreground(clearDarkTheme.palette.borderMuted)
 	default:
 		return dirtyRedStyle
 	}
@@ -1221,7 +1185,8 @@ func renderBranchPaneSelected(rows []gitquery.BranchRow, selected, scroll, width
 
 		line := "   " + branch + indicators + locationLabel
 		if i == selected {
-			line = branchSelStyle.Render(" > " + strings.TrimPrefix(line, "   "))
+			selectedLine := truncateToWidth(" > "+strings.TrimPrefix(ansi.Strip(line), "   "), width)
+			line = branchSelStyle.Width(width).Render(selectedLine)
 		}
 		content = append(content, line)
 
@@ -1821,7 +1786,8 @@ func renderWorktreePane(worktrees []gitquery.Worktree, selected, scroll, width, 
 
 		line := "   " + name + indicators + rootLabel + path
 		if i == selected {
-			line = branchSelStyle.Render(" > " + strings.TrimPrefix(line, "   "))
+			selectedLine := truncateToWidth(" > "+strings.TrimPrefix(ansi.Strip(line), "   "), width)
+			line = branchSelStyle.Width(width).Render(selectedLine)
 		}
 		content = append(content, line)
 	}
@@ -2064,7 +2030,7 @@ func renderLaunchInstructionsDialog(promptText, placeholder, input, errText stri
 	}
 	panel := lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder()).
-		BorderForeground(lipgloss.Color("12")).
+		BorderForeground(clearDarkTheme.activeBorder).
 		Width(contentWidth + 2).
 		Render(strings.Join(content, "\n"))
 	panelLines := strings.Split(panel, "\n")

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1713,6 +1713,27 @@ func TestBranchPane_RootAnnotationUsesBlueStyle(t *testing.T) {
 	}
 }
 
+func TestBranchPane_SelectedRowPreservesSemanticIndicatorStyles(t *testing.T) {
+	rows := []gitquery.BranchRow{
+		{Branch: gitquery.Branch{Name: "feat", HasUpstream: true, Ahead: 2, Dirty: true, IsWorktree: true,
+			FilesChanged: 1, LinesAdded: 5, LinesDeleted: 2}},
+	}
+	lines := renderBranchPaneSelected(rows, 0, 0, 80, 10, "")
+	joined := strings.Join(lines, "\n")
+	for _, styled := range []string{
+		selectedSegment(aheadBehindStyle, " ●"),
+		selectedStyle.Render(" +2/-0"),
+		selectedSegment(dirtyRedStyle, " ●"),
+		selectedStyle.Render(" 1 files "),
+		selectedSegment(diffAddStyle, "+5"),
+		selectedSegment(diffDelStyle, "-2"),
+	} {
+		if !strings.Contains(joined, styled) {
+			t.Fatalf("selected branch row should preserve semantic style %q in:\n%s", styled, joined)
+		}
+	}
+}
+
 func TestBranchPane_NonWorktreeNoAnnotation(t *testing.T) {
 	rows := []gitquery.BranchRow{
 		{Branch: gitquery.Branch{Name: "feat", HasUpstream: true, IsWorktree: false}},
@@ -2469,6 +2490,25 @@ func TestWorktreePane_CursorHighlight(t *testing.T) {
 	joined := strings.Join(lines, "\n")
 	if !strings.Contains(joined, "> feat") {
 		t.Error("expected '> feat' cursor on second item")
+	}
+}
+
+func TestWorktreePane_SelectedRowPreservesSemanticIndicatorStyles(t *testing.T) {
+	wts := []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true, Locked: true, LockReason: "review"},
+		{Path: "/dev/alpha-feat", BranchName: "feat", Dirty: true, FilesChanged: 2, LinesAdded: 7, LinesDeleted: 3},
+	}
+	lines := renderWorktreePane(wts, 1, 0, 100, 10)
+	joined := strings.Join(lines, "\n")
+	for _, styled := range []string{
+		selectedSegment(dirtyRedStyle, " ●"),
+		selectedStyle.Render(" 2 files "),
+		selectedSegment(diffAddStyle, "+7"),
+		selectedSegment(diffDelStyle, "-3"),
+	} {
+		if !strings.Contains(joined, styled) {
+			t.Fatalf("selected worktree row should preserve semantic style %q in:\n%s", styled, joined)
+		}
 	}
 }
 

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -13,6 +13,57 @@ import (
 	"github.com/brian-bell/wtui/sessions"
 )
 
+func TestClearDarkThemeUsesSemanticTruecolorPalette(t *testing.T) {
+	requireStyleColor(t, "repo foreground", repoStyle.GetForeground(), clearDarkPalette.success)
+	requireStyleColor(t, "branch foreground", branchStyle.GetForeground(), clearDarkPalette.fgStrong)
+	requireStyleColor(t, "status foreground", statusStyle.GetForeground(), clearDarkPalette.muted)
+	requireStyleColor(t, "root foreground", rootStyle.GetForeground(), clearDarkPalette.focus)
+	requireStyleColor(t, "locked foreground", lockedStyle.GetForeground(), clearDarkPalette.info)
+	requireStyleColor(t, "ahead behind foreground", aheadBehindStyle.GetForeground(), clearDarkPalette.warning)
+	requireStyleColor(t, "dirty foreground", dirtyRedStyle.GetForeground(), clearDarkPalette.danger)
+	requireStyleColor(t, "no upstream foreground", noUpstreamStyle.GetForeground(), clearDarkPalette.special)
+	requireStyleColor(t, "diff add foreground", diffAddStyle.GetForeground(), clearDarkPalette.success)
+	requireStyleColor(t, "diff del foreground", diffDelStyle.GetForeground(), clearDarkPalette.danger)
+	requireStyleColor(t, "diff header foreground", diffHdrStyle.GetForeground(), clearDarkPalette.info)
+}
+
+func TestClearDarkThemeSelectedRowsUseExplicitSelectionColors(t *testing.T) {
+	selectedStyles := map[string]lipgloss.Style{
+		"repo":   selectedStyle,
+		"stash":  stashSelStyle,
+		"branch": branchSelStyle,
+	}
+	for name, style := range selectedStyles {
+		if style.GetReverse() {
+			t.Fatalf("%s selected style should not use reverse video", name)
+		}
+		requireStyleColor(t, name+" foreground", style.GetForeground(), clearDarkPalette.selectionFg)
+		requireStyleColor(t, name+" background", style.GetBackground(), clearDarkPalette.selectionBg)
+		if !style.GetBold() {
+			t.Fatalf("%s selected style should be bold", name)
+		}
+	}
+}
+
+func TestClearDarkThemeBordersUseFocusAndMutedTokens(t *testing.T) {
+	if clearDarkTheme.activeBorder != clearDarkPalette.focus {
+		t.Fatalf("active border = %v, want %v", clearDarkTheme.activeBorder, clearDarkPalette.focus)
+	}
+	if clearDarkTheme.inactiveBorder != clearDarkPalette.borderMuted {
+		t.Fatalf("inactive border = %v, want %v", clearDarkTheme.inactiveBorder, clearDarkPalette.borderMuted)
+	}
+	if clearDarkTheme.destructiveBorder != clearDarkPalette.danger {
+		t.Fatalf("destructive border = %v, want %v", clearDarkTheme.destructiveBorder, clearDarkPalette.danger)
+	}
+}
+
+func requireStyleColor(t *testing.T, name string, got lipgloss.TerminalColor, want lipgloss.Color) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s = %v, want %v", name, got, want)
+	}
+}
+
 func TestStatusBar_BranchesModeContainsIndicatorLegend(t *testing.T) {
 	bar := RenderStatusBar(120, 2, 0, 1, true, false, false)
 	for _, legend := range []string{"✔ clean", "● ahead/behind", "● dirty", "● no upstream", "merged"} {


### PR DESCRIPTION
## Summary
- introduce a named Clear Dark UI theme with centralized palette and role helpers
- update rendering to consume the theme instead of inline lipgloss colors
- add theme coverage for key style roles and color choices

## Verification
- gofmt -l .
- make test
- make build