### PR TITLE
Focus interactive Flow terminals after launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,8 +343,9 @@ runtime-only embedded terminal inside the flows pane. Press `h` to choose the
 CLI command mode: headless runs `codex exec` or `claude --print`, while
 headless off runs interactive `codex` or `claude` in the same embedded Flow
 terminal. Headless-off Flow launches prefill the phase prompt without
-submitting it, so you can review or edit it before pressing enter. Creating a
-new Flow has its own default-off Headless checkbox for the
+submitting it, then focus the Flow terminal in input mode so you can review or
+edit it before pressing enter. Headless launches keep focus on the Flow list.
+Creating a new Flow has its own default-off Headless checkbox for the
 initial Plan launch; that checkbox does not change the selected-phase `h`
 setting. Manual phase launches, auto-launched phases, and new Flow Plan
 launches all use the configured agent and that agent's configured effort. Press
@@ -358,11 +359,11 @@ as it works, while `claude --print` prints its result when the run completes,
 so a Claude phase can show an empty terminal until it finishes (the terminal tab
 still shows `running`). While a Flow terminal is open,
 the Flow list uses a smaller top panel and the terminal uses a bottom panel;
-`tab` switches focus between them. Flow terminal focus starts in wtui command
-mode: `left`/`right` cycle Flow terminals, `1`-`9` switches by number, `x`
-closes, `d` detaches to tmux when available, `q`/`esc` quits, unknown ordinary
-keys do not pass through to the PTY, `ctrl+]` sends a literal `ctrl+]`, and `i`
-enters terminal input mode. In input
+`tab` switches focus between them. Manually tabbing into Flow terminal focus
+starts in wtui command mode: `left`/`right` cycle Flow terminals, `1`-`9`
+switches by number, `x` closes, `d` detaches to tmux when available, `q`/`esc`
+quits, unknown ordinary keys do not pass through to the PTY, `ctrl+]` sends a
+literal `ctrl+]`, and `i` enters terminal input mode. In input
 mode, keys pass through to the PTY (including agent shortcuts like `ctrl+g`)
 and `ctrl+]` returns to command mode. When
 Implementation is still gated by Plan Review, wtui reports the Plan Review state

--- a/docs/config.md
+++ b/docs/config.md
@@ -315,11 +315,12 @@ selected CLI `codex` and `claude` phase launches run in an embedded terminal
 inside the flows pane. Press `h` to choose the CLI command mode: headless runs
 `codex exec` or `claude --print`, while headless off runs interactive `codex` or
 `claude` in the same embedded Flow terminal. Headless-off Flow launches prefill
-the phase prompt without submitting it, so you can review or edit it before
-pressing enter. Creating a new Flow has its own default-off Headless checkbox
-for the initial Plan launch; that checkbox does not change the selected-phase
-`h` setting. Press `E` to choose the configured CLI agent's reasoning effort
-for future launches; the shortcut pane shows the current value. Manual phase
+the phase prompt without submitting it, then focus the Flow terminal in input
+mode so you can review or edit it before pressing enter. Headless launches keep
+focus on the Flow list. Creating a new Flow has its own default-off Headless
+checkbox for the initial Plan launch; that checkbox does not change the
+selected-phase `h` setting. Press `E` to choose the configured CLI agent's
+reasoning effort for future launches; the shortcut pane shows the current value. Manual phase
 launches, auto-launched phases, and new Flow Plan launches all use the
 configured agent and that agent's configured effort.
 `codex-app` remains URL/deep-link based, launches externally, and uses
@@ -327,12 +328,13 @@ app-side/default reasoning. Press `r` to resume an attached
 provider session from the selected phase row; CLI resumes open in runtime-only
 embedded PTYs in the flows pane, while `codex-app` resumes navigate externally.
 While a Flow terminal is open, `tab` switches focus between the Flow list and
-terminal. Terminal focus starts in wtui command mode: `left`/`right` cycles Flow
-terminals, `1`-`9` switches by number, `d` detaches to tmux when available, `x`
-closes, `q`/`esc` quits, unknown ordinary keys do not pass through to the PTY,
-and `ctrl+]` sends a literal `ctrl+]`; `i` enters terminal input mode. In input
-mode, keys pass through to the PTY (including agent shortcuts like `ctrl+g`) and
-`ctrl+]` returns to command mode. Embedded headless output is rendered as
+terminal. Manually tabbing into Flow terminal focus starts in wtui command mode:
+`left`/`right` cycles Flow terminals, `1`-`9` switches by number, `d` detaches to
+tmux when available, `x` closes, `q`/`esc` quits, unknown ordinary keys do not
+pass through to the PTY, and `ctrl+]` sends a literal `ctrl+]`; `i` enters
+terminal input mode. In input mode, keys pass through to the PTY (including
+agent shortcuts like `ctrl+g`) and `ctrl+]` returns to command mode. Embedded
+headless output is rendered as
 readable terminal text rather than raw provider event JSON; `codex exec` streams
 progress while it runs, whereas `claude --print` only prints its result once the
 run completes. Expanded rows

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1430,6 +1430,7 @@ func TestModel_EnterOnSelectedFlowPhaseCollapsesWithoutLaunching(t *testing.T) {
 func TestModel_CtrlJOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHeadless(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var started actions.AgentLaunchContext
+	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
 	launchAgentRan := false
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand:          "claude",
@@ -1445,7 +1446,7 @@ func TestModel_CtrlJOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHead
 		},
 		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
 			started = ctx
-			return &fakeEmbeddedTerminal{state: "running"}, nil
+			return fakeTerm, nil
 		},
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return nil, nil
@@ -1487,6 +1488,10 @@ func TestModel_CtrlJOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHead
 	}
 	if started.LaunchID == "" || started.LaunchID != launchUpdate.LaunchID {
 		t.Fatalf("launch IDs = context %q update %#v", started.LaunchID, launchUpdate)
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	if len(fakeTerm.writes) != 0 {
+		t.Fatalf("headless Flow launch should keep list focus and not forward input: %#v", fakeTerm.writes)
 	}
 }
 
@@ -1561,6 +1566,18 @@ func TestModel_CtrlJOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *
 			}
 			if strings.HasSuffix(fakeTerm.writes[0], "\r") || strings.HasSuffix(fakeTerm.writes[0], "\n") {
 				t.Fatalf("prefill write should not append submit byte, got %q", fakeTerm.writes[0])
+			}
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+			if len(fakeTerm.writes) != 2 || fakeTerm.writes[1] != "z" {
+				t.Fatalf("interactive Flow launch should focus terminal input and forward z: %#v", fakeTerm.writes)
+			}
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlCloseBracket})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+			if len(fakeTerm.writes) != 2 {
+				t.Fatalf("terminal close prefix should not forward x: %#v", fakeTerm.writes)
+			}
+			if view := m.View(); !strings.Contains(view, "Terminate embedded terminal?") {
+				t.Fatalf("ctrl+] x should open terminal close confirmation:\n%s", view)
 			}
 		})
 	}
@@ -4761,6 +4778,7 @@ func TestModel_FlowTerminalFocusCyclesLeftRightWithoutWritingPTY(t *testing.T) {
 			WorktreePath: "/dev/alpha",
 			FlowID:       "flow-1",
 			FlowPhaseID:  phaseID,
+			Headless:     true,
 		}})
 	}
 	if starts != 3 {
@@ -4809,6 +4827,7 @@ func TestModel_FlowTerminalLeftRightNoOpWithOneTerminal(t *testing.T) {
 		WorktreePath: "/dev/alpha",
 		FlowID:       "flow-1",
 		FlowPhaseID:  "implementation",
+		Headless:     true,
 	}})
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
@@ -6394,6 +6413,65 @@ func TestModel_NewFlowCLIPlanLaunchUsesCheckedHeadlessOption(t *testing.T) {
 	}
 }
 
+func TestModel_NewFlowInteractiveCLIPlanLaunchFocusesTerminalInput(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
+	var started actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:     "codex",
+		SessionStateRoot: "/state/wtui/sessions/v1",
+		StartFlowPlan: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+			return model.FlowStartResult{LaunchContext: actions.AgentLaunchContext{
+				Command:          req.AgentCommand,
+				LaunchID:         "launch-1",
+				RepoPath:         req.RepoPath,
+				WorktreePath:     "/dev/alpha-worktrees/flow-interactive-plan",
+				Branch:           "flow/interactive-plan",
+				SessionStateRoot: req.SessionStateRoot,
+				FlowID:           "flow-1",
+				FlowPhaseID:      req.PlanPhaseID,
+				InitialPrompt:    "Create and persist the plan.",
+			}}, nil
+		},
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			t.Fatalf("new Flow CLI launch should start an embedded terminal, not external launcher: %#v", ctx)
+			return actions.TerminalLaunchSpec{}, nil
+		},
+		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
+			started = ctx
+			return fakeTerm, nil
+		},
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return nil, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 20})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+
+	m, cmd := submitNewFlowPrompts(t, m, "Interactive Plan", "Write the plan", "main")
+	if cmd == nil {
+		t.Fatal("expected flow creation command")
+	}
+	msg := cmd()
+	launchMsg, ok := msg.(model.FlowEmbeddedLaunchRequestedMsg)
+	if !ok {
+		t.Fatalf("creation command returned %T, want FlowEmbeddedLaunchRequestedMsg", msg)
+	}
+	m, cmd = update(m, launchMsg)
+	if cmd == nil {
+		t.Fatal("expected embedded launch repaint/fetch command")
+	}
+	if started.FlowPhaseID != "plan" || started.Headless || !started.Embedded || !started.FlowLaunchTracked {
+		t.Fatalf("interactive new Flow plan launch context = %#v", started)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	wantPrefill := "\x1b[200~Create and persist the plan.\x1b[201~"
+	if len(fakeTerm.writes) != 2 || fakeTerm.writes[0] != wantPrefill || fakeTerm.writes[1] != "z" {
+		t.Fatalf("interactive new Flow plan launch should focus terminal input: %#v", fakeTerm.writes)
+	}
+}
+
 func TestModel_NewFlowWithCodexAppUsesExternalLaunchRoute(t *testing.T) {
 	for _, headless := range []bool{false, true} {
 		t.Run(fmt.Sprintf("headless_%v", headless), func(t *testing.T) {
@@ -7001,6 +7079,7 @@ func TestModel_NewFlowAtEmbeddedTerminalCapMarksPlanNeedsAttention(t *testing.T)
 			WorktreePath: "/dev/alpha-worktrees/flow-existing",
 			FlowID:       "flow-existing",
 			FlowPhaseID:  "implementation",
+			Headless:     true,
 		}})
 	}
 	if starts != 9 {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1495,6 +1495,57 @@ func TestModel_CtrlJOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHead
 	}
 }
 
+func TestModel_HeadlessFlowLaunchFromTerminalInputReturnsFocusToList(t *testing.T) {
+	terms := []*fakeEmbeddedTerminal{
+		{state: "running"},
+		{state: "running"},
+	}
+	starts := 0
+	m := model.NewWithOptions(testRepos(), model.Options{
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			if starts >= len(terms) {
+				t.Fatalf("unexpected embedded terminal start %d", starts+1)
+			}
+			term := terms[starts]
+			starts++
+			return term, nil
+		},
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return nil, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-selected",
+		Status:       flowstore.StatusInProgress,
+	}})
+
+	m, _ = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:     "codex",
+		FlowID:      "flow-1",
+		FlowPhaseID: "implementation",
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	if len(terms[0].writes) != 1 || terms[0].writes[0] != "z" {
+		t.Fatalf("interactive Flow launch should focus terminal input, writes = %#v", terms[0].writes)
+	}
+
+	m, _ = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:     "codex",
+		FlowID:      "flow-1",
+		FlowPhaseID: "review-loop",
+		Headless:    true,
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if len(terms[0].writes) != 1 {
+		t.Fatalf("headless Flow launch should leave previous terminal writes unchanged, got %#v", terms[0].writes)
+	}
+	if len(terms[1].writes) != 0 {
+		t.Fatalf("headless Flow launch should not inherit terminal input focus, got writes %#v", terms[1].writes)
+	}
+}
+
 func TestModel_CtrlJOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *testing.T) {
 	for _, command := range []string{"codex", "claude"} {
 		t.Run(command, func(t *testing.T) {
@@ -2574,7 +2625,7 @@ func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
-	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	if cmd == nil {
 		t.Fatal("expected selected Flow phase resume command")
 	}
@@ -2606,6 +2657,10 @@ func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 	}
 	if len(fakeTerm.writes) != 0 {
 		t.Fatalf("Flow phase resume should not prefill embedded terminal, got writes %#v", fakeTerm.writes)
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "z" {
+		t.Fatalf("interactive Flow phase resume should focus terminal input and forward z: %#v", fakeTerm.writes)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -2219,15 +2219,26 @@ func (m Model) launchFlowEmbeddedWithContext(ctx actions.AgentLaunchContext) (Mo
 		next = next.setStatus(statusOther, errText)
 		return next, nil
 	}
-	if !ctx.Headless && next.mode == ui.ModeFlows {
-		next.activePane = 1
-		next.flowFocus = flowFocusTerminal
-		next.terminalPrefixActive = false
-	}
+	next = next.updateFlowTerminalFocusAfterLaunch(ctx)
 	if needsTick {
 		return next.startEmbeddedTerminalTick()
 	}
 	return next, nil
+}
+
+func (m Model) updateFlowTerminalFocusAfterLaunch(ctx actions.AgentLaunchContext) Model {
+	if m.mode != ui.ModeFlows {
+		return m
+	}
+	if ctx.Headless {
+		m.flowFocus = flowFocusList
+		m.terminalPrefixActive = false
+		return m
+	}
+	m.activePane = 1
+	m.flowFocus = flowFocusTerminal
+	m.terminalPrefixActive = false
+	return m
 }
 
 func (m Model) launchTrackedFlowPhaseResumeWithContext(ctx actions.AgentLaunchContext) (Model, tea.Cmd) {
@@ -2266,6 +2277,7 @@ func (m Model) launchTrackedFlowPhaseResumeWithContext(ctx actions.AgentLaunchCo
 		}
 		return next, nil
 	}
+	next = next.updateFlowTerminalFocusAfterLaunch(ctx)
 	var launchCmd tea.Cmd
 	if needsTick {
 		next, launchCmd = next.startEmbeddedTerminalTick()

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -2219,6 +2219,11 @@ func (m Model) launchFlowEmbeddedWithContext(ctx actions.AgentLaunchContext) (Mo
 		next = next.setStatus(statusOther, errText)
 		return next, nil
 	}
+	if !ctx.Headless && next.mode == ui.ModeFlows {
+		next.activePane = 1
+		next.flowFocus = flowFocusTerminal
+		next.terminalPrefixActive = false
+	}
 	if needsTick {
 		return next.startEmbeddedTerminalTick()
 	}


### PR DESCRIPTION
## Summary
- focus the Flow embedded terminal in input mode after interactive CLI launches and phase-session resumes
- keep focus on the Flow list after headless launches so normal list keys do not leak into PTYs
- document the updated Flow terminal focus behavior in README and config docs

## Implementation
- added a shared Flow launch focus helper used by new embedded Flow launches and tracked phase resumes
- expanded model tests for selected phase launches, new Flow Plan launches, headless focus retention, input forwarding, and terminal command-prefix handling

## Verification
- gofmt -l .
- make test
- make build