### PR TITLE
Add high-level Flow phase commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,11 +307,21 @@ wtui flow read --flow-id "$FLOW_ID"
 # Link a saved plan artifact back to a flow.
 wtui flow plan set --flow-id "$FLOW_ID" --plan-id "$PLAN_ID"
 
-# Record Plan Review. approved_with_concerns, changes_requested, and blocked
-# require --notes. Implementation becomes ready only after approved review
-# outcomes, or after an explicit skipped-with-notes Plan Review override.
+# Record common phase outcomes without hand-assembling --status. These commands
+# print JSON with the updated phase and the next actionable phase state. For
+# Plan Review, complete defaults to approved, needs-attention defaults to
+# changes_requested, and block defaults to blocked unless --outcome is supplied.
+wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan --summary "Saved plan"
+wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review \
+  --notes "Revise the rollout section"
+wtui flow phase block --flow-id "$FLOW_ID" --phase-id implementation \
+  --notes "Waiting on review"
+
+# The lower-level phase set command remains available for explicit status,
+# outcome, summary, and notes updates. approved_with_concerns,
+# changes_requested, and blocked Plan Review outcomes require --notes.
 wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan-review \
-  --status completed --outcome approved
+  --status completed --outcome approved_with_concerns --notes "Watch rollout risk"
 
 # Split Implementation into ordered child phases. Re-running the same command
 # updates the stable child phase without duplicating it.

--- a/agent-skills/skill_docs_test.go
+++ b/agent-skills/skill_docs_test.go
@@ -19,6 +19,9 @@ func TestWtuiFlowSkillDocumentsAgentContract(t *testing.T) {
 	})
 	requireContainsAll(t, "flow commands", skill, []string{
 		"wtui flow read --flow-id",
+		"wtui flow phase complete",
+		"wtui flow phase block",
+		"wtui flow phase needs-attention",
 		"wtui flow phase set",
 		"wtui flow plan set",
 		"wtui flow pr set",
@@ -61,6 +64,15 @@ func TestWtuiFlowSkillMatchesImplementedFlowCLIContract(t *testing.T) {
 
 	if !strings.Contains(skill, "wtui flow phase set") || !strings.Contains(flowCLI, "runFlowPhaseSet") {
 		t.Fatal("skill and CLI should both expose flow phase set")
+	}
+	if !strings.Contains(skill, "wtui flow phase complete") || !strings.Contains(flowCLI, `command:        "complete"`) {
+		t.Fatal("skill and CLI should both expose flow phase complete")
+	}
+	if !strings.Contains(skill, "wtui flow phase block") || !strings.Contains(flowCLI, `command:        "block"`) {
+		t.Fatal("skill and CLI should both expose flow phase block")
+	}
+	if !strings.Contains(skill, "wtui flow phase needs-attention") || !strings.Contains(flowCLI, `command:        "needs-attention"`) {
+		t.Fatal("skill and CLI should both expose flow phase needs-attention")
 	}
 	if !strings.Contains(skill, "wtui flow plan set") || !strings.Contains(flowCLI, "runFlowPlanSet") {
 		t.Fatal("skill and CLI should both expose flow plan set")
@@ -190,9 +202,9 @@ func TestWtuiFlowSkillDocumentsPlanReviewGateOutcomes(t *testing.T) {
 		"changes_requested",
 		"blocked",
 		"wtui derives all phase readiness",
-		`--status needs_attention --outcome "changes_requested"`,
-		`--status completed --outcome "approved_with_concerns" --notes "..."`,
-		`--status blocked --outcome "blocked" --notes "..."`,
+		`wtui flow phase needs-attention --notes "..."`,
+		`wtui flow phase complete --outcome "approved_with_concerns" --notes "..."`,
+		`wtui flow phase block --notes "..."`,
 	})
 }
 

--- a/agent-skills/wtui-flow/SKILL.md
+++ b/agent-skills/wtui-flow/SKILL.md
@@ -39,28 +39,39 @@ Also use the launch metadata when present: `WTUI_FLOW_PHASE_ID`,
 Agent-facing phase statuses are `running`, `needs_attention`, `completed`,
 `blocked`, and `skipped`. Report only the status of your own phase honestly;
 wtui derives all phase readiness and ordering, so never reason about which
-phase becomes ready next. Agents cannot set `ready`. Skipped phases require
-`--notes`, and restarting a blocked or needs-attention phase as `running`
-requires `--notes`. Invalid transitions fail with the allowed next statuses;
-fix the reported state rather than retrying blindly.
+phase becomes ready next. It is fine to read the `next_phase` field returned by
+the high-level phase action commands; do not infer that state yourself. Agents
+cannot set `ready`. Skipped phases require `--notes`, and restarting a blocked
+or needs-attention phase as `running` requires `--notes`. Invalid transitions
+fail with the allowed next statuses; fix the reported state rather than
+retrying blindly.
 
 For the `plan-review` phase, wtui accepts only these review outcomes:
 `approved`, `approved_with_concerns`, `changes_requested`, and `blocked`.
 `approved_with_concerns`, `changes_requested`, and `blocked` require
 `--notes`.
 
-Use the current implemented phase update command:
+Prefer the high-level phase action commands for common outcomes. They use the
+same validation as `phase set`, persist the update, and print JSON with the
+updated phase plus the next actionable phase state:
 
 ```bash
-wtui flow phase set \
+wtui flow phase complete \
   --flow-id "$WTUI_FLOW_ID" \
   --phase-id "$WTUI_FLOW_PHASE_ID" \
-  --status completed \
-  --outcome "approved" \
-  --summary "What changed and where the next phase should begin." \
+  --summary "What changed in this phase." \
   --notes "Optional audit notes." \
   "${FLOW_STATE_ARGS[@]}"
 ```
+
+Use `wtui flow phase block --notes "..."` for blockers and
+`wtui flow phase needs-attention --notes "..."` for non-blocking concerns.
+For Plan Review only, those wrappers fill default outcomes when omitted:
+`complete` => `approved`, `needs-attention` => `changes_requested`, and
+`block` => `blocked`. The `complete` wrapper can still take an explicit
+Plan Review outcome such as `approved_with_concerns`. Use the lower-level
+`wtui flow phase set` command for `running`, `skipped`, restarts, or other
+explicit status updates.
 
 ## Persistence Failures
 
@@ -69,10 +80,11 @@ the user. These persistence failures must not be treated as successful phase
 progression. Do not say a phase advanced, a plan was saved, a PR was recorded,
 or a merge was recorded unless the corresponding command succeeded.
 
-The current Flow CLI exposes `create`, `list`, `read`, `phase set`,
-`phase add-child`, `plan set`, `pr set`, and `merge set`. Record merge metadata
-with `wtui flow merge set`; do not claim a merge was recorded unless that
-structured command succeeds.
+The current Flow CLI exposes `create`, `list`, `read`, `phase complete`,
+`phase block`, `phase needs-attention`, `phase set`, `phase add-child`,
+`plan set`, `pr set`, and `merge set`. Record merge metadata with
+`wtui flow merge set`; do not claim a merge was recorded unless that structured
+command succeeds.
 
 ## Plan Phase
 
@@ -82,7 +94,8 @@ Goal: produce a saved wtui plan artifact.
 2. Save or update the plan through `wtui plan save`.
 3. Link the saved plan artifact back to the Flow with `wtui flow plan set`.
 4. Record plan progress with `wtui plan phase set` when the plan has phases.
-5. Complete or block the Flow phase with `wtui flow phase set`.
+5. Complete or block the Flow phase with `wtui flow phase complete` or
+   `wtui flow phase block`.
 
 ```bash
 if ! PLAN_ID=$(printf '%s' "$PLAN_MARKDOWN" | wtui plan save \
@@ -144,10 +157,9 @@ if ! wtui plan read --plan-id "$PLAN_ID" "${PLAN_STATE_ARGS[@]}" >/dev/null; the
   exit 1
 fi
 
-wtui flow phase set \
+wtui flow phase complete \
   --flow-id "$WTUI_FLOW_ID" \
   --phase-id plan \
-  --status completed \
   --outcome "plan_saved" \
   --summary "Saved and linked plan $PLAN_ID." \
   "${FLOW_STATE_ARGS[@]}"
@@ -209,21 +221,20 @@ if ! wtui plan read --plan-id "$WTUI_PLAN_ID" "${PLAN_STATE_ARGS[@]}" >/dev/null
   exit 1
 fi
 
-wtui flow phase set \
+wtui flow phase complete \
   --flow-id "$WTUI_FLOW_ID" \
   --phase-id plan-review \
-  --status completed \
-  --outcome "approved" \
   --summary "Plan is ready for implementation." \
   "${FLOW_STATE_ARGS[@]}"
 ```
 
-Use `--status needs_attention --outcome "changes_requested"` when the plan
-needs revision; include `--notes` explaining the required changes. Use
-`--status completed --outcome "approved_with_concerns" --notes "..."` when
-implementation may proceed but should carry the noted concern forward. Use
-`--status blocked --outcome "blocked" --notes "..."` when human input, missing
-plan context, or an external dependency prevents review.
+Use `wtui flow phase needs-attention --notes "..."` when the plan needs
+revision; the Plan Review outcome defaults to `changes_requested`. Use
+`wtui flow phase complete --outcome "approved_with_concerns" --notes "..."`
+when implementation may proceed but should carry the noted concern forward. Use
+`wtui flow phase block --notes "..."` when human input, missing plan context,
+or an external dependency prevents review; the Plan Review outcome defaults to
+`blocked`.
 
 ## Implementation Phase
 

--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -56,7 +56,11 @@ Commands:
   create           Create a Flow; prints JSON when --json is present.
   list             List Flows as JSON.
   read             Print one Flow record as JSON.
-  phase set        Advance a Flow phase.
+  phase complete   Mark a Flow phase completed.
+  phase block      Mark a Flow phase blocked.
+  phase needs-attention
+                   Mark a Flow phase as needing attention.
+  phase set        Advance a Flow phase with explicit status.
   phase add-child  Add or update an implementation child phase.
   plan set         Link a saved plan artifact to a Flow.
   pr set           Record pull request metadata.
@@ -65,6 +69,9 @@ Commands:
 Examples:
   wtui flow create --title "Ship saved plans" --instructions "Build it" --repo-path "$REPO" --json
   wtui flow read --flow-id "$FLOW_ID"
+  wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan --summary "Saved plan"
+  wtui flow phase block --flow-id "$FLOW_ID" --phase-id implementation --notes "Waiting on review"
+  wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review --notes "Revise scope"
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan --status completed --summary "Plan saved"
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan-review --status completed --outcome approved
   wtui flow pr set --flow-id "$FLOW_ID" --provider github --number 155 --url "$PR_URL" --head "$BRANCH" --base main
@@ -278,15 +285,36 @@ func runFlowPhase(args []string, deps runDeps) error {
 		return nil
 	}
 	if len(args) < 1 {
-		return fmt.Errorf("usage: wtui flow phase <set|add-child> [flags]")
+		return fmt.Errorf("usage: wtui flow phase <set|complete|block|needs-attention|add-child> [flags]")
 	}
 	switch args[0] {
 	case "set":
 		return runFlowPhaseSet(args[1:], deps)
+	case "complete":
+		return runFlowPhaseAction(args[1:], deps, flowPhaseActionSpec{
+			command:        "complete",
+			status:         flowstore.PhaseCompleted,
+			defaultOutcome: flowstore.OutcomeApproved,
+			printHelp:      printFlowPhaseCompleteHelp,
+		})
+	case "block":
+		return runFlowPhaseAction(args[1:], deps, flowPhaseActionSpec{
+			command:        "block",
+			status:         flowstore.PhaseBlocked,
+			defaultOutcome: flowstore.OutcomeBlocked,
+			printHelp:      printFlowPhaseBlockHelp,
+		})
+	case "needs-attention":
+		return runFlowPhaseAction(args[1:], deps, flowPhaseActionSpec{
+			command:        "needs-attention",
+			status:         flowstore.PhaseNeedsAttention,
+			defaultOutcome: flowstore.OutcomeChangesRequested,
+			printHelp:      printFlowPhaseNeedsAttentionHelp,
+		})
 	case "add-child":
 		return runFlowPhaseAddChild(args[1:], deps)
 	default:
-		return unknownCommandError(args[0], []string{"set", "add-child"}, flowPhaseHelpText)
+		return unknownCommandError(args[0], []string{"set", "complete", "block", "needs-attention", "add-child"}, flowPhaseHelpText)
 	}
 }
 
@@ -294,24 +322,52 @@ func printFlowPhaseHelp(w io.Writer) {
 	io.WriteString(w, flowPhaseHelpText)
 }
 
-const flowPhaseHelpText = `Usage: wtui flow phase <set|add-child> [flags]
+const flowPhaseHelpText = `Usage: wtui flow phase <set|complete|block|needs-attention|add-child> [flags]
 
 Update Flow phase state. Readiness is derived by wtui; agents set running,
 completed, needs_attention, blocked, or skipped.
 
 Commands:
-  set        Set a phase status, outcome, summary, or notes.
-  add-child  Add or update an implementation child phase.
+  set              Set a phase status, outcome, summary, or notes.
+  complete         Mark a phase completed and print the next actionable phase.
+  block            Mark a phase blocked.
+  needs-attention  Mark a phase as needing attention.
+  add-child        Add or update an implementation child phase.
 
 Examples:
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan --status completed --summary "Saved plan"
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan-review --status completed --outcome approved
+  wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan --summary "Saved plan"
+  wtui flow phase block --flow-id "$FLOW_ID" --phase-id implementation --notes "Waiting on review"
+  wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review --outcome changes_requested --notes "Revise scope"
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id implementation --status blocked --notes "Waiting on review"
   wtui flow phase add-child --flow-id "$FLOW_ID" --parent-phase-id implementation --phase-id api --title "API work" --order 1
 
 Common flags:
   --state-root PATH  Override the artifact state root.
 `
+
+type flowPhaseActionSpec struct {
+	command        string
+	status         string
+	defaultOutcome string
+	printHelp      func(io.Writer)
+}
+
+type flowPhaseActionResult struct {
+	FlowID       string                `json:"flow_id"`
+	FlowStatus   string                `json:"flow_status"`
+	UpdatedPhase flowstore.FlowPhase   `json:"updated_phase"`
+	NextPhase    *flowPhaseActionState `json:"next_phase,omitempty"`
+	Flow         flowstore.FlowRecord  `json:"flow"`
+}
+
+type flowPhaseActionState struct {
+	PhaseID         string   `json:"phase_id"`
+	Title           string   `json:"title"`
+	Status          string   `json:"status"`
+	AllowedStatuses []string `json:"allowed_statuses,omitempty"`
+}
 
 func runFlowPhaseSet(args []string, deps runDeps) error {
 	flags := flag.NewFlagSet("flow phase set", flag.ContinueOnError)
@@ -386,6 +442,169 @@ Examples:
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan --status completed --summary "Saved plan"
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan-review --status completed --outcome approved
 `)
+}
+
+func runFlowPhaseAction(args []string, deps runDeps, spec flowPhaseActionSpec) error {
+	flags := flag.NewFlagSet("flow phase "+spec.command, flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.Usage = func() { spec.printHelp(deps.stdout) }
+	flowID := flags.String("flow-id", "", "flow id")
+	phaseID := flags.String("phase-id", "", "phase id")
+	outcome := flags.String("outcome", "", "phase outcome")
+	summary := flags.String("summary", "", "phase summary")
+	notes := flags.String("notes", "", "phase notes")
+	stateRoot := flags.String("state-root", "", "artifact state root")
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
+		return err
+	}
+	if *flowID == "" {
+		return fmt.Errorf("flow phase %s requires --flow-id", spec.command)
+	}
+	if *phaseID == "" {
+		return fmt.Errorf("flow phase %s requires --phase-id", spec.command)
+	}
+	actionOutcome := strings.TrimSpace(*outcome)
+	if actionOutcome == "" && normalizeFlowPhaseID(*phaseID) == "plan-review" {
+		actionOutcome = spec.defaultOutcome
+	}
+	store, err := newFlowStore(*stateRoot, deps)
+	if err != nil {
+		return err
+	}
+	record, err := store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  *flowID,
+		PhaseID: *phaseID,
+		Status:  spec.status,
+		Outcome: actionOutcome,
+		Notes:   *notes,
+		Summary: *summary,
+	})
+	if err != nil {
+		return err
+	}
+	updated, ok := flowPhaseByID(record, *phaseID)
+	if !ok {
+		return fmt.Errorf("phase %q not found in updated flow %q", *phaseID, *flowID)
+	}
+	return writeFlowJSON(deps.stdout, flowPhaseActionResult{
+		FlowID:       record.FlowID,
+		FlowStatus:   record.Status,
+		UpdatedPhase: updated,
+		NextPhase:    nextFlowPhaseActionState(record, updated),
+		Flow:         record,
+	})
+}
+
+func printFlowPhaseCompleteHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow phase complete [flags]
+
+Mark a Flow phase completed and print the next actionable phase state.
+
+Required flags:
+  --flow-id FLOW_ID
+  --phase-id PHASE_ID
+
+Common flags:
+  --outcome OUTCOME
+  --summary TEXT
+  --notes TEXT
+  --state-root PATH
+
+Examples:
+  wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan --summary "Saved plan"
+  wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan-review --outcome approved
+`)
+}
+
+func printFlowPhaseBlockHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow phase block [flags]
+
+Mark a Flow phase blocked and print the next actionable phase state.
+Notes may be required by phase rules.
+
+Required flags:
+  --flow-id FLOW_ID
+  --phase-id PHASE_ID
+
+Common flags:
+  --outcome OUTCOME
+  --summary TEXT
+  --notes TEXT
+  --state-root PATH
+
+Examples:
+  wtui flow phase block --flow-id "$FLOW_ID" --phase-id implementation --notes "Waiting on review"
+  wtui flow phase block --flow-id "$FLOW_ID" --phase-id plan-review --outcome blocked --notes "Waiting on product"
+`)
+}
+
+func printFlowPhaseNeedsAttentionHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow phase needs-attention [flags]
+
+Mark a Flow phase as needing attention and print the next actionable phase state.
+Notes may be required by phase rules.
+
+Required flags:
+  --flow-id FLOW_ID
+  --phase-id PHASE_ID
+
+Common flags:
+  --outcome OUTCOME
+  --summary TEXT
+  --notes TEXT
+  --state-root PATH
+
+Examples:
+  wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id implementation --notes "Tests need revision"
+  wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review --outcome changes_requested --notes "Revise scope"
+`)
+}
+
+func nextFlowPhaseActionState(record flowstore.FlowRecord, updated flowstore.FlowPhase) *flowPhaseActionState {
+	if flowPhaseIsActionable(updated) && updated.Status != flowstore.PhaseCompleted && updated.Status != flowstore.PhaseSkipped {
+		return newFlowPhaseActionState(updated)
+	}
+	for _, phase := range flowstore.OrderedPhases(record.Phases) {
+		if flowPhaseIsActionable(phase) {
+			return newFlowPhaseActionState(phase)
+		}
+	}
+	return nil
+}
+
+func flowPhaseIsActionable(phase flowstore.FlowPhase) bool {
+	switch phase.Status {
+	case flowstore.PhaseReady, flowstore.PhaseRunning, flowstore.PhaseNeedsAttention, flowstore.PhaseBlocked:
+		return true
+	default:
+		return false
+	}
+}
+
+func newFlowPhaseActionState(phase flowstore.FlowPhase) *flowPhaseActionState {
+	return &flowPhaseActionState{
+		PhaseID:         phase.PhaseID,
+		Title:           phase.Title,
+		Status:          phase.Status,
+		AllowedStatuses: flowstore.AllowedNextPhaseStatuses(phase.Status),
+	}
+}
+
+func flowPhaseByID(record flowstore.FlowRecord, phaseID string) (flowstore.FlowPhase, bool) {
+	normalized := normalizeFlowPhaseID(phaseID)
+	for _, phase := range record.Phases {
+		if normalizeFlowPhaseID(phase.PhaseID) == normalized {
+			return phase, true
+		}
+	}
+	return flowstore.FlowPhase{}, false
+}
+
+func normalizeFlowPhaseID(phaseID string) string {
+	return strings.ToLower(strings.TrimSpace(phaseID))
 }
 
 func runFlowPhaseAddChild(args []string, deps runDeps) error {

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -29,6 +29,9 @@ func TestRunFlowHelpPrintsUsageAndExamples(t *testing.T) {
 	requireContainsAll(t, stdout.String(), []string{
 		"Usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]",
 		"wtui flow read --flow-id",
+		"wtui flow phase complete --flow-id",
+		"wtui flow phase block --flow-id",
+		"wtui flow phase needs-attention --flow-id",
 		"wtui flow phase set --flow-id",
 		"wtui flow pr set --flow-id",
 		"wtui flow merge set --flow-id",
@@ -48,11 +51,74 @@ func TestRunFlowPhaseHelpPrintsUsageAndExamples(t *testing.T) {
 		t.Fatalf("run returned error: %v", err)
 	}
 	requireContainsAll(t, stdout.String(), []string{
-		"Usage: wtui flow phase <set|add-child> [flags]",
+		"Usage: wtui flow phase <set|complete|block|needs-attention|add-child> [flags]",
 		"wtui flow phase set --flow-id",
+		"wtui flow phase complete --flow-id",
+		"wtui flow phase block --flow-id",
+		"wtui flow phase needs-attention --flow-id",
 		"--status completed",
 		"wtui flow phase add-child --flow-id",
 	})
+}
+
+func TestRunFlowPhaseActionHelpPrintsExamplesWithoutLoadingConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		args  []string
+		wants []string
+	}{
+		{
+			name: "complete",
+			args: []string{"wtui", "flow", "phase", "complete", "--help"},
+			wants: []string{
+				"Usage: wtui flow phase complete [flags]",
+				"--flow-id FLOW_ID",
+				"--phase-id PHASE_ID",
+				"--outcome OUTCOME",
+				`wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan`,
+			},
+		},
+		{
+			name: "block",
+			args: []string{"wtui", "flow", "phase", "block", "--help"},
+			wants: []string{
+				"Usage: wtui flow phase block [flags]",
+				"--flow-id FLOW_ID",
+				"--phase-id PHASE_ID",
+				"--notes TEXT",
+				`wtui flow phase block --flow-id "$FLOW_ID" --phase-id implementation --notes "Waiting on review"`,
+			},
+		},
+		{
+			name: "needs-attention",
+			args: []string{"wtui", "flow", "phase", "needs-attention", "--help"},
+			wants: []string{
+				"Usage: wtui flow phase needs-attention [flags]",
+				"--flow-id FLOW_ID",
+				"--phase-id PHASE_ID",
+				"--notes TEXT",
+				`wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review --outcome changes_requested`,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			err := run(tc.args, noScanDeps(t, runDeps{
+				loadConfig: func() (config.Config, error) {
+					t.Fatal("loadConfig should not run for flow phase action help")
+					return config.Config{}, nil
+				},
+				stdout: &stdout,
+			}))
+			if err != nil {
+				t.Fatalf("run returned error: %v", err)
+			}
+			if strings.Contains(stdout.String(), "flag: help requested") {
+				t.Fatalf("help output should not contain flag error:\n%s", stdout.String())
+			}
+			requireContainsAll(t, stdout.String(), tc.wants)
+		})
+	}
 }
 
 func TestRunFlowPhaseSetHelpPrintsUsageWithoutLoadingConfig(t *testing.T) {
@@ -212,7 +278,7 @@ func TestRunFlowPhaseUnknownSubcommandSuggestsNearbyCommand(t *testing.T) {
 	}
 	requireContainsAll(t, err.Error(), []string{
 		`unknown command "ste"; did you mean "set"?`,
-		"Usage: wtui flow phase <set|add-child> [flags]",
+		"Usage: wtui flow phase <set|complete|block|needs-attention|add-child> [flags]",
 	})
 }
 
@@ -751,6 +817,244 @@ func TestRunFlowPhaseSetImplementationOutcomesAfterApprovedReview(t *testing.T) 
 			}
 			if phaseByID(updated, "review-loop").Status != tc.wantReviewStatus {
 				t.Fatalf("review-loop status = %q, want %q", phaseByID(updated, "review-loop").Status, tc.wantReviewStatus)
+			}
+		})
+	}
+}
+
+func TestRunFlowPhaseActionCompletePrintsNextActionablePhase(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	created := mustRunFlow(t, []string{"wtui", "flow", "create", "--title", "Action Complete", "--instructions", "phase it", "--repo-path", repoPath, "--json", "--state-root", root})
+
+	var stdout bytes.Buffer
+	err := run([]string{
+		"wtui", "flow", "phase", "complete",
+		"--flow-id", created.FlowID,
+		"--phase-id", "plan",
+		"--summary", "Saved the implementation plan.",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: &stdout}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	var result flowPhaseActionResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("output is not JSON action result: %v\n%s", err, stdout.String())
+	}
+	if result.FlowID != created.FlowID || result.FlowStatus != flowstore.StatusInProgress {
+		t.Fatalf("result flow state = %#v", result)
+	}
+	if result.UpdatedPhase.PhaseID != "plan" ||
+		result.UpdatedPhase.Status != flowstore.PhaseCompleted ||
+		result.UpdatedPhase.Summary != "Saved the implementation plan." {
+		t.Fatalf("updated phase = %#v", result.UpdatedPhase)
+	}
+	if result.NextPhase == nil {
+		t.Fatal("next phase is nil, want plan-review")
+	}
+	if result.NextPhase.PhaseID != "plan-review" || result.NextPhase.Status != flowstore.PhaseReady {
+		t.Fatalf("next phase = %#v, want ready plan-review", result.NextPhase)
+	}
+	if strings.Join(result.NextPhase.AllowedStatuses, ",") != strings.Join(flowstore.AllowedNextPhaseStatuses(flowstore.PhaseReady), ",") {
+		t.Fatalf("next phase allowed statuses = %#v", result.NextPhase.AllowedStatuses)
+	}
+	if phaseByID(result.Flow, "plan-review").Status != flowstore.PhaseReady {
+		t.Fatalf("embedded flow plan-review = %#v", phaseByID(result.Flow, "plan-review"))
+	}
+}
+
+func TestRunFlowPhaseActionsMapToCanonicalStatuses(t *testing.T) {
+	root := t.TempDir()
+	for _, tc := range []struct {
+		name       string
+		command    string
+		wantStatus string
+		notes      string
+	}{
+		{name: "block with notes", command: "block", wantStatus: flowstore.PhaseBlocked, notes: "Waiting on reviewer input."},
+		{name: "block without notes", command: "block", wantStatus: flowstore.PhaseBlocked},
+		{name: "needs attention with notes", command: "needs-attention", wantStatus: flowstore.PhaseNeedsAttention, notes: "Revise the generated plan."},
+		{name: "needs attention without notes", command: "needs-attention", wantStatus: flowstore.PhaseNeedsAttention},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repoPath := filepath.Join(root, "repo-"+strings.ReplaceAll(tc.name, " ", "-"))
+			created := mustRunFlow(t, []string{"wtui", "flow", "create", "--title", tc.name, "--instructions", "phase it", "--repo-path", repoPath, "--json", "--state-root", root})
+
+			args := []string{
+				"wtui", "flow", "phase", tc.command,
+				"--flow-id", created.FlowID,
+				"--phase-id", "plan",
+				"--state-root", root,
+			}
+			if tc.notes != "" {
+				args = append(args, "--notes", tc.notes)
+			}
+			var stdout bytes.Buffer
+			err := run(args, noScanDeps(t, runDeps{stdout: &stdout}))
+			if err != nil {
+				t.Fatalf("run returned error: %v", err)
+			}
+
+			var result flowPhaseActionResult
+			if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+				t.Fatalf("output is not JSON action result: %v\n%s", err, stdout.String())
+			}
+			if result.UpdatedPhase.Status != tc.wantStatus || result.UpdatedPhase.Notes != tc.notes {
+				t.Fatalf("updated phase = %#v", result.UpdatedPhase)
+			}
+			if result.NextPhase == nil || result.NextPhase.PhaseID != "plan" || result.NextPhase.Status != tc.wantStatus {
+				t.Fatalf("next phase = %#v, want current phase still actionable", result.NextPhase)
+			}
+			if strings.Join(result.NextPhase.AllowedStatuses, ",") != strings.Join(flowstore.AllowedNextPhaseStatuses(tc.wantStatus), ",") {
+				t.Fatalf("next phase allowed statuses = %#v", result.NextPhase.AllowedStatuses)
+			}
+		})
+	}
+}
+
+func TestRunFlowPhaseActionsDefaultPlanReviewOutcomes(t *testing.T) {
+	root := t.TempDir()
+	for _, tc := range []struct {
+		name        string
+		command     string
+		outcome     string
+		wantStatus  string
+		wantOutcome string
+		notes       string
+	}{
+		{name: "complete", command: "complete", wantStatus: flowstore.PhaseCompleted, wantOutcome: flowstore.OutcomeApproved},
+		{name: "complete with concerns", command: "complete", outcome: flowstore.OutcomeApprovedWithConcerns, wantStatus: flowstore.PhaseCompleted, wantOutcome: flowstore.OutcomeApprovedWithConcerns, notes: "Proceed, but keep rollout staged."},
+		{name: "block", command: "block", wantStatus: flowstore.PhaseBlocked, wantOutcome: flowstore.OutcomeBlocked, notes: "Waiting on a product decision."},
+		{name: "needs attention", command: "needs-attention", wantStatus: flowstore.PhaseNeedsAttention, wantOutcome: flowstore.OutcomeChangesRequested, notes: "Revise the plan."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repoPath := filepath.Join(root, "repo-plan-review-"+strings.ReplaceAll(tc.name, " ", "-"))
+			created := mustRunFlow(t, []string{"wtui", "flow", "create", "--title", tc.name, "--instructions", "phase it", "--repo-path", repoPath, "--json", "--state-root", root})
+			mustSetFlowPhase(t, root, created.FlowID, "plan", flowstore.PhaseCompleted, "", "", "")
+
+			args := []string{
+				"wtui", "flow", "phase", tc.command,
+				"--flow-id", created.FlowID,
+				"--phase-id", "plan-review",
+				"--state-root", root,
+			}
+			if tc.outcome != "" {
+				args = append(args, "--outcome", tc.outcome)
+			}
+			if tc.notes != "" {
+				args = append(args, "--notes", tc.notes)
+			}
+			var stdout bytes.Buffer
+			err := run(args, noScanDeps(t, runDeps{stdout: &stdout}))
+			if err != nil {
+				t.Fatalf("run returned error: %v", err)
+			}
+
+			var result flowPhaseActionResult
+			if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+				t.Fatalf("output is not JSON action result: %v\n%s", err, stdout.String())
+			}
+			review := result.UpdatedPhase
+			if review.Status != tc.wantStatus || review.Outcome != tc.wantOutcome {
+				t.Fatalf("plan-review = %#v, want status %q outcome %q", review, tc.wantStatus, tc.wantOutcome)
+			}
+		})
+	}
+}
+
+func TestRunFlowPhaseActionRejectsInvalidTransitionAndKeepsRecordUnchanged(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	created := mustRunFlow(t, []string{"wtui", "flow", "create", "--title", "Invalid Action", "--instructions", "phase it", "--repo-path", repoPath, "--json", "--state-root", root})
+
+	err := run([]string{
+		"wtui", "flow", "phase", "complete",
+		"--flow-id", created.FlowID,
+		"--phase-id", "plan-review",
+		"--outcome", flowstore.OutcomeApproved,
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
+	if err == nil || !strings.Contains(err.Error(), "invalid phase transition pending -> completed") {
+		t.Fatalf("run error = %v, want invalid transition", err)
+	}
+
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	read, err := store.Read(created.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if phaseByID(read, "plan-review").Status != flowstore.PhasePending {
+		t.Fatalf("plan-review status after rejected action = %q, want pending", phaseByID(read, "plan-review").Status)
+	}
+}
+
+func TestRunFlowPhaseActionsRejectInvalidPlanReviewOutcomes(t *testing.T) {
+	root := t.TempDir()
+	for _, tc := range []struct {
+		name    string
+		command string
+		outcome string
+		notes   string
+		want    string
+	}{
+		{
+			name:    "complete changes requested",
+			command: "complete",
+			outcome: flowstore.OutcomeChangesRequested,
+			notes:   "Revise the plan.",
+			want:    "plan-review outcome changes_requested requires needs_attention status",
+		},
+		{
+			name:    "complete approved with concerns missing notes",
+			command: "complete",
+			outcome: flowstore.OutcomeApprovedWithConcerns,
+			want:    "plan-review approved_with_concerns requires notes",
+		},
+		{
+			name:    "needs attention approved",
+			command: "needs-attention",
+			outcome: flowstore.OutcomeApproved,
+			notes:   "Looks good.",
+			want:    "plan-review outcome approved requires completed status",
+		},
+		{
+			name:    "block approved",
+			command: "block",
+			outcome: flowstore.OutcomeApproved,
+			notes:   "Waiting.",
+			want:    "plan-review blocked requires outcome blocked",
+		},
+		{
+			name:    "needs attention missing notes",
+			command: "needs-attention",
+			want:    "plan-review changes_requested requires notes",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repoPath := filepath.Join(root, "repo-invalid-plan-review-"+strings.ReplaceAll(tc.name, " ", "-"))
+			created := mustRunFlow(t, []string{"wtui", "flow", "create", "--title", tc.name, "--instructions", "phase it", "--repo-path", repoPath, "--json", "--state-root", root})
+			mustSetFlowPhase(t, root, created.FlowID, "plan", flowstore.PhaseCompleted, "", "", "")
+
+			args := []string{
+				"wtui", "flow", "phase", tc.command,
+				"--flow-id", created.FlowID,
+				"--phase-id", "plan-review",
+				"--state-root", root,
+			}
+			if tc.outcome != "" {
+				args = append(args, "--outcome", tc.outcome)
+			}
+			if tc.notes != "" {
+				args = append(args, "--notes", tc.notes)
+			}
+			err := run(args, noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("run error = %v, want %q", err, tc.want)
 			}
 		})
 	}

--- a/docs/config.md
+++ b/docs/config.md
@@ -270,6 +270,12 @@ wtui flow create --title "Ship saved plans" \
 
 wtui flow list [--repo-path PATH] [--state-root PATH] --json
 wtui flow read --flow-id ID [--state-root PATH]
+wtui flow phase complete --flow-id ID --phase-id ID \
+    [--outcome OUTCOME] [--summary TEXT] [--notes TEXT] [--state-root PATH]
+wtui flow phase block --flow-id ID --phase-id ID \
+    [--outcome OUTCOME] [--summary TEXT] [--notes TEXT] [--state-root PATH]
+wtui flow phase needs-attention --flow-id ID --phase-id ID \
+    [--outcome OUTCOME] [--summary TEXT] [--notes TEXT] [--state-root PATH]
 wtui flow phase set --flow-id ID --phase-id ID --status STATUS \
     [--outcome OUTCOME] [--summary TEXT] [--notes TEXT] [--state-root PATH]
 wtui flow phase add-child --flow-id ID --parent-phase-id implementation \
@@ -308,6 +314,16 @@ The Plan Review phase gates Implementation. Plan Review completion must use
 --notes ...` for missing inputs or external blockers. Implementation becomes
 ready only after approved Plan Review outcomes, or after an explicit
 skipped-with-notes Plan Review override.
+
+For common phase outcomes, `wtui flow phase complete`, `wtui flow phase block`,
+and `wtui flow phase needs-attention` wrap the same validation and persistence
+as `phase set`, then print JSON containing the updated phase, the next
+actionable phase state, and allowed statuses for that next action. Notes
+requirements are still enforced by the same store rules as `phase set`. Plan
+Review wrappers fill the unambiguous outcomes when omitted: `complete` uses
+`approved`, `block` uses `blocked`, and `needs-attention` uses
+`changes_requested`. Use `phase set` when a phase needs an explicit uncommon
+status, a skipped-with-notes override, or an explicit restart.
 
 Implementation can be split into ordered child phases with
 `wtui flow phase add-child`. Child phase IDs are stable and normalized (trimmed

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -37,9 +37,15 @@ readiness, agents own honest reporting of their own phase.
 | `skipped` | agent | Phase intentionally bypassed (requires notes). |
 
 Agents may set only `running`, `needs_attention`, `completed`, `blocked`, and
-`skipped` through `wtui flow phase set`. Setting `ready` is rejected with
-"readiness is derived"; the CLI rejects unknown statuses with the valid list,
-and the store rejects them as `invalid phase status`.
+`skipped` through `wtui flow phase set`. The high-level wrappers
+`wtui flow phase complete`, `wtui flow phase block`, and
+`wtui flow phase needs-attention` use the same validation and persistence path
+for the common `completed`, `blocked`, and `needs_attention` outcomes, then
+print JSON with the updated phase and next actionable phase state. These
+wrappers do not add separate notes requirements; store validation remains the
+source of truth. Setting `ready` is rejected with "readiness is derived"; the
+CLI rejects unknown statuses with the valid list, and the store rejects them as
+`invalid phase status`.
 
 ## Canonical transition table
 
@@ -79,7 +85,9 @@ predecessor satisfies its downstream gate:
 - **Default gate**: the phase is `completed`, or `skipped` with notes.
 - **Plan Review**: `completed` with outcome `approved` or
   `approved_with_concerns`, or `skipped` with notes. Any other outcome keeps
-  Implementation `pending`.
+  Implementation `pending`. The high-level Plan Review wrappers fill the
+  unambiguous outcomes when omitted: `complete` uses `approved`,
+  `needs-attention` uses `changes_requested`, and `block` uses `blocked`.
 - **PR Creation**: `completed` *and* structured PR metadata recorded via
   `wtui flow pr set` (provider, positive number, valid URL, head/base
   branches). Completion alone does not unlock Autoreview; a skipped PR


### PR DESCRIPTION
## Summary
- Add `wtui flow phase complete`, `block`, and `needs-attention` wrappers that reuse canonical Flow phase validation.
- Return JSON action results with the updated phase, flow status, next actionable phase, allowed statuses, and full Flow record.
- Document the wrappers in CLI help, README/config/phase docs, and the wtui-flow agent skill.

## Tests
- `go test ./cmd/wtui ./agent-skills`
- `git diff --check`
- `gofmt -l .`
- `make test`
- `make build`

Closes #160