### PR TITLE
Use default agent settings for Flow launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,8 @@ runtime-only embedded terminal inside the flows pane. Press `h` to choose the
 CLI command mode: headless runs `codex exec` or `claude --print`, while
 headless off runs interactive `codex` or `claude` in the same embedded Flow
 terminal. The same command mode applies to the initial Plan launch when creating
-a new Flow. Press
+a new Flow. Manual phase launches, auto-launched phases, and new Flow Plan
+launches all use the configured agent and that agent's configured effort. Press
 `E` to choose the selected CLI agent's reasoning effort; the shortcut pane shows
 the current value. Codex CLI launches use `--config
 model_reasoning_effort=<effort>`, Claude launches use `--effort <effort>`, and

--- a/docs/config.md
+++ b/docs/config.md
@@ -317,8 +317,10 @@ inside the flows pane. Press `h` to choose the CLI command mode: headless runs
 `claude` in the same embedded Flow terminal. The same command mode applies to
 the initial Plan launch when creating a new Flow. Press `E` to choose the
 configured CLI agent's reasoning effort for future launches; the shortcut pane
-shows the current value. `codex-app` remains URL/deep-link based, launches
-externally, and uses app-side/default reasoning. Press `r` to resume an attached
+shows the current value. Manual phase launches, auto-launched phases, and new
+Flow Plan launches all use the configured agent and that agent's configured
+effort. `codex-app` remains URL/deep-link based, launches externally, and uses
+app-side/default reasoning. Press `r` to resume an attached
 provider session from the selected phase row; CLI resumes open in runtime-only
 embedded PTYs in the flows pane, while `codex-app` resumes navigate externally.
 While a Flow terminal is open, `tab` switches focus between the Flow list and

--- a/model/model.go
+++ b/model/model.go
@@ -539,6 +539,11 @@ func (m Model) launchReasoningEffortFor(command string) string {
 	}
 }
 
+func (m Model) flowLaunchAgentSettings() (string, string) {
+	command := agent.Normalize(m.agentCommand)
+	return command, m.launchReasoningEffortFor(command)
+}
+
 func (m Model) flowReasoningEffortLabel() string {
 	command := agent.Normalize(m.agentCommand)
 	switch command {

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -459,14 +459,15 @@ func (m Model) createFlowAndLaunchPlan(title, instructions, baseRef string) tea.
 	if !ok {
 		return nil
 	}
+	command, reasoningEffort := m.flowLaunchAgentSettings()
 	return func() tea.Msg {
 		result, err := m.startFlowPlan(FlowStartRequest{
 			RepoPath:         repoPath,
 			Title:            title,
 			Instructions:     instructions,
 			BaseRef:          baseRef,
-			AgentCommand:     m.agentCommand,
-			ReasoningEffort:  m.launchReasoningEffortFor(m.agentCommand),
+			AgentCommand:     command,
+			ReasoningEffort:  reasoningEffort,
 			SessionStateRoot: m.sessionStateRoot,
 			PlanPhaseID:      flowPlanPhaseID,
 			PlanPhaseTitle:   "Plan",

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -146,7 +146,7 @@ func autoLaunchCommandFromFlowRefresh(t *testing.T, previous, current flowstore.
 	return cmd, &updates
 }
 
-func TestModel_FlowAutoLaunchUsesDefaultCLIAgentAndEffort(t *testing.T) {
+func TestModel_FlowAutoLaunchUsesConfiguredCLIAgentAndEffort(t *testing.T) {
 	previous := autoFlowWithPhaseStatuses(map[string]string{
 		"plan":           flowstore.PhaseCompleted,
 		"plan-review":    flowstore.PhaseRunning,
@@ -199,6 +199,90 @@ func TestModel_FlowAutoLaunchUsesDefaultCLIAgentAndEffort(t *testing.T) {
 		!launch.LaunchContext.Headless ||
 		!launch.LaunchContext.FlowLaunchTracked {
 		t.Fatalf("auto launch context = %#v", launch.LaunchContext)
+	}
+}
+
+func TestModel_FlowAutoLaunchWithCodexAppUsesExternalRouteWithoutEffort(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	var launchUpdate flowstore.PhaseLaunchUpdate
+	var launched actions.AgentLaunchContext
+	startEmbeddedRan := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:         "codex-app",
+		CodexReasoningEffort: "high",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			launchUpdate = update
+			launched := current
+			for i := range launched.Phases {
+				if launched.Phases[i].PhaseID == update.PhaseID {
+					launched.Phases[i].Status = flowstore.PhaseRunning
+					launched.Phases[i].LaunchIDs = append(launched.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return launched, nil
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launched = ctx
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			startEmbeddedRan = true
+			return &fakeEmbeddedTerminal{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+
+	m, cmd := update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd == nil {
+		t.Fatal("Flow refresh should return auto-launch command")
+	}
+	msg := cmd()
+	launchMsg, ok := msg.(model.PlanLaunchRequestedMsg)
+	if !ok {
+		t.Fatalf("auto-launch command returned %T, want PlanLaunchRequestedMsg", msg)
+	}
+	if !launchUpdate.AutoLaunch || launchUpdate.FlowID != "flow-1" || launchUpdate.PhaseID != "implementation" || launchUpdate.LaunchID == "" {
+		t.Fatalf("auto launch update = %#v", launchUpdate)
+	}
+	if launchMsg.LaunchContext.Command != "codex-app" ||
+		launchMsg.LaunchContext.ReasoningEffort != "" ||
+		launchMsg.LaunchContext.FlowID != "flow-1" ||
+		launchMsg.LaunchContext.FlowPhaseID != "implementation" ||
+		launchMsg.LaunchContext.Embedded ||
+		launchMsg.LaunchContext.Headless ||
+		launchMsg.LaunchContext.FlowLaunchTracked {
+		t.Fatalf("codex-app auto launch context = %#v", launchMsg.LaunchContext)
+	}
+
+	_, cmd = update(m, launchMsg)
+	if cmd == nil {
+		t.Fatal("expected external codex-app agent result command")
+	}
+	_ = cmd()
+	if startEmbeddedRan {
+		t.Fatal("codex-app auto launch should not start an embedded terminal")
+	}
+	if launched.Command != "codex-app" ||
+		launched.ReasoningEffort != "" ||
+		launched.FlowID != "flow-1" ||
+		launched.FlowPhaseID != "implementation" ||
+		launched.Embedded ||
+		launched.Headless ||
+		launched.FlowLaunchTracked {
+		t.Fatalf("codex-app external launch context = %#v", launched)
 	}
 }
 
@@ -5819,7 +5903,7 @@ func TestModel_NewFlowDelegatesStartAndLaunchesPlanAgent(t *testing.T) {
 	}
 }
 
-func TestModel_NewFlowLaunchNormalizesDefaultAgentCommandForPlanAndTerminal(t *testing.T) {
+func TestModel_NewFlowLaunchNormalizesConfiguredAgentCommandForPlanAndTerminal(t *testing.T) {
 	var startRequest model.FlowStartRequest
 	var started actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -146,6 +146,62 @@ func autoLaunchCommandFromFlowRefresh(t *testing.T, previous, current flowstore.
 	return cmd, &updates
 }
 
+func TestModel_FlowAutoLaunchUsesDefaultCLIAgentAndEffort(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	var launchUpdate flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:          "claude",
+		ClaudeReasoningEffort: "max",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			launchUpdate = update
+			launched := current
+			for i := range launched.Phases {
+				if launched.Phases[i].PhaseID == update.PhaseID {
+					launched.Phases[i].Status = flowstore.PhaseRunning
+					launched.Phases[i].LaunchIDs = append(launched.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return launched, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+
+	_, cmd := update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd == nil {
+		t.Fatal("Flow refresh should return auto-launch command")
+	}
+	msg := cmd()
+	launch, ok := msg.(model.FlowEmbeddedLaunchRequestedMsg)
+	if !ok {
+		t.Fatalf("auto-launch command returned %T, want FlowEmbeddedLaunchRequestedMsg", msg)
+	}
+	if !launchUpdate.AutoLaunch || launchUpdate.FlowID != "flow-1" || launchUpdate.PhaseID != "implementation" || launchUpdate.LaunchID == "" {
+		t.Fatalf("auto launch update = %#v", launchUpdate)
+	}
+	if launch.LaunchContext.Command != "claude" ||
+		launch.LaunchContext.ReasoningEffort != "max" ||
+		launch.LaunchContext.FlowID != "flow-1" ||
+		launch.LaunchContext.FlowPhaseID != "implementation" ||
+		!launch.LaunchContext.Embedded ||
+		!launch.LaunchContext.Headless ||
+		!launch.LaunchContext.FlowLaunchTracked {
+		t.Fatalf("auto launch context = %#v", launch.LaunchContext)
+	}
+}
+
 func phaseByID(record flowstore.FlowRecord, phaseID string) flowstore.FlowPhase {
 	for _, phase := range record.Phases {
 		if phase.PhaseID == phaseID {
@@ -1212,9 +1268,9 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesThatPhaseByDefaultHeadless(t *tes
 	var started actions.AgentLaunchContext
 	launchAgentRan := false
 	m := model.NewWithOptions(testRepos(), model.Options{
-		AgentCommand:         "codex",
-		CodexReasoningEffort: "high",
-		SessionStateRoot:     "/state/wtui/sessions/v1",
+		AgentCommand:          "claude",
+		ClaudeReasoningEffort: "max",
+		SessionStateRoot:      "/state/wtui/sessions/v1",
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
 			launchUpdate = update
 			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
@@ -1258,6 +1314,9 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesThatPhaseByDefaultHeadless(t *tes
 	}
 	if started.FlowPhaseID != "review-loop" || launchUpdate.PhaseID != "review-loop" {
 		t.Fatalf("selected-phase launch started %#v with update %#v, want review-loop", started, launchUpdate)
+	}
+	if started.Command != "claude" || started.ReasoningEffort != "max" {
+		t.Fatalf("selected-phase launch agent settings = command %q effort %q, want claude/max", started.Command, started.ReasoningEffort)
 	}
 	if !started.Embedded || !started.Headless || !started.FlowLaunchTracked {
 		t.Fatalf("selected-phase launch should be embedded, headless, and tracked: %#v", started)
@@ -3974,6 +4033,9 @@ func TestModel_EnterOnSelectedFlowPhaseWithCodexAppUsesExternalLaunchRoute(t *te
 	if launched.Command != "codex-app" || launched.FlowID != "flow-1" || launched.Headless || launched.Embedded {
 		t.Fatalf("codex-app launch context = %#v", launched)
 	}
+	if launched.ReasoningEffort != "" {
+		t.Fatalf("codex-app launch reasoning effort = %q, want empty", launched.ReasoningEffort)
+	}
 }
 
 func TestModel_EnterOnSelectedFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNeedsAttention(t *testing.T) {
@@ -5757,6 +5819,66 @@ func TestModel_NewFlowDelegatesStartAndLaunchesPlanAgent(t *testing.T) {
 	}
 }
 
+func TestModel_NewFlowLaunchNormalizesDefaultAgentCommandForPlanAndTerminal(t *testing.T) {
+	var startRequest model.FlowStartRequest
+	var started actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:          "codex",
+		ClaudeReasoningEffort: "max",
+		SessionStateRoot:      "/state/wtui/sessions/v1",
+		StartFlowPlan: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+			startRequest = req
+			return model.FlowStartResult{LaunchContext: actions.AgentLaunchContext{
+				Command:          req.AgentCommand,
+				LaunchID:         "launch-1",
+				RepoPath:         req.RepoPath,
+				WorktreePath:     "/dev/alpha-worktrees/flow-add-flow-mode",
+				Branch:           "flow/add-flow-mode",
+				SessionStateRoot: req.SessionStateRoot,
+				FlowID:           "flow-1",
+				FlowPhaseID:      req.PlanPhaseID,
+				ReasoningEffort:  req.ReasoningEffort,
+			}}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			t.Fatal("new Flow CLI launch should start an embedded terminal, not external launcher")
+			return actions.TerminalLaunchSpec{}, nil
+		},
+		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
+			started = ctx
+			return &fakeEmbeddedTerminal{state: "running"}, nil
+		},
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return nil, nil
+		},
+	})
+	m, _ = update(m, model.AgentSetMsg{Command: " CLAUDE "})
+	m = inRightPane(m)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 20})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+
+	m, cmd := submitNewFlowPrompts(t, m, "Add Flow Mode", "Build the thing", "main")
+	if cmd == nil {
+		t.Fatal("expected flow creation command")
+	}
+	msg := cmd()
+	launchMsg, ok := msg.(model.FlowEmbeddedLaunchRequestedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want FlowEmbeddedLaunchRequestedMsg", msg)
+	}
+	m, cmd = update(m, launchMsg)
+	if cmd == nil {
+		t.Fatal("expected embedded launch repaint/fetch command")
+	}
+
+	if startRequest.AgentCommand != "claude" || startRequest.ReasoningEffort != "max" {
+		t.Fatalf("start request agent settings = command %q effort %q, want claude/max", startRequest.AgentCommand, startRequest.ReasoningEffort)
+	}
+	if started.Command != "claude" || started.ReasoningEffort != "max" || !started.Embedded || !started.Headless {
+		t.Fatalf("embedded launch context = %#v, want normalized claude/max headless launch", started)
+	}
+}
+
 func TestModel_NewFlowCLIPlanLaunchHonorsHeadlessToggle(t *testing.T) {
 	for _, command := range []string{"codex", "claude"} {
 		t.Run(command, func(t *testing.T) {
@@ -5896,6 +6018,7 @@ func TestModel_NewFlowWithCodexAppUsesExternalLaunchRoute(t *testing.T) {
 		launched.PlanPhaseID != "plan" ||
 		launched.PlanPhaseTitle != "Plan" ||
 		launched.PlanPhaseStatus != flowstore.PhaseRunning ||
+		launched.ReasoningEffort != "" ||
 		launched.InitialPrompt == "" ||
 		launched.Embedded ||
 		launched.Headless ||

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1305,7 +1305,8 @@ func (m Model) handleLaunchSelectedFlowPhase() (tea.Model, tea.Cmd) {
 		return next, nil
 	}
 	launchID := newLaunchID()
-	switch agent.Normalize(next.agentCommand) {
+	command, _ := next.flowLaunchAgentSettings()
+	switch command {
 	case agent.CommandCodex, agent.CommandClaude:
 		return next, next.prepareFlowPhaseEmbeddedLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID, next.flowHeadless)
 	}
@@ -1345,7 +1346,8 @@ func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstor
 			continue
 		}
 		launchID := newLaunchID()
-		switch agent.Normalize(next.agentCommand) {
+		command, _ := next.flowLaunchAgentSettings()
+		switch command {
 		case agent.CommandCodex, agent.CommandClaude:
 			cmds = append(cmds, next.prepareAutoFlowPhaseEmbeddedLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID, next.flowHeadless))
 			continue
@@ -1603,9 +1605,10 @@ func (m Model) prepareFlowPhaseLaunchCmd(record flowstore.FlowRecord, phase flow
 		if persistedPhase, ok := flowPhaseByID(updated, phase.PhaseID); ok {
 			launchPhase = persistedPhase
 		}
+		command, reasoningEffort := m.flowLaunchAgentSettings()
 		return wrap(actions.AgentLaunchContext{
-			Command:          m.agentCommand,
-			ReasoningEffort:  m.launchReasoningEffortFor(m.agentCommand),
+			Command:          command,
+			ReasoningEffort:  reasoningEffort,
 			LaunchID:         launchID,
 			RepoPath:         repoPath,
 			WorktreePath:     worktreePath,


### PR DESCRIPTION
## Summary
- Route new Flow Plan launches, manual Flow phase launches, and auto-launched Flow phases through the configured default agent and that agent's configured effort.
- Keep `codex-app` Flow launches on the external deep-link path while CLI providers continue to use embedded terminals/headless mode as appropriate.
- Update README and config docs to describe the consistent Flow launch behavior.

## Implementation notes
- Added `flowLaunchAgentSettings` to centralize default-agent and reasoning-effort selection for Flow launches.
- Updated Plan creation, selected phase launch, and auto-launch paths to use that centralized selection.
- Expanded model tests for default Claude/Codex/codex-app launch behavior, Flow Plan launch behavior, and auto-launch coverage.

## Verification
- `gofmt -l .`
- `go test ./model`
- `make test`
- `make build`
