### PR TITLE
Clean up mode-specific shortcut keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ filter matches, or a load failure with details in the status bar.
 | `/` | Fuzzy filter the current item list |
 | `1`/`2`/`3`/`4`/`5`/`6`/`7`/`8` | Switch to worktrees / branches / stashes / history / reflog / sessions / plans / flows |
 | `←`/`h`/`→`/`l` | Cycle through modes |
-| `enter` | Page diff in `less` (dirty worktree, dirty branch, stash, commit, or reflog entry), resume an inline worktree session, page session transcript, or expand/collapse plan phases |
+| `enter` | Page diff in `less` (dirty worktree, dirty branch, stash, commit, or reflog entry), resume an inline worktree session, page a session transcript, or expand/collapse plan phases |
 | `n` | Create a new worktree in worktrees view, a new branch in branches view, or a new Flow in flows view |
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
 | `m` | Move or rename a linked worktree (worktrees view) |
 | `A` | Choose and persist the coding agent from a picker (`codex`, `codex-app`, or `claude`) |
-| `a` | Launch the selected coding agent in the selected worktree, or launch the selected ready Flow phase |
+| `a` | Launch the selected coding agent in the selected worktree, launch the selected plan or plan phase, or launch the selected ready Flow phase |
 | `d` | Delete worktree/branch or drop stash — requires destructive mode |
 | `p` | Prune stale worktree — requires destructive mode (worktrees view) |
 | `u` | Unlock a locked worktree (worktrees view) |
@@ -90,12 +90,12 @@ filter matches, or a load failure with details in the status bar.
 | `F` | Pull with `--ff-only` (worktrees, and branches with a checked-out worktree) |
 | `t` | Open or attach to a tmux/Zellij session for the worktree |
 | `c` | Open VSCode at worktree path |
-| `x` | Show/hide sessions for the selected worktree (worktrees view) or expand/collapse Flow phase rows (flows view) |
-| `y` | Copy hash to clipboard (history/reflog view), selected agent session ID (sessions view), or plan Markdown path (plans view) |
+| `x` | Show/hide sessions for the selected worktree (worktrees view), or expand/collapse plan and Flow phase rows |
+| `y` | Copy hash to clipboard (history/reflog view), selected agent session ID (sessions view), plan Markdown path (plans view), or Flow/phase ID (flows view) |
 | `r` | Resume selected agent session (sessions view) |
 | `s` | Page selected agent session summary (sessions view) |
-| `o` | Page selected plan Markdown (plans view), or the linked plan body (flows view) |
-| `i` | Edit launch instructions and launch the selected plan or selected plan phase (plans view) |
+| `o` | Page selected session transcript (sessions view), selected plan Markdown (plans view), or linked plan body (flows view) |
+| `i` | Alias for plan implementation launch |
 | `D` | Toggle destructive mode |
 | `tab` | Switch focus to left pane |
 | `q`/`esc` | Close a prompt/dialog or quit |
@@ -183,9 +183,10 @@ Browse HEAD reflog entries (up to 50) for the selected repo. Each row shows the 
 Browse captured Claude Code and Codex sessions associated with the selected
 repo. Rows show provider, branch, worktree, status, and summary. Use `/` to
 filter sessions by provider, session ID, launch ID, branch, worktree, model,
-status, or summary. Press `enter` to page the normalized transcript in `less -R`,
+status, or summary. Press `o` to page the normalized transcript in `less -R`,
 `s` to page the selected summary, `r` to resume the selected provider session,
-or `y` to copy the raw provider session ID.
+or `y` to copy the raw provider session ID. `enter` also pages the selected
+transcript.
 
 Session data is stored under the user state directory by default:
 `$XDG_STATE_HOME/wtui/sessions/v1`, or
@@ -206,11 +207,13 @@ stored.
 Browse saved agent plans for the selected repo. Rows show status, branch, phase
 progress (`completed/total`), the updated date, and the title. Use `/` to filter
 plans by title, summary, status, branch, worktree basename, provider, session
-ID, launch ID, and phase titles/statuses. Press `enter` to expand or collapse
+ID, launch ID, and phase titles/statuses. Press `x` to expand or collapse
 the selected plan's phase rows, `o` to page the plan Markdown in `less -R`,
-and `y` to copy the plan Markdown path. Press `i` to edit launch
+and `y` to copy the plan Markdown path. Press `a` to edit launch
 instructions for the selected plan or selected phase, then `enter` to launch
 the selected agent or `esc` to cancel; blank instructions are rejected.
+`enter` still toggles phase rows, and `i` still opens plan launch instructions
+as compatibility aliases.
 
 Plans are persisted explicitly by agents through the `wtui plan` CLI rather than
 captured from hooks. Plans share the agent-artifact root with sessions: they are
@@ -264,8 +267,9 @@ by title, instructions, status, branch, worktree basename, plan metadata, PR
 metadata, phase titles/statuses/summaries, and linked session metadata. Press
 `n` to create a new Flow, `x` to expand or collapse phase detail rows for the
 selected Flow, and `o` to page the linked plan body in `less -R`; wtui shows a
-status message when the selected Flow has no linked plan. Press `a` on a Flow
-with a ready phase to launch the configured agent for that phase. When
+status message when the selected Flow has no linked plan. Press `y` to copy the
+selected Flow ID, or the selected phase ID when a phase row is selected. Press
+`a` on a Flow with a ready phase to launch the configured agent for that phase. When
 Implementation is still gated by Plan Review, wtui reports the Plan Review state
 and notes instead of launching. When PR Creation is complete but structured PR
 metadata is missing, Autoreview remains pending and the Flow row shows

--- a/model/model.go
+++ b/model/model.go
@@ -368,6 +368,7 @@ func (m Model) PlanSelected() int               { return m.plans.SelectedIndex()
 func (m Model) PlanScroll() int                 { return m.plans.Scroll() }
 func (m Model) FlowSelected() int               { return m.flows.SelectedIndex() }
 func (m Model) FlowScroll() int                 { return m.flows.Scroll() }
+func (m Model) ExpandedPlanID() string          { return m.expandedPlanID }
 func (m Model) ExpandedFlowID() string          { return m.expandedFlowID }
 func (m Model) SelectedPlanPhaseID() string     { return m.selectedPlanPhaseID }
 func (m Model) SelectedFlowPhaseID() string     { return m.selectedFlowPhaseID }
@@ -475,6 +476,7 @@ func (m Model) View() string {
 		ExpandedFlowID:             m.expandedFlowID,
 		SelectedPlanPhaseID:        m.selectedPlanPhaseID,
 		SelectedFlowPhaseID:        m.selectedFlowPhaseID,
+		FlowPhaseLaunchReady:       m.selectedFlowPhaseLaunchReady(),
 		FlowPhaseResumableSelected: m.selectedFlowPhaseResumable(),
 		OverlayText:                modalView.Text,
 		TransientError:             m.visibleStatusText(),
@@ -985,6 +987,15 @@ func (m Model) selectedFlowPhaseResumable() bool {
 		return false
 	}
 	return agent.Validate(agent.Normalize(strings.TrimSpace(session.Provider))) == nil
+}
+
+func (m Model) selectedFlowPhaseLaunchReady() bool {
+	record, ok := m.selectedFlow()
+	if !ok {
+		return false
+	}
+	_, ok = readyFlowPhase(record)
+	return ok
 }
 
 func (m Model) clearSelectedPlanPhase() Model {

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3723,6 +3723,35 @@ func TestModel_EnterOnSessionOpensTranscriptOverlay(t *testing.T) {
 	}
 }
 
+func TestModel_OKeyOnSessionOpensTranscriptOverlay(t *testing.T) {
+	var gotProvider sessions.Provider
+	var gotSessionID string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ReadTranscript: func(provider sessions.Provider, sessionID string) ([]sessions.TranscriptEvent, error) {
+			gotProvider = provider
+			gotSessionID = sessionID
+			return []sessions.TranscriptEvent{{Role: "user", Kind: "message", Text: "Implement sessions"}}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{
+		{Provider: sessions.ProviderCodex, SessionID: "codex-1", RepoPath: "/dev/alpha"},
+	}, ListRequest: m.ListRequest(ui.ModeSessions)})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	if cmd == nil {
+		t.Fatal("expected transcript fetch command")
+	}
+	msg, ok := cmd().(model.SessionTranscriptResultMsg)
+	if !ok {
+		t.Fatalf("expected SessionTranscriptResultMsg, got %T", msg)
+	}
+	if gotProvider != sessions.ProviderCodex || gotSessionID != "codex-1" {
+		t.Fatalf("reader got provider=%q session=%q", gotProvider, gotSessionID)
+	}
+}
+
 func TestModel_SKeyShowsSelectedSessionSummary(t *testing.T) {
 	var paged []string
 	m := model.NewWithOptions(testRepos(), model.Options{PageText: recordPageText(&paged)})

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -220,6 +220,44 @@ func TestModel_FlowPhasesAutoCollapseWhenSelectionChanges(t *testing.T) {
 	}
 }
 
+func TestModel_YKeyCopiesSelectedFlowOrPhaseID(t *testing.T) {
+	var copied []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		CopyToClipboard: func(text string) error {
+			copied = append(copied, text)
+			return nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID: "flow-1",
+		Title:  "Copy flow ids",
+		Status: flowstore.StatusInProgress,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady},
+		},
+	}})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("expected flow id copy command")
+	}
+	_ = cmd()
+	if got := copied[len(copied)-1]; got != "flow-1" {
+		t.Fatalf("copied flow id = %q, want flow-1", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	_, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("expected flow phase id copy command")
+	}
+	_ = cmd()
+	if got := copied[len(copied)-1]; got != "implementation" {
+		t.Fatalf("copied phase id = %q, want implementation", got)
+	}
+}
+
 func TestModel_ExpandedFlowArrowKeysSelectPhaseRows(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
@@ -1221,6 +1259,28 @@ func TestModel_AKeyOnFlowLaunchesImplementationWithoutLinkedPlanContext(t *testi
 	}
 }
 
+func TestModel_ReadyFlowAdvertisesLaunchPhaseAction(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: "codex"})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-ready",
+		Title:        "Ready implementation",
+		Status:       flowstore.StatusInProgress,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady},
+		},
+	}})
+
+	view := m.View()
+	if !strings.Contains(view, "launch phase") {
+		t.Fatalf("ready flow view should expose launch action:\n%s", view)
+	}
+	if strings.Contains(view, "phase status") {
+		t.Fatalf("ready flow view should not downgrade launch action to status:\n%s", view)
+	}
+}
+
 func TestModel_AKeyOnFlowExplainsWhyImplementationIsNotReady(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: "codex"})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
@@ -1236,7 +1296,7 @@ func TestModel_AKeyOnFlowExplainsWhyImplementationIsNotReady(t *testing.T) {
 			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhasePending},
 		},
 	}})
-	if view := m.View(); !strings.Contains(view, "launch phase") {
+	if view := m.View(); !strings.Contains(view, "phase status") || strings.Contains(view, "launch phase") {
 		t.Fatalf("gated flow view should still expose launch/status action:\n%s", view)
 	}
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -292,6 +292,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModeSessions {
 			return m.handleCopySessionID()
 		}
+		if m.mode == ui.ModeFlows {
+			return m.handleCopyFlowID()
+		}
 		return m.handleCopyHash()
 	case "s":
 		return m.handleShowSessionSummary()
@@ -307,6 +310,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 	case "x":
 		if m.mode == ui.ModeWorktrees {
 			return m.handleToggleWorktreeSessions()
+		}
+		if m.mode == ui.ModePlans {
+			return m.handleTogglePlanPhases()
 		}
 		if m.mode == ui.ModeFlows {
 			return m.handleToggleFlowPhases()
@@ -336,6 +342,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			return m.handleNewPullRequestWorktree()
 		}
 	case "o":
+		if m.mode == ui.ModeSessions {
+			return m.handleEnter()
+		}
 		if m.mode == ui.ModePlans {
 			return m.handleOpenPlanText()
 		}
@@ -351,6 +360,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			return m.handleNewWorktree(true)
 		}
 	case "a":
+		if m.mode == ui.ModePlans {
+			return m.handleImplementPlan()
+		}
 		return m.handleOpenAgent()
 	case "d":
 		return m.handleDelete()
@@ -528,6 +540,22 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) handleTogglePlanPhases() (tea.Model, tea.Cmd) {
+	if m.mode != ui.ModePlans || len(m.filteredPlans()) == 0 {
+		return m, nil
+	}
+	planID := m.selectedPlanID()
+	if planID == "" {
+		return m, nil
+	}
+	if m.expandedPlanID == planID {
+		m = m.setExpandedPlanID("")
+	} else {
+		m = m.setExpandedPlanID(planID)
 	}
 	return m, nil
 }

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1254,6 +1254,31 @@ func (m Model) handleCopyPlanPath() (tea.Model, tea.Cmd) {
 	}
 }
 
+func (m Model) handleCopyFlowID() (tea.Model, tea.Cmd) {
+	if m.mode != ui.ModeFlows {
+		return m, nil
+	}
+	value := ""
+	if phase, ok := m.selectedFlowPhase(); ok {
+		value = phase.PhaseID
+	} else {
+		flow, ok := m.selectedFlow()
+		if !ok {
+			return m, nil
+		}
+		value = flow.FlowID
+	}
+	if strings.TrimSpace(value) == "" {
+		return m, nil
+	}
+	return m, func() tea.Msg {
+		if err := m.copyToClipboard(value); err != nil {
+			return ClipboardResultMsg{Err: err.Error()}
+		}
+		return ClipboardResultMsg{}
+	}
+}
+
 func (m Model) handleShowSessionSummary() (tea.Model, tea.Cmd) {
 	if m.mode != ui.ModeSessions {
 		return m, nil

--- a/model/model_plan_test.go
+++ b/model/model_plan_test.go
@@ -173,6 +173,43 @@ func TestModel_IKeyOpensPlanLaunchInstructionsInput(t *testing.T) {
 	}
 }
 
+func TestModel_AKeyOpensPlanLaunchInstructionsInput(t *testing.T) {
+	var launched bool
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		PlanMarkdownPath: func(planID string) (string, error) {
+			if planID != "plan-1" {
+				t.Fatalf("resolver planID = %q, want plan-1", planID)
+			}
+			return "/state/plans/plan-1/plan.md", nil
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launched = true
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true"), Interactive: true}, nil
+		},
+	})
+	m = plansInRightPane(t, m, []planstore.PlanRecord{{
+		PlanID:   "plan-1",
+		Title:    "Implement plans",
+		Status:   "approved",
+		RepoPath: "/dev/alpha",
+	}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd opening launch instructions, got %T", cmd)
+	}
+	if launched {
+		t.Fatal("opening launch instructions must not launch the agent")
+	}
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("expected launch instructions input overlay, got %d", m.Overlay())
+	}
+	if !strings.Contains(m.WorktreeInput(), "Implement the saved wtui plan") {
+		t.Fatalf("expected plan launch prompt, got %q", m.WorktreeInput())
+	}
+}
+
 func TestModel_PlanPromptTemplateReplacesSupportedPlaceholders(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand:       "codex",
@@ -400,6 +437,81 @@ func TestModel_IKeyLaunchesAgentFromSelectedPlanPhase(t *testing.T) {
 		if !strings.Contains(launchPrompt, want) {
 			t.Fatalf("phase prompt missing %q: %q", want, got.InitialPrompt)
 		}
+	}
+}
+
+func TestModel_AKeyLaunchesAgentFromSelectedPlanPhase(t *testing.T) {
+	var got actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:     "codex",
+		SessionStateRoot: "/state/wtui/sessions/v1",
+		PlanMarkdownPath: func(string) (string, error) {
+			return "/state/wtui/sessions/v1/plans/plan-1/plan.md", nil
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			got = ctx
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true"), Interactive: true}, nil
+		},
+	})
+	m = plansInRightPane(t, m, []planstore.PlanRecord{{
+		PlanID:       "plan-1",
+		Title:        "Implement plans",
+		Status:       "approved",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/plans",
+		Phases: []planstore.PlanPhase{
+			{PhaseID: "p1", Title: "Store tracer bullet", Status: "completed", Order: 1},
+			{PhaseID: "p2", Title: "CLI subcommands", Status: "pending", Order: 2},
+		},
+	}})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if gotPhase := m.SelectedPlanPhaseID(); gotPhase != "p2" {
+		t.Fatalf("selected phase = %q, want p2", gotPhase)
+	}
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd opening launch instructions, got %T", cmd)
+	}
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected submit command")
+	}
+	_, launchCmd := update(m, cmd())
+	if launchCmd == nil {
+		t.Fatal("expected agent launch command")
+	}
+	if got.PlanPhaseID != "p2" || got.PlanPhaseTitle != "CLI subcommands" || got.PlanPhaseStatus != "pending" {
+		t.Fatalf("unexpected phase launch context: %#v", got)
+	}
+}
+
+func TestModel_XKeyTogglesPlanPhaseRows(t *testing.T) {
+	m := plansInRightPane(t, model.New(testRepos()), []planstore.PlanRecord{{
+		PlanID: "plan-1",
+		Title:  "Implement plans",
+		Status: "approved",
+		Phases: []planstore.PlanPhase{
+			{PhaseID: "p1", Title: "Store tracer bullet", Status: "completed", Order: 1},
+		},
+	}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd != nil {
+		t.Fatalf("toggle phases returned command %T, want nil", cmd)
+	}
+	if got := m.ExpandedPlanID(); got != "plan-1" {
+		t.Fatalf("expanded plan = %q, want plan-1", got)
+	}
+	if got := m.SelectedPlanPhaseID(); got != "" {
+		t.Fatalf("expanding plan should keep plan row selected, got phase %q", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if got := m.ExpandedPlanID(); got != "" {
+		t.Fatalf("second toggle expanded plan = %q, want collapsed", got)
 	}
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -184,6 +184,7 @@ type RenderParams struct {
 	ExpandedFlowID             string
 	SelectedPlanPhaseID        string
 	SelectedFlowPhaseID        string
+	FlowPhaseLaunchReady       bool
 	FlowPhaseResumableSelected bool
 	OverlayText                string
 	TransientError             string
@@ -245,10 +246,15 @@ func Render(p RenderParams) string {
 	sessionSelected := p.Mode == ModeSessions && p.SessionSelected >= 0 && p.SessionSelected < len(p.Sessions)
 	planSelected := p.Mode == ModePlans && p.PlanSelected >= 0 && p.PlanSelected < len(p.Plans)
 	flowSelected := p.Mode == ModeFlows && p.FlowSelected >= 0 && p.FlowSelected < len(p.Flows)
+	flowPlanLinked := false
+	if flowSelected {
+		flowPlanLinked = strings.TrimSpace(p.Flows[p.FlowSelected].PlanID) != ""
+	}
 	worktreeSessionSelected := p.Mode == ModeWorktrees && p.InlineWorktreeSessions && p.WorktreeSessionSelected >= 0 && p.WorktreeSessionSelected < len(p.WorktreeSessions)
 	selectedPlanPhaseID := scopedSelectedPlanPhaseID(p, planSelected)
 	selectedFlowPhaseID := scopedSelectedFlowPhaseID(p, flowSelected)
 	planPhaseSelected := selectedPlanPhaseID != ""
+	flowPhaseSelected := selectedFlowPhaseID != ""
 	status := statusBarParams{
 		Width:                      p.Width,
 		Mode:                       p.Mode,
@@ -276,6 +282,9 @@ func Render(p RenderParams) string {
 		PlanSelected:               planSelected,
 		PlanPhaseSelected:          planPhaseSelected,
 		FlowSelected:               flowSelected,
+		FlowPhaseSelected:          flowPhaseSelected,
+		FlowPlanLinked:             flowPlanLinked,
+		FlowPhaseLaunchReady:       p.FlowPhaseLaunchReady,
 		FlowPhaseResumableSelected: p.FlowPhaseResumableSelected,
 		TransientError:             p.TransientError,
 		TransientErrorFadeStep:     p.TransientErrorFadeStep,
@@ -520,6 +529,9 @@ type statusBarParams struct {
 	PlanSelected               bool
 	PlanPhaseSelected          bool
 	FlowSelected               bool
+	FlowPhaseSelected          bool
+	FlowPlanLinked             bool
+	FlowPhaseLaunchReady       bool
 	FlowPhaseResumableSelected bool
 	TransientError             string
 	TransientErrorFadeStep     int
@@ -832,7 +844,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	case ModeSessions:
 		if sp.ActivePane == 1 && sp.SessionSelected {
 			actions = append(actions,
-				shortcutHint{Key: "enter", Label: "transcript"},
+				shortcutHint{Key: "o", Label: "transcript"},
 				shortcutHint{Key: "r", Label: "resume"},
 				shortcutHint{Key: "s", Label: "summary"},
 				shortcutHint{Key: "y", Label: "copy id"},
@@ -845,9 +857,9 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 				implementLabel = "implement phase"
 			}
 			actions = append(actions,
-				shortcutHint{Key: "enter", Label: "phases"},
+				shortcutHint{Key: "x", Label: "phases"},
 				shortcutHint{Key: "o", Label: "open"},
-				shortcutHint{Key: "i", Label: implementLabel},
+				shortcutHint{Key: "a", Label: implementLabel},
 				shortcutHint{Key: "y", Label: "copy path"},
 			)
 		}
@@ -856,12 +868,24 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 			actions = append(actions, shortcutHint{Key: "n", Label: "new flow"})
 			if sp.FlowSelected {
 				actions = append(actions, shortcutHint{Key: "x", Label: "phases"})
+				if sp.FlowPlanLinked {
+					actions = append(actions, shortcutHint{Key: "o", Label: "open"})
+				}
+				if sp.FlowPhaseSelected {
+					actions = append(actions, shortcutHint{Key: "y", Label: "copy phase id"})
+				} else {
+					actions = append(actions, shortcutHint{Key: "y", Label: "copy id"})
+				}
 			}
 			if sp.FlowPhaseResumableSelected {
 				actions = append(actions, shortcutHint{Key: "r", Label: "resume"})
 			}
 			if sp.AgentAvailable {
-				actions = append(actions, shortcutHint{Key: "a", Label: "launch phase"})
+				label := "phase status"
+				if sp.FlowPhaseLaunchReady {
+					label = "launch phase"
+				}
+				actions = append(actions, shortcutHint{Key: "a", Label: label})
 			}
 		}
 	}

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -53,14 +53,39 @@ func TestStatusBar_FlowsModeShowsNewFlowHint(t *testing.T) {
 
 func TestStatusBar_FlowsModeShowsPhaseToggleHintForSelectedFlow(t *testing.T) {
 	bar := renderStatusBarWithState(statusBarParams{
-		Width:        120,
-		Mode:         ModeFlows,
-		ActivePane:   1,
-		RepoSelected: true,
-		FlowSelected: true,
+		Width:          120,
+		Mode:           ModeFlows,
+		ActivePane:     1,
+		RepoSelected:   true,
+		FlowSelected:   true,
+		FlowPlanLinked: true,
 	})
-	if !strings.Contains(bar, "x: phases") {
-		t.Fatalf("expected phase toggle hint for selected flow, got %q", bar)
+	for _, want := range []string{"x: phases", "o: open", "y: copy id"} {
+		if !strings.Contains(bar, want) {
+			t.Fatalf("expected selected flow hint %q, got %q", want, bar)
+		}
+	}
+}
+
+func TestStatusBar_FlowsModeDistinguishesPhaseStatusFromLaunch(t *testing.T) {
+	base := statusBarParams{
+		Width:          120,
+		Mode:           ModeFlows,
+		ActivePane:     1,
+		RepoSelected:   true,
+		FlowSelected:   true,
+		AgentAvailable: true,
+	}
+
+	gated := renderStatusBarWithState(base)
+	if !strings.Contains(gated, "a: phase status") || strings.Contains(gated, "a: launch phase") {
+		t.Fatalf("gated Flow should expose status action, got %q", gated)
+	}
+
+	base.FlowPhaseLaunchReady = true
+	ready := renderStatusBarWithState(base)
+	if !strings.Contains(ready, "a: launch phase") || strings.Contains(ready, "a: phase status") {
+		t.Fatalf("ready Flow should expose launch action, got %q", ready)
 	}
 }
 
@@ -93,6 +118,70 @@ func TestRender_FlowsModeShowsResumeShortcutForResumableSelectedPhase(t *testing
 
 	if !strings.Contains(shortcutPaneText(view), "r      resume") {
 		t.Fatalf("resumable Flow phase should expose resume shortcut:\n%s", view)
+	}
+}
+
+func TestRender_FlowsModeShowsCopyPhaseIDShortcutForSelectedPhase(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "Phase copy flow",
+			Status: flowstore.StatusInProgress,
+			Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation",
+				Title:   "Implementation",
+				Status:  flowstore.PhaseReady,
+			}},
+		}},
+		ActivePane:          1,
+		FlowSelected:        0,
+		ExpandedFlowID:      "flow-1",
+		SelectedFlowPhaseID: "implementation",
+	})
+
+	pane := shortcutPaneText(view)
+	if !strings.Contains(pane, "y      copy phase id") {
+		t.Fatalf("selected Flow phase should expose phase-id copy shortcut:\n%s", view)
+	}
+	if strings.Contains(pane, "y      copy id") {
+		t.Fatalf("selected Flow phase should not expose whole-flow copy shortcut:\n%s", view)
+	}
+}
+
+func TestRender_FlowsModeIgnoresStaleSelectedPhaseForCopyShortcut(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "Stale phase copy flow",
+			Status: flowstore.StatusInProgress,
+			Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation",
+				Title:   "Implementation",
+				Status:  flowstore.PhaseReady,
+			}},
+		}},
+		ActivePane:          1,
+		FlowSelected:        0,
+		ExpandedFlowID:      "flow-1",
+		SelectedFlowPhaseID: "missing",
+	})
+
+	pane := shortcutPaneText(view)
+	if !strings.Contains(pane, "y      copy id") {
+		t.Fatalf("stale Flow phase selection should fall back to whole-flow copy shortcut:\n%s", view)
+	}
+	if strings.Contains(pane, "y      copy phase id") {
+		t.Fatalf("stale Flow phase selection should not expose phase-id copy shortcut:\n%s", view)
 	}
 }
 
@@ -390,10 +479,13 @@ func TestRender_FlowsModeShowsPlanReviewGateState(t *testing.T) {
 		AgentAvailable: true,
 	})
 
-	for _, want := range []string{"plan-review", "changes_requested", "1/3", "a", "launch phase"} {
+	for _, want := range []string{"plan-review", "changes_requested", "1/3", "a", "phase status"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("flows gate view missing %q:\n%s", want, view)
 		}
+	}
+	if strings.Contains(view, "launch phase") {
+		t.Fatalf("gated flows view should not advertise launchable phase:\n%s", view)
 	}
 }
 

--- a/ui/ui_plan_test.go
+++ b/ui/ui_plan_test.go
@@ -85,13 +85,15 @@ func TestRender_PlansModeShowsPlanShortcut(t *testing.T) {
 		PlanSelected: 0,
 	})
 	pane := shortcutPaneText(view)
-	for _, want := range []string{"enter  phases", "o      open", "i      implement", "y      copy path"} {
+	for _, want := range []string{"x      phases", "o      open", "a      implement", "y      copy path"} {
 		if !strings.Contains(pane, want) {
 			t.Fatalf("plans view should expose shortcut %q:\n%s", want, view)
 		}
 	}
-	if strings.Contains(pane, "a      agent") {
-		t.Fatalf("plans view should not expose normal agent shortcut:\n%s", view)
+	for _, old := range []string{"enter  phases", "i      implement"} {
+		if strings.Contains(pane, old) {
+			t.Fatalf("plans view should not advertise old shortcut %q:\n%s", old, view)
+		}
 	}
 }
 
@@ -116,10 +118,10 @@ func TestRender_PlansModeShowsPhaseShortcutWhenPhaseSelected(t *testing.T) {
 		SelectedPlanPhaseID: "p1",
 	})
 	pane := shortcutPaneText(view)
-	if !strings.Contains(pane, "i      implement phase") {
+	if !strings.Contains(pane, "a      implement phase") {
 		t.Fatalf("selected phase shortcut should expose phase implementation:\n%s", view)
 	}
-	if strings.Contains(pane, "i      implement\n") {
+	if strings.Contains(pane, "a      implement\n") {
 		t.Fatalf("selected phase shortcut should not expose whole-plan implementation:\n%s", view)
 	}
 }
@@ -145,10 +147,10 @@ func TestRender_PlansModeIgnoresStaleSelectedPhaseForShortcut(t *testing.T) {
 		SelectedPlanPhaseID: "missing",
 	})
 	pane := shortcutPaneText(view)
-	if strings.Contains(pane, "i      implement phase") {
+	if strings.Contains(pane, "a      implement phase") {
 		t.Fatalf("stale phase selection should not expose phase implementation:\n%s", view)
 	}
-	if !strings.Contains(pane, "i      implement") {
+	if !strings.Contains(pane, "a      implement") {
 		t.Fatalf("stale phase selection should fall back to whole-plan implementation:\n%s", view)
 	}
 }
@@ -164,7 +166,7 @@ func TestRender_PlansModeOmitsPlanShortcutsWhenNoPlanSelected(t *testing.T) {
 	})
 
 	pane := shortcutPaneText(view)
-	for _, forbidden := range []string{"enter  phases", "o      open", "i      implement", "y      copy path", "a      agent"} {
+	for _, forbidden := range []string{"x      phases", "o      open", "a      implement", "y      copy path", "i      implement"} {
 		if strings.Contains(pane, forbidden) {
 			t.Fatalf("empty plans view should omit %q:\n%s", forbidden, view)
 		}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -421,7 +421,7 @@ func TestRender_SessionsModeShowsSelectedSessionShortcuts(t *testing.T) {
 		SessionSelected: 0,
 	})
 	pane := shortcutPaneText(view)
-	for _, want := range []string{"enter  transcript", "r      resume", "s      summary", "y      copy id"} {
+	for _, want := range []string{"o      transcript", "r      resume", "s      summary", "y      copy id"} {
 		if !strings.Contains(pane, want) {
 			t.Fatalf("sessions view should expose selected session shortcut %q:\n%s", want, pane)
 		}
@@ -448,7 +448,7 @@ func TestRender_SessionsModeHidesSessionActionsWithoutSelection(t *testing.T) {
 		SessionSelected: -1,
 	})
 	pane := shortcutPaneText(view)
-	for _, hidden := range []string{"enter  transcript", "r      resume", "s      summary", "y      copy id", "s      copy id"} {
+	for _, hidden := range []string{"o      transcript", "r      resume", "s      summary", "y      copy id", "s      copy id"} {
 		if strings.Contains(pane, hidden) {
 			t.Fatalf("sessions view should hide %q without selected session:\n%s", hidden, pane)
 		}
@@ -1122,7 +1122,7 @@ func TestRender_ShortSessionPaneKeepsSelectedSessionActions(t *testing.T) {
 		SessionSelected: 0,
 	})
 	pane := shortcutPaneText(view)
-	for _, want := range []string{"enter  transcript", "r      resume", "s      summary", "y      copy id", shortcutOverflowMarker} {
+	for _, want := range []string{"o      transcript", "r      resume", "s      summary", "y      copy id", shortcutOverflowMarker} {
 		if !strings.Contains(pane, want) {
 			t.Fatalf("short session shortcut pane should keep selected session action %q, got:\n%s", want, pane)
 		}
@@ -2796,7 +2796,7 @@ func TestStatusBar_PlanPhaseFooterPreservesActionsAtNarrowWidth(t *testing.T) {
 	if got := lipgloss.Width(stripped); got > 80 {
 		t.Fatalf("plan phase status bar width = %d, want <= 80: %q", got, stripped)
 	}
-	for _, hint := range []string{"enter: phases", "o: open", "i: implement phase", "y: copy path"} {
+	for _, hint := range []string{"x: phases", "o: open", "a: implement phase", "y: copy path"} {
 		if !strings.Contains(bar, hint) {
 			t.Fatalf("plan phase status bar should keep action hint %q, got %q", hint, bar)
 		}


### PR DESCRIPTION
## Summary

Fixes #157.

This cleans up the mode-specific shortcut contract for Plans, Flows, and Sessions so the UI teaches the same semantics the model handles:

- Plans now advertise `x` for phase expansion and `a` for plan or phase implementation while keeping `enter` and `i` as compatibility aliases.
- Sessions now advertise `o` for transcript opening while keeping `enter` as an alias.
- Flows now expose scoped `o`/`y` actions: linked-plan opening only when a plan exists, and copy Flow ID vs selected phase ID based on validated selection state.
- Flow `a` help distinguishes launchable phases from gated status checks, showing `launch phase` only when a ready phase exists and `phase status` when the action explains why a phase is not ready.
- README key reference and mode sections now match the cleaned-up shortcut behavior.

## Testing

- `gofmt -l .`
- `go test ./model ./ui`
- `make test`
- `make build`
- `git diff --check`

## Review loop

Ran the review-loop skill for two critic passes. Loop 1 scored 7/10 and found the Flow `a` hint and Flow `y` stale-selection issues; both were fixed. Loop 2 scored 8/10, with a minor test-gap note that was addressed by adding stale Flow phase shortcut coverage.