### PR TITLE
Revise Plan Review prompt goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,11 +456,12 @@ completed or explicitly skipped with notes. Flow phase launch prompts stay
 minimal: Plan Review and Implementation point to the saved plan artifact, while
 Review Loop and PR Creation include only the worktree, branch, and start commit
 metadata needed to inspect the changes. Built-in prompts tell Plan to produce
-only a plan, Plan Review to use the review-loop skill with max 6 loops,
-Implementation to use the `commit` skill, Review Loop to use the review-loop
-workflow with goal `review-and-revise` and `commit` when revisions are made,
-PR Creation to use the `ship` skill, and Autoreview to use `ship` when fixes
-require commits or pushes without embedding phase-restart recipes. Use
+only a plan, Plan Review to use the review-loop workflow with goal
+`review-and-revise` and max 6 loops, Implementation to use the `commit` skill,
+Review Loop to use the review-loop workflow with goal `review-and-revise` and
+`commit` when revisions are made, PR Creation to use the `ship` skill, and
+Autoreview to use `ship` when fixes require commits or pushes without
+embedding phase-restart recipes. Use
 `wtui flow phase restart` to rerun a blocked or needs-attention phase as
 `running`; if notes are omitted, wtui records a standard rerun note.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ filter matches, or a load failure with details in the status bar.
 | `n` | Create a new worktree in worktrees view, a new branch in branches view, or a new Flow in flows view |
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
-| `m` | Move or rename a linked worktree (worktrees view) |
+| `m` | Move or rename a linked worktree (worktrees view), or toggle per-Flow auto mode (flows view) |
 | `A` | Choose and persist the coding agent from a picker (`codex`, `codex-app`, or `claude`) |
 | `a` | Launch the selected coding agent in the selected worktree, or launch the selected plan or plan phase |
 | `d` | Delete worktree/branch, drop stash, or delete Flow data — requires destructive mode |

--- a/docs/config.md
+++ b/docs/config.md
@@ -441,11 +441,11 @@ skipped with notes. Flow phase launch prompts stay minimal: Plan Review and
 Implementation point to the saved plan artifact, while Review Loop and PR
 Creation include only the worktree, branch, and start commit metadata needed to
 inspect the changes. Built-in prompts tell Plan to produce only a plan,
-Plan Review to use the review-loop skill with max 6 loops, Implementation to
-use the `commit` skill, Review Loop to use the review-loop workflow with goal
-`review-and-revise` and `commit` when revisions are made, PR Creation to use
-the `ship` skill, and Autoreview to use `ship` when fixes require commits or
-pushes.
+Plan Review to use the review-loop workflow with goal `review-and-revise` and
+max 6 loops, Implementation to use the `commit` skill, Review Loop to use the
+review-loop workflow with goal `review-and-revise` and `commit` when revisions
+are made, PR Creation to use the `ship` skill, and Autoreview to use `ship`
+when fixes require commits or pushes.
 Autoreview launch prompts include the PR target metadata but leave completion,
 needs-attention, blocked, and restart mechanics to the high-level Flow phase
 commands.

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/scanner"
 	"github.com/brian-bell/wtui/ui"
@@ -158,6 +160,42 @@ func TestMoveCursorSyncsActiveFlowTerminalToSelectedFlow(t *testing.T) {
 	}
 	if m.terminalPrefixActive {
 		t.Fatal("list navigation should not enable terminal command mode")
+	}
+}
+
+func TestFlowFilterSyncsActiveTerminalToSelectedFlow(t *testing.T) {
+	m := internalFlowsModel(
+		flowstore.FlowRecord{FlowID: "flow-1", RepoPath: "/dev/alpha", Title: "Alpha"},
+		flowstore.FlowRecord{FlowID: "flow-2", RepoPath: "/dev/alpha", Title: "Bravo"},
+	)
+	m.activeFlowTerminalNum = 1
+	m.embeddedTerminals = []embeddedTerminalSlot{
+		{
+			Number:   1,
+			Scope:    embeddedTerminalScopeFlow,
+			FlowID:   "flow-1",
+			Terminal: internalFakeEmbeddedTerminal{},
+		},
+		{
+			Number:   2,
+			Scope:    embeddedTerminalScopeFlow,
+			FlowID:   "flow-2",
+			Terminal: internalFakeEmbeddedTerminal{},
+		},
+	}
+	m = m.setSearchActive(true)
+
+	next, _ := m.handleSearchKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("Bravo")})
+	m = next.(Model)
+
+	if got := m.selectedFlowID(); got != "flow-2" {
+		t.Fatalf("selected Flow = %q, want flow-2", got)
+	}
+	if m.activeFlowTerminalNum != 2 {
+		t.Fatalf("active Flow terminal = %d, want selected Flow terminal 2", m.activeFlowTerminalNum)
+	}
+	if m.flowFocus != flowFocusList {
+		t.Fatalf("flow focus = %d, want list focus", m.flowFocus)
 	}
 }
 

--- a/model/model_filter.go
+++ b/model/model_filter.go
@@ -193,6 +193,9 @@ func (m Model) clampSelectionsAfterFilter() Model {
 	m = m.reflowSessions()
 	m = m.reflowPlans()
 	m = m.reflowFlows()
+	if m.mode == ui.ModeFlows && m.activePane == 1 && m.flowFocus != flowFocusTerminal {
+		m = m.syncActiveFlowTerminalToSelectedFlow()
+	}
 	return m
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -3144,7 +3144,7 @@ func TestModel_CtrlJLaunchesFlowPhaseReadyPlanReviewWithLinkedPlanContext(t *tes
 		t.Fatalf("launch context = %#v", launched)
 	}
 	wantPrompt := strings.Join([]string{
-		"Use the review-loop skill to review the saved plan, max 6 loops.",
+		"Use the review-loop workflow with goal: review-and-revise. Review the saved plan, max 6 loops.",
 		"Use the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.",
 		"",
 		"Plan: /state/wtui/sessions/v1/plans/plan-1/plan.md",
@@ -3220,6 +3220,9 @@ func TestModel_FlowPlanReviewPromptTemplateOverridesBuiltInPrompt(t *testing.T) 
 	want := "Custom plan-review for flow-1: /state/plans/plan-1/plan.md on flow/template; keep {unknown}"
 	if launched.InitialPrompt != want {
 		t.Fatalf("templated plan-review prompt = %q, want %q", launched.InitialPrompt, want)
+	}
+	if strings.Contains(launched.InitialPrompt, "review-and-revise") {
+		t.Fatalf("templated plan-review prompt should not include built-in goal wording:\n%s", launched.InitialPrompt)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1957,7 +1957,7 @@ func flowPhasePromptNeedsPlanBody(phaseID string) bool {
 }
 
 func flowPlanReviewPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
-	return flowMinimalArtifactPrompt("Use the review-loop skill to review the saved plan, max 6 loops.\nUse the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.", planPath, record, phase)
+	return flowMinimalArtifactPrompt("Use the review-loop workflow with goal: review-and-revise. Review the saved plan, max 6 loops.\nUse the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.", planPath, record, phase)
 }
 
 func flowImplementationPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {


### PR DESCRIPTION
## Summary
- update the Plan Review launch prompt so the phase explicitly reviews and revises the saved implementation plan
- document the revised Plan Review behavior in README/config docs
- keep the active Flow terminal synchronized with the selected Flow after filtering, with regression coverage

## Verification
- gofmt -l .
- make test
- make build