### PR TITLE
Show active terminal markers in repo list

### DIFF
--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -61,6 +61,7 @@ type embeddedTerminalSlot struct {
 	Scope       embeddedTerminalScope
 	Provider    string
 	Identity    string
+	RepoPath    string
 	FlowID      string
 	FlowPhaseID string
 	Terminal    EmbeddedTerminal
@@ -168,6 +169,18 @@ func (m Model) flowTerminalActivity() []ui.FlowTerminalActivity {
 		})
 	}
 	return activity
+}
+
+func (m Model) activeTerminalRepoPaths() map[string]bool {
+	active := make(map[string]bool)
+	for _, slot := range m.embeddedTerminals {
+		repoPath := cleanEmbeddedTerminalRepoPath(slot.RepoPath)
+		if repoPath == "" || !embeddedTerminalRunning(slot.Terminal) {
+			continue
+		}
+		active[repoPath] = true
+	}
+	return active
 }
 
 func (m Model) syncActiveFlowTerminalToSelectedFlow() Model {
@@ -313,6 +326,7 @@ func (m Model) openEmbeddedTerminalWithLabel(ctx actions.AgentLaunchContext, sco
 		Scope:       scope,
 		Provider:    provider,
 		Identity:    identity,
+		RepoPath:    cleanEmbeddedTerminalRepoPath(ctx.RepoPath),
 		FlowID:      flowID,
 		FlowPhaseID: flowPhaseID,
 		Terminal:    term,
@@ -324,6 +338,14 @@ func (m Model) openEmbeddedTerminalWithLabel(ctx actions.AgentLaunchContext, sco
 		m.activeEmbeddedTerminalNum = number
 	}
 	return m, true, nil
+}
+
+func cleanEmbeddedTerminalRepoPath(repoPath string) string {
+	repoPath = strings.TrimSpace(repoPath)
+	if repoPath == "" {
+		return ""
+	}
+	return filepath.Clean(repoPath)
 }
 
 func (m Model) resizeEmbeddedTerminals() Model {

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -2,12 +2,16 @@ package model
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 
+	"github.com/brian-bell/wtui/actions"
 	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/scanner"
+	"github.com/brian-bell/wtui/sessions"
 	"github.com/brian-bell/wtui/ui"
 )
 
@@ -35,6 +39,135 @@ func internalFlowsModel(records ...flowstore.FlowRecord) Model {
 			{Path: "/dev/alpha", DisplayName: "alpha"},
 		}),
 		flows: newFlowPane().SetItems(records),
+	}
+}
+
+func TestActiveTerminalRepoPathsIncludesOnlyRunningOwnedTerminals(t *testing.T) {
+	m := Model{
+		embeddedTerminals: []embeddedTerminalSlot{
+			{RepoPath: "/dev/alpha", Terminal: internalFakeEmbeddedTerminal{}},
+			{RepoPath: "/dev/beta", Terminal: internalFakeEmbeddedTerminal{state: "exited"}},
+			{RepoPath: "/dev/gamma", Terminal: internalFakeEmbeddedTerminal{state: "starting"}},
+			{RepoPath: "", Terminal: internalFakeEmbeddedTerminal{}},
+			{RepoPath: "/dev/delta", Terminal: nil},
+		},
+	}
+
+	active := m.activeTerminalRepoPaths()
+
+	for _, repoPath := range []string{"/dev/alpha", "/dev/gamma"} {
+		if !active[repoPath] {
+			t.Fatalf("active terminal repo paths missing %s: %#v", repoPath, active)
+		}
+	}
+	for _, repoPath := range []string{"/dev/beta", "", "/dev/delta"} {
+		if active[repoPath] {
+			t.Fatalf("active terminal repo paths unexpectedly includes %q: %#v", repoPath, active)
+		}
+	}
+}
+
+func TestActiveTerminalRepoPathsClearsWhenLastRunningSlotIsDismissed(t *testing.T) {
+	m := Model{
+		embeddedTerminals: []embeddedTerminalSlot{
+			{ID: 1, Number: 1, Scope: embeddedTerminalScopeSession, RepoPath: "/dev/alpha", Terminal: internalFakeEmbeddedTerminal{state: "exited"}},
+			{ID: 2, Number: 2, Scope: embeddedTerminalScopeSession, RepoPath: "/dev/alpha", Terminal: internalFakeEmbeddedTerminal{}},
+		},
+	}
+
+	if !m.activeTerminalRepoPaths()["/dev/alpha"] {
+		t.Fatalf("repo should remain active while one matching slot is running")
+	}
+
+	m = m.dismissEmbeddedTerminal(2)
+
+	if m.activeTerminalRepoPaths()["/dev/alpha"] {
+		t.Fatalf("repo should stop being active after last running slot is dismissed")
+	}
+}
+
+func TestOpenEmbeddedTerminalStoresSessionRepoPath(t *testing.T) {
+	m := Model{
+		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
+			return internalFakeEmbeddedTerminal{}, nil
+		},
+	}
+
+	next, opened, err := m.openEmbeddedTerminal(actions.AgentLaunchContext{
+		RepoPath:     "/dev/alpha/",
+		WorktreePath: "/dev/alpha-worktrees/feature",
+	}, sessions.SessionRecord{Provider: sessions.ProviderCodex, SessionID: "session-1"})
+	if err != nil {
+		t.Fatalf("open embedded terminal returned error: %v", err)
+	}
+	if !opened {
+		t.Fatal("open embedded terminal should open a slot")
+	}
+	if len(next.embeddedTerminals) != 1 {
+		t.Fatalf("embedded terminal count = %d, want 1", len(next.embeddedTerminals))
+	}
+	if got := next.embeddedTerminals[0].RepoPath; got != "/dev/alpha" {
+		t.Fatalf("slot repo path = %q, want cleaned repo path %q", got, "/dev/alpha")
+	}
+}
+
+func TestOpenFlowEmbeddedTerminalStoresFlowRepoPath(t *testing.T) {
+	m := Model{
+		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
+			return internalFakeEmbeddedTerminal{}, nil
+		},
+	}
+
+	next, opened, err := m.openFlowEmbeddedTerminal(actions.AgentLaunchContext{
+		Command:       "codex",
+		RepoPath:      "/dev/alpha",
+		WorktreePath:  "/dev/alpha-worktrees/feature",
+		FlowID:        "flow-1",
+		FlowPhaseID:   "implementation",
+		InitialPrompt: "Build it",
+	})
+	if err != nil {
+		t.Fatalf("open Flow embedded terminal returned error: %v", err)
+	}
+	if !opened {
+		t.Fatal("open Flow embedded terminal should open a slot")
+	}
+	if len(next.embeddedTerminals) != 1 {
+		t.Fatalf("embedded terminal count = %d, want 1", len(next.embeddedTerminals))
+	}
+	if got := next.embeddedTerminals[0].RepoPath; got != "/dev/alpha" {
+		t.Fatalf("slot repo path = %q, want repo path %q", got, "/dev/alpha")
+	}
+}
+
+func TestViewMarksRepoWithRunningTerminalByCleanRepoPath(t *testing.T) {
+	m := Model{
+		width:      80,
+		height:     12,
+		mode:       ui.ModeWorktrees,
+		activePane: 0,
+		repos: newRepoPane().SetItems([]scanner.Repo{
+			{Path: "/dev/alpha", DisplayName: "alpha"},
+			{Path: "/dev/alpha-worktrees/feature", DisplayName: "feature"},
+		}),
+		embeddedTerminals: []embeddedTerminalSlot{
+			{
+				RepoPath: "/dev/alpha/",
+				Terminal: internalFakeEmbeddedTerminal{},
+			},
+		},
+	}
+
+	view := ansi.Strip(m.View())
+
+	if !strings.Contains(view, " > ● alpha") {
+		t.Fatalf("view should mark repo with running terminal:\n%s", view)
+	}
+	if !strings.Contains(view, "     feature") {
+		t.Fatalf("view should reserve inactive marker spacing for worktree row without marking it:\n%s", view)
+	}
+	if strings.Contains(view, "● feature") {
+		t.Fatalf("view should not mark worktree path as active repo:\n%s", view)
 	}
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -624,6 +624,7 @@ func (m Model) View() string {
 	modalView := m.modal.View()
 	return ui.Render(ui.RenderParams{
 		Repos:                       repos,
+		ActiveTerminalRepoPaths:     m.activeTerminalRepoPaths(),
 		Selected:                    selected,
 		Width:                       m.width,
 		Height:                      m.height,

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1768,14 +1768,7 @@ func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, e
 		return lines
 	}
 
-	showActivityColumn := false
-	for i := 0; i < height; i++ {
-		idx := scroll + i
-		if idx < len(repos) && repoHasActiveTerminal(activeTerminalRepoPaths, repos[idx].Path) {
-			showActivityColumn = true
-			break
-		}
-	}
+	showActivityColumn := repoListHasActiveTerminal(repos, activeTerminalRepoPaths)
 
 	for i := 0; i < height; i++ {
 		idx := scroll + i
@@ -1816,6 +1809,18 @@ func repoHasActiveTerminal(activeTerminalRepoPaths map[string]bool, repoPath str
 		return false
 	}
 	return activeTerminalRepoPaths[filepath.Clean(repoPath)]
+}
+
+func repoListHasActiveTerminal(repos []scanner.Repo, activeTerminalRepoPaths map[string]bool) bool {
+	if len(activeTerminalRepoPaths) == 0 {
+		return false
+	}
+	for _, repo := range repos {
+		if repoHasActiveTerminal(activeTerminalRepoPaths, repo.Path) {
+			return true
+		}
+	}
+	return false
 }
 
 func renderBranchPaneSelected(rows []gitquery.BranchRow, selected, scroll, width, height int, repoPath string) []string {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -215,6 +215,7 @@ const StashPrefixWidth = 15
 // RenderParams holds everything the renderer needs.
 type RenderParams struct {
 	Repos                       []scanner.Repo
+	ActiveTerminalRepoPaths     map[string]bool
 	Selected                    int
 	Width                       int
 	Height                      int
@@ -542,7 +543,7 @@ func renderApplication(p RenderParams) string {
 	}
 
 	leftContentWidth := LeftPaneWidth - 2 // left + right border
-	leftLines := renderRepoList(p.Repos, p.Selected, p.RepoScroll, leftContentWidth, innerHeight, p.RepoEmptyMessage)
+	leftLines := renderRepoList(p.Repos, p.Selected, p.RepoScroll, leftContentWidth, innerHeight, p.RepoEmptyMessage, p.ActiveTerminalRepoPaths)
 	leftContent := strings.Join(leftLines, "\n")
 	leftPane := lipgloss.NewStyle().
 		Border(lipgloss.NormalBorder()).
@@ -1754,7 +1755,7 @@ func modeShortcutTitle(mode Mode) string {
 	}
 }
 
-func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, emptyMessage string) []string {
+func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, emptyMessage string, activeTerminalRepoPaths map[string]bool) []string {
 	if height <= 0 {
 		return nil
 	}
@@ -1767,15 +1768,32 @@ func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, e
 		return lines
 	}
 
+	showActivityColumn := false
+	for i := 0; i < height; i++ {
+		idx := scroll + i
+		if idx < len(repos) && repoHasActiveTerminal(activeTerminalRepoPaths, repos[idx].Path) {
+			showActivityColumn = true
+			break
+		}
+	}
+
 	for i := 0; i < height; i++ {
 		idx := scroll + i
 		if idx < len(repos) {
 			name := repos[idx].DisplayName
+			activeRepo := repoHasActiveTerminal(activeTerminalRepoPaths, repos[idx].Path)
+			activityMarker := ""
+			if showActivityColumn {
+				activityMarker = "  "
+				if activeRepo {
+					activityMarker = cleanStyle.Render("●") + " "
+				}
+			}
 			if idx == selected {
-				line := truncateToWidth(fmt.Sprintf(" > %s", name), width)
+				line := truncateToWidth(fmt.Sprintf(" > %s%s", activityMarker, name), width)
 				lines[i] = selectedStyle.Width(width).Render(line)
 			} else {
-				line := truncateToWidth(fmt.Sprintf("   %s", name), width)
+				line := truncateToWidth(fmt.Sprintf("   %s%s", activityMarker, name), width)
 				lines[i] = repoStyle.Width(width).Render(line)
 			}
 		} else {
@@ -1784,6 +1802,20 @@ func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, e
 	}
 
 	return lines
+}
+
+func repoHasActiveTerminal(activeTerminalRepoPaths map[string]bool, repoPath string) bool {
+	if len(activeTerminalRepoPaths) == 0 {
+		return false
+	}
+	if activeTerminalRepoPaths[repoPath] {
+		return true
+	}
+	repoPath = strings.TrimSpace(repoPath)
+	if repoPath == "" {
+		return false
+	}
+	return activeTerminalRepoPaths[filepath.Clean(repoPath)]
 }
 
 func renderBranchPaneSelected(rows []gitquery.BranchRow, selected, scroll, width, height int, repoPath string) []string {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1779,15 +1779,13 @@ func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, e
 			if showActivityColumn {
 				activityMarker = "  "
 				if activeRepo {
-					activityMarker = cleanStyle.Render("●") + " "
+					activityMarker = "● "
 				}
 			}
 			if idx == selected {
-				line := truncateToWidth(fmt.Sprintf(" > %s%s", activityMarker, name), width)
-				lines[i] = selectedStyle.Width(width).Render(line)
+				lines[i] = renderSelectedRepoRow(name, activityMarker, activeRepo, showActivityColumn, width)
 			} else {
-				line := truncateToWidth(fmt.Sprintf("   %s%s", activityMarker, name), width)
-				lines[i] = repoStyle.Width(width).Render(line)
+				lines[i] = renderRepoRow(name, activityMarker, activeRepo, showActivityColumn, width)
 			}
 		} else {
 			lines[i] = strings.Repeat(" ", width)
@@ -1795,6 +1793,32 @@ func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, e
 	}
 
 	return lines
+}
+
+func renderSelectedRepoRow(name, activityMarker string, activeRepo, showActivityColumn bool, width int) string {
+	line := selectedStyle.Render(" > ")
+	if showActivityColumn {
+		if activeRepo {
+			line += selectedSegment(cleanStyle, "●") + selectedStyle.Render(" ")
+		} else {
+			line += selectedStyle.Render(activityMarker)
+		}
+	}
+	line += selectedStyle.Render(name)
+	return renderSelectedRow(line, width)
+}
+
+func renderRepoRow(name, activityMarker string, activeRepo, showActivityColumn bool, width int) string {
+	line := repoStyle.Render("   ")
+	if showActivityColumn {
+		if activeRepo {
+			line += cleanStyle.Render("●") + repoStyle.Render(" ")
+		} else {
+			line += repoStyle.Render(activityMarker)
+		}
+	}
+	line += repoStyle.Render(name)
+	return renderStyledRow(line, repoStyle, width)
 }
 
 func repoHasActiveTerminal(activeTerminalRepoPaths map[string]bool, repoPath string) bool {
@@ -3892,9 +3916,13 @@ func selectedSegment(style lipgloss.Style, text string) string {
 }
 
 func renderSelectedRow(line string, width int) string {
+	return renderStyledRow(line, selectedStyle, width)
+}
+
+func renderStyledRow(line string, style lipgloss.Style, width int) string {
 	line = truncateToWidth(line, width)
 	if padding := width - lipgloss.Width(line); padding > 0 {
-		line += selectedStyle.Render(strings.Repeat(" ", padding))
+		line += style.Render(strings.Repeat(" ", padding))
 	}
 	return line
 }

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -2116,7 +2116,7 @@ func TestRepoList_ScrollsWhenSelectionExceedsHeight(t *testing.T) {
 		{Path: "/e", DisplayName: "echo"},
 	}
 	// Height of 3 means only 3 visible at a time; scroll=2 shows repos 2-4
-	lines := renderRepoList(repos, 4, 2, LeftPaneWidth-2, 3, "")
+	lines := renderRepoList(repos, 4, 2, LeftPaneWidth-2, 3, "", nil)
 	joined := strings.Join(lines, "\n")
 	if !strings.Contains(joined, "echo") {
 		t.Error("selected item 'echo' should be visible")
@@ -2131,11 +2131,86 @@ func TestRepoList_TruncatesLongNames(t *testing.T) {
 	repos := []scanner.Repo{
 		{Path: "/a", DisplayName: "this-is-a-very-long-repository-name-that-exceeds-width"},
 	}
-	lines := renderRepoList(repos, 0, 0, width, 3, "")
+	lines := renderRepoList(repos, 0, 0, width, 3, "", nil)
 	for i, line := range lines {
 		if lipgloss.Width(line) > width {
 			t.Errorf("line %d width %d exceeds pane width %d", i, lipgloss.Width(line), width)
 		}
+	}
+}
+
+func TestRepoList_RendersActiveTerminalMarkersWithStableSpacing(t *testing.T) {
+	forceTrueColor(t)
+	width := LeftPaneWidth - 2
+	repos := []scanner.Repo{
+		{Path: "/alpha", DisplayName: "alpha"},
+		{Path: "/bravo", DisplayName: "bravo"},
+		{Path: "/charlie", DisplayName: "charlie"},
+		{Path: "/delta", DisplayName: "delta"},
+	}
+	activeRepos := map[string]bool{
+		"/alpha":   true,
+		"/charlie": true,
+	}
+
+	lines := renderRepoList(repos, 0, 0, width, len(repos), "", activeRepos)
+	stripped := stripLines(lines)
+
+	wantPrefixes := []string{
+		" > ● alpha",
+		"     bravo",
+		"   ● charlie",
+		"     delta",
+	}
+	for i, want := range wantPrefixes {
+		if !strings.HasPrefix(stripped[i], want) {
+			t.Fatalf("line %d = %q, want prefix %q", i, stripped[i], want)
+		}
+	}
+	for i, line := range lines {
+		if !strings.Contains(line, cleanStyle.Render("●")) {
+			if i == 0 || i == 2 {
+				t.Fatalf("active line %d should render marker with clean style: %q", i, line)
+			}
+		}
+		if lipgloss.Width(line) != width {
+			t.Fatalf("line %d width = %d, want %d: %q", i, lipgloss.Width(line), width, stripped[i])
+		}
+	}
+
+	lines = renderRepoList(repos, 1, 0, width, len(repos), "", activeRepos)
+	stripped = stripLines(lines)
+	if !strings.HasPrefix(stripped[1], " >   bravo") {
+		t.Fatalf("selected inactive line = %q, want prefix %q", stripped[1], " >   bravo")
+	}
+}
+
+func TestRepoList_ActiveTerminalMarkerDoesNotExpandTruncatedRows(t *testing.T) {
+	width := LeftPaneWidth - 2
+	repos := []scanner.Repo{
+		{Path: "/active", DisplayName: "active-repository-name-that-exceeds-the-pane-width"},
+		{Path: "/inactive", DisplayName: "inactive-repository-name-that-exceeds-the-pane-width"},
+	}
+
+	lines := renderRepoList(repos, 0, 0, width, len(repos), "", map[string]bool{"/active": true})
+
+	requireLinesWithinWidth(t, stripLines(lines), width)
+	if got := lipgloss.Width(lines[0]); got != width {
+		t.Fatalf("active row width = %d, want %d", got, width)
+	}
+	if got := lipgloss.Width(lines[1]); got != width {
+		t.Fatalf("inactive row width = %d, want %d", got, width)
+	}
+}
+
+func TestRepoList_ActiveTerminalMarkerMatchesCleanedRepoPath(t *testing.T) {
+	width := LeftPaneWidth - 2
+	repos := []scanner.Repo{{Path: "/alpha/", DisplayName: "alpha"}}
+
+	lines := renderRepoList(repos, 0, 0, width, len(repos), "", map[string]bool{"/alpha": true})
+
+	if got := stripLines(lines)[0]; !strings.HasPrefix(got, " > ● alpha") {
+		t.Fatalf("line = %q, want active marker for cleaned repo path", got)
 	}
 }
 
@@ -4069,7 +4144,7 @@ func TestRender_EmptyStateMessagesDoNotPanicAtTinyHeights(t *testing.T) {
 func TestRender_EmptyStateMessagesFitPaneWidth(t *testing.T) {
 	longMessage := "No repo results for " + strings.Repeat("z", 80)
 
-	repoLines := renderRepoList(nil, 0, 0, 12, 3, longMessage)
+	repoLines := renderRepoList(nil, 0, 0, 12, 3, longMessage, nil)
 	for i, line := range repoLines {
 		if lipgloss.Width(line) > 12 {
 			t.Fatalf("repo empty line %d width %d exceeds pane width 12: %q", i, lipgloss.Width(line), line)
@@ -4085,7 +4160,7 @@ func TestRender_EmptyStateMessagesFitPaneWidth(t *testing.T) {
 }
 
 func TestRepoList_EmptyMessageIsVerticallyCentered(t *testing.T) {
-	lines := renderRepoList(nil, 0, 0, 20, 5, "No repos")
+	lines := renderRepoList(nil, 0, 0, 20, 5, "No repos", nil)
 	for i, line := range lines {
 		hasMessage := strings.Contains(line, "No repos")
 		if i == 2 && !hasMessage {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -2185,6 +2185,26 @@ func TestRepoList_RendersActiveTerminalMarkersWithStableSpacing(t *testing.T) {
 	}
 }
 
+func TestRepoList_ReservesActiveTerminalColumnWhenActiveRepoIsOffscreen(t *testing.T) {
+	width := LeftPaneWidth - 2
+	repos := []scanner.Repo{
+		{Path: "/active", DisplayName: "active"},
+		{Path: "/bravo", DisplayName: "bravo"},
+		{Path: "/charlie", DisplayName: "charlie"},
+		{Path: "/delta", DisplayName: "delta"},
+	}
+
+	lines := renderRepoList(repos, 2, 1, width, 2, "", map[string]bool{"/active": true})
+	stripped := stripLines(lines)
+
+	if !strings.HasPrefix(stripped[0], "     bravo") {
+		t.Fatalf("inactive row should reserve marker spacing for offscreen active repo, got %q", stripped[0])
+	}
+	if !strings.HasPrefix(stripped[1], " >   charlie") {
+		t.Fatalf("selected inactive row should reserve marker spacing for offscreen active repo, got %q", stripped[1])
+	}
+}
+
 func TestRepoList_ActiveTerminalMarkerDoesNotExpandTruncatedRows(t *testing.T) {
 	width := LeftPaneWidth - 2
 	repos := []scanner.Repo{

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -2168,10 +2168,11 @@ func TestRepoList_RendersActiveTerminalMarkersWithStableSpacing(t *testing.T) {
 		}
 	}
 	for i, line := range lines {
-		if !strings.Contains(line, cleanStyle.Render("●")) {
-			if i == 0 || i == 2 {
-				t.Fatalf("active line %d should render marker with clean style: %q", i, line)
-			}
+		if i == 0 && !strings.Contains(line, selectedSegment(cleanStyle, "●")) {
+			t.Fatalf("selected active line should render marker with selected clean style: %q", line)
+		}
+		if i == 2 && !strings.Contains(line, cleanStyle.Render("●")) {
+			t.Fatalf("active line %d should render marker with clean style: %q", i, line)
 		}
 		if lipgloss.Width(line) != width {
 			t.Fatalf("line %d width = %d, want %d: %q", i, lipgloss.Width(line), width, stripped[i])
@@ -2182,6 +2183,32 @@ func TestRepoList_RendersActiveTerminalMarkersWithStableSpacing(t *testing.T) {
 	stripped = stripLines(lines)
 	if !strings.HasPrefix(stripped[1], " >   bravo") {
 		t.Fatalf("selected inactive line = %q, want prefix %q", stripped[1], " >   bravo")
+	}
+}
+
+func TestRepoList_ActiveTerminalMarkerRestoresRowStyle(t *testing.T) {
+	forceTrueColor(t)
+	width := LeftPaneWidth - 2
+	repos := []scanner.Repo{
+		{Path: "/alpha", DisplayName: "alpha"},
+		{Path: "/bravo", DisplayName: "bravo"},
+	}
+	activeRepos := map[string]bool{"/alpha": true}
+
+	selectedActive := renderRepoList(repos, 0, 0, width, len(repos), "", activeRepos)[0]
+	if !strings.Contains(selectedActive, selectedSegment(cleanStyle, "●")) {
+		t.Fatalf("selected active marker should keep marker color with selected row styling: %q", selectedActive)
+	}
+	if !strings.Contains(selectedActive, selectedStyle.Render("alpha")) {
+		t.Fatalf("selected active row should restore selected styling after marker: %q", selectedActive)
+	}
+
+	unselectedActive := renderRepoList(repos, 1, 0, width, len(repos), "", activeRepos)[0]
+	if !strings.Contains(unselectedActive, cleanStyle.Render("●")) {
+		t.Fatalf("unselected active marker should keep marker color: %q", unselectedActive)
+	}
+	if !strings.Contains(unselectedActive, repoStyle.Render("alpha")) {
+		t.Fatalf("unselected active row should restore repo styling after marker: %q", unselectedActive)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Track running embedded terminal repo paths on terminal slots.
- Render a green active-terminal marker in the repo list while preserving spacing for inactive rows.
- Add model and UI tests for repo-level marker behavior and stable alignment.

## Verification
- gofmt -l .
- make test
- make build