### PR TITLE
Add discoverable CLI help

### DIFF
--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -16,6 +17,10 @@ import (
 // runFlow handles `wtui flow ...` subcommands. It may load config to resolve
 // the artifact root but must never scan repositories or start the TUI.
 func runFlow(args []string, deps runDeps) error {
+	if len(args) == 3 && isHelpArg(args[2]) {
+		printFlowHelp(deps.stdout)
+		return nil
+	}
 	if len(args) < 3 {
 		return fmt.Errorf("usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]")
 	}
@@ -35,9 +40,39 @@ func runFlow(args []string, deps runDeps) error {
 	case "merge":
 		return runFlowMerge(args[3:], deps)
 	default:
-		return fmt.Errorf("unknown flow subcommand %q", args[2])
+		return unknownCommandError(args[2], []string{"create", "list", "read", "phase", "plan", "pr", "merge"}, flowHelpText)
 	}
 }
+
+func printFlowHelp(w io.Writer) {
+	io.WriteString(w, flowHelpText)
+}
+
+const flowHelpText = `Usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]
+
+Create and update task-centric Flow records under the wtui agent-artifact root.
+
+Commands:
+  create           Create a Flow; prints JSON when --json is present.
+  list             List Flows as JSON.
+  read             Print one Flow record as JSON.
+  phase set        Advance a Flow phase.
+  phase add-child  Add or update an implementation child phase.
+  plan set         Link a saved plan artifact to a Flow.
+  pr set           Record pull request metadata.
+  merge set        Record merge metadata.
+
+Examples:
+  wtui flow create --title "Ship saved plans" --instructions "Build it" --repo-path "$REPO" --json
+  wtui flow read --flow-id "$FLOW_ID"
+  wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan --status completed --summary "Plan saved"
+  wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan-review --status completed --outcome approved
+  wtui flow pr set --flow-id "$FLOW_ID" --provider github --number 155 --url "$PR_URL" --head "$BRANCH" --base main
+  wtui flow merge set --flow-id "$FLOW_ID" --status merged --commit "$SHA" --merged-at "2026-06-09T12:00:00Z"
+
+Most commands accept:
+  --state-root PATH  Override the artifact state root after the leaf command.
+`
 
 // resolveFlowRoot applies the documented precedence:
 // --state-root > WTUI_FLOW_STATE_ROOT > WTUI_PLAN_STATE_ROOT >
@@ -73,6 +108,7 @@ func newFlowStore(stateRoot string, deps runDeps) (*flowstore.Store, error) {
 func runFlowCreate(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("flow create", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printFlowCreateHelp(deps.stdout) }
 	title := flags.String("title", "", "flow title")
 	instructions := flags.String("instructions", "", "task instructions")
 	instructionsFile := flags.String("instructions-file", "", "read task instructions from file")
@@ -83,7 +119,10 @@ func runFlowCreate(args []string, deps runDeps) error {
 	commit := flags.String("commit", "", "start commit")
 	stateRoot := flags.String("state-root", "", "artifact state root")
 	asJSON := flags.Bool("json", false, "emit JSON output")
-	if err := flags.Parse(args); err != nil {
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if !*asJSON {
@@ -91,6 +130,12 @@ func runFlowCreate(args []string, deps runDeps) error {
 	}
 	if strings.TrimSpace(*title) == "" {
 		return fmt.Errorf("flow create requires --title")
+	}
+	if strings.TrimSpace(*repoPath) == "" {
+		return fmt.Errorf("flow create requires --repo-path")
+	}
+	if !filepath.IsAbs(*repoPath) {
+		return fmt.Errorf("flow create requires absolute --repo-path")
 	}
 	body, err := readFlowInstructions(*instructions, *instructionsFile)
 	if err != nil {
@@ -115,13 +160,40 @@ func runFlowCreate(args []string, deps runDeps) error {
 	return writeFlowJSON(deps.stdout, record)
 }
 
+func printFlowCreateHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow create [flags]
+
+Create a Flow record. JSON output is required in v1.
+
+Required flags:
+  --title TITLE
+  --instructions TEXT or --instructions-file PATH
+  --repo-path PATH
+  --json
+
+Common flags:
+  --worktree-path PATH
+  --branch BRANCH
+  --base-ref REF
+  --commit SHA
+  --state-root PATH
+
+Example:
+  wtui flow create --title "Ship saved plans" --instructions "Build it" --repo-path "$REPO" --json
+`)
+}
+
 func runFlowList(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("flow list", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printFlowListHelp(deps.stdout) }
 	repoPath := flags.String("repo-path", "", "filter by repository path")
 	stateRoot := flags.String("state-root", "", "artifact state root")
 	asJSON := flags.Bool("json", false, "emit JSON output")
-	if err := flags.Parse(args); err != nil {
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if !*asJSON {
@@ -141,12 +213,33 @@ func runFlowList(args []string, deps runDeps) error {
 	return writeFlowJSON(deps.stdout, records)
 }
 
+func printFlowListHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow list [flags]
+
+List Flow records as JSON.
+
+Required flags:
+  --json
+
+Common flags:
+  --repo-path PATH
+  --state-root PATH
+
+Example:
+  wtui flow list --repo-path "$REPO" --json
+`)
+}
+
 func runFlowRead(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("flow read", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printFlowReadHelp(deps.stdout) }
 	flowID := flags.String("flow-id", "", "flow id")
 	stateRoot := flags.String("state-root", "", "artifact state root")
-	if err := flags.Parse(args); err != nil {
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if *flowID == "" {
@@ -163,7 +256,27 @@ func runFlowRead(args []string, deps runDeps) error {
 	return writeFlowJSON(deps.stdout, record)
 }
 
+func printFlowReadHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow read [flags]
+
+Print one Flow record as JSON.
+
+Required flags:
+  --flow-id FLOW_ID
+
+Common flags:
+  --state-root PATH
+
+Example:
+  wtui flow read --flow-id "$FLOW_ID"
+`)
+}
+
 func runFlowPhase(args []string, deps runDeps) error {
+	if len(args) == 1 && isHelpArg(args[0]) {
+		printFlowPhaseHelp(deps.stdout)
+		return nil
+	}
 	if len(args) < 1 {
 		return fmt.Errorf("usage: wtui flow phase <set|add-child> [flags]")
 	}
@@ -173,13 +286,37 @@ func runFlowPhase(args []string, deps runDeps) error {
 	case "add-child":
 		return runFlowPhaseAddChild(args[1:], deps)
 	default:
-		return fmt.Errorf("usage: wtui flow phase <set|add-child> [flags]")
+		return unknownCommandError(args[0], []string{"set", "add-child"}, flowPhaseHelpText)
 	}
 }
+
+func printFlowPhaseHelp(w io.Writer) {
+	io.WriteString(w, flowPhaseHelpText)
+}
+
+const flowPhaseHelpText = `Usage: wtui flow phase <set|add-child> [flags]
+
+Update Flow phase state. Readiness is derived by wtui; agents set running,
+completed, needs_attention, blocked, or skipped.
+
+Commands:
+  set        Set a phase status, outcome, summary, or notes.
+  add-child  Add or update an implementation child phase.
+
+Examples:
+  wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan --status completed --summary "Saved plan"
+  wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan-review --status completed --outcome approved
+  wtui flow phase set --flow-id "$FLOW_ID" --phase-id implementation --status blocked --notes "Waiting on review"
+  wtui flow phase add-child --flow-id "$FLOW_ID" --parent-phase-id implementation --phase-id api --title "API work" --order 1
+
+Common flags:
+  --state-root PATH  Override the artifact state root.
+`
 
 func runFlowPhaseSet(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("flow phase set", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printFlowPhaseSetHelp(deps.stdout) }
 	flowID := flags.String("flow-id", "", "flow id")
 	phaseID := flags.String("phase-id", "", "phase id")
 	status := flags.String("status", "", "phase status")
@@ -187,7 +324,10 @@ func runFlowPhaseSet(args []string, deps runDeps) error {
 	summary := flags.String("summary", "", "phase summary")
 	notes := flags.String("notes", "", "phase notes")
 	stateRoot := flags.String("state-root", "", "artifact state root")
-	if err := flags.Parse(args); err != nil {
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if *flowID == "" {
@@ -226,16 +366,42 @@ func runFlowPhaseSet(args []string, deps runDeps) error {
 	return writeFlowJSON(deps.stdout, record)
 }
 
+func printFlowPhaseSetHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow phase set [flags]
+
+Set a Flow phase status, outcome, summary, or notes.
+
+Required flags:
+  --flow-id FLOW_ID
+  --phase-id PHASE_ID
+  --status STATUS
+
+Common flags:
+  --outcome OUTCOME
+  --summary TEXT
+  --notes TEXT
+  --state-root PATH
+
+Examples:
+  wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan --status completed --summary "Saved plan"
+  wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan-review --status completed --outcome approved
+`)
+}
+
 func runFlowPhaseAddChild(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("flow phase add-child", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printFlowPhaseAddChildHelp(deps.stdout) }
 	flowID := flags.String("flow-id", "", "flow id")
 	parentPhaseID := flags.String("parent-phase-id", "implementation", "parent phase id")
 	phaseID := flags.String("phase-id", "", "child phase id")
 	title := flags.String("title", "", "child phase title")
 	order := flags.Int("order", 0, "child phase order under implementation")
 	stateRoot := flags.String("state-root", "", "artifact state root")
-	if err := flags.Parse(args); err != nil {
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if *flowID == "" {
@@ -267,21 +433,64 @@ func runFlowPhaseAddChild(args []string, deps runDeps) error {
 	return writeFlowJSON(deps.stdout, record)
 }
 
+func printFlowPhaseAddChildHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow phase add-child [flags]
+
+Add or update an implementation child phase.
+
+Required flags:
+  --flow-id FLOW_ID
+  --phase-id PHASE_ID
+  --title TITLE
+  --order N
+
+Common flags:
+  --parent-phase-id PHASE_ID
+  --state-root PATH
+
+Example:
+  wtui flow phase add-child --flow-id "$FLOW_ID" --parent-phase-id implementation --phase-id api --title "API work" --order 1
+`)
+}
+
 func runFlowPlan(args []string, deps runDeps) error {
-	if len(args) < 1 || args[0] != "set" {
+	if len(args) == 1 && isHelpArg(args[0]) {
+		printFlowPlanHelp(deps.stdout)
+		return nil
+	}
+	if len(args) < 1 {
 		return fmt.Errorf("usage: wtui flow plan set [flags]")
+	}
+	if args[0] != "set" {
+		return unknownCommandError(args[0], []string{"set"}, flowPlanHelpText)
 	}
 	return runFlowPlanSet(args[1:], deps)
 }
 
+func printFlowPlanHelp(w io.Writer) {
+	io.WriteString(w, flowPlanHelpText)
+}
+
+const flowPlanHelpText = `Usage: wtui flow plan set [flags]
+
+Link a saved plan artifact to a Flow.
+
+Example:
+  wtui flow plan set --flow-id "$FLOW_ID" --plan-id "$PLAN_ID"
+`
+
 func runFlowPlanSet(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("flow plan set", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printFlowPlanSetHelp(deps.stdout) }
 	flowID := flags.String("flow-id", "", "flow id")
 	planID := flags.String("plan-id", "", "plan id")
 	planPath := flags.String("plan-path", "", "plan markdown path")
 	stateRoot := flags.String("state-root", "", "artifact state root")
-	if err := flags.Parse(args); err != nil {
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if *flowID == "" {
@@ -305,16 +514,54 @@ func runFlowPlanSet(args []string, deps runDeps) error {
 	return writeFlowJSON(deps.stdout, record)
 }
 
+func printFlowPlanSetHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow plan set [flags]
+
+Link a saved plan artifact to a Flow.
+
+Required flags:
+  --flow-id FLOW_ID
+  --plan-id PLAN_ID
+
+Common flags:
+  --plan-path PATH
+  --state-root PATH
+
+Example:
+  wtui flow plan set --flow-id "$FLOW_ID" --plan-id "$PLAN_ID"
+`)
+}
+
 func runFlowPR(args []string, deps runDeps) error {
-	if len(args) < 1 || args[0] != "set" {
+	if len(args) == 1 && isHelpArg(args[0]) {
+		printFlowPRHelp(deps.stdout)
+		return nil
+	}
+	if len(args) < 1 {
 		return fmt.Errorf("usage: wtui flow pr set [flags]")
+	}
+	if args[0] != "set" {
+		return unknownCommandError(args[0], []string{"set"}, flowPRHelpText)
 	}
 	return runFlowPRSet(args[1:], deps)
 }
 
+func printFlowPRHelp(w io.Writer) {
+	io.WriteString(w, flowPRHelpText)
+}
+
+const flowPRHelpText = `Usage: wtui flow pr set [flags]
+
+Record pull request metadata for a Flow.
+
+Example:
+  wtui flow pr set --flow-id "$FLOW_ID" --provider github --number 155 --url "$PR_URL" --head "$BRANCH" --base main
+`
+
 func runFlowPRSet(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("flow pr set", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printFlowPRSetHelp(deps.stdout) }
 	flowID := flags.String("flow-id", "", "flow id")
 	provider := flags.String("provider", "github", "PR provider")
 	number := flags.Int("number", 0, "PR number")
@@ -323,7 +570,10 @@ func runFlowPRSet(args []string, deps runDeps) error {
 	base := flags.String("base", "", "PR base branch")
 	status := flags.String("status", "", "PR status")
 	stateRoot := flags.String("state-root", "", "artifact state root")
-	if err := flags.Parse(args); err != nil {
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if *flowID == "" {
@@ -360,22 +610,67 @@ func runFlowPRSet(args []string, deps runDeps) error {
 	return writeFlowJSON(deps.stdout, record)
 }
 
+func printFlowPRSetHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow pr set [flags]
+
+Record pull request metadata for a Flow.
+
+Required flags:
+  --flow-id FLOW_ID
+  --number N
+  --url URL
+  --head BRANCH
+  --base BRANCH
+
+Common flags:
+  --provider PROVIDER
+  --status STATUS
+  --state-root PATH
+
+Example:
+  wtui flow pr set --flow-id "$FLOW_ID" --provider github --number 155 --url "$PR_URL" --head "$BRANCH" --base main
+`)
+}
+
 func runFlowMerge(args []string, deps runDeps) error {
-	if len(args) < 1 || args[0] != "set" {
+	if len(args) == 1 && isHelpArg(args[0]) {
+		printFlowMergeHelp(deps.stdout)
+		return nil
+	}
+	if len(args) < 1 {
 		return fmt.Errorf("usage: wtui flow merge set [flags]")
+	}
+	if args[0] != "set" {
+		return unknownCommandError(args[0], []string{"set"}, flowMergeHelpText)
 	}
 	return runFlowMergeSet(args[1:], deps)
 }
 
+func printFlowMergeHelp(w io.Writer) {
+	io.WriteString(w, flowMergeHelpText)
+}
+
+const flowMergeHelpText = `Usage: wtui flow merge set [flags]
+
+Record merge metadata for a Flow.
+
+Example:
+  wtui flow merge set --flow-id "$FLOW_ID" --status merged --commit "$SHA" --merged-at "2026-06-09T12:00:00Z"
+`
+
 func runFlowMergeSet(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("flow merge set", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printFlowMergeSetHelp(deps.stdout) }
 	flowID := flags.String("flow-id", "", "flow id")
 	status := flags.String("status", "", "merge status")
 	commit := flags.String("commit", "", "merge commit")
 	mergedAt := flags.String("merged-at", "", "merge timestamp")
 	stateRoot := flags.String("state-root", "", "artifact state root")
-	if err := flags.Parse(args); err != nil {
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if *flowID == "" {
@@ -412,6 +707,27 @@ func runFlowMergeSet(args []string, deps runDeps) error {
 		return err
 	}
 	return writeFlowJSON(deps.stdout, record)
+}
+
+func printFlowMergeSetHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow merge set [flags]
+
+Record merge metadata for a Flow.
+
+Required flags:
+  --flow-id FLOW_ID
+  --status STATUS
+
+Merged status also requires:
+  --commit SHA
+  --merged-at RFC3339_TIMESTAMP
+
+Common flags:
+  --state-root PATH
+
+Example:
+  wtui flow merge set --flow-id "$FLOW_ID" --status merged --commit "$SHA" --merged-at "2026-06-09T12:00:00Z"
+`)
 }
 
 func readFlowInstructions(inline, file string) (string, error) {

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -14,6 +14,236 @@ import (
 	"github.com/brian-bell/wtui/planstore"
 )
 
+func TestRunFlowHelpPrintsUsageAndExamples(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "flow", "--help"}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for flow help")
+			return config.Config{}, nil
+		},
+		stdout: &stdout,
+	}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	requireContainsAll(t, stdout.String(), []string{
+		"Usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]",
+		"wtui flow read --flow-id",
+		"wtui flow phase set --flow-id",
+		"wtui flow pr set --flow-id",
+		"wtui flow merge set --flow-id",
+	})
+}
+
+func TestRunFlowPhaseHelpPrintsUsageAndExamples(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "flow", "phase", "--help"}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for flow phase help")
+			return config.Config{}, nil
+		},
+		stdout: &stdout,
+	}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	requireContainsAll(t, stdout.String(), []string{
+		"Usage: wtui flow phase <set|add-child> [flags]",
+		"wtui flow phase set --flow-id",
+		"--status completed",
+		"wtui flow phase add-child --flow-id",
+	})
+}
+
+func TestRunFlowPhaseSetHelpPrintsUsageWithoutLoadingConfig(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "flow", "phase", "set", "--help"}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for flow phase set help")
+			return config.Config{}, nil
+		},
+		stdout: &stdout,
+	}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if strings.Contains(stdout.String(), "flag: help requested") {
+		t.Fatalf("help output should not contain flag error:\n%s", stdout.String())
+	}
+	requireContainsAll(t, stdout.String(), []string{
+		"Usage: wtui flow phase set [flags]",
+		"--flow-id FLOW_ID",
+		"--phase-id PHASE_ID",
+		"--status STATUS",
+	})
+}
+
+func TestRunFlowPRSetHelpPrintsUsageWithoutLoadingConfig(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "flow", "pr", "set", "--help"}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for flow pr set help")
+			return config.Config{}, nil
+		},
+		stdout: &stdout,
+	}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if strings.Contains(stdout.String(), "flag: help requested") {
+		t.Fatalf("help output should not contain flag error:\n%s", stdout.String())
+	}
+	requireContainsAll(t, stdout.String(), []string{
+		"Usage: wtui flow pr set [flags]",
+		"--number N",
+		"--url URL",
+		"--head BRANCH",
+	})
+}
+
+func TestRunFlowLeafHelpPrintsUsageWithoutLoadingConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		args  []string
+		wants []string
+	}{
+		{
+			name: "create",
+			args: []string{"wtui", "flow", "create", "--help"},
+			wants: []string{
+				"Usage: wtui flow create [flags]",
+				"--title TITLE",
+				"--instructions TEXT",
+			},
+		},
+		{
+			name: "list",
+			args: []string{"wtui", "flow", "list", "--help"},
+			wants: []string{
+				"Usage: wtui flow list [flags]",
+				"--json",
+				"--repo-path PATH",
+			},
+		},
+		{
+			name: "read",
+			args: []string{"wtui", "flow", "read", "--help"},
+			wants: []string{
+				"Usage: wtui flow read [flags]",
+				"--flow-id FLOW_ID",
+				"wtui flow read --flow-id",
+			},
+		},
+		{
+			name: "phase add-child",
+			args: []string{"wtui", "flow", "phase", "add-child", "--help"},
+			wants: []string{
+				"Usage: wtui flow phase add-child [flags]",
+				"--phase-id PHASE_ID",
+				"--order N",
+			},
+		},
+		{
+			name: "plan set",
+			args: []string{"wtui", "flow", "plan", "set", "--help"},
+			wants: []string{
+				"Usage: wtui flow plan set [flags]",
+				"--flow-id FLOW_ID",
+				"--plan-id PLAN_ID",
+			},
+		},
+		{
+			name: "merge set",
+			args: []string{"wtui", "flow", "merge", "set", "--help"},
+			wants: []string{
+				"Usage: wtui flow merge set [flags]",
+				"--status STATUS",
+				"--merged-at RFC3339_TIMESTAMP",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			err := run(tc.args, noScanDeps(t, runDeps{
+				loadConfig: func() (config.Config, error) {
+					t.Fatal("loadConfig should not run for flow leaf help")
+					return config.Config{}, nil
+				},
+				stdout: &stdout,
+			}))
+			if err != nil {
+				t.Fatalf("run returned error: %v", err)
+			}
+			if strings.Contains(stdout.String(), "flag: help requested") {
+				t.Fatalf("help output should not contain flag error:\n%s", stdout.String())
+			}
+			requireContainsAll(t, stdout.String(), tc.wants)
+		})
+	}
+}
+
+func TestRunFlowUnknownSubcommandSuggestsNearbyCommand(t *testing.T) {
+	err := run([]string{"wtui", "flow", "phaze"}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for unknown flow subcommand")
+			return config.Config{}, nil
+		},
+		stdout: &bytes.Buffer{},
+	}))
+	if err == nil {
+		t.Fatal("expected unknown subcommand error")
+	}
+	requireContainsAll(t, err.Error(), []string{
+		`unknown command "phaze"; did you mean "phase"?`,
+		"Usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]",
+	})
+}
+
+func TestRunFlowPhaseUnknownSubcommandSuggestsNearbyCommand(t *testing.T) {
+	err := run([]string{"wtui", "flow", "phase", "ste"}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for unknown flow phase subcommand")
+			return config.Config{}, nil
+		},
+		stdout: &bytes.Buffer{},
+	}))
+	if err == nil {
+		t.Fatal("expected unknown subcommand error")
+	}
+	requireContainsAll(t, err.Error(), []string{
+		`unknown command "ste"; did you mean "set"?`,
+		"Usage: wtui flow phase <set|add-child> [flags]",
+	})
+}
+
+func TestRunFlowNestedSetSubcommandsSuggestSet(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "plan", args: []string{"wtui", "flow", "plan", "sete"}},
+		{name: "pr", args: []string{"wtui", "flow", "pr", "sete"}},
+		{name: "merge", args: []string{"wtui", "flow", "merge", "sete"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := run(tc.args, noScanDeps(t, runDeps{
+				loadConfig: func() (config.Config, error) {
+					t.Fatal("loadConfig should not run for unknown flow nested subcommand")
+					return config.Config{}, nil
+				},
+				stdout: &bytes.Buffer{},
+			}))
+			if err == nil {
+				t.Fatal("expected unknown subcommand error")
+			}
+			requireContainsAll(t, err.Error(), []string{
+				`unknown command "sete"; did you mean "set"?`,
+				"Usage: wtui flow",
+			})
+		})
+	}
+}
+
 func TestRunFlowCreatePrintsJSONRecord(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")
@@ -761,6 +991,38 @@ func TestRunFlowCreateRequiresJSON(t *testing.T) {
 		noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
 	if err == nil {
 		t.Fatal("expected error requiring --json")
+	}
+}
+
+func TestRunFlowCreateValidatesRepoPathBeforeLoadingConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing repo path",
+			args: []string{"wtui", "flow", "create", "--title", "P", "--instructions", "i", "--json"},
+			want: "requires --repo-path",
+		},
+		{
+			name: "relative repo path",
+			args: []string{"wtui", "flow", "create", "--title", "P", "--instructions", "i", "--repo-path", "repo", "--json"},
+			want: "requires absolute --repo-path",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := run(tc.args, noScanDeps(t, runDeps{
+				loadConfig: func() (config.Config, error) {
+					t.Fatal("loadConfig should not run before repo path validation")
+					return config.Config{}, nil
+				},
+				stdout: &bytes.Buffer{},
+			}))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("run error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -46,6 +47,10 @@ type startProgramOptions struct {
 
 func run(args []string, deps runDeps) error {
 	deps = fillRunDeps(deps)
+	if len(args) == 2 && isHelpArg(args[1]) {
+		printMainHelp(deps.stdout)
+		return nil
+	}
 	if len(args) > 1 && args[1] == "session-hook" {
 		return runSessionHook(args, deps)
 	}
@@ -62,6 +67,9 @@ func run(args []string, deps runDeps) error {
 	flags.BoolVar(versionFlag, "v", false, "print version and exit")
 	if err := flags.Parse(args[1:]); err != nil {
 		return err
+	}
+	if flags.NArg() > 0 {
+		return unknownCommandError(flags.Arg(0), []string{"plan", "flow", "session-hook"}, mainHelpText)
 	}
 
 	if *versionFlag {
@@ -100,6 +108,101 @@ func run(args []string, deps runDeps) error {
 		return fmt.Errorf("error: %w", err)
 	}
 	return nil
+}
+
+func isHelpArg(arg string) bool {
+	return arg == "--help" || arg == "-h" || arg == "help"
+}
+
+func printMainHelp(w io.Writer) {
+	io.WriteString(w, mainHelpText)
+}
+
+const mainHelpText = `Usage: wtui [--version] [command]
+
+Launch the worktree TUI, or use a command to persist agent artifacts.
+
+Commands:
+  plan          Save, list, read, and update saved plans.
+  flow          Create, inspect, and update Flow records.
+  session-hook  Capture Claude or Codex session hook payloads.
+
+Flags:
+  --version, -v  Print version and exit.
+  --help, -h     Print this help and exit.
+
+Examples:
+  wtui
+  wtui plan --help
+  wtui flow --help
+  wtui session-hook --provider codex
+`
+
+func unknownCommandError(got string, valid []string, usage string) error {
+	if suggestion := nearestCommand(got, valid); suggestion != "" {
+		return fmt.Errorf("unknown command %q; did you mean %q?\n\n%s", got, suggestion, usage)
+	}
+	return fmt.Errorf("unknown command %q\n\n%s", got, usage)
+}
+
+func nearestCommand(got string, valid []string) string {
+	best := ""
+	bestDistance := 3
+	for _, candidate := range valid {
+		distance := editDistance(got, candidate)
+		if distance < bestDistance {
+			best = candidate
+			bestDistance = distance
+		}
+	}
+	return best
+}
+
+func editDistance(a, b string) int {
+	if a == b {
+		return 0
+	}
+	prev := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr := make([]int, len(b)+1)
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = minInt(
+				curr[j-1]+1,
+				prev[j]+1,
+				prev[j-1]+cost,
+			)
+		}
+		prev = curr
+	}
+	return prev[len(b)]
+}
+
+func minInt(values ...int) int {
+	minimum := values[0]
+	for _, value := range values[1:] {
+		if value < minimum {
+			minimum = value
+		}
+	}
+	return minimum
+}
+
+func parseCommandFlags(flags *flag.FlagSet, args []string) (bool, error) {
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
 }
 
 func fillRunDeps(deps runDeps) runDeps {

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -45,6 +45,97 @@ func TestRun_VersionBypassesConfigAndScan(t *testing.T) {
 	}
 }
 
+func TestRun_HelpBypassesConfigAndScan(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "--help"}, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for --help")
+			return config.Config{}, nil
+		},
+		scan: func(scanner.ScanOptions) ([]scanner.Repo, error) {
+			t.Fatal("scan should not run for --help")
+			return nil, nil
+		},
+		startProgram: func([]scanner.Repo, config.Config) error {
+			t.Fatal("program should not start for --help")
+			return nil
+		},
+		stdout: &stdout,
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	requireContainsAll(t, stdout.String(), []string{
+		"Usage: wtui [--version] [command]",
+		"wtui plan --help",
+		"wtui flow --help",
+		"wtui session-hook --provider codex",
+	})
+}
+
+func TestRun_UnknownCommandSuggestsNearbyCommand(t *testing.T) {
+	err := run([]string{"wtui", "plna"}, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for unknown command")
+			return config.Config{}, nil
+		},
+		scan: func(scanner.ScanOptions) ([]scanner.Repo, error) {
+			t.Fatal("scan should not run for unknown command")
+			return nil, nil
+		},
+		startProgram: func([]scanner.Repo, config.Config) error {
+			t.Fatal("program should not start for unknown command")
+			return nil
+		},
+		stdout: &bytes.Buffer{},
+	})
+	if err == nil {
+		t.Fatal("expected unknown command error")
+	}
+	requireContainsAll(t, err.Error(), []string{
+		`unknown command "plna"; did you mean "plan"?`,
+		"Usage: wtui [--version] [command]",
+	})
+}
+
+func TestRun_UnknownCommandFarFromValidShowsUsageWithoutSuggestion(t *testing.T) {
+	err := run([]string{"wtui", "definitely-not-close"}, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for unknown command")
+			return config.Config{}, nil
+		},
+		scan: func(scanner.ScanOptions) ([]scanner.Repo, error) {
+			t.Fatal("scan should not run for unknown command")
+			return nil, nil
+		},
+		startProgram: func([]scanner.Repo, config.Config) error {
+			t.Fatal("program should not start for unknown command")
+			return nil
+		},
+		stdout: &bytes.Buffer{},
+	})
+	if err == nil {
+		t.Fatal("expected unknown command error")
+	}
+	if strings.Contains(err.Error(), "did you mean") {
+		t.Fatalf("far command should not suggest a command:\n%s", err)
+	}
+	requireContainsAll(t, err.Error(), []string{
+		`unknown command "definitely-not-close"`,
+		"Usage: wtui [--version] [command]",
+	})
+}
+
+func TestNearestCommandSuggestsOnlyNearbyCommands(t *testing.T) {
+	valid := []string{"plan", "flow", "session-hook"}
+	if got := nearestCommand("flw", valid); got != "flow" {
+		t.Fatalf("nearestCommand(flw) = %q, want flow", got)
+	}
+	if got := nearestCommand("definitely-not-close", valid); got != "" {
+		t.Fatalf("nearestCommand(definitely-not-close) = %q, want no suggestion", got)
+	}
+}
+
 func TestRun_LoadsConfigBeforeScanning(t *testing.T) {
 	var got scanner.ScanOptions
 	err := run([]string{"wtui"}, runDeps{
@@ -552,6 +643,15 @@ func singleSessionFile(t *testing.T, root, provider, name string) string {
 
 func quoteJSON(value string) string {
 	return `"` + strings.ReplaceAll(value, `"`, `\"`) + `"`
+}
+
+func requireContainsAll(t *testing.T, text string, wants []string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
 }
 
 func TestBootstrapHookResolverMatchesConfiguredRepoPath(t *testing.T) {

--- a/cmd/wtui/plan.go
+++ b/cmd/wtui/plan.go
@@ -16,6 +16,10 @@ import (
 // runPlan handles `wtui plan ...` subcommands. It may load config to resolve the
 // artifact root but must never scan repositories or start the TUI.
 func runPlan(args []string, deps runDeps) error {
+	if len(args) == 3 && isHelpArg(args[2]) {
+		printPlanHelp(deps.stdout)
+		return nil
+	}
 	if len(args) < 3 {
 		return fmt.Errorf("usage: wtui plan <save|list|read|phase> [flags]")
 	}
@@ -29,9 +33,34 @@ func runPlan(args []string, deps runDeps) error {
 	case "phase":
 		return runPlanPhase(args[3:], deps)
 	default:
-		return fmt.Errorf("unknown plan subcommand %q", args[2])
+		return unknownCommandError(args[2], []string{"save", "list", "read", "phase"}, planHelpText)
 	}
 }
+
+func printPlanHelp(w io.Writer) {
+	io.WriteString(w, planHelpText)
+}
+
+const planHelpText = `Usage: wtui plan <save|list|read|phase> [flags]
+
+Persist saved plan artifacts under the wtui agent-artifact root.
+
+Commands:
+  save       Save or update a Markdown plan; prints only the plan id.
+  list       List saved plans as JSON.
+  read       Print a saved plan's Markdown.
+  phase set  Create or update a saved-plan phase row.
+
+Examples:
+  printf '%s' "$PLAN_MD" | wtui plan save --title "Persist plans" --status draft
+  wtui plan save --plan-id "$PLAN_ID" --title "Persist plans" --file ./plan.md
+  wtui plan read --plan-id "$PLAN_ID"
+  wtui plan list --repo-path "$REPO" --json
+  wtui plan phase set --plan-id "$PLAN_ID" --phase-id store --title "Store" --status completed --order 1
+
+Most commands accept:
+  --state-root PATH  Override the artifact state root after the leaf command.
+`
 
 // resolvePlanRoot applies the documented precedence:
 // --state-root > WTUI_PLAN_STATE_ROOT > WTUI_SESSION_STATE_ROOT >
@@ -64,6 +93,7 @@ func newPlanStore(stateRoot string, deps runDeps) (*planstore.Store, error) {
 func runPlanSave(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("plan save", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printPlanSaveHelp(deps.stdout) }
 	title := flags.String("title", "", "plan title")
 	summary := flags.String("summary", "", "plan summary")
 	planID := flags.String("plan-id", "", "reuse an existing plan id")
@@ -78,7 +108,10 @@ func runPlanSave(args []string, deps runDeps) error {
 	commit := flags.String("commit", "", "commit hash")
 	file := flags.String("file", "", "read markdown from file instead of stdin")
 	stateRoot := flags.String("state-root", "", "artifact state root")
-	if err := flags.Parse(args); err != nil {
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if strings.TrimSpace(*title) == "" {
@@ -121,13 +154,71 @@ func runPlanSave(args []string, deps runDeps) error {
 	return nil
 }
 
+func printPlanSaveHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui plan save [flags]
+
+Save or update a Markdown plan. Markdown is read from stdin unless --file is set.
+
+Required flags:
+  --title TITLE
+
+Common flags:
+  --plan-id ID       Update an existing plan id.
+  --status STATUS    Plan status, such as draft.
+  --file PATH        Read Markdown from a file.
+  --repo-path PATH   Repository path metadata.
+  --state-root PATH  Override the artifact state root.
+
+Examples:
+  printf '%s' "$PLAN_MD" | wtui plan save --title "Persist plans" --status draft
+  wtui plan save --plan-id "$PLAN_ID" --title "Persist plans" --file ./plan.md
+`)
+}
+
+func printPlanListHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui plan list [flags]
+
+List saved plans as JSON.
+
+Required flags:
+  --json
+
+Common flags:
+  --repo-path PATH   Filter by repository path.
+  --state-root PATH  Override the artifact state root.
+
+Example:
+  wtui plan list --repo-path "$REPO" --json
+`)
+}
+
+func printPlanReadHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui plan read [flags]
+
+Print a saved plan's Markdown.
+
+Required flags:
+  --plan-id PLAN_ID
+
+Common flags:
+  --state-root PATH  Override the artifact state root.
+
+Example:
+  wtui plan read --plan-id "$PLAN_ID"
+`)
+}
+
 func runPlanList(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("plan list", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printPlanListHelp(deps.stdout) }
 	repoPath := flags.String("repo-path", "", "filter by repository path")
 	stateRoot := flags.String("state-root", "", "artifact state root")
 	asJSON := flags.Bool("json", false, "emit JSON output")
-	if err := flags.Parse(args); err != nil {
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if !*asJSON {
@@ -155,9 +246,13 @@ func runPlanList(args []string, deps runDeps) error {
 func runPlanRead(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("plan read", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printPlanReadHelp(deps.stdout) }
 	planID := flags.String("plan-id", "", "plan id")
 	stateRoot := flags.String("state-root", "", "artifact state root")
-	if err := flags.Parse(args); err != nil {
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if *planID == "" {
@@ -176,18 +271,29 @@ func runPlanRead(args []string, deps runDeps) error {
 }
 
 func runPlanPhase(args []string, deps runDeps) error {
-	if len(args) < 1 || args[0] != "set" {
+	if len(args) == 1 && isHelpArg(args[0]) {
+		printPlanPhaseHelp(deps.stdout)
+		return nil
+	}
+	if len(args) < 1 {
 		return fmt.Errorf("usage: wtui plan phase set [flags]")
+	}
+	if args[0] != "set" {
+		return unknownCommandError(args[0], []string{"set"}, planPhaseHelpText)
 	}
 	flags := flag.NewFlagSet("plan phase set", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printPlanPhaseSetHelp(deps.stdout) }
 	planID := flags.String("plan-id", "", "plan id")
 	phaseID := flags.String("phase-id", "", "phase id")
 	title := flags.String("title", "", "phase title")
 	status := flags.String("status", "", "phase status")
 	order := flags.Int("order", 0, "phase order")
 	stateRoot := flags.String("state-root", "", "artifact state root")
-	if err := flags.Parse(args[1:]); err != nil {
+	if help, err := parseCommandFlags(flags, args[1:]); help || err != nil {
+		if help {
+			return nil
+		}
 		return err
 	}
 	if *planID == "" || *phaseID == "" {
@@ -203,6 +309,38 @@ func runPlanPhase(args []string, deps runDeps) error {
 		Status:  *status,
 		Order:   *order,
 	})
+}
+
+func printPlanPhaseHelp(w io.Writer) {
+	io.WriteString(w, planPhaseHelpText)
+}
+
+const planPhaseHelpText = `Usage: wtui plan phase set [flags]
+
+Update a saved-plan phase row.
+
+Example:
+  wtui plan phase set --plan-id "$PLAN_ID" --phase-id store --title "Store" --status completed --order 1
+`
+
+func printPlanPhaseSetHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui plan phase set [flags]
+
+Create or update a saved-plan phase row.
+
+Required flags:
+  --plan-id PLAN_ID
+  --phase-id PHASE_ID
+
+Common flags:
+  --title TITLE
+  --status STATUS
+  --order N
+  --state-root PATH
+
+Example:
+  wtui plan phase set --plan-id "$PLAN_ID" --phase-id store --title "Store" --status completed --order 1
+`)
 }
 
 func readPlanInput(file string, stdin io.Reader) (string, error) {

--- a/cmd/wtui/plan_test.go
+++ b/cmd/wtui/plan_test.go
@@ -33,6 +33,165 @@ func noScanDeps(t *testing.T, deps runDeps) runDeps {
 	return deps
 }
 
+func TestRunPlanHelpPrintsUsageAndExamples(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "plan", "--help"}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for plan help")
+			return config.Config{}, nil
+		},
+		stdout: &stdout,
+	}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	requireContainsAll(t, stdout.String(), []string{
+		"Usage: wtui plan <save|list|read|phase> [flags]",
+		"wtui plan save --title",
+		"wtui plan read --plan-id",
+		"wtui plan phase set --plan-id",
+	})
+}
+
+func TestRunPlanSaveHelpPrintsUsageWithoutLoadingConfig(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "plan", "save", "--help"}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for plan save help")
+			return config.Config{}, nil
+		},
+		stdout: &stdout,
+	}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if strings.Contains(stdout.String(), "flag: help requested") {
+		t.Fatalf("help output should not contain flag error:\n%s", stdout.String())
+	}
+	requireContainsAll(t, stdout.String(), []string{
+		"Usage: wtui plan save [flags]",
+		"--title TITLE",
+		"--file PATH",
+		"--state-root PATH",
+	})
+}
+
+func TestRunPlanLeafHelpPrintsUsageWithoutLoadingConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		args  []string
+		wants []string
+	}{
+		{
+			name: "list",
+			args: []string{"wtui", "plan", "list", "--help"},
+			wants: []string{
+				"Usage: wtui plan list [flags]",
+				"--json",
+				"--repo-path PATH",
+			},
+		},
+		{
+			name: "read",
+			args: []string{"wtui", "plan", "read", "--help"},
+			wants: []string{
+				"Usage: wtui plan read [flags]",
+				"--plan-id PLAN_ID",
+				"wtui plan read --plan-id",
+			},
+		},
+		{
+			name: "phase set",
+			args: []string{"wtui", "plan", "phase", "set", "--help"},
+			wants: []string{
+				"Usage: wtui plan phase set [flags]",
+				"--plan-id PLAN_ID",
+				"--phase-id PHASE_ID",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			err := run(tc.args, noScanDeps(t, runDeps{
+				loadConfig: func() (config.Config, error) {
+					t.Fatal("loadConfig should not run for plan leaf help")
+					return config.Config{}, nil
+				},
+				stdout: &stdout,
+			}))
+			if err != nil {
+				t.Fatalf("run returned error: %v", err)
+			}
+			if strings.Contains(stdout.String(), "flag: help requested") {
+				t.Fatalf("help output should not contain flag error:\n%s", stdout.String())
+			}
+			requireContainsAll(t, stdout.String(), tc.wants)
+		})
+	}
+}
+
+func TestRunPlanSaveAllowsHelpAsFlagValue(t *testing.T) {
+	root := t.TempDir()
+	var stdout bytes.Buffer
+	err := run([]string{
+		"wtui", "plan", "save",
+		"--title", "help",
+		"--plan-id", "help-title",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run with explicit state root")
+			return config.Config{}, nil
+		},
+		stdin:  strings.NewReader("body"),
+		stdout: &stdout,
+	}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if strings.TrimSpace(stdout.String()) != "help-title" {
+		t.Fatalf("expected saved plan id, got %q", stdout.String())
+	}
+	record := readPlanRecord(t, root, "help-title")
+	if record.Title != "help" {
+		t.Fatalf("title = %q, want help", record.Title)
+	}
+}
+
+func TestRunPlanUnknownSubcommandSuggestsNearbyCommand(t *testing.T) {
+	err := run([]string{"wtui", "plan", "reed"}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for unknown plan subcommand")
+			return config.Config{}, nil
+		},
+		stdout: &bytes.Buffer{},
+	}))
+	if err == nil {
+		t.Fatal("expected unknown subcommand error")
+	}
+	requireContainsAll(t, err.Error(), []string{
+		`unknown command "reed"; did you mean "read"?`,
+		"Usage: wtui plan <save|list|read|phase> [flags]",
+	})
+}
+
+func TestRunPlanPhaseUnknownSubcommandSuggestsSet(t *testing.T) {
+	err := run([]string{"wtui", "plan", "phase", "sete"}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for unknown plan phase subcommand")
+			return config.Config{}, nil
+		},
+		stdout: &bytes.Buffer{},
+	}))
+	if err == nil {
+		t.Fatal("expected unknown subcommand error")
+	}
+	requireContainsAll(t, err.Error(), []string{
+		`unknown command "sete"; did you mean "set"?`,
+		"Usage: wtui plan phase set [flags]",
+	})
+}
+
 func TestRunPlanSaveFromStdinPrintsPlanID(t *testing.T) {
 	root := t.TempDir()
 	var stdout bytes.Buffer


### PR DESCRIPTION
## Summary
- add explicit help output for wtui top-level, plan, flow, flow phase, and relevant leaf commands
- add usage-aware command typo suggestions for top-level and nested plan/flow commands
- ensure help paths avoid config loading/repo scans, and validate flow create repo paths before store setup

Fixes #155.

## Verification
- go test ./cmd/wtui
- gofmt -l .
- make test
- make build
- git diff --check

## Review loop
- Ran review-loop with four reviewer passes; final reviewer score was 8/10
- Addressed reviewer findings around leaf --help behavior, help-as-value parsing, nested suggestions, and no-config help tests