### PR TITLE
Simplify merge phase wording to "merge the PR deliberately"

### DIFF
--- a/agent-skills/wtui-flow/SKILL.md
+++ b/agent-skills/wtui-flow/SKILL.md
@@ -365,7 +365,7 @@ wtui flow phase complete \
 
 ## Merge Phase
 
-Goal: merge deliberately after review approval.
+Goal: merge a single pr deliberately.
 
 Do not merge silently. Read the Flow first and verify the top-level `pr` object
 contains provider, number, URL, head branch, and base branch. After the explicit

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -2382,7 +2382,7 @@ func TestModel_AKeyOnFlowLaunchesMergeWithStructuredReportingPrompt(t *testing.T
 	}
 	prompt := strings.ToLower(launched.InitialPrompt)
 	for _, want := range []string{
-		"merge the reviewed pr deliberately",
+		"merge the pr deliberately",
 		"github #116",
 		"https://github.com/brian-bell/wtui/pull/116",
 		"wtui flow merge set --flow-id flow-1 --status merged",

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1580,7 +1580,7 @@ func writeFlowRestartPromptIfNeeded(b *strings.Builder, record flowstore.FlowRec
 
 func flowMergePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
 	var b strings.Builder
-	b.WriteString("Merge the reviewed PR deliberately.\n\n")
+	b.WriteString("Merge the PR deliberately.\n\n")
 	writeFlowChangeMetadata(&b, record)
 	if flowstore.HasPRTarget(record.PR) {
 		fmt.Fprintf(&b, "\n\nPR target:\n- PR: %s #%d\n- URL: %s\n- Head: %s\n- Base: %s\n", record.PR.Provider, record.PR.Number, record.PR.URL, record.PR.HeadBranch, record.PR.BaseBranch)


### PR DESCRIPTION
## Summary

Aligns the Merge phase wording in two places on the same phrasing:

- `agent-skills/wtui-flow/SKILL.md`: the Merge Phase goal now reads "merge a single pr deliberately" instead of "merge deliberately after review approval".
- `model/model_keys.go` (`flowMergePrompt`): the default merge launch prompt now opens with "Merge the PR deliberately." instead of "Merge the reviewed PR deliberately."

The old wording implied a review-approval precondition that the prompt itself never checked — the actual gating is the recorded PR target (`wtui flow pr set`) and the phase transition table. The new phrasing states what the phase does without the misleading qualifier.

## Implementation

- One-word prompt change in `flowMergePrompt`, plus the matching assertion update in `TestModel_AKeyOnFlowLaunchesMergeWithStructuredReportingPrompt`.
- One-line goal change in the canonical skill source.

## Verification

- `gofmt -l .` clean
- `go test ./model/ ./agent-skills/` passes (including the skill/CLI contract sync test in `agent-skills/skill_docs_test.go`)
- `make build` succeeds