### PR TITLE
Point plan-review launches at the wtui-flow skill

### DIFF
--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1074,6 +1074,7 @@ func TestModel_AKeyOnFlowLaunchesReadyPlanReviewWithLinkedPlanContext(t *testing
 	}
 	wantPrompt := strings.Join([]string{
 		"Use the review loop skill to review the saved plan.",
+		"Use the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.",
 		"",
 		"Plan: /state/wtui/sessions/v1/plans/plan-1/plan.md",
 		"Worktree: /dev/alpha-worktrees/flow-review",

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1874,6 +1874,7 @@ func TestModel_AKeyOnFlowLaunchesReviewLoopWithFirstLevelPrompt(t *testing.T) {
 	wantPrompt := strings.Join([]string{
 		"Use the review-loop workflow to review the changes.",
 		"Use the commit skill when revisions are made.",
+		"Use the wtui-flow skill to record the Review Loop result before finishing; the phase is not done until the result is persisted.",
 		"",
 		"Worktree: /dev/alpha-worktrees/flow-review-loop",
 		"Branch: flow/review-loop",
@@ -2128,6 +2129,7 @@ func TestModel_AKeyOnFlowLaunchesAutoreviewWithPRContext(t *testing.T) {
 	for _, want := range []string{
 		"second-level review",
 		"use the ship skill when fixes require commits or pushes",
+		"use the wtui-flow skill to record the autoreview result before finishing",
 		"worktree: /dev/alpha-worktrees/flow-pr",
 		"branch: flow/pr",
 		"start commit: ghi789",
@@ -2210,6 +2212,7 @@ func TestModel_AKeyOnFlowLaunchesAutoreviewWithRecoveryPrompt(t *testing.T) {
 	for _, want := range []string{
 		"second-level review",
 		"use the ship skill when fixes require commits or pushes",
+		"use the wtui-flow skill to record the autoreview result before finishing",
 		"worktree: /dev/alpha-worktrees/flow-pr",
 		"branch: flow/pr",
 		"start commit: ghi789",

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1502,7 +1502,7 @@ func flowPhasePromptNeedsPlanBody(phaseID string) bool {
 }
 
 func flowPlanReviewPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
-	return flowMinimalArtifactPrompt("Use the review loop skill to review the saved plan.", planPath, record, phase)
+	return flowMinimalArtifactPrompt("Use the review loop skill to review the saved plan.\nUse the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.", planPath, record, phase)
 }
 
 func flowImplementationPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1526,7 +1526,7 @@ func flowImplementationWithoutPlanPrompt(record flowstore.FlowRecord, phase flow
 }
 
 func flowReviewLoopPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
-	return flowMinimalChangePrompt("Use the review-loop workflow to review the changes.\nUse the commit skill when revisions are made.", record, phase)
+	return flowMinimalChangePrompt("Use the review-loop workflow to review the changes.\nUse the commit skill when revisions are made.\nUse the wtui-flow skill to record the Review Loop result before finishing; the phase is not done until the result is persisted.", record, phase)
 }
 
 func flowPRCreationPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
@@ -1556,7 +1556,8 @@ func flowMinimalArtifactPrompt(instruction, planPath string, record flowstore.Fl
 func flowAutoreviewPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
 	var b strings.Builder
 	b.WriteString("Use the autoreview skill for this second-level review.\n")
-	b.WriteString("Use the ship skill when fixes require commits or pushes.\n\n")
+	b.WriteString("Use the ship skill when fixes require commits or pushes.\n")
+	b.WriteString("Use the wtui-flow skill to record the Autoreview result before finishing; the phase is not done until the result is persisted.\n\n")
 	writeFlowChangeMetadata(&b, record)
 	if flowstore.HasPRTarget(record.PR) {
 		fmt.Fprintf(&b, "\nPR target:\n- PR: %s #%d\n- URL: %s\n- Head: %s\n- Base: %s", record.PR.Provider, record.PR.Number, record.PR.URL, record.PR.HeadBranch, record.PR.BaseBranch)


### PR DESCRIPTION
## Problem

Flow plan-review phases were not being completed: launched agents ran the review, then exited without ever recording a verdict, leaving the phase stuck in `running` and gating Implementation.

The root cause is in the launch prompt. Plan Review was the only phase prompt with no completion signal at all — it said only "Use the review loop skill to review the saved plan." plus location metadata. The design relied on the `wtui-flow` skill self-triggering off `WTUI_FLOW_ID`/`WTUI_FLOW_PHASE_ID`, but env vars are invisible to the model unless something tells it to look, so the skill never fired (especially in headless `claude --print` / `codex exec` launches). Every other phase prompt has some nudge: implementation says "before completing this phase", pr-creation and merge embed explicit `wtui flow` commands.

## Change

`flowPlanReviewPrompt` adds one line:

> Use the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.

This makes the skill discoverable by name while keeping the minimal-prompt rule — it is a skill pointer, not an embedded status recipe. The launch test still asserts the prompt contains no `wtui flow phase set` commands, outcome values, plan body, or phase history.

## Testing

- Updated `TestModel_AKeyOnFlowLaunchesReadyPlanReviewWithLinkedPlanContext` first (red), then implemented (green).
- `make test` passes, `gofmt -l .` clean.

## Note

The review-loop and autoreview prompts also reference only their own skills, not wtui-flow. If those phases show the same stall, the identical one-line treatment applies; left out of scope here.