### PR TITLE
Clarify Flow autoreview recovery

### DIFF
--- a/agent-skills/wtui-flow/SKILL.md
+++ b/agent-skills/wtui-flow/SKILL.md
@@ -328,6 +328,19 @@ Creation by recording the missing metadata with `wtui flow pr set`; if a PR does
 not exist or cannot be recovered, rerun PR Creation as `running` with notes and
 then mark PR Creation `blocked` with notes.
 
+If Autoreview is already `needs_attention` or `blocked`, do not mark it
+`completed` directly. First restart the phase as `running` with notes, then
+complete it after the rerun succeeds:
+
+```bash
+wtui flow phase set \
+  --flow-id "$WTUI_FLOW_ID" \
+  --phase-id autoreview \
+  --status running \
+  --notes "Rerunning Autoreview after addressing prior findings." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
 ```bash
 wtui flow phase set \
   --flow-id "$WTUI_FLOW_ID" \

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -940,6 +940,20 @@ func phaseSatisfiesDownstreamGate(record FlowRecord, phase FlowPhase) bool {
 	return phase.Status == PhaseCompleted
 }
 
+// PhasePredecessorsSatisfied reports whether all phases before phaseID satisfy
+// the Flow gate rules used to derive downstream readiness.
+func PhasePredecessorsSatisfied(record FlowRecord, phaseID string) bool {
+	for _, phase := range OrderedPhases(record.Phases) {
+		if phase.PhaseID == phaseID {
+			return true
+		}
+		if !phaseSatisfiesDownstreamGate(record, phase) {
+			return false
+		}
+	}
+	return false
+}
+
 // HasPRTarget reports whether PR metadata contains enough target context for
 // downstream Autoreview work.
 func HasPRTarget(pr PullRequest) bool {

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -561,12 +561,19 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 			return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
 		}
 		phase := record.Phases[phaseIndex]
-		if err := validatePhaseUpdate(phase, PhaseUpdate{FlowID: update.FlowID, PhaseID: update.PhaseID, Status: PhaseRunning}); err != nil {
+		launchPhaseUpdate := PhaseUpdate{FlowID: update.FlowID, PhaseID: update.PhaseID, Status: PhaseRunning}
+		if phase.Status == PhaseNeedsAttention || phase.Status == PhaseBlocked {
+			launchPhaseUpdate.Notes = fmt.Sprintf("Relaunched after %s.", phase.Status)
+		}
+		if err := validatePhaseUpdate(phase, launchPhaseUpdate); err != nil {
 			return FlowRecord{}, err
 		}
 		phase.Status = PhaseRunning
 		if clearsPhaseOutcome(phase.Status) {
 			phase.Outcome = ""
+		}
+		if launchPhaseUpdate.Notes != "" {
+			phase.Notes = launchPhaseUpdate.Notes
 		}
 		phase.LaunchIDs = appendUnique(phase.LaunchIDs, launchID)
 		phase.UpdatedAt = now
@@ -786,7 +793,15 @@ func validatePhaseUpdate(current FlowPhase, update PhaseUpdate) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("invalid phase transition %s -> %s", current.Status, update.Status)
+	return invalidPhaseTransitionError(current.Status, update.Status)
+}
+
+func invalidPhaseTransitionError(currentStatus, nextStatus string) error {
+	message := fmt.Sprintf("invalid phase transition %s -> %s", currentStatus, nextStatus)
+	if (currentStatus == PhaseNeedsAttention || currentStatus == PhaseBlocked) && nextStatus == PhaseCompleted {
+		message += "; restart with --status running --notes before completing"
+	}
+	return fmt.Errorf("%s", message)
 }
 
 func validateChildPhaseUpdate(update ChildPhaseUpdate) error {

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -463,6 +463,147 @@ func TestStoreSetPhaseRejectsInvalidTransitions(t *testing.T) {
 	}
 }
 
+func TestStoreSetPhaseExplainsNeedsAttentionRecovery(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Autoreview recovery",
+		Instructions: "explain how to recover attention phases",
+		RepoPath:     filepath.Join(root, "repo"),
+		Branch:       "flow/autoreview-recovery",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	record, err = store.SetPR(flowstore.PRUpdate{
+		FlowID:     record.FlowID,
+		Provider:   "github",
+		Number:     115,
+		URL:        "https://github.com/brian-bell/wtui/pull/115",
+		HeadBranch: "flow/autoreview-recovery",
+		BaseBranch: "main",
+		Status:     "open",
+	})
+	if err != nil {
+		t.Fatalf("SetPR() error = %v", err)
+	}
+	record, err = store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "autoreview",
+		Status:  flowstore.PhaseNeedsAttention,
+		Outcome: "needs_attention",
+		Notes:   "Follow-up findings remain.",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(autoreview needs_attention) error = %v", err)
+	}
+
+	_, err = store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "autoreview",
+		Status:  flowstore.PhaseCompleted,
+		Outcome: "passed",
+	})
+	if err == nil {
+		t.Fatal("SetPhase(needs_attention -> completed) error = nil")
+	}
+	for _, want := range []string{
+		"invalid phase transition needs_attention -> completed",
+		"restart with --status running --notes before completing",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("SetPhase() error = %q, want %q", err, want)
+		}
+	}
+
+	record, err = store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "autoreview",
+		Status:  flowstore.PhaseRunning,
+		Notes:   "Rerunning autoreview after addressing prior findings.",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(needs_attention -> running) error = %v", err)
+	}
+	if got := phaseByID(t, record, "autoreview").Status; got != flowstore.PhaseRunning {
+		t.Fatalf("autoreview status = %q, want running", got)
+	}
+	_, err = store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "autoreview",
+		Status:  flowstore.PhaseCompleted,
+		Outcome: "passed",
+		Summary: "Autoreview passed after rerun.",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(running -> completed) error = %v", err)
+	}
+}
+
+func TestStoreAddPhaseLaunchIDRestartsNeedsAttentionPhase(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Autoreview relaunch",
+		Instructions: "restart autoreview from needs_attention",
+		RepoPath:     filepath.Join(root, "repo"),
+		Branch:       "flow/autoreview-relaunch",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	record, err = store.SetPR(flowstore.PRUpdate{
+		FlowID:     record.FlowID,
+		Provider:   "github",
+		Number:     115,
+		URL:        "https://github.com/brian-bell/wtui/pull/115",
+		HeadBranch: "flow/autoreview-relaunch",
+		BaseBranch: "main",
+		Status:     "open",
+	})
+	if err != nil {
+		t.Fatalf("SetPR() error = %v", err)
+	}
+	record, err = store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "autoreview",
+		Status:  flowstore.PhaseNeedsAttention,
+		Outcome: "needs_attention",
+		Notes:   "Follow-up findings remain.",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(autoreview needs_attention) error = %v", err)
+	}
+
+	relaunched, err := store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:   record.FlowID,
+		PhaseID:  "autoreview",
+		LaunchID: "launch-autoreview-2",
+	})
+	if err != nil {
+		t.Fatalf("AddPhaseLaunchID(autoreview) error = %v", err)
+	}
+
+	phase := phaseByID(t, relaunched, "autoreview")
+	if phase.Status != flowstore.PhaseRunning || phase.Outcome != "" {
+		t.Fatalf("autoreview after relaunch = %#v, want running with cleared outcome", phase)
+	}
+	if !strings.Contains(phase.Notes, "Relaunched after needs_attention") {
+		t.Fatalf("autoreview notes = %q, want restart note", phase.Notes)
+	}
+	if len(phase.LaunchIDs) != 1 || phase.LaunchIDs[0] != "launch-autoreview-2" {
+		t.Fatalf("launch ids = %#v", phase.LaunchIDs)
+	}
+}
+
 func TestStoreSetPhaseAllowsSkippedWithNotesAndIdempotentUpdates(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1042,6 +1042,74 @@ func TestModel_AKeyOnFlowLaunchesAutoreviewWithPRContext(t *testing.T) {
 	}
 }
 
+func TestModel_AKeyOnFlowLaunchesAutoreviewWithRecoveryPrompt(t *testing.T) {
+	var launched actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		ReadPlan: func(planID string) (string, error) {
+			return "# Saved plan\n", nil
+		},
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launched = ctx
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-pr",
+		Branch:       "flow/pr",
+		PlanID:       "plan-1",
+		Status:       flowstore.StatusNeedsAttention,
+		PR: flowstore.PullRequest{
+			Provider:   "github",
+			Number:     115,
+			URL:        "https://github.com/brian-bell/wtui/pull/115",
+			HeadBranch: "flow/pr",
+			BaseBranch: "main",
+			Status:     "open",
+		},
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
+			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted},
+			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseCompleted},
+			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhaseCompleted},
+			{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseNeedsAttention, Outcome: "needs_attention", Notes: "Non-blocking concern remains."},
+		},
+	}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd == nil {
+		t.Fatal("flows-mode a should prepare an autoreview relaunch")
+	}
+	msg := cmd()
+	launchMsg, ok := msg.(model.PlanLaunchRequestedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want PlanLaunchRequestedMsg", msg)
+	}
+	_, cmd = update(m, launchMsg)
+	if cmd == nil {
+		t.Fatal("expected agent result command")
+	}
+	_ = cmd()
+
+	prompt := strings.ToLower(launched.InitialPrompt)
+	for _, want := range []string{
+		"restart required",
+		"--status running",
+		"rerunning autoreview after addressing prior findings",
+		"--status completed",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("autoreview recovery prompt missing %q:\n%s", want, launched.InitialPrompt)
+		}
+	}
+}
+
 func TestModel_AKeyOnFlowLaunchesMergeWithStructuredReportingPrompt(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1110,6 +1110,92 @@ func TestModel_AKeyOnFlowLaunchesAutoreviewWithRecoveryPrompt(t *testing.T) {
 	}
 }
 
+func TestModel_AKeyOnFlowDoesNotRelaunchAutoreviewWithoutPRTarget(t *testing.T) {
+	var launchAttempted bool
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			t.Fatalf("AddFlowPhaseLaunchID() should not run without PR metadata: %#v", update)
+			return flowstore.FlowRecord{}, nil
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launchAttempted = true
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-pr",
+		Branch:       "flow/pr",
+		Status:       flowstore.StatusBlocked,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
+			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted},
+			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseCompleted},
+			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhaseCompleted},
+			{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseBlocked, Outcome: "blocked", Notes: "PR target missing."},
+		},
+	}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd != nil {
+		t.Fatal("flows-mode a should not launch blocked autoreview without PR metadata")
+	}
+	if launchAttempted {
+		t.Fatal("LaunchAgent() ran without PR metadata")
+	}
+	if got := m.TransientError(); got != "No ready Flow phase to launch" {
+		t.Fatalf("status = %q, want no ready phase message", got)
+	}
+}
+
+func TestModel_AKeyOnFlowDoesNotRelaunchAutoreviewWhenPredecessorsAreUnsatisfied(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			t.Fatalf("AddFlowPhaseLaunchID() should not run while predecessors are unsatisfied: %#v", update)
+			return flowstore.FlowRecord{}, nil
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			t.Fatalf("LaunchAgent() should not run while predecessors are unsatisfied: %#v", ctx)
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-pr",
+		Branch:       "flow/pr",
+		Status:       flowstore.StatusBlocked,
+		PR: flowstore.PullRequest{
+			Provider:   "github",
+			Number:     115,
+			URL:        "https://github.com/brian-bell/wtui/pull/115",
+			HeadBranch: "flow/pr",
+			BaseBranch: "main",
+			Status:     "open",
+		},
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
+			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning},
+			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhasePending},
+			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhasePending},
+			{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseBlocked, Outcome: "blocked", Notes: "Needs another review."},
+		},
+	}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd != nil {
+		t.Fatal("flows-mode a should not launch blocked autoreview while predecessors are unsatisfied")
+	}
+	if got := m.TransientError(); got != "No ready Flow phase to launch" {
+		t.Fatalf("status = %q, want no ready phase message", got)
+	}
+}
+
 func TestModel_AKeyOnFlowLaunchesMergeWithStructuredReportingPrompt(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1104,11 +1104,19 @@ func implementationPromptForPhase(plan planstore.PlanRecord, planPath string, ph
 
 func readyFlowPhase(record flowstore.FlowRecord) (flowstore.FlowPhase, bool) {
 	for _, phase := range flowstore.OrderedPhases(record.Phases) {
-		if phase.Status == flowstore.PhaseReady {
+		if flowPhaseCanLaunch(phase) {
 			return phase, true
 		}
 	}
 	return flowstore.FlowPhase{}, false
+}
+
+func flowPhaseCanLaunch(phase flowstore.FlowPhase) bool {
+	if phase.Status == flowstore.PhaseReady {
+		return true
+	}
+	return phase.PhaseID == "autoreview" &&
+		(phase.Status == flowstore.PhaseNeedsAttention || phase.Status == flowstore.PhaseBlocked)
 }
 
 func flowNotReadyMessage(record flowstore.FlowRecord) string {
@@ -1158,14 +1166,14 @@ func flowPhasePromptNeedsPlanBody(phaseID string) bool {
 }
 
 func flowPlanReviewPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
-	return flowMinimalArtifactPrompt("Use the review loop skill to review the saved plan.", planPath, record)
+	return flowMinimalArtifactPrompt("Use the review loop skill to review the saved plan.", planPath, record, phase)
 }
 
 func flowImplementationPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
 	if strings.TrimSpace(planPath) == "" {
 		return flowImplementationWithoutPlanPrompt(record, phase)
 	}
-	return flowMinimalArtifactPrompt("Implement the approved plan.", planPath, record)
+	return flowMinimalArtifactPrompt("Implement the approved plan.", planPath, record, phase)
 }
 
 func flowImplementationWithoutPlanPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase) string {
@@ -1175,12 +1183,13 @@ func flowImplementationWithoutPlanPrompt(record flowstore.FlowRecord, phase flow
 	writeFlowPromptHeader(&b, record, "")
 	writeFlowPromptPlanContext(&b, record, "")
 	writeFlowPromptPhaseSummary(&b, record, "Plan Review context", "plan-review")
+	writeFlowRestartPromptIfNeeded(&b, record, phase)
 	b.WriteString("\nAdvance this phase with `wtui flow phase set` only after the implementation is complete, blocked, or needs attention.")
 	return b.String()
 }
 
 func flowReviewLoopPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
-	return flowMinimalChangePrompt("Use the review loop skill to review the changes.", record)
+	return flowMinimalChangePrompt("Use the review loop skill to review the changes.", record, phase)
 }
 
 func flowPRCreationPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
@@ -1193,16 +1202,17 @@ func flowPRCreationPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase
 		base = "<base>"
 	}
 	instruction := fmt.Sprintf("Create a PR for the changes.\nAfter the PR exists, run `wtui flow pr set --flow-id %s --provider github --number <number> --url <url> --head %s --base %s` before completing this phase.", record.FlowID, head, base)
-	return flowMinimalChangePrompt(instruction, record)
+	return flowMinimalChangePrompt(instruction, record, phase)
 }
 
-func flowMinimalArtifactPrompt(instruction, planPath string, record flowstore.FlowRecord) string {
+func flowMinimalArtifactPrompt(instruction, planPath string, record flowstore.FlowRecord, phase flowstore.FlowPhase) string {
 	var b strings.Builder
 	b.WriteString(instruction)
 	b.WriteString("\n\nPlan: ")
 	b.WriteString(planPath)
 	b.WriteString("\n")
 	writeFlowChangeMetadata(&b, record)
+	writeFlowRestartPromptIfNeeded(&b, record, phase)
 	return b.String()
 }
 
@@ -1220,10 +1230,19 @@ func flowAutoreviewPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase
 	} else {
 		b.WriteString("\nPR target: missing. Do not run Autoreview until `wtui flow pr set` records provider, number, URL, head, and base.\n")
 	}
+	writeFlowRestartPromptIfNeeded(&b, record, phase)
 	fmt.Fprintf(&b, "\ncompleted:\nwtui flow phase set --flow-id %s --phase-id %s --status completed --outcome passed --summary \"...\"\n\n", record.FlowID, phase.PhaseID)
 	fmt.Fprintf(&b, "needs_attention:\nwtui flow phase set --flow-id %s --phase-id %s --status needs_attention --outcome needs_attention --notes \"...\" --summary \"...\"\n\n", record.FlowID, phase.PhaseID)
 	fmt.Fprintf(&b, "blocked:\nwtui flow phase set --flow-id %s --phase-id %s --status blocked --outcome blocked --notes \"...\"", record.FlowID, phase.PhaseID)
 	return b.String()
+}
+
+func writeFlowRestartPromptIfNeeded(b *strings.Builder, record flowstore.FlowRecord, phase flowstore.FlowPhase) {
+	if phase.Status != flowstore.PhaseNeedsAttention && phase.Status != flowstore.PhaseBlocked {
+		return
+	}
+	fmt.Fprintf(b, "\nRestart required: this phase is %s. Before marking it completed, record the rerun:\n", phase.Status)
+	fmt.Fprintf(b, "wtui flow phase set --flow-id %s --phase-id %s --status running --notes \"Rerunning %s after addressing prior findings.\"\n", record.FlowID, phase.PhaseID, phase.Title)
 }
 
 func flowMergePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
@@ -1238,6 +1257,7 @@ func flowMergePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, pla
 	} else {
 		b.WriteString("\n\nPR target: missing. Do not merge until `wtui flow pr set` records provider, number, URL, head, and base.\n")
 	}
+	writeFlowRestartPromptIfNeeded(&b, record, phase)
 	fmt.Fprintf(&b, "\nmerged:\nwtui flow phase set --flow-id %s --phase-id %s --status completed --outcome merged --summary \"...\"\n", record.FlowID, phase.PhaseID)
 	fmt.Fprintf(&b, "wtui flow merge set --flow-id %s --status merged --commit <merge-commit> --merged-at <rfc3339>\n\n", record.FlowID)
 	fmt.Fprintf(&b, "blocked:\nwtui flow phase set --flow-id %s --phase-id %s --status blocked --outcome blocked --notes \"...\"\n", record.FlowID, phase.PhaseID)
@@ -1245,11 +1265,12 @@ func flowMergePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, pla
 	return b.String()
 }
 
-func flowMinimalChangePrompt(instruction string, record flowstore.FlowRecord) string {
+func flowMinimalChangePrompt(instruction string, record flowstore.FlowRecord, phase flowstore.FlowPhase) string {
 	var b strings.Builder
 	b.WriteString(instruction)
 	b.WriteString("\n\n")
 	writeFlowChangeMetadata(&b, record)
+	writeFlowRestartPromptIfNeeded(&b, record, phase)
 	return b.String()
 }
 
@@ -1276,6 +1297,7 @@ func flowGenericPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPha
 	b.WriteString(").\n")
 	writeFlowPromptHeader(&b, record, planPath)
 	writeFlowPromptPlanContext(&b, record, planBody)
+	writeFlowRestartPromptIfNeeded(&b, record, phase)
 	b.WriteString("\nAdvance this phase with `wtui flow phase set` only after the corresponding work is complete, blocked, or needs attention.")
 	return b.String()
 }

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1104,19 +1104,21 @@ func implementationPromptForPhase(plan planstore.PlanRecord, planPath string, ph
 
 func readyFlowPhase(record flowstore.FlowRecord) (flowstore.FlowPhase, bool) {
 	for _, phase := range flowstore.OrderedPhases(record.Phases) {
-		if flowPhaseCanLaunch(phase) {
+		if flowPhaseCanLaunch(record, phase) {
 			return phase, true
 		}
 	}
 	return flowstore.FlowPhase{}, false
 }
 
-func flowPhaseCanLaunch(phase flowstore.FlowPhase) bool {
+func flowPhaseCanLaunch(record flowstore.FlowRecord, phase flowstore.FlowPhase) bool {
 	if phase.Status == flowstore.PhaseReady {
 		return true
 	}
 	return phase.PhaseID == "autoreview" &&
-		(phase.Status == flowstore.PhaseNeedsAttention || phase.Status == flowstore.PhaseBlocked)
+		(phase.Status == flowstore.PhaseNeedsAttention || phase.Status == flowstore.PhaseBlocked) &&
+		flowstore.HasPRTarget(record.PR) &&
+		flowstore.PhasePredecessorsSatisfied(record, phase.PhaseID)
 }
 
 func flowNotReadyMessage(record flowstore.FlowRecord) string {


### PR DESCRIPTION
## Summary
- Clarifies the Flow phase transition error when an agent tries to complete a phase directly from `needs_attention` or `blocked`.
- Allows Autoreview phases in attention/blocker states to be relaunched from the TUI, with launch persistence recording the restart as `running`.
- Adds restart guidance to Flow launch prompts and documents the Autoreview restart-then-complete sequence in the wtui-flow skill.

## Verification
- `gofmt -l flowstore/store.go flowstore/store_test.go model/model_keys.go model/model_flow_test.go`
- `git diff --check`
- `make test`
- `make build`

## Notes
The stricter Flow integrity rule remains: agents still cannot mark `needs_attention -> completed` directly. The supported path is `needs_attention -> running -> completed`, and the CLI now explains that recovery path.