### PR TITLE
Reorganize Flow mode shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ filter matches, or a load failure with details in the status bar.
 | `t` | Open or attach to a tmux/Zellij session for the worktree |
 | `c` | Open VSCode at worktree path |
 | `x` | Show/hide sessions for the selected worktree (worktrees view), expand/collapse plan phase rows, or reset a selected `await-session` Flow phase after confirmation |
-| `y` | Copy hash to clipboard (history/reflog view), selected agent session ID (sessions view), plan Markdown path (plans view), or Flow/phase ID (flows view) |
+| `y` | Copy hash to clipboard (history/reflog view), selected agent session ID (sessions view), plan Markdown path (plans view), or selected Flow worktree path (flows view) |
 | `r` | Resume selected agent session (sessions view; CLI agents embed in-pane) or selected attached Flow phase session (flows view) |
 | `s` | Page selected agent session summary (sessions view) |
 | `o` | Page selected session transcript (sessions view), selected plan Markdown (plans view), or linked plan body (flows view) |
@@ -326,8 +326,8 @@ the phase list. Press
 canonical phase order. This action
 uses the selected Flow, so a highlighted pending phase row can still launch an
 earlier ready sibling, and nothing is persisted when no phase is launchable.
-Press `y` to copy the selected Flow ID, or the selected phase ID when a phase
-row is selected. Press `r` on an expanded phase row with an
+Press `y` to copy the selected Flow worktree path from either a Flow row or one
+of its expanded phase rows. Press `r` on an expanded phase row with an
 attached provider session to resume that session; CLI resumes are recorded as a
 fresh Flow phase launch attempt, while `codex-app` resumes navigate to the
 existing app thread without extra launch tracking. Press `m` on a Flow row or

--- a/docs/config.md
+++ b/docs/config.md
@@ -307,11 +307,11 @@ through `wtui flow`. Each record is stored as
 `<artifact-root>/flows/<flow-id>/meta.json`, with restrictive permissions
 (`0700` directories, `0600` files) and atomic writes. They appear in the TUI
 flows pane (mode `8`), which is the startup default. The pane shows linked plan
-IDs when present; press `n` to create a new Flow. On a Flow row, `enter`
-expands or collapses read-only phase detail rows; `o` opens the linked plan
-body from the selected Flow. On an expanded phase row, `enter` launches the
-configured agent for that selected ready phase. Press `y` to copy the selected
-Flow worktree path from either a Flow row or one of its expanded phase rows.
+IDs when present; press `n` to create a new Flow. On a Flow row or expanded
+phase row, `enter` expands or collapses read-only phase detail rows; `o` opens
+the linked plan body from the selected Flow. Press `ctrl+j` to launch the first
+launchable phase for the selected Flow. Press `y` to copy the selected Flow
+worktree path from either a Flow row or one of its expanded phase rows.
 Headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in an embedded terminal
 inside the flows pane. Press `h` to choose the CLI command mode: headless runs
@@ -516,7 +516,7 @@ manually afterward.
 
 ## Agent Session Hooks
 
-Agents launched from wtui with `a`, `N`, Flow selected-phase `enter`, or session
+Agents launched from wtui with `a`, `N`, Flow `ctrl+j`, or session
 resume `r` are wired automatically. wtui passes Claude Code or Codex a
 session-end hook that calls the current wtui binary, and it appends the
 environment metadata listed below so the hook can associate the session with
@@ -603,7 +603,7 @@ CLI resumes run inside runtime-only embedded PTYs in the sessions pane. When
 `tmux` is available at launch time, those embedded CLI terminals are backed by a
 per-launch tmux session and `ctrl+] d` detaches wtui's embedded client while the
 agent continues in tmux. When `tmux` is unavailable, wtui uses the direct
-embedded PTY path and reports detach unavailable. Fresh Flow selected-phase
+embedded PTY path and reports detach unavailable. Fresh Flow `ctrl+j`
 launches and Flow phase-session resumes run CLI agents inside runtime-only
 embedded PTYs in the flows pane; Flow headless mode chooses
 headless provider commands (`codex exec` / `claude --print`) versus interactive

--- a/docs/config.md
+++ b/docs/config.md
@@ -310,7 +310,9 @@ flows pane (mode `8`), which is the startup default. The pane shows linked plan
 IDs when present; press `n` to create a new Flow. On a Flow row, `enter`
 expands or collapses read-only phase detail rows; `o` opens the linked plan
 body from the selected Flow. On an expanded phase row, `enter` launches the
-configured agent for that selected ready phase. Headless mode is on by default:
+configured agent for that selected ready phase. Press `y` to copy the selected
+Flow worktree path from either a Flow row or one of its expanded phase rows.
+Headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in an embedded terminal
 inside the flows pane. Press `h` to choose the CLI command mode: headless runs
 `codex exec` or `claude --print`, while headless off runs interactive `codex` or

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -751,7 +751,7 @@ func TestModel_ResetShortcutHiddenWhenMatchingFlowTerminalIsRunning(t *testing.T
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on ready phase should prepare embedded terminal launch")
+		t.Fatal("ctrl+j on ready Flow should prepare embedded terminal launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, model.FlowResultMsg{RepoPath: "/dev/alpha", Flows: []flowstore.FlowRecord{flowWithAwaitingImplementation()}, ListRequest: m.ListRequest(ui.ModeFlows)})
@@ -843,7 +843,7 @@ func TestModel_XKeyKeepsFlowTerminalFocusCloseBehavior(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("enter on ready phase should prepare embedded terminal launch")
+		t.Fatal("ctrl+j on ready Flow should prepare embedded terminal launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
@@ -1480,7 +1480,7 @@ func TestModel_CtrlJOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHead
 		t.Fatalf("ctrl+j launched %#v with update %#v, want first launchable implementation", started, launchUpdate)
 	}
 	if started.Command != "claude" || started.ReasoningEffort != "max" {
-		t.Fatalf("selected-phase launch agent settings = command %q effort %q, want claude/max", started.Command, started.ReasoningEffort)
+		t.Fatalf("Flow phase launch agent settings = command %q effort %q, want claude/max", started.Command, started.ReasoningEffort)
 	}
 	if !started.Embedded || !started.Headless || !started.FlowLaunchTracked {
 		t.Fatalf("Flow launch should be embedded, headless, and tracked: %#v", started)

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1789,7 +1789,7 @@ func TestModel_FlowPhasesAutoCollapseWhenSelectionChanges(t *testing.T) {
 	}
 }
 
-func TestModel_YKeyCopiesSelectedFlowOrPhaseID(t *testing.T) {
+func TestModel_YKeyCopiesSelectedFlowWorktreePath(t *testing.T) {
 	var copied []string
 	m := model.NewWithOptions(testRepos(), model.Options{
 		CopyToClipboard: func(text string) error {
@@ -1798,9 +1798,10 @@ func TestModel_YKeyCopiesSelectedFlowOrPhaseID(t *testing.T) {
 		},
 	})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
-		FlowID: "flow-1",
-		Title:  "Copy flow ids",
-		Status: flowstore.StatusInProgress,
+		FlowID:       "flow-1",
+		Title:        "Copy flow path",
+		Status:       flowstore.StatusInProgress,
+		WorktreePath: "/dev/alpha-worktrees/flow-1",
 		Phases: []flowstore.FlowPhase{
 			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady},
 		},
@@ -1808,22 +1809,57 @@ func TestModel_YKeyCopiesSelectedFlowOrPhaseID(t *testing.T) {
 
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if cmd == nil {
-		t.Fatal("expected flow id copy command")
+		t.Fatal("expected flow worktree path copy command")
 	}
 	_ = cmd()
-	if got := copied[len(copied)-1]; got != "flow-1" {
-		t.Fatalf("copied flow id = %q, want flow-1", got)
+	if got := copied[len(copied)-1]; got != "/dev/alpha-worktrees/flow-1" {
+		t.Fatalf("copied flow worktree path = %q, want /dev/alpha-worktrees/flow-1", got)
 	}
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	_, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if cmd == nil {
-		t.Fatal("expected flow phase id copy command")
+		t.Fatal("expected selected phase to copy parent Flow worktree path")
 	}
 	_ = cmd()
-	if got := copied[len(copied)-1]; got != "implementation" {
-		t.Fatalf("copied phase id = %q, want implementation", got)
+	if got := copied[len(copied)-1]; got != "/dev/alpha-worktrees/flow-1" {
+		t.Fatalf("copied selected phase parent worktree path = %q, want /dev/alpha-worktrees/flow-1", got)
+	}
+}
+
+func TestModel_YKeyDoesNothingWhenSelectedFlowWorktreePathIsBlank(t *testing.T) {
+	copied := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		CopyToClipboard: func(string) error {
+			copied = true
+			return nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		Title:        "Blank flow path",
+		Status:       flowstore.StatusInProgress,
+		WorktreePath: "  ",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady},
+		},
+	}})
+
+	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}); cmd != nil {
+		t.Fatalf("blank Flow worktree path returned copy command %T, want nil", cmd)
+	}
+	if copied {
+		t.Fatal("blank Flow worktree path should not copy to clipboard")
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}); cmd != nil {
+		t.Fatalf("blank parent Flow worktree path from phase row returned copy command %T, want nil", cmd)
+	}
+	if copied {
+		t.Fatal("blank parent Flow worktree path should not copy to clipboard")
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -354,7 +354,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			return m.handleCopySessionID()
 		}
 		if m.mode == ui.ModeFlows {
-			return m.handleCopyFlowID()
+			return m.handleCopyFlowWorktreePath()
 		}
 		return m.handleCopyHash()
 	case "s":

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1574,20 +1574,15 @@ func (m Model) handleCopyPlanPath() (tea.Model, tea.Cmd) {
 	}
 }
 
-func (m Model) handleCopyFlowID() (tea.Model, tea.Cmd) {
+func (m Model) handleCopyFlowWorktreePath() (tea.Model, tea.Cmd) {
 	if m.mode != ui.ModeFlows {
 		return m, nil
 	}
-	value := ""
-	if phase, ok := m.selectedFlowPhase(); ok {
-		value = phase.PhaseID
-	} else {
-		flow, ok := m.selectedFlow()
-		if !ok {
-			return m, nil
-		}
-		value = flow.FlowID
+	flow, ok := m.selectedFlow()
+	if !ok {
+		return m, nil
 	}
+	value := flow.WorktreePath
 	if strings.TrimSpace(value) == "" {
 		return m, nil
 	}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -451,9 +451,11 @@ func renderApplication(p RenderParams) string {
 	planSelected := p.Mode == ModePlans && p.PlanSelected >= 0 && p.PlanSelected < len(p.Plans)
 	flowSelected := p.Mode == ModeFlows && p.FlowSelected >= 0 && p.FlowSelected < len(p.Flows)
 	flowPlanLinked := false
+	flowWorktreePathSelected := false
 	flowAutoModeSelected := false
 	if flowSelected {
 		flowPlanLinked = strings.TrimSpace(p.Flows[p.FlowSelected].PlanID) != ""
+		flowWorktreePathSelected = strings.TrimSpace(p.Flows[p.FlowSelected].WorktreePath) != ""
 		flowAutoModeSelected = p.FlowAutoModeSelected
 	}
 	worktreeSessionSelected := p.Mode == ModeWorktrees && p.InlineWorktreeSessions && p.WorktreeSessionSelected >= 0 && p.WorktreeSessionSelected < len(p.WorktreeSessions)
@@ -464,6 +466,7 @@ func renderApplication(p RenderParams) string {
 		flowSelected = false
 		selectedFlowPhaseID = ""
 		flowDeletableSelected = false
+		flowWorktreePathSelected = false
 		flowAutoModeSelected = false
 	}
 	planPhaseSelected := selectedPlanPhaseID != ""
@@ -501,6 +504,7 @@ func renderApplication(p RenderParams) string {
 		FlowSelected:                flowSelected,
 		FlowPhaseSelected:           flowPhaseSelected,
 		FlowDeletableSelected:       flowDeletableSelected,
+		FlowWorktreePathSelected:    flowWorktreePathSelected,
 		FlowPlanLinked:              flowPlanLinked,
 		FlowHeadless:                p.FlowHeadless,
 		FlowAutoModeSelected:        flowAutoModeSelected,
@@ -766,6 +770,7 @@ type statusBarParams struct {
 	FlowSelected                bool
 	FlowPhaseSelected           bool
 	FlowDeletableSelected       bool
+	FlowWorktreePathSelected    bool
 	FlowPlanLinked              bool
 	FlowHeadless                bool
 	FlowAutoModeSelected        bool
@@ -907,7 +912,7 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 	title := titleStyle.Render("Shortcuts") + "  " + modeStyle.Render(modeShortcutTitle(sp.Mode))
 	lines = append(lines, ansi.Truncate(" "+title, width, ""))
 	compact := height <= 3
-	tight := height <= 7
+	tight := height <= 7 || (sp.Mode == ModeFlows && height <= 14)
 	if !compact && !tight {
 		lines = append(lines, strings.Repeat(" ", width))
 	}
@@ -1063,6 +1068,8 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	}
 
 	var actions []shortcutHint
+	var flowModeControls []shortcutHint
+	var flowAgentControls []shortcutHint
 	if sp.ActivePane == 0 && sp.FetchVisibleAvailable {
 		actions = append(actions, shortcutHint{Key: "f", Label: "fetch visible"})
 	}
@@ -1204,7 +1211,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 				headlessLabel = "headless on"
 				headlessSuccessSuffix = "on"
 			}
-			actions = append(actions, shortcutHint{Key: "h", Label: headlessLabel, SuccessSuffix: headlessSuccessSuffix})
+			flowModeControls = append(flowModeControls, shortcutHint{Key: "h", Label: headlessLabel, SuccessSuffix: headlessSuccessSuffix})
 			if sp.FlowSelected {
 				if sp.FlowPhaseSelected {
 					actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
@@ -1214,11 +1221,12 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 					if sp.FlowPhaseResetReadySelected {
 						actions = append(actions, shortcutHint{Key: "x", Label: "reset ready"})
 					}
-					actions = append(actions, shortcutHint{Key: "y", Label: "copy phase id"})
+					if sp.FlowWorktreePathSelected {
+						actions = append(actions, shortcutHint{Key: "y", Label: "copy path"})
+					}
 					if sp.FlowPhaseResumableSelected {
 						actions = append(actions, shortcutHint{Key: "r", Label: "resume"})
 					}
-					actions = append(actions, flowAutoModeShortcutHint(sp.FlowAutoModeSelected))
 				} else {
 					actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
 					if sp.FlowNextLaunchReady {
@@ -1227,18 +1235,20 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 					if sp.FlowPlanLinked {
 						actions = append(actions, shortcutHint{Key: "o", Label: "open"})
 					}
-					actions = append(actions, shortcutHint{Key: "y", Label: "copy id"})
+					if sp.FlowWorktreePathSelected {
+						actions = append(actions, shortcutHint{Key: "y", Label: "copy path"})
+					}
 					if sp.Destructive && sp.FlowDeletableSelected {
 						actions = append(actions, shortcutHint{Key: "d", Label: "delete", Warning: true})
 					}
-					actions = append(actions, flowAutoModeShortcutHint(sp.FlowAutoModeSelected))
 				}
+				flowModeControls = append(flowModeControls, flowAutoModeShortcutHint(sp.FlowAutoModeSelected))
 			}
 		}
 		agentLabel, agentConfigured := flowAgentShortcut(sp.FlowAgentLabel)
-		actions = append(actions, shortcutHint{Key: "A", Label: agentLabel})
+		flowAgentControls = append(flowAgentControls, shortcutHint{Key: "A", Label: agentLabel})
 		if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); agentConfigured && effortLabel != "" {
-			actions = append(actions, shortcutHint{Key: "E", Label: effortLabel})
+			flowAgentControls = append(flowAgentControls, shortcutHint{Key: "E", Label: effortLabel})
 		}
 	}
 	if sp.ActivePane == 1 && sp.Mode != ModeWorktrees && sp.Mode != ModeBranches {
@@ -1251,6 +1261,20 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	}
 	if !sp.Destructive && (sp.Mode == ModeWorktrees || sp.Mode == ModeBranches || sp.Mode == ModeStashes || sp.Mode == ModeFlows) {
 		actions = append([]shortcutHint{{Key: "D", Label: "destructive mode"}}, actions...)
+	}
+	if sp.Mode == ModeFlows {
+		var sections []shortcutSection
+		if len(actions) > 0 {
+			sections = append(sections, shortcutSection{Title: "Actions", Hints: actions})
+		}
+		if len(flowModeControls) > 0 {
+			sections = append(sections, shortcutSection{Title: "Mode", Hints: flowModeControls})
+		}
+		if len(flowAgentControls) > 0 {
+			sections = append(sections, shortcutSection{Title: "Agent", Hints: flowAgentControls})
+		}
+		sections = append(sections, shortcutSection{Title: "Global", Hints: append(navigation, global...)})
+		return sections
 	}
 	var sections []shortcutSection
 	if len(actions) > 0 {
@@ -1315,6 +1339,9 @@ func muteShortcutSections(sections []shortcutSection) []shortcutSection {
 
 func shortcutSectionsForPane(sp statusBarParams, height int) []shortcutSection {
 	sections := shortcutSections(sp)
+	if sp.Mode == ModeFlows && !sp.FlowSelected && height <= 9 {
+		sections = withoutShortcutKeys(sections, "D", "n", "f5")
+	}
 	if height < 20 {
 		return withoutShortcutKey(sections, "f5")
 	}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1467,7 +1467,7 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 	if sp.EmbeddedTerminalActive {
 		return renderGenericFooterShortcuts(sp, sections)
 	}
-	full := "  " + renderFooterHintList(footerSectionOrder(sections))
+	full := "  " + renderFooterHintList(flowFooterSectionOrder(sections))
 	if lipgloss.Width(full) <= sp.Width {
 		return full
 	}
@@ -1670,6 +1670,23 @@ func footerSectionOrder(sections []shortcutSection) []shortcutSection {
 	}
 	for _, section := range sections {
 		if section.Title != "Global" && section.Title != "Navigate" && section.Title != "Actions" && section.Title != "Legend" {
+			ordered = append(ordered, section)
+		}
+	}
+	return ordered
+}
+
+func flowFooterSectionOrder(sections []shortcutSection) []shortcutSection {
+	ordered := make([]shortcutSection, 0, len(sections))
+	for _, title := range []string{"Actions", "Mode", "Agent", "Global"} {
+		for _, section := range sections {
+			if section.Title == title {
+				ordered = append(ordered, section)
+			}
+		}
+	}
+	for _, section := range sections {
+		if section.Title != "Actions" && section.Title != "Mode" && section.Title != "Agent" && section.Title != "Global" {
 			ordered = append(ordered, section)
 		}
 	}

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -444,6 +445,86 @@ func TestRender_FlowsModeShowsReasoningEffortShortcut(t *testing.T) {
 	}
 }
 
+func TestRender_FlowsModeShortcutSectionsUseFlowGroups(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   28,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID:       "flow-1",
+			Title:        "Grouped shortcuts",
+			Status:       flowstore.StatusInProgress,
+			Branch:       "flow/grouped-shortcuts",
+			WorktreePath: "/dev/wtui-worktrees/flow-grouped-shortcuts",
+			PlanID:       "plan-1",
+			AutoMode:     true,
+			Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation",
+				Title:   "Implementation",
+				Status:  flowstore.PhaseReady,
+			}},
+		}},
+		ActivePane:                 1,
+		Destructive:                true,
+		FlowSelected:               0,
+		FlowHeadless:               true,
+		FlowAutoModeSelected:       true,
+		FlowNextLaunchReady:        true,
+		FlowAgentLabel:             "codex",
+		FlowReasoningEffort:        "effort: high",
+		FlowPhaseResumableSelected: true,
+	})
+
+	pane := shortcutPaneText(view)
+	if got, want := shortcutSectionTitles(pane), []string{"Actions", "Mode", "Agent", "Global"}; !slices.Equal(got, want) {
+		t.Fatalf("Flow shortcut sections = %v, want %v:\n%s", got, want, pane)
+	}
+	for _, want := range []string{
+		"n      new flow",
+		"enter  phases",
+		"ctrl+j launch next",
+		"o      open",
+		"y      copy path",
+		"d      delete",
+		"h      headless on",
+		"m      auto: on",
+		"A      codex",
+		"E      effort: high",
+		"tab    pane",
+		"q/esc  quit",
+		"f5     refresh",
+	} {
+		if !strings.Contains(pane, want) {
+			t.Fatalf("Flow shortcut pane missing %q:\n%s", want, pane)
+		}
+	}
+	if strings.Contains(pane, "Navigate") {
+		t.Fatalf("Flow shortcut pane should not include Navigate section:\n%s", pane)
+	}
+}
+
+func shortcutSectionTitles(pane string) []string {
+	known := map[string]bool{
+		"Actions":  true,
+		"Mode":     true,
+		"Agent":    true,
+		"Global":   true,
+		"Navigate": true,
+		"Terminal": true,
+		"Legend":   true,
+	}
+	var titles []string
+	for _, line := range strings.Split(pane, "\n") {
+		line = strings.TrimSpace(line)
+		if known[line] {
+			titles = append(titles, line)
+		}
+	}
+	return titles
+}
+
 func TestRender_FlowsModeReasoningEffortShortcutHandlesSpecialLabels(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -481,15 +562,16 @@ func TestRender_FlowsModeReasoningEffortShortcutHandlesSpecialLabels(t *testing.
 
 func TestStatusBar_FlowsModeShowsPhaseToggleHintForSelectedFlow(t *testing.T) {
 	bar := renderStatusBarWithState(statusBarParams{
-		Width:          120,
-		Mode:           ModeFlows,
-		ActivePane:     1,
-		RepoSelected:   true,
-		FlowSelected:   true,
-		FlowPlanLinked: true,
-		FlowHeadless:   true,
+		Width:                    120,
+		Mode:                     ModeFlows,
+		ActivePane:               1,
+		RepoSelected:             true,
+		FlowSelected:             true,
+		FlowWorktreePathSelected: true,
+		FlowPlanLinked:           true,
+		FlowHeadless:             true,
 	})
-	for _, want := range []string{"enter: phases", "h: headless on", "o: open", "y: copy id"} {
+	for _, want := range []string{"enter: phases", "h: headless on", "o: open", "y: copy path"} {
 		if !strings.Contains(bar, want) {
 			t.Fatalf("expected selected flow hint %q, got %q", want, bar)
 		}
@@ -552,6 +634,30 @@ func TestStatusBar_FlowsModeCompactFooterKeepsAutoModeToggle(t *testing.T) {
 	})
 	if !strings.Contains(phaseRow, "m: auto: on") {
 		t.Fatalf("compact selected Flow phase should keep auto-mode on toggle, got %q", phaseRow)
+	}
+}
+
+func TestStatusBar_FlowsModeHidesCopyPathWithoutWorktreePath(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		phase bool
+	}{
+		{name: "flow row"},
+		{name: "phase row", phase: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			bar := renderStatusBarWithState(statusBarParams{
+				Width:             140,
+				Mode:              ModeFlows,
+				ActivePane:        1,
+				RepoSelected:      true,
+				FlowSelected:      true,
+				FlowPhaseSelected: tt.phase,
+			})
+			if strings.Contains(bar, "y: copy") {
+				t.Fatalf("Flow footer without worktree path should hide copy shortcut, got %q", bar)
+			}
+		})
 	}
 }
 
@@ -619,7 +725,7 @@ func TestRender_FlowsModeShowsResumeShortcutForResumableSelectedPhase(t *testing
 	}
 }
 
-func TestRender_FlowsModeShowsCopyPhaseIDShortcutForSelectedPhase(t *testing.T) {
+func TestRender_FlowsModeShowsCopyPathShortcutForSelectedPhase(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
 		Selected: 0,
@@ -627,9 +733,10 @@ func TestRender_FlowsModeShowsCopyPhaseIDShortcutForSelectedPhase(t *testing.T) 
 		Height:   16,
 		Mode:     ModeFlows,
 		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Phase copy flow",
-			Status: flowstore.StatusInProgress,
+			FlowID:       "flow-1",
+			Title:        "Phase copy flow",
+			Status:       flowstore.StatusInProgress,
+			WorktreePath: "/dev/wtui-worktrees/phase-copy-flow",
 			Phases: []flowstore.FlowPhase{{
 				PhaseID: "implementation",
 				Title:   "Implementation",
@@ -643,11 +750,11 @@ func TestRender_FlowsModeShowsCopyPhaseIDShortcutForSelectedPhase(t *testing.T) 
 	})
 
 	pane := shortcutPaneText(view)
-	if !strings.Contains(pane, "y      copy phase id") {
-		t.Fatalf("selected Flow phase should expose phase-id copy shortcut:\n%s", view)
+	if !strings.Contains(pane, "y      copy path") {
+		t.Fatalf("selected Flow phase should expose worktree-path copy shortcut:\n%s", view)
 	}
-	if strings.Contains(pane, "y      copy id") {
-		t.Fatalf("selected Flow phase should not expose whole-flow copy shortcut:\n%s", view)
+	if strings.Contains(pane, "y      copy id") || strings.Contains(pane, "y      copy phase id") {
+		t.Fatalf("selected Flow phase should not expose id copy shortcuts:\n%s", view)
 	}
 }
 
@@ -694,9 +801,10 @@ func TestRender_FlowsModeShowsLaunchAndHeadlessShortcutForLaunchableSelectedPhas
 		Height:   16,
 		Mode:     ModeFlows,
 		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Launch phase flow",
-			Status: flowstore.StatusInProgress,
+			FlowID:       "flow-1",
+			Title:        "Launch phase flow",
+			Status:       flowstore.StatusInProgress,
+			WorktreePath: "/dev/wtui-worktrees/launch-phase-flow",
 			Phases: []flowstore.FlowPhase{{
 				PhaseID: "implementation",
 				Title:   "Implementation",
@@ -712,7 +820,7 @@ func TestRender_FlowsModeShowsLaunchAndHeadlessShortcutForLaunchableSelectedPhas
 	})
 
 	pane := shortcutPaneText(view)
-	for _, want := range []string{"enter  phases", "ctrl+j launch next", "h      headless off", "y      copy phase id"} {
+	for _, want := range []string{"enter  phases", "ctrl+j launch next", "h      headless off", "y      copy path"} {
 		if !strings.Contains(pane, want) {
 			t.Fatalf("launchable selected Flow phase shortcut pane missing %q:\n%s", want, pane)
 		}
@@ -951,9 +1059,10 @@ func TestRender_FlowsModeIgnoresStaleSelectedPhaseForCopyShortcut(t *testing.T) 
 		Height:   12,
 		Mode:     ModeFlows,
 		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Stale phase copy flow",
-			Status: flowstore.StatusInProgress,
+			FlowID:       "flow-1",
+			Title:        "Stale phase copy flow",
+			Status:       flowstore.StatusInProgress,
+			WorktreePath: "/dev/wtui-worktrees/stale-phase-copy-flow",
 			Phases: []flowstore.FlowPhase{{
 				PhaseID: "implementation",
 				Title:   "Implementation",
@@ -967,11 +1076,44 @@ func TestRender_FlowsModeIgnoresStaleSelectedPhaseForCopyShortcut(t *testing.T) 
 	})
 
 	pane := shortcutPaneText(view)
-	if !strings.Contains(pane, "y      copy id") {
-		t.Fatalf("stale Flow phase selection should fall back to whole-flow copy shortcut:\n%s", view)
+	if !strings.Contains(pane, "y      copy path") {
+		t.Fatalf("stale Flow phase selection should fall back to worktree-path copy shortcut:\n%s", view)
 	}
-	if strings.Contains(pane, "y      copy phase id") {
-		t.Fatalf("stale Flow phase selection should not expose phase-id copy shortcut:\n%s", view)
+	if strings.Contains(pane, "y      copy id") || strings.Contains(pane, "y      copy phase id") {
+		t.Fatalf("stale Flow phase selection should not expose id copy shortcuts:\n%s", view)
+	}
+}
+
+func TestRender_FlowsModeHidesCopyPathShortcutWithoutWorktreePath(t *testing.T) {
+	base := RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    180,
+		Height:   16,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "No worktree path",
+			Status: flowstore.StatusInProgress,
+			Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation",
+				Title:   "Implementation",
+				Status:  flowstore.PhaseReady,
+			}},
+		}},
+		ActivePane:   1,
+		FlowSelected: 0,
+	}
+
+	if pane := shortcutPaneText(Render(base)); strings.Contains(pane, "y      copy") {
+		t.Fatalf("selected Flow without worktree path should hide copy shortcut:\n%s", pane)
+	}
+
+	phase := base
+	phase.ExpandedFlowID = "flow-1"
+	phase.SelectedFlowPhaseID = "implementation"
+	if pane := shortcutPaneText(Render(phase)); strings.Contains(pane, "y      copy") {
+		t.Fatalf("selected Flow phase without parent worktree path should hide copy shortcut:\n%s", pane)
 	}
 }
 

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -583,6 +583,34 @@ func TestStatusBar_FlowsModeShowsPhaseToggleHintForSelectedFlow(t *testing.T) {
 	}
 }
 
+func TestStatusBar_FlowsModeFullFooterPreservesSectionOrder(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:                    240,
+		Mode:                     ModeFlows,
+		ActivePane:               1,
+		RepoSelected:             true,
+		FlowSelected:             true,
+		FlowWorktreePathSelected: true,
+		FlowPlanLinked:           true,
+		FlowHeadless:             true,
+		FlowAutoModeSelected:     true,
+		FlowAgentLabel:           "codex",
+		FlowReasoningEffort:      "effort: high",
+		FlowNextLaunchReady:      true,
+	})
+
+	enterIndex := strings.Index(bar, "enter: phases")
+	headlessIndex := strings.Index(bar, "h: headless on")
+	agentIndex := strings.Index(bar, "A: codex")
+	tabIndex := strings.Index(bar, "tab: pane")
+	if enterIndex < 0 || headlessIndex < 0 || agentIndex < 0 || tabIndex < 0 {
+		t.Fatalf("full Flow footer missing expected hints, got %q", bar)
+	}
+	if !(enterIndex < headlessIndex && headlessIndex < agentIndex && agentIndex < tabIndex) {
+		t.Fatalf("full Flow footer should order Actions, Mode, Agent, Global, got %q", bar)
+	}
+}
+
 func TestStatusBar_FlowsModeShowsAutoModeToggleForSelectedFlow(t *testing.T) {
 	flowRow := renderStatusBarWithState(statusBarParams{
 		Width:                180,


### PR DESCRIPTION
## Summary

- Reorganize Flow mode footer shortcuts under Actions, Mode, Agent, and Global groups.
- Move headless and auto mode controls under Mode, and agent/effort controls under Agent.
- Change the `y` shortcut in Flow mode to copy the selected worktree path.

## Implementation

- Updates Flow footer rendering and associated snapshot expectations.
- Adjusts Flow shortcut handling so `y` copies the selected Flow worktree path.
- Refreshes README and config docs to match the revised shortcut groups and behavior.

## Verification

- `gofmt -l .`
- `go test ./ui ./model`
- `make test`
- `make build`
