### PR TITLE
Detach embedded terminals to tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ filter matches, or a load failure with details in the status bar.
 | `n` | Create a new worktree in worktrees view, a new branch in branches view, or a new Flow in flows view |
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
-| `m` | Move or rename a linked worktree (worktrees view), or toggle per-Flow auto mode (flows view) |
+| `m` | Move or rename a linked worktree (worktrees view) |
 | `A` | Choose and persist the coding agent from a picker (`codex`, `codex-app`, or `claude`) |
 | `a` | Launch the selected coding agent in the selected worktree, or launch the selected plan or plan phase |
 | `d` | Delete worktree/branch, drop stash, or delete Flow data — requires destructive mode |
@@ -464,12 +464,11 @@ completed or explicitly skipped with notes. Flow phase launch prompts stay
 minimal: Plan Review and Implementation point to the saved plan artifact, while
 Review Loop and PR Creation include only the worktree, branch, and start commit
 metadata needed to inspect the changes. Built-in prompts tell Plan to produce
-only a plan, Plan Review to use the review-loop workflow with goal
-`review-and-revise` and max 6 loops, Implementation to use the `commit` skill,
-Review Loop to use the review-loop workflow with goal `review-and-revise` and
-`commit` when revisions are made, PR Creation to use the `ship` skill, and
-Autoreview to use `ship` when fixes require commits or pushes without
-embedding phase-restart recipes. Use
+only a plan, Plan Review to use the review-loop skill with max 6 loops,
+Implementation to use the `commit` skill, Review Loop to use the review-loop
+workflow with goal `review-and-revise` and `commit` when revisions are made,
+PR Creation to use the `ship` skill, and Autoreview to use `ship` when fixes
+require commits or pushes without embedding phase-restart recipes. Use
 `wtui flow phase restart` to rerun a blocked or needs-attention phase as
 `running`; if notes are omitted, wtui records a standard rerun note.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ filter matches, or a load failure with details in the status bar.
 | `n` | Create a new worktree in worktrees view, a new branch in branches view, or a new Flow in flows view |
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
-| `m` | Move or rename a linked worktree (worktrees view) |
+| `m` | Move or rename a linked worktree (worktrees view), or toggle auto mode for the selected Flow (flows view) |
 | `A` | Choose and persist the coding agent from a picker (`codex`, `codex-app`, or `claude`) |
 | `a` | Launch the selected coding agent in the selected worktree, or launch the selected plan or plan phase |
 | `d` | Delete worktree/branch, drop stash, or delete Flow data — requires destructive mode |

--- a/README.md
+++ b/README.md
@@ -213,12 +213,19 @@ exist, the saved-session table is hidden and the pane shows a compact numbered
 terminal header plus the active terminal screen. Keys go directly to the active
 PTY (including agent shortcuts like `ctrl+g`); press `ctrl+]` for wtui
 commands: `ctrl+] 1`-`9` switches terminals, `ctrl+] l` opens a saved-session
-picker, `ctrl+] x` dismisses an exited terminal or confirms termination of a
+picker, `ctrl+] d` detaches a tmux-backed terminal to its tmux session,
+`ctrl+] x` dismisses an exited terminal or confirms termination of a
 running one, `ctrl+] q` or `ctrl+] esc` quits with cleanup, and
 `ctrl+] ctrl+]` sends a literal `ctrl+]` to the agent.
+When `tmux` is available at launch time, embedded CLI terminals start inside a
+per-launch tmux session so detach can close wtui's embedded client while the
+agent keeps running in tmux. If `tmux` is unavailable, wtui keeps the direct
+embedded PTY behavior and `ctrl+] d` reports that detach is unavailable.
 Quitting wtui from anywhere while embedded terminals are still running asks for
-confirmation and terminates them first. Embedded terminals are not restored
-after wtui restarts.
+confirmation and terminates them first. Terminate/quit cleanup kills tmux
+sessions created by that embedded launch; detached tmux sessions are no longer
+owned by wtui and are not prompted for on quit. Embedded terminals are not
+restored after wtui restarts.
 
 Session data is stored under the user state directory by default:
 `$XDG_STATE_HOME/wtui/sessions/v1`, or
@@ -351,8 +358,9 @@ still shows `running`). While a Flow terminal is open,
 the Flow list uses a smaller top panel and the terminal uses a bottom panel;
 `tab` switches focus between them. Flow terminal focus starts in wtui command
 mode: `left`/`right` cycle Flow terminals, `1`-`9` switches by number, `x`
-closes, `q`/`esc` quits, unknown ordinary keys do not pass through to the PTY,
-`ctrl+]` sends a literal `ctrl+]`, and `i` enters terminal input mode. In input
+closes, `d` detaches to tmux when available, `q`/`esc` quits, unknown ordinary
+keys do not pass through to the PTY, `ctrl+]` sends a literal `ctrl+]`, and `i`
+enters terminal input mode. In input
 mode, keys pass through to the PTY (including agent shortcuts like `ctrl+g`)
 and `ctrl+]` returns to command mode. When
 Implementation is still gated by Plan Review, wtui reports the Plan Review state

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -604,6 +604,8 @@ var ErrEmbeddedTmuxUnavailable = errors.New("tmux is not available for embedded 
 type EmbeddedTmuxAgentSpec struct {
 	SessionName        string
 	ScriptPath         string
+	StatusPath         string
+	DetachTarget       string
 	HasSessionCommand  *exec.Cmd
 	NewSessionCommand  *exec.Cmd
 	AttachCommand      *exec.Cmd
@@ -784,18 +786,22 @@ func embeddedTmuxAgentCommand(ctx AgentLaunchContext, lookPath lookPathFunc) (Em
 		return EmbeddedTmuxAgentSpec{}, err
 	}
 	sessionName := agentSessionName(sessionSource, ctx.LaunchID)
-	termCommand, err := newTerminalCommand(cmd.Dir, cmd.Env, argv, sessionName)
+	termCommand, err := newTerminalCommandWithStatus(cmd.Dir, cmd.Env, argv, sessionName)
 	if err != nil {
 		return EmbeddedTmuxAgentSpec{}, err
 	}
 	tmuxEnv := envWithoutKeys(os.Environ(), "TMUX", "ZELLIJ")
+	socketName := tmuxSocketName(sessionName)
+	tmuxArgs := isolatedTmuxArgs(socketName)
 	spec := EmbeddedTmuxAgentSpec{
 		SessionName:        sessionName,
 		ScriptPath:         termCommand.scriptPath,
-		HasSessionCommand:  exec.Command("tmux", "has-session", "-t", sessionName),
-		NewSessionCommand:  exec.Command("tmux", "new-session", "-d", "-s", sessionName, "-c", cmd.Dir, termCommand.shellCommand()),
-		AttachCommand:      exec.Command("tmux", "attach-session", "-t", sessionName),
-		KillSessionCommand: exec.Command("tmux", "kill-session", "-t", sessionName),
+		StatusPath:         termCommand.statusPath,
+		DetachTarget:       tmuxDetachTarget(socketName, sessionName),
+		HasSessionCommand:  exec.Command("tmux", append(tmuxArgs, "has-session", "-t", sessionName)...),
+		NewSessionCommand:  exec.Command("tmux", append(append([]string{}, tmuxArgs...), tmuxNewSessionArgs(sessionName, cmd.Dir, termCommand.shellCommand())...)...),
+		AttachCommand:      tmuxAttachStatusCommand(socketName, sessionName, termCommand.statusPath),
+		KillSessionCommand: exec.Command("tmux", append(tmuxArgs, "kill-session", "-t", sessionName)...),
 		Cleanup:            termCommand.cleanup,
 	}
 	spec.HasSessionCommand.Env = tmuxEnv
@@ -803,6 +809,47 @@ func embeddedTmuxAgentCommand(ctx AgentLaunchContext, lookPath lookPathFunc) (Em
 	spec.AttachCommand.Env = tmuxEnv
 	spec.KillSessionCommand.Env = tmuxEnv
 	return spec, nil
+}
+
+func isolatedTmuxArgs(socketName string) []string {
+	return []string{"-f", "/dev/null", "-L", socketName}
+}
+
+func tmuxSocketName(sessionName string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(sessionName))
+	return fmt.Sprintf("wtui-agent-%08x", h.Sum32())
+}
+
+func tmuxDetachTarget(socketName, sessionName string) string {
+	return "env -u TMUX tmux -f /dev/null -L " + shellQuote(socketName) + " attach-session -t " + shellQuote(sessionName)
+}
+
+func tmuxNewSessionArgs(sessionName, dir, shellCommand string) []string {
+	return []string{
+		"start-server",
+		";", "set-option", "-g", "prefix", "None",
+		";", "unbind-key", "C-b",
+		";", "set-option", "-g", "status", "off",
+		";", "new-session", "-d", "-s", sessionName, "-c", dir, shellCommand,
+	}
+}
+
+func tmuxAttachStatusCommand(socketName, sessionName, statusPath string) *exec.Cmd {
+	script := strings.TrimSpace(`
+tmux -f /dev/null -L "$1" attach-session -t "$2"
+tmux_status=$?
+if [ -r "$3" ]; then
+	IFS= read -r agent_status < "$3"
+	rm -f "$3"
+	case "$agent_status" in
+		""|*[!0-9]*) exit "$tmux_status" ;;
+		*) exit "$agent_status" ;;
+	esac
+fi
+exit "$tmux_status"
+`)
+	return exec.Command("/bin/sh", "-c", script, "wtui", socketName, sessionName, statusPath)
 }
 
 func agentCommandSpec(ctx AgentLaunchContext) (*exec.Cmd, []envVar, error) {
@@ -1124,17 +1171,38 @@ func wtuiSessionHookCommand(provider string) string {
 // tmux/zellij/osascript/terminal argv.
 type terminalCommand struct {
 	scriptPath string
+	statusPath string
 	// session overrides the tmux/Zellij session name for this launch. When
 	// empty, the transport falls back to WorktreeSessionName(path).
 	session string
 }
 
 func newTerminalCommand(dir string, env []string, argv []string, session string) (*terminalCommand, error) {
-	scriptPath, err := writeTerminalCommandScript(dir, env, argv)
+	return newTerminalCommandWithStatusPath(dir, env, argv, session, "")
+}
+
+func newTerminalCommandWithStatus(dir string, env []string, argv []string, session string) (*terminalCommand, error) {
+	statusFile, err := os.CreateTemp("", "wtui-agent-status-*.txt")
 	if err != nil {
 		return nil, err
 	}
-	return &terminalCommand{scriptPath: scriptPath, session: session}, nil
+	statusPath := statusFile.Name()
+	if err := statusFile.Close(); err != nil {
+		_ = os.Remove(statusPath)
+		return nil, err
+	}
+	return newTerminalCommandWithStatusPath(dir, env, argv, session, statusPath)
+}
+
+func newTerminalCommandWithStatusPath(dir string, env []string, argv []string, session, statusPath string) (*terminalCommand, error) {
+	scriptPath, err := writeTerminalCommandScript(dir, env, argv, statusPath)
+	if err != nil {
+		if statusPath != "" {
+			_ = os.Remove(statusPath)
+		}
+		return nil, err
+	}
+	return &terminalCommand{scriptPath: scriptPath, statusPath: statusPath, session: session}, nil
 }
 
 // shellCommand renders only the safe transport command. The script it calls
@@ -1148,9 +1216,12 @@ func (c *terminalCommand) cleanup() {
 	if c != nil && c.scriptPath != "" {
 		_ = os.Remove(c.scriptPath)
 	}
+	if c != nil && c.statusPath != "" {
+		_ = os.Remove(c.statusPath)
+	}
 }
 
-func writeTerminalCommandScript(dir string, env []string, argv []string) (string, error) {
+func writeTerminalCommandScript(dir string, env []string, argv []string, statusPath string) (string, error) {
 	if len(argv) == 0 {
 		return "", fmt.Errorf("agent command has no argv")
 	}
@@ -1180,12 +1251,27 @@ func writeTerminalCommandScript(dir string, env []string, argv []string) (string
 	}
 	b.WriteString("cleanup\n")
 	b.WriteString("trap - EXIT HUP INT TERM\n")
-	b.WriteString("exec")
+	if statusPath == "" {
+		b.WriteString("exec")
+	} else {
+		b.WriteString("set +e\n")
+	}
 	for _, arg := range argv {
 		b.WriteByte(' ')
 		b.WriteString(shellQuote(arg))
 	}
 	b.WriteByte('\n')
+	if statusPath != "" {
+		b.WriteString("status=$?\n")
+		b.WriteString("if [ -e ")
+		b.WriteString(shellQuote(statusPath))
+		b.WriteString(" ]; then\n")
+		b.WriteString("printf '%s\\n' \"$status\" > ")
+		b.WriteString(shellQuote(statusPath))
+		b.WriteByte('\n')
+		b.WriteString("fi\n")
+		b.WriteString("exit \"$status\"\n")
+	}
 
 	if _, err := file.WriteString(b.String()); err != nil {
 		cleanup()

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -786,7 +786,8 @@ func embeddedTmuxAgentCommand(ctx AgentLaunchContext, lookPath lookPathFunc) (Em
 		return EmbeddedTmuxAgentSpec{}, err
 	}
 	sessionName := agentSessionName(sessionSource, ctx.LaunchID)
-	termCommand, err := newTerminalCommandWithStatus(cmd.Dir, cmd.Env, argv, sessionName)
+	agentEnv := envWithoutKeys(cmd.Env, "TMUX", "ZELLIJ")
+	termCommand, err := newTerminalCommandWithStatus(cmd.Dir, agentEnv, argv, sessionName)
 	if err != nil {
 		return EmbeddedTmuxAgentSpec{}, err
 	}

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -595,6 +595,22 @@ type TerminalLaunchSpec struct {
 	Cleanup  func()
 }
 
+// ErrEmbeddedTmuxUnavailable tells callers they can use the direct embedded PTY
+// path because tmux is not installed.
+var ErrEmbeddedTmuxUnavailable = errors.New("tmux is not available for embedded terminal detach")
+
+// EmbeddedTmuxAgentSpec describes a CLI agent launch that runs inside a tmux
+// session while wtui embeds only an attached tmux client.
+type EmbeddedTmuxAgentSpec struct {
+	SessionName        string
+	ScriptPath         string
+	HasSessionCommand  *exec.Cmd
+	NewSessionCommand  *exec.Cmd
+	AttachCommand      *exec.Cmd
+	KillSessionCommand *exec.Cmd
+	Cleanup            func()
+}
+
 // LaunchOptions customizes external terminal transports without changing
 // multiplexer/session selection.
 type LaunchOptions struct {
@@ -742,6 +758,51 @@ func sanitizeSessionSuffix(s string) string {
 func AgentCommand(ctx AgentLaunchContext) (*exec.Cmd, error) {
 	cmd, _, err := agentCommandSpec(ctx)
 	return cmd, err
+}
+
+// EmbeddedTmuxAgentCommand builds the tmux lifecycle commands for a detachable
+// embedded CLI agent launch. It does not start tmux.
+func EmbeddedTmuxAgentCommand(ctx AgentLaunchContext) (EmbeddedTmuxAgentSpec, error) {
+	return embeddedTmuxAgentCommand(ctx, exec.LookPath)
+}
+
+func embeddedTmuxAgentCommand(ctx AgentLaunchContext, lookPath lookPathFunc) (EmbeddedTmuxAgentSpec, error) {
+	if !commandExists("tmux", lookPath) {
+		return EmbeddedTmuxAgentSpec{}, ErrEmbeddedTmuxUnavailable
+	}
+	ctx.Embedded = true
+	cmd, _, err := agentCommandSpec(ctx)
+	if err != nil {
+		return EmbeddedTmuxAgentSpec{}, err
+	}
+	sessionSource := ctx.WorktreePath
+	if sessionSource == "" {
+		sessionSource = cmd.Dir
+	}
+	argv, err := resolvedCommandArgv(cmd)
+	if err != nil {
+		return EmbeddedTmuxAgentSpec{}, err
+	}
+	sessionName := agentSessionName(sessionSource, ctx.LaunchID)
+	termCommand, err := newTerminalCommand(cmd.Dir, cmd.Env, argv, sessionName)
+	if err != nil {
+		return EmbeddedTmuxAgentSpec{}, err
+	}
+	tmuxEnv := envWithoutKeys(os.Environ(), "TMUX", "ZELLIJ")
+	spec := EmbeddedTmuxAgentSpec{
+		SessionName:        sessionName,
+		ScriptPath:         termCommand.scriptPath,
+		HasSessionCommand:  exec.Command("tmux", "has-session", "-t", sessionName),
+		NewSessionCommand:  exec.Command("tmux", "new-session", "-d", "-s", sessionName, "-c", cmd.Dir, termCommand.shellCommand()),
+		AttachCommand:      exec.Command("tmux", "attach-session", "-t", sessionName),
+		KillSessionCommand: exec.Command("tmux", "kill-session", "-t", sessionName),
+		Cleanup:            termCommand.cleanup,
+	}
+	spec.HasSessionCommand.Env = tmuxEnv
+	spec.NewSessionCommand.Env = tmuxEnv
+	spec.AttachCommand.Env = tmuxEnv
+	spec.KillSessionCommand.Env = tmuxEnv
+	return spec, nil
 }
 
 func agentCommandSpec(ctx AgentLaunchContext) (*exec.Cmd, []envVar, error) {
@@ -937,6 +998,24 @@ func envWithoutPrefix(prefix string) []string {
 		env = append(env, entry)
 	}
 	return env
+}
+
+func envWithoutKeys(env []string, keys ...string) []string {
+	drop := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		drop[key] = struct{}{}
+	}
+	out := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok {
+			if _, found := drop[key]; found {
+				continue
+			}
+		}
+		out = append(out, entry)
+	}
+	return out
 }
 
 func envWithOverrides(overrides ...envVar) []string {

--- a/actions/agent_launch_internal_test.go
+++ b/actions/agent_launch_internal_test.go
@@ -822,6 +822,7 @@ func TestCodexAppLaunchRejectsUnsupportedPlatform(t *testing.T) {
 func TestEmbeddedTmuxAgentCommandBuildsPrivateScriptTransport(t *testing.T) {
 	putAgentOnPath(t, "codex")
 	t.Setenv("TMUX", "/tmp/parent-tmux.sock")
+	t.Setenv("ZELLIJ", "parent-zellij")
 	ctx := planAgentContext()
 	ctx.Embedded = true
 	ctx.Headless = true
@@ -888,6 +889,11 @@ func TestEmbeddedTmuxAgentCommandBuildsPrivateScriptTransport(t *testing.T) {
 		"printf '%s\\n' \"$status\" > " + shellQuote(spec.StatusPath),
 	} {
 		requireScriptContains(t, script, want)
+	}
+	for _, blocked := range []string{"export TMUX=", "export ZELLIJ="} {
+		if strings.Contains(script, blocked) {
+			t.Fatalf("agent launch script should not inherit parent multiplexer env %q:\n%s", blocked, script)
+		}
 	}
 	spec.Cleanup()
 	if _, err := os.Stat(spec.ScriptPath); !errors.Is(err, os.ErrNotExist) {

--- a/actions/agent_launch_internal_test.go
+++ b/actions/agent_launch_internal_test.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/url"
 	"os"
@@ -818,6 +819,63 @@ func TestCodexAppLaunchRejectsUnsupportedPlatform(t *testing.T) {
 	}
 }
 
+func TestEmbeddedTmuxAgentCommandBuildsPrivateScriptTransport(t *testing.T) {
+	putAgentOnPath(t, "codex")
+	t.Setenv("TMUX", "/tmp/parent-tmux.sock")
+	ctx := planAgentContext()
+	ctx.Embedded = true
+	ctx.Headless = true
+	ctx.LaunchID = "launch/tmux"
+
+	spec, err := embeddedTmuxAgentCommand(ctx, fakeLookPath("tmux"))
+	if err != nil {
+		t.Fatalf("embeddedTmuxAgentCommand returned error: %v", err)
+	}
+	defer spec.Cleanup()
+
+	if want := WorktreeSessionName(ctx.WorktreePath) + "-agent-launch-tmux"; spec.SessionName != want {
+		t.Fatalf("session name = %q, want per-launch agent session", spec.SessionName)
+	}
+	if got, want := spec.HasSessionCommand.Args, []string{"tmux", "has-session", "-t", spec.SessionName}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("has-session args = %#v, want %#v", got, want)
+	}
+	if got, want := spec.AttachCommand.Args, []string{"tmux", "attach-session", "-t", spec.SessionName}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("attach args = %#v, want %#v", got, want)
+	}
+	if envValue(spec.AttachCommand.Env, "TMUX") != "" {
+		t.Fatalf("attach command inherited TMUX: %#v", spec.AttachCommand.Env)
+	}
+	if got, want := spec.NewSessionCommand.Args[:7], []string{"tmux", "new-session", "-d", "-s", spec.SessionName, "-c", "/repo/worktree"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("new-session args prefix = %#v, want %#v", got, want)
+	}
+	if got := spec.NewSessionCommand.Args[7]; got != "exec sh "+shellQuote(spec.ScriptPath) {
+		t.Fatalf("new-session script command = %q, want private script exec", got)
+	}
+	if got, want := spec.KillSessionCommand.Args, []string{"tmux", "kill-session", "-t", spec.SessionName}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("kill-session args = %#v, want %#v", got, want)
+	}
+
+	script := agentLaunchScript(t)
+	for _, want := range []string{
+		"cd '/repo/worktree' || exit",
+		"WTUI_LAUNCH_ID='launch/tmux'",
+		"WTUI_PLAN_ID='plan-1'",
+		"codex",
+		"exec",
+		"Read the plan and begin implementation.",
+	} {
+		requireScriptContains(t, script, want)
+	}
+}
+
+func TestEmbeddedTmuxAgentCommandReportsMissingTmux(t *testing.T) {
+	putAgentOnPath(t, "codex")
+	_, err := embeddedTmuxAgentCommand(planAgentContext(), fakeLookPath())
+	if !errors.Is(err, ErrEmbeddedTmuxUnavailable) {
+		t.Fatalf("error = %v, want ErrEmbeddedTmuxUnavailable", err)
+	}
+}
+
 func assertNoWTUIEnv(t *testing.T, env []string) {
 	t.Helper()
 	for _, entry := range env {
@@ -826,4 +884,14 @@ func assertNoWTUIEnv(t *testing.T, env []string) {
 			t.Fatalf("expected codex-app open command to scrub WTUI env, found %q in %#v", key, env)
 		}
 	}
+}
+
+func envValue(env []string, key string) string {
+	for _, entry := range env {
+		k, v, ok := strings.Cut(entry, "=")
+		if ok && k == key {
+			return v
+		}
+	}
+	return ""
 }

--- a/actions/agent_launch_internal_test.go
+++ b/actions/agent_launch_internal_test.go
@@ -836,22 +836,43 @@ func TestEmbeddedTmuxAgentCommandBuildsPrivateScriptTransport(t *testing.T) {
 	if want := WorktreeSessionName(ctx.WorktreePath) + "-agent-launch-tmux"; spec.SessionName != want {
 		t.Fatalf("session name = %q, want per-launch agent session", spec.SessionName)
 	}
-	if got, want := spec.HasSessionCommand.Args, []string{"tmux", "has-session", "-t", spec.SessionName}; !reflect.DeepEqual(got, want) {
+	if spec.StatusPath == "" {
+		t.Fatal("expected status path for tmux exit propagation")
+	}
+	socketName := spec.HasSessionCommand.Args[4]
+	if !strings.HasPrefix(socketName, "wtui-agent-") || len(socketName) != len("wtui-agent-00000000") {
+		t.Fatalf("socket name = %q, want short hashed wtui-agent name", socketName)
+	}
+	if strings.Contains(socketName, spec.SessionName) {
+		t.Fatalf("socket name %q should not embed full session name %q", socketName, spec.SessionName)
+	}
+	if got, want := spec.DetachTarget, "env -u TMUX tmux -f /dev/null -L "+shellQuote(socketName)+" attach-session -t "+shellQuote(spec.SessionName); got != want {
+		t.Fatalf("detach target = %q, want %q", got, want)
+	}
+	if got, want := spec.HasSessionCommand.Args, []string{"tmux", "-f", "/dev/null", "-L", socketName, "has-session", "-t", spec.SessionName}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("has-session args = %#v, want %#v", got, want)
 	}
-	if got, want := spec.AttachCommand.Args, []string{"tmux", "attach-session", "-t", spec.SessionName}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("attach args = %#v, want %#v", got, want)
+	if got, want := spec.AttachCommand.Args[:3], []string{"/bin/sh", "-c", "tmux -f /dev/null -L \"$1\" attach-session -t \"$2\"\ntmux_status=$?\nif [ -r \"$3\" ]; then\n\tIFS= read -r agent_status < \"$3\"\n\trm -f \"$3\"\n\tcase \"$agent_status\" in\n\t\t\"\"|*[!0-9]*) exit \"$tmux_status\" ;;\n\t\t*) exit \"$agent_status\" ;;\n\tesac\nfi\nexit \"$tmux_status\""}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("attach args prefix = %#v, want %#v", got, want)
+	}
+	if got, want := spec.AttachCommand.Args[3:], []string{"wtui", socketName, spec.SessionName, spec.StatusPath}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("attach wrapper args = %#v, want %#v", got, want)
 	}
 	if envValue(spec.AttachCommand.Env, "TMUX") != "" {
 		t.Fatalf("attach command inherited TMUX: %#v", spec.AttachCommand.Env)
 	}
-	if got, want := spec.NewSessionCommand.Args[:7], []string{"tmux", "new-session", "-d", "-s", spec.SessionName, "-c", "/repo/worktree"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("new-session args prefix = %#v, want %#v", got, want)
+	wantNewSession := []string{
+		"tmux", "-f", "/dev/null", "-L", socketName,
+		"start-server",
+		";", "set-option", "-g", "prefix", "None",
+		";", "unbind-key", "C-b",
+		";", "set-option", "-g", "status", "off",
+		";", "new-session", "-d", "-s", spec.SessionName, "-c", "/repo/worktree", "exec sh " + shellQuote(spec.ScriptPath),
 	}
-	if got := spec.NewSessionCommand.Args[7]; got != "exec sh "+shellQuote(spec.ScriptPath) {
-		t.Fatalf("new-session script command = %q, want private script exec", got)
+	if got := spec.NewSessionCommand.Args; !reflect.DeepEqual(got, wantNewSession) {
+		t.Fatalf("new-session args = %#v, want %#v", got, wantNewSession)
 	}
-	if got, want := spec.KillSessionCommand.Args, []string{"tmux", "kill-session", "-t", spec.SessionName}; !reflect.DeepEqual(got, want) {
+	if got, want := spec.KillSessionCommand.Args, []string{"tmux", "-f", "/dev/null", "-L", socketName, "kill-session", "-t", spec.SessionName}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("kill-session args = %#v, want %#v", got, want)
 	}
 
@@ -863,8 +884,17 @@ func TestEmbeddedTmuxAgentCommandBuildsPrivateScriptTransport(t *testing.T) {
 		"codex",
 		"exec",
 		"Read the plan and begin implementation.",
+		"if [ -e " + shellQuote(spec.StatusPath) + " ]; then",
+		"printf '%s\\n' \"$status\" > " + shellQuote(spec.StatusPath),
 	} {
 		requireScriptContains(t, script, want)
+	}
+	spec.Cleanup()
+	if _, err := os.Stat(spec.ScriptPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("script cleanup error = %v, want removed", err)
+	}
+	if _, err := os.Stat(spec.StatusPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("status cleanup error = %v, want removed", err)
 	}
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -326,11 +326,11 @@ provider session from the selected phase row; CLI resumes open in runtime-only
 embedded PTYs in the flows pane, while `codex-app` resumes navigate externally.
 While a Flow terminal is open, `tab` switches focus between the Flow list and
 terminal. Terminal focus starts in wtui command mode: `left`/`right` cycles Flow
-terminals, `1`-`9` switches by number, `x` closes, `q`/`esc` quits, unknown
-ordinary keys do not pass through to the PTY, and `ctrl+]` sends a literal
-`ctrl+]`; `i` enters terminal input mode. In input mode, keys pass through to the
-PTY (including agent shortcuts like `ctrl+g`) and `ctrl+]` returns to command
-mode. Embedded headless output is rendered as
+terminals, `1`-`9` switches by number, `d` detaches to tmux when available, `x`
+closes, `q`/`esc` quits, unknown ordinary keys do not pass through to the PTY,
+and `ctrl+]` sends a literal `ctrl+]`; `i` enters terminal input mode. In input
+mode, keys pass through to the PTY (including agent shortcuts like `ctrl+g`) and
+`ctrl+]` returns to command mode. Embedded headless output is rendered as
 readable terminal text rather than raw provider event JSON; `codex exec` streams
 progress while it runs, whereas `claude --print` only prints its result once the
 run completes. Expanded rows
@@ -595,15 +595,21 @@ Session resume uses the stored provider session ID. Codex resumes with
 `codex ... resume <session-id>` and Claude Code resumes with
 `claude ... --resume <session-id>`, while preserving the same wtui hook and
 metadata environment wiring as fresh launches. In the full sessions view, those
-CLI resumes run inside runtime-only embedded PTYs in the sessions pane. Fresh
-Flow selected-phase launches and Flow phase-session resumes run CLI agents
-inside runtime-only embedded PTYs in the flows pane; Flow headless mode chooses
+CLI resumes run inside runtime-only embedded PTYs in the sessions pane. When
+`tmux` is available at launch time, those embedded CLI terminals are backed by a
+per-launch tmux session and `ctrl+] d` detaches wtui's embedded client while the
+agent continues in tmux. When `tmux` is unavailable, wtui uses the direct
+embedded PTY path and reports detach unavailable. Fresh Flow selected-phase
+launches and Flow phase-session resumes run CLI agents inside runtime-only
+embedded PTYs in the flows pane; Flow headless mode chooses
 headless provider commands (`codex exec` / `claude --print`) versus interactive
 provider commands (`codex` / `claude`) inside that embedded terminal. Flow
 phase-session resumes also run inside runtime-only embedded PTYs in the flows
 pane. Other non-Flow agent launches keep using their existing external terminal
 transport, and `codex-app` Flow launches and resumes keep using deep-link
-transport. The TUI refuses to
+transport. `ctrl+] x` and quit cleanup terminate embedded terminals and kill
+tmux sessions created by the current embedded launch; detached sessions are no
+longer owned by wtui and are not terminated when wtui exits. The TUI refuses to
 resume a stored session whose provider session ID is blank (it reports this in
 the status line instead), and command construction trims resume session IDs and
 rejects whitespace-only ones, so a resume command never carries a blank `--resume`

--- a/docs/config.md
+++ b/docs/config.md
@@ -441,11 +441,11 @@ skipped with notes. Flow phase launch prompts stay minimal: Plan Review and
 Implementation point to the saved plan artifact, while Review Loop and PR
 Creation include only the worktree, branch, and start commit metadata needed to
 inspect the changes. Built-in prompts tell Plan to produce only a plan,
-Plan Review to use the review-loop workflow with goal `review-and-revise` and
-max 6 loops, Implementation to use the `commit` skill, Review Loop to use the
-review-loop workflow with goal `review-and-revise` and `commit` when revisions
-are made, PR Creation to use the `ship` skill, and Autoreview to use `ship`
-when fixes require commits or pushes.
+Plan Review to use the review-loop skill with max 6 loops, Implementation to
+use the `commit` skill, Review Loop to use the review-loop workflow with goal
+`review-and-revise` and `commit` when revisions are made, PR Creation to use
+the `ship` skill, and Autoreview to use `ship` when fixes require commits or
+pushes.
 Autoreview launch prompts include the PR target metadata but leave completion,
 needs-attention, blocked, and restart mechanics to the high-level Flow phase
 commands.

--- a/embeddedterm/tmux.go
+++ b/embeddedterm/tmux.go
@@ -74,9 +74,6 @@ func startTmuxBackedAgent(ctx context.Context, spec actions.EmbeddedTmuxAgentSpe
 		cleanup:     spec.Cleanup,
 		run:         run,
 	}
-	if owned {
-		t.cleanup = nil
-	}
 	go t.monitor()
 	return t, nil
 }
@@ -123,9 +120,10 @@ func (t *TmuxBackedTerminal) Detach() error {
 	}
 	t.detached = true
 	t.owned = false
+	t.cleanup = nil
+	t.cleaned = true
 	t.mu.Unlock()
 	err := t.term.Close()
-	t.cleanupOnce()
 	return err
 }
 
@@ -160,6 +158,8 @@ func (t *TmuxBackedTerminal) handleExit(err error) {
 	if err == nil && !t.terminating {
 		t.detached = true
 		t.owned = false
+		t.cleanup = nil
+		t.cleaned = true
 	}
 	killCommand := t.killCommand
 	run := t.run

--- a/embeddedterm/tmux.go
+++ b/embeddedterm/tmux.go
@@ -74,6 +74,9 @@ func startTmuxBackedAgent(ctx context.Context, spec actions.EmbeddedTmuxAgentSpe
 		cleanup:     spec.Cleanup,
 		run:         run,
 	}
+	if owned {
+		t.cleanup = nil
+	}
 	go t.monitor()
 	return t, nil
 }
@@ -101,7 +104,11 @@ func (t *TmuxBackedTerminal) Resize(width, height int) error {
 }
 
 func (t *TmuxBackedTerminal) Wait(ctx context.Context) error {
-	return t.term.Wait(ctx)
+	err := t.term.Wait(ctx)
+	if err == nil {
+		t.handleExit(nil)
+	}
+	return err
 }
 
 func (t *TmuxBackedTerminal) State() State { return t.term.State() }
@@ -115,6 +122,7 @@ func (t *TmuxBackedTerminal) Detach() error {
 		return nil
 	}
 	t.detached = true
+	t.owned = false
 	t.mu.Unlock()
 	err := t.term.Close()
 	t.cleanupOnce()
@@ -124,7 +132,7 @@ func (t *TmuxBackedTerminal) Detach() error {
 func (t *TmuxBackedTerminal) Terminate() error {
 	t.mu.Lock()
 	t.terminating = true
-	owned := t.owned
+	owned := t.owned && !t.detached
 	killCommand := t.killCommand
 	run := t.run
 	t.mu.Unlock()
@@ -141,16 +149,24 @@ func (t *TmuxBackedTerminal) Terminate() error {
 }
 
 func (t *TmuxBackedTerminal) monitor() {
-	_ = t.term.Wait(context.Background())
+	err := t.term.Wait(context.Background())
+	t.handleExit(err)
+	t.cleanupOnce()
+}
+
+func (t *TmuxBackedTerminal) handleExit(err error) {
 	t.mu.Lock()
-	shouldKill := t.owned && !t.detached && !t.terminating
+	shouldKill := err != nil && t.owned && !t.detached && !t.terminating
+	if err == nil && !t.terminating {
+		t.detached = true
+		t.owned = false
+	}
 	killCommand := t.killCommand
 	run := t.run
 	t.mu.Unlock()
 	if shouldKill && killCommand != nil {
 		_ = run(killCommand)
 	}
-	t.cleanupOnce()
 }
 
 func (t *TmuxBackedTerminal) cleanupOnce() {

--- a/embeddedterm/tmux.go
+++ b/embeddedterm/tmux.go
@@ -1,0 +1,168 @@
+package embeddedterm
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/brian-bell/wtui/actions"
+)
+
+type commandRunner func(*exec.Cmd) error
+
+// TmuxBackedTerminal embeds a tmux client while the agent process runs inside
+// the tmux session. Detach closes only wtui's client; Terminate remains
+// destructive for sessions this launch created.
+type TmuxBackedTerminal struct {
+	term        *Terminal
+	target      string
+	owned       bool
+	killCommand *exec.Cmd
+	cleanup     func()
+	run         commandRunner
+
+	mu          sync.Mutex
+	detached    bool
+	terminating bool
+	cleaned     bool
+}
+
+// StartTmuxBackedAgent starts a detachable embedded agent terminal from spec.
+func StartTmuxBackedAgent(ctx context.Context, spec actions.EmbeddedTmuxAgentSpec, width, height int) (*TmuxBackedTerminal, error) {
+	return startTmuxBackedAgent(ctx, spec, width, height, runCommand, NewManager().StartCommand)
+}
+
+func startTmuxBackedAgent(ctx context.Context, spec actions.EmbeddedTmuxAgentSpec, width, height int, run commandRunner, start func(context.Context, *exec.Cmd, int, int) (*Terminal, error)) (*TmuxBackedTerminal, error) {
+	if spec.HasSessionCommand == nil || spec.NewSessionCommand == nil || spec.AttachCommand == nil {
+		if spec.Cleanup != nil {
+			spec.Cleanup()
+		}
+		return nil, fmt.Errorf("tmux embedded terminal spec is incomplete")
+	}
+	owned := false
+	if err := run(spec.HasSessionCommand); err != nil {
+		if err := run(spec.NewSessionCommand); err != nil {
+			if spec.Cleanup != nil {
+				spec.Cleanup()
+			}
+			return nil, err
+		}
+		owned = true
+	} else if spec.Cleanup != nil {
+		spec.Cleanup()
+		spec.Cleanup = nil
+	}
+
+	term, err := start(ctx, spec.AttachCommand, width, height)
+	if err != nil {
+		if owned && spec.KillSessionCommand != nil {
+			_ = run(spec.KillSessionCommand)
+		}
+		if spec.Cleanup != nil {
+			spec.Cleanup()
+		}
+		return nil, err
+	}
+
+	t := &TmuxBackedTerminal{
+		term:        term,
+		target:      spec.SessionName,
+		owned:       owned,
+		killCommand: spec.KillSessionCommand,
+		cleanup:     spec.Cleanup,
+		run:         run,
+	}
+	go t.monitor()
+	return t, nil
+}
+
+func runCommand(cmd *exec.Cmd) error {
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	msg := strings.TrimSpace(string(out))
+	if msg == "" {
+		return err
+	}
+	return fmt.Errorf("%s: %w", msg, err)
+}
+
+func (t *TmuxBackedTerminal) VisibleLines(width, height int) []string {
+	return t.term.VisibleLines(width, height)
+}
+
+func (t *TmuxBackedTerminal) Write(p []byte) (int, error) { return t.term.Write(p) }
+
+func (t *TmuxBackedTerminal) Resize(width, height int) error {
+	return t.term.Resize(width, height)
+}
+
+func (t *TmuxBackedTerminal) Wait(ctx context.Context) error {
+	return t.term.Wait(ctx)
+}
+
+func (t *TmuxBackedTerminal) State() State { return t.term.State() }
+
+func (t *TmuxBackedTerminal) DetachTarget() string { return t.target }
+
+func (t *TmuxBackedTerminal) Detach() error {
+	t.mu.Lock()
+	if t.detached {
+		t.mu.Unlock()
+		return nil
+	}
+	t.detached = true
+	t.mu.Unlock()
+	err := t.term.Close()
+	t.cleanupOnce()
+	return err
+}
+
+func (t *TmuxBackedTerminal) Terminate() error {
+	t.mu.Lock()
+	t.terminating = true
+	owned := t.owned
+	killCommand := t.killCommand
+	run := t.run
+	t.mu.Unlock()
+	var killErr error
+	if owned && killCommand != nil {
+		killErr = run(killCommand)
+	}
+	termErr := t.term.Terminate()
+	t.cleanupOnce()
+	if killErr != nil {
+		return killErr
+	}
+	return termErr
+}
+
+func (t *TmuxBackedTerminal) monitor() {
+	_ = t.term.Wait(context.Background())
+	t.mu.Lock()
+	shouldKill := t.owned && !t.detached && !t.terminating
+	killCommand := t.killCommand
+	run := t.run
+	t.mu.Unlock()
+	if shouldKill && killCommand != nil {
+		_ = run(killCommand)
+	}
+	t.cleanupOnce()
+}
+
+func (t *TmuxBackedTerminal) cleanupOnce() {
+	t.mu.Lock()
+	if t.cleaned {
+		t.mu.Unlock()
+		return
+	}
+	t.cleaned = true
+	cleanup := t.cleanup
+	t.mu.Unlock()
+	if cleanup != nil {
+		cleanup()
+	}
+}

--- a/embeddedterm/tmux.go
+++ b/embeddedterm/tmux.go
@@ -66,9 +66,13 @@ func startTmuxBackedAgent(ctx context.Context, spec actions.EmbeddedTmuxAgentSpe
 		return nil, err
 	}
 
+	target := spec.DetachTarget
+	if target == "" {
+		target = spec.SessionName
+	}
 	t := &TmuxBackedTerminal{
 		term:        term,
-		target:      spec.SessionName,
+		target:      target,
 		owned:       owned,
 		killCommand: spec.KillSessionCommand,
 		cleanup:     spec.Cleanup,
@@ -129,6 +133,10 @@ func (t *TmuxBackedTerminal) Detach() error {
 
 func (t *TmuxBackedTerminal) Terminate() error {
 	t.mu.Lock()
+	if t.detached {
+		t.mu.Unlock()
+		return nil
+	}
 	t.terminating = true
 	owned := t.owned && !t.detached
 	killCommand := t.killCommand

--- a/embeddedterm/tmux_test.go
+++ b/embeddedterm/tmux_test.go
@@ -71,9 +71,7 @@ func TestTmuxBackedTerminalTerminateKillsOwnedSession(t *testing.T) {
 	if !runner.called("kill-session") {
 		t.Fatalf("terminate should kill owned tmux session, calls: %#v", runner.snapshot())
 	}
-	if got := cleanupCount.Load(); got != 0 {
-		t.Fatalf("cleanup count = %d, want owned running session to rely on script self-cleanup", got)
-	}
+	waitCleanupCount(t, cleanupCount, 1)
 }
 
 func TestTmuxBackedTerminalExistingSessionIsUnowned(t *testing.T) {
@@ -209,9 +207,7 @@ func TestTmuxBackedTerminalUnexpectedAttachExitKillsOwnedSession(t *testing.T) {
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		if runner.called("kill-session") {
-			if got := cleanupCount.Load(); got != 0 {
-				t.Fatalf("cleanup count = %d, want owned running session to rely on script self-cleanup", got)
-			}
+			waitCleanupCount(t, cleanupCount, 1)
 			return
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/embeddedterm/tmux_test.go
+++ b/embeddedterm/tmux_test.go
@@ -1,0 +1,229 @@
+package embeddedterm
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brian-bell/wtui/actions"
+)
+
+func TestTmuxBackedTerminalDetachLeavesOwnedSessionRunning(t *testing.T) {
+	spec, cleanupCount := tmuxTestSpec()
+	runner := &tmuxTestRunner{failHasSession: true}
+	term, err := startTmuxBackedAgent(context.Background(), spec, 20, 3, runner.run, startSleepTerminal)
+	if err != nil {
+		t.Fatalf("startTmuxBackedAgent returned error: %v", err)
+	}
+
+	if err := term.Detach(); err != nil {
+		t.Fatalf("Detach returned error: %v", err)
+	}
+
+	if runner.called("kill-session") {
+		t.Fatalf("detach should not kill owned tmux session, calls: %#v", runner.calls)
+	}
+	if got := *cleanupCount; got != 1 {
+		t.Fatalf("cleanup count = %d, want 1", got)
+	}
+}
+
+func TestTmuxBackedTerminalTerminateKillsOwnedSession(t *testing.T) {
+	spec, cleanupCount := tmuxTestSpec()
+	runner := &tmuxTestRunner{failHasSession: true}
+	term, err := startTmuxBackedAgent(context.Background(), spec, 20, 3, runner.run, startSleepTerminal)
+	if err != nil {
+		t.Fatalf("startTmuxBackedAgent returned error: %v", err)
+	}
+
+	if err := term.Terminate(); err != nil {
+		t.Fatalf("Terminate returned error: %v", err)
+	}
+
+	if !runner.called("kill-session") {
+		t.Fatalf("terminate should kill owned tmux session, calls: %#v", runner.calls)
+	}
+	if got := *cleanupCount; got != 1 {
+		t.Fatalf("cleanup count = %d, want 1", got)
+	}
+}
+
+func TestTmuxBackedTerminalExistingSessionIsUnowned(t *testing.T) {
+	spec, cleanupCount := tmuxTestSpec()
+	runner := &tmuxTestRunner{}
+	term, err := startTmuxBackedAgent(context.Background(), spec, 20, 3, runner.run, startSleepTerminal)
+	if err != nil {
+		t.Fatalf("startTmuxBackedAgent returned error: %v", err)
+	}
+
+	if err := term.Terminate(); err != nil {
+		t.Fatalf("Terminate returned error: %v", err)
+	}
+
+	if runner.called("new-session") || runner.called("kill-session") {
+		t.Fatalf("existing unowned session should not be created or killed, calls: %#v", runner.calls)
+	}
+	if got := *cleanupCount; got != 1 {
+		t.Fatalf("cleanup count = %d, want unused script cleaned once", got)
+	}
+}
+
+func TestTmuxBackedTerminalStartFailureCleansOwnedSession(t *testing.T) {
+	spec, cleanupCount := tmuxTestSpec()
+	runner := &tmuxTestRunner{failHasSession: true}
+	startErr := errors.New("pty start failed")
+	_, err := startTmuxBackedAgent(context.Background(), spec, 20, 3, runner.run, func(context.Context, *exec.Cmd, int, int) (*Terminal, error) {
+		return nil, startErr
+	})
+	if !errors.Is(err, startErr) {
+		t.Fatalf("error = %v, want %v", err, startErr)
+	}
+	if !runner.called("kill-session") {
+		t.Fatalf("start failure should kill newly-created tmux session, calls: %#v", runner.calls)
+	}
+	if got := *cleanupCount; got != 1 {
+		t.Fatalf("cleanup count = %d, want 1", got)
+	}
+}
+
+func TestTmuxBackedTerminalCreateFailureCleansScript(t *testing.T) {
+	spec, cleanupCount := tmuxTestSpec()
+	createErr := errors.New("tmux new-session failed")
+	runner := &tmuxTestRunner{failHasSession: true, failNewSession: createErr}
+	_, err := startTmuxBackedAgent(context.Background(), spec, 20, 3, runner.run, startSleepTerminal)
+	if !errors.Is(err, createErr) {
+		t.Fatalf("error = %v, want %v", err, createErr)
+	}
+	if got := *cleanupCount; got != 1 {
+		t.Fatalf("cleanup count = %d, want 1", got)
+	}
+}
+
+func tmuxTestSpec() (actions.EmbeddedTmuxAgentSpec, *int) {
+	cleanupCount := 0
+	return actions.EmbeddedTmuxAgentSpec{
+		SessionName:        "wtui-test-agent",
+		HasSessionCommand:  exec.Command("tmux", "has-session", "-t", "wtui-test-agent"),
+		NewSessionCommand:  exec.Command("tmux", "new-session", "-d", "-s", "wtui-test-agent"),
+		AttachCommand:      exec.Command("tmux", "attach-session", "-t", "wtui-test-agent"),
+		KillSessionCommand: exec.Command("tmux", "kill-session", "-t", "wtui-test-agent"),
+		Cleanup: func() {
+			cleanupCount++
+		},
+	}, &cleanupCount
+}
+
+func startSleepTerminal(ctx context.Context, _ *exec.Cmd, width, height int) (*Terminal, error) {
+	return NewManager().StartCommand(ctx, exec.Command("sh", "-c", "sleep 10"), width, height)
+}
+
+type tmuxTestRunner struct {
+	failHasSession bool
+	failNewSession error
+	calls          [][]string
+}
+
+func (r *tmuxTestRunner) run(cmd *exec.Cmd) error {
+	r.calls = append(r.calls, append([]string(nil), cmd.Args...))
+	switch {
+	case reflect.DeepEqual(cmd.Args[:2], []string{"tmux", "has-session"}) && r.failHasSession:
+		return errors.New("missing")
+	case reflect.DeepEqual(cmd.Args[:2], []string{"tmux", "new-session"}) && r.failNewSession != nil:
+		return r.failNewSession
+	default:
+		return nil
+	}
+}
+
+func (r *tmuxTestRunner) called(subcommand string) bool {
+	for _, call := range r.calls {
+		if len(call) > 1 && call[1] == subcommand {
+			return true
+		}
+	}
+	return false
+}
+
+func TestTmuxBackedTerminalDetachTarget(t *testing.T) {
+	spec, _ := tmuxTestSpec()
+	runner := &tmuxTestRunner{}
+	term, err := startTmuxBackedAgent(context.Background(), spec, 20, 3, runner.run, startSleepTerminal)
+	if err != nil {
+		t.Fatalf("startTmuxBackedAgent returned error: %v", err)
+	}
+	defer term.Terminate()
+
+	if got := term.DetachTarget(); got != "wtui-test-agent" {
+		t.Fatalf("DetachTarget = %q, want session name", got)
+	}
+}
+
+func TestTmuxBackedTerminalUnexpectedAttachExitKillsOwnedSession(t *testing.T) {
+	spec, cleanupCount := tmuxTestSpec()
+	runner := &tmuxTestRunner{failHasSession: true}
+	term, err := startTmuxBackedAgent(context.Background(), spec, 20, 3, runner.run, func(ctx context.Context, _ *exec.Cmd, width, height int) (*Terminal, error) {
+		return NewManager().StartCommand(ctx, exec.Command("sh", "-c", "exit 7"), width, height)
+	})
+	if err != nil {
+		t.Fatalf("startTmuxBackedAgent returned error: %v", err)
+	}
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_ = term.Wait(waitCtx)
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if runner.called("kill-session") {
+			if got := *cleanupCount; got != 1 {
+				t.Fatalf("cleanup count = %d, want 1", got)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("unexpected attach exit did not kill owned tmux session, calls: %#v", runner.calls)
+}
+
+func TestTmuxBackedTerminalRealTmuxDetachLeavesSessionAlive(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	dir := t.TempDir()
+	sessionName := "wtui-test-detach-" + strings.ReplaceAll(filepath.Base(dir), ".", "-")
+	scriptPath := filepath.Join(dir, "agent.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nsleep 30\n"), 0o700); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "kill-session", "-t", sessionName).Run()
+	})
+
+	spec := actions.EmbeddedTmuxAgentSpec{
+		SessionName:        sessionName,
+		ScriptPath:         scriptPath,
+		HasSessionCommand:  exec.Command("tmux", "has-session", "-t", sessionName),
+		NewSessionCommand:  exec.Command("tmux", "new-session", "-d", "-s", sessionName, "-c", dir, "exec sh "+scriptPath),
+		AttachCommand:      exec.Command("tmux", "attach-session", "-t", sessionName),
+		KillSessionCommand: exec.Command("tmux", "kill-session", "-t", sessionName),
+		Cleanup: func() {
+			_ = os.Remove(scriptPath)
+		},
+	}
+
+	term, err := StartTmuxBackedAgent(context.Background(), spec, 40, 10)
+	if err != nil {
+		t.Fatalf("StartTmuxBackedAgent returned error: %v", err)
+	}
+	if err := term.Detach(); err != nil {
+		t.Fatalf("Detach returned error: %v", err)
+	}
+	if err := exec.Command("tmux", "has-session", "-t", sessionName).Run(); err != nil {
+		t.Fatalf("detached tmux session is not alive: %v", err)
+	}
+}

--- a/embeddedterm/tmux_test.go
+++ b/embeddedterm/tmux_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,10 +29,30 @@ func TestTmuxBackedTerminalDetachLeavesOwnedSessionRunning(t *testing.T) {
 	}
 
 	if runner.called("kill-session") {
-		t.Fatalf("detach should not kill owned tmux session, calls: %#v", runner.calls)
+		t.Fatalf("detach should not kill owned tmux session, calls: %#v", runner.snapshot())
 	}
-	if got := *cleanupCount; got != 1 {
-		t.Fatalf("cleanup count = %d, want 1", got)
+	if got := cleanupCount.Load(); got != 0 {
+		t.Fatalf("cleanup count = %d, want owned running session to rely on script self-cleanup", got)
+	}
+}
+
+func TestTmuxBackedTerminalTerminateAfterDetachDoesNotKillOwnedSession(t *testing.T) {
+	spec, _ := tmuxTestSpec()
+	runner := &tmuxTestRunner{failHasSession: true}
+	term, err := startTmuxBackedAgent(context.Background(), spec, 20, 3, runner.run, startSleepTerminal)
+	if err != nil {
+		t.Fatalf("startTmuxBackedAgent returned error: %v", err)
+	}
+
+	if err := term.Detach(); err != nil {
+		t.Fatalf("Detach returned error: %v", err)
+	}
+	if err := term.Terminate(); err != nil {
+		t.Fatalf("Terminate after detach returned error: %v", err)
+	}
+
+	if runner.called("kill-session") {
+		t.Fatalf("terminate after detach should not kill owned tmux session, calls: %#v", runner.snapshot())
 	}
 }
 
@@ -47,10 +69,10 @@ func TestTmuxBackedTerminalTerminateKillsOwnedSession(t *testing.T) {
 	}
 
 	if !runner.called("kill-session") {
-		t.Fatalf("terminate should kill owned tmux session, calls: %#v", runner.calls)
+		t.Fatalf("terminate should kill owned tmux session, calls: %#v", runner.snapshot())
 	}
-	if got := *cleanupCount; got != 1 {
-		t.Fatalf("cleanup count = %d, want 1", got)
+	if got := cleanupCount.Load(); got != 0 {
+		t.Fatalf("cleanup count = %d, want owned running session to rely on script self-cleanup", got)
 	}
 }
 
@@ -67,11 +89,9 @@ func TestTmuxBackedTerminalExistingSessionIsUnowned(t *testing.T) {
 	}
 
 	if runner.called("new-session") || runner.called("kill-session") {
-		t.Fatalf("existing unowned session should not be created or killed, calls: %#v", runner.calls)
+		t.Fatalf("existing unowned session should not be created or killed, calls: %#v", runner.snapshot())
 	}
-	if got := *cleanupCount; got != 1 {
-		t.Fatalf("cleanup count = %d, want unused script cleaned once", got)
-	}
+	waitCleanupCount(t, cleanupCount, 1)
 }
 
 func TestTmuxBackedTerminalStartFailureCleansOwnedSession(t *testing.T) {
@@ -85,11 +105,9 @@ func TestTmuxBackedTerminalStartFailureCleansOwnedSession(t *testing.T) {
 		t.Fatalf("error = %v, want %v", err, startErr)
 	}
 	if !runner.called("kill-session") {
-		t.Fatalf("start failure should kill newly-created tmux session, calls: %#v", runner.calls)
+		t.Fatalf("start failure should kill newly-created tmux session, calls: %#v", runner.snapshot())
 	}
-	if got := *cleanupCount; got != 1 {
-		t.Fatalf("cleanup count = %d, want 1", got)
-	}
+	waitCleanupCount(t, cleanupCount, 1)
 }
 
 func TestTmuxBackedTerminalCreateFailureCleansScript(t *testing.T) {
@@ -100,13 +118,11 @@ func TestTmuxBackedTerminalCreateFailureCleansScript(t *testing.T) {
 	if !errors.Is(err, createErr) {
 		t.Fatalf("error = %v, want %v", err, createErr)
 	}
-	if got := *cleanupCount; got != 1 {
-		t.Fatalf("cleanup count = %d, want 1", got)
-	}
+	waitCleanupCount(t, cleanupCount, 1)
 }
 
-func tmuxTestSpec() (actions.EmbeddedTmuxAgentSpec, *int) {
-	cleanupCount := 0
+func tmuxTestSpec() (actions.EmbeddedTmuxAgentSpec, *atomic.Int32) {
+	cleanupCount := &atomic.Int32{}
 	return actions.EmbeddedTmuxAgentSpec{
 		SessionName:        "wtui-test-agent",
 		HasSessionCommand:  exec.Command("tmux", "has-session", "-t", "wtui-test-agent"),
@@ -114,9 +130,9 @@ func tmuxTestSpec() (actions.EmbeddedTmuxAgentSpec, *int) {
 		AttachCommand:      exec.Command("tmux", "attach-session", "-t", "wtui-test-agent"),
 		KillSessionCommand: exec.Command("tmux", "kill-session", "-t", "wtui-test-agent"),
 		Cleanup: func() {
-			cleanupCount++
+			cleanupCount.Add(1)
 		},
-	}, &cleanupCount
+	}, cleanupCount
 }
 
 func startSleepTerminal(ctx context.Context, _ *exec.Cmd, width, height int) (*Terminal, error) {
@@ -124,13 +140,16 @@ func startSleepTerminal(ctx context.Context, _ *exec.Cmd, width, height int) (*T
 }
 
 type tmuxTestRunner struct {
+	mu             sync.Mutex
 	failHasSession bool
 	failNewSession error
 	calls          [][]string
 }
 
 func (r *tmuxTestRunner) run(cmd *exec.Cmd) error {
+	r.mu.Lock()
 	r.calls = append(r.calls, append([]string(nil), cmd.Args...))
+	r.mu.Unlock()
 	switch {
 	case reflect.DeepEqual(cmd.Args[:2], []string{"tmux", "has-session"}) && r.failHasSession:
 		return errors.New("missing")
@@ -142,12 +161,22 @@ func (r *tmuxTestRunner) run(cmd *exec.Cmd) error {
 }
 
 func (r *tmuxTestRunner) called(subcommand string) bool {
-	for _, call := range r.calls {
+	for _, call := range r.snapshot() {
 		if len(call) > 1 && call[1] == subcommand {
 			return true
 		}
 	}
 	return false
+}
+
+func (r *tmuxTestRunner) snapshot() [][]string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([][]string, len(r.calls))
+	for i := range r.calls {
+		out[i] = append([]string(nil), r.calls[i]...)
+	}
+	return out
 }
 
 func TestTmuxBackedTerminalDetachTarget(t *testing.T) {
@@ -180,14 +209,52 @@ func TestTmuxBackedTerminalUnexpectedAttachExitKillsOwnedSession(t *testing.T) {
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		if runner.called("kill-session") {
-			if got := *cleanupCount; got != 1 {
-				t.Fatalf("cleanup count = %d, want 1", got)
+			if got := cleanupCount.Load(); got != 0 {
+				t.Fatalf("cleanup count = %d, want owned running session to rely on script self-cleanup", got)
 			}
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("unexpected attach exit did not kill owned tmux session, calls: %#v", runner.calls)
+	t.Fatalf("unexpected attach exit did not kill owned tmux session, calls: %#v", runner.snapshot())
+}
+
+func waitCleanupCount(t *testing.T, cleanupCount *atomic.Int32, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := cleanupCount.Load(); got == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("cleanup count = %d, want %d", cleanupCount.Load(), want)
+}
+
+func TestTmuxBackedTerminalCleanAttachExitLeavesOwnedSessionRunning(t *testing.T) {
+	spec, _ := tmuxTestSpec()
+	runner := &tmuxTestRunner{failHasSession: true}
+	term, err := startTmuxBackedAgent(context.Background(), spec, 20, 3, runner.run, func(ctx context.Context, _ *exec.Cmd, width, height int) (*Terminal, error) {
+		return NewManager().StartCommand(ctx, exec.Command("sh", "-c", "exit 0"), width, height)
+	})
+	if err != nil {
+		t.Fatalf("startTmuxBackedAgent returned error: %v", err)
+	}
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := term.Wait(waitCtx); err != nil {
+		t.Fatalf("Wait returned error: %v", err)
+	}
+
+	if runner.called("kill-session") {
+		t.Fatalf("clean attach exit should not kill owned tmux session, calls: %#v", runner.snapshot())
+	}
+	if err := term.Terminate(); err != nil {
+		t.Fatalf("Terminate after clean attach exit returned error: %v", err)
+	}
+	if runner.called("kill-session") {
+		t.Fatalf("terminate after clean attach exit should not kill owned tmux session, calls: %#v", runner.snapshot())
+	}
 }
 
 func TestTmuxBackedTerminalRealTmuxDetachLeavesSessionAlive(t *testing.T) {

--- a/embeddedterm/tmux_test.go
+++ b/embeddedterm/tmux_test.go
@@ -290,3 +290,61 @@ func TestTmuxBackedTerminalRealTmuxDetachLeavesSessionAlive(t *testing.T) {
 		t.Fatalf("detached tmux session is not alive: %v", err)
 	}
 }
+
+func TestTmuxBackedTerminalRealTmuxPropagatesAgentFailure(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux is not installed")
+	}
+	dir := t.TempDir()
+	sessionName := "wtui-test-fail-" + strings.ReplaceAll(filepath.Base(dir), ".", "-")
+	statusPath := filepath.Join(dir, "status.txt")
+	scriptPath := filepath.Join(dir, "agent.sh")
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nprintf '7\\n' > "+shellQuoteForTest(statusPath)+"\nexit 7\n"), 0o700); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "-f", "/dev/null", "-L", sessionName, "kill-session", "-t", sessionName).Run()
+	})
+
+	spec := actions.EmbeddedTmuxAgentSpec{
+		SessionName:        sessionName,
+		ScriptPath:         scriptPath,
+		StatusPath:         statusPath,
+		HasSessionCommand:  exec.Command("tmux", "-f", "/dev/null", "-L", sessionName, "has-session", "-t", sessionName),
+		NewSessionCommand:  exec.Command("tmux", "-f", "/dev/null", "-L", sessionName, "new-session", "-d", "-s", sessionName, "-c", dir, "exec sh "+shellQuoteForTest(scriptPath)),
+		AttachCommand:      exec.Command("/bin/sh", "-c", tmuxAttachStatusScriptForTest, "wtui", sessionName, sessionName, statusPath),
+		KillSessionCommand: exec.Command("tmux", "-f", "/dev/null", "-L", sessionName, "kill-session", "-t", sessionName),
+		Cleanup: func() {
+			_ = os.Remove(scriptPath)
+			_ = os.Remove(statusPath)
+		},
+	}
+	term, err := StartTmuxBackedAgent(context.Background(), spec, 40, 10)
+	if err != nil {
+		t.Fatalf("StartTmuxBackedAgent returned error: %v", err)
+	}
+	waitCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := term.Wait(waitCtx); err == nil {
+		t.Fatal("Wait returned nil, want propagated agent failure")
+	}
+	if got := term.State(); got != StateFailed {
+		t.Fatalf("State = %q, want %q", got, StateFailed)
+	}
+}
+
+const tmuxAttachStatusScriptForTest = `tmux -f /dev/null -L "$1" attach-session -t "$2"
+tmux_status=$?
+if [ -r "$3" ]; then
+	IFS= read -r agent_status < "$3"
+	rm -f "$3"
+	case "$agent_status" in
+		""|*[!0-9]*) exit "$tmux_status" ;;
+		*) exit "$agent_status" ;;
+	esac
+fi
+exit "$tmux_status"`
+
+func shellQuoteForTest(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -36,6 +37,11 @@ type EmbeddedTerminal interface {
 	Terminate() error
 	Wait(context.Context) error
 	State() string
+}
+
+type detachableEmbeddedTerminal interface {
+	Detach() error
+	DetachTarget() string
 }
 
 type EmbeddedTerminalStarter func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error)
@@ -82,11 +88,31 @@ type embeddedTerminalTickMsg struct {
 }
 
 type realEmbeddedTerminal struct {
-	term *embeddedterm.Terminal
+	term realEmbeddedTerminalRuntime
+}
+
+type realEmbeddedTerminalRuntime interface {
+	VisibleLines(width, height int) []string
+	Write([]byte) (int, error)
+	Resize(width, height int) error
+	Terminate() error
+	Wait(context.Context) error
+	State() embeddedterm.State
 }
 
 func defaultEmbeddedTerminalStarter(ctx actions.AgentLaunchContext, width, height int) (EmbeddedTerminal, error) {
 	ctx.Embedded = true
+	tmuxSpec, err := actions.EmbeddedTmuxAgentCommand(ctx)
+	if err == nil {
+		term, err := embeddedterm.StartTmuxBackedAgent(context.Background(), tmuxSpec, width, height)
+		if err != nil {
+			return nil, err
+		}
+		return realEmbeddedTerminal{term: term}, nil
+	}
+	if !errors.Is(err, actions.ErrEmbeddedTmuxUnavailable) {
+		return nil, err
+	}
 	cmd, err := actions.AgentCommand(ctx)
 	if err != nil {
 		return nil, err
@@ -111,6 +137,20 @@ func (t realEmbeddedTerminal) Wait(ctx context.Context) error {
 	return t.term.Wait(ctx)
 }
 func (t realEmbeddedTerminal) State() string { return string(t.term.State()) }
+func (t realEmbeddedTerminal) Detach() error {
+	detachable, ok := t.term.(interface{ Detach() error })
+	if !ok {
+		return fmt.Errorf("detach unavailable: tmux was not available when this terminal started")
+	}
+	return detachable.Detach()
+}
+func (t realEmbeddedTerminal) DetachTarget() string {
+	detachable, ok := t.term.(interface{ DetachTarget() string })
+	if !ok {
+		return ""
+	}
+	return detachable.DetachTarget()
+}
 
 const embeddedTerminalRepaintInterval = time.Second / 30
 
@@ -458,6 +498,8 @@ func (m Model) handleEmbeddedTerminalKeyForScope(msg tea.KeyMsg, scope embeddedT
 				return m, nil, true
 			case "x":
 				return m.handleEmbeddedTerminalClosePrefix(scope), nil, true
+			case "d":
+				return m.handleEmbeddedTerminalDetachPrefix(scope), nil, true
 			case "q", "esc":
 				next, cmd := m.handleEmbeddedTerminalQuitPrefix()
 				return next, cmd, true
@@ -485,6 +527,8 @@ func (m Model) handleEmbeddedTerminalKeyForScope(msg tea.KeyMsg, scope embeddedT
 			return m.setStatus(statusOther, "Unknown terminal prefix command"), nil, true
 		case "x":
 			return m.handleEmbeddedTerminalClosePrefix(scope), nil, true
+		case "d":
+			return m.handleEmbeddedTerminalDetachPrefix(scope), nil, true
 		case "q", "esc":
 			next, cmd := m.handleEmbeddedTerminalQuitPrefix()
 			return next, cmd, true
@@ -555,6 +599,26 @@ func (m Model) handleEmbeddedTerminalClosePrefix(scope embeddedTerminalScope) Mo
 		return func() tea.Msg { return terminateEmbeddedTerminalMsg{ID: slot.ID} }
 	})
 	return m
+}
+
+func (m Model) handleEmbeddedTerminalDetachPrefix(scope embeddedTerminalScope) Model {
+	slot, _, ok := m.activeEmbeddedTerminalForScope(scope)
+	if !ok || slot.Terminal == nil {
+		return m
+	}
+	detachable, ok := slot.Terminal.(detachableEmbeddedTerminal)
+	if !ok {
+		return m.setStatus(statusOther, "Detach unavailable: tmux was not available when this terminal started")
+	}
+	target := strings.TrimSpace(detachable.DetachTarget())
+	if err := detachable.Detach(); err != nil {
+		return m.setStatus(statusOther, err.Error())
+	}
+	m = m.dismissEmbeddedTerminal(slot.ID)
+	if target == "" {
+		target = "tmux"
+	}
+	return m.setStatus(statusOther, "Detached embedded terminal to tmux: "+target)
 }
 
 func embeddedTerminalRunning(term EmbeddedTerminal) bool {

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -44,6 +44,8 @@ type detachableEmbeddedTerminal interface {
 	DetachTarget() string
 }
 
+var errEmbeddedTerminalDetachUnavailable = errors.New("detach unavailable: tmux was not available when this terminal started")
+
 type EmbeddedTerminalStarter func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error)
 
 type embeddedTerminalScope string
@@ -140,7 +142,7 @@ func (t realEmbeddedTerminal) State() string { return string(t.term.State()) }
 func (t realEmbeddedTerminal) Detach() error {
 	detachable, ok := t.term.(interface{ Detach() error })
 	if !ok {
-		return fmt.Errorf("detach unavailable: tmux was not available when this terminal started")
+		return errEmbeddedTerminalDetachUnavailable
 	}
 	return detachable.Detach()
 }
@@ -612,6 +614,9 @@ func (m Model) handleEmbeddedTerminalDetachPrefix(scope embeddedTerminalScope) M
 	}
 	target := strings.TrimSpace(detachable.DetachTarget())
 	if err := detachable.Detach(); err != nil {
+		if errors.Is(err, errEmbeddedTerminalDetachUnavailable) {
+			return m.setStatus(statusOther, "Detach unavailable: tmux was not available when this terminal started")
+		}
 		return m.setStatus(statusOther, err.Error())
 	}
 	m = m.dismissEmbeddedTerminal(slot.ID)

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -2,11 +2,16 @@ package model
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/brian-bell/wtui/actions"
 	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/model/modal"
 	"github.com/brian-bell/wtui/scanner"
@@ -58,6 +63,111 @@ func internalFlowsModel(records ...flowstore.FlowRecord) Model {
 		}),
 		flows: newFlowPane().SetItems(records),
 	}
+}
+
+func TestDefaultEmbeddedTerminalStarterUsesTmuxWhenAvailable(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+	writeInternalFakeExecutable(t, dir, "codex", "#!/bin/sh\n/bin/sleep 30\n")
+	logPath := filepath.Join(dir, "tmux.log")
+	t.Setenv("WTUI_TMUX_LOG", logPath)
+	writeInternalFakeExecutable(t, dir, "tmux", `#!/bin/sh
+echo "$@" >> "$WTUI_TMUX_LOG"
+case "$1" in
+  has-session) exit 1 ;;
+  new-session)
+    rm -f "$6"/wtui-agent-*.sh
+    exit 0
+    ;;
+  attach-session) /bin/sleep 30 ;;
+  kill-session) exit 0 ;;
+esac
+exit 0
+`)
+	t.Setenv("PATH", dir)
+
+	term, err := defaultEmbeddedTerminalStarter(actions.AgentLaunchContext{
+		Command:       "codex",
+		LaunchID:      "launch-1",
+		WorktreePath:  dir,
+		InitialPrompt: "run",
+	}, 20, 3)
+	if err != nil {
+		t.Fatalf("defaultEmbeddedTerminalStarter returned error: %v", err)
+	}
+	defer term.Terminate()
+
+	detachable, ok := term.(detachableEmbeddedTerminal)
+	if !ok {
+		t.Fatalf("default starter returned %T, want detachable tmux-backed terminal", term)
+	}
+	if target := detachable.DetachTarget(); !strings.Contains(target, "agent-launch-1") {
+		t.Fatalf("detach target = %q, want per-launch agent tmux session", target)
+	}
+	waitInternalFileContains(t, logPath, "attach-session")
+	if err := detachable.Detach(); err != nil {
+		t.Fatalf("Detach returned error: %v", err)
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read tmux log: %v", err)
+	}
+	log := string(logBytes)
+	for _, want := range []string{"has-session", "new-session", "attach-session"} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("tmux log missing %q:\n%s", want, log)
+		}
+	}
+	if strings.Contains(log, "kill-session") {
+		t.Fatalf("detach should not kill the tmux session:\n%s", log)
+	}
+}
+
+func TestDefaultEmbeddedTerminalStarterFallsBackWhenTmuxUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	writeInternalFakeExecutable(t, dir, "codex", "#!/bin/sh\n/bin/sleep 30\n")
+	t.Setenv("PATH", dir)
+
+	term, err := defaultEmbeddedTerminalStarter(actions.AgentLaunchContext{
+		Command:       "codex",
+		LaunchID:      "launch-1",
+		WorktreePath:  dir,
+		InitialPrompt: "run",
+	}, 20, 3)
+	if err != nil {
+		t.Fatalf("defaultEmbeddedTerminalStarter returned error: %v", err)
+	}
+	defer term.Terminate()
+
+	detachable, ok := term.(detachableEmbeddedTerminal)
+	if !ok {
+		t.Fatalf("default starter returned %T, want model-facing detach method", term)
+	}
+	if err := detachable.Detach(); !errors.Is(err, errEmbeddedTerminalDetachUnavailable) {
+		t.Fatalf("Detach error = %v, want unavailable sentinel", err)
+	}
+}
+
+func writeInternalFakeExecutable(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write fake %s executable: %v", name, err)
+	}
+}
+
+func waitInternalFileContains(t *testing.T, path, want string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		body, _ := os.ReadFile(path)
+		if strings.Contains(string(body), want) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	body, _ := os.ReadFile(path)
+	t.Fatalf("%s did not contain %q:\n%s", path, want, body)
 }
 
 func TestSyncActiveFlowTerminalToSelectedFlowSelectsNewestMatchingTerminal(t *testing.T) {

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -2,11 +2,13 @@ package model
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/model/modal"
 	"github.com/brian-bell/wtui/scanner"
 	"github.com/brian-bell/wtui/ui"
 )
@@ -26,6 +28,26 @@ func (t internalFakeEmbeddedTerminal) State() string {
 	}
 	return t.state
 }
+
+type internalFakeDetachableEmbeddedTerminal struct {
+	internalFakeEmbeddedTerminal
+	target   string
+	detached bool
+	writes   [][]byte
+}
+
+func (t *internalFakeDetachableEmbeddedTerminal) Write(p []byte) (int, error) {
+	t.writes = append(t.writes, append([]byte(nil), p...))
+	return len(p), nil
+}
+
+func (t *internalFakeDetachableEmbeddedTerminal) Detach() error {
+	t.detached = true
+	t.state = "exited"
+	return nil
+}
+
+func (t *internalFakeDetachableEmbeddedTerminal) DetachTarget() string { return t.target }
 
 func internalFlowsModel(records ...flowstore.FlowRecord) Model {
 	return Model{
@@ -444,5 +466,167 @@ func TestDismissLastFlowTerminalPreservesSessionCommandState(t *testing.T) {
 	}
 	if !m.terminalPrefixActive {
 		t.Fatal("session terminal command state should survive background Flow terminal dismissal")
+	}
+}
+
+func TestSessionTerminalPrefixDDetachesActiveTerminal(t *testing.T) {
+	term := &internalFakeDetachableEmbeddedTerminal{target: "wtui-agent-session"}
+	m := Model{
+		mode:                      ui.ModeSessions,
+		activeEmbeddedTerminalNum: 1,
+		terminalPrefixActive:      true,
+		embeddedTerminals: []embeddedTerminalSlot{{
+			Number:   1,
+			Scope:    embeddedTerminalScopeSession,
+			Provider: "codex",
+			Identity: "session",
+			Terminal: term,
+			ID:       1,
+		}},
+	}
+
+	next, _, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeSession)
+
+	if !consumed {
+		t.Fatal("detach key should be consumed")
+	}
+	if !term.detached {
+		t.Fatal("terminal was not detached")
+	}
+	if len(next.embeddedTerminals) != 0 {
+		t.Fatalf("embedded terminals = %#v, want detached terminal dismissed", next.embeddedTerminals)
+	}
+	if !strings.Contains(next.status.Text, "wtui-agent-session") {
+		t.Fatalf("status = %q, want detach target", next.status.Text)
+	}
+}
+
+func TestFlowTerminalPrefixDDetachesActiveTerminalAndRenumbers(t *testing.T) {
+	term := &internalFakeDetachableEmbeddedTerminal{target: "wtui-flow-agent"}
+	m := Model{
+		mode:                  ui.ModeFlows,
+		activePane:            1,
+		flowFocus:             flowFocusTerminal,
+		activeFlowTerminalNum: 1,
+		terminalPrefixActive:  true,
+		terminalConfirmID:     1,
+		terminalConfirmScope:  embeddedTerminalScopeFlow,
+		modal:                 modal.OpenConfirm(embeddedTerminalTerminatePrompt, nil),
+		embeddedTerminals: []embeddedTerminalSlot{
+			{
+				Number:      1,
+				Scope:       embeddedTerminalScopeFlow,
+				Provider:    "codex",
+				Identity:    "implementation",
+				FlowID:      "flow-1",
+				FlowPhaseID: "implementation",
+				Terminal:    term,
+				ID:          1,
+			},
+			{
+				Number:      2,
+				Scope:       embeddedTerminalScopeFlow,
+				Provider:    "claude",
+				Identity:    "review",
+				FlowID:      "flow-1",
+				FlowPhaseID: "review",
+				Terminal:    internalFakeEmbeddedTerminal{},
+				ID:          2,
+			},
+			{
+				Number:   1,
+				Scope:    embeddedTerminalScopeSession,
+				Provider: "codex",
+				Identity: "session",
+				Terminal: internalFakeEmbeddedTerminal{},
+				ID:       3,
+			},
+		},
+	}
+
+	next, _, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeFlow)
+
+	if !consumed {
+		t.Fatal("detach key should be consumed")
+	}
+	if !term.detached {
+		t.Fatal("terminal was not detached")
+	}
+	if len(next.embeddedTerminals) != 2 {
+		t.Fatalf("embedded terminals = %#v, want detached Flow terminal removed only", next.embeddedTerminals)
+	}
+	if next.embeddedTerminals[0].Scope != embeddedTerminalScopeFlow || next.embeddedTerminals[0].Number != 1 {
+		t.Fatalf("remaining Flow terminal not renumbered to 1: %#v", next.embeddedTerminals)
+	}
+	if next.embeddedTerminals[1].Scope != embeddedTerminalScopeSession || next.embeddedTerminals[1].Number != 1 {
+		t.Fatalf("session terminal should be preserved: %#v", next.embeddedTerminals)
+	}
+	if next.terminalConfirmID != 0 || next.modal.View().Kind != modal.None {
+		t.Fatalf("stale confirmation was not cleared: confirm=%d modal=%#v", next.terminalConfirmID, next.modal.View())
+	}
+	if activity := next.flowTerminalActivity(); len(activity) != 1 || activity[0].PhaseID != "review" {
+		t.Fatalf("flow terminal activity = %#v, want only remaining Flow terminal", activity)
+	}
+}
+
+func TestTerminalPrefixDReportsUnavailableForDirectPTY(t *testing.T) {
+	m := Model{
+		mode:                      ui.ModeSessions,
+		activeEmbeddedTerminalNum: 1,
+		terminalPrefixActive:      true,
+		embeddedTerminals: []embeddedTerminalSlot{{
+			Number:   1,
+			Scope:    embeddedTerminalScopeSession,
+			Provider: "codex",
+			Identity: "session",
+			Terminal: internalFakeEmbeddedTerminal{},
+			ID:       1,
+		}},
+	}
+
+	next, _, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeSession)
+
+	if !consumed {
+		t.Fatal("detach key should be consumed")
+	}
+	if len(next.embeddedTerminals) != 1 {
+		t.Fatalf("non-detachable terminal should remain, got %#v", next.embeddedTerminals)
+	}
+	if !strings.Contains(next.status.Text, "Detach unavailable") {
+		t.Fatalf("status = %q, want unavailable message", next.status.Text)
+	}
+}
+
+func TestFlowTerminalInputModeDPassesThrough(t *testing.T) {
+	term := &internalFakeDetachableEmbeddedTerminal{target: "wtui-flow-agent"}
+	m := Model{
+		mode:                  ui.ModeFlows,
+		activePane:            1,
+		flowFocus:             flowFocusTerminal,
+		activeFlowTerminalNum: 1,
+		terminalPrefixActive:  false,
+		embeddedTerminals: []embeddedTerminalSlot{{
+			Number:   1,
+			Scope:    embeddedTerminalScopeFlow,
+			Provider: "codex",
+			Identity: "implementation",
+			Terminal: term,
+			ID:       1,
+		}},
+	}
+
+	next, _, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeFlow)
+
+	if !consumed {
+		t.Fatal("terminal input key should be consumed")
+	}
+	if term.detached {
+		t.Fatal("input-mode d should not detach")
+	}
+	if len(term.writes) != 1 || string(term.writes[0]) != "d" {
+		t.Fatalf("writes = %#v, want d passed through", term.writes)
+	}
+	if len(next.embeddedTerminals) != 1 {
+		t.Fatalf("terminal should remain, got %#v", next.embeddedTerminals)
 	}
 }

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -73,17 +73,19 @@ func TestDefaultEmbeddedTerminalStarterUsesTmuxWhenAvailable(t *testing.T) {
 	t.Setenv("WTUI_TMUX_LOG", logPath)
 	writeInternalFakeExecutable(t, dir, "tmux", `#!/bin/sh
 echo "$@" >> "$WTUI_TMUX_LOG"
-case "$1" in
-  has-session) exit 1 ;;
-  new-session)
-    rm -f "$6"/wtui-agent-*.sh
-    exit 0
-    ;;
-  attach-session) /bin/sleep 30 ;;
-  kill-session) exit 0 ;;
-esac
+for arg in "$@"; do
+  case "$arg" in
+    has-session) exit 1 ;;
+    new-session)
+      rm -f "$TMPDIR"/wtui-agent-*.sh
+      exit 0
+      ;;
+    attach-session) /bin/sleep 30 ;;
+    kill-session) exit 0 ;;
+  esac
+done
 exit 0
-`)
+	`)
 	t.Setenv("PATH", dir)
 
 	term, err := defaultEmbeddedTerminalStarter(actions.AgentLaunchContext{
@@ -101,8 +103,8 @@ exit 0
 	if !ok {
 		t.Fatalf("default starter returned %T, want detachable tmux-backed terminal", term)
 	}
-	if target := detachable.DetachTarget(); !strings.Contains(target, "agent-launch-1") {
-		t.Fatalf("detach target = %q, want per-launch agent tmux session", target)
+	if target := detachable.DetachTarget(); !strings.Contains(target, "env -u TMUX tmux -f /dev/null -L 'wtui-agent-") || !strings.Contains(target, "attach-session -t") || !strings.Contains(target, "agent-launch-1") {
+		t.Fatalf("detach target = %q, want reattach command for per-launch agent tmux session", target)
 	}
 	waitInternalFileContains(t, logPath, "attach-session")
 	if err := detachable.Detach(); err != nil {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -3144,7 +3144,7 @@ func TestModel_CtrlJLaunchesFlowPhaseReadyPlanReviewWithLinkedPlanContext(t *tes
 		t.Fatalf("launch context = %#v", launched)
 	}
 	wantPrompt := strings.Join([]string{
-		"Use the review-loop workflow with goal: review-and-revise. Review the saved plan, max 6 loops.",
+		"Use the review-loop skill to review the saved plan, max 6 loops.",
 		"Use the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.",
 		"",
 		"Plan: /state/wtui/sessions/v1/plans/plan-1/plan.md",
@@ -3220,9 +3220,6 @@ func TestModel_FlowPlanReviewPromptTemplateOverridesBuiltInPrompt(t *testing.T) 
 	want := "Custom plan-review for flow-1: /state/plans/plan-1/plan.md on flow/template; keep {unknown}"
 	if launched.InitialPrompt != want {
 		t.Fatalf("templated plan-review prompt = %q, want %q", launched.InitialPrompt, want)
-	}
-	if strings.Contains(launched.InitialPrompt, "review-and-revise") {
-		t.Fatalf("templated plan-review prompt should not include built-in goal wording:\n%s", launched.InitialPrompt)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1957,7 +1957,7 @@ func flowPhasePromptNeedsPlanBody(phaseID string) bool {
 }
 
 func flowPlanReviewPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
-	return flowMinimalArtifactPrompt("Use the review-loop workflow with goal: review-and-revise. Review the saved plan, max 6 loops.\nUse the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.", planPath, record, phase)
+	return flowMinimalArtifactPrompt("Use the review-loop skill to review the saved plan, max 6 loops.\nUse the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.", planPath, record, phase)
 }
 
 func flowImplementationPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1027,6 +1027,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 		if sp.EmbeddedTerminalPrefix {
 			hints = []shortcutHint{
 				{Key: "ctrl+]", Label: "send"},
+				{Key: "d", Label: "detach"},
 				{Key: "x", Label: "close"},
 				{Key: "q/esc", Label: "quit"},
 				{Key: "1-9", Label: "switch"},

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -933,7 +933,7 @@ func TestRender_FlowsEmbeddedTerminalShortcutsAreActiveByDefault(t *testing.T) {
 		EmbeddedTerminalPrefix: true,
 	}, 34, 12)
 	text := ansi.Strip(pane)
-	for _, want := range []string{"ctrl+] send", "i      input", "left/right terminal", "x      close", "q/esc  quit", "1-9    switch"} {
+	for _, want := range []string{"ctrl+] send", "i      input", "left/right terminal", "d      detach", "x      close", "q/esc  quit", "1-9    switch"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("Flow terminal shortcut pane missing %q:\n%s", want, text)
 		}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -712,7 +712,7 @@ func TestRender_SessionsEmbeddedTerminalShortcutsDimUntilPrefix(t *testing.T) {
 		EmbeddedTerminalPrefix: true,
 	}, 26, 12)
 	prefixText := ansi.Strip(prefix)
-	for _, want := range []string{"ctrl+] send", "l      sessions", "x      close", "q/esc  quit", "1-9    switch"} {
+	for _, want := range []string{"ctrl+] send", "l      sessions", "d      detach", "x      close", "q/esc  quit", "1-9    switch"} {
 		if !strings.Contains(prefixText, want) {
 			t.Fatalf("embedded terminal prefix shortcuts missing %q:\n%s", want, prefixText)
 		}


### PR DESCRIPTION
## Summary
- Launch embedded CLI agents through per-launch tmux sessions when tmux is available, with direct PTY fallback when it is not.
- Add detach support via `ctrl+] d` so wtui can close its client while preserving owned tmux sessions, while terminate still cleans up owned sessions.
- Update session/Flow terminal hints, docs, and tests for tmux-backed lifecycle behavior.

## Implementation Notes
- Adds tmux command construction and launch script handling in actions.
- Adds a tmux-backed embedded terminal runtime with explicit ownership revocation on detach and cleanup on terminate.
- Wires detach through sessions-mode and Flow terminal command handling, including UI labels and unavailable-action feedback for direct PTY fallback.

## Verification
- `go test ./actions ./embeddedterm ./model ./ui`
- `go test -race -count=1 ./embeddedterm -run 'TestTmuxBackedTerminal'`\n- `gofmt -l .`\n- `make test`\n- `make build`