### PR TITLE
Simplify Autoreview recovery handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ CI requires clean `gofmt -l .`, `make test`, and `make build`.
 
 `wtui` is a Go Bubble Tea TUI for managing git worktrees across repositories. User-facing behavior, key bindings, and CLI examples are documented in `README.md`; config reference is `docs/config.md`; Flow phase semantics are `docs/flow-phases.md`.
 
-- `cmd/wtui/` — entrypoint. Handles `--version`, `session-hook --provider claude|codex`, and the `plan save|list|read|phase set` and `flow create|list|read|phase set|phase add-child|plan set|pr set|merge set` subcommands (`plan.go`, `flow.go`). Subcommands resolve the artifact root without scanning repos or starting the TUI.
+- `cmd/wtui/` — entrypoint. Handles `--version`, `session-hook --provider claude|codex`, and the `plan save|list|read|phase set` and `flow create|list|read|phase complete|phase block|phase needs-attention|phase restart|phase set|phase add-child|plan set|pr set|merge set` subcommands (`plan.go`, `flow.go`). Subcommands resolve the artifact root without scanning repos or starting the TUI.
 - `config/` — optional TOML from `$XDG_CONFIG_HOME/wtui/config.toml` or `~/.config/wtui/config.toml`. Missing config is non-fatal; an existing but unreadable or malformed config is startup-fatal.
 - `scanner/` — discovers repos under `WORKTREE_ROOT`, `[scan].root`, or `~/dev` (default depth 2, reducible via `[scan].max_depth`), excluding `*-worktrees`.
 - `gitquery/` — read-only git queries. `parse.go` is pure parsing; `runner.go` defines the `Runner` seam wrapped by a `Querier` (`NewQuerier` injects a fake `Runner` for tests).

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ wtui flow plan set --flow-id "$FLOW_ID" --plan-id "$PLAN_ID"
 # print JSON with the updated phase and the next actionable phase state. For
 # Plan Review, complete defaults to approved, needs-attention defaults to
 # changes_requested, and block defaults to blocked unless --outcome is supplied.
+# Autoreview defaults are passed, needs_attention, and blocked.
 wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan --summary "Saved plan"
 wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review \
   --notes "Revise the rollout section"
@@ -365,7 +366,17 @@ metadata needed to inspect the changes. Built-in prompts tell Plan to produce
 only a plan, Implementation to use the `commit` skill, Review Loop to use the
 review-loop workflow and `commit` when revisions are made, PR Creation to use
 the `ship` skill, and Autoreview to use `ship` when fixes require commits or
-pushes. Autoreview is ready only after PR Creation is complete and
+pushes without embedding phase-restart recipes. Use
+`wtui flow phase restart` to rerun a blocked or needs-attention phase as
+`running`; if notes are omitted, wtui records a standard rerun note.
+
+For example, after addressing Autoreview findings:
+
+```bash
+wtui flow phase restart --flow-id "$FLOW_ID" --phase-id autoreview
+```
+
+Autoreview is ready only after PR Creation is complete and
 `wtui flow pr set` has recorded provider, PR number, URL, head branch, and base
 branch metadata. Merge stays an explicit phase:
 agents must record both the Merge phase update and structured merge metadata

--- a/agent-skills/skill_docs_test.go
+++ b/agent-skills/skill_docs_test.go
@@ -22,6 +22,7 @@ func TestWtuiFlowSkillDocumentsAgentContract(t *testing.T) {
 		"wtui flow phase complete",
 		"wtui flow phase block",
 		"wtui flow phase needs-attention",
+		"wtui flow phase restart",
 		"wtui flow phase set",
 		"wtui flow plan set",
 		"wtui flow pr set",
@@ -73,6 +74,9 @@ func TestWtuiFlowSkillMatchesImplementedFlowCLIContract(t *testing.T) {
 	}
 	if !strings.Contains(skill, "wtui flow phase needs-attention") || !strings.Contains(flowCLI, `command:        "needs-attention"`) {
 		t.Fatal("skill and CLI should both expose flow phase needs-attention")
+	}
+	if !strings.Contains(skill, "wtui flow phase restart") || !strings.Contains(flowCLI, "runFlowPhaseRestart") {
+		t.Fatal("skill and CLI should both expose flow phase restart")
 	}
 	if !strings.Contains(skill, "wtui flow plan set") || !strings.Contains(flowCLI, "runFlowPlanSet") {
 		t.Fatal("skill and CLI should both expose flow plan set")

--- a/agent-skills/wtui-flow/SKILL.md
+++ b/agent-skills/wtui-flow/SKILL.md
@@ -42,9 +42,10 @@ wtui derives all phase readiness and ordering, so never reason about which
 phase becomes ready next. It is fine to read the `next_phase` field returned by
 the high-level phase action commands; do not infer that state yourself. Agents
 cannot set `ready`. Skipped phases require `--notes`, and restarting a blocked
-or needs-attention phase as `running` requires `--notes`. Invalid transitions
-fail with the allowed next statuses; fix the reported state rather than
-retrying blindly.
+or needs-attention phase as `running` requires a rerun note; prefer
+`wtui flow phase restart`, which supplies a standard note when `--notes` is
+omitted. Invalid transitions fail with the allowed next statuses; fix the
+reported state rather than retrying blindly.
 
 For the `plan-review` phase, wtui accepts only these review outcomes:
 `approved`, `approved_with_concerns`, `changes_requested`, and `blocked`.
@@ -66,12 +67,14 @@ wtui flow phase complete \
 
 Use `wtui flow phase block --notes "..."` for blockers and
 `wtui flow phase needs-attention --notes "..."` for non-blocking concerns.
-For Plan Review only, those wrappers fill default outcomes when omitted:
+For Plan Review, those wrappers fill default outcomes when omitted:
 `complete` => `approved`, `needs-attention` => `changes_requested`, and
 `block` => `blocked`. The `complete` wrapper can still take an explicit
-Plan Review outcome such as `approved_with_concerns`. Use the lower-level
-`wtui flow phase set` command for `running`, `skipped`, restarts, or other
-explicit status updates.
+Plan Review outcome such as `approved_with_concerns`. For Autoreview, the
+wrappers fill `complete` => `passed`, `needs-attention` =>
+`needs_attention`, and `block` => `blocked`. Use `wtui flow phase restart`
+for reruns, and use the lower-level `wtui flow phase set` command for
+`skipped` or other explicit status updates.
 
 ## Persistence Failures
 
@@ -81,7 +84,8 @@ progression. Do not say a phase advanced, a plan was saved, a PR was recorded,
 or a merge was recorded unless the corresponding command succeeded.
 
 The current Flow CLI exposes `create`, `list`, `read`, `phase complete`,
-`phase block`, `phase needs-attention`, `phase set`, `phase add-child`,
+`phase block`, `phase needs-attention`, `phase restart`, `phase set`,
+`phase add-child`,
 `plan set`, `pr set`, and `merge set`. Record merge metadata with
 `wtui flow merge set`; do not claim a merge was recorded unless that structured
 command succeeds.
@@ -341,24 +345,20 @@ not exist or cannot be recovered, rerun PR Creation as `running` with notes and
 then mark PR Creation `blocked` with notes.
 
 If Autoreview is already `needs_attention` or `blocked`, do not mark it
-`completed` directly. First restart the phase as `running` with notes, then
+`completed` directly. First restart the phase as `running`, then
 complete it after the rerun succeeds:
 
 ```bash
-wtui flow phase set \
+wtui flow phase restart \
   --flow-id "$WTUI_FLOW_ID" \
   --phase-id autoreview \
-  --status running \
-  --notes "Rerunning Autoreview after addressing prior findings." \
   "${FLOW_STATE_ARGS[@]}"
 ```
 
 ```bash
-wtui flow phase set \
+wtui flow phase complete \
   --flow-id "$WTUI_FLOW_ID" \
   --phase-id autoreview \
-  --status completed \
-  --outcome "passed" \
   --summary "Autoreview passed; no blocking findings remain." \
   "${FLOW_STATE_ARGS[@]}"
 ```

--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -60,6 +60,7 @@ Commands:
   phase block      Mark a Flow phase blocked.
   phase needs-attention
                    Mark a Flow phase as needing attention.
+  phase restart    Restart a blocked or needs-attention phase.
   phase set        Advance a Flow phase with explicit status.
   phase add-child  Add or update an implementation child phase.
   plan set         Link a saved plan artifact to a Flow.
@@ -72,6 +73,7 @@ Examples:
   wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan --summary "Saved plan"
   wtui flow phase block --flow-id "$FLOW_ID" --phase-id implementation --notes "Waiting on review"
   wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review --notes "Revise scope"
+  wtui flow phase restart --flow-id "$FLOW_ID" --phase-id autoreview
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan --status completed --summary "Plan saved"
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan-review --status completed --outcome approved
   wtui flow pr set --flow-id "$FLOW_ID" --provider github --number 155 --url "$PR_URL" --head "$BRANCH" --base main
@@ -285,7 +287,7 @@ func runFlowPhase(args []string, deps runDeps) error {
 		return nil
 	}
 	if len(args) < 1 {
-		return fmt.Errorf("usage: wtui flow phase <set|complete|block|needs-attention|add-child> [flags]")
+		return fmt.Errorf("usage: wtui flow phase <set|complete|block|needs-attention|restart|add-child> [flags]")
 	}
 	switch args[0] {
 	case "set":
@@ -311,10 +313,12 @@ func runFlowPhase(args []string, deps runDeps) error {
 			defaultOutcome: flowstore.OutcomeChangesRequested,
 			printHelp:      printFlowPhaseNeedsAttentionHelp,
 		})
+	case "restart":
+		return runFlowPhaseRestart(args[1:], deps)
 	case "add-child":
 		return runFlowPhaseAddChild(args[1:], deps)
 	default:
-		return unknownCommandError(args[0], []string{"set", "complete", "block", "needs-attention", "add-child"}, flowPhaseHelpText)
+		return unknownCommandError(args[0], []string{"set", "complete", "block", "needs-attention", "restart", "add-child"}, flowPhaseHelpText)
 	}
 }
 
@@ -322,7 +326,7 @@ func printFlowPhaseHelp(w io.Writer) {
 	io.WriteString(w, flowPhaseHelpText)
 }
 
-const flowPhaseHelpText = `Usage: wtui flow phase <set|complete|block|needs-attention|add-child> [flags]
+const flowPhaseHelpText = `Usage: wtui flow phase <set|complete|block|needs-attention|restart|add-child> [flags]
 
 Update Flow phase state. Readiness is derived by wtui; agents set running,
 completed, needs_attention, blocked, or skipped.
@@ -332,6 +336,7 @@ Commands:
   complete         Mark a phase completed and print the next actionable phase.
   block            Mark a phase blocked.
   needs-attention  Mark a phase as needing attention.
+  restart          Restart a blocked or needs-attention phase.
   add-child        Add or update an implementation child phase.
 
 Examples:
@@ -340,6 +345,7 @@ Examples:
   wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan --summary "Saved plan"
   wtui flow phase block --flow-id "$FLOW_ID" --phase-id implementation --notes "Waiting on review"
   wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review --outcome changes_requested --notes "Revise scope"
+  wtui flow phase restart --flow-id "$FLOW_ID" --phase-id autoreview
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id implementation --status blocked --notes "Waiting on review"
   wtui flow phase add-child --flow-id "$FLOW_ID" --parent-phase-id implementation --phase-id api --title "API work" --order 1
 
@@ -467,8 +473,8 @@ func runFlowPhaseAction(args []string, deps runDeps, spec flowPhaseActionSpec) e
 		return fmt.Errorf("flow phase %s requires --phase-id", spec.command)
 	}
 	actionOutcome := strings.TrimSpace(*outcome)
-	if actionOutcome == "" && normalizeFlowPhaseID(*phaseID) == "plan-review" {
-		actionOutcome = spec.defaultOutcome
+	if actionOutcome == "" {
+		actionOutcome = defaultFlowPhaseActionOutcome(normalizeFlowPhaseID(*phaseID), spec)
 	}
 	store, err := newFlowStore(*stateRoot, deps)
 	if err != nil {
@@ -496,6 +502,88 @@ func runFlowPhaseAction(args []string, deps runDeps, spec flowPhaseActionSpec) e
 		NextPhase:    nextFlowPhaseActionState(record, updated),
 		Flow:         record,
 	})
+}
+
+func defaultFlowPhaseActionOutcome(phaseID string, spec flowPhaseActionSpec) string {
+	switch phaseID {
+	case "plan-review":
+		return spec.defaultOutcome
+	case "autoreview":
+		switch spec.status {
+		case flowstore.PhaseCompleted:
+			return "passed"
+		case flowstore.PhaseNeedsAttention:
+			return "needs_attention"
+		case flowstore.PhaseBlocked:
+			return flowstore.OutcomeBlocked
+		}
+	}
+	return ""
+}
+
+func runFlowPhaseRestart(args []string, deps runDeps) error {
+	flags := flag.NewFlagSet("flow phase restart", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printFlowPhaseRestartHelp(deps.stdout) }
+	flowID := flags.String("flow-id", "", "flow id")
+	phaseID := flags.String("phase-id", "", "phase id")
+	notes := flags.String("notes", "", "phase notes")
+	stateRoot := flags.String("state-root", "", "artifact state root")
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
+		return err
+	}
+	if *flowID == "" {
+		return fmt.Errorf("flow phase restart requires --flow-id")
+	}
+	if *phaseID == "" {
+		return fmt.Errorf("flow phase restart requires --phase-id")
+	}
+	store, err := newFlowStore(*stateRoot, deps)
+	if err != nil {
+		return err
+	}
+	note := strings.TrimSpace(*notes)
+	if note == "" {
+		note = fmt.Sprintf("Rerunning %s after addressing prior findings.", defaultPhaseTitle(*phaseID))
+	}
+	record, err := store.RestartPhase(flowstore.PhaseRestartUpdate{
+		FlowID:  *flowID,
+		PhaseID: *phaseID,
+		Notes:   note,
+	})
+	if err != nil {
+		return err
+	}
+	updated, ok := flowPhaseByID(record, *phaseID)
+	if !ok {
+		return fmt.Errorf("phase %q not found in updated flow %q", *phaseID, *flowID)
+	}
+	return writeFlowJSON(deps.stdout, flowPhaseActionResult{
+		FlowID:       record.FlowID,
+		FlowStatus:   record.Status,
+		UpdatedPhase: updated,
+		NextPhase:    nextFlowPhaseActionState(record, updated),
+		Flow:         record,
+	})
+}
+
+func defaultPhaseTitle(phaseID string) string {
+	normalized := normalizeFlowPhaseID(phaseID)
+	if normalized == "" {
+		return "phase"
+	}
+	parts := strings.Fields(strings.ReplaceAll(normalized, "-", " "))
+	for i, part := range parts {
+		if part == "pr" {
+			parts[i] = "PR"
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
 }
 
 func printFlowPhaseCompleteHelp(w io.Writer) {
@@ -560,6 +648,27 @@ Common flags:
 Examples:
   wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id implementation --notes "Tests need revision"
   wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review --outcome changes_requested --notes "Revise scope"
+`)
+}
+
+func printFlowPhaseRestartHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow phase restart [flags]
+
+Restart a blocked or needs-attention Flow phase as running and print the next
+actionable phase state.
+When --notes is omitted, wtui writes a standard rerun note.
+
+Required flags:
+  --flow-id FLOW_ID
+  --phase-id PHASE_ID
+
+Common flags:
+  --notes TEXT
+  --state-root PATH
+
+Examples:
+  wtui flow phase restart --flow-id "$FLOW_ID" --phase-id autoreview
+  wtui flow phase restart --flow-id "$FLOW_ID" --phase-id implementation --notes "Rerunning after fixing review findings."
 `)
 }
 

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -32,6 +32,7 @@ func TestRunFlowHelpPrintsUsageAndExamples(t *testing.T) {
 		"wtui flow phase complete --flow-id",
 		"wtui flow phase block --flow-id",
 		"wtui flow phase needs-attention --flow-id",
+		"wtui flow phase restart --flow-id",
 		"wtui flow phase set --flow-id",
 		"wtui flow pr set --flow-id",
 		"wtui flow merge set --flow-id",
@@ -51,11 +52,12 @@ func TestRunFlowPhaseHelpPrintsUsageAndExamples(t *testing.T) {
 		t.Fatalf("run returned error: %v", err)
 	}
 	requireContainsAll(t, stdout.String(), []string{
-		"Usage: wtui flow phase <set|complete|block|needs-attention|add-child> [flags]",
+		"Usage: wtui flow phase <set|complete|block|needs-attention|restart|add-child> [flags]",
 		"wtui flow phase set --flow-id",
 		"wtui flow phase complete --flow-id",
 		"wtui flow phase block --flow-id",
 		"wtui flow phase needs-attention --flow-id",
+		"wtui flow phase restart --flow-id",
 		"--status completed",
 		"wtui flow phase add-child --flow-id",
 	})
@@ -278,7 +280,7 @@ func TestRunFlowPhaseUnknownSubcommandSuggestsNearbyCommand(t *testing.T) {
 	}
 	requireContainsAll(t, err.Error(), []string{
 		`unknown command "ste"; did you mean "set"?`,
-		"Usage: wtui flow phase <set|complete|block|needs-attention|add-child> [flags]",
+		"Usage: wtui flow phase <set|complete|block|needs-attention|restart|add-child> [flags]",
 	})
 }
 
@@ -964,6 +966,170 @@ func TestRunFlowPhaseActionsDefaultPlanReviewOutcomes(t *testing.T) {
 	}
 }
 
+func TestRunFlowPhaseActionsDefaultAutoreviewOutcomes(t *testing.T) {
+	root := t.TempDir()
+	for _, tc := range []struct {
+		name        string
+		command     string
+		notes       string
+		wantStatus  string
+		wantOutcome string
+	}{
+		{name: "complete", command: "complete", wantStatus: flowstore.PhaseCompleted, wantOutcome: "passed"},
+		{name: "needs attention", command: "needs-attention", notes: "Follow-up concern remains.", wantStatus: flowstore.PhaseNeedsAttention, wantOutcome: "needs_attention"},
+		{name: "block", command: "block", notes: "Autoreview cannot inspect the PR.", wantStatus: flowstore.PhaseBlocked, wantOutcome: flowstore.OutcomeBlocked},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			branch := "flow/autoreview-" + strings.ReplaceAll(tc.name, " ", "-")
+			created := mustRunFlowReadyForAutoreview(t, root, tc.name, branch)
+
+			args := []string{
+				"wtui", "flow", "phase", tc.command,
+				"--flow-id", created.FlowID,
+				"--phase-id", "autoreview",
+				"--state-root", root,
+			}
+			if tc.notes != "" {
+				args = append(args, "--notes", tc.notes)
+			}
+			var stdout bytes.Buffer
+			err := run(args, noScanDeps(t, runDeps{stdout: &stdout}))
+			if err != nil {
+				t.Fatalf("run returned error: %v", err)
+			}
+
+			var result flowPhaseActionResult
+			if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+				t.Fatalf("output is not JSON action result: %v\n%s", err, stdout.String())
+			}
+			autoreview := result.UpdatedPhase
+			if autoreview.Status != tc.wantStatus || autoreview.Outcome != tc.wantOutcome {
+				t.Fatalf("autoreview = %#v, want status %q outcome %q", autoreview, tc.wantStatus, tc.wantOutcome)
+			}
+		})
+	}
+}
+
+func TestRunFlowPhaseRestartRerunsAttentionAndBlockedPhases(t *testing.T) {
+	root := t.TempDir()
+	for _, tc := range []struct {
+		name         string
+		startStatus  string
+		startOutcome string
+		startNotes   string
+	}{
+		{
+			name:         "needs attention",
+			startStatus:  flowstore.PhaseNeedsAttention,
+			startOutcome: "needs_attention",
+			startNotes:   "Follow-up concern remains.",
+		},
+		{
+			name:         "blocked",
+			startStatus:  flowstore.PhaseBlocked,
+			startOutcome: flowstore.OutcomeBlocked,
+			startNotes:   "Autoreview was blocked.",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			branch := "flow/restart-" + strings.ReplaceAll(tc.name, " ", "-")
+			created := mustRunFlowReadyForAutoreview(t, root, tc.name, branch)
+			mustSetFlowPhase(t, root, created.FlowID, "autoreview", tc.startStatus, tc.startOutcome, tc.startNotes, "")
+
+			var stdout bytes.Buffer
+			err := run([]string{
+				"wtui", "flow", "phase", "restart",
+				"--flow-id", created.FlowID,
+				"--phase-id", "autoreview",
+				"--state-root", root,
+			}, noScanDeps(t, runDeps{stdout: &stdout}))
+			if err != nil {
+				t.Fatalf("run returned error: %v", err)
+			}
+
+			var result flowPhaseActionResult
+			if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+				t.Fatalf("output is not JSON action result: %v\n%s", err, stdout.String())
+			}
+			autoreview := result.UpdatedPhase
+			if autoreview.Status != flowstore.PhaseRunning || autoreview.Outcome != "" {
+				t.Fatalf("autoreview = %#v, want running with cleared outcome", autoreview)
+			}
+			if !strings.Contains(autoreview.Notes, "Rerunning Autoreview after addressing prior findings.") {
+				t.Fatalf("autoreview notes = %q, want default rerun note", autoreview.Notes)
+			}
+		})
+	}
+}
+
+func TestRunFlowPhaseRestartRejectsNonRecoveryStates(t *testing.T) {
+	root := t.TempDir()
+	for _, tc := range []struct {
+		name        string
+		prepare     func(t *testing.T) flowstore.FlowRecord
+		wantCurrent string
+	}{
+		{
+			name: "pending",
+			prepare: func(t *testing.T) flowstore.FlowRecord {
+				return mustRunFlow(t, []string{
+					"wtui", "flow", "create",
+					"--title", "pending restart",
+					"--instructions", "phase it",
+					"--repo-path", filepath.Join(root, "repo-pending"),
+					"--json",
+					"--state-root", root,
+				})
+			},
+			wantCurrent: "pending",
+		},
+		{
+			name: "ready",
+			prepare: func(t *testing.T) flowstore.FlowRecord {
+				return mustRunFlowReadyForAutoreview(t, root, "ready restart", "flow/restart-ready")
+			},
+			wantCurrent: "ready",
+		},
+		{
+			name: "completed",
+			prepare: func(t *testing.T) flowstore.FlowRecord {
+				record := mustRunFlowReadyForAutoreview(t, root, "completed restart", "flow/restart-completed")
+				return mustSetFlowPhase(t, root, record.FlowID, "autoreview", flowstore.PhaseCompleted, "passed", "", "")
+			},
+			wantCurrent: "completed",
+		},
+		{
+			name: "skipped",
+			prepare: func(t *testing.T) flowstore.FlowRecord {
+				record := mustRunFlowReadyForAutoreview(t, root, "skipped restart", "flow/restart-skipped")
+				return mustSetFlowPhase(t, root, record.FlowID, "autoreview", flowstore.PhaseSkipped, "", "", "Autoreview intentionally skipped.")
+			},
+			wantCurrent: "skipped",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			record := tc.prepare(t)
+			err := run([]string{
+				"wtui", "flow", "phase", "restart",
+				"--flow-id", record.FlowID,
+				"--phase-id", "autoreview",
+				"--state-root", root,
+			}, noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
+			if err == nil {
+				t.Fatal("restart returned nil error for non-recovery state")
+			}
+			for _, want := range []string{
+				"flow phase restart requires current status needs_attention or blocked",
+				"autoreview is " + tc.wantCurrent,
+			} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("restart error = %q, want %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
 func TestRunFlowPhaseActionRejectsInvalidTransitionAndKeepsRecordUnchanged(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")
@@ -1341,6 +1507,36 @@ func mustRunFlow(t *testing.T, args []string) flowstore.FlowRecord {
 		t.Fatalf("output is not JSON record: %v\n%s", err, stdout.String())
 	}
 	return record
+}
+
+func mustRunFlowReadyForAutoreview(t *testing.T, root, title, branch string) flowstore.FlowRecord {
+	t.Helper()
+	created := mustRunFlow(t, []string{
+		"wtui", "flow", "create",
+		"--title", title,
+		"--instructions", "phase it",
+		"--repo-path", filepath.Join(root, "repo-"+strings.ReplaceAll(title, " ", "-")),
+		"--branch", branch,
+		"--json",
+		"--state-root", root,
+	})
+	for _, phaseID := range []string{"plan", "plan-review", "implementation", "review-loop", "pr-creation"} {
+		outcome := ""
+		if phaseID == "plan-review" {
+			outcome = flowstore.OutcomeApproved
+		}
+		mustSetFlowPhase(t, root, created.FlowID, phaseID, flowstore.PhaseCompleted, outcome, "", "")
+	}
+	return mustRunFlow(t, []string{
+		"wtui", "flow", "pr", "set",
+		"--flow-id", created.FlowID,
+		"--provider", "github",
+		"--number", "115",
+		"--url", "https://github.com/brian-bell/wtui/pull/115",
+		"--head", branch,
+		"--base", "main",
+		"--state-root", root,
+	})
 }
 
 func mustSetFlowPhase(t *testing.T, root, flowID, phaseID, status, outcome, summary, notes string) flowstore.FlowRecord {

--- a/docs/config.md
+++ b/docs/config.md
@@ -311,6 +311,8 @@ wtui flow phase block --flow-id ID --phase-id ID \
     [--outcome OUTCOME] [--summary TEXT] [--notes TEXT] [--state-root PATH]
 wtui flow phase needs-attention --flow-id ID --phase-id ID \
     [--outcome OUTCOME] [--summary TEXT] [--notes TEXT] [--state-root PATH]
+wtui flow phase restart --flow-id ID --phase-id ID \
+    [--notes TEXT] [--state-root PATH]
 wtui flow phase set --flow-id ID --phase-id ID --status STATUS \
     [--outcome OUTCOME] [--summary TEXT] [--notes TEXT] [--state-root PATH]
 wtui flow phase add-child --flow-id ID --parent-phase-id implementation \
@@ -357,8 +359,12 @@ actionable phase state, and allowed statuses for that next action. Notes
 requirements are still enforced by the same store rules as `phase set`. Plan
 Review wrappers fill the unambiguous outcomes when omitted: `complete` uses
 `approved`, `block` uses `blocked`, and `needs-attention` uses
-`changes_requested`. Use `phase set` when a phase needs an explicit uncommon
-status, a skipped-with-notes override, or an explicit restart.
+`changes_requested`. Autoreview wrappers fill `passed`, `blocked`, and
+`needs_attention` for the matching common outcomes. Use
+`wtui flow phase restart` to rerun a blocked or needs-attention phase as
+`running`; if `--notes` is omitted, wtui records a standard rerun note. Use
+`phase set` when a phase needs an explicit uncommon status or a
+skipped-with-notes override.
 
 Implementation can be split into ordered child phases with
 `wtui flow phase add-child`. Child phase IDs are stable and normalized (trimmed
@@ -374,6 +380,9 @@ inspect the changes. Built-in prompts tell Plan to produce only a plan,
 Implementation to use the `commit` skill, Review Loop to use the review-loop
 workflow and `commit` when revisions are made, PR Creation to use the `ship`
 skill, and Autoreview to use `ship` when fixes require commits or pushes.
+Autoreview launch prompts include the PR target metadata but leave completion,
+needs-attention, blocked, and restart mechanics to the high-level Flow phase
+commands.
 Override `[flow_prompts]` keys to customize those phase templates.
 
 The PR Creation phase should record structured PR metadata with

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -40,9 +40,10 @@ Agents may set only `running`, `needs_attention`, `completed`, `blocked`, and
 `skipped` through `wtui flow phase set`. The high-level wrappers
 `wtui flow phase complete`, `wtui flow phase block`, and
 `wtui flow phase needs-attention` use the same validation and persistence path
-for the common `completed`, `blocked`, and `needs_attention` outcomes, then
-print JSON with the updated phase and next actionable phase state. These
-wrappers do not add separate notes requirements; store validation remains the
+for the common `completed`, `blocked`, and `needs_attention` outcomes. The
+`wtui flow phase restart` wrapper records `running` with a rerun note. These
+wrappers print JSON with the updated phase and next actionable phase state.
+They do not add separate notes requirements; store validation remains the
 source of truth. Setting `ready` is rejected with "readiness is derived"; the
 CLI rejects unknown statuses with the valid list, and the store rejects them as
 `invalid phase status`.
@@ -56,8 +57,8 @@ CLI rejects unknown statuses with the valid list, and the store rejects them as
 | `running` | – | yes | yes | yes | yes |
 | `needs_attention` | yes (notes) | – | – | – | yes |
 | `blocked` | yes (notes) | – | – | – | yes |
-| `completed` | yes (restart) | – | – | – | – |
-| `skipped` | yes (restart) | – | – | – | – |
+| `completed` | yes | – | – | – | – |
+| `skipped` | yes | – | – | – | – |
 
 Additional rules:
 
@@ -65,7 +66,9 @@ Additional rules:
   outcome/summary/notes on the current status).
 - `skipped` always requires `--notes`, from any state.
 - Restarting a `needs_attention` or `blocked` phase as `running` requires
-  `--notes`; completing one directly is invalid — restart first.
+  `--notes`; completing one directly is invalid — restart first. The
+  high-level `wtui flow phase restart` wrapper supplies a standard note when
+  `--notes` is omitted.
 - Invalid transitions fail with the allowed next statuses, e.g.
   `invalid phase transition pending -> completed; allowed from pending: skipped`.
 
@@ -88,6 +91,9 @@ predecessor satisfies its downstream gate:
   Implementation `pending`. The high-level Plan Review wrappers fill the
   unambiguous outcomes when omitted: `complete` uses `approved`,
   `needs-attention` uses `changes_requested`, and `block` uses `blocked`.
+- **Autoreview**: the high-level wrappers fill the unambiguous outcomes when
+  omitted: `complete` uses `passed`, `needs-attention` uses
+  `needs_attention`, and `block` uses `blocked`.
 - **PR Creation**: `completed` *and* structured PR metadata recorded via
   `wtui flow pr set` (provider, positive number, valid URL, head/base
   branches). Completion alone does not unlock Autoreview; a skipped PR

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -169,6 +169,13 @@ type PhaseUpdate struct {
 	Summary string
 }
 
+// PhaseRestartUpdate restarts a blocked or needs-attention phase as running.
+type PhaseRestartUpdate struct {
+	FlowID  string
+	PhaseID string
+	Notes   string
+}
+
 // ChildPhaseUpdate creates or updates a stable child phase under Implementation.
 type ChildPhaseUpdate struct {
 	FlowID        string
@@ -380,6 +387,51 @@ func (s *Store) SetPhase(update PhaseUpdate) (FlowRecord, error) {
 		return FlowRecord{}, err
 	}
 	return record, nil
+}
+
+// RestartPhase atomically restarts a blocked or needs-attention phase as running.
+func (s *Store) RestartPhase(update PhaseRestartUpdate) (FlowRecord, error) {
+	update.PhaseID = artifacts.NormalizePhaseID(update.PhaseID)
+	if err := validateFlowID(update.FlowID); err != nil {
+		return FlowRecord{}, err
+	}
+	if err := validatePhaseID(update.PhaseID); err != nil {
+		return FlowRecord{}, err
+	}
+	if strings.TrimSpace(update.Notes) == "" {
+		return FlowRecord{}, fmt.Errorf("phase restart requires notes")
+	}
+	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+		phaseIndex := phaseIndexByID(record.Phases, update.PhaseID)
+		if phaseIndex < 0 {
+			return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
+		}
+		phase := record.Phases[phaseIndex]
+		if phase.Status != PhaseNeedsAttention && phase.Status != PhaseBlocked {
+			return FlowRecord{}, fmt.Errorf("flow phase restart requires current status needs_attention or blocked; %s is %s", phase.PhaseID, phase.Status)
+		}
+		if err := validatePhaseUpdate(phase, PhaseUpdate{
+			FlowID:  update.FlowID,
+			PhaseID: update.PhaseID,
+			Status:  PhaseRunning,
+			Notes:   update.Notes,
+		}); err != nil {
+			return FlowRecord{}, err
+		}
+		phase.Status = PhaseRunning
+		phase.Outcome = ""
+		phase.Notes = update.Notes
+		phase.PhaseID = update.PhaseID
+		phase.UpdatedAt = now
+		record.Phases[phaseIndex] = phase
+		record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
+		if phase.PhaseID == "merge" {
+			record.Merge = Merge{Status: MergePending}
+		}
+		record.UpdatedAt = now
+		record = refreshPhaseReadiness(record, now)
+		return record, nil
+	})
 }
 
 // AddChildPhase creates or updates a stable child phase under Implementation.

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -969,6 +969,135 @@ func TestStoreSetPhaseExplainsNeedsAttentionRecovery(t *testing.T) {
 	}
 }
 
+func TestStoreRestartPhaseAtomicallyRequiresRecoveryState(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Atomic restart",
+		Instructions: "restart only recovery states",
+		RepoPath:     filepath.Join(root, "repo"),
+		Branch:       "flow/atomic-restart",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	record, err = store.SetPR(flowstore.PRUpdate{
+		FlowID:     record.FlowID,
+		Provider:   "github",
+		Number:     115,
+		URL:        "https://github.com/brian-bell/wtui/pull/115",
+		HeadBranch: "flow/atomic-restart",
+		BaseBranch: "main",
+	})
+	if err != nil {
+		t.Fatalf("SetPR() error = %v", err)
+	}
+
+	_, err = store.RestartPhase(flowstore.PhaseRestartUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "autoreview",
+		Notes:   "Rerunning Autoreview after addressing prior findings.",
+	})
+	if err == nil || !strings.Contains(err.Error(), "autoreview is ready") {
+		t.Fatalf("RestartPhase(ready) error = %v, want ready rejection", err)
+	}
+
+	record, err = store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "autoreview",
+		Status:  flowstore.PhaseNeedsAttention,
+		Outcome: "needs_attention",
+		Notes:   "Follow-up concern remains.",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(needs_attention) error = %v", err)
+	}
+	record, err = store.RestartPhase(flowstore.PhaseRestartUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "autoreview",
+		Notes:   "Rerunning Autoreview after addressing prior findings.",
+	})
+	if err != nil {
+		t.Fatalf("RestartPhase(needs_attention) error = %v", err)
+	}
+	phase := phaseByID(t, record, "autoreview")
+	if phase.Status != flowstore.PhaseRunning || phase.Outcome != "" {
+		t.Fatalf("autoreview after restart = %#v, want running with cleared outcome", phase)
+	}
+}
+
+func TestStoreRestartPhaseClearsBlockedMergeMetadata(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Restart merge",
+		Instructions: "clear blocked merge metadata",
+		RepoPath:     filepath.Join(root, "repo"),
+		Branch:       "flow/restart-merge",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	record, err = store.SetPR(flowstore.PRUpdate{
+		FlowID:     record.FlowID,
+		Provider:   "github",
+		Number:     115,
+		URL:        "https://github.com/brian-bell/wtui/pull/115",
+		HeadBranch: "flow/restart-merge",
+		BaseBranch: "main",
+	})
+	if err != nil {
+		t.Fatalf("SetPR() error = %v", err)
+	}
+	mustCompleteFlowPhases(t, store, &record, "autoreview")
+	record, err = store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "merge",
+		Status:  flowstore.PhaseBlocked,
+		Outcome: flowstore.OutcomeBlocked,
+		Notes:   "CI is not green.",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(merge blocked) error = %v", err)
+	}
+	record, err = store.SetMerge(flowstore.MergeUpdate{
+		FlowID: record.FlowID,
+		Status: flowstore.MergeBlocked,
+	})
+	if err != nil {
+		t.Fatalf("SetMerge(blocked) error = %v", err)
+	}
+	if record.Merge.Status != flowstore.MergeBlocked || record.Status != flowstore.StatusBlocked {
+		t.Fatalf("blocked merge record = %#v", record)
+	}
+
+	record, err = store.RestartPhase(flowstore.PhaseRestartUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "merge",
+		Notes:   "Rerunning Merge after CI recovered.",
+	})
+	if err != nil {
+		t.Fatalf("RestartPhase(merge) error = %v", err)
+	}
+	if got := phaseByID(t, record, "merge").Status; got != flowstore.PhaseRunning {
+		t.Fatalf("merge phase status = %q, want running", got)
+	}
+	if record.Merge.Status != flowstore.MergePending {
+		t.Fatalf("merge metadata after restart = %#v, want pending", record.Merge)
+	}
+	if record.Status != flowstore.StatusInProgress {
+		t.Fatalf("flow status after merge restart = %q, want in_progress", record.Status)
+	}
+}
+
 func TestStoreAddPhaseLaunchIDRestartsNeedsAttentionPhase(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1646,6 +1646,7 @@ func TestModel_AKeyOnFlowLaunchesAutoreviewWithPRContext(t *testing.T) {
 		RepoPath:     "/dev/alpha",
 		WorktreePath: "/dev/alpha-worktrees/flow-pr",
 		Branch:       "flow/pr",
+		Commit:       "ghi789",
 		PlanID:       "plan-1",
 		Status:       flowstore.StatusInProgress,
 		PR: flowstore.PullRequest{
@@ -1685,19 +1686,21 @@ func TestModel_AKeyOnFlowLaunchesAutoreviewWithPRContext(t *testing.T) {
 	for _, want := range []string{
 		"second-level review",
 		"use the ship skill when fixes require commits or pushes",
+		"worktree: /dev/alpha-worktrees/flow-pr",
+		"branch: flow/pr",
+		"start commit: ghi789",
+		"pr target:",
 		"github #115",
 		"https://github.com/brian-bell/wtui/pull/115",
 		"head: flow/pr",
 		"base: main",
-		"wtui flow phase complete --flow-id flow-1 --phase-id autoreview",
-		"wtui flow phase needs-attention --flow-id flow-1 --phase-id autoreview",
-		"wtui flow phase block --flow-id flow-1 --phase-id autoreview",
+		"status: open",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("autoreview prompt missing %q:\n%s", want, launched.InitialPrompt)
 		}
 	}
-	for _, unwanted := range []string{"saved plan body", "--status completed", "--status needs_attention", "--status blocked"} {
+	for _, unwanted := range []string{"saved plan body", "wtui flow phase", "--status completed", "--status needs_attention", "--status blocked"} {
 		if strings.Contains(prompt, unwanted) {
 			t.Fatalf("autoreview prompt should not include %q:\n%s", unwanted, launched.InitialPrompt)
 		}
@@ -1725,6 +1728,7 @@ func TestModel_AKeyOnFlowLaunchesAutoreviewWithRecoveryPrompt(t *testing.T) {
 		RepoPath:     "/dev/alpha",
 		WorktreePath: "/dev/alpha-worktrees/flow-pr",
 		Branch:       "flow/pr",
+		Commit:       "ghi789",
 		PlanID:       "plan-1",
 		Status:       flowstore.StatusNeedsAttention,
 		PR: flowstore.PullRequest{
@@ -1762,13 +1766,23 @@ func TestModel_AKeyOnFlowLaunchesAutoreviewWithRecoveryPrompt(t *testing.T) {
 
 	prompt := strings.ToLower(launched.InitialPrompt)
 	for _, want := range []string{
-		"restart required",
-		"--status running",
-		"rerunning autoreview after addressing prior findings",
-		"wtui flow phase complete --flow-id flow-1 --phase-id autoreview",
+		"second-level review",
+		"use the ship skill when fixes require commits or pushes",
+		"worktree: /dev/alpha-worktrees/flow-pr",
+		"branch: flow/pr",
+		"start commit: ghi789",
+		"github #115",
+		"head: flow/pr",
+		"base: main",
+		"status: open",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("autoreview recovery prompt missing %q:\n%s", want, launched.InitialPrompt)
+		}
+	}
+	for _, unwanted := range []string{"restart required", "--status running", "rerunning autoreview", "wtui flow phase"} {
+		if strings.Contains(prompt, unwanted) {
+			t.Fatalf("autoreview recovery prompt should not include %q:\n%s", unwanted, launched.InitialPrompt)
 		}
 	}
 }
@@ -1809,8 +1823,9 @@ func TestModel_AKeyOnFlowDoesNotRelaunchAutoreviewWithoutPRTarget(t *testing.T) 
 	if launchAttempted {
 		t.Fatal("LaunchAgent() ran without PR metadata")
 	}
-	if got := m.TransientError(); got != "No ready Flow phase to launch" {
-		t.Fatalf("status = %q, want no ready phase message", got)
+	wantErr := "Autoreview needs PR metadata; run `wtui flow pr set` after PR Creation records the PR target"
+	if got := m.TransientError(); got != wantErr {
+		t.Fatalf("status = %q, want %q", got, wantErr)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1372,6 +1372,9 @@ func flowPhaseCanLaunch(record flowstore.FlowRecord, phase flowstore.FlowPhase) 
 }
 
 func flowNotReadyMessage(record flowstore.FlowRecord) string {
+	if flowAutoreviewMissingPRTarget(record) {
+		return "Autoreview needs PR metadata; run `wtui flow pr set` after PR Creation records the PR target"
+	}
 	impl, hasImplementation := flowPhaseByID(record, "implementation")
 	review, hasReview := flowPhaseByID(record, "plan-review")
 	if hasImplementation && impl.Status == flowstore.PhasePending && hasReview {
@@ -1387,6 +1390,20 @@ func flowNotReadyMessage(record flowstore.FlowRecord) string {
 		return "Implementation is not ready; Plan Review is " + detail
 	}
 	return "No ready Flow phase to launch"
+}
+
+func flowAutoreviewMissingPRTarget(record flowstore.FlowRecord) bool {
+	if flowstore.HasPRTarget(record.PR) {
+		return false
+	}
+	prCreation, hasPRCreation := flowPhaseByID(record, "pr-creation")
+	autoreview, hasAutoreview := flowPhaseByID(record, "autoreview")
+	if !hasPRCreation || !hasAutoreview || prCreation.Status != flowstore.PhaseCompleted {
+		return false
+	}
+	return autoreview.Status == flowstore.PhasePending ||
+		autoreview.Status == flowstore.PhaseNeedsAttention ||
+		autoreview.Status == flowstore.PhaseBlocked
 }
 
 func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string, templates FlowPromptTemplates) string {
@@ -1474,22 +1491,17 @@ func flowMinimalArtifactPrompt(instruction, planPath string, record flowstore.Fl
 
 func flowAutoreviewPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
 	var b strings.Builder
-	b.WriteString("Use the autoreview skill for this second-level review.\n\n")
-	b.WriteString("Use the ship skill when fixes require commits or pushes.\n")
+	b.WriteString("Use the autoreview skill for this second-level review.\n")
+	b.WriteString("Use the ship skill when fixes require commits or pushes.\n\n")
 	writeFlowChangeMetadata(&b, record)
 	if flowstore.HasPRTarget(record.PR) {
-		fmt.Fprintf(&b, "\nPR target:\n- PR: %s #%d\n- URL: %s\n- Head: %s\n- Base: %s\n", record.PR.Provider, record.PR.Number, record.PR.URL, record.PR.HeadBranch, record.PR.BaseBranch)
+		fmt.Fprintf(&b, "\nPR target:\n- PR: %s #%d\n- URL: %s\n- Head: %s\n- Base: %s", record.PR.Provider, record.PR.Number, record.PR.URL, record.PR.HeadBranch, record.PR.BaseBranch)
 		if record.PR.Status != "" {
-			fmt.Fprintf(&b, "- Status: %s\n", record.PR.Status)
+			fmt.Fprintf(&b, "\n- Status: %s", record.PR.Status)
 		}
 	} else {
 		b.WriteString("\nPR target: missing. Do not run Autoreview until `wtui flow pr set` records provider, number, URL, head, and base.\n")
 	}
-	writeFlowRestartPromptIfNeeded(&b, record, phase)
-	fmt.Fprintf(&b, "\nRecord the result with one of:\n")
-	fmt.Fprintf(&b, "wtui flow phase complete --flow-id %s --phase-id %s --outcome passed --summary \"...\"\n", record.FlowID, phase.PhaseID)
-	fmt.Fprintf(&b, "wtui flow phase needs-attention --flow-id %s --phase-id %s --outcome needs_attention --notes \"...\" --summary \"...\"\n", record.FlowID, phase.PhaseID)
-	fmt.Fprintf(&b, "wtui flow phase block --flow-id %s --phase-id %s --outcome blocked --notes \"...\"", record.FlowID, phase.PhaseID)
 	return b.String()
 }
 
@@ -1498,7 +1510,7 @@ func writeFlowRestartPromptIfNeeded(b *strings.Builder, record flowstore.FlowRec
 		return
 	}
 	fmt.Fprintf(b, "\nRestart required: this phase is %s. Before marking it completed, record the rerun:\n", phase.Status)
-	fmt.Fprintf(b, "wtui flow phase set --flow-id %s --phase-id %s --status running --notes \"Rerunning %s after addressing prior findings.\"\n", record.FlowID, phase.PhaseID, phase.Title)
+	fmt.Fprintf(b, "wtui flow phase restart --flow-id %s --phase-id %s --notes \"Rerunning %s after addressing prior findings.\"\n", record.FlowID, phase.PhaseID, phase.Title)
 }
 
 func flowMergePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {


### PR DESCRIPTION
Fixes #161.

## Summary
- Shorten Autoreview launch prompts so they carry only worktree/branch/commit and PR target context, without embedded phase-update recipes.
- Add `wtui flow phase restart` for blocked or needs-attention phase reruns, with atomic store validation and merge metadata reset handling.
- Default Autoreview high-level outcomes for `complete`, `needs-attention`, and `block`, and improve the missing-PR launch recovery message.
- Update README, config docs, Flow phase semantics, AGENTS, and the bundled `wtui-flow` skill contract.

## Verification
- `gofmt -l .`
- `make test`
- `make build`

## Review Loop
- Used reviewer subagents for four review-loop passes. Scores progressed 7/10 -> 8/10 -> 8/10 -> 9/10.
- Addressed findings around restart scope, atomic restart validation, merge metadata reset, stale usage text, README placement, and prompt-test brittleness.