### PR TITLE
Increase Plan Review review-loop cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,10 +410,11 @@ completed or explicitly skipped with notes. Flow phase launch prompts stay
 minimal: Plan Review and Implementation point to the saved plan artifact, while
 Review Loop and PR Creation include only the worktree, branch, and start commit
 metadata needed to inspect the changes. Built-in prompts tell Plan to produce
-only a plan, Implementation to use the `commit` skill, Review Loop to use the
-review-loop workflow and `commit` when revisions are made, PR Creation to use
-the `ship` skill, and Autoreview to use `ship` when fixes require commits or
-pushes without embedding phase-restart recipes. Use
+only a plan, Plan Review to use the review-loop skill with max 6 loops,
+Implementation to use the `commit` skill, Review Loop to use the review-loop
+workflow and `commit` when revisions are made, PR Creation to use the `ship`
+skill, and Autoreview to use `ship` when fixes require commits or pushes
+without embedding phase-restart recipes. Use
 `wtui flow phase restart` to rerun a blocked or needs-attention phase as
 `running`; if notes are omitted, wtui records a standard rerun note.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -407,9 +407,10 @@ skipped with notes. Flow phase launch prompts stay minimal: Plan Review and
 Implementation point to the saved plan artifact, while Review Loop and PR
 Creation include only the worktree, branch, and start commit metadata needed to
 inspect the changes. Built-in prompts tell Plan to produce only a plan,
-Implementation to use the `commit` skill, Review Loop to use the review-loop
-workflow and `commit` when revisions are made, PR Creation to use the `ship`
-skill, and Autoreview to use `ship` when fixes require commits or pushes.
+Plan Review to use the review-loop skill with max 6 loops, Implementation to
+use the `commit` skill, Review Loop to use the review-loop workflow and
+`commit` when revisions are made, PR Creation to use the `ship` skill, and
+Autoreview to use `ship` when fixes require commits or pushes.
 Autoreview launch prompts include the PR target metadata but leave completion,
 needs-attention, blocked, and restart mechanics to the high-level Flow phase
 commands.

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1953,7 +1953,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesReadyPlanReviewWithLinkedPlanCont
 		t.Fatalf("launch context = %#v", launched)
 	}
 	wantPrompt := strings.Join([]string{
-		"Use the review loop skill to review the saved plan.",
+		"Use the review-loop skill to review the saved plan, max 6 loops.",
 		"Use the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.",
 		"",
 		"Plan: /state/wtui/sessions/v1/plans/plan-1/plan.md",
@@ -1978,6 +1978,57 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesReadyPlanReviewWithLinkedPlanCont
 		if strings.Contains(prompt, unwanted) {
 			t.Fatalf("minimum reliable prompt should not include %q:\n%s", unwanted, launched.InitialPrompt)
 		}
+	}
+}
+
+func TestModel_FlowPlanReviewPromptTemplateOverridesBuiltInPrompt(t *testing.T) {
+	var launched actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		FlowPromptTemplates: model.FlowPromptTemplates{
+			PlanReview: "Custom {phase_id} for {flow_id}: {plan_path} on {branch}; keep {unknown}",
+		},
+		ReadPlan: func(planID string) (string, error) {
+			t.Fatalf("templated Plan Review launch should not pre-read %q", planID)
+			return "", nil
+		},
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			t.Fatalf("Flow phase CLI launch should start an embedded terminal, not LaunchAgent: %#v", ctx)
+			return actions.TerminalLaunchSpec{}, nil
+		},
+		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
+			launched = ctx
+			return &fakeEmbeddedTerminal{state: "running"}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-template",
+		Branch:       "flow/template",
+		Commit:       "c0ffee",
+		PlanID:       "plan-1",
+		PlanPath:     "/state/plans/plan-1/plan.md",
+		Status:       flowstore.StatusInProgress,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
+			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseReady},
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhasePending},
+		},
+	}})
+
+	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "plan-review")
+	if cmd == nil {
+		t.Fatal("enter on selected Flow phase should prepare a plan-review launch")
+	}
+	runPreparedFlowEmbeddedLaunch(t, m, cmd)
+
+	want := "Custom plan-review for flow-1: /state/plans/plan-1/plan.md on flow/template; keep {unknown}"
+	if launched.InitialPrompt != want {
+		t.Fatalf("templated plan-review prompt = %q, want %q", launched.InitialPrompt, want)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1553,7 +1553,7 @@ func flowPhasePromptNeedsPlanBody(phaseID string) bool {
 }
 
 func flowPlanReviewPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
-	return flowMinimalArtifactPrompt("Use the review loop skill to review the saved plan.\nUse the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.", planPath, record, phase)
+	return flowMinimalArtifactPrompt("Use the review-loop skill to review the saved plan, max 6 loops.\nUse the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.", planPath, record, phase)
 }
 
 func flowImplementationPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {


### PR DESCRIPTION
## Summary
- Update the built-in Flow Plan Review launch prompt to invoke the review-loop skill with max 6 loops.
- Keep Plan Review prompts minimal while preserving configured Plan Review prompt-template overrides.
- Align README and config docs with the new built-in Plan Review prompt behavior.

## Verification
- `gofmt -l .`
- `make test`
- `make build`