### PR TITLE
Auto-open detached embedded terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,14 +213,19 @@ exist, the saved-session table is hidden and the pane shows a compact numbered
 terminal header plus the active terminal screen. Keys go directly to the active
 PTY (including agent shortcuts like `ctrl+g`); press `ctrl+]` for wtui
 commands: `ctrl+] 1`-`9` switches terminals, `ctrl+] l` opens a saved-session
-picker, `ctrl+] d` detaches a tmux-backed terminal to its tmux session,
-`ctrl+] x` dismisses an exited terminal or confirms termination of a
+picker, `ctrl+] d` detaches a tmux-backed terminal and opens a new external
+terminal attached to that tmux session, `ctrl+] x` dismisses an exited terminal or confirms termination of a
 running one, `ctrl+] q` or `ctrl+] esc` quits with cleanup, and
 `ctrl+] ctrl+]` sends a literal `ctrl+]` to the agent.
 When `tmux` is available at launch time, embedded CLI terminals start inside a
 per-launch tmux session so detach can close wtui's embedded client while the
-agent keeps running in tmux. If `tmux` is unavailable, wtui keeps the direct
-embedded PTY behavior and `ctrl+] d` reports that detach is unavailable.
+agent keeps running in tmux. After detach, wtui opens the reattach command with
+`$TERMINAL`, then `[terminal].command`, then the macOS Terminal AppleScript
+fallback when available. Active tmux/Zellij clients and installed inactive
+tmux/Zellij commands are not used for this handoff. If no external terminal
+transport is available, wtui still leaves the agent detached in tmux and reports
+the handoff error. If `tmux` is unavailable, wtui keeps the direct embedded PTY
+behavior and `ctrl+] d` reports that detach is unavailable.
 Quitting wtui from anywhere while embedded terminals are still running asks for
 confirmation and terminates them first. Terminate/quit cleanup kills tmux
 sessions created by that embedded launch; detached tmux sessions are no longer
@@ -360,9 +365,10 @@ still shows `running`). While a Flow terminal is open,
 the Flow list uses a smaller top panel and the terminal uses a bottom panel;
 `tab` switches focus between them. Flow terminal focus starts in wtui command
 mode: `left`/`right` cycle Flow terminals, `1`-`9` switches by number, `x`
-closes, `d` detaches to tmux when available, `q`/`esc` quits, unknown ordinary
-keys do not pass through to the PTY, `ctrl+]` sends a literal `ctrl+]`, and `i`
-enters terminal input mode. In input
+closes, `d` detaches to tmux when available and opens the detached session in an
+external terminal, `q`/`esc` quits, unknown ordinary keys do not pass through to
+the PTY, `ctrl+]` sends a literal `ctrl+]`, and `i` enters terminal input mode.
+In input
 mode, keys pass through to the PTY (including agent shortcuts like `ctrl+g`)
 and `ctrl+]` returns to command mode. When
 Implementation is still gated by Plan Review, wtui reports the Plan Review state

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1343,6 +1343,37 @@ func TerminalLaunchWithOptions(path string, opts LaunchOptions) (TerminalLaunchS
 	return terminalLaunchWithOptions(path, runtime.GOOS, os.Getenv, exec.LookPath, nil, opts)
 }
 
+// DetachedTerminalLaunch builds a non-interactive handoff command that opens an
+// external terminal and runs targetShellCommand. It intentionally ignores active
+// or installed multiplexers; the target command already attaches to the
+// detached tmux-backed embedded terminal.
+func DetachedTerminalLaunch(targetShellCommand, cwd string, opts LaunchOptions) (TerminalLaunchSpec, error) {
+	return detachedTerminalLaunch(targetShellCommand, cwd, runtime.GOOS, os.Getenv, exec.LookPath, opts)
+}
+
+func detachedTerminalLaunch(targetShellCommand, cwd, goos string, getenv getenvFunc, lookPath lookPathFunc, opts LaunchOptions) (TerminalLaunchSpec, error) {
+	targetShellCommand = strings.TrimSpace(targetShellCommand)
+	if targetShellCommand == "" {
+		return TerminalLaunchSpec{}, fmt.Errorf("detached terminal handoff command cannot be empty")
+	}
+	preference := selectTerminalPreference(getenv("TERMINAL"), opts.TerminalCommand, lookPath)
+	if preference.kind != terminalPreferenceNone {
+		launch, err := detachedTerminalLaunchFromPreference(goos, cwd, lookPath, preference, targetShellCommand)
+		if err != nil {
+			return TerminalLaunchSpec{}, err
+		}
+		launch.Detached = true
+		return launch, nil
+	}
+	if goos == "darwin" && commandExists("osascript", lookPath) {
+		return TerminalLaunchSpec{
+			Cmd:      macOSTerminalScriptCommand("Terminal", targetShellCommand),
+			Detached: true,
+		}, nil
+	}
+	return TerminalLaunchSpec{}, fmt.Errorf("external terminal required for detached handoff; set TERMINAL or [terminal].command")
+}
+
 // terminalLaunch chooses a transport for path. When command is nil it opens a
 // plain shell/terminal session (the `t` shortcut). When command is non-nil it
 // runs that command inside the chosen session instead.
@@ -1543,6 +1574,32 @@ func terminalLaunchFromPreference(goos, path string, lookPath lookPathFunc, pref
 				return TerminalLaunchSpec{}, fmt.Errorf("cannot launch terminal: open is required to open %s", pref.app)
 			}
 			return TerminalLaunchSpec{Cmd: exec.Command("open", "-a", pref.app, path)}, nil
+		}
+		return TerminalLaunchSpec{}, missingTerminalCommandError(pref)
+	default:
+		return TerminalLaunchSpec{}, fmt.Errorf("%s is empty", pref.source)
+	}
+}
+
+func detachedTerminalLaunchFromPreference(goos, cwd string, lookPath lookPathFunc, pref terminalPreference, shellCommand string) (TerminalLaunchSpec, error) {
+	switch pref.kind {
+	case terminalPreferenceCLICommand:
+		cmd, err := cliTerminalLaunchForShell(pref.argv, cwd, shellCommand)
+		if err != nil {
+			return TerminalLaunchSpec{}, err
+		}
+		return TerminalLaunchSpec{Cmd: cmd}, nil
+	case terminalPreferenceGUIApp:
+		if goos != "darwin" {
+			return TerminalLaunchSpec{}, missingTerminalCommandError(pref)
+		}
+		if !commandExists("osascript", lookPath) {
+			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch detached terminal handoff: osascript is required to run a command in %s", pref.app)
+		}
+		return TerminalLaunchSpec{Cmd: macOSTerminalScriptCommand(pref.app, shellCommand)}, nil
+	case terminalPreferenceUnsupportedGUIApp:
+		if pref.reason != "" {
+			return TerminalLaunchSpec{}, fmt.Errorf("%s", pref.reason)
 		}
 		return TerminalLaunchSpec{}, missingTerminalCommandError(pref)
 	default:

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1367,7 +1367,7 @@ func detachedTerminalLaunch(targetShellCommand, cwd, goos string, getenv getenvF
 	}
 	if goos == "darwin" && commandExists("osascript", lookPath) {
 		return TerminalLaunchSpec{
-			Cmd:      macOSTerminalScriptCommand("Terminal", targetShellCommand),
+			Cmd:      macOSTerminalScriptCommand("Terminal", detachedTerminalShellCommand(targetShellCommand, cwd)),
 			Detached: true,
 		}, nil
 	}
@@ -1596,7 +1596,7 @@ func detachedTerminalLaunchFromPreference(goos, cwd string, lookPath lookPathFun
 		if !commandExists("osascript", lookPath) {
 			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch detached terminal handoff: osascript is required to run a command in %s", pref.app)
 		}
-		return TerminalLaunchSpec{Cmd: macOSTerminalScriptCommand(pref.app, shellCommand)}, nil
+		return TerminalLaunchSpec{Cmd: macOSTerminalScriptCommand(pref.app, detachedTerminalShellCommand(shellCommand, cwd))}, nil
 	case terminalPreferenceUnsupportedGUIApp:
 		if pref.reason != "" {
 			return TerminalLaunchSpec{}, fmt.Errorf("%s", pref.reason)
@@ -1605,6 +1605,14 @@ func detachedTerminalLaunchFromPreference(goos, cwd string, lookPath lookPathFun
 	default:
 		return TerminalLaunchSpec{}, fmt.Errorf("%s is empty", pref.source)
 	}
+}
+
+func detachedTerminalShellCommand(shellCommand, cwd string) string {
+	cwd = strings.TrimSpace(cwd)
+	if cwd == "" {
+		return shellCommand
+	}
+	return "cd " + shellQuote(cwd) + " && " + shellCommand
 }
 
 func cliTerminalLaunch(argv []string, path string, command *terminalCommand) (TerminalLaunchSpec, error) {

--- a/actions/actions_select_test.go
+++ b/actions/actions_select_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -451,6 +452,178 @@ func TestTerminalLaunch_ReportsMissingTerminalCommand(t *testing.T) {
 		t.Fatal("expected missing TERMINAL command error")
 	}
 	for _, want := range []string{"TERMINAL", "ghostterm"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to mention %q, got %q", want, err.Error())
+		}
+	}
+}
+
+func TestDetachedTerminalLaunch_UsesTerminalEnvCLI(t *testing.T) {
+	env := fakeGetenv(map[string]string{"TERMINAL": "alacritty"})
+	const target = `env -u TMUX tmux -f /dev/null -L 'wtui-agent' attach-session -t 'agent launch'`
+
+	launch, err := detachedTerminalLaunch(target, "/repo/worktree", "linux", env, fakeLookPath("alacritty"), LaunchOptions{})
+	if err != nil {
+		t.Fatalf("detachedTerminalLaunch returned error: %v", err)
+	}
+	if launch.Interactive {
+		t.Fatal("detached handoff should not require the caller TTY")
+	}
+	if !launch.Detached {
+		t.Fatal("detached handoff launch should be marked detached")
+	}
+	want := []string{"alacritty", "-e", "sh", "-c", target}
+	if !reflect.DeepEqual(launch.Cmd.Args, want) {
+		t.Fatalf("handoff args = %#v, want %#v", launch.Cmd.Args, want)
+	}
+	if launch.Cmd.Dir != "/repo/worktree" {
+		t.Fatalf("handoff dir = %q, want /repo/worktree", launch.Cmd.Dir)
+	}
+}
+
+func TestDetachedTerminalLaunch_UsesConfiguredCLIWhenTerminalEnvEmpty(t *testing.T) {
+	launch, err := detachedTerminalLaunch("tmux attach-session -t agent", "/repo/worktree", "linux", fakeGetenv(nil), fakeLookPath("wezterm"), LaunchOptions{
+		TerminalCommand: "wezterm start --cwd .",
+	})
+	if err != nil {
+		t.Fatalf("detachedTerminalLaunch returned error: %v", err)
+	}
+	want := []string{"wezterm", "start", "--cwd", ".", "-e", "sh", "-c", "tmux attach-session -t agent"}
+	if !reflect.DeepEqual(launch.Cmd.Args, want) {
+		t.Fatalf("handoff args = %#v, want %#v", launch.Cmd.Args, want)
+	}
+	if launch.Cmd.Dir != "/repo/worktree" {
+		t.Fatalf("handoff dir = %q, want /repo/worktree", launch.Cmd.Dir)
+	}
+}
+
+func TestDetachedTerminalLaunch_OsascriptEscapesTargetShellCommand(t *testing.T) {
+	const target = `env -u TMUX tmux -L "sock"; do shell script "touch /tmp/PWNED"; echo '$HOME' \ attach-session -t agent`
+	launch, err := detachedTerminalLaunch(target, "/repo/worktree", "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{})
+	if err != nil {
+		t.Fatalf("detachedTerminalLaunch returned error: %v", err)
+	}
+	if launch.Cmd.Args[0] != "osascript" {
+		t.Fatalf("expected osascript transport, got %#v", launch.Cmd.Args)
+	}
+
+	const prefix = `tell application "Terminal" to do script `
+	var doScript string
+	for _, arg := range launch.Cmd.Args {
+		if strings.HasPrefix(arg, prefix) {
+			doScript = strings.TrimPrefix(arg, prefix)
+		}
+	}
+	if doScript == "" {
+		t.Fatalf("no Terminal do-script argument found in %#v", launch.Cmd.Args)
+	}
+	inner, err := strconv.Unquote(doScript)
+	if err != nil {
+		t.Fatalf("do-script payload is not a valid quoted string: %q", doScript)
+	}
+	if inner != target {
+		t.Fatalf("do-script payload = %q, want exact target %q", inner, target)
+	}
+}
+
+func TestDetachedTerminalLaunch_ITermOsascriptEscapesTargetShellCommand(t *testing.T) {
+	const target = `env -u TMUX tmux -L "sock"; do shell script "touch /tmp/PWNED"; echo '$HOME' \ attach-session -t agent`
+	launch, err := detachedTerminalLaunch(target, "/repo/worktree", "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{
+		TerminalCommand: "iTerm",
+	})
+	if err != nil {
+		t.Fatalf("detachedTerminalLaunch returned error: %v", err)
+	}
+	if launch.Cmd.Args[0] != "osascript" {
+		t.Fatalf("expected osascript transport, got %#v", launch.Cmd.Args)
+	}
+
+	const prefix = `tell current session of newWindow to write text `
+	var writeText string
+	for _, arg := range launch.Cmd.Args {
+		if strings.HasPrefix(arg, prefix) {
+			writeText = strings.TrimPrefix(arg, prefix)
+		}
+	}
+	if writeText == "" {
+		t.Fatalf("no iTerm write-text argument found in %#v", launch.Cmd.Args)
+	}
+	inner, err := strconv.Unquote(writeText)
+	if err != nil {
+		t.Fatalf("write-text payload is not a valid quoted string: %q", writeText)
+	}
+	if inner != target {
+		t.Fatalf("write-text payload = %q, want exact target %q", inner, target)
+	}
+	if strings.Contains(strings.Join(launch.Cmd.Args, "\n"), "current session of current window") {
+		t.Fatalf("iTerm handoff should not write into the user's current session: %#v", launch.Cmd.Args)
+	}
+}
+
+func TestDetachedTerminalLaunch_IgnoresActiveMultiplexerWhenTerminalConfigured(t *testing.T) {
+	env := fakeGetenv(map[string]string{
+		"TMUX":     "/tmp/tmux.sock",
+		"ZELLIJ":   "0",
+		"TERMINAL": "alacritty",
+	})
+	launch, err := detachedTerminalLaunch("tmux attach-session -t agent", "/repo/worktree", "linux", env, fakeLookPath("tmux", "zellij", "alacritty"), LaunchOptions{})
+	if err != nil {
+		t.Fatalf("detachedTerminalLaunch returned error: %v", err)
+	}
+	if launch.Cmd.Args[0] != "alacritty" {
+		t.Fatalf("handoff should use configured external terminal, got %#v", launch.Cmd.Args)
+	}
+}
+
+func TestDetachedTerminalLaunch_DoesNotFallbackToMultiplexersOrShell(t *testing.T) {
+	env := fakeGetenv(map[string]string{
+		"TMUX":   "/tmp/tmux.sock",
+		"ZELLIJ": "0",
+		"SHELL":  "/bin/zsh",
+	})
+	_, err := detachedTerminalLaunch("tmux attach-session -t agent", "/repo/worktree", "linux", env, fakeLookPath("tmux", "zellij", "sh"), LaunchOptions{})
+	if err == nil {
+		t.Fatal("expected missing external terminal error")
+	}
+	if !strings.Contains(err.Error(), "external terminal required for detached handoff") {
+		t.Fatalf("error = %q, want external-terminal-required message", err.Error())
+	}
+}
+
+func TestDetachedTerminalLaunch_DarwinFallsBackToTerminalAppleScript(t *testing.T) {
+	launch, err := detachedTerminalLaunch("tmux attach-session -t agent", "/repo/worktree", "darwin", fakeGetenv(nil), fakeLookPath("tmux", "osascript"), LaunchOptions{})
+	if err != nil {
+		t.Fatalf("detachedTerminalLaunch returned error: %v", err)
+	}
+	joined := strings.Join(launch.Cmd.Args, "\n")
+	for _, want := range []string{"osascript", `tell application "Terminal" to do script `, `tell application "Terminal" to activate`} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected macOS fallback args to contain %q, got %#v", want, launch.Cmd.Args)
+		}
+	}
+}
+
+func TestDetachedTerminalLaunch_ReportsMissingExternalTerminal(t *testing.T) {
+	env := fakeGetenv(map[string]string{"TERMINAL": "ghostterm"})
+	_, err := detachedTerminalLaunch("tmux attach-session -t agent", "/repo/worktree", "linux", env, fakeLookPath(), LaunchOptions{})
+	if err == nil {
+		t.Fatal("expected missing TERMINAL command error")
+	}
+	for _, want := range []string{"TERMINAL", "ghostterm"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to mention %q, got %q", want, err.Error())
+		}
+	}
+}
+
+func TestDetachedTerminalLaunch_RejectsSupportedGUIAliasWithArgs(t *testing.T) {
+	_, err := detachedTerminalLaunch("tmux attach-session -t agent", "/repo/worktree", "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{
+		TerminalCommand: "iTerm --new-window",
+	})
+	if err == nil {
+		t.Fatal("expected supported GUI alias with args to be rejected")
+	}
+	for _, want := range []string{"[terminal].command", "iTerm --new-window", "unsupported arguments"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("expected error to mention %q, got %q", want, err.Error())
 		}

--- a/actions/actions_select_test.go
+++ b/actions/actions_select_test.go
@@ -499,7 +499,8 @@ func TestDetachedTerminalLaunch_UsesConfiguredCLIWhenTerminalEnvEmpty(t *testing
 
 func TestDetachedTerminalLaunch_OsascriptEscapesTargetShellCommand(t *testing.T) {
 	const target = `env -u TMUX tmux -L "sock"; do shell script "touch /tmp/PWNED"; echo '$HOME' \ attach-session -t agent`
-	launch, err := detachedTerminalLaunch(target, "/repo/worktree", "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{})
+	const cwd = `/repo/work tree's`
+	launch, err := detachedTerminalLaunch(target, cwd, "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{})
 	if err != nil {
 		t.Fatalf("detachedTerminalLaunch returned error: %v", err)
 	}
@@ -521,14 +522,16 @@ func TestDetachedTerminalLaunch_OsascriptEscapesTargetShellCommand(t *testing.T)
 	if err != nil {
 		t.Fatalf("do-script payload is not a valid quoted string: %q", doScript)
 	}
-	if inner != target {
-		t.Fatalf("do-script payload = %q, want exact target %q", inner, target)
+	want := "cd " + shellQuote(cwd) + " && " + target
+	if inner != want {
+		t.Fatalf("do-script payload = %q, want exact handoff command %q", inner, want)
 	}
 }
 
 func TestDetachedTerminalLaunch_ITermOsascriptEscapesTargetShellCommand(t *testing.T) {
 	const target = `env -u TMUX tmux -L "sock"; do shell script "touch /tmp/PWNED"; echo '$HOME' \ attach-session -t agent`
-	launch, err := detachedTerminalLaunch(target, "/repo/worktree", "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{
+	const cwd = `/repo/work tree's`
+	launch, err := detachedTerminalLaunch(target, cwd, "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{
 		TerminalCommand: "iTerm",
 	})
 	if err != nil {
@@ -552,11 +555,42 @@ func TestDetachedTerminalLaunch_ITermOsascriptEscapesTargetShellCommand(t *testi
 	if err != nil {
 		t.Fatalf("write-text payload is not a valid quoted string: %q", writeText)
 	}
-	if inner != target {
-		t.Fatalf("write-text payload = %q, want exact target %q", inner, target)
+	want := "cd " + shellQuote(cwd) + " && " + target
+	if inner != want {
+		t.Fatalf("write-text payload = %q, want exact handoff command %q", inner, want)
 	}
 	if strings.Contains(strings.Join(launch.Cmd.Args, "\n"), "current session of current window") {
 		t.Fatalf("iTerm handoff should not write into the user's current session: %#v", launch.Cmd.Args)
+	}
+}
+
+func TestDetachedTerminalLaunch_ConfiguredTerminalAppPreservesCWD(t *testing.T) {
+	const target = `tmux attach-session -t agent`
+	const cwd = `/repo/work tree's`
+	launch, err := detachedTerminalLaunch(target, cwd, "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{
+		TerminalCommand: "Terminal.app",
+	})
+	if err != nil {
+		t.Fatalf("detachedTerminalLaunch returned error: %v", err)
+	}
+
+	const prefix = `tell application "Terminal" to do script `
+	var doScript string
+	for _, arg := range launch.Cmd.Args {
+		if strings.HasPrefix(arg, prefix) {
+			doScript = strings.TrimPrefix(arg, prefix)
+		}
+	}
+	if doScript == "" {
+		t.Fatalf("no Terminal do-script argument found in %#v", launch.Cmd.Args)
+	}
+	inner, err := strconv.Unquote(doScript)
+	if err != nil {
+		t.Fatalf("do-script payload is not a valid quoted string: %q", doScript)
+	}
+	want := "cd " + shellQuote(cwd) + " && " + target
+	if inner != want {
+		t.Fatalf("do-script payload = %q, want exact handoff command %q", inner, want)
 	}
 }
 

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -343,6 +343,9 @@ func modelOptionsFromConfig(cfg config.Config, scanRepos func() ([]scanner.Repo,
 		LaunchTerminal: func(path string) (actions.TerminalLaunchSpec, error) {
 			return actions.TerminalLaunchWithOptions(path, launchOpts)
 		},
+		LaunchDetachedTerminal: func(targetShellCommand, cwd string) (actions.TerminalLaunchSpec, error) {
+			return actions.DetachedTerminalLaunch(targetShellCommand, cwd, launchOpts)
+		},
 		EditFile: func(path string) (actions.TerminalLaunchSpec, error) {
 			return actions.EditFileWithOptions(path, actions.EditorOptions{EditorCommand: cfg.Editor.Command})
 		},

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -466,6 +466,18 @@ func TestModelOptionsFromConfigPassesTerminalCommandToLaunchers(t *testing.T) {
 	if agentLaunch.Cleanup != nil {
 		agentLaunch.Cleanup()
 	}
+
+	detachLaunch, err := opts.LaunchDetachedTerminal("tmux attach-session -t agent", "/repo/worktree")
+	if err != nil {
+		t.Fatalf("LaunchDetachedTerminal returned error: %v", err)
+	}
+	wantDetachArgs := []string{terminalCommand, "--reuse", "-e", "sh", "-c", "tmux attach-session -t agent"}
+	if !reflect.DeepEqual(detachLaunch.Cmd.Args, wantDetachArgs) {
+		t.Fatalf("expected LaunchDetachedTerminal to use configured terminal command, got %#v", detachLaunch.Cmd.Args)
+	}
+	if detachLaunch.Cmd.Dir != "/repo/worktree" {
+		t.Fatalf("LaunchDetachedTerminal dir = %q, want /repo/worktree", detachLaunch.Cmd.Dir)
+	}
 }
 
 func TestModelOptionsFromConfigTerminalEnvOverridesConfiguredCommand(t *testing.T) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -127,9 +127,15 @@ to `$EDITOR`.
 
 ### `[terminal]`
 
-Configures the external terminal fallback used by the `t` action and by
-detached agent-launch scripts. Active tmux/Zellij sessions still take
-precedence, and `TERMINAL` still overrides this setting.
+Configures the external terminal fallback used by the `t` action, detached
+agent-launch scripts, and embedded-terminal detach handoff. Active tmux/Zellij
+sessions still take precedence for normal `t` and agent launches, and
+`TERMINAL` still overrides this setting. Embedded detach handoff is different:
+after `ctrl+] d` detaches a tmux-backed embedded terminal, wtui uses
+`TERMINAL`, then `[terminal].command`, then the macOS Terminal AppleScript
+fallback when available. It never uses the active tmux/Zellij client, installed
+inactive tmux/Zellij commands, `$SHELL`, or the current TTY as the handoff
+transport.
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -154,11 +160,12 @@ terminals and detached agent scripts open in iTerm.
 
 Other command values are treated as whitespace-separated CLI terminal commands
 when the first field exists on `PATH`; configured arguments are preserved as
-separate argv entries and agent launches append `-e sh -c <script>`. Shell
-quoting is not interpreted in this setting. On macOS, an unsupported GUI app
-name can open a plain worktree terminal with `open -a <app> <path>`, but it
-cannot run detached agent scripts. Use a supported GUI alias or a CLI terminal
-command for agent launches.
+separate argv entries and agent launches or detach handoff append
+`-e sh -c <script>`. Shell quoting is not interpreted in this setting. On macOS,
+an unsupported GUI app name can open a plain worktree terminal with
+`open -a <app> <path>`, but it cannot run detached agent scripts or detach
+handoff. Use a supported GUI alias or a CLI terminal command for agent launches
+and embedded detach handoff.
 
 ### `[provider]`
 
@@ -600,8 +607,12 @@ metadata environment wiring as fresh launches. In the full sessions view, those
 CLI resumes run inside runtime-only embedded PTYs in the sessions pane. When
 `tmux` is available at launch time, those embedded CLI terminals are backed by a
 per-launch tmux session and `ctrl+] d` detaches wtui's embedded client while the
-agent continues in tmux. When `tmux` is unavailable, wtui uses the direct
-embedded PTY path and reports detach unavailable. Fresh Flow selected-phase
+agent continues in tmux. wtui then opens a new external terminal running the
+tmux reattach command, using the detach handoff order described in
+`[terminal]`. Platforms without `$TERMINAL`, `[terminal].command`, or the macOS
+Terminal AppleScript fallback report the handoff error after detach; the agent
+continues in the detached tmux session. When `tmux` is unavailable, wtui uses
+the direct embedded PTY path and reports detach unavailable. Fresh Flow selected-phase
 launches and Flow phase-session resumes run CLI agents inside runtime-only
 embedded PTYs in the flows pane; Flow headless mode chooses
 headless provider commands (`codex exec` / `claude --print`) versus interactive

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -78,15 +78,17 @@ const (
 type embeddedTerminalID int
 
 type embeddedTerminalSlot struct {
-	Number      int
-	Scope       embeddedTerminalScope
-	Provider    string
-	Identity    string
-	RepoPath    string
-	FlowID      string
-	FlowPhaseID string
-	Terminal    EmbeddedTerminal
-	ID          embeddedTerminalID
+	Number       int
+	Scope        embeddedTerminalScope
+	Provider     string
+	Identity     string
+	RepoPath     string
+	WorktreePath string
+	WorkingDir   string
+	FlowID       string
+	FlowPhaseID  string
+	Terminal     EmbeddedTerminal
+	ID           embeddedTerminalID
 }
 
 type embeddedSessionPickerSelectedMsg struct {
@@ -384,15 +386,17 @@ func (m Model) openEmbeddedTerminalWithLabel(ctx actions.AgentLaunchContext, sco
 	}
 	m.nextEmbeddedTerminalID++
 	m.embeddedTerminals = append(m.embeddedTerminals, embeddedTerminalSlot{
-		Number:      number,
-		Scope:       scope,
-		Provider:    provider,
-		Identity:    identity,
-		RepoPath:    cleanEmbeddedTerminalRepoPath(ctx.RepoPath),
-		FlowID:      flowID,
-		FlowPhaseID: flowPhaseID,
-		Terminal:    term,
-		ID:          embeddedTerminalID(m.nextEmbeddedTerminalID),
+		Number:       number,
+		Scope:        scope,
+		Provider:     provider,
+		Identity:     identity,
+		RepoPath:     cleanEmbeddedTerminalRepoPath(ctx.RepoPath),
+		WorktreePath: cleanEmbeddedTerminalPath(ctx.WorktreePath),
+		WorkingDir:   cleanEmbeddedTerminalPath(ctx.WorkingDir),
+		FlowID:       flowID,
+		FlowPhaseID:  flowPhaseID,
+		Terminal:     term,
+		ID:           embeddedTerminalID(m.nextEmbeddedTerminalID),
 	})
 	if scope == embeddedTerminalScopeFlow {
 		m.activeFlowTerminalNum = number
@@ -506,6 +510,14 @@ func cleanEmbeddedTerminalRepoPath(repoPath string) string {
 		return ""
 	}
 	return filepath.Clean(repoPath)
+}
+
+func cleanEmbeddedTerminalPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	return filepath.Clean(path)
 }
 
 func (m Model) resizeEmbeddedTerminals() Model {
@@ -641,7 +653,8 @@ func (m Model) handleEmbeddedTerminalKeyForScope(msg tea.KeyMsg, scope embeddedT
 			case "x":
 				return m.handleEmbeddedTerminalClosePrefix(scope), nil, true
 			case "d":
-				return m.handleEmbeddedTerminalDetachPrefix(scope), nil, true
+				next, cmd := m.handleEmbeddedTerminalDetachPrefix(scope)
+				return next, cmd, true
 			case "q", "esc":
 				next, cmd := m.handleEmbeddedTerminalQuitPrefix()
 				return next, cmd, true
@@ -670,7 +683,8 @@ func (m Model) handleEmbeddedTerminalKeyForScope(msg tea.KeyMsg, scope embeddedT
 		case "x":
 			return m.handleEmbeddedTerminalClosePrefix(scope), nil, true
 		case "d":
-			return m.handleEmbeddedTerminalDetachPrefix(scope), nil, true
+			next, cmd := m.handleEmbeddedTerminalDetachPrefix(scope)
+			return next, cmd, true
 		case "q", "esc":
 			next, cmd := m.handleEmbeddedTerminalQuitPrefix()
 			return next, cmd, true
@@ -743,27 +757,57 @@ func (m Model) handleEmbeddedTerminalClosePrefix(scope embeddedTerminalScope) Mo
 	return m
 }
 
-func (m Model) handleEmbeddedTerminalDetachPrefix(scope embeddedTerminalScope) Model {
+func (m Model) handleEmbeddedTerminalDetachPrefix(scope embeddedTerminalScope) (Model, tea.Cmd) {
 	slot, _, ok := m.activeEmbeddedTerminalForScope(scope)
 	if !ok || slot.Terminal == nil {
-		return m
+		return m, nil
 	}
 	detachable, ok := slot.Terminal.(detachableEmbeddedTerminal)
 	if !ok {
-		return m.setStatus(statusOther, "Detach unavailable: tmux was not available when this terminal started")
+		return m.setStatus(statusOther, "Detach unavailable: tmux was not available when this terminal started"), nil
 	}
 	target := strings.TrimSpace(detachable.DetachTarget())
 	if err := detachable.Detach(); err != nil {
 		if errors.Is(err, errEmbeddedTerminalDetachUnavailable) {
-			return m.setStatus(statusOther, "Detach unavailable: tmux was not available when this terminal started")
+			return m.setStatus(statusOther, "Detach unavailable: tmux was not available when this terminal started"), nil
 		}
-		return m.setStatus(statusOther, err.Error())
+		return m.setStatus(statusOther, err.Error()), nil
 	}
 	m = m.dismissEmbeddedTerminal(slot.ID)
 	if target == "" {
 		target = "tmux"
 	}
-	return m.setStatus(statusOther, "Detached embedded terminal to tmux: "+target)
+	cwd := slot.detachHandoffCWD()
+	launch, err := m.launchDetachedTerminal(target, cwd)
+	if err != nil {
+		return m.setStatus(statusOther, "Detached embedded terminal, but failed to open terminal: "+err.Error()), nil
+	}
+	return m.setStatus(statusOther, "Detached embedded terminal; opening terminal: "+target), runEmbeddedTerminalDetachHandoff(target, launch)
+}
+
+func (slot embeddedTerminalSlot) detachHandoffCWD() string {
+	if slot.WorkingDir != "" {
+		return slot.WorkingDir
+	}
+	if slot.WorktreePath != "" {
+		return slot.WorktreePath
+	}
+	return slot.RepoPath
+}
+
+func runEmbeddedTerminalDetachHandoff(target string, launch actions.TerminalLaunchSpec) tea.Cmd {
+	return func() tea.Msg {
+		if launch.Cmd == nil {
+			return EmbeddedTerminalDetachHandoffResultMsg{Target: target, Err: "detached terminal handoff command is nil"}
+		}
+		if err := launch.Cmd.Run(); err != nil {
+			if launch.Cleanup != nil {
+				launch.Cleanup()
+			}
+			return EmbeddedTerminalDetachHandoffResultMsg{Target: target, Err: err.Error()}
+		}
+		return EmbeddedTerminalDetachHandoffResultMsg{Target: target}
+	}
 }
 
 func embeddedTerminalRunning(term EmbeddedTerminal) bool {

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -291,6 +292,7 @@ func TestOpenEmbeddedTerminalStoresSessionRepoPath(t *testing.T) {
 	next, opened, err := m.openEmbeddedTerminal(actions.AgentLaunchContext{
 		RepoPath:     "/dev/alpha/",
 		WorktreePath: "/dev/alpha-worktrees/feature",
+		WorkingDir:   "/dev/alpha-worktrees/feature/subdir",
 	}, sessions.SessionRecord{Provider: sessions.ProviderCodex, SessionID: "session-1"})
 	if err != nil {
 		t.Fatalf("open embedded terminal returned error: %v", err)
@@ -303,6 +305,12 @@ func TestOpenEmbeddedTerminalStoresSessionRepoPath(t *testing.T) {
 	}
 	if got := next.embeddedTerminals[0].RepoPath; got != "/dev/alpha" {
 		t.Fatalf("slot repo path = %q, want cleaned repo path %q", got, "/dev/alpha")
+	}
+	if got := next.embeddedTerminals[0].WorktreePath; got != "/dev/alpha-worktrees/feature" {
+		t.Fatalf("slot worktree path = %q, want cleaned worktree path", got)
+	}
+	if got := next.embeddedTerminals[0].WorkingDir; got != "/dev/alpha-worktrees/feature/subdir" {
+		t.Fatalf("slot working dir = %q, want cleaned working dir", got)
 	}
 }
 
@@ -777,21 +785,34 @@ func TestDismissLastFlowTerminalPreservesSessionCommandState(t *testing.T) {
 
 func TestSessionTerminalPrefixDDetachesActiveTerminal(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{target: "wtui-agent-session"}
+	var gotTarget, gotCWD string
 	m := Model{
 		mode:                      ui.ModeSessions,
 		activeEmbeddedTerminalNum: 1,
 		terminalPrefixActive:      true,
+		launchDetachedTerminal: func(target, cwd string) (actions.TerminalLaunchSpec, error) {
+			gotTarget = target
+			gotCWD = cwd
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+		finalizeAgentSession: func(actions.AgentLaunchContext) error {
+			t.Fatal("detach should not finalize the agent session")
+			return nil
+		},
 		embeddedTerminals: []embeddedTerminalSlot{{
-			Number:   1,
-			Scope:    embeddedTerminalScopeSession,
-			Provider: "codex",
-			Identity: "session",
-			Terminal: term,
-			ID:       1,
+			Number:       1,
+			Scope:        embeddedTerminalScopeSession,
+			Provider:     "codex",
+			Identity:     "session",
+			RepoPath:     "/dev/repo",
+			WorktreePath: "/dev/worktree",
+			WorkingDir:   "/dev/worktree/subdir",
+			Terminal:     term,
+			ID:           1,
 		}},
 	}
 
-	next, _, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeSession)
+	next, cmd, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeSession)
 
 	if !consumed {
 		t.Fatal("detach key should be consumed")
@@ -802,13 +823,35 @@ func TestSessionTerminalPrefixDDetachesActiveTerminal(t *testing.T) {
 	if len(next.embeddedTerminals) != 0 {
 		t.Fatalf("embedded terminals = %#v, want detached terminal dismissed", next.embeddedTerminals)
 	}
-	if !strings.Contains(next.status.Text, "wtui-agent-session") {
-		t.Fatalf("status = %q, want detach target", next.status.Text)
+	if gotTarget != "wtui-agent-session" {
+		t.Fatalf("handoff target = %q, want wtui-agent-session", gotTarget)
+	}
+	if gotCWD != "/dev/worktree/subdir" {
+		t.Fatalf("handoff cwd = %q, want /dev/worktree/subdir", gotCWD)
+	}
+	if cmd == nil {
+		t.Fatal("detach should return a handoff command")
+	}
+	if !strings.Contains(next.status.Text, "opening terminal: wtui-agent-session") {
+		t.Fatalf("status = %q, want opening-terminal detach target", next.status.Text)
+	}
+	msg, ok := cmd().(EmbeddedTerminalDetachHandoffResultMsg)
+	if !ok {
+		t.Fatalf("handoff command message = %#v, want EmbeddedTerminalDetachHandoffResultMsg", msg)
+	}
+	if msg.Target != "wtui-agent-session" || msg.Err != "" {
+		t.Fatalf("handoff message = %#v, want successful target", msg)
+	}
+	updated, _ := next.Update(msg)
+	next = updated.(Model)
+	if !strings.Contains(next.status.Text, "Detached embedded terminal and opened terminal: wtui-agent-session") {
+		t.Fatalf("status = %q, want opened-terminal detach target", next.status.Text)
 	}
 }
 
 func TestFlowTerminalPrefixDDetachesActiveTerminalAndRenumbers(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{target: "wtui-flow-agent"}
+	var gotTarget, gotCWD string
 	m := Model{
 		mode:                  ui.ModeFlows,
 		activePane:            1,
@@ -818,16 +861,27 @@ func TestFlowTerminalPrefixDDetachesActiveTerminalAndRenumbers(t *testing.T) {
 		terminalConfirmID:     1,
 		terminalConfirmScope:  embeddedTerminalScopeFlow,
 		modal:                 modal.OpenConfirm(embeddedTerminalTerminatePrompt, nil),
+		launchDetachedTerminal: func(target, cwd string) (actions.TerminalLaunchSpec, error) {
+			gotTarget = target
+			gotCWD = cwd
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+		finalizeAgentSession: func(actions.AgentLaunchContext) error {
+			t.Fatal("detach should not finalize the agent session")
+			return nil
+		},
 		embeddedTerminals: []embeddedTerminalSlot{
 			{
-				Number:      1,
-				Scope:       embeddedTerminalScopeFlow,
-				Provider:    "codex",
-				Identity:    "implementation",
-				FlowID:      "flow-1",
-				FlowPhaseID: "implementation",
-				Terminal:    term,
-				ID:          1,
+				Number:       1,
+				Scope:        embeddedTerminalScopeFlow,
+				Provider:     "codex",
+				Identity:     "implementation",
+				RepoPath:     "/dev/repo",
+				WorktreePath: "/dev/worktree",
+				FlowID:       "flow-1",
+				FlowPhaseID:  "implementation",
+				Terminal:     term,
+				ID:           1,
 			},
 			{
 				Number:      2,
@@ -850,7 +904,7 @@ func TestFlowTerminalPrefixDDetachesActiveTerminalAndRenumbers(t *testing.T) {
 		},
 	}
 
-	next, _, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeFlow)
+	next, cmd, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeFlow)
 
 	if !consumed {
 		t.Fatal("detach key should be consumed")
@@ -872,6 +926,104 @@ func TestFlowTerminalPrefixDDetachesActiveTerminalAndRenumbers(t *testing.T) {
 	}
 	if activity := next.flowTerminalActivity(); len(activity) != 1 || activity[0].PhaseID != "review" {
 		t.Fatalf("flow terminal activity = %#v, want only remaining Flow terminal", activity)
+	}
+	if gotTarget != "wtui-flow-agent" {
+		t.Fatalf("handoff target = %q, want wtui-flow-agent", gotTarget)
+	}
+	if gotCWD != "/dev/worktree" {
+		t.Fatalf("handoff cwd = %q, want /dev/worktree", gotCWD)
+	}
+	if cmd == nil {
+		t.Fatal("detach should return a handoff command")
+	}
+}
+
+func TestTerminalPrefixDReportsHandoffConstructionFailureAfterDetach(t *testing.T) {
+	term := &internalFakeDetachableEmbeddedTerminal{target: "wtui-agent-session"}
+	m := Model{
+		mode:                      ui.ModeSessions,
+		activeEmbeddedTerminalNum: 1,
+		terminalPrefixActive:      true,
+		launchDetachedTerminal: func(string, string) (actions.TerminalLaunchSpec, error) {
+			return actions.TerminalLaunchSpec{}, errors.New("no external terminal")
+		},
+		embeddedTerminals: []embeddedTerminalSlot{{
+			Number:   1,
+			Scope:    embeddedTerminalScopeSession,
+			Provider: "codex",
+			Identity: "session",
+			Terminal: term,
+			ID:       1,
+		}},
+	}
+
+	next, cmd, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeSession)
+
+	if !consumed {
+		t.Fatal("detach key should be consumed")
+	}
+	if !term.detached {
+		t.Fatal("terminal was not detached")
+	}
+	if len(next.embeddedTerminals) != 0 {
+		t.Fatalf("embedded terminals = %#v, want detached terminal dismissed", next.embeddedTerminals)
+	}
+	if cmd != nil {
+		t.Fatal("construction failure should not return a handoff command")
+	}
+	if !strings.Contains(next.status.Text, "Detached embedded terminal, but failed to open terminal: no external terminal") {
+		t.Fatalf("status = %q, want detach-success handoff failure", next.status.Text)
+	}
+}
+
+func TestTerminalPrefixDReportsHandoffRunFailureAfterDetach(t *testing.T) {
+	term := &internalFakeDetachableEmbeddedTerminal{target: "wtui-agent-session"}
+	cleaned := false
+	m := Model{
+		mode:                      ui.ModeSessions,
+		activeEmbeddedTerminalNum: 1,
+		terminalPrefixActive:      true,
+		launchDetachedTerminal: func(string, string) (actions.TerminalLaunchSpec, error) {
+			return actions.TerminalLaunchSpec{
+				Cmd:     exec.Command("sh", "-c", "exit 7"),
+				Cleanup: func() { cleaned = true },
+			}, nil
+		},
+		embeddedTerminals: []embeddedTerminalSlot{{
+			Number:   1,
+			Scope:    embeddedTerminalScopeSession,
+			Provider: "codex",
+			Identity: "session",
+			Terminal: term,
+			ID:       1,
+		}},
+	}
+
+	next, cmd, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeSession)
+
+	if !consumed {
+		t.Fatal("detach key should be consumed")
+	}
+	if len(next.embeddedTerminals) != 0 {
+		t.Fatalf("embedded terminals = %#v, want detached terminal dismissed", next.embeddedTerminals)
+	}
+	if cmd == nil {
+		t.Fatal("detach should return a handoff command")
+	}
+	msg, ok := cmd().(EmbeddedTerminalDetachHandoffResultMsg)
+	if !ok {
+		t.Fatalf("handoff command message = %#v, want EmbeddedTerminalDetachHandoffResultMsg", msg)
+	}
+	if msg.Err == "" {
+		t.Fatalf("handoff message = %#v, want run error", msg)
+	}
+	if !cleaned {
+		t.Fatal("handoff cleanup should run when handoff command fails")
+	}
+	updated, _ := next.Update(msg)
+	next = updated.(Model)
+	if !strings.Contains(next.status.Text, "Detached embedded terminal, but failed to open terminal:") {
+		t.Fatalf("status = %q, want detach-success handoff failure", next.status.Text)
 	}
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -103,6 +103,7 @@ type Model struct {
 	saveAgent                 func(string) error
 	saveAgentReasoningEffort  func(string, string) error
 	launchTerminal            func(string) (actions.TerminalLaunchSpec, error)
+	launchDetachedTerminal    func(string, string) (actions.TerminalLaunchSpec, error)
 	launchAgent               func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error)
 	startEmbeddedTerminal     EmbeddedTerminalStarter
 	embeddedTerminals         []embeddedTerminalSlot
@@ -180,6 +181,7 @@ type Options struct {
 	SaveAgentCommand         func(string) error
 	SaveAgentReasoningEffort func(string, string) error
 	LaunchTerminal           func(path string) (actions.TerminalLaunchSpec, error)
+	LaunchDetachedTerminal   func(targetShellCommand, cwd string) (actions.TerminalLaunchSpec, error)
 	LaunchAgent              func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error)
 	StartEmbeddedTerminal    EmbeddedTerminalStarter
 	FinalizeAgentSession     func(actions.AgentLaunchContext) error
@@ -309,6 +311,12 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if launchTerminal == nil {
 		launchTerminal = actions.TerminalLaunch
 	}
+	launchDetachedTerminal := opts.LaunchDetachedTerminal
+	if launchDetachedTerminal == nil {
+		launchDetachedTerminal = func(targetShellCommand, cwd string) (actions.TerminalLaunchSpec, error) {
+			return actions.DetachedTerminalLaunch(targetShellCommand, cwd, actions.LaunchOptions{})
+		}
+	}
 	launchAgent := opts.LaunchAgent
 	if launchAgent == nil {
 		launchAgent = actions.AgentLaunch
@@ -401,6 +409,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		saveAgent:                saveAgent,
 		saveAgentReasoningEffort: saveAgentReasoningEffort,
 		launchTerminal:           launchTerminal,
+		launchDetachedTerminal:   launchDetachedTerminal,
 		launchAgent:              launchAgent,
 		startEmbeddedTerminal:    startEmbeddedTerminal,
 		finalizeAgentSession:     finalizeAgentSession,
@@ -1101,6 +1110,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Err != "" {
 			m = m.setStatus(statusOther, msg.Err)
 		}
+		return m, nil
+	case EmbeddedTerminalDetachHandoffResultMsg:
+		if msg.Err != "" {
+			m = m.setStatus(statusOther, "Detached embedded terminal, but failed to open terminal: "+msg.Err)
+			return m, nil
+		}
+		target := strings.TrimSpace(msg.Target)
+		if target == "" {
+			target = "tmux"
+		}
+		m = m.setStatus(statusOther, "Detached embedded terminal and opened terminal: "+target)
 		return m, nil
 	case PlanEditResultMsg:
 		if !m.isCurrentRepo(msg.RepoPath) {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -298,6 +298,11 @@ type TerminalResultMsg struct {
 	Err string
 }
 
+type EmbeddedTerminalDetachHandoffResultMsg struct {
+	Target string
+	Err    string
+}
+
 type PlanEditResultMsg struct {
 	RepoPath string
 	Err      string


### PR DESCRIPTION
## Summary
- auto-open the configured terminal when detaching embedded terminals to tmux
- preserve the launching process working directory for macOS terminal handoff
- document the new detach terminal launch configuration

## Verification
- gofmt -l .
- go test ./gitquery
- make test
- make build