### PR TITLE
Pad embedded terminal content

### DIFF
--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -4208,6 +4208,10 @@ func TestModel_EmbeddedTerminalUsesRenderedPaneWidth(t *testing.T) {
 	if started != wantStartSize {
 		t.Fatalf("embedded terminal start size = %dx%d, want %dx%d", started[0], started[1], wantStartWidth, wantStartHeight)
 	}
+	wantPaddedStartWidth := ui.RightContentWidth(180, 14, false) - ui.EmbeddedTerminalFrameColumns - 2*ui.EmbeddedTerminalSidePadding
+	if started[0] != wantPaddedStartWidth {
+		t.Fatalf("embedded terminal start width = %d, want padded width %d", started[0], wantPaddedStartWidth)
+	}
 	_ = m.View()
 	if len(fakeTerm.visibleCalls) == 0 || fakeTerm.visibleCalls[len(fakeTerm.visibleCalls)-1] != wantStartSize {
 		t.Fatalf("embedded terminal visible calls = %#v, want latest %dx%d", fakeTerm.visibleCalls, wantStartWidth, wantStartHeight)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -161,6 +161,9 @@ const (
 	// EmbeddedTerminalHeaderRows is the non-PTY tab/header row inside the
 	// embedded terminal frame.
 	EmbeddedTerminalHeaderRows = 1
+	// EmbeddedTerminalSidePadding is the horizontal padding between each
+	// embedded terminal border and its content.
+	EmbeddedTerminalSidePadding = 1
 )
 
 // StashPrefixWidth is the visible width consumed by the stash line prefix:
@@ -291,11 +294,24 @@ func RightContentWidth(width, height int, activeStatusQuery bool) int {
 	return rightContentWidth
 }
 
-// EmbeddedTerminalRenderContentWidth returns the inner width available inside
-// the embedded terminal frame.
+// EmbeddedTerminalRenderContentWidth returns the drawable content width after
+// the embedded terminal frame and effective side padding are reserved.
 func EmbeddedTerminalRenderContentWidth(outerWidth int) int {
-	if width := outerWidth - EmbeddedTerminalFrameColumns; width > 0 {
+	available := outerWidth - EmbeddedTerminalFrameColumns
+	if available <= 0 {
+		return 0
+	}
+	width := available - 2*embeddedTerminalEffectiveSidePadding(outerWidth)
+	if width > 0 {
 		return width
+	}
+	return 0
+}
+
+func embeddedTerminalEffectiveSidePadding(outerWidth int) int {
+	available := outerWidth - EmbeddedTerminalFrameColumns
+	if available >= 2*EmbeddedTerminalSidePadding+1 {
+		return EmbeddedTerminalSidePadding
 	}
 	return 0
 }
@@ -314,7 +330,7 @@ func EmbeddedTerminalRenderBodyHeight(outerHeight int) int {
 // allocation. PTY dimensions are clamped positive because the terminal backend
 // normalizes to positive sizes, even when a tiny frame leaves no drawable body.
 func EmbeddedTerminalPTYWidth(outerWidth int) int {
-	if width := outerWidth - EmbeddedTerminalFrameColumns; width > 0 {
+	if width := EmbeddedTerminalRenderContentWidth(outerWidth); width > 0 {
 		return width
 	}
 	return 1
@@ -1835,10 +1851,10 @@ func renderEmbeddedTerminalPane(tabs []EmbeddedTerminalTab, liveLines []string, 
 	if outerHeight <= 0 {
 		return nil
 	}
-	innerWidth := EmbeddedTerminalRenderContentWidth(outerWidth)
-	header := truncateToWidth(renderEmbeddedTerminalHeader(tabs), innerWidth)
+	contentWidth := EmbeddedTerminalRenderContentWidth(outerWidth)
+	header := truncateToWidth(renderEmbeddedTerminalHeader(tabs), contentWidth)
 	if prefixActive {
-		header = truncateToWidth(header+"  "+statusStyle.Render("ctrl+g"), innerWidth)
+		header = truncateToWidth(header+"  "+statusStyle.Render("ctrl+g"), contentWidth)
 	}
 	bodyHeight := EmbeddedTerminalRenderBodyHeight(outerHeight)
 	if len(liveLines) > bodyHeight {
@@ -1853,7 +1869,7 @@ func renderEmbeddedTerminalPane(tabs []EmbeddedTerminalTab, liveLines []string, 
 		contentLines = append(contentLines, header)
 	}
 	for _, line := range liveLines {
-		contentLines = append(contentLines, truncateToWidth(line, innerWidth))
+		contentLines = append(contentLines, truncateToWidth(line, contentWidth))
 	}
 	if len(contentLines) < contentHeight {
 		contentLines = append(contentLines, make([]string, contentHeight-len(contentLines))...)
@@ -1865,10 +1881,14 @@ func renderEmbeddedTerminalFrame(contentLines []string, focused bool, outerWidth
 	if outerHeight <= 0 {
 		return nil
 	}
-	innerWidth := EmbeddedTerminalRenderContentWidth(outerWidth)
+	contentWidth := EmbeddedTerminalRenderContentWidth(outerWidth)
+	frameInnerWidth := outerWidth - EmbeddedTerminalFrameColumns
+	if frameInnerWidth < 0 {
+		frameInnerWidth = 0
+	}
 	style := embeddedTerminalBorderStyle(focused)
-	top := style.Render("┌" + strings.Repeat("─", innerWidth) + "┐")
-	bottom := style.Render("└" + strings.Repeat("─", innerWidth) + "┘")
+	top := style.Render("┌" + strings.Repeat("─", frameInnerWidth) + "┐")
+	bottom := style.Render("└" + strings.Repeat("─", frameInnerWidth) + "┘")
 	if outerWidth <= 1 {
 		top = style.Render("┌")
 		bottom = style.Render("└")
@@ -1881,7 +1901,7 @@ func renderEmbeddedTerminalFrame(contentLines []string, focused bool, outerWidth
 				if i < len(contentLines) {
 					content = contentLines[i]
 				}
-				lines = append(lines, renderEmbeddedTerminalFrameContentLine(content, style, innerWidth, outerWidth))
+				lines = append(lines, renderEmbeddedTerminalFrameContentLine(content, style, contentWidth, outerWidth))
 			}
 		}
 		lines = append(lines, bottom)
@@ -1889,18 +1909,19 @@ func renderEmbeddedTerminalFrame(contentLines []string, focused bool, outerWidth
 	return fitEmbeddedTerminalFrameLines(lines, outerWidth, outerHeight)
 }
 
-func renderEmbeddedTerminalFrameContentLine(content string, borderStyle lipgloss.Style, innerWidth, outerWidth int) string {
+func renderEmbeddedTerminalFrameContentLine(content string, borderStyle lipgloss.Style, contentWidth, outerWidth int) string {
 	if outerWidth <= 0 {
 		return ""
 	}
 	if outerWidth == 1 {
 		return borderStyle.Render("│")
 	}
-	content = truncateToWidth(content, innerWidth)
-	if padding := innerWidth - lipgloss.Width(content); padding > 0 {
+	content = truncateToWidth(content, contentWidth)
+	if padding := contentWidth - lipgloss.Width(content); padding > 0 {
 		content += strings.Repeat(" ", padding)
 	}
-	return borderStyle.Render("│") + content + borderStyle.Render("│")
+	sidePadding := strings.Repeat(" ", embeddedTerminalEffectiveSidePadding(outerWidth))
+	return borderStyle.Render("│") + sidePadding + content + sidePadding + borderStyle.Render("│")
 }
 
 func embeddedTerminalBorderStyle(focused bool) lipgloss.Style {

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -184,7 +184,7 @@ func TestRenderFlowSplitPaneWrapsOnlyTerminalPanelInBorder(t *testing.T) {
 	if !strings.Contains(lines[listHeight], "┌") {
 		t.Fatalf("terminal top border should start at index %d:\n%s", listHeight, strings.Join(lines, "\n"))
 	}
-	if !strings.Contains(lines[listHeight+1], "│1 codex implementation running") {
+	if !strings.Contains(lines[listHeight+1], "│ 1 codex implementation running") {
 		t.Fatalf("terminal header should be first framed content row:\n%s", strings.Join(lines, "\n"))
 	}
 	if !strings.Contains(lines[listHeight+terminalHeight-1], "└") {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -65,6 +65,34 @@ func requireStyleColor(t *testing.T, name string, got lipgloss.TerminalColor, wa
 	}
 }
 
+func TestEmbeddedTerminalWidthHelpersReserveSidePadding(t *testing.T) {
+	tests := []struct {
+		outerWidth int
+		wantRender int
+		wantPTY    int
+	}{
+		{outerWidth: 0, wantRender: 0, wantPTY: 1},
+		{outerWidth: 1, wantRender: 0, wantPTY: 1},
+		{outerWidth: 2, wantRender: 0, wantPTY: 1},
+		{outerWidth: 3, wantRender: 1, wantPTY: 1},
+		{outerWidth: 4, wantRender: 2, wantPTY: 2},
+		{outerWidth: 5, wantRender: 1, wantPTY: 1},
+		{outerWidth: 6, wantRender: 2, wantPTY: 2},
+		{outerWidth: 120, wantRender: 116, wantPTY: 116},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("outer_width_%d", tt.outerWidth), func(t *testing.T) {
+			if got := EmbeddedTerminalRenderContentWidth(tt.outerWidth); got != tt.wantRender {
+				t.Fatalf("render content width = %d, want %d", got, tt.wantRender)
+			}
+			if got := EmbeddedTerminalPTYWidth(tt.outerWidth); got != tt.wantPTY {
+				t.Fatalf("PTY width = %d, want %d", got, tt.wantPTY)
+			}
+		})
+	}
+}
+
 func TestStatusBar_BranchesModeContainsIndicatorLegend(t *testing.T) {
 	bar := RenderStatusBar(120, 2, 0, 1, true, false, false)
 	for _, legend := range []string{"✔ clean", "● ahead/behind", "● dirty", "● no upstream", "merged"} {
@@ -293,7 +321,7 @@ func TestRender_SessionsModeShowsEmbeddedTerminalInsteadOfSessionRows(t *testing
 	if !strings.Contains(lines[top], "┌") || bottom <= body {
 		t.Fatalf("embedded terminal frame should wrap header and body in order, got indexes top=%d header=%d body=%d bottom=%d:\n%s", top, header, body, bottom, view)
 	}
-	if !strings.Contains(lines[header], "│1 codex feature/api running") || !strings.Contains(lines[body], "│agent output") {
+	if !strings.Contains(lines[header], "│ 1 codex feature/api running") || !strings.Contains(lines[body], "│ agent output") {
 		t.Fatalf("embedded terminal header/body should be inside inner border:\n%s\n%s", lines[header], lines[body])
 	}
 }
@@ -320,9 +348,9 @@ func TestRenderEmbeddedTerminalPaneWindowsLinesInsideBorder(t *testing.T) {
 	requireLinesWithinWidth(t, stripped, 28)
 	for index, want := range map[int]string{
 		0: "┌",
-		1: "│1 codex implementation",
-		2: "│terminal line 4",
-		3: "│terminal line 5",
+		1: "│ 1 codex implementation",
+		2: "│ terminal line 4",
+		3: "│ terminal line 5",
 		4: "└",
 	} {
 		if !strings.Contains(stripped[index], want) {
@@ -336,6 +364,39 @@ func TestRenderEmbeddedTerminalPaneWindowsLinesInsideBorder(t *testing.T) {
 	}
 }
 
+func TestRenderEmbeddedTerminalFramePreservesBorderWidthWithSidePadding(t *testing.T) {
+	for _, tt := range []struct {
+		width           int
+		wantContentLine string
+		wantTop         string
+		wantBottom      string
+	}{
+		{width: 1, wantContentLine: "│", wantTop: "┌", wantBottom: "└"},
+		{width: 2, wantContentLine: "││", wantTop: "┌┐", wantBottom: "└┘"},
+		{width: 3, wantContentLine: "│a│", wantTop: "┌─┐", wantBottom: "└─┘"},
+		{width: 4, wantContentLine: "│ab│", wantTop: "┌──┐", wantBottom: "└──┘"},
+		{width: 5, wantContentLine: "│ a │", wantTop: "┌───┐", wantBottom: "└───┘"},
+	} {
+		t.Run(fmt.Sprintf("width_%d", tt.width), func(t *testing.T) {
+			contentLine := stripLines([]string{renderEmbeddedTerminalFrameContentLine("abc", lipgloss.NewStyle(), EmbeddedTerminalRenderContentWidth(tt.width), tt.width)})[0]
+			if contentLine != tt.wantContentLine {
+				t.Fatalf("content line = %q, want %q", contentLine, tt.wantContentLine)
+			}
+
+			frame := stripLines(renderEmbeddedTerminalFrame([]string{"abc"}, false, tt.width, 3))
+			if len(frame) != 3 {
+				t.Fatalf("frame lines = %#v, want 3 lines", frame)
+			}
+			if frame[0] != tt.wantTop {
+				t.Fatalf("top border = %q, want %q", frame[0], tt.wantTop)
+			}
+			if frame[2] != tt.wantBottom {
+				t.Fatalf("bottom border = %q, want %q", frame[2], tt.wantBottom)
+			}
+		})
+	}
+}
+
 func TestRenderEmbeddedTerminalPaneSmallAllocations(t *testing.T) {
 	tabs := []EmbeddedTerminalTab{{Number: 1, Provider: "codex", State: "running", Active: true}}
 	for _, tc := range []struct {
@@ -345,7 +406,7 @@ func TestRenderEmbeddedTerminalPaneSmallAllocations(t *testing.T) {
 		{height: 0, want: nil},
 		{height: 1, want: []string{"┌──────────┐"}},
 		{height: 2, want: []string{"┌──────────┐", "└──────────┘"}},
-		{height: 3, want: []string{"┌──────────┐", "│1 codex ru│", "└──────────┘"}},
+		{height: 3, want: []string{"┌──────────┐", "│ 1 codex  │", "└──────────┘"}},
 	} {
 		t.Run(fmt.Sprintf("height_%d", tc.height), func(t *testing.T) {
 			got := stripLines(renderEmbeddedTerminalPane(tabs, []string{"body"}, false, false, 12, tc.height))


### PR DESCRIPTION
## Summary
- add one horizontal padding column between embedded terminal borders and header/live output
- keep tiny pane allocations usable before applying side padding
- align PTY width with the padded rendered content width for starts, visible lines, and resizes

## Tests
- git diff --check
- gofmt -l .
- make test
- make build

## Review loop
- loop 1: 9/10, addressed helper comment clarity and brittle numeric model assertion
- loop 2: 10/10, no issues found