### PR TITLE
Add Flow auto mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ CI requires clean `gofmt -l .`, `make test`, and `make build`.
 
 `wtui` is a Go Bubble Tea TUI for managing git worktrees across repositories. User-facing behavior, key bindings, and CLI examples are documented in `README.md`; config reference is `docs/config.md`; Flow phase semantics are `docs/flow-phases.md`.
 
-- `cmd/wtui/` — entrypoint. Handles `--version`, `session-hook --provider claude|codex`, and the `plan save|list|read|phase set` and `flow create|list|read|phase complete|phase block|phase needs-attention|phase restart|phase set|phase add-child|plan set|pr set|merge set` subcommands (`plan.go`, `flow.go`). Subcommands resolve the artifact root without scanning repos or starting the TUI.
+- `cmd/wtui/` — entrypoint. Handles `--version`, `session-hook --provider claude|codex`, and the `plan save|list|read|phase set` and `flow create|list|read|phase complete|phase block|phase needs-attention|phase restart|phase set|phase add-child|plan set|pr set|merge set|auto set` subcommands (`plan.go`, `flow.go`). Subcommands resolve the artifact root without scanning repos or starting the TUI.
 - `config/` — optional TOML from `$XDG_CONFIG_HOME/wtui/config.toml` or `~/.config/wtui/config.toml`. Missing config is non-fatal; an existing but unreadable or malformed config is startup-fatal.
 - `scanner/` — discovers repos under `WORKTREE_ROOT`, `[scan].root`, or `~/dev` (default depth 2, reducible via `[scan].max_depth`), excluding `*-worktrees`.
 - `gitquery/` — read-only git queries. `parse.go` is pure parsing; `runner.go` defines the `Runner` seam wrapped by a `Querier` (`NewQuerier` injects a fake `Runner` for tests).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ filter matches, or a load failure with details in the status bar.
 | `n` | Create a new worktree in worktrees view, a new branch in branches view, or a new Flow in flows view |
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
-| `m` | Move or rename a linked worktree (worktrees view) |
+| `m` | Move or rename a linked worktree (worktrees view), or toggle auto mode for the selected Flow (flows view) |
 | `A` | Choose and persist the coding agent from a picker (`codex`, `codex-app`, or `claude`) |
 | `a` | Launch the selected coding agent in the selected worktree, or launch the selected plan or plan phase |
 | `d` | Delete worktree/branch, drop stash, or delete Flow data — requires destructive mode |
@@ -284,7 +284,8 @@ skill dirs for use across repos. v1 has no TUI plan deletion.
 
 Browse persisted Flow records for the selected repo. Rows show status, branch
 or worktree basename, phase progress plus the current phase state, linked plan
-ID when present, PR number or label, updated date, and title. Use `/` to filter
+ID when present, PR number or label, updated date, and title. Auto-mode Flows
+use a subtle non-selected row highlight. Use `/` to filter
 by title, instructions, status, branch, worktree basename, plan metadata, PR
 metadata, phase titles/statuses/summaries, and linked session metadata. Press
 `n` to create a new Flow. On a Flow row, `enter` expands or collapses phase
@@ -300,11 +301,19 @@ same Flow. Press `y` to copy the selected Flow ID, or the selected phase ID
 when a phase row is selected. Press `r` on an expanded phase row with an
 attached provider session to resume that session; CLI resumes are recorded as a
 fresh Flow phase launch attempt, while `codex-app` resumes navigate to the
-existing app thread without extra launch tracking. Flow headless mode is on by
-default: selected CLI `codex` and `claude` phase launches run in a runtime-only
-embedded terminal inside the flows pane. Press `h` to choose the CLI command
-mode: headless runs `codex exec` or `claude --print`, while headless off runs
-interactive `codex` or `claude` in the same embedded Flow terminal. The same
+existing app thread without extra launch tracking. Press `m` on a Flow row or
+expanded phase row to toggle per-Flow auto mode, which is off by default and
+persisted on that Flow record. When auto mode is on, a successful completed
+phase transition launches the next ready non-merge phase in that same Flow
+through the same path as pressing `enter`; skipped, blocked, needs-attention,
+failed-launch, or missing-PR-metadata states do not auto-launch. Automation
+stops before Merge: if Autoreview completes and Merge becomes ready, wtui keeps
+auto mode on and requires the existing manual Merge launch. Flow headless mode
+is on by default: selected CLI `codex` and `claude` phase launches run in a
+runtime-only embedded terminal inside the flows pane. Press `h` to choose the
+CLI command mode: headless runs `codex exec` or `claude --print`, while
+headless off runs interactive `codex` or `claude` in the same embedded Flow
+terminal. The same
 command mode applies to the initial Plan launch when creating a new Flow.
 `codex-app` always uses the external deep-link route. Embedded headless output
 is readable terminal text, not raw JSON events: `codex exec` streams progress
@@ -355,6 +364,9 @@ wtui flow create --title "Ship saved plans" \
 # List or read flows.
 wtui flow list --repo-path "$REPO" --json
 wtui flow read --flow-id "$FLOW_ID"
+
+# Enable or disable TUI auto mode for one flow.
+wtui flow auto set --flow-id "$FLOW_ID" --enabled true
 
 # Link a saved plan artifact back to a flow.
 wtui flow plan set --flow-id "$FLOW_ID" --plan-id "$PLAN_ID"

--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -22,7 +22,7 @@ func runFlow(args []string, deps runDeps) error {
 		return nil
 	}
 	if len(args) < 3 {
-		return fmt.Errorf("usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]")
+		return fmt.Errorf("usage: wtui flow <create|list|read|phase|plan|pr|merge|auto> [flags]")
 	}
 	switch args[2] {
 	case "create":
@@ -39,8 +39,10 @@ func runFlow(args []string, deps runDeps) error {
 		return runFlowPR(args[3:], deps)
 	case "merge":
 		return runFlowMerge(args[3:], deps)
+	case "auto":
+		return runFlowAuto(args[3:], deps)
 	default:
-		return unknownCommandError(args[2], []string{"create", "list", "read", "phase", "plan", "pr", "merge"}, flowHelpText)
+		return unknownCommandError(args[2], []string{"create", "list", "read", "phase", "plan", "pr", "merge", "auto"}, flowHelpText)
 	}
 }
 
@@ -48,7 +50,7 @@ func printFlowHelp(w io.Writer) {
 	io.WriteString(w, flowHelpText)
 }
 
-const flowHelpText = `Usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]
+const flowHelpText = `Usage: wtui flow <create|list|read|phase|plan|pr|merge|auto> [flags]
 
 Create and update task-centric Flow records under the wtui agent-artifact root.
 
@@ -66,6 +68,7 @@ Commands:
   plan set         Link a saved plan artifact to a Flow.
   pr set           Record pull request metadata.
   merge set        Record merge metadata.
+  auto set         Enable or disable TUI auto mode for a Flow.
 
 Examples:
   wtui flow create --title "Ship saved plans" --instructions "Build it" --repo-path "$REPO" --json
@@ -78,6 +81,7 @@ Examples:
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan-review --status completed --outcome approved
   wtui flow pr set --flow-id "$FLOW_ID" --provider github --number 155 --url "$PR_URL" --head "$BRANCH" --base main
   wtui flow merge set --flow-id "$FLOW_ID" --status merged --commit "$SHA" --merged-at "2026-06-09T12:00:00Z"
+  wtui flow auto set --flow-id "$FLOW_ID" --enabled true
 
 Most commands accept:
   --state-root PATH  Override the artifact state root after the leaf command.
@@ -857,6 +861,90 @@ Common flags:
 
 Example:
   wtui flow plan set --flow-id "$FLOW_ID" --plan-id "$PLAN_ID"
+`)
+}
+
+func runFlowAuto(args []string, deps runDeps) error {
+	if len(args) == 1 && isHelpArg(args[0]) {
+		printFlowAutoHelp(deps.stdout)
+		return nil
+	}
+	if len(args) < 1 {
+		return fmt.Errorf("usage: wtui flow auto set [flags]")
+	}
+	if args[0] != "set" {
+		return unknownCommandError(args[0], []string{"set"}, flowAutoHelpText)
+	}
+	return runFlowAutoSet(args[1:], deps)
+}
+
+func printFlowAutoHelp(w io.Writer) {
+	io.WriteString(w, flowAutoHelpText)
+}
+
+const flowAutoHelpText = `Usage: wtui flow auto set [flags]
+
+Enable or disable TUI auto mode for a Flow.
+
+Example:
+  wtui flow auto set --flow-id "$FLOW_ID" --enabled true
+`
+
+func runFlowAutoSet(args []string, deps runDeps) error {
+	flags := flag.NewFlagSet("flow auto set", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printFlowAutoSetHelp(deps.stdout) }
+	flowID := flags.String("flow-id", "", "flow id")
+	enabledValue := flags.String("enabled", "", "true or false")
+	stateRoot := flags.String("state-root", "", "artifact state root")
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
+		return err
+	}
+	if *flowID == "" {
+		return fmt.Errorf("flow auto set requires --flow-id")
+	}
+	var enabled bool
+	switch strings.ToLower(strings.TrimSpace(*enabledValue)) {
+	case "":
+		return fmt.Errorf("flow auto set requires --enabled true|false")
+	case "true":
+		enabled = true
+	case "false":
+		enabled = false
+	default:
+		return fmt.Errorf("invalid --enabled %q: use true or false", *enabledValue)
+	}
+	store, err := newFlowStore(*stateRoot, deps)
+	if err != nil {
+		return err
+	}
+	record, err := store.SetAutoMode(flowstore.AutoModeUpdate{
+		FlowID:  *flowID,
+		Enabled: enabled,
+	})
+	if err != nil {
+		return err
+	}
+	return writeFlowJSON(deps.stdout, record)
+}
+
+func printFlowAutoSetHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow auto set [flags]
+
+Enable or disable TUI auto mode for a Flow.
+
+Required flags:
+  --flow-id FLOW_ID
+  --enabled true|false
+
+Common flags:
+  --state-root PATH
+
+Example:
+  wtui flow auto set --flow-id "$FLOW_ID" --enabled true
 `)
 }
 

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -27,15 +27,35 @@ func TestRunFlowHelpPrintsUsageAndExamples(t *testing.T) {
 		t.Fatalf("run returned error: %v", err)
 	}
 	requireContainsAll(t, stdout.String(), []string{
-		"Usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]",
+		"Usage: wtui flow <create|list|read|phase|plan|pr|merge|auto> [flags]",
 		"wtui flow read --flow-id",
 		"wtui flow phase complete --flow-id",
 		"wtui flow phase block --flow-id",
 		"wtui flow phase needs-attention --flow-id",
 		"wtui flow phase restart --flow-id",
 		"wtui flow phase set --flow-id",
+		"wtui flow auto set --flow-id",
 		"wtui flow pr set --flow-id",
 		"wtui flow merge set --flow-id",
+	})
+}
+
+func TestRunFlowAutoHelpPrintsUsageAndExamplesWithoutLoadingConfig(t *testing.T) {
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "flow", "auto", "--help"}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			t.Fatal("loadConfig should not run for flow auto help")
+			return config.Config{}, nil
+		},
+		stdout: &stdout,
+	}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	requireContainsAll(t, stdout.String(), []string{
+		"Usage: wtui flow auto set [flags]",
+		"wtui flow auto set --flow-id",
+		"--enabled true",
 	})
 }
 
@@ -263,7 +283,7 @@ func TestRunFlowUnknownSubcommandSuggestsNearbyCommand(t *testing.T) {
 	}
 	requireContainsAll(t, err.Error(), []string{
 		`unknown command "phaze"; did you mean "phase"?`,
-		"Usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]",
+		"Usage: wtui flow <create|list|read|phase|plan|pr|merge|auto> [flags]",
 	})
 }
 
@@ -517,6 +537,94 @@ func TestRunFlowPlanSetValidatesInputsAndKeepsRecordUnchanged(t *testing.T) {
 	}
 	if read.PlanID != "" || read.PlanPath != "" {
 		t.Fatalf("rejected plan link should not mutate record: %#v", read)
+	}
+}
+
+func TestRunFlowAutoSetPrintsJSONRecord(t *testing.T) {
+	root := t.TempDir()
+	created := mustRunFlow(t, []string{
+		"wtui", "flow", "create",
+		"--title", "Auto mode",
+		"--instructions", "toggle automatic launch",
+		"--repo-path", filepath.Join(root, "repo"),
+		"--json",
+		"--state-root", root,
+	})
+
+	var stdout bytes.Buffer
+	err := run([]string{
+		"wtui", "flow", "auto", "set",
+		"--flow-id", created.FlowID,
+		"--enabled", "true",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: &stdout}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	var enabled flowstore.FlowRecord
+	if err := json.Unmarshal(stdout.Bytes(), &enabled); err != nil {
+		t.Fatalf("output is not JSON record: %v\n%s", err, stdout.String())
+	}
+	if !enabled.AutoMode {
+		t.Fatalf("AutoMode = false, want true")
+	}
+
+	stdout.Reset()
+	err = run([]string{
+		"wtui", "flow", "auto", "set",
+		"--flow-id", created.FlowID,
+		"--enabled", "false",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: &stdout}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	var disabled flowstore.FlowRecord
+	if err := json.Unmarshal(stdout.Bytes(), &disabled); err != nil {
+		t.Fatalf("output is not JSON record: %v\n%s", err, stdout.String())
+	}
+	if disabled.AutoMode {
+		t.Fatalf("AutoMode = true, want false")
+	}
+}
+
+func TestRunFlowAutoSetValidatesInputs(t *testing.T) {
+	root := t.TempDir()
+	created := mustRunFlow(t, []string{
+		"wtui", "flow", "create",
+		"--title", "Auto validation",
+		"--instructions", "validate toggle",
+		"--repo-path", filepath.Join(root, "repo"),
+		"--json",
+		"--state-root", root,
+	})
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing flow id",
+			args: []string{"wtui", "flow", "auto", "set", "--enabled", "true", "--state-root", root},
+			want: "requires --flow-id",
+		},
+		{
+			name: "missing enabled",
+			args: []string{"wtui", "flow", "auto", "set", "--flow-id", created.FlowID, "--state-root", root},
+			want: "requires --enabled true|false",
+		},
+		{
+			name: "invalid enabled",
+			args: []string{"wtui", "flow", "auto", "set", "--flow-id", created.FlowID, "--enabled", "maybe", "--state-root", root},
+			want: "invalid --enabled",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := run(tc.args, noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("run error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -94,6 +94,15 @@ standard graph; hand-authored records without one keep their stored statuses
 until a phase-affecting mutation touches them. Agents never need to know which
 phase becomes ready next; they only report their own phase.
 
+Flow auto mode is layered on top of this derived readiness. It is a persisted
+per-Flow TUI setting, not a status and not a transition-table rule. When enabled,
+the TUI watches accepted Flow refreshes for a phase that newly became
+`completed`, then launches the first currently `ready` non-Merge phase in that
+same Flow through the normal launch path. It does not launch on
+`skipped`, `blocked`, `needs_attention`, failed launches, or missing PR metadata,
+and it deliberately stops before Merge even when Autoreview completion makes
+Merge `ready`.
+
 Walking phases in order, a `pending` phase becomes `ready` once every
 predecessor satisfies its downstream gate:
 
@@ -145,6 +154,8 @@ even if the linked-plan sync later fails.
 - The persisted schema is unchanged: `schema_version` stays `1` and no status
   strings were added, removed, or renamed. Existing Flow JSON needs no
   migration.
+- `auto_mode` is additive and omitted when false. Existing Flow JSON without the
+  field reads as auto mode off.
 - Derived state is self-healing: phase-affecting mutations (`SetPhase`,
   `AddChildPhase`, `SetPR`, `AddPhaseLaunchID`,
   `ResetAwaitingSessionPhase`) re-derive readiness for any graph, and records
@@ -163,7 +174,8 @@ states (`recover-worktree`, `await-session`, `session-mismatch`,
 `missing-session-id`, `missing-pr`) are layered on top, rendered prefixed
 with the phase ID like any phase state (for example `autoreview:missing-pr`),
 and are display-only; they never change persisted phase status. See
-`docs/config.md` for the pane behavior.
+`docs/config.md` for the pane behavior. Flows with auto mode enabled receive a
+subtle non-selected row highlight, while selected-row styling remains dominant.
 
 When `await-session` is caused by an orphaned latest launch and predecessor
 gates still hold, the selected phase row can be reset with `x` after

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -23,7 +23,10 @@ const schemaVersion = 1
 
 const defaultLockTimeout = 5 * time.Second
 
-var errFlowNotFound = errors.New("flow not found")
+var (
+	errFlowNotFound       = errors.New("flow not found")
+	errAutoLaunchOutdated = errors.New("auto launch outdated")
+)
 
 const (
 	StatusPending        = "pending"
@@ -75,6 +78,12 @@ type StoreOptions struct {
 // IsNotFound reports whether err means the requested Flow record does not exist.
 func IsNotFound(err error) bool {
 	return errors.Is(err, errFlowNotFound)
+}
+
+// IsAutoLaunchOutdated reports whether err means an automatic launch request
+// lost its race with newer Flow state and should be ignored.
+func IsAutoLaunchOutdated(err error) bool {
+	return errors.Is(err, errAutoLaunchOutdated)
 }
 
 // FlowPhase is one phase in the persisted Flow pipeline.
@@ -225,10 +234,11 @@ type StartMetadataUpdate struct {
 // status (completed, skipped) records the launch without reopening the phase,
 // while non-resume launches always mark the phase running.
 type PhaseLaunchUpdate struct {
-	FlowID   string
-	PhaseID  string
-	LaunchID string
-	Resume   bool
+	FlowID     string
+	PhaseID    string
+	LaunchID   string
+	Resume     bool
+	AutoLaunch bool
 }
 
 // PhaseResetUpdate identifies one UI-owned phase recovery mutation.
@@ -743,6 +753,11 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 			return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
 		}
 		phase := record.Phases[phaseIndex]
+		if update.AutoLaunch {
+			if err := validateAutoPhaseLaunch(record, phase); err != nil {
+				return FlowRecord{}, err
+			}
+		}
 		if update.Resume && PhaseStatusTerminal(phase.Status) {
 			// Resuming a finished phase's session is read-back, not new work:
 			// record the launch so the session can re-link, but leave the
@@ -784,6 +799,20 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 		record.Status = DeriveStatus(record)
 		return record, nil
 	})
+}
+
+func validateAutoPhaseLaunch(record FlowRecord, phase FlowPhase) error {
+	phaseID := artifacts.NormalizePhaseID(phase.PhaseID)
+	switch {
+	case !record.AutoMode:
+		return fmt.Errorf("auto launch for flow %q is disabled: %w", record.FlowID, errAutoLaunchOutdated)
+	case phaseID == "" || phaseID == "merge":
+		return fmt.Errorf("auto launch target %q is not eligible: %w", phase.PhaseID, errAutoLaunchOutdated)
+	case phase.Status != PhaseReady:
+		return fmt.Errorf("auto launch target %q is %s, not ready: %w", phase.PhaseID, phase.Status, errAutoLaunchOutdated)
+	default:
+		return nil
+	}
 }
 
 // ResetAwaitingSessionPhase removes an orphaned latest launch attempt from a

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -141,6 +141,13 @@ type Merge struct {
 	MergedAt *time.Time `json:"merged_at,omitempty"`
 }
 
+// AutoModeUpdate changes whether the TUI may automatically launch ready phases
+// for a single Flow after successful phase completion.
+type AutoModeUpdate struct {
+	FlowID  string
+	Enabled bool
+}
+
 // FlowRecord is the persisted task workflow record.
 type FlowRecord struct {
 	SchemaVersion int         `json:"schema_version"`
@@ -157,6 +164,7 @@ type FlowRecord struct {
 	PlanPath      string      `json:"plan_path,omitempty"`
 	PR            PullRequest `json:"pr,omitempty"`
 	Merge         Merge       `json:"merge,omitempty"`
+	AutoMode      bool        `json:"auto_mode,omitempty"`
 	Phases        []FlowPhase `json:"phases"`
 	CreatedAt     time.Time   `json:"created_at"`
 	UpdatedAt     time.Time   `json:"updated_at"`
@@ -654,6 +662,21 @@ func (s *Store) SetMerge(update MergeUpdate) (FlowRecord, error) {
 			return record, nil
 		}
 		record.Merge = merge
+		record.UpdatedAt = now
+		return record, nil
+	})
+}
+
+// SetAutoMode enables or disables TUI-owned automatic phase launching for one Flow.
+func (s *Store) SetAutoMode(update AutoModeUpdate) (FlowRecord, error) {
+	if err := validateFlowID(update.FlowID); err != nil {
+		return FlowRecord{}, err
+	}
+	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+		if record.AutoMode == update.Enabled {
+			return record, nil
+		}
+		record.AutoMode = update.Enabled
 		record.UpdatedAt = now
 		return record, nil
 	})

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -959,6 +959,70 @@ func TestStoreAddPhaseLaunchIDMarksPhaseRunning(t *testing.T) {
 	}
 }
 
+func TestStoreAddPhaseLaunchIDAutoLaunchRequiresEnabledReadyPhase(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Auto launch guard",
+		Instructions: "only launch when still eligible",
+		RepoPath:     repoPath,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review")
+
+	_, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:     record.FlowID,
+		PhaseID:    "implementation",
+		LaunchID:   "auto-disabled",
+		AutoLaunch: true,
+	})
+	if !flowstore.IsAutoLaunchOutdated(err) {
+		t.Fatalf("AddPhaseLaunchID(auto disabled) error = %v, want auto launch outdated", err)
+	}
+
+	record, err = store.SetAutoMode(flowstore.AutoModeUpdate{FlowID: record.FlowID, Enabled: true})
+	if err != nil {
+		t.Fatalf("SetAutoMode(true) error = %v", err)
+	}
+	record, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:     record.FlowID,
+		PhaseID:    "implementation",
+		LaunchID:   "auto-1",
+		AutoLaunch: true,
+	})
+	if err != nil {
+		t.Fatalf("AddPhaseLaunchID(auto ready) error = %v", err)
+	}
+	phase := phaseByID(t, record, "implementation")
+	if phase.Status != flowstore.PhaseRunning || len(phase.LaunchIDs) != 1 || phase.LaunchIDs[0] != "auto-1" {
+		t.Fatalf("implementation after auto launch = %#v, want running with auto-1", phase)
+	}
+
+	_, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:     record.FlowID,
+		PhaseID:    "implementation",
+		LaunchID:   "auto-stale",
+		AutoLaunch: true,
+	})
+	if !flowstore.IsAutoLaunchOutdated(err) {
+		t.Fatalf("AddPhaseLaunchID(auto running) error = %v, want auto launch outdated", err)
+	}
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	phase = phaseByID(t, read, "implementation")
+	if len(phase.LaunchIDs) != 1 || phase.LaunchIDs[0] != "auto-1" {
+		t.Fatalf("stale auto launch mutated launch ids = %#v", phase.LaunchIDs)
+	}
+}
+
 func TestStoreResetAwaitingSessionPhaseReturnsRunningOrphanToReady(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -107,6 +107,127 @@ func TestStoreCreatePersistsDefaultFlowRecord(t *testing.T) {
 	}
 }
 
+func TestStoreAutoModeDefaultsOffAndMissingFieldReadsAndLists(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Add auto mode",
+		Instructions: "toggle the flow",
+		RepoPath:     repoPath,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if record.AutoMode {
+		t.Fatalf("created AutoMode = true, want false")
+	}
+
+	meta := filepath.Join(root, "flows", record.FlowID, "meta.json")
+	metaJSON, err := os.ReadFile(meta)
+	if err != nil {
+		t.Fatalf("ReadFile(meta.json) error = %v", err)
+	}
+	if strings.Contains(string(metaJSON), "auto_mode") {
+		t.Fatalf("default-off flow should omit auto_mode for old-record compatibility:\n%s", metaJSON)
+	}
+
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.AutoMode {
+		t.Fatalf("read AutoMode = true, want false")
+	}
+	listed, err := store.List(flowstore.FlowFilter{RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(listed) != 1 || listed[0].AutoMode {
+		t.Fatalf("List() = %#v, want one default-off flow", listed)
+	}
+}
+
+func TestStoreSetAutoModePersistsTrueThenFalse(t *testing.T) {
+	root := t.TempDir()
+	times := []time.Time{
+		time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 6, 7, 12, 1, 0, 0, time.UTC),
+		time.Date(2026, 6, 7, 12, 2, 0, 0, time.UTC),
+		time.Date(2026, 6, 7, 12, 3, 0, 0, time.UTC),
+		time.Date(2026, 6, 7, 12, 4, 0, 0, time.UTC),
+	}
+	i := 0
+	store, err := flowstore.NewStore(flowstore.StoreOptions{
+		Root: root,
+		Now: func() time.Time {
+			tm := times[i]
+			i++
+			return tm
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Add auto mode",
+		Instructions: "toggle the flow",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	enabled, err := store.SetAutoMode(flowstore.AutoModeUpdate{FlowID: record.FlowID, Enabled: true})
+	if err != nil {
+		t.Fatalf("SetAutoMode(true) error = %v", err)
+	}
+	if !enabled.AutoMode || !enabled.UpdatedAt.After(record.UpdatedAt) || enabled.Status != record.Status {
+		t.Fatalf("enabled flow = %#v, want auto on, later updated_at, status unchanged from %#v", enabled, record)
+	}
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read(enabled) error = %v", err)
+	}
+	if !read.AutoMode {
+		t.Fatalf("read AutoMode = false, want true")
+	}
+	meta := filepath.Join(root, "flows", record.FlowID, "meta.json")
+	metaJSON, err := os.ReadFile(meta)
+	if err != nil {
+		t.Fatalf("ReadFile(enabled meta.json) error = %v", err)
+	}
+	if !strings.Contains(string(metaJSON), `"auto_mode": true`) {
+		t.Fatalf("enabled flow should persist auto_mode true:\n%s", metaJSON)
+	}
+
+	disabled, err := store.SetAutoMode(flowstore.AutoModeUpdate{FlowID: record.FlowID, Enabled: false})
+	if err != nil {
+		t.Fatalf("SetAutoMode(false) error = %v", err)
+	}
+	if disabled.AutoMode || !disabled.UpdatedAt.After(enabled.UpdatedAt) || disabled.Status != record.Status {
+		t.Fatalf("disabled flow = %#v, want auto off, later updated_at, status unchanged from %#v", disabled, enabled)
+	}
+	read, err = store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read(disabled) error = %v", err)
+	}
+	if read.AutoMode {
+		t.Fatalf("read AutoMode = true, want false")
+	}
+	metaJSON, err = os.ReadFile(meta)
+	if err != nil {
+		t.Fatalf("ReadFile(disabled meta.json) error = %v", err)
+	}
+	if strings.Contains(string(metaJSON), "auto_mode") {
+		t.Fatalf("disabled flow should omit auto_mode:\n%s", metaJSON)
+	}
+}
+
 func assertMode(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
 	info, err := os.Stat(path)

--- a/model/model.go
+++ b/model/model.go
@@ -84,6 +84,7 @@ type Model struct {
 	listFlows                 func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error)
 	startFlowPlan             func(FlowStartRequest) (FlowStartResult, error)
 	setFlowPhase              func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
+	setFlowAutoMode           func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
 	addFlowPhaseLaunchID      func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
 	resetFlowPhase            func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error)
 	deleteFlow                func(string) error
@@ -155,6 +156,7 @@ type Options struct {
 	ListFlows             func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error)
 	StartFlowPlan         func(FlowStartRequest) (FlowStartResult, error)
 	SetFlowPhase          func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
+	SetFlowAutoMode       func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
 	AddFlowPhaseLaunchID  func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
 	ResetFlowPhase        func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error)
 	DeleteFlow            func(flowID string) error
@@ -213,6 +215,17 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 				return flowstore.FlowRecord{}, err
 			}
 			return store.SetPhase(update)
+		}
+	}
+	setFlowAutoMode := opts.SetFlowAutoMode
+	if setFlowAutoMode == nil {
+		root := opts.SessionStateRoot
+		setFlowAutoMode = func(update flowstore.AutoModeUpdate) (flowstore.FlowRecord, error) {
+			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			if err != nil {
+				return flowstore.FlowRecord{}, err
+			}
+			return store.SetAutoMode(update)
 		}
 	}
 	addFlowPhaseLaunchID := opts.AddFlowPhaseLaunchID
@@ -351,6 +364,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		listFlows:             listFlows,
 		startFlowPlan:         startFlowPlan,
 		setFlowPhase:          setFlowPhase,
+		setFlowAutoMode:       setFlowAutoMode,
 		addFlowPhaseLaunchID:  addFlowPhaseLaunchID,
 		resetFlowPhase:        resetFlowPhase,
 		deleteFlow:            deleteFlow,
@@ -385,6 +399,23 @@ func startupMode(mode ui.Mode) ui.Mode {
 		return mode
 	}
 	return ui.ModeWorktrees
+}
+
+func batchNonNil(cmds ...tea.Cmd) tea.Cmd {
+	filtered := make([]tea.Cmd, 0, len(cmds))
+	for _, cmd := range cmds {
+		if cmd != nil {
+			filtered = append(filtered, cmd)
+		}
+	}
+	switch len(filtered) {
+	case 0:
+		return nil
+	case 1:
+		return filtered[0]
+	default:
+		return tea.Batch(filtered...)
+	}
 }
 
 func newLaunchID() string {
@@ -485,6 +516,10 @@ func (m Model) View() string {
 	sessions, sessionSelected, sessionScroll := m.sessions.View()
 	plans, planSelected, planScroll := m.plans.View()
 	flows, flowSelected, flowScroll := m.flows.View()
+	flowAutoModeSelected := false
+	if flowSelected >= 0 && flowSelected < len(flows) {
+		flowAutoModeSelected = flows[flowSelected].AutoMode
+	}
 	repoEmptyMessage := m.repoEmptyMessage(len(repos))
 	rightEmptyMessage := m.rightEmptyMessage(len(repos), len(worktrees), len(rows), len(stashes), len(commits), len(reflogs), len(sessions), len(plans), len(flows))
 	if len(repos) == 0 {
@@ -569,6 +604,7 @@ func (m Model) View() string {
 		SelectedPlanPhaseID:         m.selectedPlanPhaseID,
 		SelectedFlowPhaseID:         m.selectedFlowPhaseID,
 		FlowHeadless:                m.flowHeadless,
+		FlowAutoModeSelected:        flowAutoModeSelected,
 		FlowPhaseLaunchReady:        m.selectedFlowPhaseLaunchReady(),
 		FlowPhaseResetReadySelected: m.selectedFlowPhaseResettable(),
 		FlowPhaseResumableSelected:  m.selectedFlowPhaseResumable(),
@@ -894,8 +930,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case PlanResultMsg:
 		return m.handlePlanResult(msg), nil
 	case FlowResultMsg:
-		next := m.handleFlowResult(msg)
-		return next.finishFlowRefreshFetch(ui.ModeFlows, msg.ListRequest)
+		next, autoLaunchCmd := m.handleFlowResult(msg)
+		next, refreshCmd := next.finishFlowRefreshFetch(ui.ModeFlows, msg.ListRequest)
+		return next, batchNonNil(refreshCmd, autoLaunchCmd)
+	case FlowAutoModeSetMsg:
+		return m.handleFlowAutoModeSet(msg), nil
+	case FlowAutoModeSetFailedMsg:
+		return m.handleFlowAutoModeSetFailed(msg), nil
 	case flowPhaseResetConfirmedMsg:
 		return m.handleFlowPhaseResetConfirmed(msg)
 	case flowPhaseResetMsg:

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -123,6 +124,9 @@ func autoLaunchCommandFromFlowRefresh(t *testing.T, previous, current flowstore.
 		AgentCommand: "codex",
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
 			updates = append(updates, update)
+			if !update.AutoLaunch {
+				t.Fatalf("auto launch update = %#v, want AutoLaunch true", update)
+			}
 			launched := current
 			for i := range launched.Phases {
 				if launched.Phases[i].PhaseID == update.PhaseID {
@@ -908,6 +912,142 @@ func TestModel_FlowAutoModeLaunchesAutoreviewAfterPRCreationCompletesWithPRMetad
 	}
 	if launchMsg.LaunchContext.FlowPhaseID != "autoreview" {
 		t.Fatalf("launched phase = %q, want autoreview", launchMsg.LaunchContext.FlowPhaseID)
+	}
+}
+
+func TestModel_FlowAutoModeLaunchesEveryEligibleFlowFromOneRefresh(t *testing.T) {
+	previousOne := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	currentOne := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	previousTwo := previousOne
+	previousTwo.FlowID = "flow-2"
+	previousTwo.Branch = "flow/auto-two"
+	previousTwo.WorktreePath = "/dev/alpha-worktrees/flow-auto-two"
+	currentTwo := currentOne
+	currentTwo.FlowID = "flow-2"
+	currentTwo.Branch = "flow/auto-two"
+	currentTwo.WorktreePath = "/dev/alpha-worktrees/flow-auto-two"
+
+	currentByFlowID := map[string]flowstore.FlowRecord{
+		currentOne.FlowID: currentOne,
+		currentTwo.FlowID: currentTwo,
+	}
+	var updates []flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			if !update.AutoLaunch {
+				t.Fatalf("auto launch update = %#v, want AutoLaunch true", update)
+			}
+			launched := currentByFlowID[update.FlowID]
+			for i := range launched.Phases {
+				if launched.Phases[i].PhaseID == update.PhaseID {
+					launched.Phases[i].Status = flowstore.PhaseRunning
+					launched.Phases[i].LaunchIDs = append(launched.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return launched, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previousOne, previousTwo})
+
+	_, cmd := update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{currentOne, currentTwo},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd == nil {
+		t.Fatal("two eligible auto-mode flows should return a batched launch command")
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok || len(batch) != 2 {
+		t.Fatalf("auto launch command returned %T len=%d, want BatchMsg with two commands", msg, len(batch))
+	}
+	var launchedFlowIDs []string
+	for _, subcmd := range batch {
+		raw := subcmd()
+		launch, ok := raw.(model.FlowEmbeddedLaunchRequestedMsg)
+		if !ok {
+			t.Fatalf("batched auto launch returned %T, want FlowEmbeddedLaunchRequestedMsg", raw)
+		}
+		launchedFlowIDs = append(launchedFlowIDs, launch.LaunchContext.FlowID)
+		if launch.LaunchContext.FlowPhaseID != "implementation" {
+			t.Fatalf("launched phase = %q, want implementation", launch.LaunchContext.FlowPhaseID)
+		}
+	}
+	if len(updates) != 2 {
+		t.Fatalf("launch updates = %#v, want two updates", updates)
+	}
+	for _, flowID := range []string{"flow-1", "flow-2"} {
+		if !slices.Contains(launchedFlowIDs, flowID) {
+			t.Fatalf("launched flow ids = %#v, missing %s", launchedFlowIDs, flowID)
+		}
+	}
+}
+
+func TestModel_FlowAutoModeStaleCommandNoopsAfterAutoModeDisabled(t *testing.T) {
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	current.Title = "Stale auto command"
+	current.Instructions = "do not launch after auto mode off"
+	current.RepoPath = "/dev/alpha"
+	current.AutoMode = true
+	current, err = store.Create(current)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	previous := current
+	previous.Phases = append([]flowstore.FlowPhase(nil), current.Phases...)
+	for i := range previous.Phases {
+		switch previous.Phases[i].PhaseID {
+		case "plan-review":
+			previous.Phases[i].Status = flowstore.PhaseRunning
+		case "implementation":
+			previous.Phases[i].Status = flowstore.PhasePending
+		}
+	}
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:         "codex",
+		AddFlowPhaseLaunchID: store.AddPhaseLaunchID,
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	_, cmd := update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd == nil {
+		t.Fatal("auto mode completion should prepare a launch command before auto mode is disabled")
+	}
+	if _, err := store.SetAutoMode(flowstore.AutoModeUpdate{FlowID: current.FlowID, Enabled: false}); err != nil {
+		t.Fatalf("SetAutoMode(false) error = %v", err)
+	}
+
+	if msg := cmd(); msg != nil {
+		t.Fatalf("stale auto launch command returned %T, want nil", msg)
+	}
+	read, err := store.Read(current.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(read, "implementation").Status; got != flowstore.PhaseReady {
+		t.Fatalf("implementation status = %q, want ready after stale auto command", got)
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -55,6 +55,102 @@ func flowWithAwaitingImplementation() flowstore.FlowRecord {
 	return flow
 }
 
+func autoFlowWithPhaseStatuses(statuses map[string]string) flowstore.FlowRecord {
+	defs := []struct {
+		id    string
+		title string
+		order int
+	}{
+		{id: "plan", title: "Plan", order: 1},
+		{id: "plan-review", title: "Plan Review", order: 2},
+		{id: "implementation", title: "Implementation", order: 3},
+		{id: "review-loop", title: "Review loop", order: 4},
+		{id: "pr-creation", title: "PR creation", order: 5},
+		{id: "autoreview", title: "Autoreview", order: 6},
+		{id: "merge", title: "Merge", order: 7},
+	}
+	phases := make([]flowstore.FlowPhase, 0, len(statuses))
+	for _, def := range defs {
+		status, ok := statuses[def.id]
+		if !ok {
+			continue
+		}
+		phase := flowstore.FlowPhase{
+			PhaseID: def.id,
+			Title:   def.title,
+			Status:  status,
+			Order:   def.order,
+		}
+		if def.id == "plan-review" && status == flowstore.PhaseCompleted {
+			phase.Outcome = flowstore.OutcomeApproved
+		}
+		phases = append(phases, phase)
+	}
+	return autoFlowWithPhases(phases...)
+}
+
+func autoFlowWithPhases(phases ...flowstore.FlowPhase) flowstore.FlowRecord {
+	return flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-auto",
+		Title:        "Auto Flow",
+		Status:       flowstore.StatusInProgress,
+		Branch:       "flow/auto",
+		AutoMode:     true,
+		Phases:       phases,
+	}
+}
+
+func autoLaunchFromFlowRefresh(t *testing.T, previous, current flowstore.FlowRecord) (model.FlowEmbeddedLaunchRequestedMsg, []flowstore.PhaseLaunchUpdate) {
+	t.Helper()
+	cmd, updates := autoLaunchCommandFromFlowRefresh(t, previous, current)
+	if cmd == nil {
+		t.Fatal("Flow refresh should return auto-launch command")
+	}
+	msg := cmd()
+	launch, ok := msg.(model.FlowEmbeddedLaunchRequestedMsg)
+	if !ok {
+		t.Fatalf("auto-launch command returned %T, want FlowEmbeddedLaunchRequestedMsg", msg)
+	}
+	return launch, *updates
+}
+
+func autoLaunchCommandFromFlowRefresh(t *testing.T, previous, current flowstore.FlowRecord) (tea.Cmd, *[]flowstore.PhaseLaunchUpdate) {
+	t.Helper()
+	var updates []flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			launched := current
+			for i := range launched.Phases {
+				if launched.Phases[i].PhaseID == update.PhaseID {
+					launched.Phases[i].Status = flowstore.PhaseRunning
+					launched.Phases[i].LaunchIDs = append(launched.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return launched, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	_, cmd := update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	return cmd, &updates
+}
+
+func phaseByID(record flowstore.FlowRecord, phaseID string) flowstore.FlowPhase {
+	for _, phase := range record.Phases {
+		if phase.PhaseID == phaseID {
+			return phase
+		}
+	}
+	return flowstore.FlowPhase{}
+}
+
 func expandSelectedFlowWithEnter(t *testing.T, m model.Model) model.Model {
 	t.Helper()
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -150,6 +246,113 @@ func prepareSelectedFlowPhaseEmbeddedLaunch(t *testing.T, m model.Model, phaseID
 	m = selectFlowPhaseByID(t, m, phaseID)
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	return m, cmd
+}
+
+func TestModel_MKeyTogglesFlowAutoModeFromFlowRow(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	updated := flow
+	updated.AutoMode = true
+	var calls []flowstore.AutoModeUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SetFlowAutoMode: func(update flowstore.AutoModeUpdate) (flowstore.FlowRecord, error) {
+			calls = append(calls, update)
+			return updated, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	if cmd == nil {
+		t.Fatal("m on selected Flow row should persist auto-mode toggle")
+	}
+	m, follow := update(m, cmd())
+	if follow != nil {
+		t.Fatalf("auto-mode result returned follow-up command %T, want nil", follow)
+	}
+	if len(calls) != 1 || calls[0].FlowID != "flow-1" || !calls[0].Enabled {
+		t.Fatalf("auto-mode calls = %#v, want enable flow-1", calls)
+	}
+	if got := m.Flows(); len(got) != 1 || !got[0].AutoMode {
+		t.Fatalf("Flows() = %#v, want auto mode enabled", got)
+	}
+	if m.SelectedFlowPhaseID() != "" {
+		t.Fatalf("selected phase = %q, want Flow row selected", m.SelectedFlowPhaseID())
+	}
+}
+
+func TestModel_MKeyTogglesFlowAutoModeFromPhaseRowAndPreservesSelection(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	flow.AutoMode = true
+	updated := flow
+	updated.AutoMode = false
+	var calls []flowstore.AutoModeUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SetFlowAutoMode: func(update flowstore.AutoModeUpdate) (flowstore.FlowRecord, error) {
+			calls = append(calls, update)
+			return updated, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+	m = selectFlowPhaseByID(t, m, "implementation")
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	if cmd == nil {
+		t.Fatal("m on selected Flow phase should persist auto-mode toggle")
+	}
+	m, follow := update(m, cmd())
+	if follow != nil {
+		t.Fatalf("auto-mode result returned follow-up command %T, want nil", follow)
+	}
+	if len(calls) != 1 || calls[0].FlowID != "flow-1" || calls[0].Enabled {
+		t.Fatalf("auto-mode calls = %#v, want disable flow-1", calls)
+	}
+	if got := m.Flows(); len(got) != 1 || got[0].AutoMode {
+		t.Fatalf("Flows() = %#v, want auto mode disabled", got)
+	}
+	if m.ExpandedFlowID() != "flow-1" || m.SelectedFlowPhaseID() != "implementation" {
+		t.Fatalf("expanded/phase = %q/%q, want flow-1/implementation", m.ExpandedFlowID(), m.SelectedFlowPhaseID())
+	}
+}
+
+func TestModel_MKeyFlowAutoModeFailureReportsStatus(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SetFlowAutoMode: func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{}, errors.New("state root locked")
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	if cmd == nil {
+		t.Fatal("m on selected Flow row should return persistence command")
+	}
+	m, _ = update(m, cmd())
+	if got := m.TransientError(); !strings.Contains(got, "failed to set Flow auto mode") || !strings.Contains(got, "state root locked") {
+		t.Fatalf("status = %q, want persistence failure", got)
+	}
+	if got := m.Flows(); len(got) != 1 || got[0].AutoMode {
+		t.Fatalf("Flows() = %#v, want unchanged auto mode", got)
+	}
+}
+
+func TestModel_MKeyFlowAutoModeNoopsWithoutSelectedFlow(t *testing.T) {
+	called := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SetFlowAutoMode: func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error) {
+			called = true
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, nil)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	if cmd != nil {
+		t.Fatalf("m without selected Flow returned command %T, want nil", cmd)
+	}
+	if called {
+		t.Fatal("SetFlowAutoMode should not be called without a selected Flow")
+	}
 }
 
 func TestModel_SelectedAwaitingFlowPhaseAdvertisesResetShortcut(t *testing.T) {
@@ -593,6 +796,215 @@ func TestModel_FlowFetchUsesSelectedRepoRequestAndIgnoresStaleResults(t *testing
 	m, _ = update(m, nextMsg)
 	if got := m.Flows(); len(got) != 1 || got[0].FlowID != "flow-current" {
 		t.Fatalf("Flows() = %#v, want current flow", got)
+	}
+}
+
+func TestModel_FlowAutoModeLaunchesImplementationAfterPlanReviewCompletes(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+		"review-loop":    flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+		"review-loop":    flowstore.PhasePending,
+	})
+	current.Phases[1].Outcome = flowstore.OutcomeApproved
+	launchMsg, updates := autoLaunchFromFlowRefresh(t, previous, current)
+
+	if len(updates) != 1 || updates[0].FlowID != "flow-1" || updates[0].PhaseID != "implementation" {
+		t.Fatalf("launch updates = %#v, want implementation", updates)
+	}
+	if launchMsg.LaunchContext.FlowID != "flow-1" ||
+		launchMsg.LaunchContext.FlowPhaseID != "implementation" ||
+		!launchMsg.LaunchContext.FlowLaunchTracked ||
+		!launchMsg.LaunchContext.Embedded {
+		t.Fatalf("launch context = %#v, want embedded implementation launch", launchMsg.LaunchContext)
+	}
+}
+
+func TestModel_FlowAutoModeLaunchesNextImplementationChildOrReviewLoop(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		current     flowstore.FlowRecord
+		wantPhaseID string
+	}{
+		{
+			name: "next child",
+			current: autoFlowWithPhases(
+				flowstore.FlowPhase{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted, Order: 1},
+				flowstore.FlowPhase{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved, Order: 2},
+				flowstore.FlowPhase{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted, Order: 3},
+				flowstore.FlowPhase{PhaseID: "implementation-api", ParentPhaseID: "implementation", Title: "API", Status: flowstore.PhaseCompleted, Order: 10},
+				flowstore.FlowPhase{PhaseID: "implementation-ui", ParentPhaseID: "implementation", Title: "UI", Status: flowstore.PhaseReady, Order: 20},
+				flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhasePending, Order: 4},
+			),
+			wantPhaseID: "implementation-ui",
+		},
+		{
+			name: "review loop",
+			current: autoFlowWithPhases(
+				flowstore.FlowPhase{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted, Order: 1},
+				flowstore.FlowPhase{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved, Order: 2},
+				flowstore.FlowPhase{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted, Order: 3},
+				flowstore.FlowPhase{PhaseID: "implementation-api", ParentPhaseID: "implementation", Title: "API", Status: flowstore.PhaseCompleted, Order: 10},
+				flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseReady, Order: 4},
+			),
+			wantPhaseID: "review-loop",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			previous := tc.current
+			previous.Phases = append([]flowstore.FlowPhase(nil), tc.current.Phases...)
+			for i := range previous.Phases {
+				if previous.Phases[i].PhaseID == "implementation-api" {
+					previous.Phases[i].Status = flowstore.PhaseRunning
+				}
+			}
+
+			launchMsg, updates := autoLaunchFromFlowRefresh(t, previous, tc.current)
+			if len(updates) != 1 || updates[0].PhaseID != tc.wantPhaseID {
+				t.Fatalf("launch updates = %#v, want %s", updates, tc.wantPhaseID)
+			}
+			if launchMsg.LaunchContext.FlowPhaseID != tc.wantPhaseID {
+				t.Fatalf("launched phase = %q, want %q", launchMsg.LaunchContext.FlowPhaseID, tc.wantPhaseID)
+			}
+		})
+	}
+}
+
+func TestModel_FlowAutoModeLaunchesAutoreviewAfterPRCreationCompletesWithPRMetadata(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseCompleted,
+		"review-loop":    flowstore.PhaseCompleted,
+		"pr-creation":    flowstore.PhaseRunning,
+		"autoreview":     flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseCompleted,
+		"review-loop":    flowstore.PhaseCompleted,
+		"pr-creation":    flowstore.PhaseCompleted,
+		"autoreview":     flowstore.PhaseReady,
+	})
+	current.Branch = "flow/auto"
+	current.PR = flowstore.PullRequest{
+		Provider:   "github",
+		Number:     115,
+		URL:        "https://github.com/brian-bell/wtui/pull/115",
+		HeadBranch: "flow/auto",
+		BaseBranch: "main",
+	}
+
+	launchMsg, updates := autoLaunchFromFlowRefresh(t, previous, current)
+	if len(updates) != 1 || updates[0].PhaseID != "autoreview" {
+		t.Fatalf("launch updates = %#v, want autoreview", updates)
+	}
+	if launchMsg.LaunchContext.FlowPhaseID != "autoreview" {
+		t.Fatalf("launched phase = %q, want autoreview", launchMsg.LaunchContext.FlowPhaseID)
+	}
+}
+
+func TestModel_FlowAutoModeDoesNotLaunchMergeAfterAutoreviewCompletes(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseCompleted,
+		"review-loop":    flowstore.PhaseCompleted,
+		"pr-creation":    flowstore.PhaseCompleted,
+		"autoreview":     flowstore.PhaseRunning,
+		"merge":          flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseCompleted,
+		"review-loop":    flowstore.PhaseCompleted,
+		"pr-creation":    flowstore.PhaseCompleted,
+		"autoreview":     flowstore.PhaseCompleted,
+		"merge":          flowstore.PhaseReady,
+	})
+
+	cmd, updates := autoLaunchCommandFromFlowRefresh(t, previous, current)
+	if cmd != nil {
+		t.Fatalf("autoreview completion returned auto-launch command %T, want nil", cmd)
+	}
+	if len(*updates) != 0 {
+		t.Fatalf("launch updates = %#v, want none", updates)
+	}
+	if got := current.AutoMode; !got {
+		t.Fatal("test setup should keep auto mode on after autoreview")
+	}
+}
+
+func TestModel_FlowAutoModeDoesNotLaunchForNonCompletedTransitions(t *testing.T) {
+	for _, status := range []string{flowstore.PhaseSkipped, flowstore.PhaseBlocked, flowstore.PhaseNeedsAttention} {
+		t.Run(status, func(t *testing.T) {
+			previous := autoFlowWithPhaseStatuses(map[string]string{
+				"plan":           flowstore.PhaseCompleted,
+				"plan-review":    flowstore.PhaseRunning,
+				"implementation": flowstore.PhaseReady,
+			})
+			current := autoFlowWithPhaseStatuses(map[string]string{
+				"plan":           flowstore.PhaseCompleted,
+				"plan-review":    status,
+				"implementation": flowstore.PhaseReady,
+			})
+			if status == flowstore.PhaseSkipped {
+				current.Phases[1].Notes = "Skipped by operator."
+			}
+
+			cmd, updates := autoLaunchCommandFromFlowRefresh(t, previous, current)
+			if cmd != nil {
+				t.Fatalf("%s transition returned auto-launch command %T, want nil", status, cmd)
+			}
+			if len(*updates) != 0 {
+				t.Fatalf("launch updates = %#v, want none", updates)
+			}
+		})
+	}
+}
+
+func TestModel_FlowAutoModeIgnoresStaleFlowResults(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	var updates []flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			return current, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+
+	m, cmd := update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: 999999,
+	})
+	if cmd != nil {
+		t.Fatalf("stale FlowResultMsg returned command %T, want nil", cmd)
+	}
+	if len(updates) != 0 {
+		t.Fatalf("launch updates = %#v, want none for stale result", updates)
+	}
+	if got := m.Flows(); len(got) != 1 || phaseByID(got[0], "plan-review").Status != flowstore.PhaseRunning {
+		t.Fatalf("Flows() = %#v, want previous snapshot unchanged", got)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -392,6 +392,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModeWorktrees {
 			return m.handleMoveWorktree()
 		}
+		if m.mode == ui.ModeFlows {
+			return m.handleToggleFlowAutoMode()
+		}
 	case "N":
 		if m.mode == ui.ModeWorktrees {
 			return m.handleNewWorktree(true)
@@ -638,6 +641,46 @@ func (m Model) handleToggleFlowPhases() (tea.Model, tea.Cmd) {
 		m = m.setExpandedFlowID(flowID)
 	}
 	return m, nil
+}
+
+func (m Model) handleToggleFlowAutoMode() (tea.Model, tea.Cmd) {
+	if m.mode != ui.ModeFlows || len(m.filteredFlows()) == 0 {
+		return m, nil
+	}
+	record, ok := m.selectedFlow()
+	if !ok || record.FlowID == "" {
+		return m, nil
+	}
+	repoPath := record.RepoPath
+	if repoPath == "" {
+		repoPath, _ = m.currentRepoPath()
+	}
+	if repoPath == "" {
+		return m, nil
+	}
+	return m, m.setFlowAutoModeCmd(repoPath, record.FlowID, !record.AutoMode)
+}
+
+func (m Model) setFlowAutoModeCmd(repoPath, flowID string, enabled bool) tea.Cmd {
+	return func() tea.Msg {
+		flow, err := m.setFlowAutoMode(flowstore.AutoModeUpdate{
+			FlowID:  flowID,
+			Enabled: enabled,
+		})
+		if err != nil {
+			return FlowAutoModeSetFailedMsg{
+				RepoPath: repoPath,
+				FlowID:   flowID,
+				Err:      fmt.Sprintf("failed to set Flow auto mode: %v", err),
+			}
+		}
+		return FlowAutoModeSetMsg{
+			RepoPath: repoPath,
+			FlowID:   flowID,
+			Flow:     flow,
+			Enabled:  enabled,
+		}
+	}
 }
 
 func (m Model) handleToggleWorktreeSessions() (tea.Model, tea.Cmd) {
@@ -1094,6 +1137,79 @@ func (m Model) handleLaunchSelectedFlowPhase() (tea.Model, tea.Cmd) {
 		return next, next.prepareFlowPhaseEmbeddedLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID, next.flowHeadless)
 	}
 	return next, next.prepareFlowPhaseLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID)
+}
+
+func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstore.FlowRecord) (Model, tea.Cmd) {
+	previousByFlowID := make(map[string]flowstore.FlowRecord, len(previousFlows))
+	for _, record := range previousFlows {
+		if record.FlowID != "" {
+			previousByFlowID[record.FlowID] = record
+		}
+	}
+	for _, record := range currentFlows {
+		if !record.AutoMode || record.FlowID == "" {
+			continue
+		}
+		previous, ok := previousByFlowID[record.FlowID]
+		if !ok {
+			continue
+		}
+		completedPhase, ok := newlyCompletedFlowPhase(previous, record)
+		if !ok {
+			continue
+		}
+		if artifacts.NormalizePhaseID(completedPhase.PhaseID) == "autoreview" {
+			continue
+		}
+		phase, ok := nextAutoLaunchPhase(record)
+		if !ok {
+			continue
+		}
+		target, ok, next := m.flowPhaseLaunchTarget(record, phase)
+		if !ok {
+			return next, nil
+		}
+		launchID := newLaunchID()
+		switch agent.Normalize(next.agentCommand) {
+		case agent.CommandCodex, agent.CommandClaude:
+			return next, next.prepareFlowPhaseEmbeddedLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID, next.flowHeadless)
+		}
+		return next, next.prepareFlowPhaseLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID)
+	}
+	return m, nil
+}
+
+func newlyCompletedFlowPhase(previous, current flowstore.FlowRecord) (flowstore.FlowPhase, bool) {
+	previousByPhaseID := make(map[string]flowstore.FlowPhase, len(previous.Phases))
+	for _, phase := range previous.Phases {
+		if phaseID := artifacts.NormalizePhaseID(phase.PhaseID); phaseID != "" {
+			previousByPhaseID[phaseID] = phase
+		}
+	}
+	for _, phase := range flowstore.OrderedPhases(current.Phases) {
+		phaseID := artifacts.NormalizePhaseID(phase.PhaseID)
+		if phaseID == "" || phase.Status != flowstore.PhaseCompleted {
+			continue
+		}
+		previousPhase, ok := previousByPhaseID[phaseID]
+		if ok && previousPhase.Status != flowstore.PhaseCompleted {
+			return phase, true
+		}
+	}
+	return flowstore.FlowPhase{}, false
+}
+
+func nextAutoLaunchPhase(record flowstore.FlowRecord) (flowstore.FlowPhase, bool) {
+	for _, phase := range flowstore.OrderedPhases(record.Phases) {
+		switch artifacts.NormalizePhaseID(phase.PhaseID) {
+		case "", "merge":
+			continue
+		}
+		if phase.Status == flowstore.PhaseReady {
+			return phase, true
+		}
+	}
+	return flowstore.FlowPhase{}, false
 }
 
 func (m Model) handleResetSelectedFlowPhase() (tea.Model, tea.Cmd) {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1146,6 +1146,7 @@ func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstor
 			previousByFlowID[record.FlowID] = record
 		}
 	}
+	var cmds []tea.Cmd
 	for _, record := range currentFlows {
 		if !record.AutoMode || record.FlowID == "" {
 			continue
@@ -1166,17 +1167,19 @@ func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstor
 			continue
 		}
 		target, ok, next := m.flowPhaseLaunchTarget(record, phase)
+		m = next
 		if !ok {
-			return next, nil
+			continue
 		}
 		launchID := newLaunchID()
 		switch agent.Normalize(next.agentCommand) {
 		case agent.CommandCodex, agent.CommandClaude:
-			return next, next.prepareFlowPhaseEmbeddedLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID, next.flowHeadless)
+			cmds = append(cmds, next.prepareAutoFlowPhaseEmbeddedLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID, next.flowHeadless))
+			continue
 		}
-		return next, next.prepareFlowPhaseLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID)
+		cmds = append(cmds, next.prepareAutoFlowPhaseLaunchCmd(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID))
 	}
-	return m, nil
+	return m, batchNonNil(cmds...)
 }
 
 func newlyCompletedFlowPhase(previous, current flowstore.FlowRecord) (flowstore.FlowPhase, bool) {
@@ -1375,19 +1378,33 @@ func (m Model) flowPhaseLaunchTarget(record flowstore.FlowRecord, phase flowstor
 func (m Model) prepareFlowPhaseLaunch(record flowstore.FlowRecord, phase flowstore.FlowPhase, repoPath, worktreePath, planPath, launchID string) tea.Cmd {
 	return m.prepareFlowPhaseLaunchCmd(record, phase, repoPath, worktreePath, planPath, launchID, func(ctx actions.AgentLaunchContext) tea.Msg {
 		return PlanLaunchRequestedMsg{LaunchContext: ctx}
-	})
+	}, false)
+}
+
+func (m Model) prepareAutoFlowPhaseLaunchCmd(record flowstore.FlowRecord, phase flowstore.FlowPhase, repoPath, worktreePath, planPath, launchID string) tea.Cmd {
+	return m.prepareFlowPhaseLaunchCmd(record, phase, repoPath, worktreePath, planPath, launchID, func(ctx actions.AgentLaunchContext) tea.Msg {
+		return PlanLaunchRequestedMsg{LaunchContext: ctx}
+	}, true)
 }
 
 func (m Model) prepareFlowPhaseEmbeddedLaunch(record flowstore.FlowRecord, phase flowstore.FlowPhase, repoPath, worktreePath, planPath, launchID string, headless bool) tea.Cmd {
+	return m.prepareFlowPhaseEmbeddedLaunchWithAuto(record, phase, repoPath, worktreePath, planPath, launchID, headless, false)
+}
+
+func (m Model) prepareAutoFlowPhaseEmbeddedLaunch(record flowstore.FlowRecord, phase flowstore.FlowPhase, repoPath, worktreePath, planPath, launchID string, headless bool) tea.Cmd {
+	return m.prepareFlowPhaseEmbeddedLaunchWithAuto(record, phase, repoPath, worktreePath, planPath, launchID, headless, true)
+}
+
+func (m Model) prepareFlowPhaseEmbeddedLaunchWithAuto(record flowstore.FlowRecord, phase flowstore.FlowPhase, repoPath, worktreePath, planPath, launchID string, headless, autoLaunch bool) tea.Cmd {
 	return m.prepareFlowPhaseLaunchCmd(record, phase, repoPath, worktreePath, planPath, launchID, func(ctx actions.AgentLaunchContext) tea.Msg {
 		ctx.FlowLaunchTracked = true
 		ctx.Embedded = true
 		ctx.Headless = headless
 		return FlowEmbeddedLaunchRequestedMsg{LaunchContext: ctx}
-	})
+	}, autoLaunch)
 }
 
-func (m Model) prepareFlowPhaseLaunchCmd(record flowstore.FlowRecord, phase flowstore.FlowPhase, repoPath, worktreePath, planPath, launchID string, wrap func(actions.AgentLaunchContext) tea.Msg) tea.Cmd {
+func (m Model) prepareFlowPhaseLaunchCmd(record flowstore.FlowRecord, phase flowstore.FlowPhase, repoPath, worktreePath, planPath, launchID string, wrap func(actions.AgentLaunchContext) tea.Msg, autoLaunch bool) tea.Cmd {
 	return func() tea.Msg {
 		planBody := ""
 		if record.PlanID != "" && flowPhasePromptNeedsPlanBody(phase.PhaseID) {
@@ -1398,11 +1415,15 @@ func (m Model) prepareFlowPhaseLaunchCmd(record flowstore.FlowRecord, phase flow
 			planBody = body
 		}
 		updated, err := m.addFlowPhaseLaunchID(flowstore.PhaseLaunchUpdate{
-			FlowID:   record.FlowID,
-			PhaseID:  phase.PhaseID,
-			LaunchID: launchID,
+			FlowID:     record.FlowID,
+			PhaseID:    phase.PhaseID,
+			LaunchID:   launchID,
+			AutoLaunch: autoLaunch,
 		})
 		if err != nil {
+			if autoLaunch && flowstore.IsAutoLaunchOutdated(err) {
+				return nil
+			}
 			return ActionFailedMsg{RepoPath: repoPath, Err: fmt.Sprintf("failed to mark flow phase running: %v", err)}
 		}
 		launchPhase := phase

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -247,6 +247,19 @@ type FlowResultMsg struct {
 	ListRequest uint64
 }
 
+type FlowAutoModeSetMsg struct {
+	RepoPath string
+	FlowID   string
+	Flow     flowstore.FlowRecord
+	Enabled  bool
+}
+
+type FlowAutoModeSetFailedMsg struct {
+	RepoPath string
+	FlowID   string
+	Err      string
+}
+
 type PlanReadResultMsg struct {
 	RepoPath    string
 	PlanID      string
@@ -1069,12 +1082,13 @@ func (m Model) handlePlanResult(msg PlanResultMsg) Model {
 	return m
 }
 
-func (m Model) handleFlowResult(msg FlowResultMsg) Model {
+func (m Model) handleFlowResult(msg FlowResultMsg) (Model, tea.Cmd) {
 	var ok bool
 	m, ok = m.acceptListResult(msg.RepoPath, ui.ModeFlows, msg.ListRequest)
 	if !ok {
-		return m
+		return m, nil
 	}
+	previousFlows := append([]flowstore.FlowRecord(nil), m.flows.Items()...)
 	selectedFlowID := m.selectedFlowID()
 	expandedFlowID := m.expandedFlowID
 	selectedFlowPhaseID := m.selectedFlowPhaseID
@@ -1086,7 +1100,54 @@ func (m Model) handleFlowResult(msg FlowResultMsg) Model {
 	}
 	m = m.restoreExpandedFlowSelection(expandedFlowID, selectedFlowPhaseID)
 	m = m.clampSelectionsAfterFilter()
-	return m
+	return m.prepareAutoFlowPhaseLaunch(previousFlows, msg.Flows)
+}
+
+func (m Model) handleFlowAutoModeSet(msg FlowAutoModeSetMsg) Model {
+	if !m.isCurrentRepo(msg.RepoPath) || msg.FlowID == "" {
+		return m
+	}
+	return m.replaceFlowRecord(msg.Flow)
+}
+
+func (m Model) handleFlowAutoModeSetFailed(msg FlowAutoModeSetFailedMsg) Model {
+	if !m.isCurrentRepo(msg.RepoPath) {
+		return m
+	}
+	errText := strings.TrimSpace(msg.Err)
+	if errText == "" {
+		errText = "failed to set Flow auto mode"
+	}
+	return m.setStatus(statusOther, errText)
+}
+
+func (m Model) replaceFlowRecord(flow flowstore.FlowRecord) Model {
+	if flow.FlowID == "" {
+		return m
+	}
+	selectedFlowID := m.selectedFlowID()
+	expandedFlowID := m.expandedFlowID
+	selectedFlowPhaseID := m.selectedFlowPhaseID
+	items := append([]flowstore.FlowRecord(nil), m.flows.Items()...)
+	replaced := false
+	for i := range items {
+		if items[i].FlowID == flow.FlowID {
+			items[i] = flow
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		return m
+	}
+	m.flows = m.flows.SetItems(items)
+	if selectedFlowID != "" {
+		m.flows = m.flows.SelectFunc(func(record flowstore.FlowRecord) bool {
+			return record.FlowID == selectedFlowID
+		})
+	}
+	m = m.restoreExpandedFlowSelection(expandedFlowID, selectedFlowPhaseID)
+	return m.clampSelectionsAfterFilter()
 }
 
 func (m Model) handleFlowDeleted(msg FlowDeletedMsg) (tea.Model, tea.Cmd) {

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -50,6 +50,7 @@ type themeStyles struct {
 	diffDel           lipgloss.Style
 	diffHeader        lipgloss.Style
 	flowTerminal      lipgloss.Style
+	flowAutoMode      lipgloss.Style
 	activeBorder      lipgloss.Color
 	inactiveBorder    lipgloss.Color
 	destructiveBorder lipgloss.Color
@@ -110,6 +111,7 @@ func newThemeStyles(p themePalette) themeStyles {
 		diffDel:           lipgloss.NewStyle().Foreground(p.danger),
 		diffHeader:        lipgloss.NewStyle().Foreground(p.info),
 		flowTerminal:      lipgloss.NewStyle().Foreground(p.success),
+		flowAutoMode:      lipgloss.NewStyle().Foreground(p.info),
 		activeBorder:      p.focus,
 		inactiveBorder:    p.borderMuted,
 		destructiveBorder: p.danger,
@@ -146,4 +148,5 @@ var (
 	diffDelStyle         = clearDarkTheme.diffDel
 	diffHdrStyle         = clearDarkTheme.diffHeader
 	flowTerminalStyle    = clearDarkTheme.flowTerminal
+	flowAutoModeStyle    = clearDarkTheme.flowAutoMode
 )

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -252,6 +252,7 @@ type RenderParams struct {
 	SelectedPlanPhaseID         string
 	SelectedFlowPhaseID         string
 	FlowHeadless                bool
+	FlowAutoModeSelected        bool
 	FlowPhaseLaunchReady        bool
 	FlowPhaseResetReadySelected bool
 	FlowPhaseResumableSelected  bool
@@ -413,8 +414,10 @@ func renderApplication(p RenderParams) string {
 	planSelected := p.Mode == ModePlans && p.PlanSelected >= 0 && p.PlanSelected < len(p.Plans)
 	flowSelected := p.Mode == ModeFlows && p.FlowSelected >= 0 && p.FlowSelected < len(p.Flows)
 	flowPlanLinked := false
+	flowAutoModeSelected := false
 	if flowSelected {
 		flowPlanLinked = strings.TrimSpace(p.Flows[p.FlowSelected].PlanID) != ""
+		flowAutoModeSelected = p.FlowAutoModeSelected
 	}
 	worktreeSessionSelected := p.Mode == ModeWorktrees && p.InlineWorktreeSessions && p.WorktreeSessionSelected >= 0 && p.WorktreeSessionSelected < len(p.WorktreeSessions)
 	selectedPlanPhaseID := scopedSelectedPlanPhaseID(p, planSelected)
@@ -424,6 +427,7 @@ func renderApplication(p RenderParams) string {
 		flowSelected = false
 		selectedFlowPhaseID = ""
 		flowDeletableSelected = false
+		flowAutoModeSelected = false
 	}
 	planPhaseSelected := selectedPlanPhaseID != ""
 	flowPhaseSelected := selectedFlowPhaseID != ""
@@ -461,6 +465,7 @@ func renderApplication(p RenderParams) string {
 		FlowDeletableSelected:       flowDeletableSelected,
 		FlowPlanLinked:              flowPlanLinked,
 		FlowHeadless:                p.FlowHeadless,
+		FlowAutoModeSelected:        flowAutoModeSelected,
 		FlowPhaseLaunchReady:        p.FlowPhaseLaunchReady,
 		FlowPhaseResetReadySelected: p.FlowPhaseResetReadySelected,
 		FlowPhaseResumableSelected:  p.FlowPhaseResumableSelected,
@@ -717,6 +722,7 @@ type statusBarParams struct {
 	FlowDeletableSelected       bool
 	FlowPlanLinked              bool
 	FlowHeadless                bool
+	FlowAutoModeSelected        bool
 	FlowPhaseLaunchReady        bool
 	FlowPhaseResetReadySelected bool
 	FlowPhaseResumableSelected  bool
@@ -1140,6 +1146,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 			}
 			actions = append(actions, shortcutHint{Key: "h", Label: headlessLabel, SuccessSuffix: headlessSuccessSuffix})
 			if sp.FlowSelected {
+				autoHint := flowAutoModeShortcutHint(sp.FlowAutoModeSelected)
 				if sp.FlowPhaseSelected {
 					if sp.FlowPhaseLaunchReady {
 						actions = append(actions, shortcutHint{Key: "enter", Label: "launch phase"})
@@ -1151,6 +1158,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 					if sp.FlowPhaseResumableSelected {
 						actions = append(actions, shortcutHint{Key: "r", Label: "resume"})
 					}
+					actions = append(actions, autoHint)
 				} else {
 					actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
 					if sp.FlowPlanLinked {
@@ -1160,6 +1168,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 					if sp.Destructive && sp.FlowDeletableSelected {
 						actions = append(actions, shortcutHint{Key: "d", Label: "delete", Warning: true})
 					}
+					actions = append(actions, autoHint)
 				}
 			}
 		}
@@ -1194,6 +1203,13 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	}
 	sections = append(sections, shortcutSection{Title: "Global", Hints: global})
 	return sections
+}
+
+func flowAutoModeShortcutHint(enabled bool) shortcutHint {
+	if enabled {
+		return shortcutHint{Key: "m", Label: "auto: on", SuccessSuffix: "on"}
+	}
+	return shortcutHint{Key: "m", Label: "auto: off"}
 }
 
 func shortcutsMuted(sp statusBarParams) bool {
@@ -2234,6 +2250,8 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 				updated,
 				record.Title,
 				width)
+		} else if record.AutoMode {
+			line = flowAutoModeStyle.Render(line)
 		}
 		rows = append(rows, truncateToWidth(line, width))
 		if record.FlowID == expandedFlowID {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -2231,14 +2231,30 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 			}
 		}
 		rowSelected := i == selected && selectedPhaseID == ""
+		statusCell := statusStyle.Render(fitSessionColumn(record.Status, flowStatusWidth))
+		branchCell := branchStyle.Render(fitSessionColumn(branch, flowBranchWidth))
+		phaseCell := diffHdrStyle.Render(fitSessionColumn(phase, flowPhaseWidth))
+		planCell := statusStyle.Render(fitSessionColumn(plan, flowPlanWidth))
+		prCell := statusStyle.Render(fitSessionColumn(pr, flowPRWidth))
+		updatedCell := stashDateStyle.Render(fitSessionColumn(updated, flowUpdatedWidth))
+		titleCell := stashMsgStyle.Render(record.Title)
+		if record.AutoMode && !rowSelected {
+			statusCell = flowAutoModeStyle.Render(fitSessionColumn(record.Status, flowStatusWidth))
+			branchCell = flowAutoModeStyle.Render(fitSessionColumn(branch, flowBranchWidth))
+			phaseCell = flowAutoModeStyle.Render(fitSessionColumn(phase, flowPhaseWidth))
+			planCell = flowAutoModeStyle.Render(fitSessionColumn(plan, flowPlanWidth))
+			prCell = flowAutoModeStyle.Render(fitSessionColumn(pr, flowPRWidth))
+			updatedCell = flowAutoModeStyle.Render(fitSessionColumn(updated, flowUpdatedWidth))
+			titleCell = flowAutoModeStyle.Render(record.Title)
+		}
 		line := formatFlowColumns(flowRowPrefix(false, active.hasFlow(record.FlowID)),
-			statusStyle.Render(fitSessionColumn(record.Status, flowStatusWidth)),
-			branchStyle.Render(fitSessionColumn(branch, flowBranchWidth)),
-			diffHdrStyle.Render(fitSessionColumn(phase, flowPhaseWidth)),
-			statusStyle.Render(fitSessionColumn(plan, flowPlanWidth)),
-			statusStyle.Render(fitSessionColumn(pr, flowPRWidth)),
-			stashDateStyle.Render(fitSessionColumn(updated, flowUpdatedWidth)),
-			stashMsgStyle.Render(record.Title),
+			statusCell,
+			branchCell,
+			phaseCell,
+			planCell,
+			prCell,
+			updatedCell,
+			titleCell,
 		)
 		if rowSelected {
 			line = renderSelectedFlowColumns(selectedFlowRowPrefix(active.hasFlow(record.FlowID)),
@@ -2250,8 +2266,6 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 				updated,
 				record.Title,
 				width)
-		} else if record.AutoMode {
-			line = flowAutoModeStyle.Render(line)
 		}
 		rows = append(rows, truncateToWidth(line, width))
 		if record.FlowID == expandedFlowID {

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -286,11 +286,14 @@ func TestRender_FlowsModeHighlightsAutoModeRowsWithoutShiftingColumns(t *testing
 	view := strings.Join(renderFlowPane(flows, -1, 0, 220, 6, "", "", nil), "\n")
 	autoRow := rawLineContaining(view, "flow/auto")
 	manualRow := rawLineContaining(view, "flow/manual")
-	if !strings.HasPrefix(autoRow, "\x1b[") {
-		t.Fatalf("auto-mode row should have a row-level highlight:\n%q", autoRow)
+	if want := flowAutoModeStyle.Render(fitSessionColumn(flowstore.StatusInProgress, flowStatusWidth)); !strings.Contains(autoRow, want) {
+		t.Fatalf("auto-mode row should style status with auto highlight:\n%q\nmissing %q", autoRow, want)
 	}
-	if strings.HasPrefix(manualRow, "\x1b[") {
-		t.Fatalf("manual non-selected row should not have row-level highlight:\n%q", manualRow)
+	if want := flowAutoModeStyle.Render("Auto flow"); !strings.Contains(autoRow, want) {
+		t.Fatalf("auto-mode row should style title with auto highlight:\n%q\nmissing %q", autoRow, want)
+	}
+	if unwanted := flowAutoModeStyle.Render("Manual flow"); strings.Contains(manualRow, unwanted) {
+		t.Fatalf("manual non-selected row should not use auto highlight:\n%q", manualRow)
 	}
 	if visibleColumn(ansi.Strip(autoRow), "in_progress") != visibleColumn(ansi.Strip(manualRow), "in_progress") {
 		t.Fatalf("auto-mode highlight shifted status column, auto=%q manual=%q", ansi.Strip(autoRow), ansi.Strip(manualRow))

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -251,6 +251,61 @@ func TestRender_FlowsModeMarksActiveTerminalFlowRows(t *testing.T) {
 	}
 }
 
+func TestRender_FlowsModeHighlightsAutoModeRowsWithoutShiftingColumns(t *testing.T) {
+	previousProfile := lipgloss.ColorProfile()
+	previousDarkBackground := lipgloss.HasDarkBackground()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	lipgloss.SetHasDarkBackground(true)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(previousProfile)
+		lipgloss.SetHasDarkBackground(previousDarkBackground)
+	})
+
+	flows := []flowstore.FlowRecord{
+		{
+			FlowID:   "flow-auto",
+			Title:    "Auto flow",
+			Status:   flowstore.StatusInProgress,
+			Branch:   "flow/auto",
+			AutoMode: true,
+			Phases: []flowstore.FlowPhase{
+				{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady},
+			},
+		},
+		{
+			FlowID: "flow-manual",
+			Title:  "Manual flow",
+			Status: flowstore.StatusInProgress,
+			Branch: "flow/manual",
+			Phases: []flowstore.FlowPhase{
+				{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady},
+			},
+		},
+	}
+
+	view := strings.Join(renderFlowPane(flows, -1, 0, 220, 6, "", "", nil), "\n")
+	autoRow := rawLineContaining(view, "flow/auto")
+	manualRow := rawLineContaining(view, "flow/manual")
+	if !strings.HasPrefix(autoRow, "\x1b[") {
+		t.Fatalf("auto-mode row should have a row-level highlight:\n%q", autoRow)
+	}
+	if strings.HasPrefix(manualRow, "\x1b[") {
+		t.Fatalf("manual non-selected row should not have row-level highlight:\n%q", manualRow)
+	}
+	if visibleColumn(ansi.Strip(autoRow), "in_progress") != visibleColumn(ansi.Strip(manualRow), "in_progress") {
+		t.Fatalf("auto-mode highlight shifted status column, auto=%q manual=%q", ansi.Strip(autoRow), ansi.Strip(manualRow))
+	}
+
+	view = strings.Join(renderFlowPane(flows, 0, 0, 220, 6, "", "", nil), "\n")
+	selectedAutoRow := rawLineContaining(view, "flow/auto")
+	if !strings.HasPrefix(selectedAutoRow, selectedStyle.Render(">  ")) {
+		t.Fatalf("selected auto-mode row should use selected row prefix, got %q", selectedAutoRow)
+	}
+	if want := selectedStyle.Render(fitSessionColumn(flowstore.StatusInProgress, flowStatusWidth)); !strings.Contains(selectedAutoRow, want) {
+		t.Fatalf("selected auto-mode row should keep selected styling:\n%q\nmissing %q", selectedAutoRow, want)
+	}
+}
+
 func visibleColumn(line, needle string) int {
 	index := strings.Index(line, needle)
 	if index < 0 {
@@ -535,6 +590,49 @@ func TestRender_FlowsModeShowsCopyPhaseIDShortcutForSelectedPhase(t *testing.T) 
 	}
 	if strings.Contains(pane, "y      copy id") {
 		t.Fatalf("selected Flow phase should not expose whole-flow copy shortcut:\n%s", view)
+	}
+}
+
+func TestRender_FlowsModeShowsAutoModeShortcutForSelectedFlowAndPhase(t *testing.T) {
+	base := RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   24,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "Auto mode flow",
+			Status: flowstore.StatusInProgress,
+			Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation",
+				Title:   "Implementation",
+				Status:  flowstore.PhaseReady,
+			}},
+		}},
+		ActivePane:   1,
+		FlowSelected: 0,
+	}
+
+	offPane := shortcutPaneText(Render(base))
+	if !strings.Contains(offPane, "m      auto: off") {
+		t.Fatalf("selected Flow should expose auto off shortcut:\n%s", offPane)
+	}
+	if strings.Contains(offPane, "m      move") {
+		t.Fatalf("Flows mode should not expose worktree move shortcut:\n%s", offPane)
+	}
+
+	base.FlowAutoModeSelected = true
+	onPane := shortcutPaneText(Render(base))
+	if !strings.Contains(onPane, "m      auto: on") {
+		t.Fatalf("selected Flow should expose auto on shortcut:\n%s", onPane)
+	}
+
+	base.ExpandedFlowID = "flow-1"
+	base.SelectedFlowPhaseID = "implementation"
+	phasePane := shortcutPaneText(Render(base))
+	if !strings.Contains(phasePane, "m      auto: on") {
+		t.Fatalf("selected Flow phase should expose parent auto shortcut:\n%s", phasePane)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Add persisted Flow auto-mode state with CLI controls and docs.
- Wire auto-mode behavior into the TUI model, key handling, terminal launch flow, and UI labels.
- Cover the new CLI, store, model, and UI behavior with focused tests.

Verification:
- gofmt -l .
- make test
- make build