### PR TITLE
Clarify Flow agent shortcut hint

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -543,9 +543,18 @@ func (m Model) flowReasoningEffortLabel() string {
 	command := agent.Normalize(m.agentCommand)
 	switch command {
 	case agent.CommandCodex, agent.CommandClaude:
-		return fmt.Sprintf("%s effort: %s", command, reasoningEffortDisplay(m.ReasoningEffortFor(command)))
+		return fmt.Sprintf("effort: %s", reasoningEffortDisplay(m.ReasoningEffortFor(command)))
 	case agent.CommandCodexApp:
-		return "codex-app default"
+		return "app default"
+	default:
+		return ""
+	}
+}
+
+func (m Model) flowAgentShortcutLabel() string {
+	switch command := agent.Normalize(m.agentCommand); command {
+	case agent.CommandCodex, agent.CommandCodexApp, agent.CommandClaude:
+		return command
 	default:
 		return "choose agent"
 	}
@@ -684,6 +693,7 @@ func (m Model) View() string {
 		SelectedFlowPhaseID:         m.selectedFlowPhaseID,
 		FlowHeadless:                m.flowHeadless,
 		FlowAutoModeSelected:        flowAutoModeSelected,
+		FlowAgentLabel:              m.flowAgentShortcutLabel(),
 		FlowReasoningEffort:         m.flowReasoningEffortLabel(),
 		FlowPhaseLaunchReady:        m.selectedFlowPhaseLaunchReady(),
 		FlowPhaseResetReadySelected: m.selectedFlowPhaseResettable(),

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3469,6 +3469,13 @@ func TestModel_FlowsModeLabelsAgentAndEffortSeparately(t *testing.T) {
 			notWant:    []string{"E      codex-app default"},
 		},
 		{
+			name:       "claude",
+			options:    model.Options{AgentCommand: "claude", ClaudeReasoningEffort: "max"},
+			wantAgent:  "A      claude",
+			wantEffort: "E      effort: max",
+			notWant:    []string{"E      claude effort: max"},
+		},
+		{
 			name:      "unset",
 			wantAgent: "A      choose agent",
 			notWant:   []string{"E      choose agent", "E      effort:", "E      app default"},

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3446,6 +3446,61 @@ func TestModel_FlowEffortPickerUsesCodexChoicesAndPersists(t *testing.T) {
 	}
 }
 
+func TestModel_FlowsModeLabelsAgentAndEffortSeparately(t *testing.T) {
+	tests := []struct {
+		name       string
+		options    model.Options
+		wantAgent  string
+		wantEffort string
+		notWant    []string
+	}{
+		{
+			name:       "codex",
+			options:    model.Options{AgentCommand: "codex", CodexReasoningEffort: "high"},
+			wantAgent:  "A      codex",
+			wantEffort: "E      effort: high",
+			notWant:    []string{"A      set agent", "E      codex effort: high"},
+		},
+		{
+			name:       "codex app",
+			options:    model.Options{AgentCommand: "codex-app"},
+			wantAgent:  "A      codex-app",
+			wantEffort: "E      app default",
+			notWant:    []string{"E      codex-app default"},
+		},
+		{
+			name:      "unset",
+			wantAgent: "A      choose agent",
+			notWant:   []string{"E      choose agent", "E      effort:", "E      app default"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := model.NewWithOptions(testRepos(), tt.options)
+			m = inRightPane(m)
+			m, _ = update(m, tea.WindowSizeMsg{Width: 180, Height: 12})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+
+			view := ansi.Strip(m.View())
+			agentIndex := strings.Index(view, tt.wantAgent)
+			if agentIndex < 0 {
+				t.Fatalf("Flow shortcuts missing agent label %q:\n%s", tt.wantAgent, view)
+			}
+			if tt.wantEffort != "" {
+				effortIndex := strings.Index(view, tt.wantEffort)
+				if effortIndex < 0 || agentIndex > effortIndex {
+					t.Fatalf("Flow shortcuts should group agent before effort %q:\n%s", tt.wantEffort, view)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(view, notWant) {
+					t.Fatalf("Flow shortcuts should not include %q:\n%s", notWant, view)
+				}
+			}
+		})
+	}
+}
+
 func TestModel_FlowEffortPickerUsesClaudeChoices(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: "claude"})
 	m = inRightPane(m)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1433,13 +1433,15 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 	arrow := footerHintsForKeys(hints, "←/→")
 	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "d")
 	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "x", "o", "y", "d", "r", "A", "E", "f", "F")
-	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "x", "o", "y", "d", "r", "f", "F")
+	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "x", "o", "y", "d", "r", "A", "f", "F")
+	actionsWithoutAgentAndEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "x", "o", "y", "d", "r", "f", "F")
 
 	for _, parts := range [][]string{
 		appendParts(base, upDown, arrow, actions),
 		appendParts(base, upDown, arrow, actionsWithoutEffort),
 		appendParts(base, arrow, actionsWithoutEffort),
-		appendParts(base, arrow, actions),
+		appendParts(base, upDown, arrow, actionsWithoutAgentAndEffort),
+		appendParts(base, arrow, actionsWithoutAgentAndEffort),
 		appendParts(base, arrow, coreActions),
 		appendParts(arrow, coreActions),
 		appendParts(coreActions),

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1217,8 +1217,9 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 					actions = append(actions, autoHint)
 				}
 			}
-			actions = append(actions, shortcutHint{Key: "A", Label: flowAgentShortcutLabel(sp.FlowAgentLabel)})
-			if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); effortLabel != "" {
+			agentLabel, agentConfigured := flowAgentShortcut(sp.FlowAgentLabel)
+			actions = append(actions, shortcutHint{Key: "A", Label: agentLabel})
+			if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); agentConfigured && effortLabel != "" {
 				actions = append(actions, shortcutHint{Key: "E", Label: effortLabel})
 			}
 		}
@@ -1262,12 +1263,14 @@ func flowAutoModeShortcutHint(enabled bool) shortcutHint {
 	return shortcutHint{Key: "m", Label: "auto: off"}
 }
 
-func flowAgentShortcutLabel(value string) string {
+const flowChooseAgentLabel = "choose agent"
+
+func flowAgentShortcut(value string) (string, bool) {
 	value = strings.TrimSpace(value)
-	if value == "" {
-		return "choose agent"
+	if value == "" || value == flowChooseAgentLabel {
+		return flowChooseAgentLabel, false
 	}
-	return value
+	return value, true
 }
 
 func shortcutsMuted(sp statusBarParams) bool {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1217,11 +1217,11 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 					actions = append(actions, autoHint)
 				}
 			}
-			agentLabel, agentConfigured := flowAgentShortcut(sp.FlowAgentLabel)
-			actions = append(actions, shortcutHint{Key: "A", Label: agentLabel})
-			if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); agentConfigured && effortLabel != "" {
-				actions = append(actions, shortcutHint{Key: "E", Label: effortLabel})
-			}
+		}
+		agentLabel, agentConfigured := flowAgentShortcut(sp.FlowAgentLabel)
+		actions = append(actions, shortcutHint{Key: "A", Label: agentLabel})
+		if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); agentConfigured && effortLabel != "" {
+			actions = append(actions, shortcutHint{Key: "E", Label: effortLabel})
 		}
 	}
 	if sp.ActivePane == 1 && sp.Mode != ModeWorktrees && sp.Mode != ModeBranches {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -283,6 +283,7 @@ type RenderParams struct {
 	SelectedFlowPhaseID         string
 	FlowHeadless                bool
 	FlowAutoModeSelected        bool
+	FlowAgentLabel              string
 	FlowReasoningEffort         string
 	FlowPhaseLaunchReady        bool
 	FlowPhaseResetReadySelected bool
@@ -498,6 +499,7 @@ func renderApplication(p RenderParams) string {
 		FlowPlanLinked:              flowPlanLinked,
 		FlowHeadless:                p.FlowHeadless,
 		FlowAutoModeSelected:        flowAutoModeSelected,
+		FlowAgentLabel:              p.FlowAgentLabel,
 		FlowReasoningEffort:         p.FlowReasoningEffort,
 		FlowPhaseLaunchReady:        p.FlowPhaseLaunchReady,
 		FlowPhaseResetReadySelected: p.FlowPhaseResetReadySelected,
@@ -757,6 +759,7 @@ type statusBarParams struct {
 	FlowPlanLinked              bool
 	FlowHeadless                bool
 	FlowAutoModeSelected        bool
+	FlowAgentLabel              string
 	FlowReasoningEffort         string
 	FlowPhaseLaunchReady        bool
 	FlowPhaseResetReadySelected bool
@@ -1039,8 +1042,10 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	global := []shortcutHint{
 		{Key: "tab", Label: "pane"},
 		{Key: "q/esc", Label: "quit"},
-		{Key: "A", Label: "set agent"},
 		{Key: "f5", Label: "refresh"},
+	}
+	if sp.Mode != ModeFlows {
+		global = slices.Insert(global, 2, shortcutHint{Key: "A", Label: "set agent"})
 	}
 
 	var actions []shortcutHint
@@ -1212,7 +1217,10 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 					actions = append(actions, autoHint)
 				}
 			}
-			actions = append(actions, shortcutHint{Key: "E", Label: flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort)})
+			actions = append(actions, shortcutHint{Key: "A", Label: flowAgentShortcutLabel(sp.FlowAgentLabel)})
+			if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); effortLabel != "" {
+				actions = append(actions, shortcutHint{Key: "E", Label: effortLabel})
+			}
 		}
 	}
 	if sp.ActivePane == 1 && sp.Mode != ModeWorktrees && sp.Mode != ModeBranches {
@@ -1254,15 +1262,20 @@ func flowAutoModeShortcutHint(enabled bool) shortcutHint {
 	return shortcutHint{Key: "m", Label: "auto: off"}
 }
 
+func flowAgentShortcutLabel(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "choose agent"
+	}
+	return value
+}
+
 func shortcutsMuted(sp statusBarParams) bool {
 	return (sp.Mode == ModeSessions || sp.Mode == ModeFlows) && sp.EmbeddedTerminalActive && !sp.EmbeddedTerminalPrefix
 }
 
 func flowReasoningEffortShortcutLabel(value string) string {
 	value = strings.TrimSpace(value)
-	if value == "" {
-		return "effort: default"
-	}
 	return value
 }
 
@@ -1416,7 +1429,7 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
 	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "d")
-	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "x", "o", "y", "d", "r", "E", "f", "F")
+	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "x", "o", "y", "d", "r", "A", "E", "f", "F")
 	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "x", "o", "y", "d", "r", "f", "F")
 
 	for _, parts := range [][]string{

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -504,13 +504,15 @@ func TestRender_FlowsModeShowsReasoningEffortShortcut(t *testing.T) {
 
 func TestRender_FlowsModeReasoningEffortShortcutHandlesSpecialLabels(t *testing.T) {
 	tests := []struct {
-		name   string
-		agent  string
-		effort string
-		want   string
+		name      string
+		agent     string
+		effort    string
+		want      string
+		wantNoKey string
 	}{
 		{name: "codex app", agent: "codex-app", effort: "app default", want: "A      codex-app\nE      app default"},
-		{name: "unset", agent: "choose agent", effort: "", want: "A      choose agent"},
+		{name: "unset", agent: "choose agent", effort: "", want: "A      choose agent", wantNoKey: "E"},
+		{name: "missing agent label", effort: "effort: high", want: "A      choose agent", wantNoKey: "E"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -528,8 +530,8 @@ func TestRender_FlowsModeReasoningEffortShortcutHandlesSpecialLabels(t *testing.
 			if !strings.Contains(pane, tt.want) {
 				t.Fatalf("flows shortcut pane should expose special labels %q:\n%s", tt.want, pane)
 			}
-			if tt.effort == "" && strings.Contains(pane, "E      ") {
-				t.Fatalf("flows shortcut pane should omit effort hint without configured agent:\n%s", pane)
+			if tt.wantNoKey != "" && strings.Contains(pane, tt.wantNoKey+"      ") {
+				t.Fatalf("flows shortcut pane should omit %s hint without configured agent:\n%s", tt.wantNoKey, pane)
 			}
 		})
 	}

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -891,6 +891,25 @@ func TestStatusBar_FlowsModeCompressedFooterDoesNotKeepEffortAfterDroppingAgent(
 	}
 }
 
+func TestStatusBar_FlowsModeCompressedFooterKeepsAgentWhenOnlyEffortIsDropped(t *testing.T) {
+	for width := 70; width <= 150; width++ {
+		bar := renderStatusBarWithState(statusBarParams{
+			Width:               width,
+			Mode:                ModeFlows,
+			ActivePane:          1,
+			RepoSelected:        true,
+			FlowSelected:        true,
+			FlowHeadless:        true,
+			FlowAgentLabel:      "codex",
+			FlowReasoningEffort: "effort: high",
+		})
+		if strings.Contains(bar, "A: codex") && !strings.Contains(bar, "E: effort: high") {
+			return
+		}
+	}
+	t.Fatal("compressed Flow footer never kept the agent hint while dropping only effort")
+}
+
 func TestStatusBar_FlowsModeNarrowFooterPreservesDeleteSafetyHints(t *testing.T) {
 	readOnly := renderStatusBarWithState(statusBarParams{
 		Width:        80,

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -486,25 +486,34 @@ func TestRender_FlowsModeShowsReasoningEffortShortcut(t *testing.T) {
 		Height:              12,
 		Mode:                ModeFlows,
 		ActivePane:          1,
-		FlowReasoningEffort: "codex effort: high",
+		FlowAgentLabel:      "codex",
+		FlowReasoningEffort: "effort: high",
 	})
 
 	pane := shortcutPaneText(view)
-	if !strings.Contains(pane, "E      codex effort: high") {
-		t.Fatalf("flows shortcut pane should expose reasoning effort:\n%s", pane)
+	if !strings.Contains(pane, "A      codex\nE      effort: high") {
+		t.Fatalf("flows shortcut pane should group agent before reasoning effort:\n%s", pane)
+	}
+	if strings.Contains(pane, "A      set agent") {
+		t.Fatalf("flows shortcut pane should not show generic set-agent label:\n%s", pane)
+	}
+	if strings.Contains(pane, "E      codex effort: high") {
+		t.Fatalf("flows shortcut pane should not duplicate agent in effort label:\n%s", pane)
 	}
 }
 
 func TestRender_FlowsModeReasoningEffortShortcutHandlesSpecialLabels(t *testing.T) {
 	tests := []struct {
+		name   string
+		agent  string
 		effort string
 		want   string
 	}{
-		{effort: "codex-app default", want: "codex-app default"},
-		{effort: "choose agent", want: "choose agent"},
+		{name: "codex app", agent: "codex-app", effort: "app default", want: "A      codex-app\nE      app default"},
+		{name: "unset", agent: "choose agent", effort: "", want: "A      choose agent"},
 	}
 	for _, tt := range tests {
-		t.Run(tt.effort, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			view := Render(RenderParams{
 				Repos:               []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
 				Selected:            0,
@@ -512,10 +521,15 @@ func TestRender_FlowsModeReasoningEffortShortcutHandlesSpecialLabels(t *testing.
 				Height:              12,
 				Mode:                ModeFlows,
 				ActivePane:          1,
+				FlowAgentLabel:      tt.agent,
 				FlowReasoningEffort: tt.effort,
 			})
-			if pane := shortcutPaneText(view); !strings.Contains(pane, "E      "+tt.want) {
-				t.Fatalf("flows shortcut pane should expose effort %q as %q:\n%s", tt.effort, tt.want, pane)
+			pane := shortcutPaneText(view)
+			if !strings.Contains(pane, tt.want) {
+				t.Fatalf("flows shortcut pane should expose special labels %q:\n%s", tt.want, pane)
+			}
+			if tt.effort == "" && strings.Contains(pane, "E      ") {
+				t.Fatalf("flows shortcut pane should omit effort hint without configured agent:\n%s", pane)
 			}
 		})
 	}
@@ -834,6 +848,43 @@ func TestStatusBar_FlowsModeNarrowFooterShowsEnterWithHeadlessHint(t *testing.T)
 	for _, notWant := range []string{"x: phases", "a: launch phase", "i: embed phase"} {
 		if strings.Contains(bar, notWant) {
 			t.Fatalf("narrow Flow footer should not include %q: %q", notWant, bar)
+		}
+	}
+}
+
+func TestStatusBar_FlowsModeFooterGroupsAgentAndEffort(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:               180,
+		Mode:                ModeFlows,
+		ActivePane:          1,
+		RepoSelected:        true,
+		FlowAgentLabel:      "codex",
+		FlowReasoningEffort: "effort: high",
+	})
+	agentIndex := strings.Index(bar, "A: codex")
+	effortIndex := strings.Index(bar, "E: effort: high")
+	if agentIndex < 0 || effortIndex < 0 || agentIndex > effortIndex {
+		t.Fatalf("Flow footer should group agent before effort, got %q", bar)
+	}
+	if strings.Contains(bar, "A: set agent") || strings.Contains(bar, "E: codex effort: high") {
+		t.Fatalf("Flow footer should not show generic or duplicated labels, got %q", bar)
+	}
+}
+
+func TestStatusBar_FlowsModeCompressedFooterDoesNotKeepEffortAfterDroppingAgent(t *testing.T) {
+	for width := 70; width <= 150; width++ {
+		bar := renderStatusBarWithState(statusBarParams{
+			Width:               width,
+			Mode:                ModeFlows,
+			ActivePane:          1,
+			RepoSelected:        true,
+			FlowSelected:        true,
+			FlowHeadless:        true,
+			FlowAgentLabel:      "codex",
+			FlowReasoningEffort: "effort: high",
+		})
+		if strings.Contains(bar, "E: effort: high") && !strings.Contains(bar, "A: codex") {
+			t.Fatalf("compressed Flow footer width %d should not keep effort after dropping agent, got %q", width, bar)
 		}
 	}
 }

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -873,6 +873,24 @@ func TestStatusBar_FlowsModeFooterGroupsAgentAndEffort(t *testing.T) {
 	}
 }
 
+func TestStatusBar_FlowsModeFooterShowsAgentOutsideFlowPane(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:               180,
+		Mode:                ModeFlows,
+		ActivePane:          0,
+		FlowAgentLabel:      "codex",
+		FlowReasoningEffort: "effort: high",
+	})
+	agentIndex := strings.Index(bar, "A: codex")
+	effortIndex := strings.Index(bar, "E: effort: high")
+	if agentIndex < 0 || effortIndex < 0 || agentIndex > effortIndex {
+		t.Fatalf("Flow footer should show grouped agent and effort outside Flow pane, got %q", bar)
+	}
+	if strings.Contains(bar, "A: set agent") {
+		t.Fatalf("Flow footer should not fall back to generic agent hint, got %q", bar)
+	}
+}
+
 func TestStatusBar_FlowsModeCompressedFooterDoesNotKeepEffortAfterDroppingAgent(t *testing.T) {
 	for width := 70; width <= 150; width++ {
 		bar := renderStatusBarWithState(statusBarParams{


### PR DESCRIPTION
## Summary
- show the selected Flow agent on the `A` shortcut instead of the generic set-agent label
- keep reasoning effort as a separate `E` hint without duplicating the agent name
- omit the effort hint until an agent is configured so compressed footers do not separate effort from its agent context

## Testing
- make test
- make build