### PR TITLE
Use configured terminal for launches

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -549,6 +549,12 @@ type TerminalLaunchSpec struct {
 	Cleanup  func()
 }
 
+// LaunchOptions customizes external terminal transports without changing
+// multiplexer/session selection.
+type LaunchOptions struct {
+	TerminalCommand string
+}
+
 // AgentLaunchContext carries metadata wtui knows at launch time so provider
 // hooks can associate later session records with the selected repo/worktree.
 type AgentLaunchContext struct {
@@ -578,10 +584,20 @@ type AgentLaunchContext struct {
 // over the wtui TTY. Detached transports leave the wtui TUI usable; only
 // transports that genuinely need the current TTY are returned as interactive.
 func AgentLaunch(ctx AgentLaunchContext) (TerminalLaunchSpec, error) {
-	return agentLaunch(ctx, runtime.GOOS, os.Getenv, exec.LookPath)
+	return AgentLaunchWithOptions(ctx, LaunchOptions{})
+}
+
+// AgentLaunchWithOptions is AgentLaunch with configurable terminal transport
+// selection.
+func AgentLaunchWithOptions(ctx AgentLaunchContext, opts LaunchOptions) (TerminalLaunchSpec, error) {
+	return agentLaunchWithOptions(ctx, runtime.GOOS, os.Getenv, exec.LookPath, opts)
 }
 
 func agentLaunch(ctx AgentLaunchContext, goos string, getenv getenvFunc, lookPath lookPathFunc) (TerminalLaunchSpec, error) {
+	return agentLaunchWithOptions(ctx, goos, getenv, lookPath, LaunchOptions{})
+}
+
+func agentLaunchWithOptions(ctx AgentLaunchContext, goos string, getenv getenvFunc, lookPath lookPathFunc, opts LaunchOptions) (TerminalLaunchSpec, error) {
 	command := agent.Normalize(ctx.Command)
 	if err := agent.Validate(command); err != nil {
 		return TerminalLaunchSpec{}, err
@@ -611,7 +627,7 @@ func agentLaunch(ctx AgentLaunchContext, goos string, getenv getenvFunc, lookPat
 	if err != nil {
 		return TerminalLaunchSpec{}, err
 	}
-	launch, err := terminalLaunch(cmd.Dir, goos, getenv, lookPath, termCommand)
+	launch, err := terminalLaunchWithOptions(cmd.Dir, goos, getenv, lookPath, termCommand, opts)
 	if err != nil {
 		termCommand.cleanup()
 		return TerminalLaunchSpec{}, err
@@ -1033,19 +1049,30 @@ func isShellIdentifier(s string) bool {
 // session for path. It adapts to the current environment:
 //   - inside Zellij: switch to a Zellij session with the worktree name
 //   - inside tmux: create the tmux session if needed, then switch-client
-//   - outside a multiplexer: prefer tmux, Zellij, $TERMINAL, then a platform/shell fallback
+//   - outside a multiplexer: prefer $TERMINAL, configured terminal, tmux/Zellij, then a platform/shell fallback
 func TerminalLaunch(path string) (TerminalLaunchSpec, error) {
-	return terminalLaunch(path, runtime.GOOS, os.Getenv, exec.LookPath, nil)
+	return TerminalLaunchWithOptions(path, LaunchOptions{})
+}
+
+// TerminalLaunchWithOptions is TerminalLaunch with configurable terminal
+// transport selection.
+func TerminalLaunchWithOptions(path string, opts LaunchOptions) (TerminalLaunchSpec, error) {
+	return terminalLaunchWithOptions(path, runtime.GOOS, os.Getenv, exec.LookPath, nil, opts)
 }
 
 // terminalLaunch chooses a transport for path. When command is nil it opens a
 // plain shell/terminal session (the `t` shortcut). When command is non-nil it
 // runs that command inside the chosen session instead.
 func terminalLaunch(path, goos string, getenv getenvFunc, lookPath lookPathFunc, command *terminalCommand) (TerminalLaunchSpec, error) {
+	return terminalLaunchWithOptions(path, goos, getenv, lookPath, command, LaunchOptions{})
+}
+
+func terminalLaunchWithOptions(path, goos string, getenv getenvFunc, lookPath lookPathFunc, command *terminalCommand, opts LaunchOptions) (TerminalLaunchSpec, error) {
 	sessionName := WorktreeSessionName(path)
 	if command != nil && command.session != "" {
 		sessionName = command.session
 	}
+	preference := selectTerminalPreference(getenv("TERMINAL"), opts.TerminalCommand, lookPath)
 
 	switch {
 	case getenv("ZELLIJ") != "" && commandExists("zellij", lookPath):
@@ -1065,12 +1092,22 @@ func terminalLaunch(path, goos string, getenv getenvFunc, lookPath lookPathFunc,
 			Cmd:      tmuxSwitchCommand(sessionName, path, command),
 			Detached: command != nil,
 		}, nil
+	}
+
+	if preference.kind != terminalPreferenceNone {
+		return terminalLaunchFromPreference(goos, path, lookPath, preference, command)
+	}
+
+	switch {
 	case commandExists("tmux", lookPath):
-		if goos == "darwin" && commandExists("osascript", lookPath) {
-			return TerminalLaunchSpec{
-				Cmd:      externalTerminalCommand(tmuxAttachCommand(sessionName, path, command)),
-				Detached: command != nil,
-			}, nil
+		if goos == "darwin" {
+			launch, err := macOSScriptLaunch(path, lookPath, preference, tmuxAttachCommand(sessionName, path, command), command != nil)
+			if err == nil {
+				return launch, nil
+			}
+			if preference.kind != terminalPreferenceNone {
+				return TerminalLaunchSpec{}, err
+			}
 		}
 		return TerminalLaunchSpec{
 			Cmd:         tmuxNewSessionCommand(sessionName, path, command),
@@ -1078,20 +1115,19 @@ func terminalLaunch(path, goos string, getenv getenvFunc, lookPath lookPathFunc,
 			Detached:    command != nil,
 		}, nil
 	case commandExists("zellij", lookPath):
-		if goos == "darwin" && commandExists("osascript", lookPath) {
-			return TerminalLaunchSpec{
-				Cmd:      externalTerminalCommand(zellijAttachCommand(sessionName, path, command)),
-				Detached: command != nil,
-			}, nil
+		if goos == "darwin" {
+			launch, err := macOSScriptLaunch(path, lookPath, preference, zellijAttachCommand(sessionName, path, command), command != nil)
+			if err == nil {
+				return launch, nil
+			}
+			if preference.kind != terminalPreferenceNone {
+				return TerminalLaunchSpec{}, err
+			}
 		}
 		return TerminalLaunchSpec{
 			Cmd:         zellijAttachLocalCommand(sessionName, path, command),
 			Interactive: true,
 		}, nil
-	}
-
-	if terminal := strings.TrimSpace(getenv("TERMINAL")); terminal != "" {
-		return terminalLaunchFromEnv(goos, terminal, path, lookPath, command)
 	}
 
 	if goos == "darwin" && commandExists("open", lookPath) {
@@ -1100,12 +1136,12 @@ func terminalLaunch(path, goos string, getenv getenvFunc, lookPath lookPathFunc,
 				return TerminalLaunchSpec{}, fmt.Errorf("cannot launch agent: osascript is required to run a command in Terminal")
 			}
 			return TerminalLaunchSpec{
-				Cmd:      externalTerminalCommand(command.shellCommand()),
+				Cmd:      macOSTerminalScriptCommand("Terminal", command.shellCommand()),
 				Detached: true,
 			}, nil
 		}
 		return TerminalLaunchSpec{
-			Cmd: exec.Command("open", "-a", "Terminal", path),
+			Cmd: macOSTerminalOpenCommand("Terminal", path),
 		}, nil
 	}
 
@@ -1126,6 +1162,170 @@ func terminalLaunch(path, goos string, getenv getenvFunc, lookPath lookPathFunc,
 	return TerminalLaunchSpec{Cmd: cmd, Interactive: true}, nil
 }
 
+type terminalPreferenceKind int
+
+const (
+	terminalPreferenceNone terminalPreferenceKind = iota
+	terminalPreferenceGUIApp
+	terminalPreferenceCLICommand
+	terminalPreferenceUnsupportedGUIApp
+)
+
+type terminalPreference struct {
+	source string
+	raw    string
+	kind   terminalPreferenceKind
+	app    string
+	argv   []string
+	reason string
+}
+
+func selectTerminalPreference(envTerminal, configuredTerminal string, lookPath lookPathFunc) terminalPreference {
+	if terminal := strings.TrimSpace(envTerminal); terminal != "" {
+		return parseTerminalPreference("TERMINAL", terminal, lookPath)
+	}
+	if terminal := strings.TrimSpace(configuredTerminal); terminal != "" {
+		return parseTerminalPreference("[terminal].command", terminal, lookPath)
+	}
+	return terminalPreference{kind: terminalPreferenceNone}
+}
+
+func parseTerminalPreference(source, terminal string, lookPath lookPathFunc) terminalPreference {
+	fields := strings.Fields(terminal)
+	if len(fields) == 0 {
+		return terminalPreference{source: source, raw: terminal, kind: terminalPreferenceNone}
+	}
+	if app, ok := normalizeMacOSGUIAppAlias(fields[0]); ok {
+		if len(fields) > 1 {
+			return terminalPreference{
+				source: source,
+				raw:    terminal,
+				kind:   terminalPreferenceUnsupportedGUIApp,
+				app:    fields[0],
+				reason: fmt.Sprintf("%s %q uses supported macOS GUI app %q with unsupported arguments", source, terminal, fields[0]),
+			}
+		}
+		return terminalPreference{source: source, raw: terminal, kind: terminalPreferenceGUIApp, app: app}
+	}
+	if commandExists(fields[0], lookPath) {
+		return terminalPreference{source: source, raw: terminal, kind: terminalPreferenceCLICommand, argv: fields}
+	}
+	return terminalPreference{source: source, raw: terminal, kind: terminalPreferenceUnsupportedGUIApp, app: fields[0]}
+}
+
+func normalizeMacOSGUIAppAlias(value string) (string, bool) {
+	switch strings.ToLower(value) {
+	case "terminal", "terminal.app":
+		return "Terminal", true
+	case "iterm", "iterm.app", "iterm2", "iterm2.app":
+		return "iTerm", true
+	default:
+		return "", false
+	}
+}
+
+func terminalLaunchFromPreference(goos, path string, lookPath lookPathFunc, pref terminalPreference, command *terminalCommand) (TerminalLaunchSpec, error) {
+	switch pref.kind {
+	case terminalPreferenceCLICommand:
+		return cliTerminalLaunch(pref.argv, path, command)
+	case terminalPreferenceGUIApp:
+		if goos != "darwin" {
+			return TerminalLaunchSpec{}, missingTerminalCommandError(pref)
+		}
+		if command != nil {
+			if !commandExists("osascript", lookPath) {
+				return TerminalLaunchSpec{}, fmt.Errorf("cannot launch agent: osascript is required to run a command in %s", pref.app)
+			}
+			return TerminalLaunchSpec{
+				Cmd:      macOSTerminalScriptCommand(pref.app, command.shellCommand()),
+				Detached: true,
+			}, nil
+		}
+		if pref.app == "Terminal" && !commandExists("open", lookPath) {
+			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch terminal: open is required to open Terminal")
+		}
+		if pref.app == "iTerm" && !commandExists("osascript", lookPath) {
+			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch terminal: osascript is required to open iTerm")
+		}
+		return TerminalLaunchSpec{Cmd: macOSTerminalOpenCommand(pref.app, path)}, nil
+	case terminalPreferenceUnsupportedGUIApp:
+		if pref.reason != "" {
+			return TerminalLaunchSpec{}, fmt.Errorf("%s", pref.reason)
+		}
+		if command != nil {
+			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch agent: %s %q must be a supported macOS terminal app or a command on PATH that accepts -e", pref.source, pref.raw)
+		}
+		if goos == "darwin" {
+			if !commandExists("open", lookPath) {
+				return TerminalLaunchSpec{}, fmt.Errorf("cannot launch terminal: open is required to open %s", pref.app)
+			}
+			return TerminalLaunchSpec{Cmd: exec.Command("open", "-a", pref.app, path)}, nil
+		}
+		return TerminalLaunchSpec{}, missingTerminalCommandError(pref)
+	default:
+		return TerminalLaunchSpec{}, fmt.Errorf("%s is empty", pref.source)
+	}
+}
+
+func cliTerminalLaunch(argv []string, path string, command *terminalCommand) (TerminalLaunchSpec, error) {
+	if len(argv) == 0 {
+		return TerminalLaunchSpec{}, fmt.Errorf("terminal command is empty")
+	}
+	args := append([]string(nil), argv[1:]...)
+	if command != nil {
+		args = append(args, "-e", "sh", "-c", command.shellCommand())
+	}
+	cmd := exec.Command(argv[0], args...)
+	cmd.Dir = path
+	return TerminalLaunchSpec{Cmd: cmd, Detached: command != nil}, nil
+}
+
+func macOSScriptLaunch(path string, lookPath lookPathFunc, pref terminalPreference, shellCommand string, detached bool) (TerminalLaunchSpec, error) {
+	switch pref.kind {
+	case terminalPreferenceNone:
+		if !commandExists("osascript", lookPath) {
+			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch agent: osascript is required to run a command in Terminal")
+		}
+		return TerminalLaunchSpec{Cmd: macOSTerminalScriptCommand("Terminal", shellCommand), Detached: detached}, nil
+	case terminalPreferenceGUIApp:
+		if !commandExists("osascript", lookPath) {
+			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch agent: osascript is required to run a command in %s", pref.app)
+		}
+		return TerminalLaunchSpec{Cmd: macOSTerminalScriptCommand(pref.app, shellCommand), Detached: detached}, nil
+	case terminalPreferenceCLICommand:
+		cmd, err := cliTerminalLaunchForShell(pref.argv, path, shellCommand)
+		if err != nil {
+			return TerminalLaunchSpec{}, err
+		}
+		return TerminalLaunchSpec{Cmd: cmd, Detached: detached}, nil
+	case terminalPreferenceUnsupportedGUIApp:
+		if pref.reason != "" {
+			return TerminalLaunchSpec{}, fmt.Errorf("%s", pref.reason)
+		}
+		return TerminalLaunchSpec{}, fmt.Errorf("cannot launch agent: %s %q must be a supported macOS terminal app or a command on PATH that accepts -e", pref.source, pref.raw)
+	default:
+		return TerminalLaunchSpec{}, fmt.Errorf("terminal preference is invalid")
+	}
+}
+
+func cliTerminalLaunchForShell(argv []string, path, shellCommand string) (*exec.Cmd, error) {
+	if len(argv) == 0 {
+		return nil, fmt.Errorf("terminal command is empty")
+	}
+	args := append([]string(nil), argv[1:]...)
+	args = append(args, "-e", "sh", "-c", shellCommand)
+	cmd := exec.Command(argv[0], args...)
+	cmd.Dir = path
+	return cmd, nil
+}
+
+func missingTerminalCommandError(pref terminalPreference) error {
+	if pref.source == "TERMINAL" {
+		return fmt.Errorf("TERMINAL is set to %q, but that command was not found", pref.raw)
+	}
+	return fmt.Errorf("%s is set to %q, but that command was not found", pref.source, pref.raw)
+}
+
 // resolveShell returns a runnable shell path. It accepts shell only if it is a
 // regular file with an executable bit, or resolves via lookPath; otherwise it
 // falls back to /bin/sh.
@@ -1141,37 +1341,6 @@ func resolveShell(shell string, lookPath lookPathFunc) string {
 		return shell
 	}
 	return fallback
-}
-
-func terminalLaunchFromEnv(goos, terminal, path string, lookPath lookPathFunc, command *terminalCommand) (TerminalLaunchSpec, error) {
-	fields := strings.Fields(terminal)
-	if len(fields) == 0 {
-		return TerminalLaunchSpec{}, fmt.Errorf("TERMINAL is empty")
-	}
-
-	name := fields[0]
-	args := fields[1:]
-	if commandExists(name, lookPath) {
-		if command != nil {
-			// Best-effort: most terminals accept `-e <command>` to run a
-			// command instead of an interactive shell.
-			args = append(append([]string{}, args...), "-e", "sh", "-c", command.shellCommand())
-		}
-		cmd := exec.Command(name, args...)
-		cmd.Dir = path
-		return TerminalLaunchSpec{Cmd: cmd, Detached: command != nil}, nil
-	}
-
-	if goos == "darwin" {
-		if command != nil {
-			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch agent: TERMINAL %q must be on PATH to run a command; run inside tmux/zellij or use a terminal that accepts -e", terminal)
-		}
-		return TerminalLaunchSpec{
-			Cmd: exec.Command("open", "-a", name, path),
-		}, nil
-	}
-
-	return TerminalLaunchSpec{}, fmt.Errorf("TERMINAL is set to %q, but that command was not found", terminal)
 }
 
 func selectClipboardCommand(goos string, lookPath lookPathFunc) (commandSpec, error) {
@@ -1426,18 +1595,40 @@ func commandExists(name string, lookPath lookPathFunc) bool {
 	return err == nil
 }
 
-// externalTerminalCommand opens macOS Terminal running shellCommand. shellCommand
-// is embedded via Go %q, which escapes the AppleScript string; untrusted values
-// inside it are already single-quoted by shellQuote, so they cannot break out of
-// either the AppleScript string or the shell. Exotic control characters (bell,
-// vtab) are assumed absent from paths/branches/prompts; they would be mangled by
-// the AppleScript layer but cannot inject.
-func externalTerminalCommand(shellCommand string) *exec.Cmd {
+func macOSTerminalOpenCommand(app, path string) *exec.Cmd {
+	if app == "iTerm" {
+		return macOSTerminalScriptCommand("iTerm", "cd "+shellQuote(path)+" && exec ${SHELL:-/bin/sh}")
+	}
+	return exec.Command("open", "-a", "Terminal", path)
+}
+
+// macOSTerminalScriptCommand opens a supported macOS GUI terminal running
+// shellCommand. shellCommand is embedded via Go %q, which escapes the
+// AppleScript string; untrusted values inside it are already single-quoted by
+// shellQuote, so they cannot break out of either the AppleScript string or the
+// shell. Exotic control characters (bell, vtab) are assumed absent from
+// paths/branches/prompts; they would be mangled by the AppleScript layer but
+// cannot inject.
+func macOSTerminalScriptCommand(app, shellCommand string) *exec.Cmd {
+	if app == "iTerm" {
+		return exec.Command(
+			"osascript",
+			"-e", `tell application "iTerm"`,
+			"-e", `activate`,
+			"-e", `set newWindow to (create window with default profile)`,
+			"-e", fmt.Sprintf(`tell current session of newWindow to write text %q`, shellCommand),
+			"-e", `end tell`,
+		)
+	}
 	return exec.Command(
 		"osascript",
 		"-e", fmt.Sprintf(`tell application "Terminal" to do script %q`, shellCommand),
 		"-e", `tell application "Terminal" to activate`,
 	)
+}
+
+func externalTerminalCommand(shellCommand string) *exec.Cmd {
+	return macOSTerminalScriptCommand("Terminal", shellCommand)
 }
 
 func tmuxAttachCommand(sessionName, path string, command *terminalCommand) string {

--- a/actions/actions_select_test.go
+++ b/actions/actions_select_test.go
@@ -160,6 +160,137 @@ func TestTerminalLaunch_DarwinFallsBackToTerminalApp(t *testing.T) {
 	}
 }
 
+func TestTerminalLaunchWithOptions_DarwinConfiguredITermOpensWorktree(t *testing.T) {
+	launch, err := terminalLaunchWithOptions("/repo", "darwin", fakeGetenv(nil), fakeLookPath("osascript"), nil, LaunchOptions{
+		TerminalCommand: "iTerm",
+	})
+	if err != nil {
+		t.Fatalf("terminalLaunchWithOptions returned error: %v", err)
+	}
+	if launch.Cmd.Args[0] != "osascript" {
+		t.Fatalf("expected iTerm AppleScript transport, got %#v", launch.Cmd.Args)
+	}
+	joined := strings.Join(launch.Cmd.Args, "\n")
+	for _, want := range []string{`tell application "iTerm"`, "activate", "set newWindow to (create window with default profile)", "write text", "cd '/repo' && exec ${SHELL:-/bin/sh}"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected iTerm launch args to contain %q, got %#v", want, launch.Cmd.Args)
+		}
+	}
+	if strings.Contains(joined, "current session of current window") {
+		t.Fatalf("iTerm launch should not write into the user's current session: %#v", launch.Cmd.Args)
+	}
+}
+
+func TestTerminalLaunchWithOptions_DarwinTerminalAppNormalizesToFallback(t *testing.T) {
+	launch, err := terminalLaunchWithOptions("/repo", "darwin", fakeGetenv(nil), fakeLookPath("open"), nil, LaunchOptions{
+		TerminalCommand: "Terminal.app",
+	})
+	if err != nil {
+		t.Fatalf("terminalLaunchWithOptions returned error: %v", err)
+	}
+	if !reflect.DeepEqual(launch.Cmd.Args, []string{"open", "-a", "Terminal", "/repo"}) {
+		t.Fatalf("unexpected macOS Terminal.app args: %#v", launch.Cmd.Args)
+	}
+}
+
+func TestTerminalLaunchWithOptions_ActiveTmuxWinsOverConfiguredTerminal(t *testing.T) {
+	env := fakeGetenv(map[string]string{"TMUX": "/tmp/tmux.sock"})
+	launch, err := terminalLaunchWithOptions("/repo", "darwin", env, fakeLookPath("tmux", "osascript"), nil, LaunchOptions{
+		TerminalCommand: "iTerm",
+	})
+	if err != nil {
+		t.Fatalf("terminalLaunchWithOptions returned error: %v", err)
+	}
+	if launch.Cmd.Args[0] != "sh" || !strings.Contains(strings.Join(launch.Cmd.Args, " "), "tmux") {
+		t.Fatalf("expected active tmux transport, got %#v", launch.Cmd.Args)
+	}
+}
+
+func TestTerminalLaunchWithOptions_DarwinOutsideTmuxUsesConfiguredITermWrapper(t *testing.T) {
+	launch, err := terminalLaunchWithOptions("/repo", "darwin", fakeGetenv(nil), fakeLookPath("tmux", "osascript"), nil, LaunchOptions{
+		TerminalCommand: "iTerm.app",
+	})
+	if err != nil {
+		t.Fatalf("terminalLaunchWithOptions returned error: %v", err)
+	}
+	joined := strings.Join(launch.Cmd.Args, "\n")
+	for _, want := range []string{`tell application "iTerm"`, "write text", "cd '/repo' && exec ${SHELL:-/bin/sh}"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected configured iTerm launch to contain %q, got %#v", want, launch.Cmd.Args)
+		}
+	}
+	if strings.Contains(joined, "tmux new-session -A -s") {
+		t.Fatalf("configured iTerm should win over installed tmux outside tmux, got %#v", launch.Cmd.Args)
+	}
+}
+
+func TestTerminalLaunchWithOptions_DarwinOutsideTmuxUsesConfiguredCLIWrapper(t *testing.T) {
+	launch, err := terminalLaunchWithOptions("/repo", "darwin", fakeGetenv(nil), fakeLookPath("tmux", "wezterm"), nil, LaunchOptions{
+		TerminalCommand: "wezterm start",
+	})
+	if err != nil {
+		t.Fatalf("terminalLaunchWithOptions returned error: %v", err)
+	}
+	if !reflect.DeepEqual(launch.Cmd.Args, []string{"wezterm", "start"}) {
+		t.Fatalf("expected configured CLI to win over installed tmux, got %#v", launch.Cmd.Args)
+	}
+	if launch.Cmd.Dir != "/repo" {
+		t.Fatalf("expected CLI wrapper dir /repo, got %q", launch.Cmd.Dir)
+	}
+}
+
+func TestTerminalLaunchWithOptions_TerminalEnvWinsOverInstalledTmuxOutsideTmux(t *testing.T) {
+	env := fakeGetenv(map[string]string{"TERMINAL": "alacritty"})
+	launch, err := terminalLaunchWithOptions("/repo", "linux", env, fakeLookPath("tmux", "alacritty"), nil, LaunchOptions{
+		TerminalCommand: "wezterm start",
+	})
+	if err != nil {
+		t.Fatalf("terminalLaunchWithOptions returned error: %v", err)
+	}
+	if !reflect.DeepEqual(launch.Cmd.Args, []string{"alacritty"}) {
+		t.Fatalf("expected TERMINAL to win over installed tmux, got %#v", launch.Cmd.Args)
+	}
+}
+
+func TestTerminalLaunchWithOptions_TerminalEnvWinsOverConfiguredTerminal(t *testing.T) {
+	env := fakeGetenv(map[string]string{"TERMINAL": "alacritty"})
+	launch, err := terminalLaunchWithOptions("/repo", "linux", env, fakeLookPath("alacritty", "wezterm"), nil, LaunchOptions{
+		TerminalCommand: "wezterm start",
+	})
+	if err != nil {
+		t.Fatalf("terminalLaunchWithOptions returned error: %v", err)
+	}
+	if !reflect.DeepEqual(launch.Cmd.Args, []string{"alacritty"}) {
+		t.Fatalf("expected TERMINAL to win, got %#v", launch.Cmd.Args)
+	}
+}
+
+func TestTerminalLaunchWithOptions_ConfiguredCLIUsesConfiguredArgs(t *testing.T) {
+	launch, err := terminalLaunchWithOptions("/repo", "linux", fakeGetenv(nil), fakeLookPath("wezterm"), nil, LaunchOptions{
+		TerminalCommand: "wezterm start --cwd .",
+	})
+	if err != nil {
+		t.Fatalf("terminalLaunchWithOptions returned error: %v", err)
+	}
+	if !reflect.DeepEqual(launch.Cmd.Args, []string{"wezterm", "start", "--cwd", "."}) {
+		t.Fatalf("unexpected configured CLI args: %#v", launch.Cmd.Args)
+	}
+}
+
+func TestTerminalLaunchWithOptions_RejectsSupportedGUIAliasWithArgs(t *testing.T) {
+	_, err := terminalLaunchWithOptions("/repo", "darwin", fakeGetenv(nil), fakeLookPath("osascript"), nil, LaunchOptions{
+		TerminalCommand: "iTerm --new-window",
+	})
+	if err == nil {
+		t.Fatal("expected supported GUI alias with args to be rejected")
+	}
+	for _, want := range []string{"[terminal].command", "iTerm --new-window", "unsupported arguments"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to mention %q, got %q", want, err.Error())
+		}
+	}
+}
+
 func TestTerminalLaunch_DarwinFallsBackToOpenAppWhenTerminalMissing(t *testing.T) {
 	env := fakeGetenv(map[string]string{"TERMINAL": "wezterm start"})
 	launch, err := terminalLaunch("/repo", "darwin", env, fakeLookPath("open"), nil)

--- a/actions/agent_launch_internal_test.go
+++ b/actions/agent_launch_internal_test.go
@@ -154,6 +154,34 @@ func TestAgentLaunch_DarwinExternalTerminalRunsAgent(t *testing.T) {
 	}
 }
 
+func TestAgentLaunchWithOptions_DarwinConfiguredITermRunsGeneratedScript(t *testing.T) {
+	putAgentOnPath(t, "codex")
+	launch, err := agentLaunchWithOptions(planAgentContext(), "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{
+		TerminalCommand: "iTerm2.app",
+	})
+	if err != nil {
+		t.Fatalf("agentLaunchWithOptions returned error: %v", err)
+	}
+	if launch.Interactive {
+		t.Fatal("iTerm agent launch should be detached")
+	}
+	if launch.Cleanup == nil {
+		t.Fatal("expected cleanup to be wired")
+	}
+	joined := strings.Join(launch.Cmd.Args, "\n")
+	for _, want := range []string{`tell application "iTerm"`, "activate", "write text", "exec sh '/"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected iTerm agent args to contain %q, got %#v", want, launch.Cmd.Args)
+		}
+	}
+	for _, unwanted := range []string{"Read the plan and begin implementation.", "WTUI_PLAN_ID", "codex --config"} {
+		if strings.Contains(joined, unwanted) {
+			t.Fatalf("agent details leaked into AppleScript args: %q in %#v", unwanted, launch.Cmd.Args)
+		}
+	}
+	requireScriptContains(t, agentLaunchScript(t), "Read the plan and begin implementation.")
+}
+
 func TestAgentLaunch_TerminalEnvRunsAgentWithDashE(t *testing.T) {
 	putAgentOnPath(t, "codex")
 	env := fakeGetenv(map[string]string{"TERMINAL": "alacritty"})
@@ -201,6 +229,36 @@ func TestAgentLaunch_TerminalEnvDarwinUnsupportedReturnsError(t *testing.T) {
 	_, err := agentLaunch(planAgentContext(), "darwin", env, fakeLookPath("open"))
 	if err == nil {
 		t.Fatal("expected error when a GUI-only TERMINAL cannot run an agent command")
+	}
+}
+
+func TestAgentLaunchWithOptions_DarwinUnsupportedConfiguredGUIReturnsError(t *testing.T) {
+	putAgentOnPath(t, "codex")
+	_, err := agentLaunchWithOptions(planAgentContext(), "darwin", fakeGetenv(nil), fakeLookPath("open"), LaunchOptions{
+		TerminalCommand: "GhostTerminal",
+	})
+	if err == nil {
+		t.Fatal("expected unsupported configured GUI error")
+	}
+	for _, want := range []string{"[terminal].command", "GhostTerminal", "supported macOS terminal app"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to mention %q, got %q", want, err.Error())
+		}
+	}
+}
+
+func TestAgentLaunchWithOptions_NonDarwinMissingConfiguredCommandNamesConfig(t *testing.T) {
+	putAgentOnPath(t, "codex")
+	_, err := agentLaunchWithOptions(planAgentContext(), "linux", fakeGetenv(nil), fakeLookPath(), LaunchOptions{
+		TerminalCommand: "ghostterm",
+	})
+	if err == nil {
+		t.Fatal("expected missing configured terminal error")
+	}
+	for _, want := range []string{"[terminal].command", "ghostterm"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to mention %q, got %q", want, err.Error())
+		}
 	}
 }
 
@@ -382,6 +440,47 @@ func TestAgentLaunch_OsascriptEscapesShellCommand(t *testing.T) {
 	}
 }
 
+func TestAgentLaunchWithOptions_ITermOsascriptEscapesShellCommand(t *testing.T) {
+	putAgentOnPath(t, "codex")
+	ctx := planAgentContext()
+	const prompt = `"; do shell script "touch /tmp/PWNED"; echo "`
+	ctx.InitialPrompt = prompt
+	launch, err := agentLaunchWithOptions(ctx, "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{
+		TerminalCommand: "iTerm",
+	})
+	if err != nil {
+		t.Fatalf("agentLaunchWithOptions returned error: %v", err)
+	}
+	if launch.Cmd.Args[0] != "osascript" {
+		t.Fatalf("expected osascript transport, got %#v", launch.Cmd.Args)
+	}
+
+	const prefix = `tell current session of newWindow to write text `
+	var writeText string
+	for _, arg := range launch.Cmd.Args {
+		if strings.HasPrefix(arg, prefix) {
+			writeText = strings.TrimPrefix(arg, prefix)
+		}
+	}
+	if writeText == "" {
+		t.Fatalf("no iTerm write-text argument found in %#v", launch.Cmd.Args)
+	}
+	if strings.Contains(strings.Join(launch.Cmd.Args, "\n"), "current session of current window") {
+		t.Fatalf("iTerm agent launch should not write into the user's current session: %#v", launch.Cmd.Args)
+	}
+	inner, err := strconv.Unquote(writeText)
+	if err != nil {
+		t.Fatalf("write-text payload is not a valid quoted string (escaping broke): %q", writeText)
+	}
+	if strings.Contains(inner, prompt) {
+		t.Fatalf("prompt leaked into AppleScript command: %q", inner)
+	}
+	script := agentLaunchScript(t)
+	if !strings.Contains(script, `'`+prompt+`'`) {
+		t.Fatal("expected prompt single-quoted inside the launch script")
+	}
+}
+
 func TestAgentLaunch_SessionNameIsUniquePerLaunchAndDistinctFromTerminal(t *testing.T) {
 	putAgentOnPath(t, "codex")
 	ctx := planAgentContext()
@@ -479,6 +578,24 @@ func TestCodexAppLaunchOpensNewThreadDeepLink(t *testing.T) {
 	}
 	if strings.Contains(prompt, "inherited-launch") {
 		t.Fatalf("prompt leaked inherited WTUI_LAUNCH_ID:\n%s", prompt)
+	}
+}
+
+func TestCodexAppLaunchIgnoresTerminalOptions(t *testing.T) {
+	launch, err := agentLaunchWithOptions(AgentLaunchContext{
+		Command:      "codex-app",
+		WorktreePath: "/repo/worktree",
+	}, "darwin", fakeGetenv(map[string]string{"TERMINAL": "GhostTerminal"}), fakeLookPath(), LaunchOptions{
+		TerminalCommand: "iTerm",
+	})
+	if err != nil {
+		t.Fatalf("agentLaunchWithOptions returned error: %v", err)
+	}
+	if !reflect.DeepEqual(launch.Cmd.Args[:1], []string{"open"}) {
+		t.Fatalf("expected codex-app URL open command, got %#v", launch.Cmd.Args)
+	}
+	if strings.Contains(strings.Join(launch.Cmd.Args, "\n"), "iTerm") {
+		t.Fatalf("codex-app launch should not use configured terminal, got %#v", launch.Cmd.Args)
 	}
 }
 

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -199,17 +199,30 @@ func startProgram(repos []scanner.Repo, opts startProgramOptions) error {
 	if err != nil {
 		return err
 	}
-	p := tea.NewProgram(model.NewWithOptions(repos, model.Options{
+	p := tea.NewProgram(model.NewWithOptions(repos, modelOptionsFromConfig(cfg, opts.ScanRepos, sessionStore, planStore, flowStore)), tea.WithAltScreen())
+	_, err = p.Run()
+	return err
+}
+
+func modelOptionsFromConfig(cfg config.Config, scanRepos func() ([]scanner.Repo, error), sessionStore *sessions.Store, planStore *planstore.Store, flowStore *flowstore.Store) model.Options {
+	launchOpts := actions.LaunchOptions{TerminalCommand: cfg.Terminal.Command}
+	return model.Options{
 		AgentCommand:       cfg.Agent.Command,
 		StartupMode:        ui.ModeFlows,
 		PlanPromptTemplate: cfg.Agent.PlanPrompt,
-		ScanRepos:          opts.ScanRepos,
+		ScanRepos:          scanRepos,
 		SessionStateRoot:   sessionStore.Root(),
 		ListSessions:       sessionStore.List,
 		ReadTranscript:     sessionStore.ReadTranscript,
 		ListPlans:          planStore.List,
 		ListFlows:          flowStore.List,
 		ReadPlan:           planStore.ReadPlan,
+		LaunchTerminal: func(path string) (actions.TerminalLaunchSpec, error) {
+			return actions.TerminalLaunchWithOptions(path, launchOpts)
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			return actions.AgentLaunchWithOptions(ctx, launchOpts)
+		},
 		FinalizeAgentSession: func(ctx actions.AgentLaunchContext) error {
 			return sessionStore.MarkLaunchEnded(ctx.LaunchID, time.Now().UTC())
 		},
@@ -218,9 +231,7 @@ func startProgram(repos []scanner.Repo, opts startProgramOptions) error {
 		SaveAgentCommand: func(command string) error {
 			return config.SaveAgentCommand(command)
 		},
-	}), tea.WithAltScreen())
-	_, err = p.Run()
-	return err
+	}
 }
 
 func runtimeArtifactRoot(cfg config.Config) string {

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -12,7 +14,9 @@ import (
 	"github.com/brian-bell/wtui/config"
 	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/internal/version"
+	"github.com/brian-bell/wtui/planstore"
 	"github.com/brian-bell/wtui/scanner"
+	"github.com/brian-bell/wtui/sessions"
 )
 
 func TestRun_VersionBypassesConfigAndScan(t *testing.T) {
@@ -229,6 +233,101 @@ func TestRuntimeArtifactRootFallsBackThroughPlanSessionConfig(t *testing.T) {
 	if got := runtimeArtifactRoot(cfg); got != "/from/config" {
 		t.Fatalf("artifact root = %q, want config root", got)
 	}
+}
+
+func TestModelOptionsFromConfigPassesTerminalCommandToLaunchers(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("ZELLIJ", "")
+	t.Setenv("TERMINAL", "")
+	root := t.TempDir()
+	sessionStore, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore sessions: %v", err)
+	}
+	planStore, err := planstore.NewStore(planstore.StoreOptions{Root: sessionStore.Root()})
+	if err != nil {
+		t.Fatalf("NewStore plans: %v", err)
+	}
+	flowStore, err := flowstore.NewStore(flowstore.StoreOptions{Root: sessionStore.Root()})
+	if err != nil {
+		t.Fatalf("NewStore flows: %v", err)
+	}
+	terminalCommand := putCommandOnPath(t, "wtui-test-terminal")
+	putCommandOnPath(t, "codex")
+
+	opts := modelOptionsFromConfig(config.Config{
+		Agent:    config.AgentConfig{Command: "codex"},
+		Terminal: config.TerminalConfig{Command: terminalCommand + " --reuse"},
+	}, nil, sessionStore, planStore, flowStore)
+
+	terminalLaunch, err := opts.LaunchTerminal("/repo/worktree")
+	if err != nil {
+		t.Fatalf("LaunchTerminal returned error: %v", err)
+	}
+	if !reflect.DeepEqual(terminalLaunch.Cmd.Args, []string{terminalCommand, "--reuse"}) {
+		t.Fatalf("expected LaunchTerminal to use configured terminal command, got %#v", terminalLaunch.Cmd.Args)
+	}
+	if terminalLaunch.Cmd.Dir != "/repo/worktree" {
+		t.Fatalf("LaunchTerminal dir = %q, want /repo/worktree", terminalLaunch.Cmd.Dir)
+	}
+
+	agentLaunch, err := opts.LaunchAgent(actions.AgentLaunchContext{Command: "codex", WorktreePath: "/repo/worktree"})
+	if err != nil {
+		t.Fatalf("LaunchAgent returned error: %v", err)
+	}
+	if len(agentLaunch.Cmd.Args) < 5 || !reflect.DeepEqual(agentLaunch.Cmd.Args[:5], []string{terminalCommand, "--reuse", "-e", "sh", "-c"}) {
+		t.Fatalf("expected LaunchAgent to use configured terminal command with -e, got %#v", agentLaunch.Cmd.Args)
+	}
+	if agentLaunch.Cleanup != nil {
+		agentLaunch.Cleanup()
+	}
+}
+
+func TestModelOptionsFromConfigTerminalEnvOverridesConfiguredCommand(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("ZELLIJ", "")
+	envTerminal := putCommandOnPath(t, "wtui-env-terminal")
+	configTerminal := putCommandOnPath(t, "wtui-config-terminal")
+	t.Setenv("TERMINAL", envTerminal)
+	root := t.TempDir()
+	sessionStore, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore sessions: %v", err)
+	}
+	planStore, err := planstore.NewStore(planstore.StoreOptions{Root: sessionStore.Root()})
+	if err != nil {
+		t.Fatalf("NewStore plans: %v", err)
+	}
+	flowStore, err := flowstore.NewStore(flowstore.StoreOptions{Root: sessionStore.Root()})
+	if err != nil {
+		t.Fatalf("NewStore flows: %v", err)
+	}
+
+	opts := modelOptionsFromConfig(config.Config{
+		Terminal: config.TerminalConfig{Command: configTerminal},
+	}, nil, sessionStore, planStore, flowStore)
+
+	launch, err := opts.LaunchTerminal("/repo/worktree")
+	if err != nil {
+		t.Fatalf("LaunchTerminal returned error: %v", err)
+	}
+	if !reflect.DeepEqual(launch.Cmd.Args, []string{envTerminal}) {
+		t.Fatalf("expected TERMINAL to override configured command, got %#v", launch.Cmd.Args)
+	}
+}
+
+func putCommandOnPath(t *testing.T, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake command: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if _, err := exec.LookPath(name); err != nil {
+		t.Fatalf("fake command not on PATH: %v", err)
+	}
+	return path
 }
 
 func TestRunSessionHookWritesSessionMetadata(t *testing.T) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,7 +22,7 @@ exist:
 | Setting | Highest precedence | Config fallback | Built-in default |
 |---------|--------------------|-----------------|------------------|
 | Scan root | `WORKTREE_ROOT` | `[scan].root` | `~/dev` |
-| Terminal command | `TERMINAL` | none; `[terminal].command` is parsed but unused | platform fallback |
+| Terminal command | `TERMINAL` | `[terminal].command` | platform fallback |
 | Coding agent | none | `[agent].command` | unset |
 | Plan launch prompt | none | `[agent].plan_prompt` | built-in plan implementation prompt |
 | TUI artifact root | `WTUI_FLOW_STATE_ROOT` > `WTUI_PLAN_STATE_ROOT` > `WTUI_SESSION_STATE_ROOT` | `[sessions].root` | `$XDG_STATE_HOME/wtui/sessions/v1` or `~/.local/state/wtui/sessions/v1` |
@@ -101,12 +101,36 @@ VS Code with `code`.
 
 ### `[terminal]`
 
-Parsed for future terminal-launch settings. The current terminal action still
-uses tmux/Zellij detection, then `TERMINAL`, then platform fallbacks.
+Configures the external terminal fallback used by the `t` action and by
+detached agent-launch scripts. Active tmux/Zellij sessions still take
+precedence, and `TERMINAL` still overrides this setting.
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `command` | string | Future terminal command setting. |
+| `command` | string | Terminal command or supported macOS GUI app alias. |
+
+Examples:
+
+```toml
+[terminal]
+command = "wezterm start"
+
+[terminal]
+command = "iTerm"
+```
+
+On macOS, supported GUI aliases are `Terminal`, `Terminal.app`, `iTerm`,
+`iTerm.app`, `iTerm2`, and `iTerm2.app`. Terminal aliases use the built-in
+Terminal transport. iTerm aliases use AppleScript so both plain worktree
+terminals and detached agent scripts open in iTerm.
+
+Other command values are treated as whitespace-separated CLI terminal commands
+when the first field exists on `PATH`; configured arguments are preserved as
+separate argv entries and agent launches append `-e sh -c <script>`. Shell
+quoting is not interpreted in this setting. On macOS, an unsupported GUI app
+name can open a plain worktree terminal with `open -a <app> <path>`, but it
+cannot run detached agent scripts. Use a supported GUI alias or a CLI terminal
+command for agent launches.
 
 ### `[provider]`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -114,7 +114,9 @@ Examples:
 ```toml
 [terminal]
 command = "wezterm start"
+```
 
+```toml
 [terminal]
 command = "iTerm"
 ```

--- a/model/model.go
+++ b/model/model.go
@@ -85,6 +85,7 @@ type Model struct {
 	copyToClipboard           func(string) error
 	pageText                  func(string) (actions.TerminalLaunchSpec, error)
 	saveAgent                 func(string) error
+	launchTerminal            func(string) (actions.TerminalLaunchSpec, error)
 	launchAgent               func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error)
 	finalizeAgentSession      func(actions.AgentLaunchContext) error
 	sessionStateRoot          string
@@ -139,6 +140,7 @@ type Options struct {
 	CopyToClipboard      func(text string) error
 	PageText             func(body string) (actions.TerminalLaunchSpec, error)
 	SaveAgentCommand     func(string) error
+	LaunchTerminal       func(path string) (actions.TerminalLaunchSpec, error)
 	LaunchAgent          func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error)
 	FinalizeAgentSession func(actions.AgentLaunchContext) error
 	SessionStateRoot     string
@@ -218,6 +220,10 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if pageText == nil {
 		pageText = actions.PageText
 	}
+	launchTerminal := opts.LaunchTerminal
+	if launchTerminal == nil {
+		launchTerminal = actions.TerminalLaunch
+	}
 	launchAgent := opts.LaunchAgent
 	if launchAgent == nil {
 		launchAgent = actions.AgentLaunch
@@ -292,6 +298,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		copyToClipboard:      copyToClipboard,
 		pageText:             pageText,
 		saveAgent:            saveAgent,
+		launchTerminal:       launchTerminal,
 		launchAgent:          launchAgent,
 		finalizeAgentSession: finalizeAgentSession,
 		sessionStateRoot:     opts.SessionStateRoot,

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3026,6 +3026,28 @@ func TestModel_TKey_WorktreeBranch_FiresCmd(t *testing.T) {
 	}
 }
 
+func TestModel_TKey_UsesInjectedLaunchTerminal(t *testing.T) {
+	var gotPath string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		LaunchTerminal: func(path string) (actions.TerminalLaunchSpec, error) {
+			gotPath = path
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha-worktrees/feature", BranchName: "feature"},
+	}})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	if cmd == nil {
+		t.Fatal("expected terminal launch command")
+	}
+	if gotPath != "/dev/alpha-worktrees/feature" {
+		t.Fatalf("expected launch path /dev/alpha-worktrees/feature, got %q", gotPath)
+	}
+}
+
 func TestModel_CKey_WorktreeBranch_FiresCmd(t *testing.T) {
 	m := model.New(testRepos())
 	m = inBranchesMode(m)

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -90,6 +90,14 @@ func (m Model) nextListFetchRequest(mode ui.Mode) (Model, uint64) {
 	return m, request
 }
 
+func (m Model) invalidateListRequests() Model {
+	m.listRequestSeq++
+	for i := range m.listRequests {
+		m.listRequests[i] = m.listRequestSeq
+	}
+	return m
+}
+
 func (m Model) nextWorktreeSessionRequest(repoPath, worktreePath string) (Model, uint64) {
 	m.worktreeSessionRequestSeq++
 	m.activeWorktreeSessionReq = m.worktreeSessionRequestSeq

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1552,7 +1552,7 @@ func (m Model) handleOpenTerminal() (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	launch, err := actions.TerminalLaunch(path)
+	launch, err := m.launchTerminal(path)
 	if err != nil {
 		m = m.setStatus(statusOther, err.Error())
 		return m, nil
@@ -1760,6 +1760,7 @@ func (m Model) resetModeCursors() Model {
 }
 
 func (m Model) resetRightPaneCursors() Model {
+	m = m.invalidateListRequests()
 	m.pendingBranchSelection = ""
 	m.pendingWorktreeSelection = ""
 	m.rows = m.rows.SetItems(nil).ResetSelection()

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1013,7 +1013,13 @@ func (m Model) handlePlanResult(msg PlanResultMsg) Model {
 	if !ok {
 		return m
 	}
+	selectedPlanID := m.selectedPlanID()
 	m.plans = m.plans.SetItems(msg.Plans)
+	if selectedPlanID != "" {
+		m.plans = m.plans.SelectFunc(func(record planstore.PlanRecord) bool {
+			return record.PlanID == selectedPlanID
+		})
+	}
 	m = m.setExpandedPlanID("")
 	m = m.clampSelectionsAfterFilter()
 	return m
@@ -1025,7 +1031,13 @@ func (m Model) handleFlowResult(msg FlowResultMsg) Model {
 	if !ok {
 		return m
 	}
+	selectedFlowID := m.selectedFlowID()
 	m.flows = m.flows.SetItems(msg.Flows)
+	if selectedFlowID != "" {
+		m.flows = m.flows.SelectFunc(func(record flowstore.FlowRecord) bool {
+			return record.FlowID == selectedFlowID
+		})
+	}
 	m = m.setExpandedFlowID("")
 	m = m.clampSelectionsAfterFilter()
 	return m

--- a/model/model_refresh_test.go
+++ b/model/model_refresh_test.go
@@ -327,6 +327,96 @@ func TestModel_RepoRefreshKeepsFilterAndHandlesZeroVisibleRepos(t *testing.T) {
 	}
 }
 
+func TestModel_PlanResultPreservesSelectedPlanWhenResultsReorder(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
+	m, _ = update(m, model.PlanResultMsg{
+		RepoPath: "/dev/alpha",
+		Plans: []planstore.PlanRecord{
+			{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "One"},
+			{PlanID: "plan-2", RepoPath: "/dev/alpha", Title: "Two"},
+		},
+		ListRequest: m.ListRequest(ui.ModePlans),
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.Plans()[m.PlanSelected()].PlanID; got != "plan-2" {
+		t.Fatalf("selected plan before reorder = %q, want plan-2", got)
+	}
+
+	m, _ = update(m, model.PlanResultMsg{
+		RepoPath: "/dev/alpha",
+		Plans: []planstore.PlanRecord{
+			{PlanID: "plan-2", RepoPath: "/dev/alpha", Title: "Two updated"},
+			{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "One"},
+		},
+		ListRequest: m.ListRequest(ui.ModePlans),
+	})
+
+	if got := m.Plans()[m.PlanSelected()].PlanID; got != "plan-2" {
+		t.Fatalf("selected plan after reorder = %q, want plan-2", got)
+	}
+	if got := m.PlanSelected(); got != 0 {
+		t.Fatalf("PlanSelected() after reorder = %d, want updated plan index 0", got)
+	}
+}
+
+func TestModel_FlowResultPreservesSelectedFlowWhenResultsReorder(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+	m, _ = update(m, model.FlowResultMsg{
+		RepoPath: "/dev/alpha",
+		Flows: []flowstore.FlowRecord{
+			{FlowID: "flow-1", RepoPath: "/dev/alpha", Title: "One"},
+			{FlowID: "flow-2", RepoPath: "/dev/alpha", Title: "Two"},
+		},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.Flows()[m.FlowSelected()].FlowID; got != "flow-2" {
+		t.Fatalf("selected flow before reorder = %q, want flow-2", got)
+	}
+
+	m, _ = update(m, model.FlowResultMsg{
+		RepoPath: "/dev/alpha",
+		Flows: []flowstore.FlowRecord{
+			{FlowID: "flow-2", RepoPath: "/dev/alpha", Title: "Two updated"},
+			{FlowID: "flow-1", RepoPath: "/dev/alpha", Title: "One"},
+		},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+
+	if got := m.Flows()[m.FlowSelected()].FlowID; got != "flow-2" {
+		t.Fatalf("selected flow after reorder = %q, want flow-2", got)
+	}
+	if got := m.FlowSelected(); got != 0 {
+		t.Fatalf("FlowSelected() after reorder = %d, want updated flow index 0", got)
+	}
+}
+
+func TestModel_RepoSelectionResetInvalidatesStaleNonCurrentPaneResults(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
+	stalePlanRequest := m.ListRequest(ui.ModePlans)
+	stalePlan := model.PlanResultMsg{
+		RepoPath:    "/dev/alpha",
+		ListRequest: stalePlanRequest,
+		Plans:       []planstore.PlanRecord{{PlanID: "stale-plan", RepoPath: "/dev/alpha", Title: "Stale"}},
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
+	m, _ = update(m, stalePlan)
+
+	if got := m.Plans(); len(got) != 0 {
+		t.Fatalf("stale non-current plan result repopulated cleared pane: %#v", got)
+	}
+}
+
 func TestModel_StaleRepoRefreshResultAndFailureIgnored(t *testing.T) {
 	scans := 0
 	m := model.NewWithOptions(testRepos(), model.Options{


### PR DESCRIPTION
## Summary
- honors `[terminal].command` when opening worktree terminals and detached agent sessions
- adds supported macOS GUI aliases for Terminal and iTerm, with iTerm AppleScript launch support
- wires terminal launch options through the TUI model and preserves selection/request state during refreshes

## Verification
- `make test`
- `make build`