### PR TITLE
Update Flow phase launch shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ filter matches, or a load failure with details in the status bar.
 | `←`/`→`/`l` | Cycle through modes; use arrows or `l` in flows view because `h` toggles Flow headless/interactive command mode |
 | `h` | Cycle to the previous mode outside flows view; toggle Flow headless/interactive command mode in flows view |
 | `E` | Choose and persist reasoning effort for the selected CLI agent in flows view |
-| `enter` | Page diff in `less` (dirty worktree, dirty branch, stash, commit, or reflog entry), resume an inline worktree session, page a session transcript, expand/collapse plan or Flow phases, or launch the selected launchable Flow phase |
+| `enter` | Page diff in `less` (dirty worktree, dirty branch, stash, commit, or reflog entry), resume an inline worktree session, page a session transcript, or expand/collapse plan or Flow phases |
+| `ctrl+enter` | Launch the next launchable phase for the selected Flow in flows view; supported terminals report this to Bubble Tea as `ctrl+j` |
 | `n` | Create a new worktree in worktrees view, a new branch in branches view, or a new Flow in flows view |
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
@@ -310,18 +311,21 @@ status message when the selected Flow has no linked plan. With destructive mode
 enabled (`D`), `d` deletes only the selected top-level Flow record under the
 Flow artifact store; it does not remove repositories, worktrees, branches,
 checked-out code, linked plans, sessions, transcripts, or active embedded
-terminals. Expanded phase rows cannot be deleted with this action. On an
-expanded phase row, `enter` launches the configured agent for that selected
-phase when it is ready, and it never falls back to another ready phase in the
-same Flow. Press `y` to copy the selected Flow ID, or the selected phase ID
-when a phase row is selected. Press `r` on an expanded phase row with an
+terminals. Expanded phase rows cannot be deleted with this action. On a Flow
+row or an expanded phase row, `enter` expands or collapses the phase list. Press
+`ctrl+enter` to launch the first launchable phase in the selected Flow's
+canonical phase order; in terminals this is the `ctrl+j` key event. This action
+uses the selected Flow, so a highlighted pending phase row can still launch an
+earlier ready sibling, and nothing is persisted when no phase is launchable.
+Press `y` to copy the selected Flow ID, or the selected phase ID when a phase
+row is selected. Press `r` on an expanded phase row with an
 attached provider session to resume that session; CLI resumes are recorded as a
 fresh Flow phase launch attempt, while `codex-app` resumes navigate to the
 existing app thread without extra launch tracking. Press `m` on a Flow row or
 expanded phase row to toggle per-Flow auto mode, which is off by default and
 persisted on that Flow record. When auto mode is on, a successful completed
 phase transition launches the next ready non-merge phase in that same Flow
-through the same path as pressing `enter`; skipped, blocked, needs-attention,
+through the same launch path as pressing `ctrl+enter`; skipped, blocked, needs-attention,
 failed-launch, or missing-PR-metadata states do not auto-launch. Automation
 stops before Merge: if Autoreview completes and Merge becomes ready, wtui keeps
 auto mode on and requires the existing manual Merge launch. Flow headless mode
@@ -372,7 +376,7 @@ still cannot be set through `wtui flow phase set`.
 
 Flows are task-centric workflow records stored beside sessions and plans under
 `<sessions root>/flows/<flow-id>/meta.json`. The TUI can create a new Flow and
-can record a launch for the selected ready phase; agents still perform normal
+can record a launch for the next launchable phase; agents still perform normal
 phase progression through the `wtui flow` CLI:
 
 ```bash
@@ -559,7 +563,7 @@ foundation fields for provider, launch, and agent settings.
 
 ### Agent session hooks
 
-CLI agents launched from wtui with `a`, `N`, Flow selected-phase `enter`, or
+CLI agents launched from wtui with `a`, `N`, Flow `ctrl+enter`, or
 session resume `r` are wired automatically: wtui passes Claude Code or Codex a
 session-end hook that calls the current wtui binary, and it exports `WTUI_*`
 metadata so hook records can be associated with the repo, worktree, branch, and

--- a/model/flow_delete_internal_test.go
+++ b/model/flow_delete_internal_test.go
@@ -1,0 +1,46 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/scanner"
+	"github.com/brian-bell/wtui/ui"
+)
+
+func TestConfirmFlowDeleteAllowsStalePhaseSelectionOnly(t *testing.T) {
+	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{})
+	m.mode = ui.ModeFlows
+	m.activePane = 1
+	m.destructive = true
+	m.flows = m.flows.SetItems([]flowstore.FlowRecord{{
+		FlowID:   "flow-1",
+		RepoPath: "/dev/alpha",
+		Title:    "Delete me",
+		Status:   flowstore.StatusPending,
+		Phases: []flowstore.FlowPhase{{
+			PhaseID: "plan",
+			Title:   "Plan",
+			Status:  flowstore.PhaseReady,
+		}},
+	}})
+	m.expandedFlowID = "flow-1"
+	m.selectedFlowPhaseID = "missing"
+
+	next, cmd := m.confirmFlowDelete()
+	if cmd != nil {
+		t.Fatalf("opening Flow delete confirm returned command %T, want nil", cmd)
+	}
+	if next.(Model).Overlay() != ui.OverlayConfirm {
+		t.Fatalf("stale selected phase overlay = %d, want confirm", next.(Model).Overlay())
+	}
+
+	m.selectedFlowPhaseID = "plan"
+	next, cmd = m.confirmFlowDelete()
+	if cmd != nil {
+		t.Fatalf("d on real selected Flow phase returned command %T, want nil", cmd)
+	}
+	if next.(Model).Overlay() != ui.OverlayNone {
+		t.Fatalf("real selected phase overlay = %d, want none", next.(Model).Overlay())
+	}
+}

--- a/model/model.go
+++ b/model/model.go
@@ -686,6 +686,7 @@ func (m Model) View() string {
 		FlowAutoModeSelected:        flowAutoModeSelected,
 		FlowReasoningEffort:         m.flowReasoningEffortLabel(),
 		FlowPhaseLaunchReady:        m.selectedFlowPhaseLaunchReady(),
+		FlowNextLaunchReady:         m.selectedFlowHasLaunchablePhase(),
 		FlowPhaseResetReadySelected: m.selectedFlowPhaseResettable(),
 		FlowPhaseResumableSelected:  m.selectedFlowPhaseResumable(),
 		OverlayText:                 modalView.Text,
@@ -1324,6 +1325,24 @@ func (m Model) selectedFlowPhaseLaunchReady() bool {
 	}
 	phase, ok := m.selectedFlowPhase()
 	return ok && flowPhaseCanLaunch(record, phase)
+}
+
+func (m Model) selectedFlowHasLaunchablePhase() bool {
+	_, _, ok := m.selectedFlowNextLaunchablePhase()
+	return ok
+}
+
+func (m Model) selectedFlowNextLaunchablePhase() (flowstore.FlowRecord, flowstore.FlowPhase, bool) {
+	record, ok := m.selectedFlow()
+	if !ok || record.FlowID == "" {
+		return flowstore.FlowRecord{}, flowstore.FlowPhase{}, false
+	}
+	for _, phase := range flowstore.OrderedPhases(record.Phases) {
+		if flowPhaseCanLaunch(record, phase) {
+			return record, phase, true
+		}
+	}
+	return flowstore.FlowRecord{}, flowstore.FlowPhase{}, false
 }
 
 func (m Model) selectedFlowPhaseResettable() bool {

--- a/model/model.go
+++ b/model/model.go
@@ -685,7 +685,6 @@ func (m Model) View() string {
 		FlowHeadless:                m.flowHeadless,
 		FlowAutoModeSelected:        flowAutoModeSelected,
 		FlowReasoningEffort:         m.flowReasoningEffortLabel(),
-		FlowPhaseLaunchReady:        m.selectedFlowPhaseLaunchReady(),
 		FlowNextLaunchReady:         m.selectedFlowHasLaunchablePhase(),
 		FlowPhaseResetReadySelected: m.selectedFlowPhaseResettable(),
 		FlowPhaseResumableSelected:  m.selectedFlowPhaseResumable(),
@@ -1316,15 +1315,6 @@ func (m Model) selectedFlowPhaseResumable() bool {
 		return false
 	}
 	return agent.Validate(agent.Normalize(strings.TrimSpace(session.Provider))) == nil
-}
-
-func (m Model) selectedFlowPhaseLaunchReady() bool {
-	record, ok := m.selectedFlow()
-	if !ok {
-		return false
-	}
-	phase, ok := m.selectedFlowPhase()
-	return ok && flowPhaseCanLaunch(record, phase)
 }
 
 func (m Model) selectedFlowHasLaunchablePhase() bool {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -221,7 +221,7 @@ func prepareSelectedFlowPhaseHeadlessOffLaunch(t *testing.T, m model.Model, phas
 	m = selectFlowPhaseByID(t, m, phaseID)
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
 	if cmd != nil {
-		t.Fatalf("h before selected Flow phase launch returned command %T, want nil", cmd)
+		t.Fatalf("h before Flow phase launch returned command %T, want nil", cmd)
 	}
 	m, cmd = update(m, flowCtrlEnterKey())
 	return m, cmd
@@ -230,7 +230,7 @@ func prepareSelectedFlowPhaseHeadlessOffLaunch(t *testing.T, m model.Model, phas
 func runPreparedFlowEmbeddedLaunch(t *testing.T, m model.Model, cmd tea.Cmd) model.Model {
 	t.Helper()
 	if cmd == nil {
-		t.Fatal("selected Flow phase launch should return a command")
+		t.Fatal("Flow phase launch should return a command")
 	}
 	msg := cmd()
 	launchMsg, ok := msg.(model.FlowEmbeddedLaunchRequestedMsg)
@@ -657,7 +657,7 @@ func TestModel_ResetShortcutHiddenAfterLegacyPhaseIDLaunchNormalizes(t *testing.
 
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	if started.FlowPhaseID != "implementation" {
@@ -1152,6 +1152,48 @@ func TestModel_FlowAutoModeIgnoresStaleFlowResults(t *testing.T) {
 	}
 }
 
+func TestModel_FlowAutoModeDoesNotLaunchAfterLeavingFlowsMode(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	var updates []flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			return current, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	request := m.ListRequest(ui.ModeFlows)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+
+	m, cmd := update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: request,
+	})
+	if cmd != nil {
+		t.Fatalf("accepted FlowResultMsg outside flows mode returned command %T, want nil", cmd)
+	}
+	if len(updates) != 0 {
+		t.Fatalf("launch updates = %#v, want none after leaving flows mode", updates)
+	}
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("Mode() = %d, want worktrees", m.Mode())
+	}
+	if got := m.Flows(); len(got) != 1 || phaseByID(got[0], "implementation").Status != flowstore.PhaseReady {
+		t.Fatalf("Flows() = %#v, want accepted refresh without auto launch", got)
+	}
+}
+
 func TestModel_StartsInFlowsModeAndFetchesSelectedRepoFlows(t *testing.T) {
 	var gotFilter flowstore.FlowFilter
 	want := []flowstore.FlowRecord{
@@ -1285,7 +1327,7 @@ func TestModel_CtrlEnterOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefault
 
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("ctrl+enter on selected Flow phase should prepare a headless launch")
+		t.Fatal("ctrl+enter should prepare a headless launch")
 	}
 	m, cmd = update(m, cmd())
 	if launchAgentRan {
@@ -1305,7 +1347,7 @@ func TestModel_CtrlEnterOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefault
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *testing.T) {
+func TestModel_CtrlEnterOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *testing.T) {
 	for _, command := range []string{"codex", "claude"} {
 		t.Run(command, func(t *testing.T) {
 			var launchUpdate flowstore.PhaseLaunchUpdate
@@ -1343,16 +1385,16 @@ func TestModel_EnterOnSelectedFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiv
 			m = selectFlowPhaseByID(t, m, "implementation")
 			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
 			if cmd != nil {
-				t.Fatalf("h before selected Flow phase launch returned command %T, want nil", cmd)
+				t.Fatalf("h before Flow phase launch returned command %T, want nil", cmd)
 			}
 
 			m, cmd = update(m, flowCtrlEnterKey())
 			if cmd == nil {
-				t.Fatal("ctrl+enter on selected Flow phase should prepare an embedded interactive launch")
+				t.Fatal("ctrl+enter should prepare an embedded interactive launch")
 			}
 			m, cmd = update(m, cmd())
 			if cmd == nil {
-				t.Fatal("expected embedded selected-phase launch to return repaint/fetch command")
+				t.Fatal("expected embedded Flow launch to return repaint/fetch command")
 			}
 			if started.Command != command ||
 				started.FlowID != "flow-1" ||
@@ -1364,7 +1406,7 @@ func TestModel_EnterOnSelectedFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiv
 				t.Fatalf("embedded launch context = %#v", started)
 			}
 			if !started.Embedded || started.Headless || !started.FlowLaunchTracked {
-				t.Fatalf("headless-off selected-phase launch should be embedded, interactive, and tracked: %#v", started)
+				t.Fatalf("headless-off Flow launch should be embedded, interactive, and tracked: %#v", started)
 			}
 			if started.LaunchID == "" || started.LaunchID != launchUpdate.LaunchID {
 				t.Fatalf("launch IDs = context %q update %#v", started.LaunchID, launchUpdate)
@@ -2102,7 +2144,7 @@ func TestModel_FlowDeleteDoesNotTerminateEmbeddedTerminal(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	for i := 0; i < 10 && m.SelectedFlowPhaseID() != ""; i++ {
@@ -2894,7 +2936,7 @@ func TestModel_RKeyOnFlowPhaseResumeStartFailureKeepsSkippedPhase(t *testing.T) 
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseLaunchesReadyPlanReviewWithLinkedPlanContext(t *testing.T) {
+func TestModel_CtrlEnterLaunchesFlowPhaseReadyPlanReviewWithLinkedPlanContext(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -2938,7 +2980,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesReadyPlanReviewWithLinkedPlanCont
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "plan-review")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare a plan-review launch")
+		t.Fatal("ctrl+enter should prepare a plan-review launch")
 	}
 	m = runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -3028,7 +3070,7 @@ func TestModel_FlowPlanReviewPromptTemplateOverridesBuiltInPrompt(t *testing.T) 
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "plan-review")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare a plan-review launch")
+		t.Fatal("ctrl+enter should prepare a plan-review launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -3038,7 +3080,7 @@ func TestModel_FlowPlanReviewPromptTemplateOverridesBuiltInPrompt(t *testing.T) 
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseLaunchesImplementationWithMinimalPrompt(t *testing.T) {
+func TestModel_CtrlEnterLaunchesFlowPhaseImplementationWithMinimalPrompt(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -3082,7 +3124,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesImplementationWithMinimalPrompt(t
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an implementation launch")
+		t.Fatal("ctrl+enter should prepare an implementation launch")
 	}
 	m = runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -3129,7 +3171,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesImplementationWithMinimalPrompt(t
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseLaunchesImplementationInEmbeddedHeadlessTerminalByDefault(t *testing.T) {
+func TestModel_CtrlEnterLaunchesFlowPhaseImplementationInEmbeddedHeadlessTerminalByDefault(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var started actions.AgentLaunchContext
 	var startWidth, startHeight int
@@ -3181,11 +3223,11 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesImplementationInEmbeddedHeadlessT
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded implementation launch")
+		t.Fatal("ctrl+enter should prepare an embedded implementation launch")
 	}
 	m, cmd = update(m, cmd())
 	if launchAgentRan {
-		t.Fatal("default headless enter should not call LaunchAgent for CLI providers")
+		t.Fatal("default headless ctrl+enter should not call LaunchAgent for CLI providers")
 	}
 	if cmd == nil {
 		t.Fatal("expected embedded launch to return repaint/fetch command")
@@ -3265,7 +3307,7 @@ func TestModel_FlowEmbeddedTerminalAutoClosesOnExitedTick(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, tickBatch := update(m, cmd())
 	if tickBatch == nil {
@@ -3318,7 +3360,7 @@ func TestModel_FlowEmbeddedTerminalAutoCloseKeepsRunningSessionTickAlive(t *test
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, flowTick := update(m, cmd())
 	if flowTick == nil {
@@ -3377,7 +3419,7 @@ func TestModel_FlowEmbeddedTerminalAutoClosePreservesExitedSessionTerminal(t *te
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, tickBatch := update(m, cmd())
 	if tickBatch == nil {
@@ -3448,7 +3490,7 @@ func TestModel_FlowEmbeddedTerminalAutoCloseRenumbersAndKeepsActiveFlowTerminal(
 		var cmd tea.Cmd
 		m, cmd = prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 		if cmd == nil {
-			t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+			t.Fatal("ctrl+enter should prepare an embedded launch")
 		}
 		var tickBatch tea.Cmd
 		m, tickBatch = update(m, cmd())
@@ -3522,7 +3564,7 @@ func TestModel_FlowEmbeddedTerminalAutoCloseKeepsCommandModeForPromotedTerminal(
 		var cmd tea.Cmd
 		m, cmd = prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 		if cmd == nil {
-			t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+			t.Fatal("ctrl+enter should prepare an embedded launch")
 		}
 		var nextTick tea.Cmd
 		m, nextTick = update(m, cmd())
@@ -3597,7 +3639,7 @@ func TestModel_FlowEmbeddedTerminalAutoCloseClearsStaleTerminateConfirm(t *testi
 		var cmd tea.Cmd
 		m, cmd = prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 		if cmd == nil {
-			t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+			t.Fatal("ctrl+enter should prepare an embedded launch")
 		}
 		var nextTick tea.Cmd
 		m, nextTick = update(m, cmd())
@@ -3658,7 +3700,7 @@ func TestModel_FlowEmbeddedTerminalTickKeepsFailedTerminalVisible(t *testing.T) 
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, tickBatch := update(m, cmd())
 	if tickBatch == nil {
@@ -3708,7 +3750,7 @@ func TestModel_FlowEmbeddedLaunchMarksActiveFlowAndPhaseRows(t *testing.T) {
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
@@ -3762,7 +3804,7 @@ func TestModel_FlowTerminalActivityFiltersActiveStates(t *testing.T) {
 			m = selectFlowPhaseByID(t, m, "implementation")
 			m, cmd := update(m, flowCtrlEnterKey())
 			if cmd == nil {
-				t.Fatal("ctrl+enter on selected Flow phase should prepare an embedded launch")
+				t.Fatal("ctrl+enter should prepare an embedded launch")
 			}
 			m, _ = update(m, cmd())
 			m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
@@ -3802,7 +3844,7 @@ func TestModel_DismissedFlowTerminalRemovesActiveMarker(t *testing.T) {
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
@@ -3861,7 +3903,7 @@ func TestModel_FlowTerminalActivityMatchesStructuredFlowAndPhaseIDs(t *testing.T
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
@@ -3904,7 +3946,7 @@ func TestModel_FlowEmbeddedTerminalResizesWhenSearchTogglesShortcutPane(t *testi
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -3991,7 +4033,7 @@ func TestModel_FlowEmbeddedTerminalTinyAllocationClampsPTYSize(t *testing.T) {
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -4005,7 +4047,7 @@ func TestModel_FlowEmbeddedTerminalTinyAllocationClampsPTYSize(t *testing.T) {
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseWithCodexAppUsesExternalLaunchRoute(t *testing.T) {
+func TestModel_CtrlEnterOnFlowPhaseWithCodexAppUsesExternalLaunchRoute(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	startEmbeddedRan := false
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -4037,7 +4079,7 @@ func TestModel_EnterOnSelectedFlowPhaseWithCodexAppUsesExternalLaunchRoute(t *te
 	m = selectFlowPhaseByID(t, m, "plan")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an external codex-app launch")
+		t.Fatal("ctrl+enter should prepare an external codex-app launch")
 	}
 	msg := cmd()
 	launchMsg, ok := msg.(model.PlanLaunchRequestedMsg)
@@ -4050,14 +4092,14 @@ func TestModel_EnterOnSelectedFlowPhaseWithCodexAppUsesExternalLaunchRoute(t *te
 	}
 	_ = cmd()
 	if startEmbeddedRan {
-		t.Fatal("codex-app selected-phase enter should not start an embedded terminal")
+		t.Fatal("codex-app ctrl+enter should not start an embedded terminal")
 	}
 	if launched.Command != "codex-app" || launched.FlowID != "flow-1" || launched.Headless || launched.Embedded {
 		t.Fatalf("codex-app launch context = %#v", launched)
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNeedsAttention(t *testing.T) {
+func TestModel_CtrlEnterFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNeedsAttention(t *testing.T) {
 	var phaseUpdate flowstore.PhaseUpdate
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -4086,7 +4128,7 @@ func TestModel_EnterOnSelectedFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNee
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -4135,7 +4177,7 @@ func TestModel_FlowTerminalFocusUsesPersistentCommandModeAndTabReturnsToList(t *
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -4187,7 +4229,7 @@ func TestModel_FlowEffortKeyDoesNotOpenPickerWhileFlowTerminalFocused(t *testing
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -4247,7 +4289,7 @@ func TestModel_FlowTerminalCommandModeCanEnterInputMode(t *testing.T) {
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -4290,7 +4332,7 @@ func TestModel_FlowTerminalInputModeForwardsCtrlGToAgent(t *testing.T) {
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -4333,7 +4375,7 @@ func TestModel_FlowTerminalCommandModeSendsLiteralCommandKey(t *testing.T) {
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -4363,7 +4405,7 @@ func TestModel_FlowTerminalTabLeavesFocusEvenAfterCommandKey(t *testing.T) {
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
@@ -4504,7 +4546,7 @@ func TestModel_FlowEmbeddedTerminalDismissRenumbersTabs(t *testing.T) {
 		var cmd tea.Cmd
 		m, cmd = prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 		if cmd == nil {
-			t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+			t.Fatal("ctrl+enter should prepare an embedded launch")
 		}
 		m, _ = update(m, cmd())
 	}
@@ -4556,7 +4598,7 @@ func TestModel_EmbeddedTerminalCloseUsesStableIdentityAcrossScopes(t *testing.T)
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	if view := m.View(); !strings.Contains(view, "1 codex implementation running") {
@@ -4606,7 +4648,7 @@ func TestModel_EmbeddedTerminalTerminateUsesStableIdentityAcrossScopes(t *testin
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -4663,7 +4705,7 @@ func TestModel_FlowListQuitWithRunningEmbeddedTerminalConfirmsAndTerminates(t *t
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -4703,7 +4745,7 @@ func TestModel_LeftPaneQuitWithRunningEmbeddedTerminalConfirms(t *testing.T) {
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -4717,7 +4759,7 @@ func TestModel_LeftPaneQuitWithRunningEmbeddedTerminalConfirms(t *testing.T) {
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseAtEmbeddedTerminalCapMarksPhaseNeedsAttention(t *testing.T) {
+func TestModel_CtrlEnterOnFlowPhaseAtEmbeddedTerminalCapMarksPhaseNeedsAttention(t *testing.T) {
 	var phaseUpdates []flowstore.PhaseUpdate
 	starts := 0
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -4859,7 +4901,7 @@ func TestModel_FlowSplitListScrollKeepsSelectionVisible(t *testing.T) {
 	m = selectFlowPhaseByID(t, m, "implementation")
 	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+		t.Fatal("ctrl+enter should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -4878,7 +4920,7 @@ func TestModel_FlowSplitListScrollKeepsSelectionVisible(t *testing.T) {
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseLaunchesImplementationWithoutLinkedPlanContext(t *testing.T) {
+func TestModel_CtrlEnterLaunchesFlowPhaseImplementationWithoutLinkedPlanContext(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -4916,7 +4958,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesImplementationWithoutLinkedPlanCo
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an implementation launch")
+		t.Fatal("ctrl+enter should prepare an implementation launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -4981,7 +5023,7 @@ func TestModel_FlowPromptTemplateReplacesSupportedPlaceholders(t *testing.T) {
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an implementation launch")
+		t.Fatal("ctrl+enter should prepare an implementation launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -5048,7 +5090,7 @@ func TestModel_CtrlEnterWithoutReadyFlowPhaseShowsNoLaunchableStatus(t *testing.
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseLaunchesReviewLoopWithFirstLevelPrompt(t *testing.T) {
+func TestModel_CtrlEnterLaunchesFlowPhaseReviewLoopWithFirstLevelPrompt(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -5093,7 +5135,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesReviewLoopWithFirstLevelPrompt(t 
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "review-loop")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare a review-loop launch")
+		t.Fatal("ctrl+enter should prepare a review-loop launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -5142,7 +5184,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesReviewLoopWithFirstLevelPrompt(t 
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseLaunchesPRCreationWithMinimalPrompt(t *testing.T) {
+func TestModel_CtrlEnterLaunchesFlowPhasePRCreationWithMinimalPrompt(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -5187,7 +5229,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesPRCreationWithMinimalPrompt(t *te
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "pr-creation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare a pr-creation launch")
+		t.Fatal("ctrl+enter should prepare a pr-creation launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -5223,7 +5265,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesPRCreationWithMinimalPrompt(t *te
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseLaunchesPRCreationWithStructuredMetadataPrompt(t *testing.T) {
+func TestModel_CtrlEnterLaunchesFlowPhasePRCreationWithStructuredMetadataPrompt(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -5262,7 +5304,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesPRCreationWithStructuredMetadataP
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "pr-creation")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare a pr-creation launch")
+		t.Fatal("ctrl+enter should prepare a pr-creation launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -5290,7 +5332,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesPRCreationWithStructuredMetadataP
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseLaunchesAutoreviewWithPRContext(t *testing.T) {
+func TestModel_CtrlEnterLaunchesFlowPhaseAutoreviewWithPRContext(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -5338,7 +5380,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesAutoreviewWithPRContext(t *testin
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "autoreview")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an autoreview launch")
+		t.Fatal("ctrl+enter should prepare an autoreview launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -5368,7 +5410,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesAutoreviewWithPRContext(t *testin
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseLaunchesAutoreviewWithRecoveryPrompt(t *testing.T) {
+func TestModel_CtrlEnterLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -5416,7 +5458,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesAutoreviewWithRecoveryPrompt(t *t
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "autoreview")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare an autoreview relaunch")
+		t.Fatal("ctrl+enter should prepare an autoreview relaunch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -5444,7 +5486,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesAutoreviewWithRecoveryPrompt(t *t
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseDoesNotRelaunchAutoreviewWithoutPRTarget(t *testing.T) {
+func TestModel_CtrlEnterDoesNotRelaunchFlowPhaseAutoreviewWithoutPRTarget(t *testing.T) {
 	var launchAttempted bool
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -5486,7 +5528,7 @@ func TestModel_EnterOnSelectedFlowPhaseDoesNotRelaunchAutoreviewWithoutPRTarget(
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseDoesNotRelaunchAutoreviewWhenPredecessorsAreUnsatisfied(t *testing.T) {
+func TestModel_CtrlEnterDoesNotRelaunchFlowPhaseAutoreviewWhenPredecessorsAreUnsatisfied(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
@@ -5532,7 +5574,7 @@ func TestModel_EnterOnSelectedFlowPhaseDoesNotRelaunchAutoreviewWhenPredecessors
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseLaunchesMergeWithStructuredReportingPrompt(t *testing.T) {
+func TestModel_CtrlEnterLaunchesFlowPhaseMergeWithStructuredReportingPrompt(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -5581,7 +5623,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesMergeWithStructuredReportingPromp
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "merge")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare a merge launch")
+		t.Fatal("ctrl+enter should prepare a merge launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -5605,7 +5647,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesMergeWithStructuredReportingPromp
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseUsesChildPhaseOrderingForReadyLaunch(t *testing.T) {
+func TestModel_CtrlEnterUsesFlowPhaseOrderingForReadyLaunch(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -5639,7 +5681,7 @@ func TestModel_EnterOnSelectedFlowPhaseUsesChildPhaseOrderingForReadyLaunch(t *t
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "implementation-api")
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare a child phase launch")
+		t.Fatal("ctrl+enter should prepare a child phase launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -212,7 +212,7 @@ func flowResultFromCommand(t *testing.T, cmd tea.Cmd) model.FlowResultMsg {
 func prepareSelectedFlowPhaseLaunch(t *testing.T, m model.Model, phaseID string) (model.Model, tea.Cmd) {
 	t.Helper()
 	m = selectFlowPhaseByID(t, m, phaseID)
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	return m, cmd
 }
 
@@ -223,7 +223,7 @@ func prepareSelectedFlowPhaseHeadlessOffLaunch(t *testing.T, m model.Model, phas
 	if cmd != nil {
 		t.Fatalf("h before selected Flow phase launch returned command %T, want nil", cmd)
 	}
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd = update(m, flowCtrlEnterKey())
 	return m, cmd
 }
 
@@ -248,8 +248,12 @@ func runPreparedFlowEmbeddedLaunch(t *testing.T, m model.Model, cmd tea.Cmd) mod
 func prepareSelectedFlowPhaseEmbeddedLaunch(t *testing.T, m model.Model, phaseID string) (model.Model, tea.Cmd) {
 	t.Helper()
 	m = selectFlowPhaseByID(t, m, phaseID)
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	return m, cmd
+}
+
+func flowCtrlEnterKey() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyCtrlJ}
 }
 
 func TestModel_MKeyTogglesFlowAutoModeFromFlowRow(t *testing.T) {
@@ -651,7 +655,7 @@ func TestModel_ResetShortcutHiddenAfterLegacyPhaseIDLaunchNormalizes(t *testing.
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{legacy})
 	m = selectFlowPhaseByID(t, m, "Implementation")
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -1207,7 +1211,41 @@ func TestModel_FlowPhasesCollapsedByDefaultAndToggleWithEnter(t *testing.T) {
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseLaunchesThatPhaseByDefaultHeadless(t *testing.T) {
+func TestModel_EnterOnSelectedFlowPhaseCollapsesWithoutLaunching(t *testing.T) {
+	addLaunchRan := false
+	launchAgentRan := false
+	startEmbeddedRan := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			addLaunchRan = true
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launchAgentRan = true
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			startEmbeddedRan = true
+			return &fakeEmbeddedTerminal{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
+	m = selectFlowPhaseByID(t, m, "implementation")
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("enter on selected Flow phase returned command %T, want nil", cmd)
+	}
+	if m.ExpandedFlowID() != "" || m.SelectedFlowPhaseID() != "" {
+		t.Fatalf("enter on selected Flow phase should collapse and clear phase selection, got expanded=%q phase=%q", m.ExpandedFlowID(), m.SelectedFlowPhaseID())
+	}
+	if addLaunchRan || launchAgentRan || startEmbeddedRan {
+		t.Fatalf("enter on selected Flow phase launched: add=%v launch=%v embedded=%v", addLaunchRan, launchAgentRan, startEmbeddedRan)
+	}
+}
+
+func TestModel_CtrlEnterOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHeadless(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var started actions.AgentLaunchContext
 	launchAgentRan := false
@@ -1245,22 +1283,22 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesThatPhaseByDefaultHeadless(t *tes
 	}})
 	m = selectFlowPhaseByID(t, m, "review-loop")
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter on selected Flow phase should prepare a headless launch")
+		t.Fatal("ctrl+enter on selected Flow phase should prepare a headless launch")
 	}
 	m, cmd = update(m, cmd())
 	if launchAgentRan {
-		t.Fatal("default headless selected-phase launch should not call LaunchAgent for CLI providers")
+		t.Fatal("default headless Flow launch should not call LaunchAgent for CLI providers")
 	}
 	if cmd == nil {
-		t.Fatal("expected embedded selected-phase launch to return repaint/fetch command")
+		t.Fatal("expected embedded Flow launch to return repaint/fetch command")
 	}
-	if started.FlowPhaseID != "review-loop" || launchUpdate.PhaseID != "review-loop" {
-		t.Fatalf("selected-phase launch started %#v with update %#v, want review-loop", started, launchUpdate)
+	if started.FlowPhaseID != "implementation" || launchUpdate.PhaseID != "implementation" {
+		t.Fatalf("ctrl+enter launched %#v with update %#v, want first launchable implementation", started, launchUpdate)
 	}
 	if !started.Embedded || !started.Headless || !started.FlowLaunchTracked {
-		t.Fatalf("selected-phase launch should be embedded, headless, and tracked: %#v", started)
+		t.Fatalf("Flow launch should be embedded, headless, and tracked: %#v", started)
 	}
 	if started.LaunchID == "" || started.LaunchID != launchUpdate.LaunchID {
 		t.Fatalf("launch IDs = context %q update %#v", started.LaunchID, launchUpdate)
@@ -1308,9 +1346,9 @@ func TestModel_EnterOnSelectedFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiv
 				t.Fatalf("h before selected Flow phase launch returned command %T, want nil", cmd)
 			}
 
-			m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+			m, cmd = update(m, flowCtrlEnterKey())
 			if cmd == nil {
-				t.Fatal("enter on selected Flow phase should prepare an embedded interactive launch")
+				t.Fatal("ctrl+enter on selected Flow phase should prepare an embedded interactive launch")
 			}
 			m, cmd = update(m, cmd())
 			if cmd == nil {
@@ -1335,7 +1373,56 @@ func TestModel_EnterOnSelectedFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiv
 	}
 }
 
-func TestModel_EnterOnSelectedNonLaunchableFlowPhaseDoesNotFallBackToReadySibling(t *testing.T) {
+func TestModel_CtrlEnterOnSelectedNonLaunchableFlowPhaseLaunchesFirstReadySibling(t *testing.T) {
+	var launchUpdate flowstore.PhaseLaunchUpdate
+	var started actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			launchUpdate = update
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			t.Fatal("Flow CLI launch should start an embedded terminal, not LaunchAgent")
+			return actions.TerminalLaunchSpec{}, nil
+		},
+		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
+			started = ctx
+			return &fakeEmbeddedTerminal{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-selected",
+		Status:       flowstore.StatusInProgress,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhasePending, Order: 1},
+			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseReady, Order: 2},
+		},
+	}})
+	m = selectFlowPhaseByID(t, m, "implementation")
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("enter on pending selected Flow phase returned command %T, want nil", cmd)
+	}
+	if m.ExpandedFlowID() != "" || m.SelectedFlowPhaseID() != "" {
+		t.Fatalf("enter should collapse pending selected phase, got expanded=%q phase=%q", m.ExpandedFlowID(), m.SelectedFlowPhaseID())
+	}
+	m = selectFlowPhaseByID(t, m, "implementation")
+
+	m, cmd = update(m, flowCtrlEnterKey())
+	if cmd == nil {
+		t.Fatal("ctrl+enter should launch the first launchable sibling")
+	}
+	runPreparedFlowEmbeddedLaunch(t, m, cmd)
+	if launchUpdate.PhaseID != "review-loop" || started.FlowPhaseID != "review-loop" {
+		t.Fatalf("ctrl+enter launched update %#v context %#v, want review-loop", launchUpdate, started)
+	}
+}
+
+func TestModel_CtrlEnterWithNoLaunchableFlowPhaseDoesNotMutateOrLaunch(t *testing.T) {
 	addLaunchRan := false
 	launchAgentRan := false
 	startEmbeddedRan := false
@@ -1361,26 +1448,20 @@ func TestModel_EnterOnSelectedNonLaunchableFlowPhaseDoesNotFallBackToReadySiblin
 		Status:       flowstore.StatusInProgress,
 		Phases: []flowstore.FlowPhase{
 			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhasePending, Order: 1},
-			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseReady, Order: 2},
+			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhasePending, Order: 2},
 		},
 	}})
 	m = selectFlowPhaseByID(t, m, "implementation")
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd != nil {
-		t.Fatalf("enter on pending selected Flow phase returned command %T, want nil", cmd)
+		t.Fatalf("ctrl+enter without a launchable phase returned command %T, want nil", cmd)
 	}
 	if addLaunchRan || launchAgentRan || startEmbeddedRan {
-		t.Fatalf("selected non-launchable phase fell back to sibling: add=%v launch=%v embedded=%v", addLaunchRan, launchAgentRan, startEmbeddedRan)
+		t.Fatalf("ctrl+enter without launchable phase launched: add=%v launch=%v embedded=%v", addLaunchRan, launchAgentRan, startEmbeddedRan)
 	}
-	status := m.TransientError()
-	for _, want := range []string{"implementation", "pending"} {
-		if !strings.Contains(status, want) {
-			t.Fatalf("selected-phase status missing %q: %q", want, status)
-		}
-	}
-	if strings.Contains(status, "No ready Flow phase") || strings.Contains(status, "review-loop") {
-		t.Fatalf("selected-phase status should not describe sibling readiness: %q", status)
+	if got := m.TransientError(); got != "No launchable Flow phase" {
+		t.Fatalf("status = %q, want no-launchable message", got)
 	}
 }
 
@@ -3098,7 +3179,7 @@ func TestModel_EnterOnSelectedFlowPhaseLaunchesImplementationInEmbeddedHeadlessT
 	}})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded implementation launch")
 	}
@@ -3625,7 +3706,7 @@ func TestModel_FlowEmbeddedLaunchMarksActiveFlowAndPhaseRows(t *testing.T) {
 	}})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -3679,9 +3760,9 @@ func TestModel_FlowTerminalActivityFiltersActiveStates(t *testing.T) {
 			}})
 
 			m = selectFlowPhaseByID(t, m, "implementation")
-			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+			m, cmd := update(m, flowCtrlEnterKey())
 			if cmd == nil {
-				t.Fatal("enter on selected Flow phase should prepare an embedded launch")
+				t.Fatal("ctrl+enter on selected Flow phase should prepare an embedded launch")
 			}
 			m, _ = update(m, cmd())
 			m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
@@ -3719,7 +3800,7 @@ func TestModel_DismissedFlowTerminalRemovesActiveMarker(t *testing.T) {
 	}})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -3778,7 +3859,7 @@ func TestModel_FlowTerminalActivityMatchesStructuredFlowAndPhaseIDs(t *testing.T
 	})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -3821,7 +3902,7 @@ func TestModel_FlowEmbeddedTerminalResizesWhenSearchTogglesShortcutPane(t *testi
 		},
 	}})
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -3908,7 +3989,7 @@ func TestModel_FlowEmbeddedTerminalTinyAllocationClampsPTYSize(t *testing.T) {
 	m, _ = update(m, tea.WindowSizeMsg{Width: width, Height: height})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -3954,7 +4035,7 @@ func TestModel_EnterOnSelectedFlowPhaseWithCodexAppUsesExternalLaunchRoute(t *te
 	}})
 
 	m = selectFlowPhaseByID(t, m, "plan")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an external codex-app launch")
 	}
@@ -4003,7 +4084,7 @@ func TestModel_EnterOnSelectedFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNee
 	}})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -4052,7 +4133,7 @@ func TestModel_FlowTerminalFocusUsesPersistentCommandModeAndTabReturnsToList(t *
 	})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -4104,7 +4185,7 @@ func TestModel_FlowEffortKeyDoesNotOpenPickerWhileFlowTerminalFocused(t *testing
 		},
 	}})
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -4164,7 +4245,7 @@ func TestModel_FlowTerminalCommandModeCanEnterInputMode(t *testing.T) {
 	})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -4207,7 +4288,7 @@ func TestModel_FlowTerminalInputModeForwardsCtrlGToAgent(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -4250,7 +4331,7 @@ func TestModel_FlowTerminalCommandModeSendsLiteralCommandKey(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -4280,7 +4361,7 @@ func TestModel_FlowTerminalTabLeavesFocusEvenAfterCommandKey(t *testing.T) {
 	})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -4580,7 +4661,7 @@ func TestModel_FlowListQuitWithRunningEmbeddedTerminalConfirmsAndTerminates(t *t
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -4620,7 +4701,7 @@ func TestModel_LeftPaneQuitWithRunningEmbeddedTerminalConfirms(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -4658,7 +4739,7 @@ func TestModel_EnterOnSelectedFlowPhaseAtEmbeddedTerminalCapMarksPhaseNeedsAtten
 
 	for i := 0; i < 9; i++ {
 		var cmd tea.Cmd
-		m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+		m, cmd = update(m, flowCtrlEnterKey())
 		if cmd == nil {
 			t.Fatalf("launch %d should prepare an embedded launch", i+1)
 		}
@@ -4671,9 +4752,9 @@ func TestModel_EnterOnSelectedFlowPhaseAtEmbeddedTerminalCapMarksPhaseNeedsAtten
 		t.Fatalf("phase updates before cap = %#v, want none", phaseUpdates)
 	}
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
-		t.Fatal("enter at cap should still prepare a launch attempt")
+		t.Fatal("ctrl+enter at cap should still prepare a launch attempt")
 	}
 	m, _ = update(m, cmd())
 	if starts != 9 {
@@ -4776,7 +4857,7 @@ func TestModel_FlowSplitListScrollKeepsSelectionVisible(t *testing.T) {
 	m = flowsInRightPane(t, m, flows)
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd == nil {
 		t.Fatal("enter on selected Flow phase should prepare an embedded launch")
 	}
@@ -4933,12 +5014,12 @@ func TestModel_SelectedReadyFlowPhaseAdvertisesLaunchPhaseAction(t *testing.T) {
 
 	m = selectFlowPhaseByID(t, m, "implementation")
 	view = m.View()
-	if !strings.Contains(view, "launch phase") {
-		t.Fatalf("selected ready Flow phase should expose launch action:\n%s", view)
+	if !strings.Contains(view, "ctrl+enter") || !strings.Contains(view, "launch next") {
+		t.Fatalf("selected ready Flow phase should expose next launch action:\n%s", view)
 	}
 }
 
-func TestModel_EnterOnSelectedFlowPhaseExplainsWhyImplementationIsNotReady(t *testing.T) {
+func TestModel_CtrlEnterWithoutReadyFlowPhaseShowsNoLaunchableStatus(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: "codex"})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
 		FlowID:       "flow-1",
@@ -4954,19 +5035,16 @@ func TestModel_EnterOnSelectedFlowPhaseExplainsWhyImplementationIsNotReady(t *te
 		},
 	}})
 	m = selectFlowPhaseByID(t, m, "implementation")
-	if view := m.View(); strings.Contains(view, "launch phase") {
+	if view := m.View(); strings.Contains(view, "launch phase") || strings.Contains(view, "launch next") {
 		t.Fatalf("gated selected phase should not expose launch action:\n%s", view)
 	}
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd != nil {
 		t.Fatalf("not-ready flow launch returned command %T, want nil", cmd)
 	}
-	status := m.TransientError()
-	for _, want := range []string{"Implementation is not ready", "Plan Review", "changes_requested", "Clarify rollout steps"} {
-		if !strings.Contains(status, want) {
-			t.Fatalf("status missing %q: %q", want, status)
-		}
+	if status := m.TransientError(); status != "No launchable Flow phase" {
+		t.Fatalf("status = %q, want no-launchable message", status)
 	}
 }
 
@@ -5396,16 +5474,15 @@ func TestModel_EnterOnSelectedFlowPhaseDoesNotRelaunchAutoreviewWithoutPRTarget(
 	}})
 
 	m = selectFlowPhaseByID(t, m, "autoreview")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd != nil {
-		t.Fatal("enter on selected Flow phase should not launch blocked autoreview without PR metadata")
+		t.Fatal("ctrl+enter should not launch blocked autoreview without PR metadata")
 	}
 	if launchAttempted {
 		t.Fatal("LaunchAgent() ran without PR metadata")
 	}
-	wantErr := "Autoreview needs PR metadata; run `wtui flow pr set` after PR Creation records the PR target"
-	if got := m.TransientError(); got != wantErr {
-		t.Fatalf("status = %q, want %q", got, wantErr)
+	if got := m.TransientError(); got != "No launchable Flow phase" {
+		t.Fatalf("status = %q, want no-launchable message", got)
 	}
 }
 
@@ -5446,12 +5523,12 @@ func TestModel_EnterOnSelectedFlowPhaseDoesNotRelaunchAutoreviewWhenPredecessors
 	}})
 
 	m = selectFlowPhaseByID(t, m, "autoreview")
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd := update(m, flowCtrlEnterKey())
 	if cmd != nil {
-		t.Fatal("enter on selected Flow phase should not launch blocked autoreview while predecessors are unsatisfied")
+		t.Fatal("ctrl+enter should not launch blocked autoreview while predecessors are unsatisfied")
 	}
-	if got := m.TransientError(); !strings.Contains(got, "autoreview") || !strings.Contains(got, "blocked") {
-		t.Fatalf("status = %q, want selected autoreview blocked message", got)
+	if got := m.TransientError(); got != "No launchable Flow phase" {
+		t.Fatalf("status = %q, want no-launchable message", got)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1300,14 +1300,6 @@ func (m Model) handleOpenAgent() (tea.Model, tea.Cmd) {
 	return m.launchAgentAtPath(path)
 }
 
-func (m Model) handleLaunchSelectedFlowPhase() (tea.Model, tea.Cmd) {
-	target, ok, next := m.selectedFlowPhaseLaunchTarget()
-	if !ok {
-		return next, nil
-	}
-	return next.launchFlowPhaseTarget(target)
-}
-
 func (m Model) handleLaunchNextFlowPhase() (tea.Model, tea.Cmd) {
 	target, ok, next := m.selectedFlowNextLaunchTarget()
 	if !ok {
@@ -1424,22 +1416,6 @@ type flowPhaseLaunchTarget struct {
 	repoPath     string
 	worktreePath string
 	planPath     string
-}
-
-func (m Model) selectedFlowPhaseLaunchTarget() (flowPhaseLaunchTarget, bool, Model) {
-	record, ok := m.selectedFlow()
-	if !ok {
-		return flowPhaseLaunchTarget{}, false, m
-	}
-	phase, ok := m.selectedFlowPhase()
-	if !ok {
-		return flowPhaseLaunchTarget{}, false, m
-	}
-	if !flowPhaseCanLaunch(record, phase) {
-		m = m.setStatus(statusOther, flowPhaseNotLaunchableMessage(record, phase))
-		return flowPhaseLaunchTarget{}, false, m
-	}
-	return m.flowPhaseLaunchTarget(record, phase)
 }
 
 func (m Model) selectedFlowNextLaunchTarget() (flowPhaseLaunchTarget, bool, Model) {
@@ -1912,22 +1888,6 @@ func flowPhaseCanLaunch(record flowstore.FlowRecord, phase flowstore.FlowPhase) 
 		(phase.Status == flowstore.PhaseNeedsAttention || phase.Status == flowstore.PhaseBlocked) &&
 		flowstore.HasPRTarget(record.PR) &&
 		flowstore.PhasePredecessorsSatisfied(record, phase.PhaseID)
-}
-
-func flowPhaseNotLaunchableMessage(record flowstore.FlowRecord, phase flowstore.FlowPhase) string {
-	if phase.PhaseID == "autoreview" && flowAutoreviewMissingPRTarget(record) {
-		return "Autoreview needs PR metadata; run `wtui flow pr set` after PR Creation records the PR target"
-	}
-	if phase.PhaseID == "implementation" && phase.Status == flowstore.PhasePending {
-		if review, ok := flowPhaseByID(record, "plan-review"); ok {
-			return "Implementation is not ready; Plan Review is " + flowPhaseStatusDetail(review)
-		}
-	}
-	detail := flowPhaseStatusDetail(phase)
-	if phase.PhaseID == "" {
-		return "Selected Flow phase is not launchable; status is " + detail
-	}
-	return "Selected Flow phase " + phase.PhaseID + " is not launchable; status is " + detail
 }
 
 func flowPhaseStatusDetail(phase flowstore.FlowPhase) string {
@@ -2585,7 +2545,10 @@ func (m Model) confirmWorktreeDelete() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) confirmFlowDelete() (tea.Model, tea.Cmd) {
-	if m.mode != ui.ModeFlows || m.selectedFlowPhaseID != "" {
+	if m.mode != ui.ModeFlows {
+		return m, nil
+	}
+	if _, ok := m.selectedFlowPhase(); ok {
 		return m, nil
 	}
 	record, ok := m.selectedFlow()

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -395,6 +395,10 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModeFlows {
 			m = m.clearSelectedFlowPhase()
 		}
+	case "ctrl+j", "ctrl+enter":
+		if m.mode == ui.ModeFlows {
+			return m.handleLaunchNextFlowPhase()
+		}
 	case "enter":
 		return m.handleEnter()
 	case "n":
@@ -634,10 +638,7 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleFlowEnter() (tea.Model, tea.Cmd) {
-	if m.selectedFlowPhaseID == "" {
-		return m.handleToggleFlowPhases()
-	}
-	return m.handleLaunchSelectedFlowPhase()
+	return m.handleToggleFlowPhases()
 }
 
 func (m Model) handleToggleFlowHeadless() (tea.Model, tea.Cmd) {
@@ -1304,12 +1305,24 @@ func (m Model) handleLaunchSelectedFlowPhase() (tea.Model, tea.Cmd) {
 	if !ok {
 		return next, nil
 	}
-	launchID := newLaunchID()
-	switch agent.Normalize(next.agentCommand) {
-	case agent.CommandCodex, agent.CommandClaude:
-		return next, next.prepareFlowPhaseEmbeddedLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID, next.flowHeadless)
+	return next.launchFlowPhaseTarget(target)
+}
+
+func (m Model) handleLaunchNextFlowPhase() (tea.Model, tea.Cmd) {
+	target, ok, next := m.selectedFlowNextLaunchTarget()
+	if !ok {
+		return next, nil
 	}
-	return next, next.prepareFlowPhaseLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID)
+	return next.launchFlowPhaseTarget(target)
+}
+
+func (m Model) launchFlowPhaseTarget(target flowPhaseLaunchTarget) (tea.Model, tea.Cmd) {
+	launchID := newLaunchID()
+	switch agent.Normalize(m.agentCommand) {
+	case agent.CommandCodex, agent.CommandClaude:
+		return m, m.prepareFlowPhaseEmbeddedLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID, m.flowHeadless)
+	}
+	return m, m.prepareFlowPhaseLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID)
 }
 
 func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstore.FlowRecord) (Model, tea.Cmd) {
@@ -1424,6 +1437,15 @@ func (m Model) selectedFlowPhaseLaunchTarget() (flowPhaseLaunchTarget, bool, Mod
 	}
 	if !flowPhaseCanLaunch(record, phase) {
 		m = m.setStatus(statusOther, flowPhaseNotLaunchableMessage(record, phase))
+		return flowPhaseLaunchTarget{}, false, m
+	}
+	return m.flowPhaseLaunchTarget(record, phase)
+}
+
+func (m Model) selectedFlowNextLaunchTarget() (flowPhaseLaunchTarget, bool, Model) {
+	record, phase, ok := m.selectedFlowNextLaunchablePhase()
+	if !ok {
+		m = m.setStatus(statusOther, "No launchable Flow phase")
 		return flowPhaseLaunchTarget{}, false, m
 	}
 	return m.flowPhaseLaunchTarget(record, phase)

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1222,6 +1222,9 @@ func (m Model) handleFlowResult(msg FlowResultMsg) (Model, tea.Cmd) {
 	}
 	m = m.restoreExpandedFlowSelection(expandedFlowID, selectedFlowPhaseID)
 	m = m.clampSelectionsAfterFilter()
+	if m.mode != ui.ModeFlows {
+		return m, nil
+	}
 	return m.prepareAutoFlowPhaseLaunch(previousFlows, msg.Flows)
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -285,6 +285,7 @@ type RenderParams struct {
 	FlowAutoModeSelected        bool
 	FlowReasoningEffort         string
 	FlowPhaseLaunchReady        bool
+	FlowNextLaunchReady         bool
 	FlowPhaseResetReadySelected bool
 	FlowPhaseResumableSelected  bool
 	OverlayText                 string
@@ -454,7 +455,7 @@ func renderApplication(p RenderParams) string {
 	worktreeSessionSelected := p.Mode == ModeWorktrees && p.InlineWorktreeSessions && p.WorktreeSessionSelected >= 0 && p.WorktreeSessionSelected < len(p.WorktreeSessions)
 	selectedPlanPhaseID := scopedSelectedPlanPhaseID(p, planSelected)
 	selectedFlowPhaseID := scopedSelectedFlowPhaseID(p, flowSelected)
-	flowDeletableSelected := flowSelected && p.SelectedFlowPhaseID == ""
+	flowDeletableSelected := flowSelected && selectedFlowPhaseID == ""
 	if p.FlowTerminalFocused {
 		flowSelected = false
 		selectedFlowPhaseID = ""
@@ -500,6 +501,7 @@ func renderApplication(p RenderParams) string {
 		FlowAutoModeSelected:        flowAutoModeSelected,
 		FlowReasoningEffort:         p.FlowReasoningEffort,
 		FlowPhaseLaunchReady:        p.FlowPhaseLaunchReady,
+		FlowNextLaunchReady:         p.FlowNextLaunchReady,
 		FlowPhaseResetReadySelected: p.FlowPhaseResetReadySelected,
 		FlowPhaseResumableSelected:  p.FlowPhaseResumableSelected,
 		TransientError:              p.TransientError,
@@ -651,8 +653,12 @@ func scopedSelectedFlowPhaseID(p RenderParams, flowSelected bool) string {
 	if p.ExpandedFlowID != flow.FlowID {
 		return ""
 	}
+	wantPhaseID := artifacts.NormalizePhaseID(p.SelectedFlowPhaseID)
+	if wantPhaseID == "" {
+		return ""
+	}
 	for _, phase := range flowstore.OrderedPhases(flow.Phases) {
-		if phase.PhaseID == p.SelectedFlowPhaseID {
+		if artifacts.NormalizePhaseID(phase.PhaseID) == wantPhaseID {
 			return p.SelectedFlowPhaseID
 		}
 	}
@@ -759,6 +765,7 @@ type statusBarParams struct {
 	FlowAutoModeSelected        bool
 	FlowReasoningEffort         string
 	FlowPhaseLaunchReady        bool
+	FlowNextLaunchReady         bool
 	FlowPhaseResetReadySelected bool
 	FlowPhaseResumableSelected  bool
 	TransientError              string
@@ -1189,8 +1196,9 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 			if sp.FlowSelected {
 				autoHint := flowAutoModeShortcutHint(sp.FlowAutoModeSelected)
 				if sp.FlowPhaseSelected {
-					if sp.FlowPhaseLaunchReady {
-						actions = append(actions, shortcutHint{Key: "enter", Label: "launch phase"})
+					actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
+					if sp.FlowNextLaunchReady {
+						actions = append(actions, shortcutHint{Key: "ctrl+enter", Label: "launch next"})
 					}
 					if sp.FlowPhaseResetReadySelected {
 						actions = append(actions, shortcutHint{Key: "x", Label: "reset ready"})
@@ -1202,6 +1210,9 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 					actions = append(actions, autoHint)
 				} else {
 					actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
+					if sp.FlowNextLaunchReady {
+						actions = append(actions, shortcutHint{Key: "ctrl+enter", Label: "launch next"})
+					}
 					if sp.FlowPlanLinked {
 						actions = append(actions, shortcutHint{Key: "o", Label: "open"})
 					}
@@ -1415,9 +1426,9 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 	base := footerHintsForKeys(hints, "tab", "q/esc")
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
-	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "d")
-	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "x", "o", "y", "d", "r", "E", "f", "F")
-	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "x", "o", "y", "d", "r", "f", "F")
+	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "ctrl+enter", "d")
+	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "ctrl+enter", "x", "o", "y", "d", "r", "E", "f", "F")
+	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "ctrl+enter", "x", "o", "y", "d", "r", "f", "F")
 
 	for _, parts := range [][]string{
 		appendParts(base, upDown, arrow, actions),

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -284,7 +284,6 @@ type RenderParams struct {
 	FlowHeadless                bool
 	FlowAutoModeSelected        bool
 	FlowReasoningEffort         string
-	FlowPhaseLaunchReady        bool
 	FlowNextLaunchReady         bool
 	FlowPhaseResetReadySelected bool
 	FlowPhaseResumableSelected  bool
@@ -500,7 +499,6 @@ func renderApplication(p RenderParams) string {
 		FlowHeadless:                p.FlowHeadless,
 		FlowAutoModeSelected:        flowAutoModeSelected,
 		FlowReasoningEffort:         p.FlowReasoningEffort,
-		FlowPhaseLaunchReady:        p.FlowPhaseLaunchReady,
 		FlowNextLaunchReady:         p.FlowNextLaunchReady,
 		FlowPhaseResetReadySelected: p.FlowPhaseResetReadySelected,
 		FlowPhaseResumableSelected:  p.FlowPhaseResumableSelected,
@@ -764,7 +762,6 @@ type statusBarParams struct {
 	FlowHeadless                bool
 	FlowAutoModeSelected        bool
 	FlowReasoningEffort         string
-	FlowPhaseLaunchReady        bool
 	FlowNextLaunchReady         bool
 	FlowPhaseResetReadySelected bool
 	FlowPhaseResumableSelected  bool

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -543,7 +543,7 @@ func TestStatusBar_FlowsModeShowsPhaseToggleHintForSelectedFlow(t *testing.T) {
 	}
 }
 
-func TestStatusBar_FlowsModeShowsLaunchOnlyForLaunchableSelectedPhase(t *testing.T) {
+func TestStatusBar_FlowsModeShowsNextLaunchOnlyWhenFlowHasLaunchablePhase(t *testing.T) {
 	base := statusBarParams{
 		Width:        120,
 		Mode:         ModeFlows,
@@ -553,19 +553,19 @@ func TestStatusBar_FlowsModeShowsLaunchOnlyForLaunchableSelectedPhase(t *testing
 	}
 
 	flowRow := renderStatusBarWithState(base)
-	if strings.Contains(flowRow, "launch phase") {
+	if strings.Contains(flowRow, "launch next") {
 		t.Fatalf("Flow row should not expose launch action, got %q", flowRow)
 	}
 
 	base.FlowPhaseSelected = true
 	gated := renderStatusBarWithState(base)
-	if strings.Contains(gated, "launch phase") {
+	if strings.Contains(gated, "launch next") {
 		t.Fatalf("gated Flow phase should not expose launch action, got %q", gated)
 	}
 
-	base.FlowPhaseLaunchReady = true
+	base.FlowNextLaunchReady = true
 	ready := renderStatusBarWithState(base)
-	if !strings.Contains(ready, "enter: launch phase") {
+	if !strings.Contains(ready, "ctrl+enter: launch next") {
 		t.Fatalf("ready selected Flow phase should expose launch action, got %q", ready)
 	}
 	for _, notWant := range []string{"a: launch phase", "a: phase status", "i: embed phase"} {
@@ -580,7 +580,7 @@ func TestRender_FlowsModeShowsResumeShortcutForResumableSelectedPhase(t *testing
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
 		Selected: 0,
 		Width:    180,
-		Height:   12,
+		Height:   14,
 		Mode:     ModeFlows,
 		Flows: []flowstore.FlowRecord{{
 			FlowID: "flow-1",
@@ -612,7 +612,7 @@ func TestRender_FlowsModeShowsCopyPhaseIDShortcutForSelectedPhase(t *testing.T) 
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
 		Selected: 0,
 		Width:    180,
-		Height:   12,
+		Height:   16,
 		Mode:     ModeFlows,
 		Flows: []flowstore.FlowRecord{{
 			FlowID: "flow-1",
@@ -687,7 +687,7 @@ func TestRender_FlowsModeShowsResetShortcutForResettableSelectedPhase(t *testing
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
 		Selected: 0,
 		Width:    180,
-		Height:   12,
+		Height:   16,
 		Mode:     ModeFlows,
 		Flows: []flowstore.FlowRecord{{
 			FlowID: "flow-1",
@@ -723,7 +723,7 @@ func TestRender_FlowsModeShowsLaunchAndHeadlessShortcutForLaunchableSelectedPhas
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
 		Selected: 0,
 		Width:    180,
-		Height:   12,
+		Height:   16,
 		Mode:     ModeFlows,
 		Flows: []flowstore.FlowRecord{{
 			FlowID: "flow-1",
@@ -735,21 +735,21 @@ func TestRender_FlowsModeShowsLaunchAndHeadlessShortcutForLaunchableSelectedPhas
 				Status:  flowstore.PhaseReady,
 			}},
 		}},
-		ActivePane:           1,
-		FlowSelected:         0,
-		ExpandedFlowID:       "flow-1",
-		SelectedFlowPhaseID:  "implementation",
-		FlowPhaseLaunchReady: true,
-		FlowHeadless:         false,
+		ActivePane:          1,
+		FlowSelected:        0,
+		ExpandedFlowID:      "flow-1",
+		SelectedFlowPhaseID: "implementation",
+		FlowNextLaunchReady: true,
+		FlowHeadless:        false,
 	})
 
 	pane := shortcutPaneText(view)
-	for _, want := range []string{"enter  launch phase", "h      headless off", "y      copy phase id"} {
+	for _, want := range []string{"enter  phases", "ctrl+enter launch next", "h      headless off", "y      copy phase id"} {
 		if !strings.Contains(pane, want) {
 			t.Fatalf("launchable selected Flow phase shortcut pane missing %q:\n%s", want, pane)
 		}
 	}
-	for _, notWant := range []string{"x      phases", "a      launch phase", "i      embed phase", "y      copy id"} {
+	for _, notWant := range []string{"enter  launch phase", "x      phases", "a      launch phase", "i      embed phase", "y      copy id"} {
 		if strings.Contains(pane, notWant) {
 			t.Fatalf("launchable selected Flow phase shortcut pane should not include %q:\n%s", notWant, pane)
 		}
@@ -805,8 +805,8 @@ func TestRender_FlowsModeShowsDestructiveModeAndDeleteShortcuts(t *testing.T) {
 	stalePhase := destructive
 	stalePhase.ExpandedFlowID = "flow-1"
 	stalePhase.SelectedFlowPhaseID = "old-phase"
-	if pane := shortcutPaneText(Render(stalePhase)); strings.Contains(pane, "d      delete") {
-		t.Fatalf("stale non-empty Flow phase selection should not expose delete shortcut:\n%s", pane)
+	if pane := shortcutPaneText(Render(stalePhase)); !strings.Contains(pane, "d      delete") {
+		t.Fatalf("stale non-empty Flow phase selection should fall back to whole-flow delete shortcut:\n%s", pane)
 	}
 
 	terminalFocused := destructive
@@ -819,14 +819,15 @@ func TestRender_FlowsModeShowsDestructiveModeAndDeleteShortcuts(t *testing.T) {
 
 func TestStatusBar_FlowsModeNarrowFooterShowsEnterWithHeadlessHint(t *testing.T) {
 	bar := renderStatusBarWithState(statusBarParams{
-		Width:        80,
-		Mode:         ModeFlows,
-		ActivePane:   1,
-		RepoSelected: true,
-		FlowSelected: true,
-		FlowHeadless: true,
+		Width:               80,
+		Mode:                ModeFlows,
+		ActivePane:          1,
+		RepoSelected:        true,
+		FlowSelected:        true,
+		FlowHeadless:        true,
+		FlowNextLaunchReady: true,
 	})
-	for _, want := range []string{"←/→ pane/view", "h: headless on", "enter: phases"} {
+	for _, want := range []string{"h: headless on", "enter: phases", "ctrl+enter: launch next"} {
 		if !strings.Contains(bar, want) {
 			t.Fatalf("narrow Flow footer missing %q: %q", want, bar)
 		}

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -706,7 +706,6 @@ func TestRender_FlowsModeShowsResetShortcutForResettableSelectedPhase(t *testing
 		SelectedFlowPhaseID:         "implementation",
 		FlowPhaseResetReadySelected: true,
 		FlowPhaseResumableSelected:  false,
-		FlowPhaseLaunchReady:        false,
 	})
 
 	pane := shortcutPaneText(view)


### PR DESCRIPTION
## Summary
- move Flow phase launch to Ctrl+G so Enter can be reserved for expanding and collapsing Flow rows
- refresh Flow shortcut hints and README documentation to match the new behavior
- add regression coverage for Flow row expansion, launch shortcuts, and delete prompt behavior

## Verification
- gofmt -l .
- make test
- make build