### PR TITLE
Extract compact picker modal

### DIFF
--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -686,6 +686,7 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 	if err := validateFlowID(update.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
+	requestedPhaseID := strings.TrimSpace(update.PhaseID)
 	update.PhaseID = artifacts.NormalizePhaseID(update.PhaseID)
 	if update.PhaseID == "" {
 		return FlowRecord{}, fmt.Errorf("phase id is required")
@@ -695,7 +696,11 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 		return FlowRecord{}, fmt.Errorf("launch id is required")
 	}
 	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
-		phaseIndex := phaseIndexByID(record.Phases, update.PhaseID)
+		// Launch bookkeeping targets the requested phase row. Legacy records may
+		// contain an earlier stale duplicate whose id only matches after
+		// normalization; prefer the exact row before deciding whether a resume
+		// should preserve terminal state or restart active work.
+		phaseIndex := phaseIndexPreferringExactID(record.Phases, requestedPhaseID)
 		if phaseIndex < 0 {
 			return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
 		}
@@ -749,6 +754,7 @@ func (s *Store) AttachSession(update SessionAttachUpdate) (FlowRecord, error) {
 	if err := validateFlowID(update.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
+	requestedPhaseID := strings.TrimSpace(update.PhaseID)
 	update.PhaseID = artifacts.NormalizePhaseID(update.PhaseID)
 	if update.PhaseID == "" {
 		return FlowRecord{}, fmt.Errorf("phase id is required")
@@ -765,7 +771,7 @@ func (s *Store) AttachSession(update SessionAttachUpdate) (FlowRecord, error) {
 		// still holds a stale duplicate ahead of the active row, collapsing
 		// into the first normalized match would silently drop the active
 		// row's status.
-		phaseIndex := phaseIndexPreferringExactID(record.Phases, update.PhaseID)
+		phaseIndex := phaseIndexPreferringExactID(record.Phases, requestedPhaseID)
 		if phaseIndex < 0 {
 			return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
 		}

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -3070,6 +3070,131 @@ func TestStoreAddPhaseLaunchIDMatchesNormalizedPhaseIDVariants(t *testing.T) {
 	}
 }
 
+func TestStoreAddPhaseLaunchIDResumePrefersExactRowOverEarlierTerminalDuplicate(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		FlowID:       "exact-row-launch",
+		Title:        "Exact row launch",
+		Instructions: "resume launch targets active duplicate",
+		RepoPath:     filepath.Join(root, "repo"),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted, Order: 1, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved, Order: 2, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted, Order: 3, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "Step-1", ParentPhaseID: "implementation", Title: "Step 1", Status: flowstore.PhaseCompleted, Kind: "implementation_child", Order: 10, CreatedAt: now, UpdatedAt: now},
+			{
+				PhaseID: "step-1", ParentPhaseID: "implementation", Title: "Step 1",
+				Status: flowstore.PhaseNeedsAttention, Outcome: "needs_attention", Notes: "PTY startup failed.",
+				Kind:      "implementation_child",
+				Order:     10,
+				LaunchIDs: []string{"launch-1"},
+				CreatedAt: now, UpdatedAt: now,
+			},
+			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhasePending, Order: 4, CreatedAt: now, UpdatedAt: now},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	record, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:   record.FlowID,
+		PhaseID:  "step-1",
+		LaunchID: "launch-2",
+		Resume:   true,
+	})
+	if err != nil {
+		t.Fatalf("AddPhaseLaunchID(step-1 resume) error = %v", err)
+	}
+
+	count := 0
+	var survivor flowstore.FlowPhase
+	for _, phase := range record.Phases {
+		if phase.ParentPhaseID == "implementation" {
+			count++
+			survivor = phase
+		}
+	}
+	if count != 1 {
+		t.Fatalf("duplicate child rows not collapsed on launch: %#v", record.Phases)
+	}
+	if survivor.PhaseID != "step-1" {
+		t.Fatalf("survivor phase id = %q, want step-1", survivor.PhaseID)
+	}
+	if survivor.Status != flowstore.PhaseRunning || survivor.Outcome != "" {
+		t.Fatalf("survivor after resume launch = %#v, want running with cleared outcome", survivor)
+	}
+	if !strings.Contains(survivor.Notes, "Relaunched after needs_attention") {
+		t.Fatalf("survivor notes = %q, want relaunch note", survivor.Notes)
+	}
+	if len(survivor.LaunchIDs) != 2 || survivor.LaunchIDs[0] != "launch-1" || survivor.LaunchIDs[1] != "launch-2" {
+		t.Fatalf("launch ids = %#v, want [launch-1 launch-2]", survivor.LaunchIDs)
+	}
+}
+
+func TestStoreAddPhaseLaunchIDResumePrefersRawExactRowBeforeNormalizedDuplicate(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		FlowID:       "raw-exact-row-launch",
+		Title:        "Raw exact row launch",
+		Instructions: "resume launch targets requested duplicate casing",
+		RepoPath:     filepath.Join(root, "repo"),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted, Order: 1, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved, Order: 2, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted, Order: 3, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "step-1", ParentPhaseID: "implementation", Title: "Step 1", Status: flowstore.PhaseCompleted, Kind: "implementation_child", Order: 10, CreatedAt: now, UpdatedAt: now},
+			{
+				PhaseID: "Step-1", ParentPhaseID: "implementation", Title: "Step 1",
+				Status: flowstore.PhaseNeedsAttention, Outcome: "needs_attention", Notes: "PTY startup failed.",
+				Kind:      "implementation_child",
+				Order:     10,
+				LaunchIDs: []string{"launch-1"},
+				CreatedAt: now, UpdatedAt: now,
+			},
+			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhasePending, Order: 4, CreatedAt: now, UpdatedAt: now},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	record, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:   record.FlowID,
+		PhaseID:  "Step-1",
+		LaunchID: "launch-2",
+		Resume:   true,
+	})
+	if err != nil {
+		t.Fatalf("AddPhaseLaunchID(Step-1 resume) error = %v", err)
+	}
+
+	phase := phaseByID(t, record, "step-1")
+	if phase.Status != flowstore.PhaseRunning || phase.Outcome != "" {
+		t.Fatalf("phase after resume launch = %#v, want running with cleared outcome", phase)
+	}
+	if !strings.Contains(phase.Notes, "Relaunched after needs_attention") {
+		t.Fatalf("phase notes = %q, want relaunch note", phase.Notes)
+	}
+	if len(phase.LaunchIDs) != 2 || phase.LaunchIDs[0] != "launch-1" || phase.LaunchIDs[1] != "launch-2" {
+		t.Fatalf("launch ids = %#v, want [launch-1 launch-2]", phase.LaunchIDs)
+	}
+}
+
 func TestStoreAttachSessionMatchesNormalizedPhaseIDVariants(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
@@ -3166,6 +3291,61 @@ func TestStoreAttachSessionPrefersExactRowOverEarlierDuplicate(t *testing.T) {
 	}
 	if len(survivor.Sessions) != 1 || survivor.Sessions[0].SessionID != "sess-9" {
 		t.Fatalf("sessions = %#v, want attached sess-9", survivor.Sessions)
+	}
+}
+
+func TestStoreAttachSessionPrefersRawExactRowBeforeNormalizedDuplicate(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		FlowID:       "raw-exact-row-attach",
+		Title:        "Raw exact row attach",
+		Instructions: "attach session to requested duplicate casing",
+		RepoPath:     filepath.Join(root, "repo"),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted, Order: 1, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved, Order: 2, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted, Order: 3, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "step-1", ParentPhaseID: "implementation", Title: "Step 1", Status: flowstore.PhaseCompleted, Kind: "implementation_child", Order: 10, CreatedAt: now, UpdatedAt: now},
+			{
+				PhaseID: "Step-1", ParentPhaseID: "implementation", Title: "Step 1",
+				Status:    flowstore.PhaseRunning,
+				Kind:      "implementation_child",
+				Order:     10,
+				LaunchIDs: []string{"launch-1"},
+				CreatedAt: now, UpdatedAt: now,
+			},
+			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhasePending, Order: 4, CreatedAt: now, UpdatedAt: now},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	record, err = store.AttachSession(flowstore.SessionAttachUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "Step-1",
+		Session: flowstore.Session{Provider: "codex", SessionID: "sess-9"},
+	})
+	if err != nil {
+		t.Fatalf("AttachSession(Step-1) error = %v", err)
+	}
+
+	phase := phaseByID(t, record, "step-1")
+	if phase.Status != flowstore.PhaseRunning {
+		t.Fatalf("phase status = %q, want running; metadata-only attach must not change phase status", phase.Status)
+	}
+	if len(phase.LaunchIDs) != 1 || phase.LaunchIDs[0] != "launch-1" {
+		t.Fatalf("launch ids lost in collapse: %#v", phase.LaunchIDs)
+	}
+	if len(phase.Sessions) != 1 || phase.Sessions[0].SessionID != "sess-9" {
+		t.Fatalf("sessions = %#v, want attached sess-9", phase.Sessions)
 	}
 }
 

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -635,7 +635,7 @@ func (m Model) openEmbeddedSessionPicker() Model {
 			Value: strconv.Itoa(i),
 		})
 	}
-	m.modal = modal.OpenSelect("Resume session", items, 0, func(value string) tea.Cmd {
+	m.modal = modal.OpenSelectWithLayout("Resume session", items, 0, modal.Layout{Width: 72, Height: 12, Placement: modal.PlacementCenter}, func(value string) tea.Cmd {
 		return func() tea.Msg {
 			index, err := strconv.Atoi(value)
 			if err != nil {

--- a/model/modal/modal.go
+++ b/model/modal/modal.go
@@ -42,6 +42,20 @@ type SelectItem struct {
 	Value string
 }
 
+type Placement int
+
+const (
+	PlacementCenter Placement = iota
+	PlacementTopCenter
+	PlacementBottomCenter
+)
+
+type Layout struct {
+	Width     int
+	Height    int
+	Placement Placement
+}
+
 type InputMode int
 
 const (
@@ -52,43 +66,45 @@ const (
 // Modal is the single in-process state machine for transient modal UI. Its
 // zero value is closed.
 type Modal struct {
-	kind        Kind
-	prompt      string
-	placeholder string
-	force       bool
-	action      func() tea.Cmd
-	input       string
-	inputMode   InputMode
-	inputCursor int
-	inputColumn int
-	inputErr    string
-	validate    func(string) error
-	submit      func(string) tea.Cmd
-	selectItems []SelectItem
-	selectIndex int
-	diffKind    DiffKind
-	diff        string
-	text        string
-	scroll      int
-	request     uint64
+	kind         Kind
+	prompt       string
+	placeholder  string
+	force        bool
+	action       func() tea.Cmd
+	input        string
+	inputMode    InputMode
+	inputCursor  int
+	inputColumn  int
+	inputErr     string
+	validate     func(string) error
+	submit       func(string) tea.Cmd
+	selectItems  []SelectItem
+	selectIndex  int
+	selectLayout Layout
+	diffKind     DiffKind
+	diff         string
+	text         string
+	scroll       int
+	request      uint64
 }
 
 type View struct {
-	Kind        Kind
-	Prompt      string
-	Placeholder string
-	Force       bool
-	Input       string
-	InputMode   InputMode
-	InputCursor int
-	InputErr    string
-	SelectItems []SelectItem
-	SelectIndex int
-	DiffKind    DiffKind
-	Diff        string
-	Text        string
-	Scroll      int
-	Request     uint64
+	Kind         Kind
+	Prompt       string
+	Placeholder  string
+	Force        bool
+	Input        string
+	InputMode    InputMode
+	InputCursor  int
+	InputErr     string
+	SelectItems  []SelectItem
+	SelectIndex  int
+	SelectLayout Layout
+	DiffKind     DiffKind
+	Diff         string
+	Text         string
+	Scroll       int
+	Request      uint64
 }
 
 func OpenConfirm(prompt string, action func() tea.Cmd) Modal {
@@ -132,16 +148,21 @@ func OpenMultiLineInput(prompt, placeholder, initial string, validate func(strin
 }
 
 func OpenSelect(prompt string, items []SelectItem, selectedIndex int, submit func(string) tea.Cmd) Modal {
+	return OpenSelectWithLayout(prompt, items, selectedIndex, Layout{Placement: PlacementCenter}, submit)
+}
+
+func OpenSelectWithLayout(prompt string, items []SelectItem, selectedIndex int, layout Layout, submit func(string) tea.Cmd) Modal {
 	if selectedIndex < 0 || selectedIndex >= len(items) {
 		selectedIndex = 0
 	}
 	copiedItems := append([]SelectItem(nil), items...)
 	return Modal{
-		kind:        Select,
-		prompt:      prompt,
-		selectItems: copiedItems,
-		selectIndex: selectedIndex,
-		submit:      submit,
+		kind:         Select,
+		prompt:       prompt,
+		selectItems:  copiedItems,
+		selectIndex:  selectedIndex,
+		selectLayout: normalizeLayout(layout),
+		submit:       submit,
 	}
 }
 
@@ -197,22 +218,38 @@ func (m Modal) IsOpen() bool {
 
 func (m Modal) View() View {
 	return View{
-		Kind:        m.kind,
-		Prompt:      m.prompt,
-		Placeholder: m.placeholder,
-		Force:       m.force,
-		Input:       m.input,
-		InputMode:   m.inputMode,
-		InputCursor: clampInputCursor(m.input, m.inputCursor),
-		InputErr:    m.inputErr,
-		SelectItems: append([]SelectItem(nil), m.selectItems...),
-		SelectIndex: m.selectIndex,
-		DiffKind:    m.diffKind,
-		Diff:        m.diff,
-		Text:        m.text,
-		Scroll:      m.scroll,
-		Request:     m.request,
+		Kind:         m.kind,
+		Prompt:       m.prompt,
+		Placeholder:  m.placeholder,
+		Force:        m.force,
+		Input:        m.input,
+		InputMode:    m.inputMode,
+		InputCursor:  clampInputCursor(m.input, m.inputCursor),
+		InputErr:     m.inputErr,
+		SelectItems:  append([]SelectItem(nil), m.selectItems...),
+		SelectIndex:  m.selectIndex,
+		SelectLayout: m.selectLayout,
+		DiffKind:     m.diffKind,
+		Diff:         m.diff,
+		Text:         m.text,
+		Scroll:       m.scroll,
+		Request:      m.request,
 	}
+}
+
+func normalizeLayout(layout Layout) Layout {
+	if layout.Width < 0 {
+		layout.Width = 0
+	}
+	if layout.Height < 0 {
+		layout.Height = 0
+	}
+	switch layout.Placement {
+	case PlacementCenter, PlacementTopCenter, PlacementBottomCenter:
+	default:
+		layout.Placement = PlacementCenter
+	}
+	return layout
 }
 
 func (m Modal) Update(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {

--- a/model/modal/modal_test.go
+++ b/model/modal/modal_test.go
@@ -479,6 +479,71 @@ func TestSelectSnapshotsPromptItemsAndInitialSelection(t *testing.T) {
 	}
 }
 
+func TestSelectDefaultsToAutoCenteredLayout(t *testing.T) {
+	view := modal.OpenSelect("Choose agent", []modal.SelectItem{
+		{Label: "codex", Value: "codex"},
+	}, 0, nil).View()
+
+	want := modal.Layout{Placement: modal.PlacementCenter}
+	if view.SelectLayout != want {
+		t.Fatalf("select layout = %#v, want %#v", view.SelectLayout, want)
+	}
+}
+
+func TestSelectCarriesExplicitLayoutWithoutChangingSelectionBehavior(t *testing.T) {
+	items := []modal.SelectItem{
+		{Label: "Codex", Value: "codex"},
+		{Label: "Claude", Value: "claude"},
+	}
+	layout := modal.Layout{Width: 32, Height: 6, Placement: modal.PlacementBottomCenter}
+	var submitted string
+	m := modal.OpenSelectWithLayout("Choose agent", items, 99, layout, func(value string) tea.Cmd {
+		submitted = value
+		return func() tea.Msg { return sentinelMsg("saved") }
+	})
+	items[0] = modal.SelectItem{Label: "mutated", Value: "mutated"}
+
+	view := m.View()
+	if view.SelectLayout != layout {
+		t.Fatalf("select layout = %#v, want %#v", view.SelectLayout, layout)
+	}
+	if view.SelectIndex != 0 {
+		t.Fatalf("out-of-range selected index = %d, want clamped 0", view.SelectIndex)
+	}
+	if got := view.SelectItems[0]; got.Label != "Codex" || got.Value != "codex" {
+		t.Fatalf("select items were not copied before caller mutation: %#v", view.SelectItems)
+	}
+
+	m, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if out != modal.Consumed || cmd != nil {
+		t.Fatalf("down outcome=%v cmd=%T, want consumed nil cmd", out, cmd)
+	}
+	view = m.View()
+	if view.SelectIndex != 1 {
+		t.Fatalf("down selected index = %d, want 1", view.SelectIndex)
+	}
+	if view.SelectLayout != layout {
+		t.Fatalf("layout changed after movement: %#v", view.SelectLayout)
+	}
+
+	next, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if out != modal.Accepted {
+		t.Fatalf("enter outcome = %v, want Accepted", out)
+	}
+	if next.IsOpen() {
+		t.Fatal("expected modal closed after enter")
+	}
+	if cmd == nil {
+		t.Fatal("expected submit command")
+	}
+	if got := cmd(); got != sentinelMsg("saved") {
+		t.Fatalf("submit command returned %T %[1]v", got)
+	}
+	if submitted != "claude" {
+		t.Fatalf("submitted = %q, want claude", submitted)
+	}
+}
+
 func TestSelectMovesWithWrapping(t *testing.T) {
 	m := modal.OpenSelect("Choose agent", []modal.SelectItem{
 		{Label: "codex", Value: "codex"},

--- a/model/model.go
+++ b/model/model.go
@@ -482,6 +482,9 @@ func (m Model) View() string {
 		SelectPrompt:               modalView.Prompt,
 		SelectItems:                uiSelectItems(modalView.SelectItems),
 		SelectSelected:             modalView.SelectIndex,
+		SelectWidth:                modalView.SelectLayout.Width,
+		SelectHeight:               modalView.SelectLayout.Height,
+		SelectPlacement:            uiSelectPlacement(modalView.SelectLayout.Placement),
 		BranchScroll:               branchScroll,
 		RepoScroll:                 repoScroll,
 		StashScroll:                stashScroll,
@@ -673,7 +676,7 @@ func (m Model) overlayState() ui.OverlayState {
 	case modal.Input:
 		return ui.OverlayInput
 	case modal.Select:
-		return ui.OverlayAgentSelect
+		return ui.OverlaySelect
 	case modal.Diff:
 		switch view.DiffKind {
 		case modal.DiffStash:
@@ -700,6 +703,17 @@ func uiInputMode(mode modal.InputMode) ui.InputMode {
 		return ui.InputMultiLine
 	}
 	return ui.InputSingleLine
+}
+
+func uiSelectPlacement(placement modal.Placement) ui.SelectPlacement {
+	switch placement {
+	case modal.PlacementTopCenter:
+		return ui.SelectPlacementTopCenter
+	case modal.PlacementBottomCenter:
+		return ui.SelectPlacementBottomCenter
+	default:
+		return ui.SelectPlacementCenter
+	}
 }
 
 func uiSelectItems(items []modal.SelectItem) []ui.SelectItem {

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/creack/pty"
 
 	"github.com/brian-bell/wtui/actions"
@@ -3147,8 +3148,8 @@ func TestModel_ShiftAOpensAgentSelectFromBothPanes(t *testing.T) {
 		t.Run(setup.name, func(t *testing.T) {
 			m := setup.fn(model.New(testRepos()))
 			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
-			if m.Overlay() != ui.OverlayAgentSelect {
-				t.Fatalf("expected agent select overlay, got %d", m.Overlay())
+			if m.Overlay() != ui.OverlaySelect {
+				t.Fatalf("expected select overlay, got %d", m.Overlay())
 			}
 			view := m.View()
 			for _, want := range []string{"Choose interactive helper", "codex", "codex-app", "claude"} {
@@ -3156,6 +3157,7 @@ func TestModel_ShiftAOpensAgentSelectFromBothPanes(t *testing.T) {
 					t.Fatalf("expected agent select view to contain %q", want)
 				}
 			}
+			assertRenderedSelectPanel(t, view, "Choose interactive helper", 32, 6, 24, 8)
 			if cmd != nil {
 				t.Fatalf("expected nil cmd opening agent select, got %T", cmd)
 			}
@@ -3184,6 +3186,88 @@ func TestModel_ShiftAAgentSelectPreselectsCurrentAgent(t *testing.T) {
 			}
 		})
 	}
+}
+
+type renderedSelectPanelBounds struct {
+	x      int
+	y      int
+	width  int
+	height int
+}
+
+func assertRenderedSelectPanel(t *testing.T, view, prompt string, wantWidth, wantHeight, wantX, wantY int) {
+	t.Helper()
+	bounds := renderedSelectPanelBoundsForPrompt(t, view, prompt)
+	if bounds.width != wantWidth || bounds.height != wantHeight || bounds.x != wantX || bounds.y != wantY {
+		t.Fatalf("select panel bounds = x:%d y:%d w:%d h:%d, want x:%d y:%d w:%d h:%d:\n%s",
+			bounds.x, bounds.y, bounds.width, bounds.height,
+			wantX, wantY, wantWidth, wantHeight,
+			ansi.Strip(view))
+	}
+}
+
+func renderedSelectPanelBoundsForPrompt(t *testing.T, view, prompt string) renderedSelectPanelBounds {
+	t.Helper()
+	lines := strings.Split(ansi.Strip(view), "\n")
+	var found bool
+	var best renderedSelectPanelBounds
+	for y, line := range lines {
+		runes := []rune(line)
+		for x, r := range runes {
+			if r != '┌' {
+				continue
+			}
+			for right := x + 1; right < len(runes); right++ {
+				if runes[right] != '┐' {
+					continue
+				}
+				for bottom := y + 1; bottom < len(lines); bottom++ {
+					bottomRunes := []rune(lines[bottom])
+					if x >= len(bottomRunes) || right >= len(bottomRunes) {
+						continue
+					}
+					if bottomRunes[x] != '└' || bottomRunes[right] != '┘' {
+						continue
+					}
+					candidate := renderedSelectPanelBounds{
+						x:      x,
+						y:      y,
+						width:  right - x + 1,
+						height: bottom - y + 1,
+					}
+					if !renderedPanelContainsPrompt(lines, candidate, prompt) {
+						continue
+					}
+					if !found || candidate.width < best.width {
+						found = true
+						best = candidate
+					}
+				}
+			}
+		}
+	}
+	if found {
+		return best
+	}
+	t.Fatalf("select panel for prompt %q not found:\n%s", prompt, ansi.Strip(view))
+	return renderedSelectPanelBounds{}
+}
+
+func renderedPanelContainsPrompt(lines []string, bounds renderedSelectPanelBounds, prompt string) bool {
+	for row := bounds.y; row < bounds.y+bounds.height && row < len(lines); row++ {
+		runes := []rune(lines[row])
+		if bounds.x >= len(runes) {
+			continue
+		}
+		right := bounds.x + bounds.width
+		if right > len(runes) {
+			right = len(runes)
+		}
+		if strings.Contains(string(runes[bounds.x:right]), prompt) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestModel_AgentSelectSavesAndSetsCodex(t *testing.T) {
@@ -4314,11 +4398,13 @@ func TestModel_EmbeddedTerminalPrefixPickerOpensSecondSession(t *testing.T) {
 	if cmd != nil {
 		t.Fatalf("opening picker should not return command, got %T", cmd)
 	}
-	if m.Overlay() != ui.OverlayAgentSelect {
+	if m.Overlay() != ui.OverlaySelect {
 		t.Fatalf("expected picker overlay, got %d", m.Overlay())
 	}
 	if view := m.View(); !strings.Contains(view, "Resume session") || !strings.Contains(view, "claude docs") {
 		t.Fatalf("picker view missing sessions:\n%s", view)
+	} else {
+		assertRenderedSelectPanel(t, view, "Resume session", 72, 12, 54, 0)
 	}
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1301,6 +1301,54 @@ func TestModel_RKeyOnFlowPhaseResumeFailureUsesNormalizedPersistedPhaseID(t *tes
 	}
 }
 
+func TestModel_RKeyOnFlowPhaseResumeFailurePrefersExactPersistedDuplicate(t *testing.T) {
+	var phaseUpdates []flowstore.PhaseUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID, Phases: []flowstore.FlowPhase{
+				{PhaseID: "review-loop", Status: flowstore.PhaseCompleted},
+				{PhaseID: "Review-Loop", Status: flowstore.PhaseRunning},
+			}}, nil
+		},
+		SetFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+			phaseUpdates = append(phaseUpdates, update)
+			return flowstore.FlowRecord{}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			return actions.TerminalLaunchSpec{}, errors.New("terminal unavailable")
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		Title:        "Resume duplicate phase failure",
+		Status:       flowstore.StatusInProgress,
+		Branch:       "flow/resume-duplicate-failure",
+		WorktreePath: "/dev/alpha-worktrees/flow-resume-duplicate-failure",
+		Phases: []flowstore.FlowPhase{{
+			PhaseID: "Review-Loop",
+			Title:   "Review loop",
+			Status:  flowstore.PhaseCompleted,
+			Sessions: []flowstore.Session{
+				{Provider: "codex", SessionID: "codex-review", Status: "ended"},
+			},
+		}},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if len(phaseUpdates) != 1 {
+		t.Fatalf("phase updates = %#v, want one; exact persisted running phase must override stale terminal duplicate", phaseUpdates)
+	}
+	if update := phaseUpdates[0]; update.FlowID != "flow-1" ||
+		update.PhaseID != "Review-Loop" ||
+		update.Status != flowstore.PhaseNeedsAttention ||
+		!strings.Contains(update.Notes, "terminal unavailable") {
+		t.Fatalf("phase update = %#v", update)
+	}
+}
+
 func TestModel_RKeyOnFlowPhaseResumeFailureKeepsPhaseCompletedInStore(t *testing.T) {
 	var phaseUpdates []flowstore.PhaseUpdate
 	m := model.NewWithOptions(testRepos(), model.Options{

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1749,7 +1749,13 @@ func writeFlowPhaseContext(b *strings.Builder, phase flowstore.FlowPhase) {
 }
 
 func flowPhaseByID(record flowstore.FlowRecord, phaseID string) (flowstore.FlowPhase, bool) {
-	want := artifacts.NormalizePhaseID(phaseID)
+	requested := strings.TrimSpace(phaseID)
+	for _, phase := range record.Phases {
+		if phase.PhaseID == requested {
+			return phase, true
+		}
+	}
+	want := artifacts.NormalizePhaseID(requested)
 	for _, phase := range record.Phases {
 		if artifacts.NormalizePhaseID(phase.PhaseID) == want {
 			return phase, true

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -717,10 +717,11 @@ func (m Model) handleDelete() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleSetAgent() (tea.Model, tea.Cmd) {
-	m.modal = modal.OpenSelect(
+	m.modal = modal.OpenSelectWithLayout(
 		"Choose interactive helper",
 		agentSelectItems(),
 		selectedAgentIndex(m.agentCommand),
+		modal.Layout{Width: 32, Height: 6, Placement: modal.PlacementCenter},
 		func(value string) tea.Cmd { return m.setAgent(agent.Normalize(value)) },
 	)
 	return m, nil

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -31,7 +31,8 @@ const (
 	OverlaySessionTranscript
 	OverlayPlanText
 	OverlayInput
-	OverlayAgentSelect
+	OverlaySelect
+	OverlayAgentSelect   = OverlaySelect
 	OverlayWorktreeInput = OverlayInput
 )
 
@@ -40,6 +41,14 @@ type InputMode int
 const (
 	InputSingleLine InputMode = iota
 	InputMultiLine
+)
+
+type SelectPlacement int
+
+const (
+	SelectPlacementCenter SelectPlacement = iota
+	SelectPlacementTopCenter
+	SelectPlacementBottomCenter
 )
 
 const BranchPrompt = "New branch"
@@ -199,6 +208,9 @@ type RenderParams struct {
 	SelectPrompt               string
 	SelectItems                []SelectItem
 	SelectSelected             int
+	SelectWidth                int
+	SelectHeight               int
+	SelectPlacement            SelectPlacement
 	BranchScroll               int
 	RepoScroll                 int
 	StashScroll                int
@@ -355,11 +367,17 @@ func Render(p RenderParams) string {
 		p.Height = 24
 	}
 
-	// Overlay takes over the entire screen
 	if p.Overlay != OverlayNone {
+		if p.Overlay == OverlaySelect {
+			return renderSelectOverlay(p)
+		}
 		return renderOverlay(p)
 	}
 
+	return renderApplication(p)
+}
+
+func renderApplication(p RenderParams) string {
 	var repoPath string
 	if p.Selected >= 0 && p.Selected < len(p.Repos) {
 		repoPath = p.Repos[p.Selected].Path
@@ -786,8 +804,8 @@ func renderStatusBarWithState(sp statusBarParams) string {
 			return renderStatusText(width, "  enter: submit  alt+enter: newline  esc: cancel  bksp/del: edit")
 		}
 		return renderStatusText(width, "  enter: submit  esc: cancel  bksp/del: edit  left/right: move")
-	case overlay == OverlayAgentSelect:
-		return statusStyle.Width(width).Render("  up/down select  enter: confirm  esc: cancel")
+	case overlay == OverlaySelect:
+		return renderStatusText(width, "  up/down select  enter: confirm  esc: cancel")
 	case overlay != OverlayNone:
 		return statusStyle.Width(width).Render("  ↑/↓ scroll  esc: close")
 	}
@@ -2637,6 +2655,288 @@ func renderSelectedWorktreeRow(wt gitquery.Worktree, width int) string {
 	return renderSelectedRow(line, width)
 }
 
+func renderSelectOverlay(p RenderParams) string {
+	bodyHeight := p.Height - 1
+	if bodyHeight < 0 {
+		bodyHeight = 0
+	}
+	statusBar := renderSelectOverlayStatusBar(p)
+	body := selectOverlayBaseBody(p, bodyHeight)
+	if p.Width <= 0 || bodyHeight <= 0 {
+		return joinBodyAndStatus(body, statusBar)
+	}
+
+	panelWidth, panelHeight := selectPanelDimensions(p.SelectPrompt, p.SelectItems, p.SelectWidth, p.SelectHeight, p.Width, bodyHeight)
+	if panelWidth <= 0 || panelHeight <= 0 {
+		return joinBodyAndStatus(body, statusBar)
+	}
+	panel := renderSelectPanel(p.SelectPrompt, p.SelectItems, p.SelectSelected, panelWidth, panelHeight)
+	x, y := selectPanelPosition(p.Width, bodyHeight, panelWidth, panelHeight, p.SelectPlacement)
+	body = compositePanel(body, panel, x, y, p.Width)
+	return joinBodyAndStatus(body, statusBar)
+}
+
+func renderSelectOverlayStatusBar(p RenderParams) string {
+	return renderStatusBarWithState(statusBarParams{
+		Width:                  p.Width,
+		Mode:                   p.Mode,
+		Overlay:                p.Overlay,
+		ActivePane:             p.ActivePane,
+		Destructive:            p.Destructive,
+		TransientError:         p.TransientError,
+		TransientErrorFadeStep: p.TransientErrorFadeStep,
+		SearchActive:           p.SearchActive,
+		RepoSearch:             p.RepoSearch,
+		ItemSearch:             p.ItemSearch,
+		FetchAvailable:         p.FetchAvailable,
+		PullAvailable:          p.PullAvailable,
+		AgentAvailable:         p.AgentAvailable,
+		NewAgent:               p.NewAgentAvailable,
+	})
+}
+
+func selectOverlayBaseBody(p RenderParams, bodyHeight int) []string {
+	if bodyHeight <= 0 {
+		return nil
+	}
+	if p.Width <= 0 || p.Width < LeftPaneWidth+2 || p.Height < RepoContentOverhead {
+		return blankLines(p.Width, bodyHeight)
+	}
+	base := p
+	base.Overlay = OverlayNone
+	lines := strings.Split(renderApplication(base), "\n")
+	if len(lines) > 0 {
+		lines = lines[:len(lines)-1]
+	}
+	body := make([]string, bodyHeight)
+	copy(body, lines)
+	for i := range body {
+		body[i] = fitLineToWidth(body[i], p.Width)
+	}
+	return body
+}
+
+func blankLines(width, height int) []string {
+	lines := make([]string, height)
+	if width <= 0 {
+		return lines
+	}
+	blank := strings.Repeat(" ", width)
+	for i := range lines {
+		lines[i] = blank
+	}
+	return lines
+}
+
+func joinBodyAndStatus(body []string, statusBar string) string {
+	if len(body) == 0 {
+		return statusBar
+	}
+	return strings.Join(body, "\n") + "\n" + statusBar
+}
+
+func selectPanelDimensions(prompt string, items []SelectItem, configuredWidth, configuredHeight, terminalWidth, bodyHeight int) (int, int) {
+	if terminalWidth <= 0 || bodyHeight <= 0 {
+		return 0, 0
+	}
+	width := configuredWidth
+	if width <= 0 {
+		width = autoSelectPanelWidth(prompt, items)
+	}
+	width = min(width, terminalWidth)
+	if width < 1 {
+		width = 1
+	}
+	height := configuredHeight
+	if height <= 0 {
+		height = 2 + 1 + len(items)
+	}
+	height = min(height, bodyHeight)
+	if height < 1 {
+		height = 1
+	}
+	return width, height
+}
+
+func autoSelectPanelWidth(prompt string, items []SelectItem) int {
+	if prompt == "" {
+		prompt = "Choose"
+	}
+	widest := lipgloss.Width(prompt)
+	for _, item := range items {
+		label := selectItemLabel(item)
+		if width := lipgloss.Width(label); width > widest {
+			widest = width
+		}
+	}
+	return max(12, widest+4)
+}
+
+func selectPanelPosition(terminalWidth, bodyHeight, panelWidth, panelHeight int, placement SelectPlacement) (int, int) {
+	x := (terminalWidth - panelWidth) / 2
+	if x < 0 {
+		x = 0
+	}
+	var y int
+	switch placement {
+	case SelectPlacementTopCenter:
+		y = 0
+	case SelectPlacementBottomCenter:
+		y = bodyHeight - panelHeight
+	default:
+		y = (bodyHeight - panelHeight) / 2
+	}
+	if y < 0 {
+		y = 0
+	}
+	return x, y
+}
+
+func renderSelectPanel(prompt string, items []SelectItem, selected, width, height int) []string {
+	if width <= 0 || height <= 0 {
+		return nil
+	}
+	if prompt == "" {
+		prompt = "Choose"
+	}
+	if selected < 0 || selected >= len(items) {
+		selected = 0
+	}
+	lines := make([]string, 0, height)
+	lines = append(lines, selectPanelBorderLine("┌", "─", "┐", width))
+	if height > 1 {
+		lines = append(lines, selectPanelContentLine(activeModeStyle.Render(prompt), width))
+	}
+	itemRows := height - 3
+	if itemRows < 0 {
+		itemRows = 0
+	}
+	start := selectItemViewportStart(len(items), selected, itemRows)
+	for i := 0; i < itemRows; i++ {
+		itemIndex := start + i
+		if itemIndex >= len(items) {
+			lines = append(lines, selectPanelContentLine("", width))
+			continue
+		}
+		label := selectItemLabel(items[itemIndex])
+		line := "  " + label
+		if itemIndex == selected {
+			line = selectedStyle.Render("> " + label)
+		}
+		lines = append(lines, selectPanelContentLine(line, width))
+	}
+	if height > 2 {
+		lines = append(lines, selectPanelBorderLine("└", "─", "┘", width))
+	}
+	for len(lines) < height {
+		lines = append(lines, selectPanelContentLine("", width))
+	}
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	for i := range lines {
+		lines[i] = truncateToWidth(lines[i], width)
+	}
+	return lines
+}
+
+func selectPanelBorderLine(left, fill, right string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	line := left + strings.Repeat(fill, max(0, width-2)) + right
+	return truncateToWidth(lipgloss.NewStyle().Foreground(clearDarkTheme.activeBorder).Render(line), width)
+}
+
+func selectPanelContentLine(content string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	border := lipgloss.NewStyle().Foreground(clearDarkTheme.activeBorder)
+	if width == 1 {
+		return truncateToWidth(border.Render("│"), width)
+	}
+	innerWidth := width - 2
+	if width >= 4 {
+		if strings.HasPrefix(ansi.Strip(content), "> ") {
+			content = truncateToWidth(content, innerWidth)
+			padding := innerWidth - lipgloss.Width(content)
+			if padding < 0 {
+				padding = 0
+			}
+			return border.Render("│") + content + strings.Repeat(" ", padding) + border.Render("│")
+		}
+		contentWidth := width - 4
+		content = truncateToWidth(content, contentWidth)
+		padding := contentWidth - lipgloss.Width(content)
+		if padding < 0 {
+			padding = 0
+		}
+		inner := " " + content + strings.Repeat(" ", padding) + " "
+		return border.Render("│") + inner + border.Render("│")
+	}
+	content = truncateToWidth(content, innerWidth)
+	padding := innerWidth - lipgloss.Width(content)
+	if padding < 0 {
+		padding = 0
+	}
+	return border.Render("│") + content + strings.Repeat(" ", padding) + border.Render("│")
+}
+
+func selectItemViewportStart(total, selected, visibleRows int) int {
+	if total <= 0 || visibleRows <= 0 || total <= visibleRows {
+		return 0
+	}
+	if selected < 0 || selected >= total {
+		selected = 0
+	}
+	start := selected - visibleRows + 1
+	if start < 0 {
+		return 0
+	}
+	maxStart := total - visibleRows
+	if start > maxStart {
+		return maxStart
+	}
+	return start
+}
+
+func selectItemLabel(item SelectItem) string {
+	if item.Label != "" {
+		return item.Label
+	}
+	return item.Value
+}
+
+func compositePanel(base, panel []string, x, y, width int) []string {
+	if width <= 0 {
+		return base
+	}
+	out := append([]string(nil), base...)
+	for i, panelLine := range panel {
+		row := y + i
+		if row < 0 || row >= len(out) {
+			continue
+		}
+		panelLine = truncateToWidth(panelLine, width-x)
+		panelWidth := lipgloss.Width(panelLine)
+		line := fitLineToWidth(out[row], width)
+		left := ansi.Cut(line, 0, x)
+		right := ansi.Cut(line, x+panelWidth, width)
+		out[row] = fitLineToWidth(left+panelLine+right, width)
+	}
+	return out
+}
+
+func fitLineToWidth(line string, width int) string {
+	line = truncateToWidth(line, width)
+	padding := width - lipgloss.Width(line)
+	if padding > 0 {
+		line += strings.Repeat(" ", padding)
+	}
+	return line
+}
+
 func renderOverlay(p RenderParams) string {
 	inputParams := inputRenderParamsFrom(p)
 	statusBar := renderStatusBarWithState(statusBarParams{
@@ -2666,10 +2966,6 @@ func renderOverlay(p RenderParams) string {
 	}
 	if p.Overlay == OverlayInput {
 		lines := renderInputDialog(inputParams, p.Width, contentHeight)
-		return strings.Join(lines, "\n") + "\n" + statusBar
-	}
-	if p.Overlay == OverlayAgentSelect {
-		lines := renderSelectDialog(p.SelectPrompt, p.SelectItems, p.SelectSelected, p.Width, contentHeight)
 		return strings.Join(lines, "\n") + "\n" + statusBar
 	}
 	if p.Overlay == OverlayPlanText {
@@ -2734,44 +3030,6 @@ func renderConfirmDialog(prompt string, force bool, width, height int) []string 
 			style = dirtyRedStyle.Bold(true)
 		}
 		lines[mid] = strings.Repeat(" ", pad) + style.Render(prompt)
-	}
-	return lines
-}
-
-func renderSelectDialog(prompt string, items []SelectItem, selected int, width, height int) []string {
-	lines := make([]string, height)
-	if height <= 0 {
-		return lines
-	}
-	if prompt == "" {
-		prompt = "Choose"
-	}
-	if selected < 0 || selected >= len(items) {
-		selected = 0
-	}
-
-	blockHeight := len(items) + 1
-	start := (height - blockHeight) / 2
-	if start < 0 {
-		start = 0
-	}
-	if start < len(lines) {
-		lines[start] = centeredLine(activeModeStyle.Render(prompt), width)
-	}
-	for i, item := range items {
-		row := start + 1 + i
-		if row >= len(lines) {
-			break
-		}
-		label := item.Label
-		if label == "" {
-			label = item.Value
-		}
-		line := "  " + label
-		if i == selected {
-			line = selectedStyle.Render("> " + label)
-		}
-		lines[row] = centeredLine(line, width)
 	}
 	return lines
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -2887,7 +2887,8 @@ func selectPanelContentLine(content string, width int) string {
 	}
 	innerWidth := width - 2
 	if width >= 4 {
-		if strings.HasPrefix(ansi.Strip(content), "> ") {
+		strippedContent := ansi.Strip(content)
+		if strings.HasPrefix(strippedContent, "> ") || strings.HasPrefix(strippedContent, "  ") {
 			content = truncateToWidth(content, innerWidth)
 			padding := innerWidth - lipgloss.Width(content)
 			if padding < 0 {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -2740,6 +2740,27 @@ func TestRender_SelectOverlayAutoSizesFromPromptAndItems(t *testing.T) {
 	}
 }
 
+func TestRender_SelectOverlayAutoWidthFitsLongestUnselectedItem(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:          40,
+		Height:         10,
+		Mode:           ModeWorktrees,
+		Overlay:        OverlaySelect,
+		SelectPrompt:   "Pick",
+		SelectItems:    []SelectItem{{Label: "tiny", Value: "tiny"}, {Label: "", Value: "fallback-value"}},
+		SelectSelected: 0,
+	})
+
+	bounds := requireSelectPanelBounds(t, view, "Pick")
+	if bounds.width != len("fallback-value")+4 {
+		t.Fatalf("auto select width = %d, want %d:\n%s", bounds.width, len("fallback-value")+4, ansi.Strip(view))
+	}
+	if !strings.Contains(ansi.Strip(view), "fallback-value") {
+		t.Fatalf("auto-sized select panel should not truncate longest unselected item:\n%s", ansi.Strip(view))
+	}
+}
+
 func TestRender_SelectOverlayPlacementsUseTerminalBody(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1003,15 +1003,17 @@ func TestStatusBar_InputOverlayShowsMultiLineHints(t *testing.T) {
 	}
 }
 
-func TestStatusBar_AgentSelectOverlayShowsSelectHints(t *testing.T) {
-	bar := RenderStatusBar(120, 1, OverlayAgentSelect, 1, false, false, false)
+func TestStatusBar_SelectOverlayShowsSelectHints(t *testing.T) {
+	bar := RenderStatusBar(120, 1, OverlaySelect, 1, false, false, false)
 	for _, hint := range []string{"up/down select", "enter: confirm", "esc: cancel"} {
 		if !strings.Contains(bar, hint) {
-			t.Errorf("expected hint %q in agent select overlay bar %q", hint, bar)
+			t.Errorf("expected hint %q in select overlay bar %q", hint, bar)
 		}
 	}
-	if strings.Contains(bar, "backspace: delete") {
-		t.Fatalf("agent select status should not show text-input hint: %q", bar)
+	for _, forbidden := range []string{"bksp", "backspace", "left/right"} {
+		if strings.Contains(bar, forbidden) {
+			t.Fatalf("select status should not show text-input hint %q: %q", forbidden, bar)
+		}
 	}
 }
 
@@ -2656,13 +2658,13 @@ func TestRender_PullRequestWorktreeInputDialogShowsPromptAndPlaceholder(t *testi
 	}
 }
 
-func TestRender_AgentSelectDialogShowsPromptItemsAndSelection(t *testing.T) {
+func TestRender_SelectDialogShowsPromptItemsAndSelection(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
 		Width:          80,
 		Height:         24,
 		Mode:           1,
-		Overlay:        OverlayAgentSelect,
+		Overlay:        OverlaySelect,
 		SelectPrompt:   "Choose interactive helper",
 		SelectItems:    []SelectItem{{Label: "codex", Value: "codex"}, {Label: "codex-app", Value: "codex-app"}, {Label: "claude", Value: "claude"}},
 		SelectSelected: 2,
@@ -2670,12 +2672,279 @@ func TestRender_AgentSelectDialogShowsPromptItemsAndSelection(t *testing.T) {
 	stripped := ansi.Strip(view)
 	for _, want := range []string{"Choose interactive helper", "codex", "codex-app", "claude"} {
 		if !strings.Contains(stripped, want) {
-			t.Fatalf("agent select dialog should show %q:\n%s", want, stripped)
+			t.Fatalf("select dialog should show %q:\n%s", want, stripped)
 		}
 	}
 	if !strings.Contains(stripped, "> claude") {
-		t.Fatalf("agent select dialog should mark selected choice:\n%s", stripped)
+		t.Fatalf("select dialog should mark selected choice:\n%s", stripped)
 	}
+}
+
+func TestRender_SelectOverlayUsesBoundedPanelAndKeepsBaseVisible(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Selected:         0,
+		Width:            80,
+		Height:           16,
+		Mode:             ModeWorktrees,
+		ActivePane:       1,
+		Worktrees:        []gitquery.Worktree{{Path: "/dev/alpha-worktrees/feature", BranchName: "feature/picker"}},
+		WorktreeSelected: 0,
+		Overlay:          OverlaySelect,
+		SelectPrompt:     "Choose helper",
+		SelectItems:      []SelectItem{{Label: "codex", Value: "codex"}, {Label: "claude", Value: "claude"}},
+		SelectWidth:      32,
+		SelectHeight:     6,
+		SelectPlacement:  SelectPlacementTopCenter,
+	})
+
+	bounds := requireSelectPanelBounds(t, view, "Choose helper")
+	if bounds.width != 32 || bounds.height != 6 {
+		t.Fatalf("select panel dimensions = %dx%d, want 32x6:\n%s", bounds.width, bounds.height, ansi.Strip(view))
+	}
+	if bounds.x != 24 || bounds.y != 0 {
+		t.Fatalf("select panel position = (%d,%d), want (24,0):\n%s", bounds.x, bounds.y, ansi.Strip(view))
+	}
+	stripped := ansi.Strip(view)
+	for _, want := range []string{"alpha", "alpha-worktrees/feature"} {
+		if !strings.Contains(stripped, want) {
+			t.Fatalf("compact select overlay should keep base UI text %q visible:\n%s", want, stripped)
+		}
+	}
+	if !strings.Contains(stripped, "up/down select") || strings.Contains(stripped, "bksp") {
+		t.Fatalf("select overlay status bar should use select hints only:\n%s", stripped)
+	}
+}
+
+func TestRender_SelectOverlayAutoSizesFromPromptAndItems(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:          40,
+		Height:         10,
+		Mode:           ModeWorktrees,
+		Overlay:        OverlaySelect,
+		SelectPrompt:   "Pick",
+		SelectItems:    []SelectItem{{Label: "", Value: "fallback-value"}, {Label: "tiny", Value: "tiny"}},
+		SelectSelected: 0,
+	})
+
+	bounds := requireSelectPanelBounds(t, view, "Pick")
+	if bounds.width != len("fallback-value")+4 {
+		t.Fatalf("auto select width = %d, want %d:\n%s", bounds.width, len("fallback-value")+4, ansi.Strip(view))
+	}
+	if bounds.height != 5 {
+		t.Fatalf("auto select height = %d, want 5:\n%s", bounds.height, ansi.Strip(view))
+	}
+	if !strings.Contains(ansi.Strip(view), "> fallback-value") {
+		t.Fatalf("empty select label should fall back to value:\n%s", ansi.Strip(view))
+	}
+}
+
+func TestRender_SelectOverlayPlacementsUseTerminalBody(t *testing.T) {
+	tests := []struct {
+		name      string
+		placement SelectPlacement
+		wantY     int
+	}{
+		{name: "center", placement: SelectPlacementCenter, wantY: 3},
+		{name: "top", placement: SelectPlacementTopCenter, wantY: 0},
+		{name: "bottom", placement: SelectPlacementBottomCenter, wantY: 7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			view := Render(RenderParams{
+				Repos:           []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+				Width:           40,
+				Height:          13,
+				Mode:            ModeWorktrees,
+				Overlay:         OverlaySelect,
+				SelectPrompt:    "Pick",
+				SelectItems:     []SelectItem{{Label: "one", Value: "1"}},
+				SelectWidth:     20,
+				SelectHeight:    5,
+				SelectPlacement: tt.placement,
+			})
+			bounds := requireSelectPanelBounds(t, view, "Pick")
+			if bounds.x != 10 || bounds.y != tt.wantY {
+				t.Fatalf("select panel position = (%d,%d), want (10,%d):\n%s", bounds.x, bounds.y, tt.wantY, ansi.Strip(view))
+			}
+		})
+	}
+}
+
+func TestRender_SelectOverlayPreservesStyledBaseRowsAroundPanel(t *testing.T) {
+	previousProfile := lipgloss.ColorProfile()
+	previousDarkBackground := lipgloss.HasDarkBackground()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	lipgloss.SetHasDarkBackground(true)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(previousProfile)
+		lipgloss.SetHasDarkBackground(previousDarkBackground)
+	})
+
+	view := Render(RenderParams{
+		Repos:           []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Selected:        0,
+		Width:           72,
+		Height:          12,
+		Mode:            ModeBranches,
+		ActivePane:      1,
+		Branches:        []gitquery.BranchRow{{Branch: gitquery.Branch{Name: "main", IsWorktree: true}, WorktreePath: "/dev/alpha"}},
+		BranchSelected:  0,
+		Overlay:         OverlaySelect,
+		SelectPrompt:    "Pick",
+		SelectItems:     []SelectItem{{Label: "codex", Value: "codex"}},
+		SelectWidth:     24,
+		SelectHeight:    4,
+		SelectPlacement: SelectPlacementBottomCenter,
+	})
+
+	if !strings.Contains(view, "\x1b[") {
+		t.Fatalf("expected styled base rows to remain styled:\n%s", view)
+	}
+	strippedLines := strings.Split(ansi.Strip(view), "\n")
+	for i, line := range strippedLines {
+		if got := lipgloss.Width(line); got > 72 {
+			t.Fatalf("visible line %d width = %d, want <= 72: %q", i, got, line)
+		}
+	}
+	if !strings.Contains(strings.Join(strippedLines[:4], "\n"), "main") {
+		t.Fatalf("styled base branch row above panel should remain visible:\n%s", strings.Join(strippedLines, "\n"))
+	}
+}
+
+func TestRender_SelectOverlayShortHeightKeepsSelectedItemVisible(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:          64,
+		Height:         10,
+		Mode:           ModeWorktrees,
+		Overlay:        OverlaySelect,
+		SelectPrompt:   "Pick",
+		SelectItems:    []SelectItem{{Label: "first", Value: "1"}, {Label: "second", Value: "2"}, {Label: "third", Value: "3"}, {Label: "fourth", Value: "4"}, {Label: "fifth", Value: "5"}},
+		SelectSelected: 4,
+		SelectWidth:    20,
+		SelectHeight:   5,
+	})
+
+	stripped := ansi.Strip(view)
+	if !strings.Contains(stripped, "> fifth") {
+		t.Fatalf("short select panel should keep selected item visible:\n%s", stripped)
+	}
+	if strings.Contains(stripped, "first") {
+		t.Fatalf("short select panel should viewport past first item when selected is last:\n%s", stripped)
+	}
+}
+
+func TestRender_SelectOverlayTinyTerminalsClampWithoutOverflow(t *testing.T) {
+	for _, size := range []struct {
+		width  int
+		height int
+	}{
+		{width: 1, height: 1},
+		{width: 2, height: 2},
+		{width: 3, height: 3},
+		{width: 8, height: 2},
+		{width: 8, height: 4},
+	} {
+		t.Run(fmt.Sprintf("%dx%d", size.width, size.height), func(t *testing.T) {
+			view := Render(RenderParams{
+				Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+				Width:          size.width,
+				Height:         size.height,
+				Mode:           ModeWorktrees,
+				Overlay:        OverlaySelect,
+				SelectPrompt:   "Pick a helper",
+				SelectItems:    []SelectItem{{Label: "codex", Value: "codex"}},
+				SelectSelected: 0,
+				SelectWidth:    32,
+				SelectHeight:   6,
+			})
+			lines := strings.Split(ansi.Strip(view), "\n")
+			if len(lines) != size.height {
+				t.Fatalf("line count = %d, want %d:\n%s", len(lines), size.height, ansi.Strip(view))
+			}
+			for i, line := range lines {
+				if got := lipgloss.Width(line); got > size.width {
+					t.Fatalf("line %d width = %d, want <= %d: %q", i, got, size.width, line)
+				}
+			}
+		})
+	}
+}
+
+type selectPanelBounds struct {
+	x      int
+	y      int
+	width  int
+	height int
+}
+
+func requireSelectPanelBounds(t *testing.T, view, prompt string) selectPanelBounds {
+	t.Helper()
+	lines := strings.Split(ansi.Strip(view), "\n")
+	var found bool
+	var best selectPanelBounds
+	for y, line := range lines {
+		runes := []rune(line)
+		for x, r := range runes {
+			if r != '┌' {
+				continue
+			}
+			for right := x + 1; right < len(runes); right++ {
+				if runes[right] != '┐' {
+					continue
+				}
+				for bottom := y + 1; bottom < len(lines); bottom++ {
+					bottomRunes := []rune(lines[bottom])
+					if x >= len(bottomRunes) || right >= len(bottomRunes) {
+						continue
+					}
+					if bottomRunes[x] != '└' || bottomRunes[right] != '┘' {
+						continue
+					}
+					candidate := selectPanelBounds{
+						x:      x,
+						y:      y,
+						width:  right - x + 1,
+						height: bottom - y + 1,
+					}
+					if !selectPanelCandidateContainsPrompt(lines, candidate, prompt) {
+						continue
+					}
+					if !found || candidate.width < best.width {
+						found = true
+						best = candidate
+					}
+				}
+			}
+		}
+	}
+	if found {
+		return best
+	}
+	t.Fatalf("select panel bounds not found:\n%s", ansi.Strip(view))
+	return selectPanelBounds{}
+}
+
+func selectPanelCandidateContainsPrompt(lines []string, bounds selectPanelBounds, prompt string) bool {
+	if prompt == "" {
+		return true
+	}
+	for row := bounds.y; row < bounds.y+bounds.height && row < len(lines); row++ {
+		runes := []rune(lines[row])
+		if bounds.x >= len(runes) {
+			continue
+		}
+		right := bounds.x + bounds.width
+		if right > len(runes) {
+			right = len(runes)
+		}
+		if strings.Contains(string(runes[bounds.x:right]), prompt) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestRender_LaunchInstructionsInputDialogWrapsInCompactPanel(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add a reusable compact select modal with configurable sizing and placement.
- Move agent and embedded-session picker rendering onto the shared modal path.
- Add regression coverage for picker sizing, placement, and Flow phase normalization edge cases.

## Verification
- gofmt -l .
- make test
- make build