### PR TITLE
Add arrow key pane navigation

### DIFF
--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -370,8 +370,11 @@ func TestModel_RightNavigationReachesFlowsWithoutChangingExistingModeNumbers(t *
 	if m.Mode() != ui.ModeFlows {
 		t.Fatalf("right from flows mode = %d, want still flows", m.Mode())
 	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("right from flows active pane = %d, want left pane", m.ActivePane())
+	}
 	if cmd != nil {
-		t.Fatalf("right from terminal mode should not fetch, got %T", cmd)
+		t.Fatalf("right from flows mode should not fetch, got %T", cmd)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -191,6 +191,10 @@ func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 	switch key {
 	case "tab":
 		m.activePane = 1
+	case "left":
+		return m.handleHorizontalNavigation(-1)
+	case "right":
+		return m.handleHorizontalNavigation(1)
 	case "up", "k":
 		if len(m.filteredRepos()) > 0 {
 			m.repos = m.repos.Move(-1, m.repoContentHeight(), ui.LeftPaneWidth-2)
@@ -217,13 +221,17 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleCursorUp()
 	case "down", "j":
 		return m.handleCursorDown()
-	case "left", "h":
+	case "left":
+		return m.handleHorizontalNavigation(-1)
+	case "right":
+		return m.handleHorizontalNavigation(1)
+	case "h":
 		if m.mode > ui.ModeWorktrees {
 			m.mode--
 			m = m.resetModeCursors()
 			return m.startFetchForMode()
 		}
-	case "right", "l":
+	case "l":
 		if m.mode < ui.ModeFlows {
 			m.mode++
 			m = m.resetModeCursors()
@@ -356,6 +364,39 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 	return m, nil
+}
+
+func (m Model) handleHorizontalNavigation(direction int) (tea.Model, tea.Cmd) {
+	if direction == 0 {
+		return m, nil
+	}
+	if m.activePane == 0 {
+		m.activePane = 1
+		if direction < 0 && m.mode != ui.ModeFlows {
+			m.mode = ui.ModeFlows
+			m = m.resetModeCursors()
+			return m.startFetchForMode()
+		}
+		return m, nil
+	}
+
+	if direction > 0 {
+		if m.mode == ui.ModeFlows {
+			m.activePane = 0
+			return m, nil
+		}
+		m.mode++
+		m = m.resetModeCursors()
+		return m.startFetchForMode()
+	}
+
+	if m.mode == ui.ModeWorktrees {
+		m.activePane = 0
+		return m, nil
+	}
+	m.mode--
+	m = m.resetModeCursors()
+	return m.startFetchForMode()
 }
 
 // --- Cursor navigation ---

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -372,8 +372,12 @@ func (m Model) handleHorizontalNavigation(direction int) (tea.Model, tea.Cmd) {
 	}
 	if m.activePane == 0 {
 		m.activePane = 1
-		if direction < 0 && m.mode != ui.ModeFlows {
-			m.mode = ui.ModeFlows
+		targetMode := ui.ModeWorktrees
+		if direction < 0 {
+			targetMode = ui.ModeFlows
+		}
+		if m.mode != targetMode {
+			m.mode = targetMode
 			m = m.resetModeCursors()
 			return m.startFetchForMode()
 		}

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/model"
 	"github.com/brian-bell/wtui/scanner"
@@ -77,6 +78,39 @@ func stampListRequest(m model.Model, msg tea.Msg) tea.Msg {
 		return msg
 	default:
 		return msg
+	}
+}
+
+func listRequests(m model.Model) map[ui.Mode]uint64 {
+	requests := make(map[ui.Mode]uint64, int(ui.ModeFlows))
+	for mode := ui.ModeWorktrees; mode <= ui.ModeFlows; mode++ {
+		requests[mode] = m.ListRequest(mode)
+	}
+	return requests
+}
+
+func assertListRequestsUnchanged(t *testing.T, before map[ui.Mode]uint64, after model.Model) {
+	t.Helper()
+	for mode, request := range before {
+		if got := after.ListRequest(mode); got != request {
+			t.Fatalf("ListRequest(%d) = %d, want unchanged %d", mode, got, request)
+		}
+	}
+}
+
+func assertOnlyListRequestAdvanced(t *testing.T, before map[ui.Mode]uint64, after model.Model, advanced ui.Mode) {
+	t.Helper()
+	for mode, request := range before {
+		got := after.ListRequest(mode)
+		if mode == advanced {
+			if got != request+1 {
+				t.Fatalf("ListRequest(%d) = %d, want %d", mode, got, request+1)
+			}
+			continue
+		}
+		if got != request {
+			t.Fatalf("ListRequest(%d) = %d, want unchanged %d", mode, got, request)
+		}
 	}
 }
 
@@ -525,20 +559,118 @@ func TestModel_LeftPaneDownResetsRightPaneCursors(t *testing.T) {
 
 func TestModel_LeftPaneModeKeysAreNoOps(t *testing.T) {
 	m := model.New(testRepos())
-	// 2, right, l — should not change mode in left pane
 	for _, key := range []tea.KeyMsg{
 		{Type: tea.KeyRunes, Runes: []rune{'2'}},
-		{Type: tea.KeyRight},
+		{Type: tea.KeyRunes, Runes: []rune{'h'}},
 		{Type: tea.KeyRunes, Runes: []rune{'l'}},
 	} {
+		before := listRequests(m)
 		m2, cmd := update(m, key)
 		if m2.Mode() != 1 {
 			t.Errorf("key %v changed mode in left pane: got %d", key, m2.Mode())
 		}
+		if m2.ActivePane() != 0 {
+			t.Errorf("key %v changed active pane in left pane: got %d", key, m2.ActivePane())
+		}
 		if cmd != nil {
 			t.Errorf("key %v produced cmd in left pane: %T", key, cmd)
 		}
+		assertListRequestsUnchanged(t, before, m2)
 	}
+}
+
+func TestModel_RightArrowFromLeftPaneMovesToRightPaneWithoutChangingMode(t *testing.T) {
+	m := model.New(testRepos())
+	before := listRequests(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
+
+	if m.ActivePane() != 1 {
+		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
+	}
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("Mode() = %d, want worktrees", m.Mode())
+	}
+	if cmd != nil {
+		t.Fatalf("right from left pane produced cmd %T, want nil", cmd)
+	}
+	assertListRequestsUnchanged(t, before, m)
+}
+
+func TestModel_LeftArrowFromLeftPaneWrapsToFlowsMode(t *testing.T) {
+	m := model.New(testRepos())
+	before := listRequests(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
+
+	if m.ActivePane() != 1 {
+		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
+	}
+	if m.Mode() != ui.ModeFlows {
+		t.Fatalf("Mode() = %d, want flows", m.Mode())
+	}
+	if cmd == nil {
+		t.Fatal("left from left pane should fetch flows")
+	}
+	assertOnlyListRequestAdvanced(t, before, m, ui.ModeFlows)
+}
+
+func TestModel_RightArrowFromLeftPanePreservesCurrentModeAndCursor(t *testing.T) {
+	m := model.New(testRepos())
+	m = inBranchesMode(m)
+	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: []gitquery.Branch{
+		{Name: "main"}, {Name: "feature"},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	before := listRequests(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
+
+	if m.ActivePane() != 1 {
+		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
+	}
+	if m.Mode() != ui.ModeBranches {
+		t.Fatalf("Mode() = %d, want branches", m.Mode())
+	}
+	if m.BranchSelected() != 1 {
+		t.Fatalf("BranchSelected() = %d, want preserved cursor 1", m.BranchSelected())
+	}
+	if cmd != nil {
+		t.Fatalf("right from left pane in branches produced cmd %T, want nil", cmd)
+	}
+	assertListRequestsUnchanged(t, before, m)
+}
+
+func TestModel_LeftArrowFromLeftPaneAtFlowsIsPaneOnlyMove(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+	m, _ = update(m, model.FlowResultMsg{RepoPath: "/dev/alpha", Flows: []flowstore.FlowRecord{
+		flow,
+		{FlowID: "flow-2", RepoPath: "/dev/alpha", Title: "Second flow", Status: flowstore.StatusPending},
+	}, ListRequest: m.ListRequest(ui.ModeFlows)})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	before := listRequests(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
+
+	if m.ActivePane() != 1 {
+		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
+	}
+	if m.Mode() != ui.ModeFlows {
+		t.Fatalf("Mode() = %d, want flows", m.Mode())
+	}
+	if m.FlowSelected() != 1 || m.ExpandedFlowID() != "flow-2" {
+		t.Fatalf("flow state selected=%d expanded=%q, want selected 1 expanded flow-2", m.FlowSelected(), m.ExpandedFlowID())
+	}
+	if cmd != nil {
+		t.Fatalf("left from left pane at flows produced cmd %T, want nil", cmd)
+	}
+	assertListRequestsUnchanged(t, before, m)
 }
 
 func TestModel_LeftPaneActionKeysAreNoOps(t *testing.T) {
@@ -596,6 +728,95 @@ func TestModel_SlashFiltersReposInLeftPane(t *testing.T) {
 		if strings.Contains(view, name) {
 			t.Errorf("filtered repo view should not contain %s", name)
 		}
+	}
+}
+
+func TestModel_SearchActiveSuppressesHorizontalArrowNavigation(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		setup     func(model.Model) model.Model
+		wantPane  int
+		wantMode  ui.Mode
+		wantQuery string
+	}{
+		{
+			name: "left pane repo search",
+			setup: func(m model.Model) model.Model {
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+				return m
+			},
+			wantPane:  0,
+			wantMode:  ui.ModeWorktrees,
+			wantQuery: "a",
+		},
+		{
+			name: "right pane item search",
+			setup: func(m model.Model) model.Model {
+				m = inRightPane(m)
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'w'}})
+				return m
+			},
+			wantPane:  1,
+			wantMode:  ui.ModeWorktrees,
+			wantQuery: "w",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.setup(model.New(testRepos()))
+			for _, key := range []tea.KeyMsg{{Type: tea.KeyLeft}, {Type: tea.KeyRight}} {
+				before := listRequests(m)
+				m2, cmd := update(m, key)
+				if cmd != nil {
+					t.Fatalf("key %v produced cmd %T, want nil", key, cmd)
+				}
+				if !m2.SearchActive() {
+					t.Fatalf("key %v deactivated search", key)
+				}
+				if m2.ActivePane() != tc.wantPane || m2.Mode() != tc.wantMode {
+					t.Fatalf("key %v activePane=%d mode=%d, want pane=%d mode=%d", key, m2.ActivePane(), m2.Mode(), tc.wantPane, tc.wantMode)
+				}
+				query := m2.RepoSearch()
+				if tc.wantPane == 1 {
+					query = m2.ItemSearch()
+				}
+				if query != tc.wantQuery {
+					t.Fatalf("key %v query=%q, want %q", key, query, tc.wantQuery)
+				}
+				assertListRequestsUnchanged(t, before, m2)
+			}
+		})
+	}
+}
+
+func TestModel_ModalSuppressesHorizontalArrowNavigation(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if cmd != nil {
+		t.Fatalf("opening worktree input produced cmd %T, want nil", cmd)
+	}
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("Overlay() = %d, want worktree input", m.Overlay())
+	}
+
+	for _, key := range []tea.KeyMsg{{Type: tea.KeyLeft}, {Type: tea.KeyRight}} {
+		before := listRequests(m)
+		m2, cmd := update(m, key)
+		if cmd != nil {
+			t.Fatalf("key %v produced cmd %T, want nil", key, cmd)
+		}
+		if m2.Overlay() != ui.OverlayWorktreeInput {
+			t.Fatalf("key %v overlay=%d, want worktree input", key, m2.Overlay())
+		}
+		if m2.ActivePane() != 1 || m2.Mode() != ui.ModeWorktrees {
+			t.Fatalf("key %v activePane=%d mode=%d, want right pane worktrees", key, m2.ActivePane(), m2.Mode())
+		}
+		if m2.WorktreeInput() != "" {
+			t.Fatalf("key %v input=%q, want empty", key, m2.WorktreeInput())
+		}
+		assertListRequestsUnchanged(t, before, m2)
 	}
 }
 
@@ -1251,75 +1472,142 @@ func TestModel_HLSwitchModes(t *testing.T) {
 	}
 }
 
-func TestModel_RightCyclesThroughAllFiveModes(t *testing.T) {
+func TestModel_RightCyclesThroughAllViewsAndWrapsToLeftPane(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	// Start at ModeWorktrees (1)
-	if m.Mode() != 1 {
-		t.Fatalf("expected starting mode 1, got %d", m.Mode())
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("expected starting mode worktrees, got %d", m.Mode())
 	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 2
-	if m.Mode() != 2 {
-		t.Errorf("expected mode 2 after first right, got %d", m.Mode())
-	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 3
-	if m.Mode() != 3 {
-		t.Errorf("expected mode 3 after second right, got %d", m.Mode())
-	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 4
-	if m.Mode() != 4 {
-		t.Errorf("expected mode 4 after third right, got %d", m.Mode())
-	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 5
-	if m.Mode() != 5 {
-		t.Errorf("expected mode 5 after fourth right, got %d", m.Mode())
-	}
-}
 
-func TestModel_LeftCyclesBackThroughAllFiveModes(t *testing.T) {
-	m := model.New(testRepos())
-	m = inRightPane(m)
-	// Go to mode 5
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
-	// Left through 4, 3, 2, 1
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft}) // 4
-	if m.Mode() != 4 {
-		t.Errorf("expected mode 4 after first left, got %d", m.Mode())
+	for want := ui.ModeBranches; want <= ui.ModeFlows; want++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})
+		if m.Mode() != want {
+			t.Fatalf("mode after right = %d, want %d", m.Mode(), want)
+		}
+		if m.ActivePane() != 1 {
+			t.Fatalf("ActivePane() = %d, want right pane while moving through modes", m.ActivePane())
+		}
 	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft}) // 3
-	if m.Mode() != 3 {
-		t.Errorf("expected mode 3 after second left, got %d", m.Mode())
-	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft}) // 2
-	if m.Mode() != 2 {
-		t.Errorf("expected mode 2 after third left, got %d", m.Mode())
-	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft}) // 1
-	if m.Mode() != 1 {
-		t.Errorf("expected mode 1 after fourth left, got %d", m.Mode())
-	}
-}
 
-func TestModel_ModeClampsAtEdges(t *testing.T) {
-	m := model.New(testRepos())
-	m = inRightPane(m)
-	// Already at mode 1 (ModeWorktrees), left should stay at 1
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft})
-	if m.Mode() != 1 {
-		t.Errorf("expected mode 1 (clamped), got %d", m.Mode())
-	}
-	// Go to mode 8 (ModeFlows), right should stay at 8
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 2
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 3
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 4
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 5
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 6
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 7
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // 8
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight}) // still 8
+	before := listRequests(m)
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
 	if m.Mode() != ui.ModeFlows {
-		t.Errorf("expected flows mode (clamped), got %d", m.Mode())
+		t.Fatalf("Mode() = %d, want flows after wrapping to left pane", m.Mode())
 	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
+	}
+	if cmd != nil {
+		t.Fatalf("right from flows produced cmd %T, want nil", cmd)
+	}
+	assertListRequestsUnchanged(t, before, m)
+}
+
+func TestModel_LeftCyclesBackThroughAllViewsAndWrapsToLeftPane(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+
+	for want := ui.ModePlans; want >= ui.ModeWorktrees; want-- {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft})
+		if m.Mode() != want {
+			t.Fatalf("mode after left = %d, want %d", m.Mode(), want)
+		}
+		if m.ActivePane() != 1 {
+			t.Fatalf("ActivePane() = %d, want right pane while moving through modes", m.ActivePane())
+		}
+	}
+
+	before := listRequests(m)
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("Mode() = %d, want worktrees after wrapping to left pane", m.Mode())
+	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
+	}
+	if cmd != nil {
+		t.Fatalf("left from worktrees produced cmd %T, want nil", cmd)
+	}
+	assertListRequestsUnchanged(t, before, m)
+}
+
+func TestModel_ArrowNavigationWrapsFromModeEdgesToLeftPane(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+		{Path: "/dev/alpha-worktrees/feature", BranchName: "feature"},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	before := listRequests(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("Mode() = %d, want worktrees", m.Mode())
+	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
+	}
+	if m.WorktreeSelected() != 1 {
+		t.Fatalf("WorktreeSelected() = %d, want preserved cursor 1", m.WorktreeSelected())
+	}
+	if cmd != nil {
+		t.Fatalf("left from worktrees produced cmd %T, want nil", cmd)
+	}
+	assertListRequestsUnchanged(t, before, m)
+
+	flow := flowWithPhaseDetails()
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+	m, _ = update(m, model.FlowResultMsg{RepoPath: "/dev/alpha", Flows: []flowstore.FlowRecord{
+		flow,
+		{FlowID: "flow-2", RepoPath: "/dev/alpha", Title: "Second flow", Status: flowstore.StatusPending},
+	}, ListRequest: m.ListRequest(ui.ModeFlows)})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	before = listRequests(m)
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRight})
+	if m.Mode() != ui.ModeFlows {
+		t.Fatalf("Mode() = %d, want flows", m.Mode())
+	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
+	}
+	if m.FlowSelected() != 1 || m.ExpandedFlowID() != "flow-2" {
+		t.Fatalf("flow state selected=%d expanded=%q, want selected 1 expanded flow-2", m.FlowSelected(), m.ExpandedFlowID())
+	}
+	if cmd != nil {
+		t.Fatalf("right from flows produced cmd %T, want nil", cmd)
+	}
+	assertListRequestsUnchanged(t, before, m)
+}
+
+func TestModel_HLClampAtModeEdges(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	before := listRequests(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	if m.ActivePane() != 1 || m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("h at worktrees activePane=%d mode=%d, want right pane worktrees", m.ActivePane(), m.Mode())
+	}
+	if cmd != nil {
+		t.Fatalf("h at worktrees produced cmd %T, want nil", cmd)
+	}
+	assertListRequestsUnchanged(t, before, m)
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+	before = listRequests(m)
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if m.ActivePane() != 1 || m.Mode() != ui.ModeFlows {
+		t.Fatalf("l at flows activePane=%d mode=%d, want right pane flows", m.ActivePane(), m.Mode())
+	}
+	if cmd != nil {
+		t.Fatalf("l at flows produced cmd %T, want nil", cmd)
+	}
+	assertListRequestsUnchanged(t, before, m)
 }
 
 func TestModel_RightFromStashesGoesToHistory(t *testing.T) {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -114,6 +114,22 @@ func assertOnlyListRequestAdvanced(t *testing.T, before map[ui.Mode]uint64, afte
 	}
 }
 
+func assertOnlyListRequestChanged(t *testing.T, before map[ui.Mode]uint64, after model.Model, changed ui.Mode) {
+	t.Helper()
+	for mode, request := range before {
+		got := after.ListRequest(mode)
+		if mode == changed {
+			if got == request {
+				t.Fatalf("ListRequest(%d) = %d, want changed from previous request", mode, got)
+			}
+			continue
+		}
+		if got != request {
+			t.Fatalf("ListRequest(%d) = %d, want unchanged %d", mode, got, request)
+		}
+	}
+}
+
 // inRightPane switches focus to the right pane.
 func inRightPane(m model.Model) model.Model {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
@@ -615,7 +631,7 @@ func TestModel_LeftArrowFromLeftPaneWrapsToFlowsMode(t *testing.T) {
 	assertOnlyListRequestAdvanced(t, before, m, ui.ModeFlows)
 }
 
-func TestModel_RightArrowFromLeftPanePreservesCurrentModeAndCursor(t *testing.T) {
+func TestModel_RightArrowFromLeftPaneEntersWorktreesFromNonEdgeMode(t *testing.T) {
 	m := model.New(testRepos())
 	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: []gitquery.Branch{
@@ -630,16 +646,16 @@ func TestModel_RightArrowFromLeftPanePreservesCurrentModeAndCursor(t *testing.T)
 	if m.ActivePane() != 1 {
 		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
 	}
-	if m.Mode() != ui.ModeBranches {
-		t.Fatalf("Mode() = %d, want branches", m.Mode())
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("Mode() = %d, want worktrees", m.Mode())
 	}
-	if m.BranchSelected() != 1 {
-		t.Fatalf("BranchSelected() = %d, want preserved cursor 1", m.BranchSelected())
+	if m.BranchSelected() != 0 {
+		t.Fatalf("BranchSelected() = %d, want reset cursor 0", m.BranchSelected())
 	}
-	if cmd != nil {
-		t.Fatalf("right from left pane in branches produced cmd %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("right from left pane in branches should fetch worktrees")
 	}
-	assertListRequestsUnchanged(t, before, m)
+	assertOnlyListRequestChanged(t, before, m, ui.ModeWorktrees)
 }
 
 func TestModel_LeftArrowFromLeftPaneAtFlowsIsPaneOnlyMove(t *testing.T) {
@@ -1501,6 +1517,19 @@ func TestModel_RightCyclesThroughAllViewsAndWrapsToLeftPane(t *testing.T) {
 		t.Fatalf("right from flows produced cmd %T, want nil", cmd)
 	}
 	assertListRequestsUnchanged(t, before, m)
+
+	before = listRequests(m)
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRight})
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("Mode() = %d, want worktrees after re-entering from left pane", m.Mode())
+	}
+	if m.ActivePane() != 1 {
+		t.Fatalf("ActivePane() = %d, want right pane after re-entering from left pane", m.ActivePane())
+	}
+	if cmd == nil {
+		t.Fatal("right from left pane at flows should fetch worktrees")
+	}
+	assertOnlyListRequestChanged(t, before, m, ui.ModeWorktrees)
 }
 
 func TestModel_LeftCyclesBackThroughAllViewsAndWrapsToLeftPane(t *testing.T) {
@@ -1530,6 +1559,19 @@ func TestModel_LeftCyclesBackThroughAllViewsAndWrapsToLeftPane(t *testing.T) {
 		t.Fatalf("left from worktrees produced cmd %T, want nil", cmd)
 	}
 	assertListRequestsUnchanged(t, before, m)
+
+	before = listRequests(m)
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyLeft})
+	if m.Mode() != ui.ModeFlows {
+		t.Fatalf("Mode() = %d, want flows after re-entering from left pane", m.Mode())
+	}
+	if m.ActivePane() != 1 {
+		t.Fatalf("ActivePane() = %d, want right pane after re-entering from left pane", m.ActivePane())
+	}
+	if cmd == nil {
+		t.Fatal("left from left pane at worktrees should fetch flows")
+	}
+	assertOnlyListRequestChanged(t, before, m, ui.ModeFlows)
 }
 
 func TestModel_ArrowNavigationWrapsFromModeEdgesToLeftPane(t *testing.T) {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -661,6 +661,10 @@ func sidebarShortcutHints(hints []shortcutHint) []shortcutHint {
 		if i+1 < len(hints) {
 			next := hints[i+1]
 			switch {
+			case hint.Key == "↑/↓" && next.Key == "←/→":
+				grouped = append(grouped, shortcutHint{Key: "↑/↓ ←/→", Label: "select/pane/view", Warning: hint.Warning || next.Warning})
+				i++
+				continue
 			case hint.Key == "f" && next.Key == "F":
 				grouped = append(grouped, shortcutHint{Key: "f/F", Label: hint.Label + " / " + next.Label, Warning: hint.Warning || next.Warning})
 				i++
@@ -685,7 +689,10 @@ func padShortcutKey(key string, width int) string {
 }
 
 func shortcutSections(sp statusBarParams) []shortcutSection {
-	navigation := []shortcutHint{{Key: "↑/↓", Label: "select", Inline: true}}
+	navigation := []shortcutHint{
+		{Key: "↑/↓", Label: "select", Inline: true},
+		{Key: "←/→", Label: "pane/view", Inline: true},
+	}
 	global := []shortcutHint{
 		{Key: "tab", Label: "pane"},
 		{Key: "q/esc", Label: "quit"},
@@ -874,13 +881,22 @@ func shortcutSectionsForPane(sp statusBarParams, height int) []shortcutSection {
 }
 
 func withoutShortcutKey(sections []shortcutSection, key string) []shortcutSection {
+	return withoutShortcutKeys(sections, key)
+}
+
+func withoutShortcutKeys(sections []shortcutSection, keys ...string) []shortcutSection {
+	drop := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		drop[key] = struct{}{}
+	}
 	filtered := make([]shortcutSection, 0, len(sections))
 	for _, section := range sections {
 		hints := make([]shortcutHint, 0, len(section.Hints))
 		for _, hint := range section.Hints {
-			if hint.Key != key {
-				hints = append(hints, hint)
+			if _, ok := drop[hint.Key]; ok {
+				continue
 			}
+			hints = append(hints, hint)
 		}
 		if len(hints) == 0 {
 			continue
@@ -896,16 +912,9 @@ func renderFooterShortcuts(sp statusBarParams, sections []shortcutSection) strin
 		return renderWorktreeFooterShortcuts(sp, sections)
 	}
 	if sp.Mode == ModeBranches {
-		legend, rest := splitLegendSection(sections)
-		rest = withoutSection(rest, "Navigate")
-		rest = branchFooterSectionOrder(rest)
-		keys := renderFooterHintList(rest)
-		if keys != "" {
-			return renderFooterLegend(legend) + "  |  " + keys
-		}
-		return renderFooterLegend(legend)
+		return renderBranchFooterShortcuts(sp, sections)
 	}
-	return "  " + renderFooterHintList(footerSectionOrder(sections))
+	return renderGenericFooterShortcuts(sp, sections)
 }
 
 func transientStatusStyle(fadeStep int) lipgloss.Style {
@@ -921,59 +930,160 @@ func transientStatusStyle(fadeStep int) lipgloss.Style {
 
 func renderWorktreeFooterShortcuts(sp statusBarParams, sections []shortcutSection) string {
 	hints := flattenShortcutHints(sections)
-	parts := []string{}
-	for _, key := range []string{"tab", "q/esc"} {
-		if hint, ok := findShortcutHint(hints, key); ok {
-			parts = append(parts, renderFooterHint(hint))
-		}
-	}
+	base := footerHintsForKeys(hints, "tab", "q/esc")
+	agent := footerHintsForKeys(hints, "A")
+	upDown := footerHintsForKeys(hints, "↑/↓")
+	arrow := footerHintsForKeys(hints, "←/→")
+	safety := footerHintsForKeys(hints, "D")
+	allActions := worktreeFooterParts(hints, false)
+	compactActions := worktreeCompactFooterParts(hints)
 
-	required := worktreeFooterParts(hints, false)
-	requiredWithDestructive := worktreeFooterParts(hints, true)
-	if hint, ok := findShortcutHint(hints, "A"); ok {
-		candidate := append(append([]string{}, parts...), renderFooterHint(hint))
-		// When agent actions are visible, keep A by making room from the D
-		// toggle first; otherwise preserve D ahead of lower-priority A.
-		if sp.AgentAvailable || sp.NewAgent {
-			if footerPartsFit(sp.Width, candidate, append([]string{renderFooterHint(shortcutHint{Key: "↑/↓", Label: "select", Inline: true})}, required...)...) {
-				parts = candidate
+	if len(allActions) == 0 {
+		for _, parts := range [][]string{
+			appendParts(base, agent, upDown, arrow, safety),
+			appendParts(base, upDown, arrow, safety),
+			appendParts(base, arrow, safety),
+			appendParts(base, arrow),
+			appendParts(base, upDown, safety),
+			base,
+		} {
+			if candidate, ok := footerCandidate(sp.Width, parts); ok {
+				return candidate
 			}
-		} else if footerPartsFit(sp.Width, candidate, append([]string{renderFooterHint(shortcutHint{Key: "↑/↓", Label: "select", Inline: true})}, requiredWithDestructive...)...) {
-			parts = candidate
 		}
 	}
-	if hint, ok := findShortcutHint(hints, "↑/↓"); ok {
-		parts = append(parts, renderFooterHint(hint))
+
+	candidates := [][]string{
+		appendParts(base, agent, upDown, arrow, safety, allActions),
+		appendParts(base, upDown, safety, allActions),
+		appendParts(base, upDown, allActions),
+		appendParts(base, arrow, compactActions),
+		appendParts(base, compactActions),
+		appendParts(arrow, compactActions),
+		compactActions,
+		base,
 	}
-	if hint, ok := findShortcutHint(hints, "D"); ok {
-		candidate := append(append([]string{}, parts...), renderFooterHint(hint))
-		if footerPartsFit(sp.Width, candidate, required...) {
-			parts = candidate
+	for _, parts := range candidates {
+		if candidate, ok := footerCandidate(sp.Width, parts); ok {
+			return candidate
 		}
 	}
-	for _, key := range []string{"n", "N", "m", "d", "p", "u", "enter", "f", "F"} {
+	candidate := "  " + strings.Join(compactActions, " ")
+	return ansi.Truncate(candidate, sp.Width, "")
+}
+
+func renderGenericFooterShortcuts(sp statusBarParams, sections []shortcutSection) string {
+	for _, drop := range [][]string{
+		{},
+		{"f5"},
+		{"f5", "A"},
+		{"f5", "A", "D"},
+		{"f5", "A", "D", "←/→"},
+		{"f5", "A", "D", "←/→", "↑/↓"},
+		{"f5", "A", "D", "←/→", "↑/↓", "q/esc"},
+		{"f5", "A", "D", "←/→", "↑/↓", "q/esc", "tab"},
+	} {
+		candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, drop...)))
+		if lipgloss.Width(candidate) <= sp.Width {
+			return candidate
+		}
+	}
+	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "A", "D", "←/→", "↑/↓", "q/esc", "tab")))
+	return ansi.Truncate(candidate, sp.Width, "")
+}
+
+func renderBranchFooterShortcuts(sp statusBarParams, sections []shortcutSection) string {
+	legend, rest := splitLegendSection(sections)
+	rest = branchFooterSectionOrder(rest)
+	hints := flattenShortcutHints(rest)
+	base := footerHintsForKeys(hints, "tab", "q/esc")
+	nav := footerHintsForKeys(hints, "↑/↓", "←/→")
+	actions := footerHintsForKeys(hints, "D", "n", "enter", "d", "f", "F", "t", "c", "a")
+
+	full := append(append(append([]string{}, base...), actions...), nav...)
+	baseActions := append(append([]string{}, base...), actions...)
+	baseNav := append(append([]string{}, base...), nav...)
+	baseArrow := footerHintsForKeys(hints, "tab", "q/esc", "←/→")
+
+	for _, parts := range [][]string{full, baseActions} {
+		if candidate, ok := branchFooterCandidateWithLegend(sp.Width, legend, parts); ok {
+			return candidate
+		}
+	}
+	if sp.BranchDirtySelected {
+		for _, parts := range [][]string{full, baseActions} {
+			if candidate, ok := branchFooterCandidateWithoutLegend(sp.Width, parts); ok {
+				return candidate
+			}
+		}
+	}
+	for _, parts := range [][]string{baseNav, baseArrow, base} {
+		if candidate, ok := branchFooterCandidateWithLegend(sp.Width, legend, parts); ok {
+			return candidate
+		}
+	}
+	for _, parts := range [][]string{full, baseActions, baseNav, baseArrow, base} {
+		if candidate, ok := branchFooterCandidateWithoutLegend(sp.Width, parts); ok {
+			return candidate
+		}
+	}
+	if len(base) > 0 {
+		return "  " + strings.Join(base, " ")
+	}
+	return renderFooterLegend(legend)
+}
+
+func branchFooterCandidateWithLegend(width int, legend []shortcutHint, parts []string) (string, bool) {
+	keys := strings.Join(parts, "  ")
+	if keys == "" {
+		candidate := renderFooterLegend(legend)
+		return candidate, lipgloss.Width(candidate) <= width
+	}
+	candidate := renderFooterLegend(legend) + "  |  " + keys
+	return candidate, lipgloss.Width(candidate) <= width
+}
+
+func branchFooterCandidateWithoutLegend(width int, parts []string) (string, bool) {
+	keys := strings.Join(parts, "  ")
+	if keys == "" {
+		return "", false
+	}
+	candidate := "  " + keys
+	return candidate, lipgloss.Width(candidate) <= width
+}
+
+func footerHintsForKeys(hints []shortcutHint, keys ...string) []string {
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
 		if hint, ok := findShortcutHint(hints, key); ok {
 			parts = append(parts, renderFooterHint(hint))
 		}
 	}
+	return parts
+}
 
-	open := ""
-	if _, ok := findShortcutHint(hints, "t"); ok {
-		if _, ok := findShortcutHint(hints, "c"); ok {
-			open = "t: terminal c: code"
-		}
+func appendParts(groups ...[]string) []string {
+	var parts []string
+	for _, group := range groups {
+		parts = append(parts, group...)
 	}
-	if open != "" {
-		parts = append(parts, open)
-	}
-	if hint, ok := findShortcutHint(hints, "P"); ok {
-		parts = append(parts, renderFooterHint(hint))
-	}
-	if hint, ok := findShortcutHint(hints, "a"); ok {
-		parts = append(parts, renderFooterHint(hint))
-	}
+	return parts
+}
 
-	return "  " + strings.Join(parts, " ")
+func footerCandidate(width int, parts []string) (string, bool) {
+	if len(parts) == 0 {
+		return "", false
+	}
+	candidate := "  " + strings.Join(parts, " ")
+	return candidate, lipgloss.Width(candidate) <= width
+}
+
+func worktreeCompactFooterParts(hints []shortcutHint) []string {
+	critical := footerHintsForKeys(hints, "d", "p", "u", "enter")
+	if len(critical) > 0 {
+		return appendParts(critical, footerHintsForKeys(hints, "f", "F"))
+	}
+	return appendParts(footerHintsForKeys(hints, "n", "N", "m"), footerHintsForKeys(hints, "f", "F"))
 }
 
 func worktreeFooterParts(hints []shortcutHint, includeDestructiveMode bool) []string {
@@ -999,11 +1109,6 @@ func worktreeFooterParts(hints []shortcutHint, includeDestructiveMode bool) []st
 		parts = append(parts, renderFooterHint(hint))
 	}
 	return parts
-}
-
-func footerPartsFit(width int, parts []string, extra ...string) bool {
-	all := append(append([]string{}, parts...), extra...)
-	return lipgloss.Width("  "+strings.Join(all, " ")) <= width
 }
 
 func flattenShortcutHints(sections []shortcutSection) []shortcutHint {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1186,6 +1186,18 @@ func TestRender_LeftPaneShortcutPaneOmitsModeNumberHint(t *testing.T) {
 	}
 }
 
+func TestRender_ShortcutPaneShowsArrowPaneViewHint(t *testing.T) {
+	for _, activePane := range []int{0, 1} {
+		pane := shortcutPaneText(renderShortcutPane(statusBarParams{
+			Mode:       ModeFlows,
+			ActivePane: activePane,
+		}, 26, 18))
+		if !strings.Contains(pane, "←/→") || !strings.Contains(pane, "pane/view") {
+			t.Fatalf("shortcut pane activePane=%d should include arrow pane/view hint, got:\n%s", activePane, pane)
+		}
+	}
+}
+
 func TestRender_BranchShortcutPaneKeepsLegend(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
@@ -2256,7 +2268,8 @@ func TestStatusBar_StashesModeHintsSpacing(t *testing.T) {
 	}
 	for _, pair := range [][2]string{
 		{"tab: pane", "q/esc: quit"},
-		{"↑/↓ select", "enter: diff"},
+		{"↑/↓ select", "←/→ pane/view"},
+		{"←/→ pane/view", "enter: diff"},
 		{"enter: diff", "d: drop"},
 	} {
 		a := strings.Index(bar, pair[0])
@@ -2638,10 +2651,154 @@ func TestWorktreePane_ScrollOffset(t *testing.T) {
 }
 
 func TestStatusBar_WorktreesModeShowsNavHints(t *testing.T) {
-	bar := RenderStatusBar(120, 1, 0, 1, false, false, false)
-	for _, hint := range []string{"tab: pane", "q/esc: quit", "↑/↓ select"} {
+	bar := RenderStatusBar(160, 1, 0, 1, false, false, false)
+	for _, hint := range []string{"tab: pane", "q/esc: quit", "↑/↓ select", "←/→ pane/view"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("worktrees mode status bar should contain %q", hint)
+		}
+	}
+}
+
+func TestStatusBar_ShowsArrowPaneViewHintWhenLeftPaneActive(t *testing.T) {
+	bar := RenderStatusBar(80, ModeFlows, OverlayNone, 0, false, false, false)
+	if !strings.Contains(bar, "←/→ pane/view") {
+		t.Fatalf("left-pane status bar should advertise arrow pane/view navigation, got %q", bar)
+	}
+}
+
+func TestStatusBar_BranchesModeShowsArrowPaneViewHint(t *testing.T) {
+	bar := RenderStatusBar(120, ModeBranches, OverlayNone, 1, false, false, false)
+	if !strings.Contains(bar, "←/→ pane/view") {
+		t.Fatalf("branches status bar should advertise arrow pane/view navigation, got %q", bar)
+	}
+}
+
+func TestStatusBar_BranchesModeDoesNotWrapNarrowFooter(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		width       int
+		destructive bool
+	}{
+		{name: "compact navigation", width: 80},
+		{name: "legend navigation", width: 120},
+		{name: "action heavy", width: 160, destructive: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bar := RenderStatusBar(tc.width, ModeBranches, OverlayNone, 1, tc.destructive, false, false)
+			stripped := ansi.Strip(bar)
+			if strings.Contains(stripped, "\n") {
+				t.Fatalf("branch status bar width %d should stay one line, got %q", tc.width, stripped)
+			}
+			if got := lipgloss.Width(stripped); got > tc.width {
+				t.Fatalf("branch status bar width = %d, want <= %d: %q", got, tc.width, stripped)
+			}
+		})
+	}
+}
+
+func TestStatusBar_BranchesModePrefersActionsOverLegendWhenTight(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:                   130,
+		Mode:                    ModeBranches,
+		Overlay:                 OverlayNone,
+		ActivePane:              1,
+		Destructive:             true,
+		RepoSelected:            true,
+		BranchDirtySelected:     true,
+		BranchDeletableSelected: true,
+		BranchOpenableSelected:  true,
+		FetchAvailable:          true,
+	})
+	stripped := ansi.Strip(bar)
+	if strings.Contains(stripped, "\n") {
+		t.Fatalf("branch status bar should stay one line, got %q", stripped)
+	}
+	if got := lipgloss.Width(stripped); got > 130 {
+		t.Fatalf("branch status bar width = %d, want <= 130: %q", got, stripped)
+	}
+	for _, hint := range []string{"n: new branch", "enter: diff", "d: delete", "f: fetch", "t: terminal", "c: code"} {
+		if !strings.Contains(bar, hint) {
+			t.Fatalf("branch status bar should keep action hint %q when it fits without legend, got %q", hint, bar)
+		}
+	}
+	if strings.Contains(bar, "no upstream") {
+		t.Fatalf("branch status bar should drop legend before action hints when tight, got %q", bar)
+	}
+}
+
+func TestStatusBar_ArrowPaneViewHintFitsNarrowFooter(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode Mode
+		pane int
+	}{
+		{name: "worktrees left pane", mode: ModeWorktrees, pane: 0},
+		{name: "branches", mode: ModeBranches, pane: 1},
+		{name: "flows", mode: ModeFlows, pane: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bar := RenderStatusBar(80, tc.mode, OverlayNone, tc.pane, false, false, false)
+			stripped := ansi.Strip(bar)
+			if strings.Contains(stripped, "\n") {
+				t.Fatalf("status bar should stay one line, got %q", stripped)
+			}
+			if got := lipgloss.Width(stripped); got > 80 {
+				t.Fatalf("status bar width = %d, want <= 80: %q", got, bar)
+			}
+			if !strings.Contains(bar, "←/→ pane/view") {
+				t.Fatalf("status bar should include arrow pane/view hint, got %q", bar)
+			}
+		})
+	}
+}
+
+func TestStatusBar_GenericActionModesDoNotWrapNarrowFooter(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		mode        Mode
+		destructive bool
+		wantHints   []string
+	}{
+		{name: "stashes destructive", mode: ModeStashes, destructive: true, wantHints: []string{"←/→ pane/view", "enter: diff", "d: drop"}},
+		{name: "reflog", mode: ModeReflog, wantHints: []string{"←/→ pane/view", "enter: diff", "y: copy hash"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bar := RenderStatusBar(80, tc.mode, OverlayNone, 1, tc.destructive, false, false)
+			stripped := ansi.Strip(bar)
+			if strings.Contains(stripped, "\n") {
+				t.Fatalf("status bar should stay one line, got %q", stripped)
+			}
+			if got := lipgloss.Width(stripped); got > 80 {
+				t.Fatalf("status bar width = %d, want <= 80: %q", got, stripped)
+			}
+			for _, hint := range tc.wantHints {
+				if !strings.Contains(bar, hint) {
+					t.Fatalf("status bar should contain %q, got %q", hint, bar)
+				}
+			}
+		})
+	}
+}
+
+func TestStatusBar_PlanPhaseFooterPreservesActionsAtNarrowWidth(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:             80,
+		Mode:              ModePlans,
+		Overlay:           OverlayNone,
+		ActivePane:        1,
+		PlanSelected:      true,
+		PlanPhaseSelected: true,
+	})
+	stripped := ansi.Strip(bar)
+	if strings.Contains(stripped, "\n") {
+		t.Fatalf("plan phase status bar should stay one line, got %q", stripped)
+	}
+	if got := lipgloss.Width(stripped); got > 80 {
+		t.Fatalf("plan phase status bar width = %d, want <= 80: %q", got, stripped)
+	}
+	for _, hint := range []string{"enter: phases", "o: open", "i: implement phase", "y: copy path"} {
+		if !strings.Contains(bar, hint) {
+			t.Fatalf("plan phase status bar should keep action hint %q, got %q", hint, bar)
 		}
 	}
 }
@@ -2718,6 +2875,37 @@ func TestStatusBar_WorktreesModeReadOnlyShowsDestructiveHintBeforeActions(t *tes
 	}
 	if dIdx > nIdx {
 		t.Fatalf("expected destructive hint before worktree actions, got %q", bar)
+	}
+}
+
+func TestStatusBar_WorktreesModeDoesNotWrapNarrowFooter(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		destructive bool
+		stale       bool
+		dirty       bool
+		wantHints   []string
+	}{
+		{name: "clean", wantHints: []string{"←/→ pane/view", "n: new worktree", "f: fetch", "F: pull"}},
+		{name: "dirty", dirty: true, wantHints: []string{"←/→ pane/view", "enter: diff"}},
+		{name: "destructive", destructive: true, wantHints: []string{"←/→ pane/view", "d: delete"}},
+		{name: "stale", destructive: true, stale: true, wantHints: []string{"←/→ pane/view", "p: prune"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bar := RenderStatusBar(80, ModeWorktrees, OverlayNone, 1, tc.destructive, tc.stale, tc.dirty)
+			stripped := ansi.Strip(bar)
+			if strings.Contains(stripped, "\n") {
+				t.Fatalf("worktree status bar should stay one line, got %q", stripped)
+			}
+			if got := lipgloss.Width(stripped); got > 80 {
+				t.Fatalf("worktree status bar width = %d, want <= 80: %q", got, stripped)
+			}
+			for _, hint := range tc.wantHints {
+				if !strings.Contains(bar, hint) {
+					t.Fatalf("worktree status bar should contain %q, got %q", hint, bar)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds left/right arrow navigation across the repo pane and right-pane views, including edge wrapping back to the repo pane.
- Keeps existing `h`/`l` mode-switching behavior scoped to right-pane modes.
- Updates footer shortcut rendering so the new `←/→ pane/view` hint appears without wrapping narrow status bars.

## Verification
- `gofmt -l .`
- `make test`
- `make build`
