### PR TITLE
Add wtui Flow creation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,12 +430,19 @@ The flow state root is resolved with this precedence: `--state-root` >
 relocates the shared artifact root for sessions, plans, and flows.
 
 Flow-launched agents should use the canonical `wtui-flow` skill source at
-`agent-skills/wtui-flow/`. Install or symlink it beside
-`agent-skills/wtui-plan-persist/` in the user-level skill directory for your
-agent, such as `~/.codex/skills/wtui-flow` for Codex or the equivalent Claude
-skills directory. The skill activates when `WTUI_FLOW_ID` and
-`WTUI_FLOW_PHASE_ID` are present, reads the active flow before updates, and uses
-the implemented `wtui flow` and `wtui plan` commands for persistence.
+`agent-skills/wtui-flow/`. Ad hoc planning sessions that need to create a new
+Flow from the current task or an already-written plan should use
+`wtui-flow-create` from `agent-skills/wtui-flow-create/`. Install or symlink
+both skills beside `agent-skills/wtui-plan-persist/` in the user-level skill
+directory for your agent, such as `~/.codex/skills/wtui-flow` and
+`~/.codex/skills/wtui-flow-create` for Codex or the equivalent Claude skills
+directory. `wtui-flow` activates when `WTUI_FLOW_ID` and `WTUI_FLOW_PHASE_ID`
+are present, reads the active flow before updates, and uses the implemented
+`wtui flow` and `wtui plan` commands for persistence. `wtui-flow-create` works
+outside a Flow-launched session by calling `wtui flow create`, optionally saving
+and linking an existing plan. In v1, that import persists the Flow and linked
+plan artifacts but does not attach the current ad hoc provider session to the
+Flow; future phase launches and resumes are tracked normally.
 
 ## Configuration
 

--- a/agent-skills/skill_docs_test.go
+++ b/agent-skills/skill_docs_test.go
@@ -199,6 +199,78 @@ func TestWtuiFlowCreateSkillDocumentsAgentContract(t *testing.T) {
 	}
 }
 
+func TestWtuiFlowCreateSkillGuardsPersistenceFailures(t *testing.T) {
+	root := repoRoot(t)
+	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow-create", "SKILL.md"))
+	createBlock := fencedBashBlockContaining(t, skill, "FLOW_JSON=$(wtui flow create")
+	importBlock := fencedBashBlockContaining(t, skill, "PLAN_ID=$(printf")
+
+	requireContainsAll(t, "flow creation persistence guards", skill, []string{
+		"if ! FLOW_JSON=$(wtui flow create",
+		"if ! FLOW_ID=$(printf '%s' \"$FLOW_JSON\" | python3",
+		"if ! wtui flow read --flow-id \"$FLOW_ID\"",
+		"case \"${WTUI_REPO_PATH:-}\" in",
+		"absolute WTUI_REPO_PATH",
+		"exit 1",
+	})
+	assertGuardedFailureBodies(t, createBlock, "if ! FLOW_JSON=$(wtui flow create", 2, []string{
+		"wtui flow create failed",
+		"exit 1",
+	})
+	assertGuardedFailureBodies(t, createBlock, "if ! FLOW_ID=$(printf", 1, []string{
+		"flow_id",
+		"exit 1",
+	})
+	assertGuardedFailureBodies(t, createBlock, `if ! wtui flow read --flow-id "$FLOW_ID"`, 1, []string{
+		"wtui flow read failed",
+		"exit 1",
+	})
+
+	requireContainsAll(t, "plan import persistence guards", skill, []string{
+		"record_plan_import_failure",
+		"if ! PLAN_ID=$(printf '%s' \"${PLAN_MARKDOWN:-}\" | wtui plan save",
+		"if ! wtui flow plan set",
+		"if ! wtui plan read --plan-id \"$PLAN_ID\"",
+		"if ! wtui flow phase complete",
+		"wtui flow phase block failed after plan import failure",
+		"exit 1",
+	})
+	for _, guard := range []string{
+		"if ! PLAN_ID=$(printf",
+		"if ! wtui flow plan set",
+		`if ! wtui plan read --plan-id "$PLAN_ID"`,
+		"if ! wtui flow phase complete",
+	} {
+		assertGuardedFailureBodies(t, importBlock, guard, 1, []string{
+			"record_plan_import_failure",
+			"exit 1",
+		})
+	}
+
+	readbackIndex := strings.Index(skill, `if ! wtui plan read --plan-id "$PLAN_ID"`)
+	completeIndex := strings.Index(skill, "if ! wtui flow phase complete")
+	if readbackIndex < 0 || completeIndex < 0 || completeIndex < readbackIndex {
+		t.Fatal("skill should guard plan readback before attempting to complete the Flow plan phase")
+	}
+}
+
+func TestWtuiFlowCreateSkillExamplesAreUnsetSafe(t *testing.T) {
+	root := repoRoot(t)
+	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow-create", "SKILL.md"))
+
+	requireContainsAll(t, "unset-safe shell variables", skill, []string{
+		"${FLOW_TITLE:-}",
+		"${FLOW_INSTRUCTIONS_FILE:-}",
+		"${FLOW_INSTRUCTIONS:-}",
+		"${WTUI_REPO_PATH:-}",
+		"${WTUI_WORKTREE_PATH:-}",
+		"${WTUI_BRANCH:-}",
+		"${WTUI_COMMIT:-}",
+		"${FLOW_ID:-}",
+		"${PLAN_MARKDOWN:-}",
+	})
+}
+
 func TestWtuiFlowCreateSkillMatchesImplementedCLIContract(t *testing.T) {
 	root := repoRoot(t)
 	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow-create", "SKILL.md"))
@@ -226,6 +298,18 @@ func TestWtuiFlowSkillKeepsPlanAndFlowStateRootsTogether(t *testing.T) {
 	root := repoRoot(t)
 	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow", "SKILL.md"))
 
+	assertSkillKeepsPlanAndFlowStateRootsTogether(t, skill)
+}
+
+func TestWtuiFlowCreateSkillKeepsPlanAndFlowStateRootsTogether(t *testing.T) {
+	root := repoRoot(t)
+	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow-create", "SKILL.md"))
+
+	assertSkillKeepsPlanAndFlowStateRootsTogether(t, skill)
+}
+
+func assertSkillKeepsPlanAndFlowStateRootsTogether(t *testing.T, skill string) {
+	t.Helper()
 	requireContainsAll(t, "shared artifact root setup", skill, []string{
 		"WTUI_ARTIFACT_ROOT",
 		"WTUI_FLOW_STATE_ROOT",
@@ -352,44 +436,117 @@ func hasRunnableCommandExample(markdown, command string) bool {
 	return false
 }
 
+func fencedBashBlockContaining(t *testing.T, markdown, text string) string {
+	t.Helper()
+	for _, block := range fencedBashBlocks(markdown) {
+		if strings.Contains(block, text) {
+			return block
+		}
+	}
+	t.Fatalf("no fenced bash block contains %q", text)
+	return ""
+}
+
+func assertGuardedFailureBodies(t *testing.T, block, guard string, wantCount int, wants []string) {
+	t.Helper()
+	searchFrom := 0
+	for count := 0; count < wantCount; count++ {
+		start := strings.Index(block[searchFrom:], guard)
+		if start < 0 {
+			t.Fatalf("guard %q occurrence %d missing in block:\n%s", guard, count+1, block)
+		}
+		start += searchFrom
+		thenIndex := strings.Index(block[start:], "then")
+		if thenIndex < 0 {
+			t.Fatalf("guard %q occurrence %d missing then body", guard, count+1)
+		}
+		bodyStart := start + thenIndex + len("then")
+		bodyEnd := guardedBodyEnd(block[bodyStart:])
+		if bodyEnd < 0 {
+			t.Fatalf("guard %q occurrence %d missing closing fi", guard, count+1)
+		}
+		body := block[bodyStart : bodyStart+bodyEnd]
+		for _, want := range wants {
+			if !strings.Contains(body, want) {
+				t.Fatalf("guard %q occurrence %d body missing %q:\n%s", guard, count+1, want, body)
+			}
+		}
+		searchFrom = bodyStart + bodyEnd
+	}
+	if extra := strings.Index(block[searchFrom:], guard); extra >= 0 {
+		t.Fatalf("guard %q has more than %d occurrences", guard, wantCount)
+	}
+}
+
+func guardedBodyEnd(text string) int {
+	offset := 0
+	for _, line := range strings.SplitAfter(text, "\n") {
+		if strings.TrimSpace(line) == "fi" {
+			return offset
+		}
+		offset += len(line)
+	}
+	return -1
+}
+
 func assertRunnableExampleFlagsExist(t *testing.T, markdown, cliSource, command string) {
 	t.Helper()
-	for _, flagName := range runnableCommandFlags(markdown, command) {
-		if !cliHasFlag(cliSource, flagName) {
-			t.Fatalf("runnable wtui %s example documents --%s but CLI does not expose it", command, flagName)
+	for _, use := range runnableCommandFlagUses(markdown, command) {
+		source, ok := commandFlagSource(cliSource, append([]string{command}, use.Subcommands...))
+		if !ok {
+			t.Fatalf("runnable %s example has no CLI contract mapping", use.Command())
+		}
+		if !cliHasFlag(source, use.FlagName) {
+			t.Fatalf("runnable %s example documents --%s but that CLI command does not expose it", use.Command(), use.FlagName)
 		}
 	}
 }
 
-func runnableCommandFlags(markdown, command string) []string {
-	var flags []string
+type runnableCommandFlagUse struct {
+	TopCommand  string
+	Subcommands []string
+	FlagName    string
+}
+
+func (u runnableCommandFlagUse) Command() string {
+	return "wtui " + strings.Join(append([]string{u.TopCommand}, u.Subcommands...), " ")
+}
+
+func runnableCommandFlagUses(markdown, command string) []runnableCommandFlagUse {
+	var uses []runnableCommandFlagUse
 	seen := map[string]bool{}
 	flagPattern := regexp.MustCompile(`--([A-Za-z0-9][A-Za-z0-9-]*)`)
 
 	for _, block := range fencedBashBlocks(markdown) {
-		var activeCommand string
+		var activeSubcommands []string
 		continues := false
 		for _, line := range strings.Split(block, "\n") {
 			trimmed := strings.TrimSpace(line)
 			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 				if !continues {
-					activeCommand = ""
+					activeSubcommands = nil
 				}
 				continue
 			}
 
-			if hasRunnableWtuiCommand(trimmed, command) {
-				activeCommand = command
+			if subcommands, ok := runnableWtuiSubcommands(trimmed, command); ok {
+				activeSubcommands = subcommands
 			} else if !continues {
-				activeCommand = ""
+				activeSubcommands = nil
 			}
 
-			if activeCommand == command {
-				for _, match := range flagPattern.FindAllStringSubmatch(trimmed, -1) {
+			if len(activeSubcommands) > 0 {
+				unquoted := stripShellQuotedSpans(trimmed)
+				for _, match := range flagPattern.FindAllStringSubmatch(unquoted, -1) {
 					flagName := match[1]
-					if !seen[flagName] {
-						flags = append(flags, flagName)
-						seen[flagName] = true
+					key := strings.Join(activeSubcommands, " ") + "\x00" + flagName
+					if !seen[key] {
+						uses = append(uses, runnableCommandFlagUse{
+							TopCommand:  command,
+							Subcommands: append([]string(nil), activeSubcommands...),
+							FlagName:    flagName,
+						})
+						seen[key] = true
 					}
 				}
 			}
@@ -398,20 +555,133 @@ func runnableCommandFlags(markdown, command string) []string {
 		}
 	}
 
-	return flags
+	return uses
+}
+
+func stripShellQuotedSpans(line string) string {
+	var b strings.Builder
+	var quote rune
+	escaped := false
+	for _, r := range line {
+		switch {
+		case escaped:
+			b.WriteRune(' ')
+			escaped = false
+		case quote != '\'' && r == '\\':
+			b.WriteRune(' ')
+			escaped = true
+		case quote != 0:
+			b.WriteRune(' ')
+			if r == quote {
+				quote = 0
+			}
+		case r == '\'' || r == '"':
+			b.WriteRune(' ')
+			quote = r
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 func hasRunnableWtuiCommand(line, command string) bool {
+	_, ok := runnableWtuiSubcommands(line, command)
+	return ok
+}
+
+func runnableWtuiSubcommands(line, command string) ([]string, bool) {
 	pattern := "wtui " + command + " "
-	if strings.HasPrefix(line, pattern) {
-		return true
+	index := strings.Index(line, pattern)
+	if index < 0 {
+		return nil, false
 	}
-	for _, marker := range []string{"| ", "$(", "! "} {
-		if strings.Contains(line, marker+pattern) {
-			return true
+
+	if index > 0 {
+		prefix := line[:index]
+		startsRunnableCommand := false
+		for _, marker := range []string{"| ", "$(", "! "} {
+			if strings.HasSuffix(prefix, marker) {
+				startsRunnableCommand = true
+				break
+			}
+		}
+		if !startsRunnableCommand {
+			return nil, false
 		}
 	}
-	return false
+
+	fields := strings.Fields(line[index:])
+	if len(fields) < 3 || fields[0] != "wtui" || fields[1] != command {
+		return nil, false
+	}
+	var subcommands []string
+	for _, field := range fields[2:] {
+		field = strings.Trim(field, `"'();`)
+		if field == "" || field == `\` || strings.HasPrefix(field, "-") || strings.HasPrefix(field, "$") || strings.ContainsAny(field, "[]{}") {
+			break
+		}
+		subcommands = append(subcommands, field)
+	}
+	if len(subcommands) == 0 {
+		return nil, false
+	}
+	return subcommands, true
+}
+
+func commandFlagSource(cliSource string, commandParts []string) (string, bool) {
+	functionName, ok := commandFunctionName(commandParts)
+	if !ok {
+		return "", false
+	}
+	return functionSource(cliSource, functionName)
+}
+
+func commandFunctionName(commandParts []string) (string, bool) {
+	key := strings.Join(commandParts, " ")
+	functions := map[string]string{
+		"flow create":                "runFlowCreate",
+		"flow read":                  "runFlowRead",
+		"flow phase set":             "runFlowPhaseSet",
+		"flow phase complete":        "runFlowPhaseAction",
+		"flow phase block":           "runFlowPhaseAction",
+		"flow phase needs-attention": "runFlowPhaseAction",
+		"flow phase restart":         "runFlowPhaseRestart",
+		"flow phase add-child":       "runFlowPhaseAddChild",
+		"flow plan set":              "runFlowPlanSet",
+		"flow pr set":                "runFlowPRSet",
+		"flow merge set":             "runFlowMergeSet",
+		"plan save":                  "runPlanSave",
+		"plan read":                  "runPlanRead",
+		"plan phase set":             "runPlanPhase",
+	}
+	functionName, ok := functions[key]
+	return functionName, ok
+}
+
+func functionSource(source, functionName string) (string, bool) {
+	start := strings.Index(source, "func "+functionName+"(")
+	if start < 0 {
+		return "", false
+	}
+	bodyStart := strings.Index(source[start:], "{")
+	if bodyStart < 0 {
+		return "", false
+	}
+	bodyStart += start
+	depth := 0
+	for i := bodyStart; i < len(source); i++ {
+		switch source[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return source[start : i+1], true
+			}
+		}
+	}
+	return "", false
 }
 
 func cliHasFlag(cliSource, flagName string) bool {

--- a/agent-skills/skill_docs_test.go
+++ b/agent-skills/skill_docs_test.go
@@ -3,6 +3,7 @@ package agentskills
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -61,6 +62,7 @@ func TestWtuiFlowSkillMatchesImplementedFlowCLIContract(t *testing.T) {
 	root := repoRoot(t)
 	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow", "SKILL.md"))
 	flowCLI := readFile(t, filepath.Join(root, "cmd", "wtui", "flow.go"))
+	planCLI := readFile(t, filepath.Join(root, "cmd", "wtui", "plan.go"))
 	flowStore := readFile(t, filepath.Join(root, "flowstore", "store.go"))
 
 	if !strings.Contains(skill, "wtui flow phase set") || !strings.Contains(flowCLI, "runFlowPhaseSet") {
@@ -110,6 +112,8 @@ func TestWtuiFlowSkillMatchesImplementedFlowCLIContract(t *testing.T) {
 			t.Fatalf("skill documents --%s but flow CLI does not expose it", flagName)
 		}
 	}
+	assertRunnableExampleFlagsExist(t, skill, flowCLI, "flow")
+	assertRunnableExampleFlagsExist(t, skill, planCLI, "plan")
 
 	for _, constant := range []string{
 		"PhaseRunning",
@@ -142,6 +146,80 @@ func TestWtuiFlowSkillMatchesImplementedFlowCLIContract(t *testing.T) {
 			t.Fatalf("skill includes a runnable example for unimplemented command %q", unimplementedCommand)
 		}
 	}
+}
+
+func TestWtuiFlowCreateSkillDocumentsAgentContract(t *testing.T) {
+	root := repoRoot(t)
+	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow-create", "SKILL.md"))
+
+	requireContainsAll(t, "skill metadata", skill, []string{
+		"name: wtui-flow-create",
+		"make a flow from this",
+		"add this as a wtui flow",
+		"create a wtui flow for this plan",
+	})
+	requireContainsAll(t, "independent flow creation", skill, []string{
+		"does not require `WTUI_FLOW_ID` or `WTUI_FLOW_PHASE_ID`",
+		"Codex App prompt-only metadata",
+		"ask the user",
+		"absolute",
+	})
+	requireContainsAll(t, "shared artifact root setup", skill, []string{
+		"WTUI_ARTIFACT_ROOT",
+		"WTUI_FLOW_STATE_ROOT",
+		"WTUI_PLAN_STATE_ROOT",
+		"WTUI_SESSION_STATE_ROOT",
+		"FLOW_STATE_ARGS",
+		"PLAN_STATE_ARGS",
+	})
+	requireContainsAll(t, "flow creation commands", skill, []string{
+		"wtui flow create",
+		"--json",
+		"--instructions-file",
+		"--instructions",
+		"wtui flow read --flow-id",
+	})
+	requireContainsAll(t, "plan import commands", skill, []string{
+		"wtui plan save",
+		"wtui flow plan set",
+		"wtui plan read",
+		"wtui flow phase complete",
+		"Imported plan",
+	})
+	requireContainsAll(t, "failure handling", skill, []string{
+		"persistence failures",
+		"must not be treated as success",
+		"report the command error",
+		"wtui flow phase block",
+		"wtui flow phase needs-attention",
+	})
+
+	if hasRunnableCommandExample(skill, "wtui flow session attach") {
+		t.Fatal("skill includes a runnable example for unimplemented command \"wtui flow session attach\"")
+	}
+}
+
+func TestWtuiFlowCreateSkillMatchesImplementedCLIContract(t *testing.T) {
+	root := repoRoot(t)
+	skill := readFile(t, filepath.Join(root, "agent-skills", "wtui-flow-create", "SKILL.md"))
+	flowCLI := readFile(t, filepath.Join(root, "cmd", "wtui", "flow.go"))
+	planCLI := readFile(t, filepath.Join(root, "cmd", "wtui", "plan.go"))
+
+	requireContainsAll(t, "flow CLI contract", flowCLI, []string{
+		"runFlowCreate",
+		"runFlowRead",
+		"runFlowPlanSet",
+		`command:        "complete"`,
+		`command:        "block"`,
+		`command:        "needs-attention"`,
+	})
+	requireContainsAll(t, "plan CLI contract", planCLI, []string{
+		"runPlanSave",
+		"runPlanRead",
+	})
+
+	assertRunnableExampleFlagsExist(t, skill, flowCLI, "flow")
+	assertRunnableExampleFlagsExist(t, skill, planCLI, "plan")
 }
 
 func TestWtuiFlowSkillKeepsPlanAndFlowStateRootsTogether(t *testing.T) {
@@ -219,13 +297,17 @@ func TestWtuiFlowInstallationDocs(t *testing.T) {
 
 	requireContainsAll(t, "README installation docs", readme, []string{
 		"agent-skills/wtui-flow/",
+		"agent-skills/wtui-flow-create/",
 		"wtui-flow",
+		"wtui-flow-create",
 		"wtui-plan-persist",
 		"symlink",
 	})
 	requireContainsAll(t, "config installation docs", configDocs, []string{
 		"agent-skills/wtui-flow/",
+		"agent-skills/wtui-flow-create/",
 		"wtui-flow",
+		"wtui-flow-create",
 		"wtui-plan-persist",
 		"symlink",
 	})
@@ -265,6 +347,77 @@ func hasRunnableCommandExample(markdown, command string) bool {
 			if strings.Contains(line, command) {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func assertRunnableExampleFlagsExist(t *testing.T, markdown, cliSource, command string) {
+	t.Helper()
+	for _, flagName := range runnableCommandFlags(markdown, command) {
+		if !cliHasFlag(cliSource, flagName) {
+			t.Fatalf("runnable wtui %s example documents --%s but CLI does not expose it", command, flagName)
+		}
+	}
+}
+
+func runnableCommandFlags(markdown, command string) []string {
+	var flags []string
+	seen := map[string]bool{}
+	flagPattern := regexp.MustCompile(`--([A-Za-z0-9][A-Za-z0-9-]*)`)
+
+	for _, block := range fencedBashBlocks(markdown) {
+		var activeCommand string
+		continues := false
+		for _, line := range strings.Split(block, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+				if !continues {
+					activeCommand = ""
+				}
+				continue
+			}
+
+			if hasRunnableWtuiCommand(trimmed, command) {
+				activeCommand = command
+			} else if !continues {
+				activeCommand = ""
+			}
+
+			if activeCommand == command {
+				for _, match := range flagPattern.FindAllStringSubmatch(trimmed, -1) {
+					flagName := match[1]
+					if !seen[flagName] {
+						flags = append(flags, flagName)
+						seen[flagName] = true
+					}
+				}
+			}
+
+			continues = strings.HasSuffix(trimmed, `\`)
+		}
+	}
+
+	return flags
+}
+
+func hasRunnableWtuiCommand(line, command string) bool {
+	pattern := "wtui " + command + " "
+	if strings.HasPrefix(line, pattern) {
+		return true
+	}
+	for _, marker := range []string{"| ", "$(", "! "} {
+		if strings.Contains(line, marker+pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func cliHasFlag(cliSource, flagName string) bool {
+	for _, flagType := range []string{"String", "Int", "Bool"} {
+		if strings.Contains(cliSource, `flags.`+flagType+`("`+flagName+`"`) {
+			return true
 		}
 	}
 	return false

--- a/agent-skills/wtui-flow-create/SKILL.md
+++ b/agent-skills/wtui-flow-create/SKILL.md
@@ -56,29 +56,57 @@ sentence; use `--instructions` for compact task text. `wtui flow create --json`
 prints machine-readable output containing `flow_id`.
 
 ```bash
-if [ -n "$FLOW_INSTRUCTIONS_FILE" ]; then
-  FLOW_JSON=$(wtui flow create \
-    --title "$FLOW_TITLE" \
-    --instructions-file "$FLOW_INSTRUCTIONS_FILE" \
-    --repo-path "$WTUI_REPO_PATH" \
-    --worktree-path "$WTUI_WORKTREE_PATH" \
-    --branch "$WTUI_BRANCH" \
-    --commit "$WTUI_COMMIT" \
-    --json \
-    "${FLOW_STATE_ARGS[@]}")
-else
-  FLOW_JSON=$(wtui flow create \
-    --title "$FLOW_TITLE" \
-    --instructions "$FLOW_INSTRUCTIONS" \
-    --repo-path "$WTUI_REPO_PATH" \
-    --worktree-path "$WTUI_WORKTREE_PATH" \
-    --branch "$WTUI_BRANCH" \
-    --commit "$WTUI_COMMIT" \
-    --json \
-    "${FLOW_STATE_ARGS[@]}")
+if [ -z "${FLOW_TITLE:-}" ] || [ -z "${WTUI_REPO_PATH:-}" ]; then
+  echo "Flow creation requires FLOW_TITLE and absolute WTUI_REPO_PATH; ask the user for missing values." >&2
+  exit 1
 fi
-FLOW_ID=$(printf '%s' "$FLOW_JSON" | python3 -c 'import json, sys; print(json.load(sys.stdin)["flow_id"])')
-wtui flow read --flow-id "$FLOW_ID" "${FLOW_STATE_ARGS[@]}" >/dev/null
+case "${WTUI_REPO_PATH:-}" in
+  /*) ;;
+  *)
+    echo "Flow creation requires an absolute WTUI_REPO_PATH; ask the user for the repository path." >&2
+    exit 1
+    ;;
+esac
+if [ -z "${FLOW_INSTRUCTIONS_FILE:-}" ] && [ -z "${FLOW_INSTRUCTIONS:-}" ]; then
+  echo "Flow creation requires FLOW_INSTRUCTIONS or FLOW_INSTRUCTIONS_FILE; ask the user for the task instructions." >&2
+  exit 1
+fi
+
+if [ -n "${FLOW_INSTRUCTIONS_FILE:-}" ]; then
+  if ! FLOW_JSON=$(wtui flow create \
+    --title "${FLOW_TITLE:-}" \
+    --instructions-file "${FLOW_INSTRUCTIONS_FILE:-}" \
+    --repo-path "${WTUI_REPO_PATH:-}" \
+    --worktree-path "${WTUI_WORKTREE_PATH:-}" \
+    --branch "${WTUI_BRANCH:-}" \
+    --commit "${WTUI_COMMIT:-}" \
+    --json \
+    "${FLOW_STATE_ARGS[@]}"); then
+    echo "wtui flow create failed; report the command error to the user." >&2
+    exit 1
+  fi
+else
+  if ! FLOW_JSON=$(wtui flow create \
+    --title "${FLOW_TITLE:-}" \
+    --instructions "${FLOW_INSTRUCTIONS:-}" \
+    --repo-path "${WTUI_REPO_PATH:-}" \
+    --worktree-path "${WTUI_WORKTREE_PATH:-}" \
+    --branch "${WTUI_BRANCH:-}" \
+    --commit "${WTUI_COMMIT:-}" \
+    --json \
+    "${FLOW_STATE_ARGS[@]}"); then
+    echo "wtui flow create failed; report the command error to the user." >&2
+    exit 1
+  fi
+fi
+if ! FLOW_ID=$(printf '%s' "$FLOW_JSON" | python3 -c 'import json, sys; print(json.load(sys.stdin)["flow_id"])'); then
+  echo "wtui flow create returned JSON that could not be parsed for flow_id; report the command error to the user." >&2
+  exit 1
+fi
+if ! wtui flow read --flow-id "$FLOW_ID" "${FLOW_STATE_ARGS[@]}" >/dev/null; then
+  echo "wtui flow read failed for $FLOW_ID; report the command error to the user." >&2
+  exit 1
+fi
 ```
 
 If any command in this section fails, report the command error and stop. Do not
@@ -91,27 +119,59 @@ If the current session already has a concrete plan body, save it and link it to
 the new Flow. Do not invent a plan body just to satisfy this path.
 
 ```bash
-PLAN_ID=$(printf '%s' "$PLAN_MARKDOWN" | wtui plan save \
-  --title "$FLOW_TITLE" \
-  --status approved \
-  --repo-path "$WTUI_REPO_PATH" \
-  --worktree-path "$WTUI_WORKTREE_PATH" \
-  --branch "$WTUI_BRANCH" \
-  --commit "$WTUI_COMMIT" \
-  "${PLAN_STATE_ARGS[@]}")
+if [ -z "${FLOW_ID:-}" ]; then
+  echo "Plan import requires FLOW_ID from a verified wtui flow create result." >&2
+  exit 1
+fi
+if [ -z "${PLAN_MARKDOWN:-}" ]; then
+  echo "No concrete PLAN_MARKDOWN is available; report Flow ${FLOW_ID:-} and leave Plan ready." >&2
+  exit 0
+fi
 
-wtui flow plan set \
+record_plan_import_failure() {
+  notes="${1:-}"
+  if ! wtui flow phase block \
+    --flow-id "$FLOW_ID" \
+    --phase-id plan \
+    --notes "$notes" \
+    "${FLOW_STATE_ARGS[@]}"; then
+    echo "wtui flow phase block failed after plan import failure; report both command errors to the user." >&2
+  fi
+}
+
+if ! PLAN_ID=$(printf '%s' "${PLAN_MARKDOWN:-}" | wtui plan save \
+  --title "${FLOW_TITLE:-}" \
+  --status approved \
+  --repo-path "${WTUI_REPO_PATH:-}" \
+  --worktree-path "${WTUI_WORKTREE_PATH:-}" \
+  --branch "${WTUI_BRANCH:-}" \
+  --commit "${WTUI_COMMIT:-}" \
+  "${PLAN_STATE_ARGS[@]}"); then
+  record_plan_import_failure "wtui plan save failed; report the command error to the user."
+  exit 1
+fi
+
+if ! wtui flow plan set \
   --flow-id "$FLOW_ID" \
   --plan-id "$PLAN_ID" \
-  "${FLOW_STATE_ARGS[@]}"
+  "${FLOW_STATE_ARGS[@]}"; then
+  record_plan_import_failure "wtui flow plan set failed for plan $PLAN_ID; report the command error to the user."
+  exit 1
+fi
 
-wtui plan read --plan-id "$PLAN_ID" "${PLAN_STATE_ARGS[@]}" >/dev/null
+if ! wtui plan read --plan-id "$PLAN_ID" "${PLAN_STATE_ARGS[@]}" >/dev/null; then
+  record_plan_import_failure "wtui plan read failed for $PLAN_ID; report the command error to the user."
+  exit 1
+fi
 
-wtui flow phase complete \
+if ! wtui flow phase complete \
   --flow-id "$FLOW_ID" \
   --phase-id plan \
   --summary "Imported plan $PLAN_ID." \
-  "${FLOW_STATE_ARGS[@]}"
+  "${FLOW_STATE_ARGS[@]}"; then
+  record_plan_import_failure "wtui flow phase complete failed after importing plan $PLAN_ID; report the command error to the user."
+  exit 1
+fi
 ```
 
 Only complete the new Flow's `plan` phase after all four steps succeed: plan
@@ -128,7 +188,7 @@ unless the corresponding command succeeded.
 
 When the Flow exists but imported-plan persistence fails, attempt to record the
 failed import on the new Flow Plan phase and report whether that persistence
-also succeeded:
+also succeeded. The import snippet above uses this recovery command:
 
 ```bash
 wtui flow phase block \

--- a/agent-skills/wtui-flow-create/SKILL.md
+++ b/agent-skills/wtui-flow-create/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: wtui-flow-create
+description: Create a new persisted wtui Flow from an ad hoc planning session or already-written plan, then optionally save and link the plan artifact.
+---
+
+# Creating wtui Flows
+
+Use this skill when the user explicitly asks to turn the current work into a
+wtui Flow, with phrasing such as "make a flow from this", "add this as a wtui
+flow", or "create a wtui flow for this plan".
+
+This skill is for ad hoc sessions. It does not require `WTUI_FLOW_ID` or
+`WTUI_FLOW_PHASE_ID`; those belong to the `wtui-flow` skill for agents already
+launched inside an existing Flow phase. This skill can create a Flow and link a
+saved plan, but v1 cannot attach the current provider session to the new Flow.
+Do not claim the session is attached, and do not run `wtui flow session attach`
+unless a future CLI implements it.
+
+## Start With Shared State
+
+Build reusable state-root arguments before running commands. `wtui flow` reads
+`WTUI_FLOW_STATE_ROOT`, and `wtui plan` reads `WTUI_PLAN_STATE_ROOT`, but passing
+the same explicit root keeps created flows and imported plans together.
+Codex App prompt-only metadata is used instead of inherited shell
+environment, so copy the provided `--state-root` value manually when needed.
+
+```bash
+WTUI_ARTIFACT_ROOT="${WTUI_FLOW_STATE_ROOT:-${WTUI_PLAN_STATE_ROOT:-${WTUI_SESSION_STATE_ROOT:-}}}"
+FLOW_STATE_ARGS=()
+PLAN_STATE_ARGS=()
+if [ -n "$WTUI_ARTIFACT_ROOT" ]; then
+  FLOW_STATE_ARGS=(--state-root "$WTUI_ARTIFACT_ROOT")
+  PLAN_STATE_ARGS=(--state-root "$WTUI_ARTIFACT_ROOT")
+fi
+```
+
+## Resolve Required Metadata
+
+Resolve Flow metadata from launch metadata first, then from the current git
+checkout. Required values:
+
+- `FLOW_TITLE`: short task title.
+- `FLOW_INSTRUCTIONS` or `FLOW_INSTRUCTIONS_FILE`: the task instructions used to
+  seed the Flow.
+- `WTUI_REPO_PATH`: absolute repository path.
+
+Use `WTUI_WORKTREE_PATH`, `WTUI_BRANCH`, and `WTUI_COMMIT` when known. If
+`WTUI_REPO_PATH` is missing, relative, or unclear, ask the user instead of
+creating a malformed Flow. If git metadata cannot be recovered, create the Flow
+with the known required values and report which optional fields were omitted.
+
+## Create And Verify The Flow
+
+Prefer `--instructions-file` when the instructions are more than a short
+sentence; use `--instructions` for compact task text. `wtui flow create --json`
+prints machine-readable output containing `flow_id`.
+
+```bash
+if [ -n "$FLOW_INSTRUCTIONS_FILE" ]; then
+  FLOW_JSON=$(wtui flow create \
+    --title "$FLOW_TITLE" \
+    --instructions-file "$FLOW_INSTRUCTIONS_FILE" \
+    --repo-path "$WTUI_REPO_PATH" \
+    --worktree-path "$WTUI_WORKTREE_PATH" \
+    --branch "$WTUI_BRANCH" \
+    --commit "$WTUI_COMMIT" \
+    --json \
+    "${FLOW_STATE_ARGS[@]}")
+else
+  FLOW_JSON=$(wtui flow create \
+    --title "$FLOW_TITLE" \
+    --instructions "$FLOW_INSTRUCTIONS" \
+    --repo-path "$WTUI_REPO_PATH" \
+    --worktree-path "$WTUI_WORKTREE_PATH" \
+    --branch "$WTUI_BRANCH" \
+    --commit "$WTUI_COMMIT" \
+    --json \
+    "${FLOW_STATE_ARGS[@]}")
+fi
+FLOW_ID=$(printf '%s' "$FLOW_JSON" | python3 -c 'import json, sys; print(json.load(sys.stdin)["flow_id"])')
+wtui flow read --flow-id "$FLOW_ID" "${FLOW_STATE_ARGS[@]}" >/dev/null
+```
+
+If any command in this section fails, report the command error and stop. Do not
+say a Flow was created unless `wtui flow create` succeeded and `wtui flow read
+--flow-id "$FLOW_ID"` verified it.
+
+## Import An Existing Plan
+
+If the current session already has a concrete plan body, save it and link it to
+the new Flow. Do not invent a plan body just to satisfy this path.
+
+```bash
+PLAN_ID=$(printf '%s' "$PLAN_MARKDOWN" | wtui plan save \
+  --title "$FLOW_TITLE" \
+  --status approved \
+  --repo-path "$WTUI_REPO_PATH" \
+  --worktree-path "$WTUI_WORKTREE_PATH" \
+  --branch "$WTUI_BRANCH" \
+  --commit "$WTUI_COMMIT" \
+  "${PLAN_STATE_ARGS[@]}")
+
+wtui flow plan set \
+  --flow-id "$FLOW_ID" \
+  --plan-id "$PLAN_ID" \
+  "${FLOW_STATE_ARGS[@]}"
+
+wtui plan read --plan-id "$PLAN_ID" "${PLAN_STATE_ARGS[@]}" >/dev/null
+
+wtui flow phase complete \
+  --flow-id "$FLOW_ID" \
+  --phase-id plan \
+  --summary "Imported plan $PLAN_ID." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+Only complete the new Flow's `plan` phase after all four steps succeed: plan
+save, flow-plan link, plan readback, and phase completion. If there is no
+concrete plan body, report the new Flow ID and leave Plan ready for a normal
+Flow Plan launch.
+
+## Persistence Failures
+
+If any `wtui flow` or `wtui plan` command exits non-zero, report the command
+error. These persistence failures must not be treated as success. Do not say a
+Flow was created, a plan was saved, a plan was linked, or a phase was completed
+unless the corresponding command succeeded.
+
+When the Flow exists but imported-plan persistence fails, attempt to record the
+failed import on the new Flow Plan phase and report whether that persistence
+also succeeded:
+
+```bash
+wtui flow phase block \
+  --flow-id "$FLOW_ID" \
+  --phase-id plan \
+  --notes "Plan import failed; report the wtui command error to the user." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+Use `wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan
+--notes "..." "${FLOW_STATE_ARGS[@]}"` instead when the Flow can continue but
+the imported plan should be reviewed before implementation. If this recovery
+update fails too, report both the original command error and the recovery
+command error.

--- a/docs/config.md
+++ b/docs/config.md
@@ -418,14 +418,22 @@ The flow state root is resolved as: `--state-root` >
 `WTUI_FLOW_STATE_ROOT` has highest precedence for the shared artifact root; if
 it is set, the TUI reads sessions, plans, and flows from that root.
 
-The canonical provider-agnostic Flow skill lives at
-`agent-skills/wtui-flow/`, beside `agent-skills/wtui-plan-persist/`. Install or
-symlink `wtui-flow` into the user-level skill directory for supported agents
-such as Codex or Claude; for Codex, a typical target is
-`~/.codex/skills/wtui-flow`. The skill activates when `WTUI_FLOW_ID` and
-`WTUI_FLOW_PHASE_ID` are present, reads the active flow with
+The canonical provider-agnostic Flow phase skill lives at
+`agent-skills/wtui-flow/`, beside `agent-skills/wtui-plan-persist/`. The
+companion creation skill lives at `agent-skills/wtui-flow-create/`. Install or
+symlink both `wtui-flow` and `wtui-flow-create` into the user-level skill
+directory for supported agents such as Codex or Claude; for Codex, typical
+targets are `~/.codex/skills/wtui-flow` and
+`~/.codex/skills/wtui-flow-create`. `wtui-flow` activates when `WTUI_FLOW_ID`
+and `WTUI_FLOW_PHASE_ID` are present, reads the active flow with
 `wtui flow read --flow-id "$WTUI_FLOW_ID"`, and documents the implemented
 `wtui flow` / `wtui plan` commands for phase persistence and saved-plan linkage.
+`wtui-flow-create` is for ad hoc sessions where the user asks to create a Flow
+from the current task or an already-written plan. It creates the Flow, can save
+and link an imported plan, and reports persistence failures explicitly. In v1,
+the imported ad hoc session itself is not attached to the Flow; the created
+Flow and linked plan are persisted artifacts, and future phase launches or
+resumes are tracked normally.
 
 ### `[bootstrap]`
 


### PR DESCRIPTION
## Summary
- add the `wtui-flow-create` agent skill for turning an existing planning or ad hoc session into a persisted wtui Flow
- document the required Flow/plan metadata, state-root handling, and recovery behavior for creating and linking artifacts
- extend agent-skill contract tests for the new skill and update README/config docs to reference the canonical skill source

## Verification
- `go test ./agent-skills`
- `gofmt -l .`
- `make test`
- `make build`
