### PR TITLE
Deepen model list fetch handling

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -746,7 +746,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m = m.clearFlowCreateRequest(msg.Request)
 		next, launchCmd := m.launchAgentWithContext(msg.LaunchContext)
 		if msg.LaunchContext.FlowID != "" && next.mode == ui.ModeFlows {
-			next, fetchCmd := next.startFetchFlows()
+			next, fetchCmd := next.startFetchMode(ui.ModeFlows)
 			return next, tea.Batch(fetchCmd, launchCmd)
 		}
 		return next, launchCmd
@@ -774,7 +774,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m, resultErr = m.markFlowLaunchNeedsAttention(msg.LaunchContext, resultErr)
 			m = m.setStatus(statusOther, resultErr)
 			if msg.LaunchContext.FlowID != "" && m.mode == ui.ModeFlows {
-				return m.startFetchFlows()
+				return m.startFetchMode(ui.ModeFlows)
 			}
 		} else if msg.Detached {
 			m = m.setStatus(statusOther, agentLaunchedStatus(msg.LaunchContext.Command))
@@ -789,7 +789,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ActionFailedMsg:
 		next := m.handleActionFailed(msg)
 		if next.mode == ui.ModeFlows && next.isCurrentRepo(msg.RepoPath) {
-			return next.startFetchFlows()
+			return next.startFetchMode(ui.ModeFlows)
 		}
 		return next, nil
 	}

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -22,48 +22,11 @@ const visibleRepoFetchStatusTTL = 3 * time.Second
 const visibleRepoFetchFadeStepDuration = 1 * time.Second
 
 func (m Model) startFetchForMode() (Model, tea.Cmd) {
-	switch m.mode {
-	case ui.ModeWorktrees:
-		return m.startFetchWorktrees()
-	case ui.ModeBranches:
-		return m.startFetchBranches()
-	case ui.ModeStashes:
-		return m.startFetchStashes()
-	case ui.ModeHistory:
-		return m.startFetchCommits()
-	case ui.ModeReflog:
-		return m.startFetchReflog()
-	case ui.ModeSessions:
-		return m.startFetchSessions()
-	case ui.ModePlans:
-		return m.startFetchPlans()
-	case ui.ModeFlows:
-		return m.startFetchFlows()
-	}
-	return m, nil
+	return m.startFetchMode(m.mode)
 }
 
 func (m Model) fetchForMode() tea.Cmd {
-	request := m.currentListRequest(m.mode)
-	switch m.mode {
-	case ui.ModeWorktrees:
-		return m.fetchWorktrees(request)
-	case ui.ModeBranches:
-		return m.fetchBranches(request)
-	case ui.ModeStashes:
-		return m.fetchStashes(request)
-	case ui.ModeHistory:
-		return m.fetchCommits(request)
-	case ui.ModeReflog:
-		return m.fetchReflog(request)
-	case ui.ModeSessions:
-		return m.fetchSessions(request)
-	case ui.ModePlans:
-		return m.fetchPlans(request)
-	case ui.ModeFlows:
-		return m.fetchFlows(request)
-	}
-	return nil
+	return m.fetchMode(m.mode, m.currentListRequest(m.mode))
 }
 
 func (m Model) currentListRequest(mode ui.Mode) uint64 {
@@ -116,47 +79,6 @@ func (m Model) clearFlowCreateRequest(request uint64) Model {
 	return m
 }
 
-func (m Model) startFetchWorktrees() (Model, tea.Cmd) {
-	m, request := m.nextListFetchRequest(ui.ModeWorktrees)
-	return m, m.fetchWorktrees(request)
-}
-
-func (m Model) startFetchBranches() (Model, tea.Cmd) {
-	m, request := m.nextListFetchRequest(ui.ModeBranches)
-	return m, m.fetchBranches(request)
-}
-
-func (m Model) startFetchStashes() (Model, tea.Cmd) {
-	m, request := m.nextListFetchRequest(ui.ModeStashes)
-	return m, m.fetchStashes(request)
-}
-
-func (m Model) startFetchCommits() (Model, tea.Cmd) {
-	m, request := m.nextListFetchRequest(ui.ModeHistory)
-	return m, m.fetchCommits(request)
-}
-
-func (m Model) startFetchReflog() (Model, tea.Cmd) {
-	m, request := m.nextListFetchRequest(ui.ModeReflog)
-	return m, m.fetchReflog(request)
-}
-
-func (m Model) startFetchSessions() (Model, tea.Cmd) {
-	m, request := m.nextListFetchRequest(ui.ModeSessions)
-	return m, m.fetchSessions(request)
-}
-
-func (m Model) startFetchPlans() (Model, tea.Cmd) {
-	m, request := m.nextListFetchRequest(ui.ModePlans)
-	m = m.setExpandedPlanID("")
-	return m, m.fetchPlans(request)
-}
-
-func (m Model) startFetchFlows() (Model, tea.Cmd) {
-	m, request := m.nextListFetchRequest(ui.ModeFlows)
-	return m, m.fetchFlows(request)
-}
-
 func (m Model) startFetchVisibleRepos() (Model, tea.Cmd) {
 	if m.visibleRepoFetch.Request != 0 {
 		return m, nil
@@ -195,6 +117,169 @@ func (m Model) startFetchVisibleRepos() (Model, tea.Cmd) {
 		CapturedPaths: capturedPaths,
 	}
 	return m, tea.Batch(cmds...)
+}
+
+type listFetchDescriptor struct {
+	mode        ui.Mode
+	pane        string
+	errorPrefix string
+	load        func(Model, string, uint64) (tea.Msg, error)
+	beforeStart func(Model) Model
+}
+
+func listFetchDescriptorForMode(mode ui.Mode) (listFetchDescriptor, bool) {
+	switch mode {
+	case ui.ModeWorktrees:
+		return listFetchDescriptor{
+			mode:        ui.ModeWorktrees,
+			pane:        "worktrees",
+			errorPrefix: "failed to load worktrees",
+			load: func(_ Model, repoPath string, request uint64) (tea.Msg, error) {
+				worktrees, err := gitquery.ListWorktrees(repoPath)
+				if err != nil {
+					return nil, err
+				}
+				return WorktreeResultMsg{RepoPath: repoPath, Worktrees: worktrees, ListRequest: request}, nil
+			},
+		}, true
+	case ui.ModeBranches:
+		return listFetchDescriptor{
+			mode:        ui.ModeBranches,
+			pane:        "branches",
+			errorPrefix: "failed to load branches",
+			load: func(_ Model, repoPath string, request uint64) (tea.Msg, error) {
+				branches, err := gitquery.ListBranches(repoPath)
+				if err != nil {
+					return nil, err
+				}
+				return BranchResultMsg{RepoPath: repoPath, Branches: branches, ListRequest: request}, nil
+			},
+		}, true
+	case ui.ModeStashes:
+		return listFetchDescriptor{
+			mode:        ui.ModeStashes,
+			pane:        "stashes",
+			errorPrefix: "failed to load stashes",
+			load: func(_ Model, repoPath string, request uint64) (tea.Msg, error) {
+				stashes, err := gitquery.ListStashes(repoPath)
+				if err != nil {
+					return nil, err
+				}
+				return StashResultMsg{RepoPath: repoPath, Stashes: stashes, ListRequest: request}, nil
+			},
+		}, true
+	case ui.ModeHistory:
+		return listFetchDescriptor{
+			mode:        ui.ModeHistory,
+			pane:        "history",
+			errorPrefix: "failed to load commits",
+			load: func(_ Model, repoPath string, request uint64) (tea.Msg, error) {
+				commits, err := gitquery.ListCommits(repoPath)
+				if err != nil {
+					return nil, err
+				}
+				return CommitResultMsg{RepoPath: repoPath, Commits: commits, ListRequest: request}, nil
+			},
+		}, true
+	case ui.ModeReflog:
+		return listFetchDescriptor{
+			mode:        ui.ModeReflog,
+			pane:        "reflog",
+			errorPrefix: "failed to load reflog",
+			load: func(_ Model, repoPath string, request uint64) (tea.Msg, error) {
+				reflogs, err := gitquery.ListReflog(repoPath)
+				if err != nil {
+					return nil, err
+				}
+				return ReflogResultMsg{RepoPath: repoPath, Reflogs: reflogs, ListRequest: request}, nil
+			},
+		}, true
+	case ui.ModeSessions:
+		return listFetchDescriptor{
+			mode:        ui.ModeSessions,
+			pane:        "sessions",
+			errorPrefix: "failed to load sessions",
+			load: func(m Model, repoPath string, request uint64) (tea.Msg, error) {
+				records, err := m.listSessions(sessions.SessionFilter{RepoPath: repoPath})
+				if err != nil {
+					return nil, err
+				}
+				return SessionResultMsg{RepoPath: repoPath, Sessions: records, ListRequest: request}, nil
+			},
+		}, true
+	case ui.ModePlans:
+		return listFetchDescriptor{
+			mode:        ui.ModePlans,
+			pane:        "plans",
+			errorPrefix: "failed to load plans",
+			beforeStart: func(m Model) Model {
+				return m.setExpandedPlanID("")
+			},
+			load: func(m Model, repoPath string, request uint64) (tea.Msg, error) {
+				records, err := m.listPlans(planstore.PlanFilter{RepoPath: repoPath})
+				if err != nil {
+					return nil, err
+				}
+				return PlanResultMsg{RepoPath: repoPath, Plans: records, ListRequest: request}, nil
+			},
+		}, true
+	case ui.ModeFlows:
+		return listFetchDescriptor{
+			mode:        ui.ModeFlows,
+			pane:        "flows",
+			errorPrefix: "failed to load flows",
+			load: func(m Model, repoPath string, request uint64) (tea.Msg, error) {
+				records, err := m.listFlows(flowstore.FlowFilter{RepoPath: repoPath})
+				if err != nil {
+					return nil, err
+				}
+				return FlowResultMsg{RepoPath: repoPath, Flows: records, ListRequest: request}, nil
+			},
+		}, true
+	default:
+		return listFetchDescriptor{}, false
+	}
+}
+
+func (m Model) startFetchMode(mode ui.Mode) (Model, tea.Cmd) {
+	desc, ok := listFetchDescriptorForMode(mode)
+	if !ok {
+		return m, nil
+	}
+	m, request := m.nextListFetchRequest(desc.mode)
+	if desc.beforeStart != nil {
+		m = desc.beforeStart(m)
+	}
+	return m, m.fetchList(desc, request)
+}
+
+func (m Model) fetchMode(mode ui.Mode, request uint64) tea.Cmd {
+	desc, ok := listFetchDescriptorForMode(mode)
+	if !ok {
+		return nil
+	}
+	return m.fetchList(desc, request)
+}
+
+func (m Model) fetchList(desc listFetchDescriptor, request uint64) tea.Cmd {
+	repoPath, ok := m.currentRepoPath()
+	if !ok {
+		return nil
+	}
+	return func() tea.Msg {
+		msg, err := desc.load(m, repoPath, request)
+		if err != nil {
+			return FetchErrorMsg{
+				RepoPath:    repoPath,
+				Pane:        desc.pane,
+				Err:         fmt.Sprintf("%s: %v", desc.errorPrefix, err),
+				Kind:        FetchList,
+				Mode:        desc.mode,
+				ListRequest: request,
+			}
+		}
+		return msg
+	}
 }
 
 func (m Model) canFetch() bool {
@@ -444,48 +529,6 @@ func createdWorktreeBranch(worktreePath, ref string, kind actions.WorktreeCreate
 	return ""
 }
 
-func (m Model) fetchWorktrees(request uint64) tea.Cmd {
-	repoPath, ok := m.currentRepoPath()
-	if !ok {
-		return nil
-	}
-	return func() tea.Msg {
-		worktrees, err := gitquery.ListWorktrees(repoPath)
-		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "worktrees", Err: fmt.Sprintf("failed to load worktrees: %v", err), Kind: FetchList, Mode: ui.ModeWorktrees, ListRequest: request}
-		}
-		return WorktreeResultMsg{RepoPath: repoPath, Worktrees: worktrees, ListRequest: request}
-	}
-}
-
-func (m Model) fetchBranches(request uint64) tea.Cmd {
-	repoPath, ok := m.currentRepoPath()
-	if !ok {
-		return nil
-	}
-	return func() tea.Msg {
-		branches, err := gitquery.ListBranches(repoPath)
-		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "branches", Err: fmt.Sprintf("failed to load branches: %v", err), Kind: FetchList, Mode: ui.ModeBranches, ListRequest: request}
-		}
-		return BranchResultMsg{RepoPath: repoPath, Branches: branches, ListRequest: request}
-	}
-}
-
-func (m Model) fetchStashes(request uint64) tea.Cmd {
-	repoPath, ok := m.currentRepoPath()
-	if !ok {
-		return nil
-	}
-	return func() tea.Msg {
-		stashes, err := gitquery.ListStashes(repoPath)
-		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "stashes", Err: fmt.Sprintf("failed to load stashes: %v", err), Kind: FetchList, Mode: ui.ModeStashes, ListRequest: request}
-		}
-		return StashResultMsg{RepoPath: repoPath, Stashes: stashes, ListRequest: request}
-	}
-}
-
 func (m Model) fetchBranchDiff() tea.Cmd {
 	repoPath, ok := m.currentRepoPath()
 	if !ok {
@@ -595,76 +638,6 @@ func (m Model) fetchStashDiff() tea.Cmd {
 			DiffRequest: diffRequest,
 			Diff:        diff,
 		}
-	}
-}
-
-func (m Model) fetchCommits(request uint64) tea.Cmd {
-	repoPath, ok := m.currentRepoPath()
-	if !ok {
-		return nil
-	}
-	return func() tea.Msg {
-		commits, err := gitquery.ListCommits(repoPath)
-		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "history", Err: fmt.Sprintf("failed to load commits: %v", err), Kind: FetchList, Mode: ui.ModeHistory, ListRequest: request}
-		}
-		return CommitResultMsg{RepoPath: repoPath, Commits: commits, ListRequest: request}
-	}
-}
-
-func (m Model) fetchReflog(request uint64) tea.Cmd {
-	repoPath, ok := m.currentRepoPath()
-	if !ok {
-		return nil
-	}
-	return func() tea.Msg {
-		reflogs, err := gitquery.ListReflog(repoPath)
-		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "reflog", Err: fmt.Sprintf("failed to load reflog: %v", err), Kind: FetchList, Mode: ui.ModeReflog, ListRequest: request}
-		}
-		return ReflogResultMsg{RepoPath: repoPath, Reflogs: reflogs, ListRequest: request}
-	}
-}
-
-func (m Model) fetchSessions(request uint64) tea.Cmd {
-	repoPath, ok := m.currentRepoPath()
-	if !ok {
-		return nil
-	}
-	return func() tea.Msg {
-		records, err := m.listSessions(sessions.SessionFilter{RepoPath: repoPath})
-		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "sessions", Err: fmt.Sprintf("failed to load sessions: %v", err), Kind: FetchList, Mode: ui.ModeSessions, ListRequest: request}
-		}
-		return SessionResultMsg{RepoPath: repoPath, Sessions: records, ListRequest: request}
-	}
-}
-
-func (m Model) fetchPlans(request uint64) tea.Cmd {
-	repoPath, ok := m.currentRepoPath()
-	if !ok {
-		return nil
-	}
-	return func() tea.Msg {
-		records, err := m.listPlans(planstore.PlanFilter{RepoPath: repoPath})
-		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "plans", Err: fmt.Sprintf("failed to load plans: %v", err), Kind: FetchList, Mode: ui.ModePlans, ListRequest: request}
-		}
-		return PlanResultMsg{RepoPath: repoPath, Plans: records, ListRequest: request}
-	}
-}
-
-func (m Model) fetchFlows(request uint64) tea.Cmd {
-	repoPath, ok := m.currentRepoPath()
-	if !ok {
-		return nil
-	}
-	return func() tea.Msg {
-		records, err := m.listFlows(flowstore.FlowFilter{RepoPath: repoPath})
-		if err != nil {
-			return FetchErrorMsg{RepoPath: repoPath, Pane: "flows", Err: fmt.Sprintf("failed to load flows: %v", err), Kind: FetchList, Mode: ui.ModeFlows, ListRequest: request}
-		}
-		return FlowResultMsg{RepoPath: repoPath, Flows: records, ListRequest: request}
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -229,49 +229,49 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode != ui.ModeWorktrees {
 			m.mode = ui.ModeWorktrees
 			m = m.resetModeCursors()
-			return m.startFetchWorktrees()
+			return m.startFetchMode(ui.ModeWorktrees)
 		}
 	case "2":
 		if m.mode != ui.ModeBranches {
 			m.mode = ui.ModeBranches
 			m = m.resetModeCursors()
-			return m.startFetchBranches()
+			return m.startFetchMode(ui.ModeBranches)
 		}
 	case "3":
 		if m.mode != ui.ModeStashes {
 			m.mode = ui.ModeStashes
 			m = m.resetModeCursors()
-			return m.startFetchStashes()
+			return m.startFetchMode(ui.ModeStashes)
 		}
 	case "4":
 		if m.mode != ui.ModeHistory {
 			m.mode = ui.ModeHistory
 			m = m.resetModeCursors()
-			return m.startFetchCommits()
+			return m.startFetchMode(ui.ModeHistory)
 		}
 	case "5":
 		if m.mode != ui.ModeReflog {
 			m.mode = ui.ModeReflog
 			m = m.resetModeCursors()
-			return m.startFetchReflog()
+			return m.startFetchMode(ui.ModeReflog)
 		}
 	case "6":
 		if m.mode != ui.ModeSessions {
 			m.mode = ui.ModeSessions
 			m = m.resetModeCursors()
-			return m.startFetchSessions()
+			return m.startFetchMode(ui.ModeSessions)
 		}
 	case "7":
 		if m.mode != ui.ModePlans {
 			m.mode = ui.ModePlans
 			m = m.resetModeCursors()
-			return m.startFetchPlans()
+			return m.startFetchMode(ui.ModePlans)
 		}
 	case "8":
 		if m.mode != ui.ModeFlows {
 			m.mode = ui.ModeFlows
 			m = m.resetModeCursors()
-			return m.startFetchFlows()
+			return m.startFetchMode(ui.ModeFlows)
 		}
 	case "y":
 		if m.mode == ui.ModePlans {
@@ -660,7 +660,7 @@ func (m Model) handleFlowCreateFailed(msg FlowCreateFailedMsg) (Model, tea.Cmd) 
 	}
 	m = m.setStatus(statusOther, errText)
 	if m.mode == ui.ModeFlows {
-		return m.startFetchFlows()
+		return m.startFetchMode(ui.ModeFlows)
 	}
 	return m, nil
 }

--- a/model/model_list_fetch_test.go
+++ b/model/model_list_fetch_test.go
@@ -1,0 +1,280 @@
+package model_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/gitquery"
+	"github.com/brian-bell/wtui/model"
+	"github.com/brian-bell/wtui/planstore"
+	"github.com/brian-bell/wtui/sessions"
+	"github.com/brian-bell/wtui/ui"
+)
+
+func TestModel_ListFetchModesShareRequestAndStaleResultBehavior(t *testing.T) {
+	const selectedRepo = "/dev/bravo"
+
+	cases := []struct {
+		name          string
+		mode          ui.Mode
+		pane          string
+		errorPrefix   string
+		result        func(string, uint64) tea.Msg
+		assertApplied func(t *testing.T, m model.Model)
+	}{
+		{
+			name:        "worktrees",
+			mode:        ui.ModeWorktrees,
+			pane:        "worktrees",
+			errorPrefix: "failed to load worktrees",
+			result: func(repoPath string, request uint64) tea.Msg {
+				return model.WorktreeResultMsg{
+					RepoPath:    repoPath,
+					ListRequest: request,
+					Worktrees:   []gitquery.Worktree{{Path: repoPath, BranchName: "main"}},
+				}
+			},
+			assertApplied: func(t *testing.T, m model.Model) {
+				t.Helper()
+				if got := m.Worktrees(); len(got) != 1 || got[0].Path != selectedRepo {
+					t.Fatalf("Worktrees() = %#v, want selected repo worktree", got)
+				}
+			},
+		},
+		{
+			name:        "branches",
+			mode:        ui.ModeBranches,
+			pane:        "branches",
+			errorPrefix: "failed to load branches",
+			result: func(repoPath string, request uint64) tea.Msg {
+				return model.BranchResultMsg{
+					RepoPath:    repoPath,
+					ListRequest: request,
+					Branches:    []gitquery.Branch{{Name: "feature/list-fetch", IsWorktree: true, WorktreePaths: []string{repoPath}}},
+				}
+			},
+			assertApplied: func(t *testing.T, m model.Model) {
+				t.Helper()
+				if got := m.Rows(); len(got) != 1 || got[0].Branch.Name != "feature/list-fetch" {
+					t.Fatalf("Rows() = %#v, want fetched branch row", got)
+				}
+			},
+		},
+		{
+			name:        "stashes",
+			mode:        ui.ModeStashes,
+			pane:        "stashes",
+			errorPrefix: "failed to load stashes",
+			result: func(repoPath string, request uint64) tea.Msg {
+				return model.StashResultMsg{
+					RepoPath:    repoPath,
+					ListRequest: request,
+					Stashes:     []gitquery.Stash{{Index: 0, Date: "2026-06-08", Message: "WIP list fetch"}},
+				}
+			},
+			assertApplied: func(t *testing.T, m model.Model) {
+				t.Helper()
+				if got := m.Stashes(); len(got) != 1 || got[0].Message != "WIP list fetch" {
+					t.Fatalf("Stashes() = %#v, want fetched stash", got)
+				}
+			},
+		},
+		{
+			name:        "history",
+			mode:        ui.ModeHistory,
+			pane:        "history",
+			errorPrefix: "failed to load commits",
+			result: func(repoPath string, request uint64) tea.Msg {
+				return model.CommitResultMsg{
+					RepoPath:    repoPath,
+					ListRequest: request,
+					Commits:     []gitquery.Commit{{Hash: "abc1234", Subject: "deepen list fetching"}},
+				}
+			},
+			assertApplied: func(t *testing.T, m model.Model) {
+				t.Helper()
+				if got := m.Commits(); len(got) != 1 || got[0].Hash != "abc1234" {
+					t.Fatalf("Commits() = %#v, want fetched commit", got)
+				}
+			},
+		},
+		{
+			name:        "reflog",
+			mode:        ui.ModeReflog,
+			pane:        "reflog",
+			errorPrefix: "failed to load reflog",
+			result: func(repoPath string, request uint64) tea.Msg {
+				return model.ReflogResultMsg{
+					RepoPath:    repoPath,
+					ListRequest: request,
+					Reflogs:     []gitquery.ReflogEntry{{Hash: "def5678", Selector: "HEAD@{0}", Subject: "checkout"}},
+				}
+			},
+			assertApplied: func(t *testing.T, m model.Model) {
+				t.Helper()
+				if got := m.Reflogs(); len(got) != 1 || got[0].Hash != "def5678" {
+					t.Fatalf("Reflogs() = %#v, want fetched reflog", got)
+				}
+			},
+		},
+		{
+			name:        "sessions",
+			mode:        ui.ModeSessions,
+			pane:        "sessions",
+			errorPrefix: "failed to load sessions",
+			result: func(repoPath string, request uint64) tea.Msg {
+				return model.SessionResultMsg{
+					RepoPath:    repoPath,
+					ListRequest: request,
+					Sessions:    []sessions.SessionRecord{{Provider: sessions.ProviderCodex, SessionID: "session-1", RepoPath: repoPath}},
+				}
+			},
+			assertApplied: func(t *testing.T, m model.Model) {
+				t.Helper()
+				if got := m.Sessions(); len(got) != 1 || got[0].SessionID != "session-1" {
+					t.Fatalf("Sessions() = %#v, want fetched session", got)
+				}
+			},
+		},
+		{
+			name:        "plans",
+			mode:        ui.ModePlans,
+			pane:        "plans",
+			errorPrefix: "failed to load plans",
+			result: func(repoPath string, request uint64) tea.Msg {
+				return model.PlanResultMsg{
+					RepoPath:    repoPath,
+					ListRequest: request,
+					Plans:       []planstore.PlanRecord{{PlanID: "plan-1", RepoPath: repoPath, Title: "Deepen list fetching"}},
+				}
+			},
+			assertApplied: func(t *testing.T, m model.Model) {
+				t.Helper()
+				if got := m.Plans(); len(got) != 1 || got[0].PlanID != "plan-1" {
+					t.Fatalf("Plans() = %#v, want fetched plan", got)
+				}
+			},
+		},
+		{
+			name:        "flows",
+			mode:        ui.ModeFlows,
+			pane:        "flows",
+			errorPrefix: "failed to load flows",
+			result: func(repoPath string, request uint64) tea.Msg {
+				return model.FlowResultMsg{
+					RepoPath:    repoPath,
+					ListRequest: request,
+					Flows:       []flowstore.FlowRecord{{FlowID: "flow-1", RepoPath: repoPath, Title: "Deepen list fetching"}},
+				}
+			},
+			assertApplied: func(t *testing.T, m model.Model) {
+				t.Helper()
+				if got := m.Flows(); len(got) != 1 || got[0].FlowID != "flow-1" {
+					t.Fatalf("Flows() = %#v, want fetched flow", got)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loadCount := 0
+			m := model.NewWithOptions(testRepos(), model.Options{
+				StartupMode: tc.mode,
+				ListSessions: func(filter sessions.SessionFilter) ([]sessions.SessionRecord, error) {
+					loadCount++
+					if filter.RepoPath != selectedRepo {
+						t.Fatalf("SessionFilter.RepoPath = %q, want %q", filter.RepoPath, selectedRepo)
+					}
+					return nil, errors.New("session store unavailable")
+				},
+				ListPlans: func(filter planstore.PlanFilter) ([]planstore.PlanRecord, error) {
+					loadCount++
+					if filter.RepoPath != selectedRepo {
+						t.Fatalf("PlanFilter.RepoPath = %q, want %q", filter.RepoPath, selectedRepo)
+					}
+					return nil, errors.New("plan store unavailable")
+				},
+				ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+					loadCount++
+					if filter.RepoPath != selectedRepo {
+						t.Fatalf("FlowFilter.RepoPath = %q, want %q", filter.RepoPath, selectedRepo)
+					}
+					return nil, errors.New("flow store unavailable")
+				},
+			})
+			beforeRequest := m.ListRequest(tc.mode)
+
+			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyDown})
+			started := m
+			request := m.ListRequest(tc.mode)
+			if request == 0 || request == beforeRequest {
+				t.Fatalf("ListRequest(%v) = %d, want new nonzero request after %d", tc.mode, request, beforeRequest)
+			}
+			if cmd == nil {
+				t.Fatal("expected fetch command")
+			}
+			if loadCount != 0 {
+				t.Fatalf("list adapter ran before command execution: %d call(s)", loadCount)
+			}
+
+			switched, _ := update(m, tea.KeyMsg{Type: tea.KeyDown})
+			msg := cmd()
+			assertListFetchCommandError(t, msg, tc.mode, request, selectedRepo, tc.pane, tc.errorPrefix)
+			switched, _ = update(switched, msg)
+			if got := switched.TransientError(); got != "" {
+				t.Fatalf("captured command for old repo changed current repo status: TransientError() = %q", got)
+			}
+
+			m = started
+			m, _ = update(m, model.FetchErrorMsg{
+				RepoPath:    selectedRepo,
+				Pane:        tc.name,
+				Err:         "matching list fetch failed",
+				Kind:        model.FetchList,
+				Mode:        tc.mode,
+				ListRequest: request,
+			})
+			if got := m.TransientError(); got != "matching list fetch failed" {
+				t.Fatalf("TransientError() after fetch error = %q, want matching list fetch failed", got)
+			}
+
+			m, _ = update(m, tc.result("/dev/charlie", request))
+			if got := m.TransientError(); got != "matching list fetch failed" {
+				t.Fatalf("wrong-repo result cleared status: TransientError() = %q", got)
+			}
+
+			m, _ = update(m, tc.result(selectedRepo, request-1))
+			if got := m.TransientError(); got != "matching list fetch failed" {
+				t.Fatalf("stale result cleared status: TransientError() = %q", got)
+			}
+
+			m, _ = update(m, tc.result(selectedRepo, request))
+			if got := m.TransientError(); got != "" {
+				t.Fatalf("matching result did not clear status: TransientError() = %q", got)
+			}
+			tc.assertApplied(t, m)
+		})
+	}
+}
+
+func assertListFetchCommandError(t *testing.T, msg tea.Msg, mode ui.Mode, request uint64, repoPath, pane, errorPrefix string) {
+	t.Helper()
+
+	got, ok := msg.(model.FetchErrorMsg)
+	if !ok {
+		t.Fatalf("expected FetchErrorMsg, got %T", msg)
+	}
+	if got.Pane != pane ||
+		got.Kind != model.FetchList ||
+		got.Mode != mode ||
+		got.ListRequest != request ||
+		got.RepoPath != repoPath ||
+		!strings.HasPrefix(got.Err, errorPrefix+": ") {
+		t.Fatalf("FetchErrorMsg = %#v, want pane=%q kind=FetchList mode=%v request=%d repo=%q err prefix %q", got, pane, mode, request, repoPath, errorPrefix+": ")
+	}
+}

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -407,6 +407,13 @@ func (m Model) isCurrentListRequest(mode ui.Mode, request uint64) bool {
 	return m.listRequests[int(mode)] == request
 }
 
+func (m Model) acceptListResult(repoPath string, mode ui.Mode, request uint64) (Model, bool) {
+	if !m.isCurrentRepo(repoPath) || !m.isCurrentListRequest(mode, request) {
+		return m, false
+	}
+	return m.clearFetchListStatus(mode), true
+}
+
 func (m Model) clearAnyStatus() Model {
 	m.status = statusError{}
 	return m
@@ -429,10 +436,11 @@ func (m Model) visibleStatusFadeStep() int {
 }
 
 func (m Model) handleWorktreeResult(msg WorktreeResultMsg) Model {
-	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeWorktrees, msg.ListRequest) {
+	var ok bool
+	m, ok = m.acceptListResult(msg.RepoPath, ui.ModeWorktrees, msg.ListRequest)
+	if !ok {
 		return m
 	}
-	m = m.clearFetchListStatus(ui.ModeWorktrees)
 	m.worktrees = m.worktrees.SetItems(msg.Worktrees)
 	if m.pendingWorktreeSelection != "" {
 		pendingPath := m.pendingWorktreeSelection
@@ -453,7 +461,7 @@ func (m Model) handleWorktreeRemoved(msg WorktreeRemovedMsg) (tea.Model, tea.Cmd
 		m.worktrees = m.worktrees.Move(-1, m.worktreeContentHeight(), m.contentWidth())
 	}
 	if msg.BranchName == "" {
-		return m.startFetchWorktrees()
+		return m.startFetchMode(ui.ModeWorktrees)
 	}
 	repoPath := msg.RepoPath
 	branchName := msg.BranchName
@@ -470,7 +478,7 @@ func (m Model) handleWorktreeRemoved(msg WorktreeRemovedMsg) (tea.Model, tea.Cmd
 			return WorktreeDeleteCompletedMsg{RepoPath: repoPath}
 		}
 	})
-	return m.startFetchWorktrees()
+	return m.startFetchMode(ui.ModeWorktrees)
 }
 
 func (m Model) handleWorktreePruned(msg WorktreePrunedMsg) (tea.Model, tea.Cmd) {
@@ -478,7 +486,7 @@ func (m Model) handleWorktreePruned(msg WorktreePrunedMsg) (tea.Model, tea.Cmd) 
 		if m.WorktreeSelected() >= len(m.Worktrees())-1 && m.WorktreeSelected() > 0 {
 			m.worktrees = m.worktrees.Move(-1, m.worktreeContentHeight(), m.contentWidth())
 		}
-		return m.startFetchWorktrees()
+		return m.startFetchMode(ui.ModeWorktrees)
 	}
 	return m, nil
 }
@@ -486,7 +494,7 @@ func (m Model) handleWorktreePruned(msg WorktreePrunedMsg) (tea.Model, tea.Cmd) 
 func (m Model) handleWorktreeUnlocked(msg WorktreeUnlockedMsg) (tea.Model, tea.Cmd) {
 	if m.isCurrentRepo(msg.RepoPath) {
 		m = m.clearStatus(statusOther)
-		return m.startFetchWorktrees()
+		return m.startFetchMode(ui.ModeWorktrees)
 	}
 	return m, nil
 }
@@ -596,7 +604,7 @@ func (m Model) handleWorktreeCreated(msg WorktreeCreatedMsg) (tea.Model, tea.Cmd
 	m = m.clearWorktreeCreateRequest(msg.Request)
 	m.mode = ui.ModeWorktrees
 	m.worktrees = m.worktrees.ResetSelection()
-	m, fetchCmd := m.startFetchWorktrees()
+	m, fetchCmd := m.startFetchMode(ui.ModeWorktrees)
 	if !msg.LaunchAgent {
 		return m, fetchCmd
 	}
@@ -618,7 +626,7 @@ func (m Model) handleWorktreeBootstrapFailed(msg WorktreeBootstrapFailedMsg) (te
 	m.mode = ui.ModeWorktrees
 	m.worktrees = m.worktrees.ResetSelection()
 	m = m.setStatus(statusGitMutation, errText)
-	return m.startFetchWorktrees()
+	return m.startFetchMode(ui.ModeWorktrees)
 }
 
 func (m Model) handleWorktreeCreateFailed(msg WorktreeCreateFailedMsg) Model {
@@ -657,7 +665,7 @@ func (m Model) handleWorktreeMoved(msg WorktreeMovedMsg) (tea.Model, tea.Cmd) {
 	}
 	m.pendingWorktreeSelection = msg.NewPath
 	m = m.clearStatus(statusOther)
-	return m.startFetchWorktrees()
+	return m.startFetchMode(ui.ModeWorktrees)
 }
 
 func (m Model) handleWorktreeMoveFailed(msg WorktreeMoveFailedMsg) Model {
@@ -696,10 +704,11 @@ func (m Model) handleAgentSetFailed(msg AgentSetFailedMsg) Model {
 }
 
 func (m Model) handleBranchResult(msg BranchResultMsg) Model {
-	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeBranches, msg.ListRequest) {
+	var ok bool
+	m, ok = m.acceptListResult(msg.RepoPath, ui.ModeBranches, msg.ListRequest)
+	if !ok {
 		return m
 	}
-	m = m.clearFetchListStatus(ui.ModeBranches)
 	repo, _ := m.currentRepo()
 	m.rows = m.rows.SetItems(branchRowsForRepo(repo, msg.Branches))
 	if m.pendingBranchSelection != "" {
@@ -750,10 +759,11 @@ func canonicalPath(path string) string {
 }
 
 func (m Model) handleStashResult(msg StashResultMsg) Model {
-	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeStashes, msg.ListRequest) {
+	var ok bool
+	m, ok = m.acceptListResult(msg.RepoPath, ui.ModeStashes, msg.ListRequest)
+	if !ok {
 		return m
 	}
-	m = m.clearFetchListStatus(ui.ModeStashes)
 	m.stashes = m.stashes.SetItems(msg.Stashes)
 	m = m.clampSelectionsAfterFilter()
 	return m
@@ -791,14 +801,14 @@ func (m Model) handleStashDropped(msg StashDroppedMsg) (tea.Model, tea.Cmd) {
 		if m.StashSelected() >= len(m.Stashes())-1 && m.StashSelected() > 0 {
 			m.stashes = m.stashes.Move(-1, m.stashContentHeight(), m.contentWidth())
 		}
-		return m.startFetchStashes()
+		return m.startFetchMode(ui.ModeStashes)
 	}
 	return m, nil
 }
 
 func (m Model) handleBranchDeleted(msg BranchDeletedMsg) (tea.Model, tea.Cmd) {
 	if m.isCurrentRepo(msg.RepoPath) {
-		return m.startFetchBranches()
+		return m.startFetchMode(ui.ModeBranches)
 	}
 	return m, nil
 }
@@ -808,7 +818,7 @@ func (m Model) handleBranchCreated(msg BranchCreatedMsg) (tea.Model, tea.Cmd) {
 		m.mode = ui.ModeBranches
 		m.rows = m.rows.SetQuery("")
 		m.pendingBranchSelection = msg.Name
-		return m.startFetchBranches()
+		return m.startFetchMode(ui.ModeBranches)
 	}
 	return m, nil
 }
@@ -885,40 +895,44 @@ func (m Model) handleActionFailed(msg ActionFailedMsg) Model {
 }
 
 func (m Model) handleCommitResult(msg CommitResultMsg) Model {
-	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeHistory, msg.ListRequest) {
+	var ok bool
+	m, ok = m.acceptListResult(msg.RepoPath, ui.ModeHistory, msg.ListRequest)
+	if !ok {
 		return m
 	}
-	m = m.clearFetchListStatus(ui.ModeHistory)
 	m.commits = m.commits.SetItems(msg.Commits)
 	m = m.clampSelectionsAfterFilter()
 	return m
 }
 
 func (m Model) handleReflogResult(msg ReflogResultMsg) Model {
-	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeReflog, msg.ListRequest) {
+	var ok bool
+	m, ok = m.acceptListResult(msg.RepoPath, ui.ModeReflog, msg.ListRequest)
+	if !ok {
 		return m
 	}
-	m = m.clearFetchListStatus(ui.ModeReflog)
 	m.reflogs = m.reflogs.SetItems(msg.Reflogs)
 	m = m.clampSelectionsAfterFilter()
 	return m
 }
 
 func (m Model) handleSessionResult(msg SessionResultMsg) Model {
-	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeSessions, msg.ListRequest) {
+	var ok bool
+	m, ok = m.acceptListResult(msg.RepoPath, ui.ModeSessions, msg.ListRequest)
+	if !ok {
 		return m
 	}
-	m = m.clearFetchListStatus(ui.ModeSessions)
 	m.sessions = m.sessions.SetItems(msg.Sessions)
 	m = m.clampSelectionsAfterFilter()
 	return m
 }
 
 func (m Model) handlePlanResult(msg PlanResultMsg) Model {
-	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModePlans, msg.ListRequest) {
+	var ok bool
+	m, ok = m.acceptListResult(msg.RepoPath, ui.ModePlans, msg.ListRequest)
+	if !ok {
 		return m
 	}
-	m = m.clearFetchListStatus(ui.ModePlans)
 	m.plans = m.plans.SetItems(msg.Plans)
 	m = m.setExpandedPlanID("")
 	m = m.clampSelectionsAfterFilter()
@@ -926,10 +940,11 @@ func (m Model) handlePlanResult(msg PlanResultMsg) Model {
 }
 
 func (m Model) handleFlowResult(msg FlowResultMsg) Model {
-	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentListRequest(ui.ModeFlows, msg.ListRequest) {
+	var ok bool
+	m, ok = m.acceptListResult(msg.RepoPath, ui.ModeFlows, msg.ListRequest)
+	if !ok {
 		return m
 	}
-	m = m.clearFetchListStatus(ui.ModeFlows)
 	m.flows = m.flows.SetItems(msg.Flows)
 	m = m.setExpandedFlowID("")
 	m = m.clampSelectionsAfterFilter()


### PR DESCRIPTION
## Summary
- Centralize model list fetch command creation behind a descriptor/helper for repo capture, request stamping, loader execution, and FetchErrorMsg shaping.
- Preserve typed list result messages and pane-specific result handlers while factoring shared stale/wrong-repo acceptance and fetch-status clearing.
- Add all-mode characterization coverage for request sequencing, deferred command execution, captured repo behavior, error shaping, wrong-repo/stale-result rejection, and matching status clearing.

## Verification
- `go test ./model -count=1`
- `go test ./...`
- `gofmt -l .`
- `make build`

## Notes
- `go run honnef.co/go/tools/cmd/staticcheck@latest ./...` reports existing Staticcheck findings in older tests, none in the new/changed production code.
- `go run golang.org/x/tools/cmd/deadcode@latest -test ./...` reports existing unreachable `model/modal.OpenText`; left untouched as unrelated.
