### PR TITLE
Add global repo refresh

### DIFF
--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -29,13 +29,19 @@ func main() {
 }
 
 type runDeps struct {
-	loadConfig   func() (config.Config, error)
-	getenv       func(string) string
-	getwd        func() (string, error)
-	scan         func(scanner.ScanOptions) ([]scanner.Repo, error)
-	startProgram func([]scanner.Repo, config.Config) error
-	stdin        io.Reader
-	stdout       io.Writer
+	loadConfig              func() (config.Config, error)
+	getenv                  func(string) string
+	getwd                   func() (string, error)
+	scan                    func(scanner.ScanOptions) ([]scanner.Repo, error)
+	startProgram            func([]scanner.Repo, config.Config) error
+	startProgramWithOptions func([]scanner.Repo, startProgramOptions) error
+	stdin                   io.Reader
+	stdout                  io.Writer
+}
+
+type startProgramOptions struct {
+	Config    config.Config
+	ScanRepos func() ([]scanner.Repo, error)
 }
 
 func run(args []string, deps runDeps) error {
@@ -81,7 +87,16 @@ func run(args []string, deps runDeps) error {
 		return fmt.Errorf("error scanning repos: %w", err)
 	}
 
-	if err := deps.startProgram(repos, cfg); err != nil {
+	scanOptions := scanner.ScanOptions{
+		Root:     root,
+		MaxDepth: cfg.Scan.MaxDepth,
+	}
+	if err := deps.startProgramWithOptions(repos, startProgramOptions{
+		Config: cfg,
+		ScanRepos: func() ([]scanner.Repo, error) {
+			return deps.scan(scanOptions)
+		},
+	}); err != nil {
 		return fmt.Errorf("error: %w", err)
 	}
 	return nil
@@ -102,8 +117,14 @@ func fillRunDeps(deps runDeps) runDeps {
 	if deps.scan == nil {
 		deps.scan = scanner.Scan
 	}
-	if deps.startProgram == nil {
-		deps.startProgram = startProgram
+	if deps.startProgramWithOptions == nil {
+		if deps.startProgram != nil {
+			deps.startProgramWithOptions = func(repos []scanner.Repo, opts startProgramOptions) error {
+				return deps.startProgram(repos, opts.Config)
+			}
+		} else {
+			deps.startProgramWithOptions = startProgram
+		}
 	}
 	if deps.stdin == nil {
 		deps.stdin = os.Stdin
@@ -160,7 +181,8 @@ func runSessionHook(args []string, deps runDeps) error {
 	return err
 }
 
-func startProgram(repos []scanner.Repo, cfg config.Config) error {
+func startProgram(repos []scanner.Repo, opts startProgramOptions) error {
+	cfg := opts.Config
 	artifactRoot := runtimeArtifactRoot(cfg)
 	sessionStore, err := sessions.NewStore(sessions.StoreOptions{
 		Root:               artifactRoot,
@@ -181,6 +203,7 @@ func startProgram(repos []scanner.Repo, cfg config.Config) error {
 		AgentCommand:       cfg.Agent.Command,
 		StartupMode:        ui.ModeFlows,
 		PlanPromptTemplate: cfg.Agent.PlanPrompt,
+		ScanRepos:          opts.ScanRepos,
 		SessionStateRoot:   sessionStore.Root(),
 		ListSessions:       sessionStore.List,
 		ReadTranscript:     sessionStore.ReadTranscript,

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -103,6 +103,53 @@ func TestRun_WorktreeRootEnvOverridesConfigRoot(t *testing.T) {
 	}
 }
 
+func TestRun_PassesRefreshScannerWithResolvedScanOptions(t *testing.T) {
+	var startupScan scanner.ScanOptions
+	var refreshScan scanner.ScanOptions
+	scans := 0
+	err := run([]string{"wtui"}, runDeps{
+		loadConfig: func() (config.Config, error) {
+			return config.Config{
+				Scan: config.ScanConfig{Root: "/from/config", MaxDepth: 1},
+			}, nil
+		},
+		getenv: func(key string) string {
+			if key == "WORKTREE_ROOT" {
+				return "/from/env"
+			}
+			return ""
+		},
+		scan: func(opts scanner.ScanOptions) ([]scanner.Repo, error) {
+			scans++
+			if scans == 1 {
+				startupScan = opts
+			} else {
+				refreshScan = opts
+			}
+			return []scanner.Repo{{Path: "/repo", DisplayName: "repo"}}, nil
+		},
+		startProgramWithOptions: func(_ []scanner.Repo, opts startProgramOptions) error {
+			if opts.ScanRepos == nil {
+				t.Fatal("expected refresh scanner")
+			}
+			_, err := opts.ScanRepos()
+			return err
+		},
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if scans != 2 {
+		t.Fatalf("scan count = %d, want startup + refresh", scans)
+	}
+	if startupScan.Root != "/from/env" || refreshScan.Root != "/from/env" {
+		t.Fatalf("scan roots startup=%q refresh=%q, want WORKTREE_ROOT", startupScan.Root, refreshScan.Root)
+	}
+	if startupScan.MaxDepth != 1 || refreshScan.MaxDepth != 1 {
+		t.Fatalf("scan max depth startup=%d refresh=%d, want 1", startupScan.MaxDepth, refreshScan.MaxDepth)
+	}
+}
+
 func TestRun_ConfigErrorStopsBeforeScan(t *testing.T) {
 	scanned := false
 	err := run([]string{"wtui"}, runDeps{

--- a/model/model.go
+++ b/model/model.go
@@ -54,6 +54,8 @@ type Model struct {
 	activeWorktreeCreate      uint64
 	flowCreateSeq             uint64
 	activeFlowCreate          uint64
+	repoRefreshSeq            uint64
+	activeRepoRefresh         uint64
 	listRequests              [listRequestSlots]uint64
 	activePane                int // 0=left (repos), 1=right (content)
 	destructive               bool
@@ -66,6 +68,7 @@ type Model struct {
 	pendingWorktreeSelection  string
 	agentCommand              string
 	planPromptTemplate        string
+	scanRepos                 func() ([]scanner.Repo, error)
 	fetchRepo                 func(string) error
 	listSessions              func(sessions.SessionFilter) ([]sessions.SessionRecord, error)
 	readTranscript            func(sessions.Provider, string) ([]sessions.TranscriptEvent, error)
@@ -119,6 +122,7 @@ type Options struct {
 	AgentCommand         string
 	StartupMode          ui.Mode
 	PlanPromptTemplate   string
+	ScanRepos            func() ([]scanner.Repo, error)
 	FetchRepo            func(string) error
 	ListSessions         func(sessions.SessionFilter) ([]sessions.SessionRecord, error)
 	ReadTranscript       func(sessions.Provider, string) ([]sessions.TranscriptEvent, error)
@@ -271,6 +275,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		mode:                 startupMode(opts.StartupMode),
 		agentCommand:         agent.Normalize(opts.AgentCommand),
 		planPromptTemplate:   opts.PlanPromptTemplate,
+		scanRepos:            opts.ScanRepos,
 		fetchRepo:            fetchRepo,
 		listSessions:         listSessions,
 		readTranscript:       readTranscript,
@@ -708,6 +713,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleVisibleRepoFetchStatusFade(msg), nil
 	case VisibleRepoFetchStatusExpiredMsg:
 		return m.handleVisibleRepoFetchStatusExpired(msg), nil
+	case RepoRefreshResultMsg:
+		return m.handleRepoRefreshResult(msg)
+	case RepoRefreshFailedMsg:
+		return m.handleRepoRefreshFailed(msg), nil
 	case GitPulledMsg:
 		return m.handleGitPulled(msg)
 	case GitPullFailedMsg:

--- a/model/model.go
+++ b/model/model.go
@@ -50,6 +50,9 @@ type Model struct {
 	activeWorktreeSessionReq  uint64
 	inlineWorktreeSessionRepo string
 	inlineWorktreeSessionPath string
+	pendingInlineSessionRepo  string
+	pendingInlineSessionPath  string
+	pendingInlineSessionList  uint64
 	worktreeCreateSeq         uint64
 	activeWorktreeCreate      uint64
 	flowCreateSeq             uint64
@@ -692,7 +695,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case BranchCreateFailedMsg:
 		return m.handleBranchCreateFailed(msg), nil
 	case WorktreeResultMsg:
-		return m.handleWorktreeResult(msg), nil
+		return m.handleWorktreeResult(msg)
 	case WorktreeRemovedMsg:
 		return m.handleWorktreeRemoved(msg)
 	case WorktreeDeleteCompletedMsg:

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -46,10 +46,19 @@ func (m Model) startGlobalRefresh() (Model, tea.Cmd) {
 	}
 
 	cmds := []tea.Cmd{scanCmd}
-	if _, ok := m.currentRepoPath(); ok {
+	if repoPath, ok := m.currentRepoPath(); ok {
 		if _, ok := listFetchDescriptorForMode(m.mode); ok {
+			inlineWorktreePath := ""
+			if m.mode == ui.ModeWorktrees && m.inlineWorktreeSessionPath != "" {
+				inlineWorktreePath = m.inlineWorktreeSessionPath
+			}
 			var fetchCmd tea.Cmd
 			m, fetchCmd = m.startFetchForMode()
+			if inlineWorktreePath != "" && fetchCmd != nil {
+				m.pendingInlineSessionRepo = repoPath
+				m.pendingInlineSessionPath = inlineWorktreePath
+				m.pendingInlineSessionList = m.currentListRequest(ui.ModeWorktrees)
+			}
 			if fetchCmd != nil {
 				cmds = append(cmds, fetchCmd)
 			}
@@ -95,6 +104,13 @@ func (m Model) isCurrentWorktreeSessionRequest(msg WorktreeSessionResultMsg) boo
 		msg.Request == m.activeWorktreeSessionReq &&
 		msg.RepoPath == m.inlineWorktreeSessionRepo &&
 		msg.WorktreePath == m.inlineWorktreeSessionPath
+}
+
+func (m Model) pendingInlineSessionRefresh(repoPath string, listRequest uint64) (string, bool) {
+	if m.pendingInlineSessionRepo != repoPath || m.pendingInlineSessionList != listRequest {
+		return "", false
+	}
+	return m.pendingInlineSessionPath, m.pendingInlineSessionPath != ""
 }
 
 func (m Model) nextWorktreeCreateRequest() (Model, uint64) {

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/planstore"
+	"github.com/brian-bell/wtui/scanner"
 	"github.com/brian-bell/wtui/sessions"
 	"github.com/brian-bell/wtui/ui"
 )
@@ -23,6 +24,41 @@ const visibleRepoFetchFadeStepDuration = 1 * time.Second
 
 func (m Model) startFetchForMode() (Model, tea.Cmd) {
 	return m.startFetchMode(m.mode)
+}
+
+func (m Model) startGlobalRefresh() (Model, tea.Cmd) {
+	if m.scanRepos == nil {
+		m = m.setStatus(statusOther, "refresh unavailable")
+		return m, nil
+	}
+
+	m.repoRefreshSeq++
+	request := m.repoRefreshSeq
+	m.activeRepoRefresh = request
+
+	scanRepos := m.scanRepos
+	scanCmd := func() tea.Msg {
+		repos, err := scanRepos()
+		if err != nil {
+			return RepoRefreshFailedMsg{Request: request, Err: err.Error()}
+		}
+		return RepoRefreshResultMsg{Request: request, Repos: repos}
+	}
+
+	cmds := []tea.Cmd{scanCmd}
+	if _, ok := m.currentRepoPath(); ok {
+		if _, ok := listFetchDescriptorForMode(m.mode); ok {
+			var fetchCmd tea.Cmd
+			m, fetchCmd = m.startFetchForMode()
+			if fetchCmd != nil {
+				cmds = append(cmds, fetchCmd)
+			}
+		}
+	}
+	if len(cmds) == 1 {
+		return m, scanCmd
+	}
+	return m, tea.Batch(cmds...)
 }
 
 func (m Model) fetchForMode() tea.Cmd {
@@ -354,6 +390,24 @@ func visibleRepoNoun(count int) string {
 		return "repo"
 	}
 	return "repos"
+}
+
+func (m Model) replaceReposPreservingVisibleSelection(repos []scanner.Repo, previousPath string) (Model, bool, bool) {
+	m.repos = m.repos.SetItems(repos)
+	visible := m.filteredRepos()
+	if len(visible) == 0 {
+		return m.reflowRepos(), previousPath != "", false
+	}
+	if previousPath != "" {
+		for _, repo := range visible {
+			if repo.Path == previousPath {
+				m = m.selectFilteredRepo(previousPath)
+				return m, false, true
+			}
+		}
+	}
+	currentPath, _ := m.currentRepoPath()
+	return m.reflowRepos(), previousPath != currentPath, true
 }
 
 func expireVisibleRepoFetchStatus(request uint64, text string) tea.Cmd {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -76,6 +76,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleSetAgent()
 	}
 
+	if key == "f5" {
+		return m.startGlobalRefresh()
+	}
+
 	if m.activePane == 0 {
 		return m.handleLeftPaneKey(key)
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1781,6 +1781,9 @@ func (m Model) clearInlineWorktreeSessions() Model {
 	m.activeWorktreeSessionReq = 0
 	m.inlineWorktreeSessionRepo = ""
 	m.inlineWorktreeSessionPath = ""
+	m.pendingInlineSessionRepo = ""
+	m.pendingInlineSessionPath = ""
+	m.pendingInlineSessionList = 0
 	m.worktreeSessions = newSessionPane()
 	return m
 }

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -143,6 +143,16 @@ type VisibleRepoFetchStatusExpiredMsg struct {
 	Text    string
 }
 
+type RepoRefreshResultMsg struct {
+	Request uint64
+	Repos   []scanner.Repo
+}
+
+type RepoRefreshFailedMsg struct {
+	Request uint64
+	Err     string
+}
+
 type GitPulledMsg struct {
 	RepoPath string
 }
@@ -588,6 +598,43 @@ func (m Model) handleVisibleRepoFetchStatusExpired(msg VisibleRepoFetchStatusExp
 		m.status = statusError{}
 	}
 	return m
+}
+
+func (m Model) handleRepoRefreshResult(msg RepoRefreshResultMsg) (tea.Model, tea.Cmd) {
+	if msg.Request == 0 || msg.Request != m.activeRepoRefresh {
+		return m, nil
+	}
+	m.activeRepoRefresh = 0
+
+	oldPath, oldOK := m.currentRepoPath()
+	var selectedChanged, hasSelection bool
+	m, selectedChanged, hasSelection = m.replaceReposPreservingVisibleSelection(msg.Repos, oldPath)
+	if !hasSelection {
+		m = m.resetRightPaneCursors()
+		if len(msg.Repos) == 0 {
+			m = m.setStatus(statusOther, "No repositories found")
+		} else {
+			m = m.setStatus(statusOther, "No repositories match filter")
+		}
+		return m, nil
+	}
+	if selectedChanged || !oldOK {
+		m = m.resetRightPaneCursors()
+		return m.startFetchForMode()
+	}
+	return m.clearStatus(statusOther), nil
+}
+
+func (m Model) handleRepoRefreshFailed(msg RepoRefreshFailedMsg) Model {
+	if msg.Request == 0 || msg.Request != m.activeRepoRefresh {
+		return m
+	}
+	m.activeRepoRefresh = 0
+	errText := msg.Err
+	if errText == "" {
+		errText = "unknown error"
+	}
+	return m.setStatus(statusOther, "failed to refresh repos: "+errText)
 }
 
 func (m Model) handleGitPulled(msg GitPulledMsg) (tea.Model, tea.Cmd) {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -452,12 +452,13 @@ func (m Model) visibleStatusFadeStep() int {
 	return m.status.FadeStep
 }
 
-func (m Model) handleWorktreeResult(msg WorktreeResultMsg) Model {
+func (m Model) handleWorktreeResult(msg WorktreeResultMsg) (Model, tea.Cmd) {
 	var ok bool
 	m, ok = m.acceptListResult(msg.RepoPath, ui.ModeWorktrees, msg.ListRequest)
 	if !ok {
-		return m
+		return m, nil
 	}
+	inlineRefreshPath, refreshInline := m.pendingInlineSessionRefresh(msg.RepoPath, msg.ListRequest)
 	m.worktrees = m.worktrees.SetItems(msg.Worktrees)
 	m = m.clearInlineWorktreeSessions()
 	if m.pendingWorktreeSelection != "" {
@@ -467,8 +468,22 @@ func (m Model) handleWorktreeResult(msg WorktreeResultMsg) Model {
 		})
 		m.pendingWorktreeSelection = ""
 	}
+	if refreshInline {
+		for _, wt := range m.filteredWorktrees() {
+			if wt.Path != inlineRefreshPath {
+				continue
+			}
+			m.worktrees = m.worktrees.SelectFunc(func(wt gitquery.Worktree) bool {
+				return wt.Path == inlineRefreshPath
+			})
+			var request uint64
+			m, request = m.nextWorktreeSessionRequest(msg.RepoPath, inlineRefreshPath)
+			m = m.clampSelectionsAfterFilter()
+			return m, m.fetchWorktreeSessions(inlineRefreshPath, request)
+		}
+	}
 	m = m.clampSelectionsAfterFilter()
-	return m
+	return m, nil
 }
 
 func (m Model) handleWorktreeRemoved(msg WorktreeRemovedMsg) (tea.Model, tea.Cmd) {

--- a/model/model_refresh_test.go
+++ b/model/model_refresh_test.go
@@ -1,0 +1,365 @@
+package model_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/model"
+	"github.com/brian-bell/wtui/planstore"
+	"github.com/brian-bell/wtui/scanner"
+	"github.com/brian-bell/wtui/sessions"
+	"github.com/brian-bell/wtui/ui"
+)
+
+func TestModel_F5RefreshesReposAndCurrentFetchBackedMode(t *testing.T) {
+	modes := []ui.Mode{
+		ui.ModeWorktrees,
+		ui.ModeBranches,
+		ui.ModeStashes,
+		ui.ModeHistory,
+		ui.ModeReflog,
+		ui.ModeSessions,
+		ui.ModePlans,
+		ui.ModeFlows,
+	}
+
+	for _, mode := range modes {
+		t.Run(fmt.Sprintf("mode-%d", mode), func(t *testing.T) {
+			scans := 0
+			m := model.NewWithOptions(testRepos(), model.Options{
+				StartupMode: mode,
+				ScanRepos: func() ([]scanner.Repo, error) {
+					scans++
+					return testRepos(), nil
+				},
+				ListSessions: func(filter sessions.SessionFilter) ([]sessions.SessionRecord, error) {
+					return []sessions.SessionRecord{{Provider: sessions.ProviderCodex, SessionID: "s1", RepoPath: filter.RepoPath}}, nil
+				},
+				ListPlans: func(filter planstore.PlanFilter) ([]planstore.PlanRecord, error) {
+					return []planstore.PlanRecord{{PlanID: "p1", RepoPath: filter.RepoPath, Title: "Plan"}}, nil
+				},
+				ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+					return []flowstore.FlowRecord{{FlowID: "f1", RepoPath: filter.RepoPath, Title: "Flow"}}, nil
+				},
+			})
+			m = inRightPane(m)
+			beforeRequest := m.ListRequest(mode)
+
+			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF5})
+			if scans != 0 {
+				t.Fatalf("scanner ran before command execution: %d call(s)", scans)
+			}
+			if got := m.ListRequest(mode); got == beforeRequest {
+				t.Fatalf("ListRequest(%v) did not advance after f5", mode)
+			}
+
+			msgs := runBatchCmd(t, cmd)
+			if scans != 1 {
+				t.Fatalf("scanner ran %d times, want 1", scans)
+			}
+			if !hasRepoRefreshResult(msgs) {
+				t.Fatalf("refresh command messages = %#v, want RepoRefreshResultMsg", msgs)
+			}
+			if !hasListFetchForMode(msgs, mode, m.ListRequest(mode)) {
+				t.Fatalf("refresh command messages = %#v, want list fetch for mode %v request %d", msgs, mode, m.ListRequest(mode))
+			}
+		})
+	}
+}
+
+func TestModel_F5WithNoScannerReportsUnavailable(t *testing.T) {
+	m := model.New(testRepos())
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF5})
+
+	if cmd != nil {
+		t.Fatal("expected no command without refresh scanner")
+	}
+	if got := m.TransientError(); got != "refresh unavailable" {
+		t.Fatalf("TransientError() = %q, want refresh unavailable", got)
+	}
+}
+
+func TestModel_F5DuringModalOrSearchDoesNotRefresh(t *testing.T) {
+	scans := 0
+	opts := model.Options{
+		ScanRepos: func() ([]scanner.Repo, error) {
+			scans++
+			return testRepos(), nil
+		},
+	}
+
+	searchModel := model.NewWithOptions(testRepos(), opts)
+	searchModel, _ = update(searchModel, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	searchModel, cmd := update(searchModel, tea.KeyMsg{Type: tea.KeyF5})
+	if cmd != nil {
+		t.Fatal("search f5 should not start refresh command")
+	}
+	if scans != 0 {
+		t.Fatalf("scanner ran during search: %d", scans)
+	}
+	if !searchModel.SearchActive() {
+		t.Fatal("f5 should leave search input active")
+	}
+
+	modalModel := model.NewWithOptions(testRepos(), opts)
+	modalModel = inRightPane(modalModel)
+	modalModel, _ = update(modalModel, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if modalModel.Overlay() == ui.OverlayNone {
+		t.Fatal("expected modal to open")
+	}
+	modalModel, cmd = update(modalModel, tea.KeyMsg{Type: tea.KeyF5})
+	if cmd != nil {
+		t.Fatal("modal f5 should not start refresh command")
+	}
+	if scans != 0 {
+		t.Fatalf("scanner ran during modal: %d", scans)
+	}
+}
+
+func TestModel_RepoRefreshFailureLeavesReposAndShowsStatus(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ScanRepos: func() ([]scanner.Repo, error) {
+			return nil, errors.New("scan failed")
+		},
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF5})
+	msgs := runBatchCmd(t, cmd)
+	var failure tea.Msg
+	for _, msg := range msgs {
+		if _, ok := msg.(model.RepoRefreshFailedMsg); ok {
+			failure = msg
+			break
+		}
+	}
+	if failure == nil {
+		t.Fatalf("refresh messages = %#v, want scan failure", msgs)
+	}
+	m, _ = update(m, failure)
+
+	if got := m.TransientError(); got != "failed to refresh repos: scan failed" {
+		t.Fatalf("TransientError() = %q, want scan failure", got)
+	}
+	if got := m.Selected(); got != 0 {
+		t.Fatalf("Selected() = %d, want existing selection intact", got)
+	}
+}
+
+func TestModel_RepoRefreshPreservesSelectionAndKeepsCurrentListWhileFetchPending(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		StartupMode: ui.ModeSessions,
+		ScanRepos: func() ([]scanner.Repo, error) {
+			return []scanner.Repo{
+				{Path: "/dev/alpha", DisplayName: "alpha"},
+				{Path: "/dev/bravo", DisplayName: "bravo-renamed"},
+				{Path: "/dev/delta", DisplayName: "delta"},
+			}, nil
+		},
+		ListSessions: func(filter sessions.SessionFilter) ([]sessions.SessionRecord, error) {
+			return []sessions.SessionRecord{{Provider: sessions.ProviderCodex, SessionID: "fresh", RepoPath: filter.RepoPath}}, nil
+		},
+	})
+	m = selectBravo(m)
+	m, _ = update(m, model.SessionResultMsg{
+		RepoPath:    "/dev/bravo",
+		ListRequest: m.ListRequest(ui.ModeSessions),
+		Sessions: []sessions.SessionRecord{
+			{Provider: sessions.ProviderCodex, SessionID: "existing", RepoPath: "/dev/bravo"},
+		},
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF5})
+	scanMsg := repoRefreshResultFromBatch(t, runBatchCmd(t, cmd))
+	m, followup := update(m, scanMsg)
+	if followup != nil {
+		t.Fatal("unchanged selected repo should not start a second post-scan fetch")
+	}
+	if got := m.Sessions(); len(got) != 1 || got[0].SessionID != "existing" {
+		t.Fatalf("Sessions() after scan = %#v, want existing list while refresh fetch is pending", got)
+	}
+}
+
+func TestModel_RepoRefreshClampsSelectionAndFetchesNewRepoWhenOldDisappears(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		StartupMode: ui.ModeSessions,
+		ScanRepos: func() ([]scanner.Repo, error) {
+			return []scanner.Repo{
+				{Path: "/dev/bravo", DisplayName: "bravo"},
+				{Path: "/dev/charlie", DisplayName: "charlie"},
+			}, nil
+		},
+		ListSessions: func(filter sessions.SessionFilter) ([]sessions.SessionRecord, error) {
+			return []sessions.SessionRecord{{Provider: sessions.ProviderCodex, SessionID: filter.RepoPath, RepoPath: filter.RepoPath}}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, model.SessionResultMsg{
+		RepoPath:    "/dev/alpha",
+		ListRequest: m.ListRequest(ui.ModeSessions),
+		Sessions: []sessions.SessionRecord{
+			{Provider: sessions.ProviderCodex, SessionID: "old-alpha", RepoPath: "/dev/alpha"},
+		},
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF5})
+	msgs := runBatchCmd(t, cmd)
+	preScanFetch := sessionResultFromMessages(t, msgs, "/dev/alpha")
+	scanMsg := repoRefreshResultFromBatch(t, msgs)
+
+	m, followup := update(m, scanMsg)
+	if got := m.Sessions(); len(got) != 0 {
+		t.Fatalf("Sessions() after selected repo changed = %#v, want stale list cleared", got)
+	}
+	if followup == nil {
+		t.Fatal("expected post-scan fetch for new selected repo")
+	}
+	postScanMsg, ok := followup().(model.SessionResultMsg)
+	if !ok {
+		t.Fatalf("post-scan fetch = %T, want SessionResultMsg", postScanMsg)
+	}
+	if postScanMsg.RepoPath != "/dev/bravo" {
+		t.Fatalf("post-scan fetch repo = %q, want /dev/bravo", postScanMsg.RepoPath)
+	}
+
+	m, _ = update(m, preScanFetch)
+	if got := m.Sessions(); len(got) != 0 {
+		t.Fatalf("stale pre-scan fetch applied after repo change: %#v", got)
+	}
+	m, _ = update(m, postScanMsg)
+	if got := m.Sessions(); len(got) != 1 || got[0].RepoPath != "/dev/bravo" {
+		t.Fatalf("Sessions() after post-scan fetch = %#v, want bravo session", got)
+	}
+}
+
+func TestModel_RepoRefreshKeepsFilterAndHandlesZeroVisibleRepos(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ScanRepos: func() ([]scanner.Repo, error) {
+			return []scanner.Repo{{Path: "/dev/delta", DisplayName: "delta"}}, nil
+		},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	for _, r := range "zzz" {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF5})
+	scanMsg := repoRefreshResultFromBatch(t, runBatchCmd(t, cmd))
+	m, followup := update(m, scanMsg)
+
+	if followup != nil {
+		t.Fatal("zero visible repos should not fetch right pane")
+	}
+	if got := m.RepoSearch(); got != "zzz" {
+		t.Fatalf("RepoSearch() = %q, want preserved query zzz", got)
+	}
+	if got := m.TransientError(); got != "No repositories match filter" {
+		t.Fatalf("TransientError() = %q, want zero-match status", got)
+	}
+}
+
+func TestModel_StaleRepoRefreshResultAndFailureIgnored(t *testing.T) {
+	scans := 0
+	m := model.NewWithOptions(testRepos(), model.Options{
+		StartupMode: ui.ModeSessions,
+		ScanRepos: func() ([]scanner.Repo, error) {
+			scans++
+			if scans == 1 {
+				return []scanner.Repo{{Path: "/dev/charlie", DisplayName: "charlie"}}, nil
+			}
+			return []scanner.Repo{{Path: "/dev/bravo", DisplayName: "bravo"}}, nil
+		},
+		ListSessions: func(filter sessions.SessionFilter) ([]sessions.SessionRecord, error) {
+			return []sessions.SessionRecord{{Provider: sessions.ProviderCodex, SessionID: filter.RepoPath, RepoPath: filter.RepoPath}}, nil
+		},
+	})
+
+	m, cmdA := update(m, tea.KeyMsg{Type: tea.KeyF5})
+	msgA := repoRefreshResultFromBatch(t, runBatchCmd(t, cmdA))
+	m, cmdB := update(m, tea.KeyMsg{Type: tea.KeyF5})
+	msgB := repoRefreshResultFromBatch(t, runBatchCmd(t, cmdB))
+
+	m, followup := update(m, msgB)
+	if followup == nil {
+		t.Fatal("fresh refresh should fetch selected repo after clamping")
+	}
+	freshMsg, ok := followup().(model.SessionResultMsg)
+	if !ok {
+		t.Fatalf("fresh post-scan fetch = %T, want SessionResultMsg", freshMsg)
+	}
+	if freshMsg.RepoPath != "/dev/bravo" {
+		t.Fatalf("fresh post-scan fetch repo = %q, want /dev/bravo", freshMsg.RepoPath)
+	}
+
+	m, _ = update(m, model.RepoRefreshFailedMsg{Request: msgA.Request, Err: "old failure"})
+	if got := m.TransientError(); got != "" {
+		t.Fatalf("stale refresh failure set status %q", got)
+	}
+	m, _ = update(m, msgA)
+	m, _ = update(m, freshMsg)
+	if got := m.Sessions(); len(got) != 1 || got[0].RepoPath != "/dev/bravo" {
+		t.Fatalf("stale refresh result changed selected repo or blocked fresh result: %#v", got)
+	}
+}
+
+func hasRepoRefreshResult(msgs []tea.Msg) bool {
+	for _, msg := range msgs {
+		if _, ok := msg.(model.RepoRefreshResultMsg); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func repoRefreshResultFromBatch(t *testing.T, msgs []tea.Msg) model.RepoRefreshResultMsg {
+	t.Helper()
+	for _, msg := range msgs {
+		if got, ok := msg.(model.RepoRefreshResultMsg); ok {
+			return got
+		}
+	}
+	t.Fatalf("messages = %#v, want RepoRefreshResultMsg", msgs)
+	return model.RepoRefreshResultMsg{}
+}
+
+func sessionResultFromMessages(t *testing.T, msgs []tea.Msg, repoPath string) model.SessionResultMsg {
+	t.Helper()
+	for _, msg := range msgs {
+		if got, ok := msg.(model.SessionResultMsg); ok && got.RepoPath == repoPath {
+			return got
+		}
+	}
+	t.Fatalf("messages = %#v, want SessionResultMsg for %s", msgs, repoPath)
+	return model.SessionResultMsg{}
+}
+
+func hasListFetchForMode(msgs []tea.Msg, mode ui.Mode, request uint64) bool {
+	for _, msg := range msgs {
+		switch msg := msg.(type) {
+		case model.WorktreeResultMsg:
+			return mode == ui.ModeWorktrees && msg.ListRequest == request
+		case model.BranchResultMsg:
+			return mode == ui.ModeBranches && msg.ListRequest == request
+		case model.StashResultMsg:
+			return mode == ui.ModeStashes && msg.ListRequest == request
+		case model.CommitResultMsg:
+			return mode == ui.ModeHistory && msg.ListRequest == request
+		case model.ReflogResultMsg:
+			return mode == ui.ModeReflog && msg.ListRequest == request
+		case model.SessionResultMsg:
+			return mode == ui.ModeSessions && msg.ListRequest == request
+		case model.PlanResultMsg:
+			return mode == ui.ModePlans && msg.ListRequest == request
+		case model.FlowResultMsg:
+			return mode == ui.ModeFlows && msg.ListRequest == request
+		case model.FetchErrorMsg:
+			return msg.Kind == model.FetchList && msg.Mode == mode && msg.ListRequest == request
+		}
+	}
+	return false
+}

--- a/model/model_refresh_test.go
+++ b/model/model_refresh_test.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/model"
 	"github.com/brian-bell/wtui/planstore"
 	"github.com/brian-bell/wtui/scanner"
@@ -181,6 +182,69 @@ func TestModel_RepoRefreshPreservesSelectionAndKeepsCurrentListWhileFetchPending
 	}
 	if got := m.Sessions(); len(got) != 1 || got[0].SessionID != "existing" {
 		t.Fatalf("Sessions() after scan = %#v, want existing list while refresh fetch is pending", got)
+	}
+}
+
+func TestModel_F5RefreshesOpenInlineWorktreeSessionsAfterWorktreeListRefresh(t *testing.T) {
+	var gotFilters []sessions.SessionFilter
+	m := model.NewWithOptions(testRepos(), model.Options{
+		StartupMode: ui.ModeWorktrees,
+		ScanRepos: func() ([]scanner.Repo, error) {
+			return testRepos(), nil
+		},
+		ListSessions: func(filter sessions.SessionFilter) ([]sessions.SessionRecord, error) {
+			gotFilters = append(gotFilters, filter)
+			return []sessions.SessionRecord{{
+				Provider:     sessions.ProviderCodex,
+				SessionID:    fmt.Sprintf("inline-refresh-%d", len(gotFilters)),
+				RepoPath:     filter.RepoPath,
+				WorktreePath: filter.WorktreePath,
+				Branch:       "feature/inline",
+			}}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{
+		RepoPath:    "/dev/alpha",
+		ListRequest: m.ListRequest(ui.ModeWorktrees),
+		Worktrees: []gitquery.Worktree{
+			{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+			{Path: "/dev/alpha-worktrees/inline", BranchName: "feature/inline"},
+		},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd == nil {
+		t.Fatal("expected initial inline session fetch")
+	}
+	m, _ = update(m, cmd())
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF5})
+	if cmd == nil {
+		t.Fatal("expected f5 refresh command")
+	}
+	refreshRequest := m.ListRequest(ui.ModeWorktrees)
+	m, followup := update(m, model.WorktreeResultMsg{
+		RepoPath:    "/dev/alpha",
+		ListRequest: refreshRequest,
+		Worktrees: []gitquery.Worktree{
+			{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+			{Path: "/dev/alpha-worktrees/inline", BranchName: "feature/inline"},
+		},
+	})
+	if followup == nil {
+		t.Fatal("expected refreshed worktree list to fetch inline sessions")
+	}
+	m, _ = update(m, followup())
+
+	if len(gotFilters) != 2 {
+		t.Fatalf("ListSessions called %d times, want initial open plus f5 refresh", len(gotFilters))
+	}
+	if got := gotFilters[1]; got.RepoPath != "/dev/alpha" || got.WorktreePath != "/dev/alpha-worktrees/inline" {
+		t.Fatalf("refreshed SessionFilter = %#v, want repo and inline worktree", got)
+	}
+	if got := m.WorktreeSessions(); len(got) != 1 || got[0].SessionID != "inline-refresh-2" {
+		t.Fatalf("WorktreeSessions() = %#v, want refreshed inline sessions", got)
 	}
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -588,7 +588,12 @@ func renderStatusBarWithState(sp statusBarParams) string {
 		return statusStyle.Width(width).Render("  ↑/↓ scroll  esc: close")
 	}
 
-	return statusStyle.Width(width).Render(renderFooterShortcuts(sp, shortcutSections(sp)))
+	sections := shortcutSections(sp)
+	shortcuts := renderFooterShortcuts(sp, sections)
+	if strings.Contains(shortcuts, "\n") || lipgloss.Width(shortcuts) > width {
+		shortcuts = renderFooterShortcuts(sp, withoutShortcutKey(sections, "f5"))
+	}
+	return statusStyle.Width(width).Render(shortcuts)
 }
 
 func renderShortcutPane(sp statusBarParams, width, height int) string {
@@ -605,7 +610,7 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 	}
 	sectionCount := 0
 
-	for _, section := range shortcutSections(sp) {
+	for _, section := range shortcutSectionsForPane(sp, height) {
 		hints := sidebarShortcutHints(section.Hints)
 		if len(hints) == 0 {
 			continue
@@ -685,6 +690,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 		{Key: "tab", Label: "pane"},
 		{Key: "q/esc", Label: "quit"},
 		{Key: "A", Label: "set agent"},
+		{Key: "f5", Label: "refresh"},
 	}
 
 	var actions []shortcutHint
@@ -842,10 +848,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	if len(actions) > 0 {
 		sections = append(sections, shortcutSection{Title: "Actions", Hints: actions})
 	}
-	sections = append(sections,
-		shortcutSection{Title: "Navigate", Hints: navigation},
-		shortcutSection{Title: "Global", Hints: global},
-	)
+	sections = append(sections, shortcutSection{Title: "Navigate", Hints: navigation})
 	if sp.Mode == ModeBranches {
 		sections = append(sections, shortcutSection{
 			Title: "Legend",
@@ -858,7 +861,34 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 			},
 		})
 	}
+	sections = append(sections, shortcutSection{Title: "Global", Hints: global})
 	return sections
+}
+
+func shortcutSectionsForPane(sp statusBarParams, height int) []shortcutSection {
+	sections := shortcutSections(sp)
+	if height < 20 {
+		return withoutShortcutKey(sections, "f5")
+	}
+	return sections
+}
+
+func withoutShortcutKey(sections []shortcutSection, key string) []shortcutSection {
+	filtered := make([]shortcutSection, 0, len(sections))
+	for _, section := range sections {
+		hints := make([]shortcutHint, 0, len(section.Hints))
+		for _, hint := range section.Hints {
+			if hint.Key != key {
+				hints = append(hints, hint)
+			}
+		}
+		if len(hints) == 0 {
+			continue
+		}
+		section.Hints = hints
+		filtered = append(filtered, section)
+	}
+	return filtered
 }
 
 func renderFooterShortcuts(sp statusBarParams, sections []shortcutSection) string {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -974,6 +974,20 @@ func TestRender_ShortcutPaneStylesModeTitleSeparately(t *testing.T) {
 	}
 }
 
+func TestRender_StatusBarShowsGlobalRefreshShortcut(t *testing.T) {
+	bar := ansi.Strip(RenderStatusBar(180, ModeFlows, OverlayNone, 1, false, false, false))
+	if !strings.Contains(bar, "f5: refresh") {
+		t.Fatalf("status bar should expose refresh shortcut, got %q", bar)
+	}
+}
+
+func TestRender_ShortcutPaneShowsGlobalRefreshShortcut(t *testing.T) {
+	pane := shortcutPaneText(renderShortcutPane(statusBarParams{Mode: ModeWorktrees}, 26, 20))
+	if !strings.Contains(pane, "f5     refresh") {
+		t.Fatalf("shortcut pane should expose refresh shortcut, got:\n%s", pane)
+	}
+}
+
 func TestSidebarShortcutHintsGroupsOnlyAdjacentPairs(t *testing.T) {
 	grouped := sidebarShortcutHints([]shortcutHint{
 		{Key: "f", Label: "fetch"},


### PR DESCRIPTION
## Summary
- add an F5 global refresh path that rescans repositories using the resolved startup scan options
- refresh the current fetch-backed pane while preserving visible repo selection and ignoring stale refresh results
- expose the refresh shortcut in the footer and shortcut pane with overflow handling

## Verification
- make test
- make build
- gofmt -l .