### PR TITLE
Fix Flow form multiline navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,9 +458,9 @@ Review Loop and PR Creation include only the worktree, branch, and start commit
 metadata needed to inspect the changes. Built-in prompts tell Plan to produce
 only a plan, Plan Review to use the review-loop skill with max 6 loops,
 Implementation to use the `commit` skill, Review Loop to use the review-loop
-workflow with goal `review-and-revise` and `commit` when revisions are made,
-PR Creation to use the `ship` skill, and Autoreview to use `ship` when fixes
-require commits or pushes without embedding phase-restart recipes. Use
+workflow and `commit` when revisions are made, PR Creation to use the `ship`
+skill, and Autoreview to use `ship` when fixes require commits or pushes
+without embedding phase-restart recipes. Use
 `wtui flow phase restart` to rerun a blocked or needs-attention phase as
 `running`; if notes are omitted, wtui records a standard rerun note.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -442,10 +442,9 @@ Implementation point to the saved plan artifact, while Review Loop and PR
 Creation include only the worktree, branch, and start commit metadata needed to
 inspect the changes. Built-in prompts tell Plan to produce only a plan,
 Plan Review to use the review-loop skill with max 6 loops, Implementation to
-use the `commit` skill, Review Loop to use the review-loop workflow with goal
-`review-and-revise` and `commit` when revisions are made, PR Creation to use
-the `ship` skill, and Autoreview to use `ship` when fixes require commits or
-pushes.
+use the `commit` skill, Review Loop to use the review-loop workflow and
+`commit` when revisions are made, PR Creation to use the `ship` skill, and
+Autoreview to use `ship` when fixes require commits or pushes.
 Autoreview launch prompts include the PR target metadata but leave completion,
 needs-attention, blocked, and restart mechanics to the high-level Flow phase
 commands.

--- a/model/modal/modal.go
+++ b/model/modal/modal.go
@@ -129,6 +129,7 @@ type Modal struct {
 	formTitle    string
 	formFields   []FormField
 	formFocus    int
+	formColumn   int
 	formErr      string
 	formValidate func(FormValues) error
 	formSubmit   func(FormValues) tea.Cmd
@@ -224,6 +225,7 @@ func OpenForm(spec FormSpec) Modal {
 		formPurpose:  spec.Purpose,
 		formTitle:    spec.Title,
 		formFields:   normalizeFormFields(spec.Fields),
+		formColumn:   -1,
 		formValidate: spec.Validate,
 		formSubmit:   spec.Submit,
 	}
@@ -548,6 +550,21 @@ func moveCursorVertically(input string, cursor, delta, preferredColumn int) (int
 	return cursorForLineColumn(runes, starts, targetLine, column), column
 }
 
+func moveCursorVerticallyIfPossible(input string, cursor, delta, preferredColumn int) (int, int, bool) {
+	runes := []rune(input)
+	cursor = clampInputCursor(input, cursor)
+	starts := lineStarts(runes)
+	line, column := lineColumn(runes, starts, cursor)
+	if preferredColumn >= 0 {
+		column = preferredColumn
+	}
+	targetLine := line + delta
+	if targetLine < 0 || targetLine >= len(starts) {
+		return cursor, column, false
+	}
+	return cursorForLineColumn(runes, starts, targetLine, column), column, true
+}
+
 func lineStarts(runes []rune) []int {
 	starts := []int{0}
 	for i, r := range runes {
@@ -648,9 +665,11 @@ func (m Modal) updateForm(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 		return Modal{}, Cancelled, nil
 	case "tab":
 		m.formFocus = nextSelectIndex(m.formFocus, len(m.formFields))
+		m.formColumn = -1
 		return m, Consumed, nil
 	case "shift+tab":
 		m.formFocus = previousSelectIndex(m.formFocus, len(m.formFields))
+		m.formColumn = -1
 		return m, Consumed, nil
 	}
 
@@ -665,9 +684,11 @@ func (m Modal) updateForm(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 		switch msg.String() {
 		case "down":
 			m.formFocus = nextSelectIndex(m.formFocus, len(m.formFields))
+			m.formColumn = -1
 			return m, Consumed, nil
 		case "up":
 			m.formFocus = previousSelectIndex(m.formFocus, len(m.formFields))
+			m.formColumn = -1
 			return m, Consumed, nil
 		}
 		if msg.Type == tea.KeySpace {
@@ -678,9 +699,11 @@ func (m Modal) updateForm(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 		switch msg.String() {
 		case "down":
 			m.formFocus = nextSelectIndex(m.formFocus, len(m.formFields))
+			m.formColumn = -1
 			return m, Consumed, nil
 		case "up":
 			m.formFocus = previousSelectIndex(m.formFocus, len(m.formFields))
+			m.formColumn = -1
 			return m, Consumed, nil
 		case "left", "h":
 			field.SelectedIndex = previousSelectIndex(field.SelectedIndex, len(field.Options))
@@ -704,43 +727,67 @@ func (m Modal) updateFormTextField(msg tea.KeyMsg, field *FormField) (Modal, Out
 	case "alt+enter":
 		if field.Kind == FormMultilineText {
 			field.Value, field.Cursor = insertRunes(field.Value, field.Cursor, []rune{'\n'})
+			m.formColumn = -1
 		}
 	case "backspace", "ctrl+h":
 		field.Value, field.Cursor = deleteRuneBefore(field.Value, field.Cursor)
+		m.formColumn = -1
 	case "delete":
 		field.Value, field.Cursor = deleteRuneAt(field.Value, field.Cursor)
+		m.formColumn = -1
 	case "left":
 		if field.Cursor > 0 {
 			field.Cursor--
 		}
+		m.formColumn = -1
 	case "right":
 		if field.Cursor < inputLength(field.Value) {
 			field.Cursor++
 		}
+		m.formColumn = -1
 	case "up":
 		if field.Kind == FormMultilineText {
-			field.Cursor, _ = moveCursorVertically(field.Value, field.Cursor, -1, -1)
+			if cursor, column, ok := moveCursorVerticallyIfPossible(field.Value, field.Cursor, -1, m.formColumn); ok {
+				field.Cursor = cursor
+				m.formColumn = column
+			} else {
+				m.formFocus = previousSelectIndex(m.formFocus, len(m.formFields))
+				m.formColumn = -1
+			}
 		} else {
 			m.formFocus = previousSelectIndex(m.formFocus, len(m.formFields))
+			m.formColumn = -1
 		}
 	case "down":
 		if field.Kind == FormMultilineText {
-			field.Cursor, _ = moveCursorVertically(field.Value, field.Cursor, 1, -1)
+			if cursor, column, ok := moveCursorVerticallyIfPossible(field.Value, field.Cursor, 1, m.formColumn); ok {
+				field.Cursor = cursor
+				m.formColumn = column
+			} else {
+				m.formFocus = nextSelectIndex(m.formFocus, len(m.formFields))
+				m.formColumn = -1
+			}
 		} else {
 			m.formFocus = nextSelectIndex(m.formFocus, len(m.formFields))
+			m.formColumn = -1
 		}
 	case "home", "ctrl+a":
 		field.Cursor = 0
+		m.formColumn = -1
 	case "end", "ctrl+e":
 		field.Cursor = inputLength(field.Value)
+		m.formColumn = -1
 	case "ctrl+u":
 		field.Value = ""
 		field.Cursor = 0
+		m.formColumn = -1
 	default:
 		if msg.Type == tea.KeySpace {
 			field.Value, field.Cursor = insertRunes(field.Value, field.Cursor, []rune{' '})
+			m.formColumn = -1
 		} else if msg.Type == tea.KeyRunes {
 			field.Value, field.Cursor = insertRunes(field.Value, field.Cursor, msg.Runes)
+			m.formColumn = -1
 		}
 	}
 	m.formErr = ""

--- a/model/modal/modal_test.go
+++ b/model/modal/modal_test.go
@@ -807,6 +807,61 @@ func TestFormMultilineTextFieldAcceptsNewlinesAndSubmitsStructuredValues(t *test
 	}
 }
 
+func TestFormMultilineTextFieldArrowNavigationMovesWithinLinesAndAcrossFields(t *testing.T) {
+	m := modal.OpenForm(modal.FormSpec{
+		Purpose: "flow-create",
+		Title:   "New flow",
+		Fields: []modal.FormField{
+			{ID: "title", Kind: modal.FormText, Label: "Title"},
+			{ID: "instructions", Kind: modal.FormMultilineText, Label: "Instructions"},
+			{ID: "base-ref", Kind: modal.FormText, Label: "Base ref"},
+			{ID: "headless", Kind: modal.FormCheckbox, Label: "Headless"},
+		},
+	})
+
+	m, _, _ = m.Update(keyRunes("Build"))
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.View().Form.FocusIndex; got != 1 {
+		t.Fatalf("down from title focus = %d, want instructions", got)
+	}
+
+	m, _, _ = m.Update(keyRunes("first"))
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter, Alt: true})
+	m, _, _ = m.Update(keyRunes("second line"))
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter, Alt: true})
+	m, _, _ = m.Update(keyRunes("xy"))
+
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	view := m.View().Form
+	if view.FocusIndex != 1 {
+		t.Fatalf("up within instructions focus = %d, want instructions", view.FocusIndex)
+	}
+	if got := view.Fields[1].Cursor; got != len([]rune("first\nse")) {
+		t.Fatalf("cursor after up = %d, want same column on previous line", got)
+	}
+
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	view = m.View().Form
+	if view.FocusIndex != 1 {
+		t.Fatalf("second up within instructions focus = %d, want instructions", view.FocusIndex)
+	}
+	if got := view.Fields[1].Cursor; got != len([]rune("fi")) {
+		t.Fatalf("cursor after second up = %d, want preferred column on first line", got)
+	}
+
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if got := m.View().Form.FocusIndex; got != 0 {
+		t.Fatalf("up from first instructions line focus = %d, want title", got)
+	}
+
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnd})
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.View().Form.FocusIndex; got != 2 {
+		t.Fatalf("down from last instructions line focus = %d, want base ref", got)
+	}
+}
+
 func TestFormShiftTabNavigatesBackwards(t *testing.T) {
 	m := modal.OpenForm(modal.FormSpec{
 		Purpose: "repo-create",

--- a/model/modal/modal_test.go
+++ b/model/modal/modal_test.go
@@ -862,6 +862,40 @@ func TestFormMultilineTextFieldArrowNavigationMovesWithinLinesAndAcrossFields(t 
 	}
 }
 
+func TestFormMultilineTextFieldResetsPreferredColumnAfterHorizontalMove(t *testing.T) {
+	m := modal.OpenForm(modal.FormSpec{
+		Purpose: "flow-create",
+		Title:   "New flow",
+		Fields: []modal.FormField{
+			{ID: "title", Kind: modal.FormText, Label: "Title"},
+			{ID: "instructions", Kind: modal.FormMultilineText, Label: "Instructions"},
+			{ID: "base-ref", Kind: modal.FormText, Label: "Base ref"},
+		},
+	})
+
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m, _, _ = m.Update(keyRunes("abcd"))
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter, Alt: true})
+	m, _, _ = m.Update(keyRunes("x"))
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter, Alt: true})
+	m, _, _ = m.Update(keyRunes("abcdef"))
+
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if got := m.View().Form.Fields[1].Cursor; got != len([]rune("abcd\nx")) {
+		t.Fatalf("cursor after up to short line = %d, want end of short line", got)
+	}
+
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if got := m.View().Form.Fields[1].Cursor; got != len([]rune("abcd\n")) {
+		t.Fatalf("cursor after left = %d, want start of short line", got)
+	}
+
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.View().Form.Fields[1].Cursor; got != len([]rune("abcd\nx\n")) {
+		t.Fatalf("cursor after down = %d, want reset column at start of next line", got)
+	}
+}
+
 func TestFormShiftTabNavigatesBackwards(t *testing.T) {
 	m := modal.OpenForm(modal.FormSpec{
 		Purpose: "repo-create",

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -5292,7 +5292,7 @@ func TestModel_CtrlEnterLaunchesFlowPhaseReviewLoopWithFirstLevelPrompt(t *testi
 		t.Fatalf("launch context = %#v", launched)
 	}
 	wantPrompt := strings.Join([]string{
-		"Use the review-loop workflow with goal: review-and-revise.",
+		"Use the review-loop workflow to review the changes.",
 		"Use the commit skill when revisions are made.",
 		"Use the wtui-flow skill to record the Review Loop result before finishing; the phase is not done until the result is persisted.",
 		"",
@@ -5327,61 +5327,6 @@ func TestModel_CtrlEnterLaunchesFlowPhaseReviewLoopWithFirstLevelPrompt(t *testi
 		if strings.Contains(strings.ToLower(launched.InitialPrompt), unwanted) {
 			t.Fatalf("review-loop prompt should not include %q:\n%s", unwanted, launched.InitialPrompt)
 		}
-	}
-}
-
-func TestModel_FlowReviewLoopPromptTemplateOverridesBuiltInPrompt(t *testing.T) {
-	var launched actions.AgentLaunchContext
-	m := model.NewWithOptions(testRepos(), model.Options{
-		AgentCommand: "codex",
-		FlowPromptTemplates: model.FlowPromptTemplates{
-			ReviewLoop: "Custom {phase_id} for {flow_id}: {worktree_path} on {branch} from {commit}; plan {plan_path}; keep {unknown}",
-		},
-		ReadPlan: func(planID string) (string, error) {
-			t.Fatalf("templated Review Loop launch should not pre-read %q", planID)
-			return "", nil
-		},
-		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
-			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
-		},
-		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
-			t.Fatalf("Flow phase CLI launch should start an embedded terminal, not LaunchAgent: %#v", ctx)
-			return actions.TerminalLaunchSpec{}, nil
-		},
-		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
-			launched = ctx
-			return &fakeEmbeddedTerminal{state: "running"}, nil
-		},
-	})
-	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
-		FlowID:       "flow-1",
-		RepoPath:     "/dev/alpha",
-		WorktreePath: "/dev/alpha-worktrees/flow-review-template",
-		Branch:       "flow/review-template",
-		Commit:       "baddad",
-		PlanID:       "plan-1",
-		PlanPath:     "/state/plans/plan-1/plan.md",
-		Status:       flowstore.StatusInProgress,
-		Phases: []flowstore.FlowPhase{
-			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
-			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
-			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted},
-			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseReady},
-		},
-	}})
-
-	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "review-loop")
-	if cmd == nil {
-		t.Fatal("ctrl+enter should prepare a review-loop launch")
-	}
-	runPreparedFlowEmbeddedLaunch(t, m, cmd)
-
-	want := "Custom review-loop for flow-1: /dev/alpha-worktrees/flow-review-template on flow/review-template from baddad; plan /state/plans/plan-1/plan.md; keep {unknown}"
-	if launched.InitialPrompt != want {
-		t.Fatalf("templated review-loop prompt = %q, want %q", launched.InitialPrompt, want)
-	}
-	if strings.Contains(launched.InitialPrompt, "review-and-revise") {
-		t.Fatalf("templated review-loop prompt should not include built-in goal wording:\n%s", launched.InitialPrompt)
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -5973,6 +5973,79 @@ func TestModel_NewFlowOpensSingleCreationForm(t *testing.T) {
 	}
 }
 
+func TestModel_NewFlowFormArrowNavigationSubmitsMultilineInstructions(t *testing.T) {
+	var startRequest model.FlowStartRequest
+	startCalls := 0
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		StartFlowPlan: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+			startCalls++
+			startRequest = req
+			return model.FlowStartResult{LaunchContext: actions.AgentLaunchContext{
+				Command:     req.AgentCommand,
+				LaunchID:    "launch-1",
+				RepoPath:    req.RepoPath,
+				FlowID:      "flow-1",
+				FlowPhaseID: req.PlanPhaseID,
+			}}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Arrow Flow")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.FormView().FocusIndex; got != 1 {
+		t.Fatalf("down from title focus = %d, want instructions", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("first line")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter, Alt: true})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("second line")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.FormView().FocusIndex; got != 1 {
+		t.Fatalf("internal instruction navigation focus = %d, want instructions", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.FormView().FocusIndex; got != 2 {
+		t.Fatalf("down from last instruction line focus = %d, want base ref", got)
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("main")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.FormView().FocusIndex; got != 3 {
+		t.Fatalf("down from base ref focus = %d, want headless", got)
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeySpace})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected flow creation command")
+	}
+	msg := cmd()
+	launchMsg, ok := msg.(model.FlowEmbeddedLaunchRequestedMsg)
+	if !ok {
+		t.Fatalf("creation command returned %T, want FlowEmbeddedLaunchRequestedMsg", msg)
+	}
+	if startCalls != 1 {
+		t.Fatalf("StartFlowPlan calls = %d, want 1", startCalls)
+	}
+	if startRequest.RepoPath != "/dev/alpha" ||
+		startRequest.Title != "Arrow Flow" ||
+		startRequest.Instructions != "first line\nsecond line" ||
+		startRequest.BaseRef != "main" {
+		t.Fatalf("StartFlowPlan request = %#v", startRequest)
+	}
+	if !launchMsg.LaunchContext.Headless {
+		t.Fatalf("headless launch context = %#v, want checked headless option", launchMsg.LaunchContext)
+	}
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("overlay after submit = %d, want none", m.Overlay())
+	}
+}
+
 func TestModel_NewFlowDelegatesStartAndLaunchesPlanAgent(t *testing.T) {
 	for _, command := range []string{"codex", "claude"} {
 		t.Run(command, func(t *testing.T) {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1980,7 +1980,7 @@ func flowImplementationWithoutPlanPrompt(record flowstore.FlowRecord, phase flow
 }
 
 func flowReviewLoopPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
-	return flowMinimalChangePrompt("Use the review-loop workflow with goal: review-and-revise.\nUse the commit skill when revisions are made.\nUse the wtui-flow skill to record the Review Loop result before finishing; the phase is not done until the result is persisted.", record, phase)
+	return flowMinimalChangePrompt("Use the review-loop workflow to review the changes.\nUse the commit skill when revisions are made.\nUse the wtui-flow skill to record the Review Loop result before finishing; the phase is not done until the result is persisted.", record, phase)
 }
 
 func flowPRCreationPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {


### PR DESCRIPTION
## Summary
- Fix Flow creation form Up/Down handling so multiline fields can move between visual lines and between form inputs predictably.
- Track preferred columns for multiline form navigation separately from standalone input cursor state.
- Add focused modal/form regression coverage for multiline arrows, checkbox navigation, and preferred-column resets.
- Refresh Flow keybinding docs around launch-next navigation.

## Verification
- make test
- make build