### PR TITLE
Show Flow auto-mode shortcut

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1216,6 +1216,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 					if sp.FlowPhaseResumableSelected {
 						actions = append(actions, shortcutHint{Key: "r", Label: "resume"})
 					}
+					actions = append(actions, flowAutoModeShortcutHint(sp.FlowAutoModeSelected))
 				} else {
 					actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
 					if sp.FlowNextLaunchReady {
@@ -1228,6 +1229,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 					if sp.Destructive && sp.FlowDeletableSelected {
 						actions = append(actions, shortcutHint{Key: "d", Label: "delete", Warning: true})
 					}
+					actions = append(actions, flowAutoModeShortcutHint(sp.FlowAutoModeSelected))
 				}
 			}
 		}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1447,9 +1447,11 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
 	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "ctrl+enter", "d")
-	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "ctrl+enter", "x", "o", "y", "d", "r", "A", "E", "f", "F")
-	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "ctrl+enter", "x", "o", "y", "d", "r", "A", "f", "F")
-	actionsWithoutAgentAndEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "ctrl+enter", "x", "o", "y", "d", "r", "f", "F")
+	coreActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "ctrl+enter", "d", "m")
+	selectedActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "ctrl+enter", "x", "o", "y", "d", "r", "m")
+	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "ctrl+enter", "x", "o", "y", "d", "r", "m", "A", "E", "f", "F")
+	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "ctrl+enter", "x", "o", "y", "d", "r", "m", "A", "f", "F")
+	actionsWithoutAgentAndEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "ctrl+enter", "x", "o", "y", "d", "r", "m", "f", "F")
 
 	for _, parts := range [][]string{
 		appendParts(base, upDown, arrow, actions),
@@ -1457,8 +1459,13 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 		appendParts(base, arrow, actionsWithoutEffort),
 		appendParts(base, upDown, arrow, actionsWithoutAgentAndEffort),
 		appendParts(base, arrow, actionsWithoutAgentAndEffort),
+		appendParts(base, arrow, selectedActionsWithAuto),
+		appendParts(arrow, selectedActionsWithAuto),
+		appendParts(base, arrow, coreActionsWithAuto),
 		appendParts(base, arrow, coreActions),
+		appendParts(arrow, coreActionsWithAuto),
 		appendParts(arrow, coreActions),
+		appendParts(coreActionsWithAuto),
 		appendParts(coreActions),
 		base,
 	} {

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -501,6 +501,33 @@ func TestStatusBar_FlowsModeShowsPhaseToggleHintForSelectedFlow(t *testing.T) {
 	}
 }
 
+func TestStatusBar_FlowsModeShowsAutoModeToggleForSelectedFlow(t *testing.T) {
+	flowRow := renderStatusBarWithState(statusBarParams{
+		Width:                180,
+		Mode:                 ModeFlows,
+		ActivePane:           1,
+		RepoSelected:         true,
+		FlowSelected:         true,
+		FlowAutoModeSelected: false,
+	})
+	if !strings.Contains(flowRow, "m: auto: off") {
+		t.Fatalf("selected Flow row should expose auto-mode off toggle, got %q", flowRow)
+	}
+
+	phaseRow := renderStatusBarWithState(statusBarParams{
+		Width:                180,
+		Mode:                 ModeFlows,
+		ActivePane:           1,
+		RepoSelected:         true,
+		FlowSelected:         true,
+		FlowPhaseSelected:    true,
+		FlowAutoModeSelected: true,
+	})
+	if !strings.Contains(phaseRow, "m: auto: on") {
+		t.Fatalf("selected Flow phase should expose auto-mode on toggle, got %q", phaseRow)
+	}
+}
+
 func TestStatusBar_FlowsModeShowsNextLaunchOnlyWhenFlowHasLaunchablePhase(t *testing.T) {
 	base := statusBarParams{
 		Width:        120,

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -528,6 +528,33 @@ func TestStatusBar_FlowsModeShowsAutoModeToggleForSelectedFlow(t *testing.T) {
 	}
 }
 
+func TestStatusBar_FlowsModeCompactFooterKeepsAutoModeToggle(t *testing.T) {
+	flowRow := renderStatusBarWithState(statusBarParams{
+		Width:                120,
+		Mode:                 ModeFlows,
+		ActivePane:           1,
+		RepoSelected:         true,
+		FlowSelected:         true,
+		FlowAutoModeSelected: false,
+	})
+	if !strings.Contains(flowRow, "m: auto: off") {
+		t.Fatalf("compact selected Flow row should keep auto-mode off toggle, got %q", flowRow)
+	}
+
+	phaseRow := renderStatusBarWithState(statusBarParams{
+		Width:                120,
+		Mode:                 ModeFlows,
+		ActivePane:           1,
+		RepoSelected:         true,
+		FlowSelected:         true,
+		FlowPhaseSelected:    true,
+		FlowAutoModeSelected: true,
+	})
+	if !strings.Contains(phaseRow, "m: auto: on") {
+		t.Fatalf("compact selected Flow phase should keep auto-mode on toggle, got %q", phaseRow)
+	}
+}
+
 func TestStatusBar_FlowsModeShowsNextLaunchOnlyWhenFlowHasLaunchablePhase(t *testing.T) {
 	base := statusBarParams{
 		Width:        120,


### PR DESCRIPTION
## Summary
- expose the existing Flow auto-mode toggle in the Flows shortcut footer
- show the current auto-mode state for selected Flow rows and selected phase rows
- add UI coverage for the on/off shortcut labels

## Verification
- gofmt -l .
- make test
- make build