### PR TITLE
Add Flow phase reset recovery key

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ filter matches, or a load failure with details in the status bar.
 | `F` | Pull with `--ff-only` (worktrees, and branches with a checked-out worktree) |
 | `t` | Open or attach to a tmux/Zellij session for the worktree |
 | `c` | Open VSCode at worktree path |
-| `x` | Show/hide sessions for the selected worktree (worktrees view), or expand/collapse plan phase rows |
+| `x` | Show/hide sessions for the selected worktree (worktrees view), expand/collapse plan phase rows, or reset a selected `await-session` Flow phase after confirmation |
 | `y` | Copy hash to clipboard (history/reflog view), selected agent session ID (sessions view), plan Markdown path (plans view), or Flow/phase ID (flows view) |
 | `r` | Resume selected agent session (sessions view; CLI agents embed in-pane) or selected attached Flow phase session (flows view) |
 | `s` | Page selected agent session summary (sessions view) |
@@ -331,6 +331,13 @@ launch ID does not match the phase's launch attempts shows `session-mismatch`,
 and an attached session that lacks a provider session ID shows
 `missing-session-id`. A pending Autoreview phase whose PR Creation predecessor
 completed without structured PR metadata shows `missing-pr`.
+
+When an expanded phase row shows `await-session`, and no running or starting
+embedded Flow terminal is attached to that same Flow phase, the selected phase
+row exposes `x reset ready`. Confirming the prompt removes the newest orphan
+launch attempt and lets wtui derive the phase back to `ready`. This is TUI
+recovery for an abandoned launch attempt, not a new agent transition; `ready`
+still cannot be set through `wtui flow phase set`.
 
 Flows are task-centric workflow records stored beside sessions and plans under
 `<sessions root>/flows/<flow-id>/meta.json`. The TUI can create a new Flow and

--- a/docs/config.md
+++ b/docs/config.md
@@ -374,6 +374,11 @@ when an attached session lacks a provider session ID, and `missing-pr` on a
 pending Autoreview phase when PR Creation completed without structured PR
 metadata.
 
+On a selected `await-session` phase row, `x` offers a confirmed reset back to
+derived `ready` only when no running or starting embedded Flow terminal is
+attached to that same Flow phase. The reset removes the orphan launch attempt;
+agents still cannot set `ready` directly.
+
 The Plan Review phase gates Implementation. Plan Review completion must use
 `--outcome approved` or `--outcome approved_with_concerns`; the latter requires
 `--notes`. Use `--status needs_attention --outcome changes_requested --notes

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -78,16 +78,21 @@ Additional rules:
   `codex-app` resume deep links are untracked app navigation because they cannot
   carry wtui launch metadata. Reopening a finished phase deliberately remains
   `wtui flow phase restart`.
+- The TUI can also recover a selected `await-session` phase after confirmation
+  by removing the newest orphan launch attempt and re-deriving readiness. This
+  is a UI-owned recovery mutation, not an agent-settable transition, and it is
+  unavailable while a running or starting embedded Flow terminal is attached to
+  the same Flow phase.
 
 ## Derived readiness
 
-The phase-affecting mutations (`SetPhase`, `AddChildPhase`, `SetPR`, and
-`AddPhaseLaunchID`) re-derive readiness with `refreshPhaseReadiness`,
-regardless of graph shape. Loads and the remaining mutations normalize only
-records containing a `plan-review` phase — the standard graph; hand-authored
-records without one keep their stored statuses until a phase-affecting
-mutation touches them. Agents never need to know which phase becomes ready
-next; they only report their own phase.
+The phase-affecting mutations (`SetPhase`, `AddChildPhase`, `SetPR`,
+`AddPhaseLaunchID`, and `ResetAwaitingSessionPhase`) re-derive readiness with
+`refreshPhaseReadiness`, regardless of graph shape. Loads and the remaining
+mutations normalize only records containing a `plan-review` phase — the
+standard graph; hand-authored records without one keep their stored statuses
+until a phase-affecting mutation touches them. Agents never need to know which
+phase becomes ready next; they only report their own phase.
 
 Walking phases in order, a `pending` phase becomes `ready` once every
 predecessor satisfies its downstream gate:
@@ -141,12 +146,12 @@ even if the linked-plan sync later fails.
   strings were added, removed, or renamed. Existing Flow JSON needs no
   migration.
 - Derived state is self-healing: phase-affecting mutations (`SetPhase`,
-  `AddChildPhase`, `SetPR`, `AddPhaseLaunchID`) re-derive readiness for any
-  graph, and records containing a `plan-review` phase (the standard graph)
-  are additionally normalized on load, so records written before a gate rule
-  existed converge to correct `pending`/`ready` values. Records without a
-  `plan-review` phase keep their stored statuses until a phase-affecting
-  mutation touches them.
+  `AddChildPhase`, `SetPR`, `AddPhaseLaunchID`,
+  `ResetAwaitingSessionPhase`) re-derive readiness for any graph, and records
+  containing a `plan-review` phase (the standard graph) are additionally
+  normalized on load, so records written before a gate rule existed converge to
+  correct `pending`/`ready` values. Records without a `plan-review` phase keep
+  their stored statuses until a phase-affecting mutation touches them.
 - Completed plan-review phases persisted before outcomes existed are
   normalized to `approved` on read.
 
@@ -159,3 +164,9 @@ states (`recover-worktree`, `await-session`, `session-mismatch`,
 with the phase ID like any phase state (for example `autoreview:missing-pr`),
 and are display-only; they never change persisted phase status. See
 `docs/config.md` for the pane behavior.
+
+When `await-session` is caused by an orphaned latest launch and predecessor
+gates still hold, the selected phase row can be reset with `x` after
+confirmation. The reset removes that orphan launch, persists the phase as
+`pending`, then lets derived readiness promote it to `ready`; if readiness
+cannot be derived, the mutation is rejected and the record is left unchanged.

--- a/flowstore/session_select.go
+++ b/flowstore/session_select.go
@@ -48,6 +48,29 @@ func PhaseAwaitingSession(phase FlowPhase) bool {
 	return true
 }
 
+// PhaseSessionLaunchMismatch reports whether any attached session cannot be
+// matched back to one of the phase launch attempts.
+func PhaseSessionLaunchMismatch(phase FlowPhase) bool {
+	if len(phase.Sessions) == 0 {
+		return false
+	}
+	launches := make(map[string]struct{}, len(phase.LaunchIDs))
+	for _, launchID := range phase.LaunchIDs {
+		if launchID != "" {
+			launches[launchID] = struct{}{}
+		}
+	}
+	for _, session := range phase.Sessions {
+		if session.LaunchID == "" {
+			return true
+		}
+		if _, ok := launches[session.LaunchID]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
 func LatestPhaseLaunchID(phase FlowPhase) string {
 	for i := len(phase.LaunchIDs) - 1; i >= 0; i-- {
 		if phase.LaunchIDs[i] != "" {

--- a/flowstore/session_select_test.go
+++ b/flowstore/session_select_test.go
@@ -59,6 +59,45 @@ func TestPhaseAwaitingSessionReportsNewestLaunchWithoutAttachedSession(t *testin
 	}
 }
 
+func TestPhaseSessionLaunchMismatch(t *testing.T) {
+	tests := []struct {
+		name  string
+		phase flowstore.FlowPhase
+		want  bool
+	}{
+		{
+			name: "older matched session and newer orphan launch",
+			phase: flowstore.FlowPhase{
+				LaunchIDs: []string{"launch-old", "launch-orphan"},
+				Sessions:  []flowstore.Session{{Provider: "codex", SessionID: "session-old", LaunchID: "launch-old"}},
+			},
+		},
+		{
+			name: "stale session outside phase launches",
+			phase: flowstore.FlowPhase{
+				LaunchIDs: []string{"launch-orphan"},
+				Sessions:  []flowstore.Session{{Provider: "codex", SessionID: "session-stale", LaunchID: "launch-stale"}},
+			},
+			want: true,
+		},
+		{
+			name: "attached session missing launch id",
+			phase: flowstore.FlowPhase{
+				LaunchIDs: []string{"launch-orphan"},
+				Sessions:  []flowstore.Session{{Provider: "codex", SessionID: "session-stale"}},
+			},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := flowstore.PhaseSessionLaunchMismatch(tc.phase); got != tc.want {
+				t.Fatalf("PhaseSessionLaunchMismatch() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLatestPhaseSessionDistinguishesMalformedLatestSession(t *testing.T) {
 	phase := flowstore.FlowPhase{
 		LaunchIDs: []string{"launch-new"},

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -790,7 +790,7 @@ func (s *Store) ResetAwaitingSessionPhase(update PhaseResetUpdate) (FlowRecord, 
 		if !PhasePredecessorsSatisfied(record, phase.PhaseID) {
 			return FlowRecord{}, fmt.Errorf("flow phase reset requires satisfied predecessors for %s", phase.PhaseID)
 		}
-		launchIDs, ok := removeLatestPhaseLaunchID(phase.LaunchIDs)
+		launchIDs, removedLaunchID, ok := removeLatestPhaseLaunchID(phase.LaunchIDs)
 		if !ok {
 			return FlowRecord{}, fmt.Errorf("flow phase reset requires an orphan launch id")
 		}
@@ -800,6 +800,11 @@ func (s *Store) ResetAwaitingSessionPhase(update PhaseResetUpdate) (FlowRecord, 
 		phase.UpdatedAt = now
 		record.Phases[phaseIndex] = phase
 		record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
+		if resetIndex := phaseIndexByID(record.Phases, update.PhaseID); resetIndex >= 0 {
+			resetPhase := record.Phases[resetIndex]
+			resetPhase.LaunchIDs = removePhaseLaunchID(resetPhase.LaunchIDs, removedLaunchID)
+			record.Phases[resetIndex] = resetPhase
+		}
 		record.UpdatedAt = now
 		record = refreshPhaseReadiness(record, now)
 		resetIndex := phaseIndexByID(record.Phases, update.PhaseID)
@@ -811,16 +816,30 @@ func (s *Store) ResetAwaitingSessionPhase(update PhaseResetUpdate) (FlowRecord, 
 	})
 }
 
-func removeLatestPhaseLaunchID(values []string) ([]string, bool) {
+func removeLatestPhaseLaunchID(values []string) ([]string, string, bool) {
 	for i := len(values) - 1; i >= 0; i-- {
 		if values[i] == "" {
 			continue
 		}
 		out := append([]string(nil), values[:i]...)
 		out = append(out, values[i+1:]...)
-		return out, true
+		return out, values[i], true
 	}
-	return values, false
+	return values, "", false
+}
+
+func removePhaseLaunchID(values []string, target string) []string {
+	if target == "" {
+		return values
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == target {
+			continue
+		}
+		out = append(out, value)
+	}
+	return out
 }
 
 // AttachSession records a provider session against a phase. Re-attaching the

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -787,6 +787,9 @@ func (s *Store) ResetAwaitingSessionPhase(update PhaseResetUpdate) (FlowRecord, 
 		if !PhaseAwaitingSession(phase) {
 			return FlowRecord{}, fmt.Errorf("flow phase reset requires latest launch without an attached session")
 		}
+		if PhaseSessionLaunchMismatch(phase) {
+			return FlowRecord{}, fmt.Errorf("flow phase reset requires attached sessions to match phase launch ids")
+		}
 		if !PhasePredecessorsSatisfied(record, phase.PhaseID) {
 			return FlowRecord{}, fmt.Errorf("flow phase reset requires satisfied predecessors for %s", phase.PhaseID)
 		}

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -806,6 +806,9 @@ func (s *Store) ResetAwaitingSessionPhase(update PhaseResetUpdate) (FlowRecord, 
 		if resetIndex := phaseIndexByID(record.Phases, update.PhaseID); resetIndex >= 0 {
 			resetPhase := record.Phases[resetIndex]
 			resetPhase.LaunchIDs = removePhaseLaunchID(resetPhase.LaunchIDs, removedLaunchID)
+			if PhaseSessionLaunchMismatch(resetPhase) {
+				return FlowRecord{}, fmt.Errorf("flow phase reset requires attached sessions to match phase launch ids")
+			}
 			record.Phases[resetIndex] = resetPhase
 		}
 		record.UpdatedAt = now

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -223,6 +223,12 @@ type PhaseLaunchUpdate struct {
 	Resume   bool
 }
 
+// PhaseResetUpdate identifies one UI-owned phase recovery mutation.
+type PhaseResetUpdate struct {
+	FlowID  string
+	PhaseID string
+}
+
 // SessionAttachUpdate attaches a captured provider session to a Flow phase.
 type SessionAttachUpdate struct {
 	FlowID  string
@@ -755,6 +761,66 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 		record.Status = DeriveStatus(record)
 		return record, nil
 	})
+}
+
+// ResetAwaitingSessionPhase removes an orphaned latest launch attempt from a
+// running phase and lets wtui derive it back to ready. This is intentionally
+// not part of the agent-facing phase transition table.
+func (s *Store) ResetAwaitingSessionPhase(update PhaseResetUpdate) (FlowRecord, error) {
+	if err := validateFlowID(update.FlowID); err != nil {
+		return FlowRecord{}, err
+	}
+	requestedPhaseID := strings.TrimSpace(update.PhaseID)
+	update.PhaseID = artifacts.NormalizePhaseID(update.PhaseID)
+	if update.PhaseID == "" {
+		return FlowRecord{}, fmt.Errorf("phase id is required")
+	}
+	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+		phaseIndex := phaseIndexPreferringExactID(record.Phases, requestedPhaseID)
+		if phaseIndex < 0 {
+			return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
+		}
+		phase := record.Phases[phaseIndex]
+		if phase.Status != PhaseRunning {
+			return FlowRecord{}, fmt.Errorf("flow phase reset requires running await-session; %s is %s", phase.PhaseID, phase.Status)
+		}
+		if !PhaseAwaitingSession(phase) {
+			return FlowRecord{}, fmt.Errorf("flow phase reset requires latest launch without an attached session")
+		}
+		if !PhasePredecessorsSatisfied(record, phase.PhaseID) {
+			return FlowRecord{}, fmt.Errorf("flow phase reset requires satisfied predecessors for %s", phase.PhaseID)
+		}
+		launchIDs, ok := removeLatestPhaseLaunchID(phase.LaunchIDs)
+		if !ok {
+			return FlowRecord{}, fmt.Errorf("flow phase reset requires an orphan launch id")
+		}
+		phase.LaunchIDs = launchIDs
+		phase.Status = PhasePending
+		phase.PhaseID = update.PhaseID
+		phase.UpdatedAt = now
+		record.Phases[phaseIndex] = phase
+		record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
+		record.UpdatedAt = now
+		record = refreshPhaseReadiness(record, now)
+		resetIndex := phaseIndexByID(record.Phases, update.PhaseID)
+		if resetIndex < 0 || record.Phases[resetIndex].Status != PhaseReady {
+			return FlowRecord{}, fmt.Errorf("flow phase reset could not derive %s back to ready", update.PhaseID)
+		}
+		record.Status = DeriveStatus(record)
+		return record, nil
+	})
+}
+
+func removeLatestPhaseLaunchID(values []string) ([]string, bool) {
+	for i := len(values) - 1; i >= 0; i-- {
+		if values[i] == "" {
+			continue
+		}
+		out := append([]string(nil), values[:i]...)
+		out = append(out, values[i+1:]...)
+		return out, true
+	}
+	return values, false
 }
 
 // AttachSession records a provider session against a phase. Re-attaching the

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -1015,6 +1015,39 @@ func TestStoreResetAwaitingSessionPhaseRejectsIneligiblePhases(t *testing.T) {
 			phaseID: "beta",
 			want:    "requires satisfied predecessors",
 		},
+		{
+			name: "duplicate row session references orphan launch",
+			setup: func(t *testing.T, store *flowstore.Store) flowstore.FlowRecord {
+				t.Helper()
+				record, err := store.Create(flowstore.FlowRecord{
+					FlowID:       "duplicate-orphan-session-reset",
+					Title:        "Duplicate orphan session reset rejection",
+					Instructions: "do not reset when duplicate history attaches the orphan launch",
+					RepoPath:     filepath.Join(t.TempDir(), "repo"),
+					Phases: []flowstore.FlowPhase{
+						{PhaseID: "alpha", Title: "Alpha", Status: flowstore.PhaseCompleted, Order: 1},
+						{
+							PhaseID:   "Step-1",
+							Title:     "Step 1",
+							Status:    flowstore.PhaseCompleted,
+							Order:     2,
+							LaunchIDs: []string{"launch-orphan"},
+							Sessions: []flowstore.Session{
+								{Provider: "codex", SessionID: "session-orphan", LaunchID: "launch-orphan"},
+							},
+						},
+						{PhaseID: "step-1", Title: "Step 1", Status: flowstore.PhaseRunning, Order: 2, LaunchIDs: []string{"launch-orphan"}},
+						{PhaseID: "omega", Title: "Omega", Status: flowstore.PhasePending, Order: 3},
+					},
+				})
+				if err != nil {
+					t.Fatalf("Create(duplicate) error = %v", err)
+				}
+				return record
+			},
+			phaseID: "step-1",
+			want:    "requires attached sessions to match phase launch ids",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			root := t.TempDir()

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -838,6 +838,225 @@ func TestStoreAddPhaseLaunchIDMarksPhaseRunning(t *testing.T) {
 	}
 }
 
+func TestStoreResetAwaitingSessionPhaseReturnsRunningOrphanToReady(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Reset orphaned implementation launch",
+		Instructions: "recover a phase stuck waiting on session capture",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review")
+	record, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:   record.FlowID,
+		PhaseID:  "implementation",
+		LaunchID: "launch-old",
+	})
+	if err != nil {
+		t.Fatalf("AddPhaseLaunchID(old) error = %v", err)
+	}
+	record, err = store.AttachSession(flowstore.SessionAttachUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "implementation",
+		Session: flowstore.Session{
+			Provider:  "codex",
+			SessionID: "session-old",
+			LaunchID:  "launch-old",
+		},
+	})
+	if err != nil {
+		t.Fatalf("AttachSession(old) error = %v", err)
+	}
+	record, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:   record.FlowID,
+		PhaseID:  "implementation",
+		LaunchID: "launch-orphan",
+	})
+	if err != nil {
+		t.Fatalf("AddPhaseLaunchID(orphan) error = %v", err)
+	}
+	if phase := phaseByID(t, record, "implementation"); phase.Status != flowstore.PhaseRunning || !flowstore.PhaseAwaitingSession(phase) {
+		t.Fatalf("implementation before reset = %#v, want running await-session", phase)
+	}
+
+	reset, err := store.ResetAwaitingSessionPhase(flowstore.PhaseResetUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "implementation",
+	})
+	if err != nil {
+		t.Fatalf("ResetAwaitingSessionPhase() error = %v", err)
+	}
+
+	phase := phaseByID(t, reset, "implementation")
+	if phase.Status != flowstore.PhaseReady {
+		t.Fatalf("implementation status = %q, want ready", phase.Status)
+	}
+	if flowstore.PhaseAwaitingSession(phase) {
+		t.Fatalf("implementation should no longer be awaiting session: %#v", phase)
+	}
+	if len(phase.LaunchIDs) != 1 || phase.LaunchIDs[0] != "launch-old" {
+		t.Fatalf("launch ids = %#v, want only older attached launch", phase.LaunchIDs)
+	}
+	if len(phase.Sessions) != 1 || phase.Sessions[0].LaunchID != "launch-old" || phase.Sessions[0].SessionID != "session-old" {
+		t.Fatalf("sessions = %#v, want older session preserved", phase.Sessions)
+	}
+	if reset.Status != flowstore.StatusInProgress {
+		t.Fatalf("flow status = %q, want in_progress", reset.Status)
+	}
+}
+
+func TestStoreResetAwaitingSessionPhaseRejectsIneligiblePhases(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		setup   func(t *testing.T, store *flowstore.Store) flowstore.FlowRecord
+		phaseID string
+		want    string
+	}{
+		{
+			name: "ready phase",
+			setup: func(t *testing.T, store *flowstore.Store) flowstore.FlowRecord {
+				t.Helper()
+				record := mustCreateFlow(t, store, "Ready reset rejection")
+				mustCompleteFlowPhases(t, store, &record, "plan", "plan-review")
+				return record
+			},
+			phaseID: "implementation",
+			want:    "requires running await-session",
+		},
+		{
+			name: "latest launch has attached session",
+			setup: func(t *testing.T, store *flowstore.Store) flowstore.FlowRecord {
+				t.Helper()
+				record := mustCreateFlow(t, store, "Attached session reset rejection")
+				mustCompleteFlowPhases(t, store, &record, "plan", "plan-review")
+				var err error
+				record, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{FlowID: record.FlowID, PhaseID: "implementation", LaunchID: "launch-1"})
+				if err != nil {
+					t.Fatalf("AddPhaseLaunchID() error = %v", err)
+				}
+				record, err = store.AttachSession(flowstore.SessionAttachUpdate{
+					FlowID:  record.FlowID,
+					PhaseID: "implementation",
+					Session: flowstore.Session{Provider: "codex", SessionID: "session-1", LaunchID: "launch-1"},
+				})
+				if err != nil {
+					t.Fatalf("AttachSession() error = %v", err)
+				}
+				return record
+			},
+			phaseID: "implementation",
+			want:    "requires latest launch without an attached session",
+		},
+		{
+			name: "missing phase",
+			setup: func(t *testing.T, store *flowstore.Store) flowstore.FlowRecord {
+				t.Helper()
+				return mustCreateFlow(t, store, "Missing phase reset rejection")
+			},
+			phaseID: "missing-phase",
+			want:    `phase "missing-phase" not found`,
+		},
+		{
+			name: "predecessors unsatisfied",
+			setup: func(t *testing.T, store *flowstore.Store) flowstore.FlowRecord {
+				t.Helper()
+				record, err := store.Create(flowstore.FlowRecord{
+					FlowID:       "unsatisfied-reset",
+					Title:        "Unsatisfied reset rejection",
+					Instructions: "do not reset behind an open predecessor",
+					RepoPath:     filepath.Join(t.TempDir(), "repo"),
+					Phases: []flowstore.FlowPhase{
+						{PhaseID: "alpha", Title: "Alpha", Status: flowstore.PhaseRunning, Order: 1},
+						{PhaseID: "beta", Title: "Beta", Status: flowstore.PhaseRunning, Order: 2, LaunchIDs: []string{"launch-orphan"}},
+					},
+				})
+				if err != nil {
+					t.Fatalf("Create(custom) error = %v", err)
+				}
+				return record
+			},
+			phaseID: "beta",
+			want:    "requires satisfied predecessors",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			if err != nil {
+				t.Fatalf("NewStore() error = %v", err)
+			}
+			record := tc.setup(t, store)
+
+			_, err = store.ResetAwaitingSessionPhase(flowstore.PhaseResetUpdate{FlowID: record.FlowID, PhaseID: tc.phaseID})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("ResetAwaitingSessionPhase() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestStoreResetAwaitingSessionPhaseCollapsesDuplicateRows(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		FlowID:       "duplicate-reset",
+		Title:        "Duplicate reset",
+		Instructions: "reset the active duplicate row",
+		RepoPath:     filepath.Join(root, "repo"),
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "alpha", Title: "Alpha", Status: flowstore.PhaseCompleted, Order: 1},
+			{
+				PhaseID: "Step-1", Title: "Step 1", Status: flowstore.PhaseCompleted, Order: 2,
+				LaunchIDs: []string{"launch-old"},
+				Sessions:  []flowstore.Session{{Provider: "codex", SessionID: "session-old", LaunchID: "launch-old"}},
+			},
+			{PhaseID: "step-1", Title: "Step 1", Status: flowstore.PhaseRunning, Order: 2, LaunchIDs: []string{"launch-orphan"}},
+			{PhaseID: "omega", Title: "Omega", Status: flowstore.PhasePending, Order: 3},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	record, err = store.ResetAwaitingSessionPhase(flowstore.PhaseResetUpdate{FlowID: record.FlowID, PhaseID: "step-1"})
+	if err != nil {
+		t.Fatalf("ResetAwaitingSessionPhase() error = %v", err)
+	}
+
+	count := 0
+	var survivor flowstore.FlowPhase
+	for _, phase := range record.Phases {
+		if strings.EqualFold(phase.PhaseID, "step-1") {
+			count++
+			survivor = phase
+		}
+	}
+	if count != 1 {
+		t.Fatalf("duplicate rows not collapsed: %#v", record.Phases)
+	}
+	if survivor.PhaseID != "step-1" || survivor.Status != flowstore.PhaseReady {
+		t.Fatalf("survivor = %#v, want normalized ready step-1", survivor)
+	}
+	if len(survivor.LaunchIDs) != 1 || survivor.LaunchIDs[0] != "launch-old" {
+		t.Fatalf("survivor launch ids = %#v, want older launch only", survivor.LaunchIDs)
+	}
+	if len(survivor.Sessions) != 1 || survivor.Sessions[0].SessionID != "session-old" {
+		t.Fatalf("survivor sessions = %#v, want older session preserved", survivor.Sessions)
+	}
+	if got := phaseByID(t, record, "omega").Status; got != flowstore.PhasePending {
+		t.Fatalf("omega status = %q, want pending behind ready reset phase", got)
+	}
+}
+
 func TestStoreSetPhaseRejectsInvalidTransitions(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
@@ -3903,6 +4122,19 @@ func maybePlanPhaseByID(record planstore.PlanRecord, phaseID string) (planstore.
 		}
 	}
 	return planstore.PlanPhase{}, false
+}
+
+func mustCreateFlow(t *testing.T, store *flowstore.Store, title string) flowstore.FlowRecord {
+	t.Helper()
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        title,
+		Instructions: "test flow",
+		RepoPath:     filepath.Join(t.TempDir(), "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create(%q) error = %v", title, err)
+	}
+	return record
 }
 
 func mustCompleteFlowPhases(t *testing.T, store *flowstore.Store, record *flowstore.FlowRecord, phaseIDs ...string) {

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -954,6 +954,37 @@ func TestStoreResetAwaitingSessionPhaseRejectsIneligiblePhases(t *testing.T) {
 			want:    "requires latest launch without an attached session",
 		},
 		{
+			name: "attached session launch mismatch",
+			setup: func(t *testing.T, store *flowstore.Store) flowstore.FlowRecord {
+				t.Helper()
+				record, err := store.Create(flowstore.FlowRecord{
+					Title:        "Mismatched session reset rejection",
+					Instructions: "do not reset mismatched sessions",
+					RepoPath:     filepath.Join(t.TempDir(), "repo"),
+					Phases: []flowstore.FlowPhase{
+						{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted, Order: 1},
+						{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Order: 2},
+						{
+							PhaseID:   "implementation",
+							Title:     "Implementation",
+							Status:    flowstore.PhaseRunning,
+							Order:     3,
+							LaunchIDs: []string{"launch-orphan"},
+							Sessions: []flowstore.Session{
+								{Provider: "codex", SessionID: "session-stale", LaunchID: "launch-stale"},
+							},
+						},
+					},
+				})
+				if err != nil {
+					t.Fatalf("Create(mismatched) error = %v", err)
+				}
+				return record
+			},
+			phaseID: "implementation",
+			want:    "requires attached sessions to match phase launch ids",
+		},
+		{
 			name: "missing phase",
 			setup: func(t *testing.T, store *flowstore.Store) flowstore.FlowRecord {
 				t.Helper()

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -1016,7 +1016,7 @@ func TestStoreResetAwaitingSessionPhaseCollapsesDuplicateRows(t *testing.T) {
 			{PhaseID: "alpha", Title: "Alpha", Status: flowstore.PhaseCompleted, Order: 1},
 			{
 				PhaseID: "Step-1", Title: "Step 1", Status: flowstore.PhaseCompleted, Order: 2,
-				LaunchIDs: []string{"launch-old"},
+				LaunchIDs: []string{"launch-old", "launch-orphan"},
 				Sessions:  []flowstore.Session{{Provider: "codex", SessionID: "session-old", LaunchID: "launch-old"}},
 			},
 			{PhaseID: "step-1", Title: "Step 1", Status: flowstore.PhaseRunning, Order: 2, LaunchIDs: []string{"launch-orphan"}},
@@ -1048,6 +1048,9 @@ func TestStoreResetAwaitingSessionPhaseCollapsesDuplicateRows(t *testing.T) {
 	}
 	if len(survivor.LaunchIDs) != 1 || survivor.LaunchIDs[0] != "launch-old" {
 		t.Fatalf("survivor launch ids = %#v, want older launch only", survivor.LaunchIDs)
+	}
+	if flowstore.PhaseAwaitingSession(survivor) {
+		t.Fatalf("survivor should not keep duplicate orphan launch after reset: %#v", survivor)
 	}
 	if len(survivor.Sessions) != 1 || survivor.Sessions[0].SessionID != "session-old" {
 		t.Fatalf("survivor sessions = %#v, want older session preserved", survivor.Sessions)

--- a/model/model.go
+++ b/model/model.go
@@ -84,6 +84,7 @@ type Model struct {
 	startFlowPlan             func(FlowStartRequest) (FlowStartResult, error)
 	setFlowPhase              func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
 	addFlowPhaseLaunchID      func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
+	resetFlowPhase            func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error)
 	deleteFlow                func(string) error
 	readPlan                  func(string) (string, error)
 	planMarkdownPath          func(string) (string, error)
@@ -154,6 +155,7 @@ type Options struct {
 	StartFlowPlan         func(FlowStartRequest) (FlowStartResult, error)
 	SetFlowPhase          func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
 	AddFlowPhaseLaunchID  func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
+	ResetFlowPhase        func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error)
 	DeleteFlow            func(flowID string) error
 	ReadPlan              func(string) (string, error)
 	PlanMarkdownPath      func(planID string) (string, error)
@@ -221,6 +223,17 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 				return flowstore.FlowRecord{}, err
 			}
 			return store.AddPhaseLaunchID(update)
+		}
+	}
+	resetFlowPhase := opts.ResetFlowPhase
+	if resetFlowPhase == nil {
+		root := opts.SessionStateRoot
+		resetFlowPhase = func(update flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error) {
+			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			if err != nil {
+				return flowstore.FlowRecord{}, err
+			}
+			return store.ResetAwaitingSessionPhase(update)
 		}
 	}
 	deleteFlow := opts.DeleteFlow
@@ -338,6 +351,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		startFlowPlan:         startFlowPlan,
 		setFlowPhase:          setFlowPhase,
 		addFlowPhaseLaunchID:  addFlowPhaseLaunchID,
+		resetFlowPhase:        resetFlowPhase,
 		deleteFlow:            deleteFlow,
 		readPlan:              readPlan,
 		planMarkdownPath:      planMarkdownPath,
@@ -484,93 +498,94 @@ func (m Model) View() string {
 	}
 	modalView := m.modal.View()
 	return ui.Render(ui.RenderParams{
-		Repos:                      repos,
-		Selected:                   selected,
-		Width:                      m.width,
-		Height:                     m.height,
-		Mode:                       m.mode,
-		Branches:                   rows,
-		Stashes:                    stashes,
-		BranchSelected:             branchSelected,
-		StashSelected:              stashSelected,
-		Overlay:                    m.overlayState(),
-		OverlayDiff:                modalView.Diff,
-		OverlayScroll:              modalView.Scroll,
-		ConfirmPrompt:              modalView.Prompt,
-		ConfirmForce:               modalView.Force,
-		InputPrompt:                modalView.Prompt,
-		InputPlaceholder:           modalView.Placeholder,
-		InputValue:                 modalView.Input,
-		InputError:                 modalView.InputErr,
-		InputMode:                  uiInputMode(modalView.InputMode),
-		InputCursor:                modalView.InputCursor,
-		WorktreeInputPrompt:        modalView.Prompt,
-		WorktreeInputPlaceholder:   modalView.Placeholder,
-		WorktreeInput:              modalView.Input,
-		WorktreeInputErr:           modalView.InputErr,
-		SelectPrompt:               modalView.Prompt,
-		SelectItems:                uiSelectItems(modalView.SelectItems),
-		SelectSelected:             modalView.SelectIndex,
-		SelectWidth:                modalView.SelectLayout.Width,
-		SelectHeight:               modalView.SelectLayout.Height,
-		SelectPlacement:            uiSelectPlacement(modalView.SelectLayout.Placement),
-		BranchScroll:               branchScroll,
-		RepoScroll:                 repoScroll,
-		StashScroll:                stashScroll,
-		ActivePane:                 m.activePane,
-		Destructive:                m.destructive,
-		Worktrees:                  worktrees,
-		WorktreeSelected:           worktreeSelected,
-		WorktreeScroll:             worktreeScroll,
-		WorktreeSessions:           worktreeSessions,
-		WorktreeSessionSelected:    worktreeSessionSelected,
-		WorktreeSessionScroll:      worktreeSessionScroll,
-		InlineWorktreeSessions:     m.inlineWorktreeSessionPath != "",
-		Commits:                    commits,
-		CommitSelected:             commitSelected,
-		CommitScroll:               commitScroll,
-		Reflogs:                    reflogs,
-		ReflogSelected:             reflogSelected,
-		ReflogScroll:               reflogScroll,
-		Sessions:                   sessions,
-		SessionSelected:            sessionSelected,
-		SessionScroll:              sessionScroll,
-		EmbeddedTerminals:          m.embeddedTerminalTabs(),
-		EmbeddedTerminalLines:      m.embeddedTerminalLines(),
-		EmbeddedTerminalPrefix:     m.terminalPrefixActive,
-		Plans:                      plans,
-		PlanSelected:               planSelected,
-		PlanScroll:                 planScroll,
-		Flows:                      flows,
-		FlowSelected:               flowSelected,
-		FlowScroll:                 flowScroll,
-		FlowEmbeddedTerminals:      m.flowEmbeddedTerminalTabs(),
-		FlowEmbeddedTerminalLines:  m.flowEmbeddedTerminalLines(),
-		FlowEmbeddedTerminalPrefix: m.terminalPrefixActive && m.flowFocus == flowFocusTerminal,
-		FlowTerminalActivity:       m.flowTerminalActivity(),
-		FlowTerminalFocused:        m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow),
-		ExpandedPlanID:             m.expandedPlanID,
-		ExpandedFlowID:             m.expandedFlowID,
-		SelectedPlanPhaseID:        m.selectedPlanPhaseID,
-		SelectedFlowPhaseID:        m.selectedFlowPhaseID,
-		FlowHeadless:               m.flowHeadless,
-		FlowPhaseLaunchReady:       m.selectedFlowPhaseLaunchReady(),
-		FlowPhaseResumableSelected: m.selectedFlowPhaseResumable(),
-		OverlayText:                modalView.Text,
-		TransientError:             m.visibleStatusText(),
-		TransientErrorFadeStep:     m.visibleStatusFadeStep(),
-		SearchActive:               m.searchActive,
-		RepoSearch:                 m.repos.Query(),
-		ItemSearch:                 m.activeItemPaneQuery(),
-		RepoEmptyMessage:           repoEmptyMessage,
-		RightEmptyMessage:          rightEmptyMessage,
-		FetchAvailable:             m.canFetch(),
-		FetchVisibleAvailable:      m.canFetchVisibleRepos(),
-		PullAvailable:              m.canPull(),
-		WorktreeMoveAvailable:      m.canMoveWorktree(),
-		WorktreeSessionsOpen:       m.inlineWorktreeSessionPath != "",
-		AgentAvailable:             m.canLaunchAgent(),
-		NewAgentAvailable:          m.canCreateAndLaunchAgent(),
+		Repos:                       repos,
+		Selected:                    selected,
+		Width:                       m.width,
+		Height:                      m.height,
+		Mode:                        m.mode,
+		Branches:                    rows,
+		Stashes:                     stashes,
+		BranchSelected:              branchSelected,
+		StashSelected:               stashSelected,
+		Overlay:                     m.overlayState(),
+		OverlayDiff:                 modalView.Diff,
+		OverlayScroll:               modalView.Scroll,
+		ConfirmPrompt:               modalView.Prompt,
+		ConfirmForce:                modalView.Force,
+		InputPrompt:                 modalView.Prompt,
+		InputPlaceholder:            modalView.Placeholder,
+		InputValue:                  modalView.Input,
+		InputError:                  modalView.InputErr,
+		InputMode:                   uiInputMode(modalView.InputMode),
+		InputCursor:                 modalView.InputCursor,
+		WorktreeInputPrompt:         modalView.Prompt,
+		WorktreeInputPlaceholder:    modalView.Placeholder,
+		WorktreeInput:               modalView.Input,
+		WorktreeInputErr:            modalView.InputErr,
+		SelectPrompt:                modalView.Prompt,
+		SelectItems:                 uiSelectItems(modalView.SelectItems),
+		SelectSelected:              modalView.SelectIndex,
+		SelectWidth:                 modalView.SelectLayout.Width,
+		SelectHeight:                modalView.SelectLayout.Height,
+		SelectPlacement:             uiSelectPlacement(modalView.SelectLayout.Placement),
+		BranchScroll:                branchScroll,
+		RepoScroll:                  repoScroll,
+		StashScroll:                 stashScroll,
+		ActivePane:                  m.activePane,
+		Destructive:                 m.destructive,
+		Worktrees:                   worktrees,
+		WorktreeSelected:            worktreeSelected,
+		WorktreeScroll:              worktreeScroll,
+		WorktreeSessions:            worktreeSessions,
+		WorktreeSessionSelected:     worktreeSessionSelected,
+		WorktreeSessionScroll:       worktreeSessionScroll,
+		InlineWorktreeSessions:      m.inlineWorktreeSessionPath != "",
+		Commits:                     commits,
+		CommitSelected:              commitSelected,
+		CommitScroll:                commitScroll,
+		Reflogs:                     reflogs,
+		ReflogSelected:              reflogSelected,
+		ReflogScroll:                reflogScroll,
+		Sessions:                    sessions,
+		SessionSelected:             sessionSelected,
+		SessionScroll:               sessionScroll,
+		EmbeddedTerminals:           m.embeddedTerminalTabs(),
+		EmbeddedTerminalLines:       m.embeddedTerminalLines(),
+		EmbeddedTerminalPrefix:      m.terminalPrefixActive,
+		Plans:                       plans,
+		PlanSelected:                planSelected,
+		PlanScroll:                  planScroll,
+		Flows:                       flows,
+		FlowSelected:                flowSelected,
+		FlowScroll:                  flowScroll,
+		FlowEmbeddedTerminals:       m.flowEmbeddedTerminalTabs(),
+		FlowEmbeddedTerminalLines:   m.flowEmbeddedTerminalLines(),
+		FlowEmbeddedTerminalPrefix:  m.terminalPrefixActive && m.flowFocus == flowFocusTerminal,
+		FlowTerminalActivity:        m.flowTerminalActivity(),
+		FlowTerminalFocused:         m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow),
+		ExpandedPlanID:              m.expandedPlanID,
+		ExpandedFlowID:              m.expandedFlowID,
+		SelectedPlanPhaseID:         m.selectedPlanPhaseID,
+		SelectedFlowPhaseID:         m.selectedFlowPhaseID,
+		FlowHeadless:                m.flowHeadless,
+		FlowPhaseLaunchReady:        m.selectedFlowPhaseLaunchReady(),
+		FlowPhaseResetReadySelected: m.selectedFlowPhaseResettable(),
+		FlowPhaseResumableSelected:  m.selectedFlowPhaseResumable(),
+		OverlayText:                 modalView.Text,
+		TransientError:              m.visibleStatusText(),
+		TransientErrorFadeStep:      m.visibleStatusFadeStep(),
+		SearchActive:                m.searchActive,
+		RepoSearch:                  m.repos.Query(),
+		ItemSearch:                  m.activeItemPaneQuery(),
+		RepoEmptyMessage:            repoEmptyMessage,
+		RightEmptyMessage:           rightEmptyMessage,
+		FetchAvailable:              m.canFetch(),
+		FetchVisibleAvailable:       m.canFetchVisibleRepos(),
+		PullAvailable:               m.canPull(),
+		WorktreeMoveAvailable:       m.canMoveWorktree(),
+		WorktreeSessionsOpen:        m.inlineWorktreeSessionPath != "",
+		AgentAvailable:              m.canLaunchAgent(),
+		NewAgentAvailable:           m.canCreateAndLaunchAgent(),
 	})
 }
 
@@ -880,6 +895,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case FlowResultMsg:
 		next := m.handleFlowResult(msg)
 		return next.finishFlowRefreshFetch(ui.ModeFlows, msg.ListRequest)
+	case flowPhaseResetConfirmedMsg:
+		return m.handleFlowPhaseResetConfirmed(msg)
+	case flowPhaseResetMsg:
+		return m.handleFlowPhaseReset(msg)
+	case flowPhaseResetFailedMsg:
+		return m.handleFlowPhaseResetFailed(msg)
 	case FlowDeletedMsg:
 		return m.handleFlowDeleted(msg)
 	case FlowDeleteFailedMsg:
@@ -1144,6 +1165,30 @@ func (m Model) selectedFlowPhaseLaunchReady() bool {
 	}
 	phase, ok := m.selectedFlowPhase()
 	return ok && flowPhaseCanLaunch(record, phase)
+}
+
+func (m Model) selectedFlowPhaseResettable() bool {
+	record, ok := m.selectedFlow()
+	if !ok {
+		return false
+	}
+	phase, ok := m.selectedFlowPhase()
+	return ok && m.flowPhaseResettable(record, phase)
+}
+
+func (m Model) flowPhaseByID(flowID, phaseID string) (flowstore.FlowRecord, flowstore.FlowPhase, bool) {
+	for _, record := range m.flows.Items() {
+		if record.FlowID != flowID {
+			continue
+		}
+		for _, phase := range flowstore.OrderedPhases(record.Phases) {
+			if phase.PhaseID == phaseID {
+				return record, phase, true
+			}
+		}
+		return record, flowstore.FlowPhase{}, false
+	}
+	return flowstore.FlowRecord{}, flowstore.FlowPhase{}, false
 }
 
 func (m Model) clearSelectedPlanPhase() Model {

--- a/model/model.go
+++ b/model/model.go
@@ -13,6 +13,7 @@ import (
 	"github.com/brian-bell/wtui/agent"
 	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/gitquery"
+	"github.com/brian-bell/wtui/internal/artifacts"
 	"github.com/brian-bell/wtui/model/modal"
 	"github.com/brian-bell/wtui/model/pane"
 	"github.com/brian-bell/wtui/planstore"
@@ -1122,12 +1123,7 @@ func (m Model) selectedFlowPhase() (flowstore.FlowPhase, bool) {
 	if !ok || record.FlowID == "" || record.FlowID != m.expandedFlowID || m.selectedFlowPhaseID == "" {
 		return flowstore.FlowPhase{}, false
 	}
-	for _, phase := range flowstore.OrderedPhases(record.Phases) {
-		if phase.PhaseID == m.selectedFlowPhaseID {
-			return phase, true
-		}
-	}
-	return flowstore.FlowPhase{}, false
+	return flowRecordPhaseByID(record, m.selectedFlowPhaseID)
 }
 
 func (m Model) selectedFlowPhaseIndex() (int, bool) {
@@ -1135,12 +1131,8 @@ func (m Model) selectedFlowPhaseIndex() (int, bool) {
 	if !ok || record.FlowID == "" || record.FlowID != m.expandedFlowID || m.selectedFlowPhaseID == "" {
 		return 0, false
 	}
-	for i, phase := range flowstore.OrderedPhases(record.Phases) {
-		if phase.PhaseID == m.selectedFlowPhaseID {
-			return i, true
-		}
-	}
-	return 0, false
+	index, _, ok := flowRecordPhaseIndexByID(record, m.selectedFlowPhaseID)
+	return index, ok
 }
 
 func (m Model) selectedFlowPhaseResumable() bool {
@@ -1181,14 +1173,37 @@ func (m Model) flowPhaseByID(flowID, phaseID string) (flowstore.FlowRecord, flow
 		if record.FlowID != flowID {
 			continue
 		}
-		for _, phase := range flowstore.OrderedPhases(record.Phases) {
-			if phase.PhaseID == phaseID {
-				return record, phase, true
-			}
+		if phase, ok := flowRecordPhaseByID(record, phaseID); ok {
+			return record, phase, true
 		}
 		return record, flowstore.FlowPhase{}, false
 	}
 	return flowstore.FlowRecord{}, flowstore.FlowPhase{}, false
+}
+
+func flowRecordPhaseByID(record flowstore.FlowRecord, phaseID string) (flowstore.FlowPhase, bool) {
+	_, phase, ok := flowRecordPhaseIndexByID(record, phaseID)
+	return phase, ok
+}
+
+func flowRecordPhaseIndexByID(record flowstore.FlowRecord, phaseID string) (int, flowstore.FlowPhase, bool) {
+	requested := strings.TrimSpace(phaseID)
+	phases := flowstore.OrderedPhases(record.Phases)
+	for i, phase := range phases {
+		if phase.PhaseID == requested {
+			return i, phase, true
+		}
+	}
+	want := artifacts.NormalizePhaseID(requested)
+	if want == "" {
+		return 0, flowstore.FlowPhase{}, false
+	}
+	for i, phase := range phases {
+		if artifacts.NormalizePhaseID(phase.PhaseID) == want {
+			return i, phase, true
+		}
+	}
+	return 0, flowstore.FlowPhase{}, false
 }
 
 func (m Model) clearSelectedPlanPhase() Model {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -224,6 +224,54 @@ func TestModel_XKeyOnResettableFlowPhaseConfirmsAndResets(t *testing.T) {
 	}
 }
 
+func TestModel_ResetFlowPhaseRefreshKeepsSelectionAfterPhaseIDNormalization(t *testing.T) {
+	awaiting := flowWithAwaitingImplementation()
+	awaiting.FlowID = "flow-legacy"
+	awaiting.Phases[2].PhaseID = "Implementation"
+	reset := awaiting
+	reset.Phases = append([]flowstore.FlowPhase(nil), awaiting.Phases...)
+	reset.Phases[2].PhaseID = "implementation"
+	reset.Phases[2].Status = flowstore.PhaseReady
+	reset.Phases[2].LaunchIDs = nil
+	var resetCalls []flowstore.PhaseResetUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ResetFlowPhase: func(update flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error) {
+			resetCalls = append(resetCalls, update)
+			return reset, nil
+		},
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{reset}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{awaiting})
+	m = selectFlowPhaseByID(t, m, "Implementation")
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("accepting reset confirmation should return reset command")
+	}
+	m, resetCmd := update(m, cmd())
+	if resetCmd == nil {
+		t.Fatal("confirmed reset should return persistence command")
+	}
+	m, fetchCmd := update(m, resetCmd())
+	if len(resetCalls) != 1 || resetCalls[0].PhaseID != "Implementation" {
+		t.Fatalf("reset calls = %#v", resetCalls)
+	}
+	if fetchCmd == nil {
+		t.Fatal("successful reset should refresh Flow rows")
+	}
+	m, _ = update(m, flowResultFromCommand(t, fetchCmd))
+
+	if got := m.ExpandedFlowID(); got != "flow-legacy" {
+		t.Fatalf("expanded flow after reset refresh = %q, want flow-legacy", got)
+	}
+	if got := m.SelectedFlowPhaseID(); got != "implementation" {
+		t.Fatalf("selected phase after reset refresh = %q, want normalized implementation", got)
+	}
+}
+
 func TestModel_XKeyOnResettableFlowPhaseCancelDoesNotPersist(t *testing.T) {
 	resetCalled := false
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -335,6 +383,61 @@ func TestModel_ResetShortcutHiddenWhenMatchingFlowTerminalIsRunning(t *testing.T
 	}
 	if resetCalled {
 		t.Fatal("reset should not be called while matching Flow terminal is running")
+	}
+}
+
+func TestModel_ResetShortcutHiddenAfterLegacyPhaseIDLaunchNormalizes(t *testing.T) {
+	legacy := flowWithPhaseDetails()
+	legacy.Phases[2].PhaseID = "Implementation"
+	awaiting := flowWithAwaitingImplementation()
+	var started actions.AgentLaunchContext
+	resetCalled := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			if update.PhaseID != "Implementation" {
+				t.Fatalf("launch update phase id = %q, want legacy Implementation", update.PhaseID)
+			}
+			return awaiting, nil
+		},
+		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
+			started = ctx
+			return &fakeEmbeddedTerminal{state: "running"}, nil
+		},
+		ResetFlowPhase: func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error) {
+			resetCalled = true
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{legacy})
+	m = selectFlowPhaseByID(t, m, "Implementation")
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+	}
+	m, _ = update(m, cmd())
+	if started.FlowPhaseID != "implementation" {
+		t.Fatalf("embedded launch phase id = %q, want canonical implementation", started.FlowPhaseID)
+	}
+	m, _ = update(m, model.FlowResultMsg{RepoPath: "/dev/alpha", Flows: []flowstore.FlowRecord{awaiting}, ListRequest: m.ListRequest(ui.ModeFlows)})
+	if got := m.SelectedFlowPhaseID(); got != "implementation" {
+		t.Fatalf("selected phase after normalized refresh = %q, want implementation", got)
+	}
+
+	view := ansi.Strip(m.View())
+	if strings.Contains(view, "reset ready") {
+		t.Fatalf("running normalized Flow terminal should hide reset shortcut:\n%s", view)
+	}
+	if !strings.Contains(view, "   >● running") {
+		t.Fatalf("normalized Flow terminal should mark selected phase active:\n%s", view)
+	}
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd != nil || m.Overlay() != ui.OverlayNone {
+		t.Fatalf("x with normalized running Flow terminal returned cmd=%T overlay=%d", cmd, m.Overlay())
+	}
+	if resetCalled {
+		t.Fatal("reset should not be called while normalized Flow terminal is running")
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -43,6 +43,18 @@ func flowWithPhaseDetails() flowstore.FlowRecord {
 	}
 }
 
+func flowWithAwaitingImplementation() flowstore.FlowRecord {
+	flow := flowWithPhaseDetails()
+	for i := range flow.Phases {
+		if flow.Phases[i].PhaseID == "implementation" {
+			flow.Phases[i].Status = flowstore.PhaseRunning
+			flow.Phases[i].LaunchIDs = []string{"launch-orphan"}
+			flow.Phases[i].Sessions = nil
+		}
+	}
+	return flow
+}
+
 func expandSelectedFlowWithEnter(t *testing.T, m model.Model) model.Model {
 	t.Helper()
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -138,6 +150,228 @@ func prepareSelectedFlowPhaseEmbeddedLaunch(t *testing.T, m model.Model, phaseID
 	m = selectFlowPhaseByID(t, m, phaseID)
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	return m, cmd
+}
+
+func TestModel_SelectedAwaitingFlowPhaseAdvertisesResetShortcut(t *testing.T) {
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithAwaitingImplementation()})
+	m = selectFlowPhaseByID(t, m, "implementation")
+
+	view := m.View()
+	if !strings.Contains(view, "x      reset ready") {
+		t.Fatalf("await-session Flow phase should expose reset shortcut:\n%s", m.View())
+	}
+	if strings.Contains(view, "r      resume") {
+		t.Fatalf("await-session Flow phase should not expose resume shortcut:\n%s", m.View())
+	}
+}
+
+func TestModel_XKeyOnResettableFlowPhaseConfirmsAndResets(t *testing.T) {
+	awaiting := flowWithAwaitingImplementation()
+	reset := flowWithPhaseDetails()
+	var resetCalls []flowstore.PhaseResetUpdate
+	listCalls := 0
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ResetFlowPhase: func(update flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error) {
+			resetCalls = append(resetCalls, update)
+			return reset, nil
+		},
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			listCalls++
+			return []flowstore.FlowRecord{reset}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{awaiting})
+	m = selectFlowPhaseByID(t, m, "implementation")
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd != nil {
+		t.Fatalf("opening reset confirmation returned command %T, want nil", cmd)
+	}
+	if m.Overlay() != ui.OverlayConfirm || !strings.Contains(m.ConfirmPrompt(), "Reset Flow phase implementation") {
+		t.Fatalf("reset confirmation prompt = %q overlay=%d", m.ConfirmPrompt(), m.Overlay())
+	}
+	if len(resetCalls) != 0 {
+		t.Fatalf("reset called before confirmation: %#v", resetCalls)
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("accepting reset confirmation should return reset command")
+	}
+	m, resetCmd := update(m, cmd())
+	if resetCmd == nil {
+		t.Fatal("confirmed reset should return persistence command")
+	}
+	m, fetchCmd := update(m, resetCmd())
+	if len(resetCalls) != 1 || resetCalls[0].FlowID != "flow-1" || resetCalls[0].PhaseID != "implementation" {
+		t.Fatalf("reset calls = %#v", resetCalls)
+	}
+	if got := m.TransientError(); !strings.Contains(got, "Reset Flow phase implementation to ready") {
+		t.Fatalf("status after reset = %q, want success", got)
+	}
+	if fetchCmd == nil {
+		t.Fatal("successful reset should refresh Flow rows")
+	}
+	m, _ = update(m, flowResultFromCommand(t, fetchCmd))
+	if listCalls == 0 {
+		t.Fatal("ListFlows should run during reset refresh")
+	}
+	if got := m.SelectedFlowPhaseID(); got != "implementation" {
+		t.Fatalf("selected phase after reset refresh = %q, want implementation", got)
+	}
+	if phase := m.Flows()[0].Phases[2]; phase.Status != flowstore.PhaseReady {
+		t.Fatalf("implementation after reset refresh = %#v, want ready", phase)
+	}
+}
+
+func TestModel_XKeyOnResettableFlowPhaseCancelDoesNotPersist(t *testing.T) {
+	resetCalled := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ResetFlowPhase: func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error) {
+			resetCalled = true
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithAwaitingImplementation()})
+	m = selectFlowPhaseByID(t, m, "implementation")
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if cmd != nil {
+		t.Fatalf("canceling reset confirmation returned command %T, want nil", cmd)
+	}
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("overlay after cancel = %d, want none", m.Overlay())
+	}
+	if resetCalled {
+		t.Fatal("reset should not be called after cancellation")
+	}
+}
+
+func TestModel_XKeyOnResettableFlowPhaseReportsResetFailure(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ResetFlowPhase: func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{}, errors.New("state root locked")
+		},
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			t.Fatal("ListFlows should not run after reset failure")
+			return nil, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithAwaitingImplementation()})
+	m = selectFlowPhaseByID(t, m, "implementation")
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("accepting reset confirmation should return reset command")
+	}
+	m, resetCmd := update(m, cmd())
+	if resetCmd == nil {
+		t.Fatal("confirmed reset should return persistence command")
+	}
+	m, fetchCmd := update(m, resetCmd())
+	if fetchCmd != nil {
+		t.Fatalf("reset failure returned refresh command %T, want nil", fetchCmd)
+	}
+	if got := m.TransientError(); !strings.Contains(got, "state root locked") {
+		t.Fatalf("status after reset failure = %q, want persistence error", got)
+	}
+}
+
+func TestModel_XKeyIgnoredWhenSelectedFlowPhaseIsNotAwaitingSession(t *testing.T) {
+	resetCalled := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ResetFlowPhase: func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error) {
+			resetCalled = true
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
+	m = selectFlowPhaseByID(t, m, "implementation")
+	if strings.Contains(m.View(), "reset ready") {
+		t.Fatalf("ready Flow phase should hide reset shortcut:\n%s", m.View())
+	}
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd != nil || m.Overlay() != ui.OverlayNone {
+		t.Fatalf("x on non-awaiting phase returned cmd=%T overlay=%d", cmd, m.Overlay())
+	}
+	if resetCalled {
+		t.Fatal("reset should not be called for non-awaiting phase")
+	}
+}
+
+func TestModel_ResetShortcutHiddenWhenMatchingFlowTerminalIsRunning(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
+	resetCalled := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return fakeTerm, nil
+		},
+		ResetFlowPhase: func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error) {
+			resetCalled = true
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
+	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
+	if cmd == nil {
+		t.Fatal("enter on ready phase should prepare embedded terminal launch")
+	}
+	m, _ = update(m, cmd())
+	m, _ = update(m, model.FlowResultMsg{RepoPath: "/dev/alpha", Flows: []flowstore.FlowRecord{flowWithAwaitingImplementation()}, ListRequest: m.ListRequest(ui.ModeFlows)})
+	m = selectFlowPhaseByID(t, m, "implementation")
+
+	if strings.Contains(m.View(), "reset ready") {
+		t.Fatalf("matching running Flow terminal should hide reset shortcut:\n%s", m.View())
+	}
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd != nil || m.Overlay() != ui.OverlayNone {
+		t.Fatalf("x with matching running Flow terminal returned cmd=%T overlay=%d", cmd, m.Overlay())
+	}
+	if resetCalled {
+		t.Fatal("reset should not be called while matching Flow terminal is running")
+	}
+}
+
+func TestModel_XKeyKeepsFlowTerminalFocusCloseBehavior(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
+	resetCalled := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return fakeTerm, nil
+		},
+		ResetFlowPhase: func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error) {
+			resetCalled = true
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
+	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
+	if cmd == nil {
+		t.Fatal("enter on ready phase should prepare embedded terminal launch")
+	}
+	m, _ = update(m, cmd())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd != nil {
+		t.Fatalf("terminal x close prompt returned command %T, want nil", cmd)
+	}
+	if m.Overlay() != ui.OverlayConfirm || m.ConfirmPrompt() != "Terminate embedded terminal?" {
+		t.Fatalf("terminal x prompt = %q overlay=%d", m.ConfirmPrompt(), m.Overlay())
+	}
+	if resetCalled {
+		t.Fatal("terminal-focused x should not call flow phase reset")
+	}
 }
 
 func TestModel_Key8SwitchesToFlowsAndFetches(t *testing.T) {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -165,6 +165,38 @@ func TestModel_SelectedAwaitingFlowPhaseAdvertisesResetShortcut(t *testing.T) {
 	}
 }
 
+func TestModel_SelectedSessionMismatchFlowPhaseHidesResetShortcut(t *testing.T) {
+	flow := flowWithAwaitingImplementation()
+	flow.Phases[2].LaunchIDs = []string{"launch-orphan"}
+	flow.Phases[2].Sessions = []flowstore.Session{
+		{Provider: "codex", SessionID: "session-stale", LaunchID: "launch-stale", Status: "ended"},
+	}
+	resetCalled := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ResetFlowPhase: func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error) {
+			resetCalled = true
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+	m = selectFlowPhaseByID(t, m, "implementation")
+
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "implementation:session-mismatch") {
+		t.Fatalf("mismatched selected Flow phase should render session-mismatch:\n%s", view)
+	}
+	if strings.Contains(view, "reset ready") {
+		t.Fatalf("session-mismatch Flow phase should hide reset shortcut:\n%s", view)
+	}
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd != nil || m.Overlay() != ui.OverlayNone {
+		t.Fatalf("x on session-mismatch phase returned cmd=%T overlay=%d", cmd, m.Overlay())
+	}
+	if resetCalled {
+		t.Fatal("reset should not be called for session-mismatch phase")
+	}
+}
+
 func TestModel_XKeyOnResettableFlowPhaseConfirmsAndResets(t *testing.T) {
 	awaiting := flowWithAwaitingImplementation()
 	reset := flowWithPhaseDetails()

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -342,6 +342,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModePlans {
 			return m.handleTogglePlanPhases()
 		}
+		if m.mode == ui.ModeFlows {
+			return m.handleResetSelectedFlowPhase()
+		}
 	case "tab":
 		if m.mode == ui.ModeFlows && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
 			m.flowFocus = flowFocusTerminal
@@ -1093,6 +1096,23 @@ func (m Model) handleLaunchSelectedFlowPhase() (tea.Model, tea.Cmd) {
 	return next, next.prepareFlowPhaseLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID)
 }
 
+func (m Model) handleResetSelectedFlowPhase() (tea.Model, tea.Cmd) {
+	record, phase, repoPath, ok := m.selectedFlowPhaseResetTarget()
+	if !ok {
+		return m, nil
+	}
+	m.modal = modal.OpenConfirm(fmt.Sprintf("Reset Flow phase %s to ready?", phase.PhaseID), func() tea.Cmd {
+		return func() tea.Msg {
+			return flowPhaseResetConfirmedMsg{
+				RepoPath: repoPath,
+				FlowID:   record.FlowID,
+				PhaseID:  phase.PhaseID,
+			}
+		}
+	})
+	return m, nil
+}
+
 type flowPhaseLaunchTarget struct {
 	record       flowstore.FlowRecord
 	phase        flowstore.FlowPhase
@@ -1115,6 +1135,81 @@ func (m Model) selectedFlowPhaseLaunchTarget() (flowPhaseLaunchTarget, bool, Mod
 		return flowPhaseLaunchTarget{}, false, m
 	}
 	return m.flowPhaseLaunchTarget(record, phase)
+}
+
+func (m Model) selectedFlowPhaseResetTarget() (flowstore.FlowRecord, flowstore.FlowPhase, string, bool) {
+	record, ok := m.selectedFlow()
+	if !ok {
+		return flowstore.FlowRecord{}, flowstore.FlowPhase{}, "", false
+	}
+	phase, ok := m.selectedFlowPhase()
+	if !ok {
+		return flowstore.FlowRecord{}, flowstore.FlowPhase{}, "", false
+	}
+	repoPath := record.RepoPath
+	if repoPath == "" {
+		repoPath, _ = m.currentRepoPath()
+	}
+	if repoPath == "" || !m.flowPhaseResettable(record, phase) {
+		return flowstore.FlowRecord{}, flowstore.FlowPhase{}, "", false
+	}
+	return record, phase, repoPath, true
+}
+
+func (m Model) flowPhaseResettable(record flowstore.FlowRecord, phase flowstore.FlowPhase) bool {
+	return phase.Status == flowstore.PhaseRunning &&
+		flowstore.PhaseAwaitingSession(phase) &&
+		flowstore.PhasePredecessorsSatisfied(record, phase.PhaseID) &&
+		!m.hasRunningFlowEmbeddedTerminalForPhase(record.FlowID, phase.PhaseID)
+}
+
+func (m Model) hasRunningFlowEmbeddedTerminalForPhase(flowID, phaseID string) bool {
+	for _, slot := range m.embeddedTerminals {
+		if slot.Scope == embeddedTerminalScopeFlow &&
+			slot.FlowID == flowID &&
+			slot.FlowPhaseID == phaseID &&
+			embeddedTerminalRunning(slot.Terminal) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m Model) handleFlowPhaseResetConfirmed(msg flowPhaseResetConfirmedMsg) (Model, tea.Cmd) {
+	if !m.isCurrentRepo(msg.RepoPath) {
+		return m, nil
+	}
+	if m.hasRunningFlowEmbeddedTerminalForPhase(msg.FlowID, msg.PhaseID) {
+		return m.setStatus(statusOther, "Flow phase has an active embedded terminal"), nil
+	}
+	record, phase, ok := m.flowPhaseByID(msg.FlowID, msg.PhaseID)
+	if !ok || !m.flowPhaseResettable(record, phase) {
+		return m.setStatus(statusOther, "Flow phase is not awaiting session recovery"), nil
+	}
+	return m, m.resetFlowPhaseCmd(msg.RepoPath, msg.FlowID, msg.PhaseID)
+}
+
+func (m Model) resetFlowPhaseCmd(repoPath, flowID, phaseID string) tea.Cmd {
+	return func() tea.Msg {
+		flow, err := m.resetFlowPhase(flowstore.PhaseResetUpdate{
+			FlowID:  flowID,
+			PhaseID: phaseID,
+		})
+		if err != nil {
+			return flowPhaseResetFailedMsg{
+				RepoPath: repoPath,
+				FlowID:   flowID,
+				PhaseID:  phaseID,
+				Err:      fmt.Sprintf("failed to reset Flow phase: %v", err),
+			}
+		}
+		return flowPhaseResetMsg{
+			RepoPath: repoPath,
+			FlowID:   flowID,
+			PhaseID:  phaseID,
+			Flow:     flow,
+		}
+	}
 }
 
 func (m Model) flowPhaseLaunchTarget(record flowstore.FlowRecord, phase flowstore.FlowPhase) (flowPhaseLaunchTarget, bool, Model) {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1164,10 +1164,14 @@ func (m Model) flowPhaseResettable(record flowstore.FlowRecord, phase flowstore.
 }
 
 func (m Model) hasRunningFlowEmbeddedTerminalForPhase(flowID, phaseID string) bool {
+	wantPhaseID := artifacts.NormalizePhaseID(phaseID)
+	if wantPhaseID == "" {
+		return false
+	}
 	for _, slot := range m.embeddedTerminals {
 		if slot.Scope == embeddedTerminalScopeFlow &&
 			slot.FlowID == flowID &&
-			slot.FlowPhaseID == phaseID &&
+			artifacts.NormalizePhaseID(slot.FlowPhaseID) == wantPhaseID &&
 			embeddedTerminalRunning(slot.Terminal) {
 			return true
 		}
@@ -1276,12 +1280,17 @@ func (m Model) prepareFlowPhaseLaunchCmd(record flowstore.FlowRecord, phase flow
 			}
 			planBody = body
 		}
-		if _, err := m.addFlowPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		updated, err := m.addFlowPhaseLaunchID(flowstore.PhaseLaunchUpdate{
 			FlowID:   record.FlowID,
 			PhaseID:  phase.PhaseID,
 			LaunchID: launchID,
-		}); err != nil {
+		})
+		if err != nil {
 			return ActionFailedMsg{RepoPath: repoPath, Err: fmt.Sprintf("failed to mark flow phase running: %v", err)}
+		}
+		launchPhase := phase
+		if persistedPhase, ok := flowPhaseByID(updated, phase.PhaseID); ok {
+			launchPhase = persistedPhase
 		}
 		return wrap(actions.AgentLaunchContext{
 			Command:          m.agentCommand,
@@ -1294,8 +1303,8 @@ func (m Model) prepareFlowPhaseLaunchCmd(record flowstore.FlowRecord, phase flow
 			PlanID:           record.PlanID,
 			PlanPath:         planPath,
 			FlowID:           record.FlowID,
-			FlowPhaseID:      phase.PhaseID,
-			InitialPrompt:    flowPhasePrompt(record, phase, planPath, planBody, m.flowPromptTemplates),
+			FlowPhaseID:      launchPhase.PhaseID,
+			InitialPrompt:    flowPhasePrompt(record, launchPhase, planPath, planBody, m.flowPromptTemplates),
 		})
 	}
 }
@@ -1639,7 +1648,7 @@ func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, pla
 }
 
 func flowPhasePromptNeedsPlanBody(phaseID string) bool {
-	switch phaseID {
+	switch artifacts.NormalizePhaseID(phaseID) {
 	case "plan-review", "implementation", "review-loop", "pr-creation", "autoreview", "merge":
 		return false
 	default:

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1159,6 +1159,7 @@ func (m Model) selectedFlowPhaseResetTarget() (flowstore.FlowRecord, flowstore.F
 func (m Model) flowPhaseResettable(record flowstore.FlowRecord, phase flowstore.FlowPhase) bool {
 	return phase.Status == flowstore.PhaseRunning &&
 		flowstore.PhaseAwaitingSession(phase) &&
+		!flowstore.PhaseSessionLaunchMismatch(phase) &&
 		flowstore.PhasePredecessorsSatisfied(record, phase.PhaseID) &&
 		!m.hasRunningFlowEmbeddedTerminalForPhase(record.FlowID, phase.PhaseID)
 }

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -334,6 +334,26 @@ type FlowDeleteFailedMsg struct {
 	NotFound bool
 }
 
+type flowPhaseResetConfirmedMsg struct {
+	RepoPath string
+	FlowID   string
+	PhaseID  string
+}
+
+type flowPhaseResetMsg struct {
+	RepoPath string
+	FlowID   string
+	PhaseID  string
+	Flow     flowstore.FlowRecord
+}
+
+type flowPhaseResetFailedMsg struct {
+	RepoPath string
+	FlowID   string
+	PhaseID  string
+	Err      string
+}
+
 type DeleteFailedMsg struct {
 	RepoPath    string
 	Target      string       // display name (branch name or worktree path)
@@ -1075,6 +1095,30 @@ func (m Model) handleFlowDeleted(msg FlowDeletedMsg) (tea.Model, tea.Cmd) {
 	}
 	m = m.clearDeletedFlowState(msg.FlowID)
 	return m.startFetchMode(ui.ModeFlows)
+}
+
+func (m Model) handleFlowPhaseReset(msg flowPhaseResetMsg) (tea.Model, tea.Cmd) {
+	if !m.isCurrentRepo(msg.RepoPath) {
+		return m, nil
+	}
+	phaseID := strings.TrimSpace(msg.PhaseID)
+	if phaseID == "" {
+		phaseID = "phase"
+	}
+	m = m.setStatus(statusOther, fmt.Sprintf("Reset Flow phase %s to ready", phaseID))
+	return m.startFetchMode(ui.ModeFlows)
+}
+
+func (m Model) handleFlowPhaseResetFailed(msg flowPhaseResetFailedMsg) (tea.Model, tea.Cmd) {
+	if !m.isCurrentRepo(msg.RepoPath) {
+		return m, nil
+	}
+	errText := strings.TrimSpace(msg.Err)
+	if errText == "" {
+		errText = "failed to reset Flow phase"
+	}
+	m = m.setStatus(statusOther, errText)
+	return m, nil
 }
 
 func (m Model) handleFlowDeleteFailed(msg FlowDeleteFailedMsg) (tea.Model, tea.Cmd) {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1170,22 +1170,17 @@ func (m Model) restoreExpandedFlowSelection(flowID, phaseID string) Model {
 	if !ok || record.FlowID != flowID {
 		return m.setExpandedFlowID("")
 	}
-	if phaseID != "" && !flowRecordHasPhase(record, phaseID) {
-		return m.setExpandedFlowID("")
+	if phaseID != "" {
+		phase, ok := flowRecordPhaseByID(record, phaseID)
+		if !ok {
+			return m.setExpandedFlowID("")
+		}
+		phaseID = phase.PhaseID
 	}
 	m.expandedFlowID = flowID
 	m.selectedFlowPhaseID = phaseID
 	m.flows = m.flows.SetItemHeight(flowItemHeight(flowID))
 	return m.reflowFlows()
-}
-
-func flowRecordHasPhase(record flowstore.FlowRecord, phaseID string) bool {
-	for _, phase := range flowstore.OrderedPhases(record.Phases) {
-		if phase.PhaseID == phaseID {
-			return true
-		}
-	}
-	return false
 }
 
 func (m Model) handleSessionTranscriptResult(msg SessionTranscriptResultMsg) (Model, tea.Cmd) {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/gitquery"
+	"github.com/brian-bell/wtui/internal/artifacts"
 	"github.com/brian-bell/wtui/planstore"
 	"github.com/brian-bell/wtui/scanner"
 	"github.com/brian-bell/wtui/sessions"
@@ -2298,13 +2299,14 @@ func newFlowTerminalActivitySet(activity []FlowTerminalActivity) flowTerminalAct
 			continue
 		}
 		set.flows[item.FlowID] = struct{}{}
-		if item.PhaseID == "" {
+		phaseID := artifacts.NormalizePhaseID(item.PhaseID)
+		if phaseID == "" {
 			continue
 		}
 		if set.phases[item.FlowID] == nil {
 			set.phases[item.FlowID] = make(map[string]struct{}, 1)
 		}
-		set.phases[item.FlowID][item.PhaseID] = struct{}{}
+		set.phases[item.FlowID][phaseID] = struct{}{}
 	}
 	return set
 }
@@ -2319,7 +2321,7 @@ func (s flowTerminalActivitySet) hasPhase(flowID, phaseID string) bool {
 	if !ok {
 		return false
 	}
-	_, ok = phases[phaseID]
+	_, ok = phases[artifacts.NormalizePhaseID(phaseID)]
 	return ok
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -2451,24 +2451,7 @@ func flowPhaseAwaitingSession(phase flowstore.FlowPhase) bool {
 }
 
 func flowPhaseSessionMismatch(phase flowstore.FlowPhase) bool {
-	if len(phase.Sessions) == 0 {
-		return false
-	}
-	launches := make(map[string]struct{}, len(phase.LaunchIDs))
-	for _, launchID := range phase.LaunchIDs {
-		if launchID != "" {
-			launches[launchID] = struct{}{}
-		}
-	}
-	for _, session := range phase.Sessions {
-		if session.LaunchID == "" {
-			return true
-		}
-		if _, ok := launches[session.LaunchID]; !ok {
-			return true
-		}
-	}
-	return false
+	return flowstore.PhaseSessionLaunchMismatch(phase)
 }
 
 func flowPhaseSessionSummary(phase flowstore.FlowPhase) string {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -181,93 +181,94 @@ const StashPrefixWidth = 15
 
 // RenderParams holds everything the renderer needs.
 type RenderParams struct {
-	Repos                      []scanner.Repo
-	Selected                   int
-	Width                      int
-	Height                     int
-	Mode                       Mode
-	Branches                   []gitquery.BranchRow
-	Stashes                    []gitquery.Stash
-	BranchSelected             int
-	StashSelected              int
-	Overlay                    OverlayState
-	OverlayDiff                string
-	OverlayScroll              int
-	ConfirmPrompt              string
-	ConfirmForce               bool
-	InputPrompt                string
-	InputPlaceholder           string
-	InputValue                 string
-	InputError                 string
-	InputMode                  InputMode
-	InputCursor                int
-	WorktreeInputPrompt        string
-	WorktreeInputPlaceholder   string
-	WorktreeInput              string
-	WorktreeInputErr           string
-	SelectPrompt               string
-	SelectItems                []SelectItem
-	SelectSelected             int
-	SelectWidth                int
-	SelectHeight               int
-	SelectPlacement            SelectPlacement
-	BranchScroll               int
-	RepoScroll                 int
-	StashScroll                int
-	ActivePane                 int
-	Destructive                bool
-	Worktrees                  []gitquery.Worktree
-	WorktreeSelected           int
-	WorktreeScroll             int
-	WorktreeSessions           []sessions.SessionRecord
-	WorktreeSessionSelected    int
-	WorktreeSessionScroll      int
-	InlineWorktreeSessions     bool
-	Commits                    []gitquery.Commit
-	CommitSelected             int
-	CommitScroll               int
-	Reflogs                    []gitquery.ReflogEntry
-	ReflogSelected             int
-	ReflogScroll               int
-	Sessions                   []sessions.SessionRecord
-	SessionSelected            int
-	SessionScroll              int
-	EmbeddedTerminals          []EmbeddedTerminalTab
-	EmbeddedTerminalLines      []string
-	EmbeddedTerminalPrefix     bool
-	Plans                      []planstore.PlanRecord
-	PlanSelected               int
-	PlanScroll                 int
-	Flows                      []flowstore.FlowRecord
-	FlowSelected               int
-	FlowScroll                 int
-	FlowEmbeddedTerminals      []EmbeddedTerminalTab
-	FlowEmbeddedTerminalLines  []string
-	FlowEmbeddedTerminalPrefix bool
-	FlowTerminalActivity       []FlowTerminalActivity
-	FlowTerminalFocused        bool
-	ExpandedPlanID             string
-	ExpandedFlowID             string
-	SelectedPlanPhaseID        string
-	SelectedFlowPhaseID        string
-	FlowHeadless               bool
-	FlowPhaseLaunchReady       bool
-	FlowPhaseResumableSelected bool
-	OverlayText                string
-	TransientError             string
-	TransientErrorFadeStep     int
-	SearchActive               bool
-	RepoSearch                 string
-	ItemSearch                 string
-	RepoEmptyMessage           string
-	RightEmptyMessage          string
-	FetchAvailable             bool
-	FetchVisibleAvailable      bool
-	PullAvailable              bool
-	WorktreeMoveAvailable      bool
-	WorktreeSessionsOpen       bool
-	AgentAvailable             bool
-	NewAgentAvailable          bool
+	Repos                       []scanner.Repo
+	Selected                    int
+	Width                       int
+	Height                      int
+	Mode                        Mode
+	Branches                    []gitquery.BranchRow
+	Stashes                     []gitquery.Stash
+	BranchSelected              int
+	StashSelected               int
+	Overlay                     OverlayState
+	OverlayDiff                 string
+	OverlayScroll               int
+	ConfirmPrompt               string
+	ConfirmForce                bool
+	InputPrompt                 string
+	InputPlaceholder            string
+	InputValue                  string
+	InputError                  string
+	InputMode                   InputMode
+	InputCursor                 int
+	WorktreeInputPrompt         string
+	WorktreeInputPlaceholder    string
+	WorktreeInput               string
+	WorktreeInputErr            string
+	SelectPrompt                string
+	SelectItems                 []SelectItem
+	SelectSelected              int
+	SelectWidth                 int
+	SelectHeight                int
+	SelectPlacement             SelectPlacement
+	BranchScroll                int
+	RepoScroll                  int
+	StashScroll                 int
+	ActivePane                  int
+	Destructive                 bool
+	Worktrees                   []gitquery.Worktree
+	WorktreeSelected            int
+	WorktreeScroll              int
+	WorktreeSessions            []sessions.SessionRecord
+	WorktreeSessionSelected     int
+	WorktreeSessionScroll       int
+	InlineWorktreeSessions      bool
+	Commits                     []gitquery.Commit
+	CommitSelected              int
+	CommitScroll                int
+	Reflogs                     []gitquery.ReflogEntry
+	ReflogSelected              int
+	ReflogScroll                int
+	Sessions                    []sessions.SessionRecord
+	SessionSelected             int
+	SessionScroll               int
+	EmbeddedTerminals           []EmbeddedTerminalTab
+	EmbeddedTerminalLines       []string
+	EmbeddedTerminalPrefix      bool
+	Plans                       []planstore.PlanRecord
+	PlanSelected                int
+	PlanScroll                  int
+	Flows                       []flowstore.FlowRecord
+	FlowSelected                int
+	FlowScroll                  int
+	FlowEmbeddedTerminals       []EmbeddedTerminalTab
+	FlowEmbeddedTerminalLines   []string
+	FlowEmbeddedTerminalPrefix  bool
+	FlowTerminalActivity        []FlowTerminalActivity
+	FlowTerminalFocused         bool
+	ExpandedPlanID              string
+	ExpandedFlowID              string
+	SelectedPlanPhaseID         string
+	SelectedFlowPhaseID         string
+	FlowHeadless                bool
+	FlowPhaseLaunchReady        bool
+	FlowPhaseResetReadySelected bool
+	FlowPhaseResumableSelected  bool
+	OverlayText                 string
+	TransientError              string
+	TransientErrorFadeStep      int
+	SearchActive                bool
+	RepoSearch                  string
+	ItemSearch                  string
+	RepoEmptyMessage            string
+	RightEmptyMessage           string
+	FetchAvailable              bool
+	FetchVisibleAvailable       bool
+	PullAvailable               bool
+	WorktreeMoveAvailable       bool
+	WorktreeSessionsOpen        bool
+	AgentAvailable              bool
+	NewAgentAvailable           bool
 }
 
 func FlowSplitPanelHeights(height int) (listHeight, terminalHeight int) {
@@ -426,51 +427,52 @@ func renderApplication(p RenderParams) string {
 	planPhaseSelected := selectedPlanPhaseID != ""
 	flowPhaseSelected := selectedFlowPhaseID != ""
 	status := statusBarParams{
-		Width:                      p.Width,
-		Mode:                       p.Mode,
-		Overlay:                    p.Overlay,
-		InputMode:                  inputRenderParamsFrom(p).mode,
-		WorktreeInputPrompt:        p.WorktreeInputPrompt,
-		ActivePane:                 p.ActivePane,
-		Destructive:                p.Destructive,
-		RepoSelected:               repoPath != "",
-		WorktreeSelected:           worktreeSelected,
-		StaleSelected:              staleSelected,
-		DirtySelected:              dirtySelected,
-		LockedSelected:             lockedSelected,
-		WorktreeDeletableSelected:  worktreeDeletableSelected,
-		WorktreeOpenableSelected:   worktreeOpenableSelected,
-		WorktreeMoveSelected:       worktreeMoveSelected,
-		WorktreeSessionsOpen:       p.WorktreeSessionsOpen,
-		WorktreeSessionSelected:    worktreeSessionSelected,
-		BranchDirtySelected:        branchDirtySelected,
-		BranchDeletableSelected:    branchDeletableSelected,
-		BranchOpenableSelected:     branchOpenableSelected,
-		StashSelected:              stashSelected,
-		CommitSelected:             commitSelected,
-		ReflogSelected:             reflogSelected,
-		SessionSelected:            sessionSelected,
-		EmbeddedTerminalActive:     terminalShortcutsActive,
-		EmbeddedTerminalPrefix:     p.EmbeddedTerminalPrefix || p.FlowEmbeddedTerminalPrefix,
-		PlanSelected:               planSelected,
-		PlanPhaseSelected:          planPhaseSelected,
-		FlowSelected:               flowSelected,
-		FlowPhaseSelected:          flowPhaseSelected,
-		FlowDeletableSelected:      flowDeletableSelected,
-		FlowPlanLinked:             flowPlanLinked,
-		FlowHeadless:               p.FlowHeadless,
-		FlowPhaseLaunchReady:       p.FlowPhaseLaunchReady,
-		FlowPhaseResumableSelected: p.FlowPhaseResumableSelected,
-		TransientError:             p.TransientError,
-		TransientErrorFadeStep:     p.TransientErrorFadeStep,
-		SearchActive:               p.SearchActive,
-		RepoSearch:                 p.RepoSearch,
-		ItemSearch:                 p.ItemSearch,
-		FetchAvailable:             p.FetchAvailable,
-		FetchVisibleAvailable:      p.FetchVisibleAvailable,
-		PullAvailable:              p.PullAvailable,
-		AgentAvailable:             p.AgentAvailable,
-		NewAgent:                   p.NewAgentAvailable,
+		Width:                       p.Width,
+		Mode:                        p.Mode,
+		Overlay:                     p.Overlay,
+		InputMode:                   inputRenderParamsFrom(p).mode,
+		WorktreeInputPrompt:         p.WorktreeInputPrompt,
+		ActivePane:                  p.ActivePane,
+		Destructive:                 p.Destructive,
+		RepoSelected:                repoPath != "",
+		WorktreeSelected:            worktreeSelected,
+		StaleSelected:               staleSelected,
+		DirtySelected:               dirtySelected,
+		LockedSelected:              lockedSelected,
+		WorktreeDeletableSelected:   worktreeDeletableSelected,
+		WorktreeOpenableSelected:    worktreeOpenableSelected,
+		WorktreeMoveSelected:        worktreeMoveSelected,
+		WorktreeSessionsOpen:        p.WorktreeSessionsOpen,
+		WorktreeSessionSelected:     worktreeSessionSelected,
+		BranchDirtySelected:         branchDirtySelected,
+		BranchDeletableSelected:     branchDeletableSelected,
+		BranchOpenableSelected:      branchOpenableSelected,
+		StashSelected:               stashSelected,
+		CommitSelected:              commitSelected,
+		ReflogSelected:              reflogSelected,
+		SessionSelected:             sessionSelected,
+		EmbeddedTerminalActive:      terminalShortcutsActive,
+		EmbeddedTerminalPrefix:      p.EmbeddedTerminalPrefix || p.FlowEmbeddedTerminalPrefix,
+		PlanSelected:                planSelected,
+		PlanPhaseSelected:           planPhaseSelected,
+		FlowSelected:                flowSelected,
+		FlowPhaseSelected:           flowPhaseSelected,
+		FlowDeletableSelected:       flowDeletableSelected,
+		FlowPlanLinked:              flowPlanLinked,
+		FlowHeadless:                p.FlowHeadless,
+		FlowPhaseLaunchReady:        p.FlowPhaseLaunchReady,
+		FlowPhaseResetReadySelected: p.FlowPhaseResetReadySelected,
+		FlowPhaseResumableSelected:  p.FlowPhaseResumableSelected,
+		TransientError:              p.TransientError,
+		TransientErrorFadeStep:      p.TransientErrorFadeStep,
+		SearchActive:                p.SearchActive,
+		RepoSearch:                  p.RepoSearch,
+		ItemSearch:                  p.ItemSearch,
+		FetchAvailable:              p.FetchAvailable,
+		FetchVisibleAvailable:       p.FetchVisibleAvailable,
+		PullAvailable:               p.PullAvailable,
+		AgentAvailable:              p.AgentAvailable,
+		NewAgent:                    p.NewAgentAvailable,
 	}
 	innerHeight := p.Height - 3 // status bar + top/bottom borders
 	activeStatusQuery := hasActiveStatusQuery(status)
@@ -681,51 +683,52 @@ func RenderStatusBar(width int, mode Mode, overlay OverlayState, activePane int,
 // statusBarParams groups the many fields the status-bar renderer needs,
 // avoiding a long and error-prone positional parameter list.
 type statusBarParams struct {
-	Width                      int
-	Mode                       Mode
-	Overlay                    OverlayState
-	InputMode                  InputMode
-	WorktreeInputPrompt        string
-	ActivePane                 int
-	Destructive                bool
-	RepoSelected               bool
-	WorktreeSelected           bool
-	StaleSelected              bool
-	DirtySelected              bool
-	LockedSelected             bool
-	WorktreeDeletableSelected  bool
-	WorktreeOpenableSelected   bool
-	WorktreeMoveSelected       bool
-	WorktreeSessionsOpen       bool
-	WorktreeSessionSelected    bool
-	BranchDirtySelected        bool
-	BranchDeletableSelected    bool
-	BranchOpenableSelected     bool
-	StashSelected              bool
-	CommitSelected             bool
-	ReflogSelected             bool
-	SessionSelected            bool
-	EmbeddedTerminalActive     bool
-	EmbeddedTerminalPrefix     bool
-	PlanSelected               bool
-	PlanPhaseSelected          bool
-	FlowSelected               bool
-	FlowPhaseSelected          bool
-	FlowDeletableSelected      bool
-	FlowPlanLinked             bool
-	FlowHeadless               bool
-	FlowPhaseLaunchReady       bool
-	FlowPhaseResumableSelected bool
-	TransientError             string
-	TransientErrorFadeStep     int
-	SearchActive               bool
-	RepoSearch                 string
-	ItemSearch                 string
-	FetchAvailable             bool
-	FetchVisibleAvailable      bool
-	PullAvailable              bool
-	AgentAvailable             bool
-	NewAgent                   bool
+	Width                       int
+	Mode                        Mode
+	Overlay                     OverlayState
+	InputMode                   InputMode
+	WorktreeInputPrompt         string
+	ActivePane                  int
+	Destructive                 bool
+	RepoSelected                bool
+	WorktreeSelected            bool
+	StaleSelected               bool
+	DirtySelected               bool
+	LockedSelected              bool
+	WorktreeDeletableSelected   bool
+	WorktreeOpenableSelected    bool
+	WorktreeMoveSelected        bool
+	WorktreeSessionsOpen        bool
+	WorktreeSessionSelected     bool
+	BranchDirtySelected         bool
+	BranchDeletableSelected     bool
+	BranchOpenableSelected      bool
+	StashSelected               bool
+	CommitSelected              bool
+	ReflogSelected              bool
+	SessionSelected             bool
+	EmbeddedTerminalActive      bool
+	EmbeddedTerminalPrefix      bool
+	PlanSelected                bool
+	PlanPhaseSelected           bool
+	FlowSelected                bool
+	FlowPhaseSelected           bool
+	FlowDeletableSelected       bool
+	FlowPlanLinked              bool
+	FlowHeadless                bool
+	FlowPhaseLaunchReady        bool
+	FlowPhaseResetReadySelected bool
+	FlowPhaseResumableSelected  bool
+	TransientError              string
+	TransientErrorFadeStep      int
+	SearchActive                bool
+	RepoSearch                  string
+	ItemSearch                  string
+	FetchAvailable              bool
+	FetchVisibleAvailable       bool
+	PullAvailable               bool
+	AgentAvailable              bool
+	NewAgent                    bool
 }
 
 type shortcutHint struct {
@@ -1140,6 +1143,9 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 					if sp.FlowPhaseLaunchReady {
 						actions = append(actions, shortcutHint{Key: "enter", Label: "launch phase"})
 					}
+					if sp.FlowPhaseResetReadySelected {
+						actions = append(actions, shortcutHint{Key: "x", Label: "reset ready"})
+					}
 					actions = append(actions, shortcutHint{Key: "y", Label: "copy phase id"})
 					if sp.FlowPhaseResumableSelected {
 						actions = append(actions, shortcutHint{Key: "r", Label: "resume"})
@@ -1343,7 +1349,7 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
 	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "d")
-	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "o", "y", "d", "r", "f", "F")
+	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "x", "o", "y", "d", "r", "f", "F")
 
 	for _, parts := range [][]string{
 		appendParts(base, upDown, arrow, actions),

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -350,7 +350,7 @@ func TestRender_FlowsModeMarksActiveTerminalExpandedPhaseRows(t *testing.T) {
 		},
 	}
 	view := strings.Join(renderFlowPane(flows, 0, 0, 220, 8, "flow-1", "implementation", []FlowTerminalActivity{
-		{FlowID: "flow-1", PhaseID: "implementation"},
+		{FlowID: "flow-1", PhaseID: "Implementation"},
 		{FlowID: "flow-2", PhaseID: "review-loop"},
 	}), "\n")
 

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -538,6 +538,42 @@ func TestRender_FlowsModeShowsCopyPhaseIDShortcutForSelectedPhase(t *testing.T) 
 	}
 }
 
+func TestRender_FlowsModeShowsResetShortcutForResettableSelectedPhase(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   12,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "Resettable flow",
+			Status: flowstore.StatusInProgress,
+			Phases: []flowstore.FlowPhase{{
+				PhaseID:   "implementation",
+				Title:     "Implementation",
+				Status:    flowstore.PhaseRunning,
+				LaunchIDs: []string{"launch-orphan"},
+			}},
+		}},
+		ActivePane:                  1,
+		FlowSelected:                0,
+		ExpandedFlowID:              "flow-1",
+		SelectedFlowPhaseID:         "implementation",
+		FlowPhaseResetReadySelected: true,
+		FlowPhaseResumableSelected:  false,
+		FlowPhaseLaunchReady:        false,
+	})
+
+	pane := shortcutPaneText(view)
+	if !strings.Contains(pane, "x      reset ready") {
+		t.Fatalf("resettable selected Flow phase should expose reset shortcut:\n%s", view)
+	}
+	if strings.Contains(pane, "x      phases") {
+		t.Fatalf("selected Flow phase should not expose top-level phases shortcut:\n%s", view)
+	}
+}
+
 func TestRender_FlowsModeShowsLaunchAndHeadlessShortcutForLaunchableSelectedPhase(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},


### PR DESCRIPTION
## Summary
- add a Flow store recovery path that removes orphaned latest launch attempts and re-derives ready state
- expose an `x` reset action for eligible `await-session` Flow phases with confirmation and refresh behavior
- preserve running-terminal safeguards and legacy phase normalization edge cases
- document the recovery path in README/config/Flow phase docs

## Verification
- `gofmt -l .`
- `make test`
- `make build`