### PR TITLE
Add Flow phase session resume

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -558,22 +558,23 @@ type LaunchOptions struct {
 // AgentLaunchContext carries metadata wtui knows at launch time so provider
 // hooks can associate later session records with the selected repo/worktree.
 type AgentLaunchContext struct {
-	Command          string
-	LaunchID         string
-	RepoPath         string
-	WorktreePath     string
-	WorkingDir       string
-	Branch           string
-	Commit           string
-	SessionStateRoot string
-	ResumeSessionID  string
-	PlanID           string
-	PlanPath         string
-	PlanPhaseID      string
-	PlanPhaseTitle   string
-	PlanPhaseStatus  string
-	FlowID           string
-	FlowPhaseID      string
+	Command           string
+	LaunchID          string
+	RepoPath          string
+	WorktreePath      string
+	WorkingDir        string
+	Branch            string
+	Commit            string
+	SessionStateRoot  string
+	ResumeSessionID   string
+	PlanID            string
+	PlanPath          string
+	PlanPhaseID       string
+	PlanPhaseTitle    string
+	PlanPhaseStatus   string
+	FlowID            string
+	FlowPhaseID       string
+	FlowLaunchTracked bool
 	// InitialPrompt is passed to providers when they support a launch-time prompt.
 	InitialPrompt string
 }

--- a/flowstore/session_select.go
+++ b/flowstore/session_select.go
@@ -1,0 +1,86 @@
+package flowstore
+
+import "strings"
+
+// LatestPhaseSession returns the display/latest session for a phase. A session
+// attached to the latest non-empty launch ID wins; otherwise timestamps and
+// slice order provide deterministic legacy-record fallback.
+func LatestPhaseSession(phase FlowPhase, requireSessionID bool) (Session, bool) {
+	latestLaunchID := LatestPhaseLaunchID(phase)
+	if latestLaunchID != "" {
+		for i := len(phase.Sessions) - 1; i >= 0; i-- {
+			session := phase.Sessions[i]
+			if session.LaunchID == latestLaunchID && (!requireSessionID || strings.TrimSpace(session.SessionID) != "") {
+				return session, true
+			}
+		}
+	}
+	var best Session
+	bestIndex := -1
+	for i, session := range phase.Sessions {
+		if requireSessionID && strings.TrimSpace(session.SessionID) == "" {
+			continue
+		}
+		if bestIndex < 0 || sessionNewer(session, best) || sessionSameTime(session, best) {
+			best = session
+			bestIndex = i
+		}
+	}
+	if bestIndex < 0 {
+		return Session{}, false
+	}
+	return best, true
+}
+
+// PhaseAwaitingSession reports whether the newest phase launch has not attached
+// any session record yet. A malformed attached record is handled separately by
+// callers as missing session metadata.
+func PhaseAwaitingSession(phase FlowPhase) bool {
+	latestLaunchID := LatestPhaseLaunchID(phase)
+	if latestLaunchID == "" {
+		return false
+	}
+	for _, session := range phase.Sessions {
+		if session.LaunchID == latestLaunchID {
+			return false
+		}
+	}
+	return true
+}
+
+func LatestPhaseLaunchID(phase FlowPhase) string {
+	for i := len(phase.LaunchIDs) - 1; i >= 0; i-- {
+		if phase.LaunchIDs[i] != "" {
+			return phase.LaunchIDs[i]
+		}
+	}
+	return ""
+}
+
+func sessionNewer(a, b Session) bool {
+	aStarted, bStarted := !a.StartedAt.IsZero(), !b.StartedAt.IsZero()
+	if aStarted || bStarted {
+		if aStarted != bStarted {
+			return aStarted
+		}
+		return a.StartedAt.After(b.StartedAt)
+	}
+	aEnded, bEnded := !a.EndedAt.IsZero(), !b.EndedAt.IsZero()
+	if aEnded || bEnded {
+		if aEnded != bEnded {
+			return aEnded
+		}
+		return a.EndedAt.After(b.EndedAt)
+	}
+	return false
+}
+
+func sessionSameTime(a, b Session) bool {
+	if !a.StartedAt.IsZero() || !b.StartedAt.IsZero() {
+		return a.StartedAt.Equal(b.StartedAt)
+	}
+	if !a.EndedAt.IsZero() || !b.EndedAt.IsZero() {
+		return a.EndedAt.Equal(b.EndedAt)
+	}
+	return true
+}

--- a/flowstore/session_select_test.go
+++ b/flowstore/session_select_test.go
@@ -1,0 +1,82 @@
+package flowstore_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/brian-bell/wtui/flowstore"
+)
+
+func TestLatestPhaseSessionLatestLaunchWins(t *testing.T) {
+	phase := flowstore.FlowPhase{
+		LaunchIDs: []string{"launch-old", "launch-new"},
+		Sessions: []flowstore.Session{
+			{Provider: "claude", SessionID: "claude-newer-time", LaunchID: "launch-old", StartedAt: time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)},
+			{Provider: "codex", SessionID: "codex-latest-launch", LaunchID: "launch-new", StartedAt: time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)},
+		},
+	}
+
+	session, ok := flowstore.LatestPhaseSession(phase, true)
+	if !ok {
+		t.Fatal("LatestPhaseSession() ok = false, want true")
+	}
+	if session.SessionID != "codex-latest-launch" {
+		t.Fatalf("LatestPhaseSession() = %#v, want latest launch session", session)
+	}
+}
+
+func TestLatestPhaseSessionLegacyFallbackUsesTimeAndSliceOrder(t *testing.T) {
+	phase := flowstore.FlowPhase{
+		Sessions: []flowstore.Session{
+			{Provider: "codex", SessionID: "first", StartedAt: time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)},
+			{Provider: "claude", SessionID: "latest", StartedAt: time.Date(2026, 6, 7, 11, 0, 0, 0, time.UTC)},
+			{Provider: "codex", SessionID: "tie-wins", StartedAt: time.Date(2026, 6, 7, 11, 0, 0, 0, time.UTC)},
+		},
+	}
+
+	session, ok := flowstore.LatestPhaseSession(phase, true)
+	if !ok {
+		t.Fatal("LatestPhaseSession() ok = false, want true")
+	}
+	if session.SessionID != "tie-wins" {
+		t.Fatalf("LatestPhaseSession() = %#v, want later equal-time slice entry", session)
+	}
+}
+
+func TestPhaseAwaitingSessionReportsNewestLaunchWithoutAttachedSession(t *testing.T) {
+	phase := flowstore.FlowPhase{
+		LaunchIDs: []string{"launch-old", "launch-new"},
+		Sessions: []flowstore.Session{
+			{Provider: "codex", SessionID: "codex-old", LaunchID: "launch-old"},
+		},
+	}
+
+	if !flowstore.PhaseAwaitingSession(phase) {
+		t.Fatal("PhaseAwaitingSession() = false, want true")
+	}
+	if session, ok := flowstore.LatestPhaseSession(phase, true); !ok || session.SessionID != "codex-old" {
+		t.Fatalf("LatestPhaseSession() = %#v, %v; want stale legacy fallback for display only", session, ok)
+	}
+}
+
+func TestLatestPhaseSessionDistinguishesMalformedLatestSession(t *testing.T) {
+	phase := flowstore.FlowPhase{
+		LaunchIDs: []string{"launch-new"},
+		Sessions: []flowstore.Session{
+			{Provider: "codex", LaunchID: "launch-new", Status: "ended"},
+			{Provider: "claude", SessionID: "claude-legacy", Status: "ended"},
+		},
+	}
+
+	session, ok := flowstore.LatestPhaseSession(phase, false)
+	if !ok {
+		t.Fatal("LatestPhaseSession(requireSessionID=false) ok = false, want true")
+	}
+	if session.SessionID != "" || session.LaunchID != "launch-new" {
+		t.Fatalf("LatestPhaseSession(requireSessionID=false) = %#v, want malformed latest launch session", session)
+	}
+	session, ok = flowstore.LatestPhaseSession(phase, true)
+	if !ok || session.SessionID != "claude-legacy" {
+		t.Fatalf("LatestPhaseSession(requireSessionID=true) = %#v, %v; want legacy usable fallback", session, ok)
+	}
+}

--- a/model/model.go
+++ b/model/model.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -40,6 +41,7 @@ type Model struct {
 	expandedPlanID            string
 	expandedFlowID            string
 	selectedPlanPhaseID       string
+	selectedFlowPhaseID       string
 	modal                     modal.Modal
 	diffRequestSeq            uint64
 	activeViewRequest         uint64
@@ -368,6 +370,7 @@ func (m Model) FlowSelected() int               { return m.flows.SelectedIndex()
 func (m Model) FlowScroll() int                 { return m.flows.Scroll() }
 func (m Model) ExpandedFlowID() string          { return m.expandedFlowID }
 func (m Model) SelectedPlanPhaseID() string     { return m.selectedPlanPhaseID }
+func (m Model) SelectedFlowPhaseID() string     { return m.selectedFlowPhaseID }
 func (m Model) ReflogSelected() int             { return m.reflogs.SelectedIndex() }
 func (m Model) ReflogScroll() int               { return m.reflogs.Scroll() }
 func (m Model) Overlay() ui.OverlayState        { return m.overlayState() }
@@ -420,72 +423,74 @@ func (m Model) View() string {
 	}
 	modalView := m.modal.View()
 	return ui.Render(ui.RenderParams{
-		Repos:                    repos,
-		Selected:                 selected,
-		Width:                    m.width,
-		Height:                   m.height,
-		Mode:                     m.mode,
-		Branches:                 rows,
-		Stashes:                  stashes,
-		BranchSelected:           branchSelected,
-		StashSelected:            stashSelected,
-		Overlay:                  m.overlayState(),
-		OverlayDiff:              modalView.Diff,
-		OverlayScroll:            modalView.Scroll,
-		ConfirmPrompt:            modalView.Prompt,
-		ConfirmForce:             modalView.Force,
-		WorktreeInputPrompt:      modalView.Prompt,
-		WorktreeInputPlaceholder: modalView.Placeholder,
-		WorktreeInput:            modalView.Input,
-		WorktreeInputErr:         modalView.InputErr,
-		SelectPrompt:             modalView.Prompt,
-		SelectItems:              uiSelectItems(modalView.SelectItems),
-		SelectSelected:           modalView.SelectIndex,
-		BranchScroll:             branchScroll,
-		RepoScroll:               repoScroll,
-		StashScroll:              stashScroll,
-		ActivePane:               m.activePane,
-		Destructive:              m.destructive,
-		Worktrees:                worktrees,
-		WorktreeSelected:         worktreeSelected,
-		WorktreeScroll:           worktreeScroll,
-		WorktreeSessions:         worktreeSessions,
-		WorktreeSessionSelected:  worktreeSessionSelected,
-		WorktreeSessionScroll:    worktreeSessionScroll,
-		InlineWorktreeSessions:   m.inlineWorktreeSessionPath != "",
-		Commits:                  commits,
-		CommitSelected:           commitSelected,
-		CommitScroll:             commitScroll,
-		Reflogs:                  reflogs,
-		ReflogSelected:           reflogSelected,
-		ReflogScroll:             reflogScroll,
-		Sessions:                 sessions,
-		SessionSelected:          sessionSelected,
-		SessionScroll:            sessionScroll,
-		Plans:                    plans,
-		PlanSelected:             planSelected,
-		PlanScroll:               planScroll,
-		Flows:                    flows,
-		FlowSelected:             flowSelected,
-		FlowScroll:               flowScroll,
-		ExpandedPlanID:           m.expandedPlanID,
-		ExpandedFlowID:           m.expandedFlowID,
-		SelectedPlanPhaseID:      m.selectedPlanPhaseID,
-		OverlayText:              modalView.Text,
-		TransientError:           m.visibleStatusText(),
-		TransientErrorFadeStep:   m.visibleStatusFadeStep(),
-		SearchActive:             m.searchActive,
-		RepoSearch:               m.repos.Query(),
-		ItemSearch:               m.activeItemPaneQuery(),
-		RepoEmptyMessage:         repoEmptyMessage,
-		RightEmptyMessage:        rightEmptyMessage,
-		FetchAvailable:           m.canFetch(),
-		FetchVisibleAvailable:    m.canFetchVisibleRepos(),
-		PullAvailable:            m.canPull(),
-		WorktreeMoveAvailable:    m.canMoveWorktree(),
-		WorktreeSessionsOpen:     m.inlineWorktreeSessionPath != "",
-		AgentAvailable:           m.canLaunchAgent(),
-		NewAgentAvailable:        m.canCreateAndLaunchAgent(),
+		Repos:                      repos,
+		Selected:                   selected,
+		Width:                      m.width,
+		Height:                     m.height,
+		Mode:                       m.mode,
+		Branches:                   rows,
+		Stashes:                    stashes,
+		BranchSelected:             branchSelected,
+		StashSelected:              stashSelected,
+		Overlay:                    m.overlayState(),
+		OverlayDiff:                modalView.Diff,
+		OverlayScroll:              modalView.Scroll,
+		ConfirmPrompt:              modalView.Prompt,
+		ConfirmForce:               modalView.Force,
+		WorktreeInputPrompt:        modalView.Prompt,
+		WorktreeInputPlaceholder:   modalView.Placeholder,
+		WorktreeInput:              modalView.Input,
+		WorktreeInputErr:           modalView.InputErr,
+		SelectPrompt:               modalView.Prompt,
+		SelectItems:                uiSelectItems(modalView.SelectItems),
+		SelectSelected:             modalView.SelectIndex,
+		BranchScroll:               branchScroll,
+		RepoScroll:                 repoScroll,
+		StashScroll:                stashScroll,
+		ActivePane:                 m.activePane,
+		Destructive:                m.destructive,
+		Worktrees:                  worktrees,
+		WorktreeSelected:           worktreeSelected,
+		WorktreeScroll:             worktreeScroll,
+		WorktreeSessions:           worktreeSessions,
+		WorktreeSessionSelected:    worktreeSessionSelected,
+		WorktreeSessionScroll:      worktreeSessionScroll,
+		InlineWorktreeSessions:     m.inlineWorktreeSessionPath != "",
+		Commits:                    commits,
+		CommitSelected:             commitSelected,
+		CommitScroll:               commitScroll,
+		Reflogs:                    reflogs,
+		ReflogSelected:             reflogSelected,
+		ReflogScroll:               reflogScroll,
+		Sessions:                   sessions,
+		SessionSelected:            sessionSelected,
+		SessionScroll:              sessionScroll,
+		Plans:                      plans,
+		PlanSelected:               planSelected,
+		PlanScroll:                 planScroll,
+		Flows:                      flows,
+		FlowSelected:               flowSelected,
+		FlowScroll:                 flowScroll,
+		ExpandedPlanID:             m.expandedPlanID,
+		ExpandedFlowID:             m.expandedFlowID,
+		SelectedPlanPhaseID:        m.selectedPlanPhaseID,
+		SelectedFlowPhaseID:        m.selectedFlowPhaseID,
+		FlowPhaseResumableSelected: m.selectedFlowPhaseResumable(),
+		OverlayText:                modalView.Text,
+		TransientError:             m.visibleStatusText(),
+		TransientErrorFadeStep:     m.visibleStatusFadeStep(),
+		SearchActive:               m.searchActive,
+		RepoSearch:                 m.repos.Query(),
+		ItemSearch:                 m.activeItemPaneQuery(),
+		RepoEmptyMessage:           repoEmptyMessage,
+		RightEmptyMessage:          rightEmptyMessage,
+		FetchAvailable:             m.canFetch(),
+		FetchVisibleAvailable:      m.canFetchVisibleRepos(),
+		PullAvailable:              m.canPull(),
+		WorktreeMoveAvailable:      m.canMoveWorktree(),
+		WorktreeSessionsOpen:       m.inlineWorktreeSessionPath != "",
+		AgentAvailable:             m.canLaunchAgent(),
+		NewAgentAvailable:          m.canCreateAndLaunchAgent(),
 	})
 }
 
@@ -941,8 +946,54 @@ func (m Model) selectedPlanPhaseIndex() (int, bool) {
 	return 0, false
 }
 
+func (m Model) selectedFlowPhase() (flowstore.FlowPhase, bool) {
+	record, ok := m.selectedFlow()
+	if !ok || record.FlowID == "" || record.FlowID != m.expandedFlowID || m.selectedFlowPhaseID == "" {
+		return flowstore.FlowPhase{}, false
+	}
+	for _, phase := range flowstore.OrderedPhases(record.Phases) {
+		if phase.PhaseID == m.selectedFlowPhaseID {
+			return phase, true
+		}
+	}
+	return flowstore.FlowPhase{}, false
+}
+
+func (m Model) selectedFlowPhaseIndex() (int, bool) {
+	record, ok := m.selectedFlow()
+	if !ok || record.FlowID == "" || record.FlowID != m.expandedFlowID || m.selectedFlowPhaseID == "" {
+		return 0, false
+	}
+	for i, phase := range flowstore.OrderedPhases(record.Phases) {
+		if phase.PhaseID == m.selectedFlowPhaseID {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func (m Model) selectedFlowPhaseResumable() bool {
+	phase, ok := m.selectedFlowPhase()
+	if !ok || flowstore.PhaseAwaitingSession(phase) {
+		return false
+	}
+	if session, ok := flowstore.LatestPhaseSession(phase, false); ok && strings.TrimSpace(session.SessionID) == "" {
+		return false
+	}
+	session, ok := flowstore.LatestPhaseSession(phase, true)
+	if !ok {
+		return false
+	}
+	return agent.Validate(agent.Normalize(strings.TrimSpace(session.Provider))) == nil
+}
+
 func (m Model) clearSelectedPlanPhase() Model {
 	m.selectedPlanPhaseID = ""
+	return m
+}
+
+func (m Model) clearSelectedFlowPhase() Model {
+	m.selectedFlowPhaseID = ""
 	return m
 }
 
@@ -959,6 +1010,7 @@ func (m Model) setExpandedPlanID(planID string) Model {
 
 func (m Model) setExpandedFlowID(flowID string) Model {
 	m.expandedFlowID = flowID
+	m.selectedFlowPhaseID = ""
 	m.flows = m.flows.SetItemHeight(flowItemHeight(flowID))
 	return m.reflowFlows()
 }
@@ -1116,6 +1168,46 @@ func (m Model) moveSelectedPlanPhase(delta int) (Model, bool) {
 	return m.ensureSelectedPlanPhaseVisible(), true
 }
 
+func (m Model) moveSelectedFlowPhase(delta int) (Model, bool) {
+	if m.mode != ui.ModeFlows || m.expandedFlowID == "" || m.selectedFlowID() != m.expandedFlowID {
+		return m, false
+	}
+	record, ok := m.selectedFlow()
+	phases := flowstore.OrderedPhases(record.Phases)
+	if !ok || len(phases) == 0 {
+		return m, false
+	}
+
+	index, hasPhase := m.selectedFlowPhaseIndex()
+	if !hasPhase {
+		if delta > 0 {
+			m.selectedFlowPhaseID = phases[0].PhaseID
+			return m.ensureSelectedFlowPhaseVisible(), true
+		}
+		return m, false
+	}
+
+	nextIndex := index + delta
+	if nextIndex < 0 {
+		m = m.clearSelectedFlowPhase()
+		return m.reflowExpandedFlow(), true
+	}
+	if nextIndex >= len(phases) {
+		if m.flows.Len() <= 1 {
+			return m.ensureSelectedFlowPhaseVisible(), true
+		}
+		before := m.selectedFlowID()
+		m.flows = m.flows.Move(delta, m.contentHeightForMode(), m.contentWidth())
+		if after := m.selectedFlowID(); before != "" && after != before {
+			m = m.clearSelectedFlowPhase()
+			m = m.setExpandedFlowID("")
+		}
+		return m, true
+	}
+	m.selectedFlowPhaseID = phases[nextIndex].PhaseID
+	return m.ensureSelectedFlowPhaseVisible(), true
+}
+
 func (m Model) ensureSelectedPlanPhaseVisible() Model {
 	index, ok := m.selectedPlanPhaseIndex()
 	if !ok {
@@ -1144,6 +1236,34 @@ func (m Model) ensureSelectedPlanPhaseVisible() Model {
 	return m
 }
 
+func (m Model) ensureSelectedFlowPhaseVisible() Model {
+	index, ok := m.selectedFlowPhaseIndex()
+	if !ok {
+		return m.reflowExpandedFlow()
+	}
+	line, ok := m.selectedFlowVisualLine()
+	if !ok {
+		return m
+	}
+	line += 1 + index
+	viewHeight := m.flowContentHeight()
+	if viewHeight <= 0 {
+		viewHeight = 1
+	}
+	scroll := m.FlowScroll()
+	target := scroll
+	if line < target {
+		target = line
+	}
+	if line >= target+viewHeight {
+		target = line - viewHeight + 1
+	}
+	if target != scroll {
+		m.flows = m.flows.ScrollBy(target-scroll, viewHeight, m.contentWidth())
+	}
+	return m
+}
+
 func (m Model) selectedPlanVisualLine() (int, bool) {
 	plans := m.filteredPlans()
 	selected := m.PlanSelected()
@@ -1153,6 +1273,19 @@ func (m Model) selectedPlanVisualLine() (int, bool) {
 	line := 0
 	for i := 0; i < selected; i++ {
 		line += planVisualHeight(plans[i], m.expandedPlanID)
+	}
+	return line, true
+}
+
+func (m Model) selectedFlowVisualLine() (int, bool) {
+	flows := m.filteredFlows()
+	selected := m.FlowSelected()
+	if selected < 0 || selected >= len(flows) {
+		return 0, false
+	}
+	line := 0
+	for i := 0; i < selected; i++ {
+		line += flowVisualHeight(flows[i], m.expandedFlowID)
 	}
 	return line, true
 }
@@ -1220,6 +1353,9 @@ func (m Model) reflowPlans() Model {
 
 func (m Model) reflowFlows() Model {
 	m.flows = m.flows.Reflow(m.flowContentHeight(), m.contentWidth())
+	if m.selectedFlowPhaseID != "" {
+		return m.ensureSelectedFlowPhaseVisible()
+	}
 	if m.expandedFlowID != "" {
 		return m.reflowExpandedFlow()
 	}

--- a/model/model.go
+++ b/model/model.go
@@ -974,7 +974,7 @@ func (m Model) selectedFlowPhaseIndex() (int, bool) {
 
 func (m Model) selectedFlowPhaseResumable() bool {
 	phase, ok := m.selectedFlowPhase()
-	if !ok || flowstore.PhaseAwaitingSession(phase) {
+	if !ok || (phase.Status == flowstore.PhaseRunning && flowstore.PhaseAwaitingSession(phase)) {
 		return false
 	}
 	if session, ok := flowstore.LatestPhaseSession(phase, false); ok && strings.TrimSpace(session.SessionID) == "" {

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/brian-bell/wtui/actions"
+	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/model"
 	"github.com/brian-bell/wtui/scanner"
@@ -3980,13 +3981,52 @@ func TestModel_RKeyResumePrefersSessionCWD(t *testing.T) {
 		got.Commit != "abc123" ||
 		got.SessionStateRoot != "/state/wtui/sessions/v1" ||
 		got.PlanID != "plan-1" ||
-		got.PlanPath != "/state/wtui/plans/plan-1/plan.md" ||
-		got.FlowID != "flow-1" ||
-		got.FlowPhaseID != "review-loop" {
+		got.PlanPath != "/state/wtui/plans/plan-1/plan.md" {
 		t.Fatalf("unexpected resume launch context: %#v", got)
+	}
+	if got.FlowID != "" || got.FlowPhaseID != "" {
+		t.Fatalf("ordinary session resume should not export Flow metadata: %#v", got)
 	}
 	if got.LaunchID == "" || got.LaunchID == "old-launch" {
 		t.Fatalf("expected fresh launch id, got %#v", got)
+	}
+}
+
+func TestModel_RKeySessionResumeWithFlowMetadataRunFailureDoesNotUpdateFlow(t *testing.T) {
+	var phaseUpdates []flowstore.PhaseUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SetFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+			phaseUpdates = append(phaseUpdates, update)
+			return flowstore.FlowRecord{}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("false"), Detached: true}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{
+		{
+			Provider:     sessions.ProviderCodex,
+			SessionID:    "codex-session-1",
+			RepoPath:     "/dev/alpha",
+			WorktreePath: "/dev/alpha-worktrees/feat",
+			FlowID:       "flow-1",
+			FlowPhaseID:  "review-loop",
+		},
+	}, ListRequest: m.ListRequest(ui.ModeSessions)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("expected session resume command")
+	}
+	result, ok := cmd().(model.AgentResultMsg)
+	if !ok || result.Err == "" {
+		t.Fatalf("expected failing AgentResultMsg, got %#v", result)
+	}
+	m, _ = update(m, result)
+	if len(phaseUpdates) != 0 {
+		t.Fatalf("ordinary session resume should not update Flow phase, got %#v", phaseUpdates)
 	}
 }
 
@@ -4259,10 +4299,11 @@ func TestModel_EnterResumesInlineWorktreeSession(t *testing.T) {
 		got.Commit != "abc123" ||
 		got.SessionStateRoot != "/state/wtui/sessions/v1" ||
 		got.PlanID != "plan-1" ||
-		got.PlanPath != "/state/wtui/plans/plan-1/plan.md" ||
-		got.FlowID != "flow-1" ||
-		got.FlowPhaseID != "implementation" {
+		got.PlanPath != "/state/wtui/plans/plan-1/plan.md" {
 		t.Fatalf("unexpected inline resume launch context: %#v", got)
+	}
+	if got.FlowID != "" || got.FlowPhaseID != "" {
+		t.Fatalf("inline session resume should not export Flow metadata: %#v", got)
 	}
 	if got.LaunchID == "" || got.LaunchID == "old-launch" {
 		t.Fatalf("expected fresh launch id, got %#v", got)

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -597,9 +597,14 @@ func TestModel_OKeyOnFlowWithoutPlanShowsStatus(t *testing.T) {
 }
 
 func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
+	var launchUpdate flowstore.PhaseLaunchUpdate
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		SessionStateRoot: "/state/wtui",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			launchUpdate = update
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
 		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
 			launched = ctx
 			return actions.TerminalLaunchSpec{Cmd: exec.Command("true"), Detached: true}, nil
@@ -631,8 +636,20 @@ func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected selected Flow phase resume command")
 	}
-	msg, ok := cmd().(model.AgentResultMsg)
-	if !ok || msg.Err != "" {
+	var msg model.AgentResultMsg
+	switch got := cmd().(type) {
+	case tea.BatchMsg:
+		for _, batched := range got {
+			if agentResult, ok := batched().(model.AgentResultMsg); ok {
+				msg = agentResult
+			}
+		}
+	case model.AgentResultMsg:
+		msg = got
+	default:
+		t.Fatalf("expected AgentResultMsg or BatchMsg from resume command, got %T", got)
+	}
+	if msg.Err != "" || msg.LaunchContext.ResumeSessionID == "" {
 		t.Fatalf("expected successful AgentResultMsg from resume command, got %#v", msg)
 	}
 	if launched.Command != "codex" ||
@@ -647,8 +664,14 @@ func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 		launched.SessionStateRoot != "/state/wtui" {
 		t.Fatalf("unexpected Flow phase resume context: %#v", launched)
 	}
-	if launched.LaunchID != "launch-new" {
-		t.Fatalf("expected Flow phase resume to reuse tracked launch id, got %#v", launched)
+	if launched.LaunchID == "" || launched.LaunchID == "launch-new" {
+		t.Fatalf("expected Flow phase resume to use a fresh launch id, got %#v", launched.LaunchID)
+	}
+	if launchUpdate.FlowID != "flow-1" || launchUpdate.PhaseID != "implementation" || launchUpdate.LaunchID != launched.LaunchID {
+		t.Fatalf("launch update = %#v, want fresh resume launch id %#v", launchUpdate, launched.LaunchID)
+	}
+	if !launched.FlowLaunchTracked {
+		t.Fatalf("expected Flow phase resume context to be marked tracked: %#v", launched)
 	}
 }
 
@@ -773,9 +796,58 @@ func TestModel_RKeyOnFlowPhaseAwaitingLatestSessionDoesNotResumeOlderSession(t *
 	}
 }
 
-func TestModel_RKeyOnFlowPhaseResumeFailureDoesNotMarkPhaseNeedsAttention(t *testing.T) {
+func TestModel_RKeyOnFlowPhaseNeedsAttentionCanResumeOlderValidSession(t *testing.T) {
+	var launched actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launched = ctx
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true"), Detached: true}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		Title:        "Attention latest",
+		Status:       flowstore.StatusNeedsAttention,
+		Branch:       "flow/attention-latest",
+		WorktreePath: "/dev/alpha-worktrees/flow-attention-latest",
+		Phases: []flowstore.FlowPhase{{
+			PhaseID:   "implementation",
+			Title:     "Implementation",
+			Status:    flowstore.PhaseNeedsAttention,
+			LaunchIDs: []string{"launch-old", "launch-new"},
+			Sessions: []flowstore.Session{
+				{Provider: "codex", SessionID: "codex-old", LaunchID: "launch-old", Status: "ended"},
+			},
+		}},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	if !strings.Contains(m.View(), "r      resume") {
+		t.Fatalf("needs_attention phase should advertise Flow phase resume:\n%s", m.View())
+	}
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("expected needs_attention phase to resume older valid session")
+	}
+	_ = cmd()
+	if launched.ResumeSessionID != "codex-old" {
+		t.Fatalf("resume session = %#v, want older valid session", launched.ResumeSessionID)
+	}
+}
+
+func TestModel_RKeyOnFlowPhaseResumeSetupFailureMarksTrackedLaunchNeedsAttention(t *testing.T) {
+	var launchUpdate flowstore.PhaseLaunchUpdate
 	var phaseUpdates []flowstore.PhaseUpdate
 	m := model.NewWithOptions(testRepos(), model.Options{
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			launchUpdate = update
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
 		SetFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
 			phaseUpdates = append(phaseUpdates, update)
 			return flowstore.FlowRecord{}, nil
@@ -807,11 +879,92 @@ func TestModel_RKeyOnFlowPhaseResumeFailureDoesNotMarkPhaseNeedsAttention(t *tes
 	if cmd != nil {
 		t.Fatalf("immediate resume failure should not return command, got %T", cmd)
 	}
-	if len(phaseUpdates) != 0 {
-		t.Fatalf("resume failure should not update Flow phase, got %#v", phaseUpdates)
+	if launchUpdate.FlowID != "flow-1" || launchUpdate.PhaseID != "review-loop" || launchUpdate.LaunchID == "" {
+		t.Fatalf("launch update = %#v", launchUpdate)
+	}
+	if len(phaseUpdates) != 1 {
+		t.Fatalf("phase updates = %#v, want one launch failure update", phaseUpdates)
+	}
+	if update := phaseUpdates[0]; update.FlowID != "flow-1" ||
+		update.PhaseID != "review-loop" ||
+		update.Status != flowstore.PhaseNeedsAttention ||
+		!strings.Contains(update.Notes, "terminal unavailable") {
+		t.Fatalf("phase update = %#v", update)
 	}
 	if got := m.TransientError(); !strings.Contains(got, "terminal unavailable") {
 		t.Fatalf("status = %q, want launch failure", got)
+	}
+}
+
+func TestModel_RKeyOnFlowPhaseResumeRunFailureMarksTrackedLaunchNeedsAttention(t *testing.T) {
+	var launchUpdate flowstore.PhaseLaunchUpdate
+	var phaseUpdate flowstore.PhaseUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{}, nil
+		},
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			launchUpdate = update
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		SetFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+			phaseUpdate = update
+			return flowstore.FlowRecord{}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("false"), Detached: true}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		Title:        "Resume run failure",
+		Status:       flowstore.StatusInProgress,
+		Branch:       "flow/resume-run-failure",
+		WorktreePath: "/dev/alpha-worktrees/flow-resume-run-failure",
+		Phases: []flowstore.FlowPhase{{
+			PhaseID:   "review-loop",
+			Title:     "Review loop",
+			Status:    flowstore.PhaseCompleted,
+			LaunchIDs: []string{"launch-old"},
+			Sessions: []flowstore.Session{
+				{Provider: "codex", SessionID: "codex-review", LaunchID: "launch-old", Status: "ended"},
+			},
+		}},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("expected resume launch command")
+	}
+	var result model.AgentResultMsg
+	switch got := cmd().(type) {
+	case tea.BatchMsg:
+		for _, batched := range got {
+			if agentResult, ok := batched().(model.AgentResultMsg); ok {
+				result = agentResult
+			}
+		}
+	case model.AgentResultMsg:
+		result = got
+	default:
+		t.Fatalf("expected AgentResultMsg or BatchMsg from resume command, got %T", got)
+	}
+	if result.Err == "" {
+		t.Fatalf("expected launch command failure, got %#v", result)
+	}
+	m, _ = update(m, result)
+
+	if launchUpdate.FlowID != "flow-1" || launchUpdate.PhaseID != "review-loop" || launchUpdate.LaunchID == "" {
+		t.Fatalf("launch update = %#v", launchUpdate)
+	}
+	if phaseUpdate.FlowID != "flow-1" ||
+		phaseUpdate.PhaseID != "review-loop" ||
+		phaseUpdate.Status != flowstore.PhaseNeedsAttention ||
+		!strings.Contains(phaseUpdate.Notes, "exit status") {
+		t.Fatalf("phase update = %#v", phaseUpdate)
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -208,12 +208,91 @@ func TestModel_FlowPhasesAutoCollapseWhenSelectionChanges(t *testing.T) {
 		t.Fatal("expected selected flow to expand")
 	}
 
+	for range flowstore.OrderedPhases(flowWithPhaseDetails().Phases) {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if got := m.FlowSelected(); got != 1 {
 		t.Fatalf("flow selection = %d, want second flow", got)
 	}
 	if m.ExpandedFlowID() != "" {
 		t.Fatalf("expanded flow = %q, want collapsed after selecting another flow", m.ExpandedFlowID())
+	}
+}
+
+func TestModel_ExpandedFlowArrowKeysSelectPhaseRows(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if got := m.SelectedFlowPhaseID(); got != "" {
+		t.Fatalf("expanded flow should keep flow row selected, got phase %q", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.FlowSelected(); got != 0 {
+		t.Fatalf("flow selection changed while entering phases: %d", got)
+	}
+	if got := m.SelectedFlowPhaseID(); got != "plan" {
+		t.Fatalf("selected flow phase = %q, want plan", got)
+	}
+	if view := m.View(); !strings.Contains(view, "> completed") {
+		t.Fatalf("selected phase row should be visually marked:\n%s", view)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.SelectedFlowPhaseID(); got != "plan-review" {
+		t.Fatalf("selected flow phase = %q, want plan-review", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
+	if got := m.SelectedFlowPhaseID(); got != "" {
+		t.Fatalf("up from first phase should return to flow row, got phase %q", got)
+	}
+}
+
+func TestModel_SelectedFlowPhaseClearsWhenFlowSelectionChanges(t *testing.T) {
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{
+		flowWithPhaseDetails(),
+		{FlowID: "flow-2", RepoPath: "/dev/alpha", Title: "Second flow", Status: flowstore.StatusPending, Phases: []flowstore.FlowPhase{{PhaseID: "plan", Title: "Plan", Status: flowstore.PhasePending}}},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.SelectedFlowPhaseID(); got == "" {
+		t.Fatal("expected selected flow phase before changing flows")
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.FlowSelected(); got != 1 {
+		t.Fatalf("flow selection = %d, want second flow", got)
+	}
+	if got := m.SelectedFlowPhaseID(); got != "" {
+		t.Fatalf("selected flow phase after changing flows = %q, want cleared", got)
+	}
+	if got := m.ExpandedFlowID(); got != "" {
+		t.Fatalf("expanded flow after changing flows = %q, want collapsed", got)
+	}
+}
+
+func TestModel_SelectedFlowPhaseClearsWhenLeavingRightPane(t *testing.T) {
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyTab},
+		{Type: tea.KeyRight},
+	} {
+		m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithPhaseDetails()})
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+		if got := m.SelectedFlowPhaseID(); got == "" {
+			t.Fatal("expected selected flow phase before leaving right pane")
+		}
+
+		m, _ = update(m, key)
+		if got := m.SelectedFlowPhaseID(); got != "" {
+			t.Fatalf("%s left selected flow phase = %q, want cleared", key.String(), got)
+		}
 	}
 }
 
@@ -255,7 +334,9 @@ func TestModel_ExpandedSingleFlowScrollsWithinManyPhases(t *testing.T) {
 	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 10})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	for i := 0; i < 4; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
 
 	if got := m.FlowSelected(); got != 0 {
 		t.Fatalf("single expanded flow should remain selected, got %d", got)
@@ -278,6 +359,30 @@ func TestModel_ExpandedSingleFlowScrollsWithinManyPhases(t *testing.T) {
 	view = m.View()
 	if !strings.Contains(view, "autoreview:pending") {
 		t.Fatalf("expanded flow should stay scrolled to the last phase:\n%s", view)
+	}
+}
+
+func TestModel_SelectedFlowPhaseStaysVisibleAfterResize(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	flow.Phases = append(flow.Phases,
+		flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review Loop", Status: flowstore.PhasePending},
+		flowstore.FlowPhase{PhaseID: "pr-creation", Title: "PR Creation", Status: flowstore.PhasePending},
+		flowstore.FlowPhase{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhasePending},
+	)
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	for i := 0; i < 6; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if got := m.SelectedFlowPhaseID(); got != "autoreview" {
+		t.Fatalf("selected flow phase = %q, want autoreview", got)
+	}
+
+	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 10})
+
+	view := m.View()
+	if !strings.Contains(view, "autoreview:pending") {
+		t.Fatalf("selected flow phase should stay visible after resize:\n%s", view)
 	}
 }
 
@@ -488,6 +593,225 @@ func TestModel_OKeyOnFlowWithoutPlanShowsStatus(t *testing.T) {
 	}
 	if got := m.TransientError(); !strings.Contains(got, "Flow has no linked plan") {
 		t.Fatalf("status = %q, want missing linked plan message", got)
+	}
+}
+
+func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
+	var launched actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SessionStateRoot: "/state/wtui",
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launched = ctx
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true"), Detached: true}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		Title:        "Resume sessions",
+		Status:       flowstore.StatusInProgress,
+		Branch:       "flow/resume-sessions",
+		WorktreePath: "/dev/alpha-worktrees/flow-resume-sessions",
+		Commit:       "abc123",
+		Phases: []flowstore.FlowPhase{{
+			PhaseID:   "implementation",
+			Title:     "Implementation",
+			Status:    flowstore.PhaseCompleted,
+			LaunchIDs: []string{"launch-old", "launch-new"},
+			Sessions: []flowstore.Session{
+				{Provider: "claude", SessionID: "claude-old", LaunchID: "launch-old", Status: "ended", StartedAt: time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)},
+				{Provider: "codex", SessionID: "codex-new", LaunchID: "launch-new", Status: "ended", StartedAt: time.Date(2026, 6, 7, 11, 0, 0, 0, time.UTC)},
+			},
+		}},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("expected selected Flow phase resume command")
+	}
+	msg, ok := cmd().(model.AgentResultMsg)
+	if !ok || msg.Err != "" {
+		t.Fatalf("expected successful AgentResultMsg from resume command, got %#v", msg)
+	}
+	if launched.Command != "codex" ||
+		launched.ResumeSessionID != "codex-new" ||
+		launched.FlowID != "flow-1" ||
+		launched.FlowPhaseID != "implementation" ||
+		launched.RepoPath != "/dev/alpha" ||
+		launched.WorktreePath != "/dev/alpha-worktrees/flow-resume-sessions" ||
+		launched.WorkingDir != "/dev/alpha-worktrees/flow-resume-sessions" ||
+		launched.Branch != "flow/resume-sessions" ||
+		launched.Commit != "abc123" ||
+		launched.SessionStateRoot != "/state/wtui" {
+		t.Fatalf("unexpected Flow phase resume context: %#v", launched)
+	}
+	if launched.LaunchID == "" || launched.LaunchID == "launch-new" {
+		t.Fatalf("expected fresh Flow phase resume launch id, got %#v", launched)
+	}
+}
+
+func TestModel_RKeyOnSelectedFlowPhaseUsesCodexAppPreferenceForCodexSession(t *testing.T) {
+	var launched actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex-app",
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launched = ctx
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true"), Detached: true}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		Title:        "Resume codex app",
+		Status:       flowstore.StatusInProgress,
+		WorktreePath: "/dev/alpha-worktrees/flow-resume-codex-app",
+		Phases: []flowstore.FlowPhase{{
+			PhaseID: "implementation",
+			Title:   "Implementation",
+			Status:  flowstore.PhaseCompleted,
+			Sessions: []flowstore.Session{
+				{Provider: " CoDeX ", SessionID: "codex-new", Status: "ended"},
+			},
+		}},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("expected selected Flow phase resume command")
+	}
+	msg, ok := cmd().(model.AgentResultMsg)
+	if !ok || msg.Err != "" {
+		t.Fatalf("expected successful AgentResultMsg from resume command, got %#v", msg)
+	}
+	if launched.Command != "codex-app" || launched.ResumeSessionID != "codex-new" {
+		t.Fatalf("unexpected Flow phase codex-app resume context: %#v", launched)
+	}
+}
+
+func TestModel_FlowPhaseWithUnsupportedProviderDoesNotAdvertiseResume(t *testing.T) {
+	launchRan := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launchRan = true
+			return actions.TerminalLaunchSpec{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		Title:        "Unsupported provider",
+		Status:       flowstore.StatusInProgress,
+		WorktreePath: "/dev/alpha-worktrees/flow-unsupported-provider",
+		Phases: []flowstore.FlowPhase{{
+			PhaseID: "implementation",
+			Title:   "Implementation",
+			Status:  flowstore.PhaseCompleted,
+			Sessions: []flowstore.Session{
+				{Provider: "unsupported-agent", SessionID: "session-1", Status: "ended"},
+			},
+		}},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	if strings.Contains(m.View(), "r      resume") {
+		t.Fatalf("unsupported provider should not advertise Flow phase resume:\n%s", m.View())
+	}
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd != nil {
+		t.Fatalf("unsupported provider should not launch, got %T", cmd)
+	}
+	if launchRan {
+		t.Fatal("LaunchAgent ran for unsupported Flow phase provider")
+	}
+	if got := m.TransientError(); !strings.Contains(got, "unsupported") {
+		t.Fatalf("status = %q, want unsupported provider validation", got)
+	}
+}
+
+func TestModel_RKeyOnFlowPhaseAwaitingLatestSessionDoesNotResumeOlderSession(t *testing.T) {
+	launchRan := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launchRan = true
+			return actions.TerminalLaunchSpec{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		Title:        "Await latest",
+		Status:       flowstore.StatusInProgress,
+		Branch:       "flow/await-latest",
+		WorktreePath: "/dev/alpha-worktrees/flow-await-latest",
+		Phases: []flowstore.FlowPhase{{
+			PhaseID:   "implementation",
+			Title:     "Implementation",
+			Status:    flowstore.PhaseRunning,
+			LaunchIDs: []string{"launch-old", "launch-new"},
+			Sessions: []flowstore.Session{
+				{Provider: "codex", SessionID: "codex-old", LaunchID: "launch-old", Status: "ended"},
+			},
+		}},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd != nil {
+		t.Fatalf("awaiting latest session should not launch, got %T", cmd)
+	}
+	if launchRan {
+		t.Fatal("LaunchAgent ran for stale Flow phase session")
+	}
+	if got := m.TransientError(); !strings.Contains(got, "awaiting session") {
+		t.Fatalf("status = %q, want awaiting session", got)
+	}
+}
+
+func TestModel_RKeyOnFlowPhaseResumeFailureDoesNotMarkPhaseNeedsAttention(t *testing.T) {
+	var phaseUpdates []flowstore.PhaseUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SetFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+			phaseUpdates = append(phaseUpdates, update)
+			return flowstore.FlowRecord{}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			return actions.TerminalLaunchSpec{}, errors.New("terminal unavailable")
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		Title:        "Resume failure",
+		Status:       flowstore.StatusInProgress,
+		Branch:       "flow/resume-failure",
+		WorktreePath: "/dev/alpha-worktrees/flow-resume-failure",
+		Phases: []flowstore.FlowPhase{{
+			PhaseID: "review-loop",
+			Title:   "Review loop",
+			Status:  flowstore.PhaseCompleted,
+			Sessions: []flowstore.Session{
+				{Provider: "codex", SessionID: "codex-review", Status: "ended"},
+			},
+		}},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd != nil {
+		t.Fatalf("immediate resume failure should not return command, got %T", cmd)
+	}
+	if len(phaseUpdates) != 0 {
+		t.Fatalf("resume failure should not update Flow phase, got %#v", phaseUpdates)
+	}
+	if got := m.TransientError(); !strings.Contains(got, "terminal unavailable") {
+		t.Fatalf("status = %q, want launch failure", got)
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -647,8 +647,8 @@ func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 		launched.SessionStateRoot != "/state/wtui" {
 		t.Fatalf("unexpected Flow phase resume context: %#v", launched)
 	}
-	if launched.LaunchID == "" || launched.LaunchID == "launch-new" {
-		t.Fatalf("expected fresh Flow phase resume launch id, got %#v", launched)
+	if launched.LaunchID != "launch-new" {
+		t.Fatalf("expected Flow phase resume to reuse tracked launch id, got %#v", launched)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1066,7 +1066,7 @@ func (m Model) handleResumeFlowPhaseSession() (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	if flowstore.PhaseAwaitingSession(phase) {
+	if phase.Status == flowstore.PhaseRunning && flowstore.PhaseAwaitingSession(phase) {
 		m = m.setStatus(statusOther, "Flow phase is awaiting session capture")
 		return m, nil
 	}
@@ -1083,7 +1083,15 @@ func (m Model) handleResumeFlowPhaseSession() (tea.Model, tea.Cmd) {
 	if !ok {
 		return next, nil
 	}
-	return next.launchAgentWithContext(ctx)
+	if ctx.Command == agent.CommandCodexApp {
+		// Codex App resume deep links cannot carry wtui launch metadata, so treat
+		// them as app navigation instead of a tracked Flow launch attempt.
+		ctx.LaunchID = ""
+		ctx.FlowID = ""
+		ctx.FlowPhaseID = ""
+		return next.launchAgentWithContext(ctx)
+	}
+	return next.launchTrackedFlowPhaseResumeWithContext(ctx)
 }
 
 func (m Model) sessionResumeLaunchContext(record sessions.SessionRecord) (actions.AgentLaunchContext, bool, Model) {
@@ -1111,8 +1119,6 @@ func (m Model) sessionResumeLaunchContext(record sessions.SessionRecord) (action
 		ResumeSessionID:  record.SessionID,
 		PlanID:           record.PlanID,
 		PlanPath:         record.PlanPath,
-		FlowID:           record.FlowID,
-		FlowPhaseID:      record.FlowPhaseID,
 	}
 	return ctx, true, m
 }
@@ -1146,7 +1152,7 @@ func (m Model) flowPhaseSessionResumeLaunchContext(record flowstore.FlowRecord, 
 	}
 	ctx := actions.AgentLaunchContext{
 		Command:          command,
-		LaunchID:         flowPhaseSessionResumeLaunchID(phase, session),
+		LaunchID:         newLaunchID(),
 		RepoPath:         repoPath,
 		WorktreePath:     record.WorktreePath,
 		WorkingDir:       workingDir,
@@ -1160,13 +1166,6 @@ func (m Model) flowPhaseSessionResumeLaunchContext(record flowstore.FlowRecord, 
 		FlowPhaseID:      phase.PhaseID,
 	}
 	return ctx, true, m
-}
-
-func flowPhaseSessionResumeLaunchID(phase flowstore.FlowPhase, session flowstore.Session) string {
-	if launchID := strings.TrimSpace(session.LaunchID); launchID != "" {
-		return launchID
-	}
-	return flowstore.LatestPhaseLaunchID(phase)
 }
 
 func (m Model) handleImplementPlan() (tea.Model, tea.Cmd) {
@@ -1598,6 +1597,35 @@ func (m Model) launchAgentWithContext(ctx actions.AgentLaunchContext) (Model, te
 		m = m.setStatus(statusOther, errText)
 		return m, nil
 	}
+	return m.runAgentLaunchWithContext(ctx, launch)
+}
+
+func (m Model) launchTrackedFlowPhaseResumeWithContext(ctx actions.AgentLaunchContext) (Model, tea.Cmd) {
+	ctx.FlowLaunchTracked = true
+	if _, err := m.addFlowPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:   ctx.FlowID,
+		PhaseID:  ctx.FlowPhaseID,
+		LaunchID: ctx.LaunchID,
+	}); err != nil {
+		m = m.setStatus(statusOther, fmt.Sprintf("failed to mark flow phase resume: %v", err))
+		return m, nil
+	}
+	launch, err := m.launchAgent(ctx)
+	if err != nil {
+		errText := err.Error()
+		m, errText = m.markFlowLaunchNeedsAttention(ctx, errText)
+		m = m.setStatus(statusOther, errText)
+		return m, nil
+	}
+	next, launchCmd := m.runAgentLaunchWithContext(ctx, launch)
+	if next.mode == ui.ModeFlows {
+		next, fetchCmd := next.startFetchMode(ui.ModeFlows)
+		return next, tea.Batch(fetchCmd, launchCmd)
+	}
+	return next, launchCmd
+}
+
+func (m Model) runAgentLaunchWithContext(ctx actions.AgentLaunchContext, launch actions.TerminalLaunchSpec) (Model, tea.Cmd) {
 	if launch.Interactive {
 		// wtui hands over the TTY until the launch command exits. Some launch
 		// commands are only terminal/multiplexer clients; launch.Detached records
@@ -1626,7 +1654,7 @@ func (m Model) launchAgentWithContext(ctx actions.AgentLaunchContext) (Model, te
 }
 
 func (m Model) markFlowLaunchNeedsAttention(ctx actions.AgentLaunchContext, errText string) (Model, string) {
-	if ctx.FlowID == "" || ctx.FlowPhaseID == "" || ctx.ResumeSessionID != "" {
+	if ctx.FlowID == "" || ctx.FlowPhaseID == "" || (ctx.ResumeSessionID != "" && !ctx.FlowLaunchTracked) {
 		return m, errText
 	}
 	notes := "Agent launch failed"

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1146,7 +1146,7 @@ func (m Model) flowPhaseSessionResumeLaunchContext(record flowstore.FlowRecord, 
 	}
 	ctx := actions.AgentLaunchContext{
 		Command:          command,
-		LaunchID:         newLaunchID(),
+		LaunchID:         flowPhaseSessionResumeLaunchID(phase, session),
 		RepoPath:         repoPath,
 		WorktreePath:     record.WorktreePath,
 		WorkingDir:       workingDir,
@@ -1160,6 +1160,13 @@ func (m Model) flowPhaseSessionResumeLaunchContext(record flowstore.FlowRecord, 
 		FlowPhaseID:      phase.PhaseID,
 	}
 	return ctx, true, m
+}
+
+func flowPhaseSessionResumeLaunchID(phase flowstore.FlowPhase, session flowstore.Session) string {
+	if launchID := strings.TrimSpace(session.LaunchID); launchID != "" {
+		return launchID
+	}
+	return flowstore.LatestPhaseLaunchID(phase)
 }
 
 func (m Model) handleImplementPlan() (tea.Model, tea.Cmd) {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -296,6 +296,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 	case "s":
 		return m.handleShowSessionSummary()
 	case "r":
+		if m.mode == ui.ModeFlows {
+			return m.handleResumeFlowPhaseSession()
+		}
 		return m.handleResumeSession()
 	case "i":
 		if m.mode == ui.ModePlans {
@@ -312,6 +315,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		m.activePane = 0
 		if m.mode == ui.ModePlans {
 			m = m.clearSelectedPlanPhase()
+		}
+		if m.mode == ui.ModeFlows {
+			m = m.clearSelectedFlowPhase()
 		}
 	case "enter":
 		return m.handleEnter()
@@ -387,6 +393,7 @@ func (m Model) handleHorizontalNavigation(direction int) (tea.Model, tea.Cmd) {
 	if direction > 0 {
 		if m.mode == ui.ModeFlows {
 			m.activePane = 0
+			m = m.clearSelectedFlowPhase()
 			return m, nil
 		}
 		m.mode++
@@ -451,6 +458,9 @@ func (m Model) moveCursor(delta int) Model {
 			m = m.setExpandedPlanID("")
 		}
 	case ui.ModeFlows:
+		if next, ok := m.moveSelectedFlowPhase(delta); ok {
+			return next
+		}
 		if m.canScrollExpandedFlow(delta, h) {
 			m.flows = m.flows.ScrollBy(delta, h, w)
 			return m
@@ -1044,6 +1054,38 @@ func (m Model) handleResumeSession() (tea.Model, tea.Cmd) {
 	return next.launchAgentWithContext(ctx)
 }
 
+func (m Model) handleResumeFlowPhaseSession() (tea.Model, tea.Cmd) {
+	if m.mode != ui.ModeFlows {
+		return m, nil
+	}
+	record, ok := m.selectedFlow()
+	if !ok || record.FlowID == "" || record.FlowID != m.expandedFlowID || m.selectedFlowPhaseID == "" {
+		return m, nil
+	}
+	phase, ok := m.selectedFlowPhase()
+	if !ok {
+		return m, nil
+	}
+	if flowstore.PhaseAwaitingSession(phase) {
+		m = m.setStatus(statusOther, "Flow phase is awaiting session capture")
+		return m, nil
+	}
+	if session, ok := flowstore.LatestPhaseSession(phase, false); ok && strings.TrimSpace(session.SessionID) == "" {
+		m = m.setStatus(statusOther, "Flow phase has missing session id")
+		return m, nil
+	}
+	session, ok := flowstore.LatestPhaseSession(phase, true)
+	if !ok {
+		m = m.setStatus(statusOther, "Flow phase has no session to resume")
+		return m, nil
+	}
+	ctx, ok, next := m.flowPhaseSessionResumeLaunchContext(record, phase, session)
+	if !ok {
+		return next, nil
+	}
+	return next.launchAgentWithContext(ctx)
+}
+
 func (m Model) sessionResumeLaunchContext(record sessions.SessionRecord) (actions.AgentLaunchContext, bool, Model) {
 	command := string(record.Provider)
 	if record.Provider == sessions.ProviderCodex && agent.Normalize(m.agentCommand) == agent.CommandCodexApp {
@@ -1071,6 +1113,51 @@ func (m Model) sessionResumeLaunchContext(record sessions.SessionRecord) (action
 		PlanPath:         record.PlanPath,
 		FlowID:           record.FlowID,
 		FlowPhaseID:      record.FlowPhaseID,
+	}
+	return ctx, true, m
+}
+
+func (m Model) flowPhaseSessionResumeLaunchContext(record flowstore.FlowRecord, phase flowstore.FlowPhase, session flowstore.Session) (actions.AgentLaunchContext, bool, Model) {
+	command := agent.Normalize(strings.TrimSpace(session.Provider))
+	if command == "" {
+		m = m.setStatus(statusOther, "Flow phase session has no provider")
+		return actions.AgentLaunchContext{}, false, m
+	}
+	if command == agent.CommandCodex && agent.Normalize(m.agentCommand) == agent.CommandCodexApp {
+		command = agent.CommandCodexApp
+	}
+	if err := agent.Validate(command); err != nil {
+		m = m.setStatus(statusOther, err.Error())
+		return actions.AgentLaunchContext{}, false, m
+	}
+	sessionID := strings.TrimSpace(session.SessionID)
+	if sessionID == "" {
+		m = m.setStatus(statusOther, "Flow phase has missing session id")
+		return actions.AgentLaunchContext{}, false, m
+	}
+	repoPath := record.RepoPath
+	if repoPath == "" {
+		repoPath, _ = m.currentRepoPath()
+	}
+	workingDir := record.WorktreePath
+	if workingDir == "" && command != agent.CommandCodexApp {
+		m = m.setStatus(statusOther, "Flow phase has no worktree path to resume from")
+		return actions.AgentLaunchContext{}, false, m
+	}
+	ctx := actions.AgentLaunchContext{
+		Command:          command,
+		LaunchID:         newLaunchID(),
+		RepoPath:         repoPath,
+		WorktreePath:     record.WorktreePath,
+		WorkingDir:       workingDir,
+		Branch:           record.Branch,
+		Commit:           record.Commit,
+		SessionStateRoot: m.sessionStateRoot,
+		ResumeSessionID:  sessionID,
+		PlanID:           record.PlanID,
+		PlanPath:         record.PlanPath,
+		FlowID:           record.FlowID,
+		FlowPhaseID:      phase.PhaseID,
 	}
 	return ctx, true, m
 }
@@ -1532,7 +1619,7 @@ func (m Model) launchAgentWithContext(ctx actions.AgentLaunchContext) (Model, te
 }
 
 func (m Model) markFlowLaunchNeedsAttention(ctx actions.AgentLaunchContext, errText string) (Model, string) {
-	if ctx.FlowID == "" || ctx.FlowPhaseID == "" {
+	if ctx.FlowID == "" || ctx.FlowPhaseID == "" || ctx.ResumeSessionID != "" {
 		return m, errText
 	}
 	notes := "Agent launch failed"

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -132,72 +132,74 @@ const StashPrefixWidth = 15
 
 // RenderParams holds everything the renderer needs.
 type RenderParams struct {
-	Repos                    []scanner.Repo
-	Selected                 int
-	Width                    int
-	Height                   int
-	Mode                     Mode
-	Branches                 []gitquery.BranchRow
-	Stashes                  []gitquery.Stash
-	BranchSelected           int
-	StashSelected            int
-	Overlay                  OverlayState
-	OverlayDiff              string
-	OverlayScroll            int
-	ConfirmPrompt            string
-	ConfirmForce             bool
-	WorktreeInputPrompt      string
-	WorktreeInputPlaceholder string
-	WorktreeInput            string
-	WorktreeInputErr         string
-	SelectPrompt             string
-	SelectItems              []SelectItem
-	SelectSelected           int
-	BranchScroll             int
-	RepoScroll               int
-	StashScroll              int
-	ActivePane               int
-	Destructive              bool
-	Worktrees                []gitquery.Worktree
-	WorktreeSelected         int
-	WorktreeScroll           int
-	WorktreeSessions         []sessions.SessionRecord
-	WorktreeSessionSelected  int
-	WorktreeSessionScroll    int
-	InlineWorktreeSessions   bool
-	Commits                  []gitquery.Commit
-	CommitSelected           int
-	CommitScroll             int
-	Reflogs                  []gitquery.ReflogEntry
-	ReflogSelected           int
-	ReflogScroll             int
-	Sessions                 []sessions.SessionRecord
-	SessionSelected          int
-	SessionScroll            int
-	Plans                    []planstore.PlanRecord
-	PlanSelected             int
-	PlanScroll               int
-	Flows                    []flowstore.FlowRecord
-	FlowSelected             int
-	FlowScroll               int
-	ExpandedPlanID           string
-	ExpandedFlowID           string
-	SelectedPlanPhaseID      string
-	OverlayText              string
-	TransientError           string
-	TransientErrorFadeStep   int
-	SearchActive             bool
-	RepoSearch               string
-	ItemSearch               string
-	RepoEmptyMessage         string
-	RightEmptyMessage        string
-	FetchAvailable           bool
-	FetchVisibleAvailable    bool
-	PullAvailable            bool
-	WorktreeMoveAvailable    bool
-	WorktreeSessionsOpen     bool
-	AgentAvailable           bool
-	NewAgentAvailable        bool
+	Repos                      []scanner.Repo
+	Selected                   int
+	Width                      int
+	Height                     int
+	Mode                       Mode
+	Branches                   []gitquery.BranchRow
+	Stashes                    []gitquery.Stash
+	BranchSelected             int
+	StashSelected              int
+	Overlay                    OverlayState
+	OverlayDiff                string
+	OverlayScroll              int
+	ConfirmPrompt              string
+	ConfirmForce               bool
+	WorktreeInputPrompt        string
+	WorktreeInputPlaceholder   string
+	WorktreeInput              string
+	WorktreeInputErr           string
+	SelectPrompt               string
+	SelectItems                []SelectItem
+	SelectSelected             int
+	BranchScroll               int
+	RepoScroll                 int
+	StashScroll                int
+	ActivePane                 int
+	Destructive                bool
+	Worktrees                  []gitquery.Worktree
+	WorktreeSelected           int
+	WorktreeScroll             int
+	WorktreeSessions           []sessions.SessionRecord
+	WorktreeSessionSelected    int
+	WorktreeSessionScroll      int
+	InlineWorktreeSessions     bool
+	Commits                    []gitquery.Commit
+	CommitSelected             int
+	CommitScroll               int
+	Reflogs                    []gitquery.ReflogEntry
+	ReflogSelected             int
+	ReflogScroll               int
+	Sessions                   []sessions.SessionRecord
+	SessionSelected            int
+	SessionScroll              int
+	Plans                      []planstore.PlanRecord
+	PlanSelected               int
+	PlanScroll                 int
+	Flows                      []flowstore.FlowRecord
+	FlowSelected               int
+	FlowScroll                 int
+	ExpandedPlanID             string
+	ExpandedFlowID             string
+	SelectedPlanPhaseID        string
+	SelectedFlowPhaseID        string
+	FlowPhaseResumableSelected bool
+	OverlayText                string
+	TransientError             string
+	TransientErrorFadeStep     int
+	SearchActive               bool
+	RepoSearch                 string
+	ItemSearch                 string
+	RepoEmptyMessage           string
+	RightEmptyMessage          string
+	FetchAvailable             bool
+	FetchVisibleAvailable      bool
+	PullAvailable              bool
+	WorktreeMoveAvailable      bool
+	WorktreeSessionsOpen       bool
+	AgentAvailable             bool
+	NewAgentAvailable          bool
 }
 
 // Render produces the full terminal view string.
@@ -245,44 +247,46 @@ func Render(p RenderParams) string {
 	flowSelected := p.Mode == ModeFlows && p.FlowSelected >= 0 && p.FlowSelected < len(p.Flows)
 	worktreeSessionSelected := p.Mode == ModeWorktrees && p.InlineWorktreeSessions && p.WorktreeSessionSelected >= 0 && p.WorktreeSessionSelected < len(p.WorktreeSessions)
 	selectedPlanPhaseID := scopedSelectedPlanPhaseID(p, planSelected)
+	selectedFlowPhaseID := scopedSelectedFlowPhaseID(p, flowSelected)
 	planPhaseSelected := selectedPlanPhaseID != ""
 	status := statusBarParams{
-		Width:                     p.Width,
-		Mode:                      p.Mode,
-		Overlay:                   p.Overlay,
-		WorktreeInputPrompt:       p.WorktreeInputPrompt,
-		ActivePane:                p.ActivePane,
-		Destructive:               p.Destructive,
-		RepoSelected:              repoPath != "",
-		WorktreeSelected:          worktreeSelected,
-		StaleSelected:             staleSelected,
-		DirtySelected:             dirtySelected,
-		LockedSelected:            lockedSelected,
-		WorktreeDeletableSelected: worktreeDeletableSelected,
-		WorktreeOpenableSelected:  worktreeOpenableSelected,
-		WorktreeMoveSelected:      worktreeMoveSelected,
-		WorktreeSessionsOpen:      p.WorktreeSessionsOpen,
-		WorktreeSessionSelected:   worktreeSessionSelected,
-		BranchDirtySelected:       branchDirtySelected,
-		BranchDeletableSelected:   branchDeletableSelected,
-		BranchOpenableSelected:    branchOpenableSelected,
-		StashSelected:             stashSelected,
-		CommitSelected:            commitSelected,
-		ReflogSelected:            reflogSelected,
-		SessionSelected:           sessionSelected,
-		PlanSelected:              planSelected,
-		PlanPhaseSelected:         planPhaseSelected,
-		FlowSelected:              flowSelected,
-		TransientError:            p.TransientError,
-		TransientErrorFadeStep:    p.TransientErrorFadeStep,
-		SearchActive:              p.SearchActive,
-		RepoSearch:                p.RepoSearch,
-		ItemSearch:                p.ItemSearch,
-		FetchAvailable:            p.FetchAvailable,
-		FetchVisibleAvailable:     p.FetchVisibleAvailable,
-		PullAvailable:             p.PullAvailable,
-		AgentAvailable:            p.AgentAvailable,
-		NewAgent:                  p.NewAgentAvailable,
+		Width:                      p.Width,
+		Mode:                       p.Mode,
+		Overlay:                    p.Overlay,
+		WorktreeInputPrompt:        p.WorktreeInputPrompt,
+		ActivePane:                 p.ActivePane,
+		Destructive:                p.Destructive,
+		RepoSelected:               repoPath != "",
+		WorktreeSelected:           worktreeSelected,
+		StaleSelected:              staleSelected,
+		DirtySelected:              dirtySelected,
+		LockedSelected:             lockedSelected,
+		WorktreeDeletableSelected:  worktreeDeletableSelected,
+		WorktreeOpenableSelected:   worktreeOpenableSelected,
+		WorktreeMoveSelected:       worktreeMoveSelected,
+		WorktreeSessionsOpen:       p.WorktreeSessionsOpen,
+		WorktreeSessionSelected:    worktreeSessionSelected,
+		BranchDirtySelected:        branchDirtySelected,
+		BranchDeletableSelected:    branchDeletableSelected,
+		BranchOpenableSelected:     branchOpenableSelected,
+		StashSelected:              stashSelected,
+		CommitSelected:             commitSelected,
+		ReflogSelected:             reflogSelected,
+		SessionSelected:            sessionSelected,
+		PlanSelected:               planSelected,
+		PlanPhaseSelected:          planPhaseSelected,
+		FlowSelected:               flowSelected,
+		FlowPhaseResumableSelected: p.FlowPhaseResumableSelected,
+		TransientError:             p.TransientError,
+		TransientErrorFadeStep:     p.TransientErrorFadeStep,
+		SearchActive:               p.SearchActive,
+		RepoSearch:                 p.RepoSearch,
+		ItemSearch:                 p.ItemSearch,
+		FetchAvailable:             p.FetchAvailable,
+		FetchVisibleAvailable:      p.FetchVisibleAvailable,
+		PullAvailable:              p.PullAvailable,
+		AgentAvailable:             p.AgentAvailable,
+		NewAgent:                   p.NewAgentAvailable,
 	}
 	innerHeight := p.Height - 3 // status bar + top/bottom borders
 	showShortcutPane := !hasActiveStatusQuery(status) && shouldRenderShortcutPane(p.Width, innerHeight, status)
@@ -344,6 +348,7 @@ func Render(p RenderParams) string {
 		planSel = -1
 		flowSel = -1
 		selectedPlanPhaseID = ""
+		selectedFlowPhaseID = ""
 	}
 
 	var rightLines []string
@@ -363,7 +368,7 @@ func Render(p RenderParams) string {
 	case p.Mode == ModePlans && len(p.Plans) > 0:
 		rightLines = renderPlanPane(p.Plans, planSel, p.PlanScroll, rightContentWidth, rightContentHeight, p.ExpandedPlanID, selectedPlanPhaseID)
 	case p.Mode == ModeFlows && len(p.Flows) > 0:
-		rightLines = renderFlowPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID)
+		rightLines = renderFlowPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID)
 	default:
 		rightLines = renderPlaceholderPane(rightContentWidth, rightContentHeight, p.RightEmptyMessage)
 	}
@@ -404,6 +409,22 @@ func scopedSelectedPlanPhaseID(p RenderParams, planSelected bool) string {
 	for _, phase := range plan.Phases {
 		if phase.PhaseID == p.SelectedPlanPhaseID {
 			return p.SelectedPlanPhaseID
+		}
+	}
+	return ""
+}
+
+func scopedSelectedFlowPhaseID(p RenderParams, flowSelected bool) string {
+	if !flowSelected || p.SelectedFlowPhaseID == "" {
+		return ""
+	}
+	flow := p.Flows[p.FlowSelected]
+	if p.ExpandedFlowID != flow.FlowID {
+		return ""
+	}
+	for _, phase := range flowstore.OrderedPhases(flow.Phases) {
+		if phase.PhaseID == p.SelectedFlowPhaseID {
+			return p.SelectedFlowPhaseID
 		}
 	}
 	return ""
@@ -473,42 +494,43 @@ func RenderStatusBar(width int, mode Mode, overlay OverlayState, activePane int,
 // statusBarParams groups the many fields the status-bar renderer needs,
 // avoiding a long and error-prone positional parameter list.
 type statusBarParams struct {
-	Width                     int
-	Mode                      Mode
-	Overlay                   OverlayState
-	WorktreeInputPrompt       string
-	ActivePane                int
-	Destructive               bool
-	RepoSelected              bool
-	WorktreeSelected          bool
-	StaleSelected             bool
-	DirtySelected             bool
-	LockedSelected            bool
-	WorktreeDeletableSelected bool
-	WorktreeOpenableSelected  bool
-	WorktreeMoveSelected      bool
-	WorktreeSessionsOpen      bool
-	WorktreeSessionSelected   bool
-	BranchDirtySelected       bool
-	BranchDeletableSelected   bool
-	BranchOpenableSelected    bool
-	StashSelected             bool
-	CommitSelected            bool
-	ReflogSelected            bool
-	SessionSelected           bool
-	PlanSelected              bool
-	PlanPhaseSelected         bool
-	FlowSelected              bool
-	TransientError            string
-	TransientErrorFadeStep    int
-	SearchActive              bool
-	RepoSearch                string
-	ItemSearch                string
-	FetchAvailable            bool
-	FetchVisibleAvailable     bool
-	PullAvailable             bool
-	AgentAvailable            bool
-	NewAgent                  bool
+	Width                      int
+	Mode                       Mode
+	Overlay                    OverlayState
+	WorktreeInputPrompt        string
+	ActivePane                 int
+	Destructive                bool
+	RepoSelected               bool
+	WorktreeSelected           bool
+	StaleSelected              bool
+	DirtySelected              bool
+	LockedSelected             bool
+	WorktreeDeletableSelected  bool
+	WorktreeOpenableSelected   bool
+	WorktreeMoveSelected       bool
+	WorktreeSessionsOpen       bool
+	WorktreeSessionSelected    bool
+	BranchDirtySelected        bool
+	BranchDeletableSelected    bool
+	BranchOpenableSelected     bool
+	StashSelected              bool
+	CommitSelected             bool
+	ReflogSelected             bool
+	SessionSelected            bool
+	PlanSelected               bool
+	PlanPhaseSelected          bool
+	FlowSelected               bool
+	FlowPhaseResumableSelected bool
+	TransientError             string
+	TransientErrorFadeStep     int
+	SearchActive               bool
+	RepoSearch                 string
+	ItemSearch                 string
+	FetchAvailable             bool
+	FetchVisibleAvailable      bool
+	PullAvailable              bool
+	AgentAvailable             bool
+	NewAgent                   bool
 }
 
 type shortcutHint struct {
@@ -834,6 +856,9 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 			actions = append(actions, shortcutHint{Key: "n", Label: "new flow"})
 			if sp.FlowSelected {
 				actions = append(actions, shortcutHint{Key: "x", Label: "phases"})
+			}
+			if sp.FlowPhaseResumableSelected {
+				actions = append(actions, shortcutHint{Key: "r", Label: "resume"})
 			}
 			if sp.AgentAvailable {
 				actions = append(actions, shortcutHint{Key: "a", Label: "launch phase"})
@@ -1680,7 +1705,7 @@ const (
 	flowUpdatedWidth = 10
 )
 
-func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, height int, expandedFlowID string) []string {
+func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, height int, expandedFlowID, selectedPhaseID string) []string {
 	if height <= 0 {
 		return nil
 	}
@@ -1713,7 +1738,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 			stashDateStyle.Render(fitSessionColumn(updated, flowUpdatedWidth)),
 			stashMsgStyle.Render(record.Title),
 		)
-		if i == selected {
+		if i == selected && selectedPhaseID == "" {
 			selectedLine := truncateToWidth(formatFlowColumns(" > ",
 				record.Status,
 				branch,
@@ -1727,22 +1752,26 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 		}
 		rows = append(rows, truncateToWidth(line, width))
 		if record.FlowID == expandedFlowID {
-			rows = append(rows, renderFlowPhaseRows(record, width)...)
+			rows = append(rows, renderFlowPhaseRows(record, width, selectedPhaseID)...)
 		}
 	}
 	return append([]string{header}, scrollAndPad(rows, scroll, rowHeight)...)
 }
 
-func renderFlowPhaseRows(record flowstore.FlowRecord, width int) []string {
+func renderFlowPhaseRows(record flowstore.FlowRecord, width int, selectedPhaseID string) []string {
 	if len(record.Phases) == 0 {
 		return []string{truncateToWidth("      No phases", width)}
 	}
 	rows := make([]string, 0, len(record.Phases))
 	for _, phase := range flowstore.OrderedPhases(record.Phases) {
 		state := flowPhaseState(record, phase)
+		sessionSummary := flowPhaseSessionSummary(phase)
 		title := phase.Title
 		if phase.ParentPhaseID != "" {
 			title = "  " + title
+		}
+		if sessionSummary != "" {
+			title += "  " + sessionSummary
 		}
 		line := formatFlowColumns("      ",
 			statusStyle.Render(fitSessionColumn(phase.Status, flowStatusWidth)),
@@ -1753,6 +1782,18 @@ func renderFlowPhaseRows(record flowstore.FlowRecord, width int) []string {
 			"",
 			stashMsgStyle.Render(title),
 		)
+		if phase.PhaseID == selectedPhaseID {
+			selectedLine := truncateToWidth(formatFlowColumns(" > ",
+				phase.Status,
+				"",
+				phase.PhaseID+":"+state,
+				"",
+				"",
+				"",
+				title,
+			), width)
+			line = stashSelStyle.Width(width).Render(selectedLine)
+		}
 		rows = append(rows, truncateToWidth(line, width))
 	}
 	return rows
@@ -1809,6 +1850,9 @@ func flowPhaseState(record flowstore.FlowRecord, phase flowstore.FlowPhase) stri
 	if phase.Status == flowstore.PhaseRunning && flowPhaseAwaitingSession(phase) {
 		return "await-session"
 	}
+	if session, ok := flowstore.LatestPhaseSession(phase, false); ok && strings.TrimSpace(session.SessionID) == "" {
+		return "missing-session-id"
+	}
 	if phase.PhaseID == "autoreview" && flowMissingPRTarget(record) && phaseCanReportMissingPR(phase) {
 		return "missing-pr"
 	}
@@ -1832,22 +1876,7 @@ func flowMissingWorktree(record flowstore.FlowRecord) bool {
 }
 
 func flowPhaseAwaitingSession(phase flowstore.FlowPhase) bool {
-	latestLaunchID := ""
-	for i := len(phase.LaunchIDs) - 1; i >= 0; i-- {
-		if phase.LaunchIDs[i] != "" {
-			latestLaunchID = phase.LaunchIDs[i]
-			break
-		}
-	}
-	if latestLaunchID == "" {
-		return false
-	}
-	for _, session := range phase.Sessions {
-		if session.LaunchID == latestLaunchID {
-			return false
-		}
-	}
-	return true
+	return flowstore.PhaseAwaitingSession(phase)
 }
 
 func flowPhaseSessionMismatch(phase flowstore.FlowPhase) bool {
@@ -1869,6 +1898,37 @@ func flowPhaseSessionMismatch(phase flowstore.FlowPhase) bool {
 		}
 	}
 	return false
+}
+
+func flowPhaseSessionSummary(phase flowstore.FlowPhase) string {
+	if session, ok := flowstore.LatestPhaseSession(phase, false); ok && strings.TrimSpace(session.SessionID) == "" {
+		return ""
+	}
+	session, ok := flowstore.LatestPhaseSession(phase, true)
+	if !ok {
+		return ""
+	}
+	count := 0
+	for _, session := range phase.Sessions {
+		if strings.TrimSpace(session.SessionID) != "" {
+			count++
+		}
+	}
+	if count == 0 {
+		return ""
+	}
+	label := "sessions"
+	if count == 1 {
+		label = "session"
+	}
+	parts := []string{fmt.Sprintf("%d %s", count, label)}
+	if session.Provider != "" {
+		parts = append(parts, session.Provider)
+	}
+	if session.Status != "" {
+		parts = append(parts, session.Status)
+	}
+	return strings.Join(parts, " ")
 }
 
 func flowPlanLabel(record flowstore.FlowRecord) string {

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -64,6 +64,67 @@ func TestStatusBar_FlowsModeShowsPhaseToggleHintForSelectedFlow(t *testing.T) {
 	}
 }
 
+func TestRender_FlowsModeShowsResumeShortcutForResumableSelectedPhase(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "Resumable flow",
+			Status: flowstore.StatusInProgress,
+			Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation",
+				Title:   "Implementation",
+				Status:  flowstore.PhaseCompleted,
+				Sessions: []flowstore.Session{
+					{Provider: "codex", SessionID: "codex-1", Status: "ended"},
+				},
+			}},
+		}},
+		ActivePane:                 1,
+		FlowSelected:               0,
+		ExpandedFlowID:             "flow-1",
+		SelectedFlowPhaseID:        "implementation",
+		FlowPhaseResumableSelected: true,
+	})
+
+	if !strings.Contains(shortcutPaneText(view), "r      resume") {
+		t.Fatalf("resumable Flow phase should expose resume shortcut:\n%s", view)
+	}
+}
+
+func TestRender_FlowsModeHidesResumeShortcutWithoutResumableSelectedPhase(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "Awaiting flow",
+			Status: flowstore.StatusInProgress,
+			Phases: []flowstore.FlowPhase{{
+				PhaseID:   "implementation",
+				Title:     "Implementation",
+				Status:    flowstore.PhaseRunning,
+				LaunchIDs: []string{"launch-new"},
+			}},
+		}},
+		ActivePane:          1,
+		FlowSelected:        0,
+		ExpandedFlowID:      "flow-1",
+		SelectedFlowPhaseID: "implementation",
+	})
+
+	if strings.Contains(shortcutPaneText(view), "r      resume") {
+		t.Fatalf("non-resumable Flow phase should not expose resume shortcut:\n%s", view)
+	}
+}
+
 func TestRender_FlowsModeShowsExpandedPhaseRowsWithFullPhaseIDs(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
@@ -95,6 +156,82 @@ func TestRender_FlowsModeShowsExpandedPhaseRowsWithFullPhaseIDs(t *testing.T) {
 		if strings.Contains(view, clipped) {
 			t.Fatalf("expanded phase ID appears clipped as %q:\n%s", clipped, view)
 		}
+	}
+}
+
+func TestRender_FlowsModeExpandedPhaseRowsShowSessionSummary(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    240,
+		Height:   10,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID:       "flow-1",
+			Title:        "Flow sessions",
+			Status:       flowstore.StatusInProgress,
+			Branch:       "flow/sessions",
+			WorktreePath: "/dev/wtui-worktrees/flow-sessions",
+			Phases: []flowstore.FlowPhase{{
+				PhaseID:   "implementation",
+				Title:     "Implementation",
+				Status:    flowstore.PhaseCompleted,
+				LaunchIDs: []string{"launch-1", "launch-2"},
+				Sessions: []flowstore.Session{
+					{Provider: "claude", SessionID: "claude-old", LaunchID: "launch-1", Status: "ended", StartedAt: time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)},
+					{Provider: "codex", SessionID: "codex-new", LaunchID: "launch-2", Status: "ended", StartedAt: time.Date(2026, 6, 7, 11, 0, 0, 0, time.UTC)},
+				},
+			}},
+		}},
+		ActivePane:     1,
+		FlowSelected:   0,
+		ExpandedFlowID: "flow-1",
+	})
+
+	for _, want := range []string{"implementation:completed", "2 sessions", "codex", "ended"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expanded phase session summary missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestRender_FlowsModeExpandedPhaseRowsShowMissingSessionID(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    240,
+		Height:   10,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID:       "flow-1",
+			Title:        "Legacy sessions",
+			Status:       flowstore.StatusNeedsAttention,
+			Branch:       "flow/legacy-sessions",
+			WorktreePath: "/dev/wtui-worktrees/flow-legacy-sessions",
+			Phases: []flowstore.FlowPhase{{
+				PhaseID:   "review-loop",
+				Title:     "Review loop",
+				Status:    flowstore.PhaseNeedsAttention,
+				LaunchIDs: []string{"launch-old", "launch-1"},
+				Sessions: []flowstore.Session{
+					{Provider: "codex", LaunchID: "launch-1", Status: "ended"},
+					{Provider: "claude", SessionID: "claude-old", LaunchID: "launch-old", Status: "ended", StartedAt: time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)},
+				},
+			}},
+		}},
+		ActivePane:     1,
+		FlowSelected:   0,
+		ExpandedFlowID: "flow-1",
+	})
+
+	if !strings.Contains(view, "review-loop:missing-session-id") {
+		t.Fatalf("malformed attached session should render missing-session-id:\n%s", view)
+	}
+	if strings.Contains(view, "1 session codex ended") {
+		t.Fatalf("malformed attached session should not render as resumable metadata:\n%s", view)
+	}
+	if strings.Contains(view, "1 session claude ended") {
+		t.Fatalf("malformed latest session should not render older session metadata:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds selectable rows for expanded Flow phases so users can move through phase detail rows directly in the flows pane.

Adds Flow phase session selection helpers that prefer the latest launch-attached session while still handling legacy session records deterministically.

Surfaces phase session summaries and recovery labels in the Flow UI, and lets users press `r` on a resumable selected Flow phase to resume the latest valid captured session.

## Validation

- `make test`
- `make build`