### PR TITLE
Prefill interactive Flow launch prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,9 @@ is on by default: selected CLI `codex` and `claude` phase launches run in a
 runtime-only embedded terminal inside the flows pane. Press `h` to choose the
 CLI command mode: headless runs `codex exec` or `claude --print`, while
 headless off runs interactive `codex` or `claude` in the same embedded Flow
-terminal. Creating a new Flow has its own default-off Headless checkbox for the
+terminal. Headless-off Flow launches prefill the phase prompt without
+submitting it, so you can review or edit it before pressing enter. Creating a
+new Flow has its own default-off Headless checkbox for the
 initial Plan launch; that checkbox does not change the selected-phase `h`
 setting. Manual phase launches, auto-launched phases, and new Flow Plan
 launches all use the configured agent and that agent's configured effort. Press

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -628,7 +628,8 @@ type AgentLaunchContext struct {
 	Embedded          bool
 	Headless          bool
 	ReasoningEffort   string
-	// InitialPrompt is passed to providers when they support a launch-time prompt.
+	// InitialPrompt is canonical launch metadata. It is delivered either as a
+	// provider argv or by embedded PTY prefill, depending on launch mode.
 	InitialPrompt string
 }
 
@@ -744,6 +745,18 @@ func AgentCommand(ctx AgentLaunchContext) (*exec.Cmd, error) {
 	return cmd, err
 }
 
+func ShouldPrefillEmbeddedPrompt(ctx AgentLaunchContext) bool {
+	command := agent.Normalize(ctx.Command)
+	return (command == agent.CommandCodex || command == agent.CommandClaude) &&
+		ctx.Embedded &&
+		!ctx.Headless &&
+		ctx.ResumeSessionID == "" &&
+		ctx.InitialPrompt != "" &&
+		ctx.FlowID != "" &&
+		ctx.FlowPhaseID != "" &&
+		ctx.FlowLaunchTracked
+}
+
 func agentCommandSpec(ctx AgentLaunchContext) (*exec.Cmd, []envVar, error) {
 	command := agent.Normalize(ctx.Command)
 	if err := agent.Validate(command); err != nil {
@@ -769,7 +782,7 @@ func agentCommandSpec(ctx AgentLaunchContext) (*exec.Cmd, []envVar, error) {
 		}
 	}
 	args := agentLaunchArgs(command, resumeSessionID, ctx.Embedded, ctx.Headless, reasoningEffort)
-	if ctx.InitialPrompt != "" {
+	if ctx.InitialPrompt != "" && !ShouldPrefillEmbeddedPrompt(ctx) {
 		args = append(args, ctx.InitialPrompt)
 	}
 	cmd := exec.Command(command, args...)

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1897,6 +1897,76 @@ func TestAgentCommandRejectsResumeWithReasoningEffort(t *testing.T) {
 
 func TestAgentCommandBuildsEmbeddedInteractiveCodexCommand(t *testing.T) {
 	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
+		Command:           "codex",
+		LaunchID:          "launch-1",
+		RepoPath:          "/repo",
+		WorktreePath:      "/repo/worktree",
+		SessionStateRoot:  "/state/wtui/sessions/v1",
+		FlowID:            "flow-1",
+		FlowPhaseID:       "implementation",
+		FlowLaunchTracked: true,
+		Embedded:          true,
+		InitialPrompt:     "Implement this phase.",
+	})
+	if err != nil {
+		t.Fatalf("AgentCommand returned error: %v", err)
+	}
+
+	args := cmd.Args
+	if len(args) != 4 {
+		t.Fatalf("args = %#v, want command plus no-alt-screen and hook config", args)
+	}
+	if args[0] != "codex" || args[1] != "--no-alt-screen" || args[2] != "--config" {
+		t.Fatalf("unexpected embedded interactive codex args: %#v", args)
+	}
+	if slices.Contains(args, "Implement this phase.") {
+		t.Fatalf("tracked embedded interactive Flow codex args should not include prompt, got %#v", args)
+	}
+	if slices.Contains(args, "exec") {
+		t.Fatalf("embedded interactive codex args should not include exec, got %#v", args)
+	}
+	if !strings.Contains(args[3], "session-hook --provider codex") {
+		t.Fatalf("expected codex hook config in args, got %#v", args)
+	}
+}
+
+func TestAgentCommandBuildsEmbeddedInteractiveClaudeCommand(t *testing.T) {
+	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
+		Command:           "claude",
+		LaunchID:          "launch-1",
+		RepoPath:          "/repo",
+		WorktreePath:      "/repo/worktree",
+		SessionStateRoot:  "/state/wtui/sessions/v1",
+		FlowID:            "flow-1",
+		FlowPhaseID:       "implementation",
+		FlowLaunchTracked: true,
+		Embedded:          true,
+		InitialPrompt:     "Implement this phase.",
+	})
+	if err != nil {
+		t.Fatalf("AgentCommand returned error: %v", err)
+	}
+
+	args := cmd.Args
+	if len(args) != 3 {
+		t.Fatalf("args = %#v, want command plus hook settings", args)
+	}
+	if args[0] != "claude" || args[1] != "--settings" {
+		t.Fatalf("unexpected embedded interactive claude args: %#v", args)
+	}
+	if slices.Contains(args, "Implement this phase.") {
+		t.Fatalf("tracked embedded interactive Flow claude args should not include prompt, got %#v", args)
+	}
+	if slices.Contains(args, "--print") {
+		t.Fatalf("embedded interactive claude args should not include --print, got %#v", args)
+	}
+	if !strings.Contains(args[2], "session-hook --provider claude") {
+		t.Fatalf("expected claude hook settings in args, got %#v", args)
+	}
+}
+
+func TestAgentCommandEmbeddedInteractiveUntrackedFlowKeepsPromptArg(t *testing.T) {
+	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
 		Command:          "codex",
 		LaunchID:         "launch-1",
 		RepoPath:         "/repo",
@@ -1910,50 +1980,46 @@ func TestAgentCommandBuildsEmbeddedInteractiveCodexCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AgentCommand returned error: %v", err)
 	}
-
-	args := cmd.Args
-	if len(args) != 5 {
-		t.Fatalf("args = %#v, want command plus no-alt-screen, hook config, and prompt", args)
-	}
-	if args[0] != "codex" || args[1] != "--no-alt-screen" || args[2] != "--config" || args[4] != "Implement this phase." {
-		t.Fatalf("unexpected embedded interactive codex args: %#v", args)
-	}
-	if slices.Contains(args, "exec") {
-		t.Fatalf("embedded interactive codex args should not include exec, got %#v", args)
-	}
-	if !strings.Contains(args[3], "session-hook --provider codex") {
-		t.Fatalf("expected codex hook config in args, got %#v", args)
+	if got := cmd.Args[len(cmd.Args)-1]; got != "Implement this phase." {
+		t.Fatalf("last arg = %q, want prompt", got)
 	}
 }
 
-func TestAgentCommandBuildsEmbeddedInteractiveClaudeCommand(t *testing.T) {
-	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
-		Command:          "claude",
-		LaunchID:         "launch-1",
-		RepoPath:         "/repo",
-		WorktreePath:     "/repo/worktree",
-		SessionStateRoot: "/state/wtui/sessions/v1",
-		FlowID:           "flow-1",
-		FlowPhaseID:      "implementation",
-		Embedded:         true,
-		InitialPrompt:    "Implement this phase.",
-	})
-	if err != nil {
-		t.Fatalf("AgentCommand returned error: %v", err)
+func TestShouldPrefillEmbeddedPrompt(t *testing.T) {
+	base := actions.AgentLaunchContext{
+		Command:           "codex",
+		WorktreePath:      "/repo/worktree",
+		FlowID:            "flow-1",
+		FlowPhaseID:       "implementation",
+		FlowLaunchTracked: true,
+		Embedded:          true,
+		InitialPrompt:     "Implement this phase.",
+	}
+	if !actions.ShouldPrefillEmbeddedPrompt(base) {
+		t.Fatalf("ShouldPrefillEmbeddedPrompt(%#v) = false, want true", base)
 	}
 
-	args := cmd.Args
-	if len(args) != 4 {
-		t.Fatalf("args = %#v, want command plus hook settings and prompt", args)
+	cases := []struct {
+		name string
+		mut  func(*actions.AgentLaunchContext)
+	}{
+		{name: "codex app", mut: func(ctx *actions.AgentLaunchContext) { ctx.Command = "codex-app" }},
+		{name: "not embedded", mut: func(ctx *actions.AgentLaunchContext) { ctx.Embedded = false }},
+		{name: "headless", mut: func(ctx *actions.AgentLaunchContext) { ctx.Headless = true }},
+		{name: "resume", mut: func(ctx *actions.AgentLaunchContext) { ctx.ResumeSessionID = "session-1" }},
+		{name: "empty prompt", mut: func(ctx *actions.AgentLaunchContext) { ctx.InitialPrompt = "" }},
+		{name: "missing flow", mut: func(ctx *actions.AgentLaunchContext) { ctx.FlowID = "" }},
+		{name: "missing phase", mut: func(ctx *actions.AgentLaunchContext) { ctx.FlowPhaseID = "" }},
+		{name: "untracked", mut: func(ctx *actions.AgentLaunchContext) { ctx.FlowLaunchTracked = false }},
 	}
-	if args[0] != "claude" || args[1] != "--settings" || args[3] != "Implement this phase." {
-		t.Fatalf("unexpected embedded interactive claude args: %#v", args)
-	}
-	if slices.Contains(args, "--print") {
-		t.Fatalf("embedded interactive claude args should not include --print, got %#v", args)
-	}
-	if !strings.Contains(args[2], "session-hook --provider claude") {
-		t.Fatalf("expected claude hook settings in args, got %#v", args)
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := base
+			tt.mut(&ctx)
+			if actions.ShouldPrefillEmbeddedPrompt(ctx) {
+				t.Fatalf("ShouldPrefillEmbeddedPrompt(%#v) = true, want false", ctx)
+			}
+		})
 	}
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -314,12 +314,14 @@ configured agent for that selected ready phase. Headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in an embedded terminal
 inside the flows pane. Press `h` to choose the CLI command mode: headless runs
 `codex exec` or `claude --print`, while headless off runs interactive `codex` or
-`claude` in the same embedded Flow terminal. Creating a new Flow has its own
-default-off Headless checkbox for the initial Plan launch; that checkbox does
-not change the selected-phase `h` setting. Press `E` to choose the configured
-CLI agent's reasoning effort for future launches; the shortcut pane shows the
-current value. Manual phase launches, auto-launched phases, and new Flow Plan
-launches all use the configured agent and that agent's configured effort.
+`claude` in the same embedded Flow terminal. Headless-off Flow launches prefill
+the phase prompt without submitting it, so you can review or edit it before
+pressing enter. Creating a new Flow has its own default-off Headless checkbox
+for the initial Plan launch; that checkbox does not change the selected-phase
+`h` setting. Press `E` to choose the configured CLI agent's reasoning effort
+for future launches; the shortcut pane shows the current value. Manual phase
+launches, auto-launched phases, and new Flow Plan launches all use the
+configured agent and that agent's configured effort.
 `codex-app` remains URL/deep-link based, launches externally, and uses
 app-side/default reasoning. Press `r` to resume an attached
 provider session from the selected phase row; CLI resumes open in runtime-only

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -29,6 +29,11 @@ const (
 	embeddedPromptPasteEnd   = "\x1b[201~"
 )
 
+var (
+	embeddedPromptPrefillTimeout      = 2 * time.Second
+	embeddedPromptPrefillPollInterval = 25 * time.Millisecond
+)
+
 // terminalCommandKey toggles wtui command handling inside embedded terminals.
 // It must stay off keys interactive agents bind themselves (Claude Code and
 // Codex both use ctrl+g, ctrl+b, ctrl+r, ctrl+t, ...); ctrl+] is the
@@ -360,6 +365,7 @@ func prefillEmbeddedPromptIfNeeded(term EmbeddedTerminal, ctx actions.AgentLaunc
 	if !actions.ShouldPrefillEmbeddedPrompt(ctx) {
 		return nil
 	}
+	waitForEmbeddedPromptPrefillReady(term)
 	payload := []byte(embeddedPromptPasteStart + sanitizeEmbeddedPromptPaste(ctx.InitialPrompt) + embeddedPromptPasteEnd)
 	n, err := term.Write(payload)
 	if err != nil {
@@ -369,6 +375,34 @@ func prefillEmbeddedPromptIfNeeded(term EmbeddedTerminal, ctx actions.AgentLaunc
 		return fmt.Errorf("prefill embedded prompt: %w: wrote %d of %d bytes", io.ErrShortWrite, n, len(payload))
 	}
 	return nil
+}
+
+func waitForEmbeddedPromptPrefillReady(term EmbeddedTerminal) {
+	if term == nil || embeddedPromptPrefillTimeout <= 0 {
+		return
+	}
+	deadline := time.Now().Add(embeddedPromptPrefillTimeout)
+	for {
+		lines := term.VisibleLines(80, 24)
+		if len(lines) == 0 || embeddedTerminalHasVisibleOutput(lines) {
+			return
+		}
+		if !embeddedTerminalRunning(term) || !time.Now().Before(deadline) {
+			return
+		}
+		if embeddedPromptPrefillPollInterval > 0 {
+			time.Sleep(embeddedPromptPrefillPollInterval)
+		}
+	}
+}
+
+func embeddedTerminalHasVisibleOutput(lines []string) bool {
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func sanitizeEmbeddedPromptPaste(prompt string) string {

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -344,7 +346,7 @@ func prefillEmbeddedPromptIfNeeded(term EmbeddedTerminal, ctx actions.AgentLaunc
 	if !actions.ShouldPrefillEmbeddedPrompt(ctx) {
 		return nil
 	}
-	payload := []byte(embeddedPromptPasteStart + ctx.InitialPrompt + embeddedPromptPasteEnd)
+	payload := []byte(embeddedPromptPasteStart + sanitizeEmbeddedPromptPaste(ctx.InitialPrompt) + embeddedPromptPasteEnd)
 	n, err := term.Write(payload)
 	if err != nil {
 		return fmt.Errorf("prefill embedded prompt: %w", err)
@@ -353,6 +355,60 @@ func prefillEmbeddedPromptIfNeeded(term EmbeddedTerminal, ctx actions.AgentLaunc
 		return fmt.Errorf("prefill embedded prompt: %w: wrote %d of %d bytes", io.ErrShortWrite, n, len(payload))
 	}
 	return nil
+}
+
+func sanitizeEmbeddedPromptPaste(prompt string) string {
+	var b strings.Builder
+	b.Grow(len(prompt))
+	for i := 0; i < len(prompt); {
+		c := prompt[i]
+		if c == 0x1b {
+			i = skipTerminalEscape(prompt, i)
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(prompt[i:])
+		if r == utf8.RuneError && size == 1 {
+			i++
+			continue
+		}
+		i += size
+		switch r {
+		case '\n', '\t':
+			b.WriteRune(r)
+		default:
+			if !unicode.IsControl(r) {
+				b.WriteRune(r)
+			}
+		}
+	}
+	return b.String()
+}
+
+func skipTerminalEscape(s string, i int) int {
+	if i+1 >= len(s) {
+		return len(s)
+	}
+	switch s[i+1] {
+	case '[':
+		for j := i + 2; j < len(s); j++ {
+			if s[j] >= 0x40 && s[j] <= 0x7e {
+				return j + 1
+			}
+		}
+		return len(s)
+	case ']':
+		for j := i + 2; j < len(s); j++ {
+			if s[j] == 0x07 {
+				return j + 1
+			}
+			if s[j] == 0x1b && j+1 < len(s) && s[j+1] == '\\' {
+				return j + 2
+			}
+		}
+		return len(s)
+	default:
+		return i + 2
+	}
 }
 
 func (m Model) resizeEmbeddedTerminals() Model {

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -2,7 +2,9 @@ package model
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -19,6 +21,11 @@ import (
 )
 
 const embeddedTerminalTerminatePrompt = "Terminate embedded terminal?"
+
+const (
+	embeddedPromptPasteStart = "\x1b[200~"
+	embeddedPromptPasteEnd   = "\x1b[201~"
+)
 
 // terminalCommandKey toggles wtui command handling inside embedded terminals.
 // It must stay off keys interactive agents bind themselves (Claude Code and
@@ -307,6 +314,13 @@ func (m Model) openEmbeddedTerminalWithLabel(ctx actions.AgentLaunchContext, sco
 		m = m.setStatus(statusOther, err.Error())
 		return m, false, err
 	}
+	if err := prefillEmbeddedPromptIfNeeded(term, ctx); err != nil {
+		if terminateErr := term.Terminate(); terminateErr != nil {
+			err = errors.Join(err, fmt.Errorf("terminate embedded terminal after prefill failure: %w", terminateErr))
+		}
+		m = m.setStatus(statusOther, err.Error())
+		return m, false, err
+	}
 	m.nextEmbeddedTerminalID++
 	m.embeddedTerminals = append(m.embeddedTerminals, embeddedTerminalSlot{
 		Number:      number,
@@ -324,6 +338,21 @@ func (m Model) openEmbeddedTerminalWithLabel(ctx actions.AgentLaunchContext, sco
 		m.activeEmbeddedTerminalNum = number
 	}
 	return m, true, nil
+}
+
+func prefillEmbeddedPromptIfNeeded(term EmbeddedTerminal, ctx actions.AgentLaunchContext) error {
+	if !actions.ShouldPrefillEmbeddedPrompt(ctx) {
+		return nil
+	}
+	payload := []byte(embeddedPromptPasteStart + ctx.InitialPrompt + embeddedPromptPasteEnd)
+	n, err := term.Write(payload)
+	if err != nil {
+		return fmt.Errorf("prefill embedded prompt: %w", err)
+	}
+	if n != len(payload) {
+		return fmt.Errorf("prefill embedded prompt: %w: wrote %d of %d bytes", io.ErrShortWrite, n, len(payload))
+	}
+	return nil
 }
 
 func (m Model) resizeEmbeddedTerminals() Model {

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -31,6 +31,69 @@ func (t internalFakeEmbeddedTerminal) State() string {
 	return t.state
 }
 
+type prefillReadyFakeEmbeddedTerminal struct {
+	lines       [][]string
+	visibleHits int
+	writes      []string
+}
+
+func (t *prefillReadyFakeEmbeddedTerminal) VisibleLines(int, int) []string {
+	t.visibleHits++
+	if len(t.lines) == 0 {
+		return nil
+	}
+	index := t.visibleHits - 1
+	if index >= len(t.lines) {
+		index = len(t.lines) - 1
+	}
+	return t.lines[index]
+}
+
+func (t *prefillReadyFakeEmbeddedTerminal) Write(p []byte) (int, error) {
+	t.writes = append(t.writes, string(p))
+	return len(p), nil
+}
+
+func (t *prefillReadyFakeEmbeddedTerminal) Resize(int, int) error      { return nil }
+func (t *prefillReadyFakeEmbeddedTerminal) Terminate() error           { return nil }
+func (t *prefillReadyFakeEmbeddedTerminal) Wait(context.Context) error { return nil }
+func (t *prefillReadyFakeEmbeddedTerminal) State() string              { return "running" }
+
+func TestPrefillEmbeddedPromptWaitsForVisibleTerminalOutput(t *testing.T) {
+	originalInterval := embeddedPromptPrefillPollInterval
+	embeddedPromptPrefillPollInterval = 0
+	t.Cleanup(func() {
+		embeddedPromptPrefillPollInterval = originalInterval
+	})
+
+	term := &prefillReadyFakeEmbeddedTerminal{
+		lines: [][]string{
+			{"", "   "},
+			{"Codex ready", ""},
+		},
+	}
+
+	err := prefillEmbeddedPromptIfNeeded(term, actions.AgentLaunchContext{
+		Command:           "codex",
+		Embedded:          true,
+		FlowID:            "flow-1",
+		FlowPhaseID:       "implementation",
+		FlowLaunchTracked: true,
+		InitialPrompt:     "Build it",
+	})
+	if err != nil {
+		t.Fatalf("prefill returned error: %v", err)
+	}
+
+	if term.visibleHits != 2 {
+		t.Fatalf("visible calls = %d, want wait until second ready frame", term.visibleHits)
+	}
+	wantWrite := embeddedPromptPasteStart + "Build it" + embeddedPromptPasteEnd
+	if len(term.writes) != 1 || term.writes[0] != wantWrite {
+		t.Fatalf("writes = %#v, want %q", term.writes, wantWrite)
+	}
+}
+
 func internalFlowsModel(records ...flowstore.FlowRecord) Model {
 	return Model{
 		mode:       ui.ModeFlows,

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -4296,8 +4296,13 @@ type fakeEmbeddedTerminal struct {
 	lines        []string
 	visibleCalls [][2]int
 	writes       []string
+	writeErr     error
+	writeN       int
+	forceWriteN  bool
 	resizes      [][2]int
 	state        string
+	terminateErr error
+	terminates   int
 }
 
 func (t *fakeEmbeddedTerminal) VisibleLines(width, height int) []string {
@@ -4306,13 +4311,23 @@ func (t *fakeEmbeddedTerminal) VisibleLines(width, height int) []string {
 }
 func (t *fakeEmbeddedTerminal) Write(p []byte) (int, error) {
 	t.writes = append(t.writes, string(p))
+	if t.forceWriteN {
+		return t.writeN, t.writeErr
+	}
+	if t.writeErr != nil {
+		return 0, t.writeErr
+	}
 	return len(p), nil
 }
 func (t *fakeEmbeddedTerminal) Resize(width, height int) error {
 	t.resizes = append(t.resizes, [2]int{width, height})
 	return nil
 }
-func (t *fakeEmbeddedTerminal) Terminate() error { t.state = "terminated"; return nil }
+func (t *fakeEmbeddedTerminal) Terminate() error {
+	t.terminates++
+	t.state = "terminated"
+	return t.terminateErr
+}
 func (t *fakeEmbeddedTerminal) Wait(context.Context) error {
 	return nil
 }

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1566,6 +1566,52 @@ func TestModel_CtrlJOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *
 	}
 }
 
+func TestModel_CtrlJOnFlowPhaseEmbeddedInteractivePrefillSanitizesTerminalControls(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		FlowPromptTemplates: model.FlowPromptTemplates{
+			Implementation: "Alpha\x1b[201~\nBeta\x1b[200~\x1b[31m\a\tOmega\rDone",
+		},
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return fakeTerm, nil
+		},
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return nil, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-interactive",
+		Status:       flowstore.StatusInProgress,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady, Order: 1},
+		},
+	}})
+	m = selectFlowPhaseByID(t, m, "implementation")
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	if cmd != nil {
+		t.Fatalf("h before Flow phase launch returned command %T, want nil", cmd)
+	}
+	m, cmd = update(m, flowCtrlJKey())
+	if cmd == nil {
+		t.Fatal("ctrl+j should prepare an embedded interactive launch")
+	}
+	m, cmd = update(m, cmd())
+	if cmd == nil {
+		t.Fatal("expected embedded Flow launch to return repaint/fetch command")
+	}
+
+	wantWrite := "\x1b[200~Alpha\nBeta\tOmegaDone\x1b[201~"
+	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != wantWrite {
+		t.Fatalf("prefill writes = %#v, want exact sanitized bracketed paste %q", fakeTerm.writes, wantWrite)
+	}
+}
+
 func TestModel_CtrlJOnSelectedNonLaunchableFlowPhaseLaunchesFirstReadySibling(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var started actions.AgentLaunchContext

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1495,6 +1495,7 @@ func TestModel_CtrlJOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *
 		t.Run(command, func(t *testing.T) {
 			var launchUpdate flowstore.PhaseLaunchUpdate
 			var started actions.AgentLaunchContext
+			fakeTerm := &fakeEmbeddedTerminal{state: "running"}
 			m := model.NewWithOptions(testRepos(), model.Options{
 				AgentCommand:     command,
 				SessionStateRoot: "/state/wtui/sessions/v1",
@@ -1508,7 +1509,7 @@ func TestModel_CtrlJOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *
 				},
 				StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
 					started = ctx
-					return &fakeEmbeddedTerminal{state: "running"}, nil
+					return fakeTerm, nil
 				},
 				ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 					return nil, nil
@@ -1553,6 +1554,13 @@ func TestModel_CtrlJOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *
 			}
 			if started.LaunchID == "" || started.LaunchID != launchUpdate.LaunchID {
 				t.Fatalf("launch IDs = context %q update %#v", started.LaunchID, launchUpdate)
+			}
+			wantWrite := "\x1b[200~" + started.InitialPrompt + "\x1b[201~"
+			if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != wantWrite {
+				t.Fatalf("prefill writes = %#v, want exact bracketed paste %q", fakeTerm.writes, wantWrite)
+			}
+			if strings.HasSuffix(fakeTerm.writes[0], "\r") || strings.HasSuffix(fakeTerm.writes[0], "\n") {
+				t.Fatalf("prefill write should not append submit byte, got %q", fakeTerm.writes[0])
 			}
 		})
 	}
@@ -2463,6 +2471,7 @@ func TestModel_OKeyOnFlowWithoutPlanShowsStatus(t *testing.T) {
 func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var started actions.AgentLaunchContext
+	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand:         "codex",
 		CodexReasoningEffort: "high",
@@ -2477,7 +2486,7 @@ func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 		},
 		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
 			started = ctx
-			return &fakeEmbeddedTerminal{state: "running"}, nil
+			return fakeTerm, nil
 		},
 	})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
@@ -2531,6 +2540,9 @@ func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 	}
 	if !launchUpdate.Resume {
 		t.Fatalf("launch update = %#v, want resume launch so terminal phases keep their status", launchUpdate)
+	}
+	if len(fakeTerm.writes) != 0 {
+		t.Fatalf("Flow phase resume should not prefill embedded terminal, got writes %#v", fakeTerm.writes)
 	}
 }
 
@@ -3407,6 +3419,9 @@ func TestModel_CtrlJLaunchesFlowPhaseImplementationInEmbeddedHeadlessTerminalByD
 	wantStartHeight := ui.EmbeddedTerminalPTYHeight(terminalOuterHeight)
 	if startWidth != wantStartWidth || startHeight != wantStartHeight {
 		t.Fatalf("embedded terminal start size = %dx%d, want %dx%d", startWidth, startHeight, wantStartWidth, wantStartHeight)
+	}
+	if len(fakeTerm.writes) != 0 {
+		t.Fatalf("headless Flow launch should not prefill embedded terminal, got writes %#v", fakeTerm.writes)
 	}
 	_ = m.View()
 	wantStartSize := [2]int{wantStartWidth, wantStartHeight}
@@ -4289,6 +4304,107 @@ func TestModel_CtrlJFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNeedsAttentio
 	}
 	if got := m.TransientError(); !strings.Contains(got, "pty unavailable") {
 		t.Fatalf("status = %q, want PTY error", got)
+	}
+}
+
+func TestModel_CtrlJFlowPhaseEmbeddedInteractivePrefillFailureCleansUpTerminal(t *testing.T) {
+	tests := []struct {
+		name           string
+		term           *fakeEmbeddedTerminal
+		wantStatusText []string
+	}{
+		{
+			name: "write error",
+			term: &fakeEmbeddedTerminal{
+				lines:    []string{"agent output"},
+				state:    "running",
+				writeErr: errors.New("input rejected"),
+			},
+			wantStatusText: []string{"prefill embedded prompt", "input rejected"},
+		},
+		{
+			name: "short write",
+			term: &fakeEmbeddedTerminal{
+				lines:       []string{"agent output"},
+				state:       "running",
+				forceWriteN: true,
+				writeN:      3,
+			},
+			wantStatusText: []string{"prefill embedded prompt", "short write"},
+		},
+		{
+			name: "cleanup failure",
+			term: &fakeEmbeddedTerminal{
+				lines:        []string{"agent output"},
+				state:        "running",
+				writeErr:     errors.New("input rejected"),
+				terminateErr: errors.New("terminate failed"),
+			},
+			wantStatusText: []string{"prefill embedded prompt", "input rejected", "terminate failed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var phaseUpdate flowstore.PhaseUpdate
+			m := model.NewWithOptions(testRepos(), model.Options{
+				AgentCommand: "codex",
+				AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+					return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+				},
+				SetFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+					phaseUpdate = update
+					return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+				},
+				StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+					return tt.term, nil
+				},
+			})
+			m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				RepoPath:     "/dev/alpha",
+				WorktreePath: "/dev/alpha-worktrees/flow-prefill-failure",
+				Branch:       "flow/prefill-failure",
+				Status:       flowstore.StatusInProgress,
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady},
+				},
+			}})
+
+			m = selectFlowPhaseByID(t, m, "implementation")
+			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+			if cmd != nil {
+				t.Fatalf("h before Flow phase launch returned command %T, want nil", cmd)
+			}
+			m, cmd = update(m, flowCtrlJKey())
+			if cmd == nil {
+				t.Fatal("ctrl+j should prepare an embedded launch")
+			}
+			m, cmd = update(m, cmd())
+			if cmd == nil {
+				t.Fatal("failed embedded prefill should still refresh Flow state")
+			}
+
+			if tt.term.terminates != 1 || tt.term.State() != "terminated" {
+				t.Fatalf("terminal cleanup = terminates %d state %q, want one terminated cleanup", tt.term.terminates, tt.term.State())
+			}
+			if phaseUpdate.FlowID != "flow-1" ||
+				phaseUpdate.PhaseID != "implementation" ||
+				phaseUpdate.Status != flowstore.PhaseNeedsAttention {
+				t.Fatalf("phase update = %#v", phaseUpdate)
+			}
+			for _, want := range tt.wantStatusText {
+				if !strings.Contains(phaseUpdate.Notes, want) {
+					t.Fatalf("phase notes = %q, want to contain %q", phaseUpdate.Notes, want)
+				}
+				if !strings.Contains(m.TransientError(), want) {
+					t.Fatalf("status = %q, want to contain %q", m.TransientError(), want)
+				}
+			}
+			if strings.Contains(m.View(), "agent output") {
+				t.Fatalf("failed prefill should not append a terminal slot:\n%s", m.View())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- prefill interactive Flow launch prompts with minimal phase context when launching CLI providers
- keep completed/skipped Flow phase launches from reopening phases while still recording launch metadata
- harden embedded terminal prompt handling and document the interactive launch behavior

## Verification
- gofmt -l .
- make test
- make build