### PR TITLE
Ensure Flow prompts require completion persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,9 @@ only a plan, Plan Review to use the review-loop skill with max 6 loops,
 Implementation to use the `commit` skill, Review Loop to use the review-loop
 workflow with goal `review-and-revise` and `commit` when revisions are made,
 PR Creation to use the `ship` skill, and Autoreview to use `ship` when fixes
-require commits or pushes without embedding phase-restart recipes. Use
+require commits or pushes without embedding phase-restart recipes. All Flow
+phase launch prompts also end with the common instruction to mark the phase
+done with `wtui-flow` after completing the phase goal. Use
 `wtui flow phase restart` to rerun a blocked or needs-attention phase as
 `running`; if notes are omitted, wtui records a standard rerun note.
 
@@ -565,7 +567,9 @@ the parent directory for left-pane repo creation.
 configure provider-specific effort for new CLI agent launches; empty or
 `default` keeps provider defaults. `[agent].plan_prompt` customizes the
 editable instructions shown before launching an agent from the plans pane, while
-`[flow_prompts]` customizes Flow phase launch templates.
+`[flow_prompts]` customizes Flow phase launch templates. wtui appends the
+common phase-done instruction to configured Flow templates unless the template
+already ends with that exact standalone instruction.
 `[editor].command` customizes the editor used by the plans pane edit action.
 See [docs/config.md](docs/config.md) for the full config reference, including
 sessions storage, bootstrap hook settings, terminal settings, and parsed

--- a/README.md
+++ b/README.md
@@ -478,9 +478,9 @@ Implementation to use the `commit` skill, Review Loop to use the review-loop
 workflow with goal `review-and-revise` and `commit` when revisions are made,
 PR Creation to use the `ship` skill, and Autoreview to use `ship` when fixes
 require commits or pushes without embedding phase-restart recipes. All Flow
-phase launch prompts also end with the common instruction to mark the phase
-done with `wtui-flow` after completing the phase goal. Use
-`wtui flow phase restart` to rerun a blocked or needs-attention phase as
+phase launch prompts also end with:
+`After completing this phase goal, mark this Flow phase done with wtui-flow.`
+Use `wtui flow phase restart` to rerun a blocked or needs-attention phase as
 `running`; if notes are omitted, wtui records a standard rerun note.
 
 For example, after addressing Autoreview findings:
@@ -567,9 +567,10 @@ the parent directory for left-pane repo creation.
 configure provider-specific effort for new CLI agent launches; empty or
 `default` keeps provider defaults. `[agent].plan_prompt` customizes the
 editable instructions shown before launching an agent from the plans pane, while
-`[flow_prompts]` customizes Flow phase launch templates. wtui appends the
-common phase-done instruction to configured Flow templates unless the template
-already ends with that exact standalone instruction.
+`[flow_prompts]` customizes Flow phase launch templates. wtui appends
+`After completing this phase goal, mark this Flow phase done with wtui-flow.`
+to configured Flow templates unless the template already ends with that exact
+standalone instruction.
 `[editor].command` customizes the editor used by the plans pane edit action.
 See [docs/config.md](docs/config.md) for the full config reference, including
 sessions storage, bootstrap hook settings, terminal settings, and parsed

--- a/docs/config.md
+++ b/docs/config.md
@@ -207,9 +207,9 @@ link path cannot carry a verified effort setting.
 
 Optional templates for Flow phase launch prompts. Blank or omitted keys use
 the built-in prompt for that phase. Unknown placeholders remain literal. wtui
-appends the common phase-done instruction to both built-in prompts and
-configured templates unless the template already ends with that exact
-standalone instruction.
+appends `After completing this phase goal, mark this Flow phase done with wtui-flow.`
+to both built-in prompts and configured templates unless the template already
+ends with that exact standalone instruction.
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -461,8 +461,8 @@ Plan Review to use the review-loop skill with max 6 loops, Implementation to
 use the `commit` skill, Review Loop to use the review-loop workflow with goal
 `review-and-revise` and `commit` when revisions are made, PR Creation to use
 the `ship` skill, and Autoreview to use `ship` when fixes require commits or
-pushes. All Flow phase launch prompts also end with the common instruction to
-mark the phase done with `wtui-flow` after completing the phase goal.
+pushes. All Flow phase launch prompts also end with:
+`After completing this phase goal, mark this Flow phase done with wtui-flow.`
 Autoreview launch prompts include the PR target metadata but leave detailed
 completion, needs-attention, blocked, and restart mechanics to the high-level
 Flow phase commands.

--- a/docs/config.md
+++ b/docs/config.md
@@ -206,7 +206,10 @@ link path cannot carry a verified effort setting.
 ### `[flow_prompts]`
 
 Optional templates for Flow phase launch prompts. Blank or omitted keys use
-the built-in prompt for that phase. Unknown placeholders remain literal.
+the built-in prompt for that phase. Unknown placeholders remain literal. wtui
+appends the common phase-done instruction to both built-in prompts and
+configured templates unless the template already ends with that exact
+standalone instruction.
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -458,11 +461,13 @@ Plan Review to use the review-loop skill with max 6 loops, Implementation to
 use the `commit` skill, Review Loop to use the review-loop workflow with goal
 `review-and-revise` and `commit` when revisions are made, PR Creation to use
 the `ship` skill, and Autoreview to use `ship` when fixes require commits or
-pushes.
-Autoreview launch prompts include the PR target metadata but leave completion,
-needs-attention, blocked, and restart mechanics to the high-level Flow phase
-commands.
-Override `[flow_prompts]` keys to customize those phase templates.
+pushes. All Flow phase launch prompts also end with the common instruction to
+mark the phase done with `wtui-flow` after completing the phase goal.
+Autoreview launch prompts include the PR target metadata but leave detailed
+completion, needs-attention, blocked, and restart mechanics to the high-level
+Flow phase commands.
+Override `[flow_prompts]` keys to customize those phase templates; wtui still
+appends the common phase-done instruction to custom templates.
 
 The PR Creation phase should record structured PR metadata with
 `wtui flow pr set` after a pull request exists. The command currently supports

--- a/model/export_test.go
+++ b/model/export_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"github.com/brian-bell/wtui/embeddedterm"
+	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/ui"
 )
 
@@ -23,4 +24,16 @@ func ActiveFlowCreateForTest(m Model) uint64 {
 
 func FlowHeadlessForTest(m Model) bool {
 	return m.flowHeadless
+}
+
+func FlowPhaseDoneInstructionForTest() string {
+	return flowPhaseDoneInstruction
+}
+
+func FlowPlanPromptForTest(record flowstore.FlowRecord, templates FlowPromptTemplates) string {
+	return flowPlanPrompt(record, templates)
+}
+
+func FlowPhasePromptForTest(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string, templates FlowPromptTemplates) string {
+	return flowPhasePrompt(record, phase, planPath, planBody, templates)
 }

--- a/model/flow_prompt_completion_test.go
+++ b/model/flow_prompt_completion_test.go
@@ -139,8 +139,8 @@ func TestFlowPromptPhaseDoneInstructionDuplicateGuard(t *testing.T) {
 		Commit:       "abc123",
 	}
 
-	t.Run("plan template final standalone line", func(t *testing.T) {
-		template := "Plan {flow_id}\n\n" + instruction + "  \n\n"
+	t.Run("plan template exact final standalone line", func(t *testing.T) {
+		template := "Plan {flow_id}\n\n" + instruction + "\n\n"
 		got := model.FlowPlanPromptForTest(record, model.FlowPromptTemplates{Plan: template})
 		if strings.Count(got, instruction) != 1 {
 			t.Fatalf("prompt should contain one completion instruction:\n%s", got)
@@ -148,11 +148,20 @@ func TestFlowPromptPhaseDoneInstructionDuplicateGuard(t *testing.T) {
 		assertFinalFlowDoneInstruction(t, got)
 	})
 
-	t.Run("non-plan template final standalone line", func(t *testing.T) {
-		template := "Review {flow_id}\n\n" + instruction + "  \n\n"
+	t.Run("non-plan template exact final standalone line", func(t *testing.T) {
+		template := "Review {flow_id}\n\n" + instruction + "\n\n"
 		got := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review Loop"}, record.PlanPath, "", model.FlowPromptTemplates{ReviewLoop: template})
 		if strings.Count(got, instruction) != 1 {
 			t.Fatalf("prompt should contain one completion instruction:\n%s", got)
+		}
+		assertFinalFlowDoneInstruction(t, got)
+	})
+
+	t.Run("trailing spaces on final line still appends exact instruction", func(t *testing.T) {
+		template := "Review {flow_id}\n\n" + instruction + "  \n\n"
+		got := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review Loop"}, record.PlanPath, "", model.FlowPromptTemplates{ReviewLoop: template})
+		if strings.Count(got, instruction) != 2 {
+			t.Fatalf("prompt should append completion instruction when the authored final line has extra spaces:\n%s", got)
 		}
 		assertFinalFlowDoneInstruction(t, got)
 	})
@@ -185,6 +194,35 @@ func TestFlowPromptPhaseDoneInstructionDuplicateGuard(t *testing.T) {
 	})
 }
 
+func TestFlowGenericPhasePromptPreservesContextAndAppendsPhaseDoneInstruction(t *testing.T) {
+	record := flowstore.FlowRecord{
+		Instructions: "Build the requested change.",
+		PlanID:       "plan-1",
+		PlanPath:     "/state/plans/plan-1/plan.md",
+	}
+	phase := flowstore.FlowPhase{PhaseID: "qa-check", Title: "QA Check"}
+	planBody := "Confirm the release notes."
+
+	want := appendFlowDoneInstructionForTest(strings.Join([]string{
+		"Use the wtui-flow skill for this launch.",
+		"",
+		"Flow phase: QA Check (qa-check).",
+		"",
+		"Custom instructions:",
+		"Build the requested change.",
+		"",
+		"Linked plan: plan-1 at /state/plans/plan-1/plan.md",
+		"",
+		"Saved plan body:",
+		"Confirm the release notes.",
+		"",
+		"Advance this phase with `wtui flow phase set` only after the corresponding work is complete, blocked, or needs attention.",
+	}, "\n"))
+	if got := model.FlowPhasePromptForTest(record, phase, record.PlanPath, planBody, model.FlowPromptTemplates{}); got != want {
+		t.Fatalf("generic phase prompt = %q, want %q", got, want)
+	}
+}
+
 func assertFinalFlowDoneInstruction(t *testing.T, prompt string) {
 	t.Helper()
 	instruction := model.FlowPhaseDoneInstructionForTest()
@@ -194,10 +232,11 @@ func assertFinalFlowDoneInstruction(t *testing.T, prompt string) {
 }
 
 func lastNonEmptyLine(text string) string {
-	lines := strings.Split(strings.TrimRight(text, " \t\r\n"), "\n")
+	lines := strings.Split(text, "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
-		if trimmed := strings.TrimSpace(lines[i]); trimmed != "" {
-			return trimmed
+		line := strings.TrimSuffix(lines[i], "\r")
+		if strings.TrimSpace(line) != "" {
+			return line
 		}
 	}
 	return ""

--- a/model/flow_prompt_completion_test.go
+++ b/model/flow_prompt_completion_test.go
@@ -1,0 +1,208 @@
+package model_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/model"
+)
+
+func TestFlowPlanPromptAppendsPhaseDoneInstruction(t *testing.T) {
+	record := flowstore.FlowRecord{
+		Instructions: "Build the thing",
+	}
+
+	want := strings.Join([]string{
+		"Use the wtui-flow skill for this launch.",
+		"",
+		"Build the thing",
+		"",
+		"Produce a plan only; do not start coding in this phase.",
+		"Create and persist the plan with wtui plan save, link it back with wtui flow plan set, then report Flow persistence failures explicitly before ending.",
+		"",
+		model.FlowPhaseDoneInstructionForTest(),
+	}, "\n")
+	if got := model.FlowPlanPromptForTest(record, model.FlowPromptTemplates{}); got != want {
+		t.Fatalf("plan prompt = %q, want %q", got, want)
+	}
+}
+
+func TestFlowPhasePromptsAppendPhaseDoneInstruction(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		Instructions: "Build the requested change.",
+		PlanID:       "plan-1",
+		PlanPath:     "/state/plans/plan-1/plan.md",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-build",
+		Branch:       "flow/build",
+		Commit:       "abc123",
+		BaseRef:      "main",
+		PR: flowstore.PullRequest{
+			Provider:   "github",
+			Number:     42,
+			URL:        "https://github.com/brian-bell/wtui/pull/42",
+			HeadBranch: "flow/build",
+			BaseBranch: "main",
+			Status:     "open",
+		},
+	}
+	tests := []struct {
+		name     string
+		phase    flowstore.FlowPhase
+		planPath string
+		planBody string
+	}{
+		{name: "plan-review", phase: flowstore.FlowPhase{PhaseID: "plan-review", Title: "Plan Review"}, planPath: record.PlanPath},
+		{name: "implementation with plan", phase: flowstore.FlowPhase{PhaseID: "implementation", Title: "Implementation"}, planPath: record.PlanPath},
+		{name: "implementation without plan", phase: flowstore.FlowPhase{PhaseID: "implementation", Title: "Implementation"}},
+		{name: "review-loop", phase: flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review Loop"}},
+		{name: "pr-creation", phase: flowstore.FlowPhase{PhaseID: "pr-creation", Title: "PR Creation"}},
+		{name: "autoreview", phase: flowstore.FlowPhase{PhaseID: "autoreview", Title: "Autoreview"}},
+		{name: "merge", phase: flowstore.FlowPhase{PhaseID: "merge", Title: "Merge"}},
+		{name: "generic", phase: flowstore.FlowPhase{PhaseID: "qa-check", Title: "QA Check"}, planPath: record.PlanPath, planBody: "Confirm the release notes."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := model.FlowPhasePromptForTest(record, tt.phase, tt.planPath, tt.planBody, model.FlowPromptTemplates{})
+			assertFinalFlowDoneInstruction(t, got)
+		})
+	}
+}
+
+func TestFlowPromptTemplatesAppendPhaseDoneInstruction(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		Instructions: "Build the thing",
+		PlanID:       "plan-1",
+		PlanPath:     "/state/plans/plan-1/plan.md",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-template",
+		Branch:       "flow/template",
+		Commit:       "c0ffee",
+		BaseRef:      "main",
+		PR: flowstore.PullRequest{
+			Provider:   "github",
+			Number:     24,
+			URL:        "https://github.com/brian-bell/wtui/pull/24",
+			HeadBranch: "flow/template",
+			BaseBranch: "main",
+			Status:     "open",
+		},
+	}
+	template := "Custom {phase_id} for {flow_id}: {plan_path} at {worktree_path}; keep {unknown}"
+	tests := []struct {
+		name      string
+		phase     flowstore.FlowPhase
+		templates model.FlowPromptTemplates
+	}{
+		{name: "plan", phase: flowstore.FlowPhase{PhaseID: "plan", Title: "Plan"}, templates: model.FlowPromptTemplates{Plan: template}},
+		{name: "plan_review", phase: flowstore.FlowPhase{PhaseID: "plan-review", Title: "Plan Review"}, templates: model.FlowPromptTemplates{PlanReview: template}},
+		{name: "implementation", phase: flowstore.FlowPhase{PhaseID: "implementation", Title: "Implementation"}, templates: model.FlowPromptTemplates{Implementation: template}},
+		{name: "review_loop", phase: flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review Loop"}, templates: model.FlowPromptTemplates{ReviewLoop: template}},
+		{name: "pr_creation", phase: flowstore.FlowPhase{PhaseID: "pr-creation", Title: "PR Creation"}, templates: model.FlowPromptTemplates{PRCreation: template}},
+		{name: "autoreview", phase: flowstore.FlowPhase{PhaseID: "autoreview", Title: "Autoreview"}, templates: model.FlowPromptTemplates{Autoreview: template}},
+		{name: "merge", phase: flowstore.FlowPhase{PhaseID: "merge", Title: "Merge"}, templates: model.FlowPromptTemplates{Merge: template}},
+		{name: "generic", phase: flowstore.FlowPhase{PhaseID: "qa-check", Title: "QA Check"}, templates: model.FlowPromptTemplates{Generic: template}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			if tt.phase.PhaseID == "plan" {
+				got = model.FlowPlanPromptForTest(record, tt.templates)
+			} else {
+				got = model.FlowPhasePromptForTest(record, tt.phase, record.PlanPath, "", tt.templates)
+			}
+			want := strings.ReplaceAll(template, "{phase_id}", tt.phase.PhaseID)
+			want = strings.ReplaceAll(want, "{flow_id}", record.FlowID)
+			want = strings.ReplaceAll(want, "{plan_path}", record.PlanPath)
+			want = strings.ReplaceAll(want, "{worktree_path}", record.WorktreePath)
+			want += "\n\n" + model.FlowPhaseDoneInstructionForTest()
+			if got != want {
+				t.Fatalf("templated prompt = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestFlowPromptPhaseDoneInstructionDuplicateGuard(t *testing.T) {
+	instruction := model.FlowPhaseDoneInstructionForTest()
+	record := flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		Instructions: "Earlier placeholder says: " + instruction,
+		PlanPath:     "/state/plans/plan-1/plan.md",
+		WorktreePath: "/dev/alpha-worktrees/flow-template",
+		Branch:       "flow/template",
+		Commit:       "abc123",
+	}
+
+	t.Run("plan template final standalone line", func(t *testing.T) {
+		template := "Plan {flow_id}\n\n" + instruction + "  \n\n"
+		got := model.FlowPlanPromptForTest(record, model.FlowPromptTemplates{Plan: template})
+		if strings.Count(got, instruction) != 1 {
+			t.Fatalf("prompt should contain one completion instruction:\n%s", got)
+		}
+		assertFinalFlowDoneInstruction(t, got)
+	})
+
+	t.Run("non-plan template final standalone line", func(t *testing.T) {
+		template := "Review {flow_id}\n\n" + instruction + "  \n\n"
+		got := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review Loop"}, record.PlanPath, "", model.FlowPromptTemplates{ReviewLoop: template})
+		if strings.Count(got, instruction) != 1 {
+			t.Fatalf("prompt should contain one completion instruction:\n%s", got)
+		}
+		assertFinalFlowDoneInstruction(t, got)
+	})
+
+	t.Run("earlier occurrence still appends final instruction", func(t *testing.T) {
+		template := instruction + "\n\nContinue {phase_id}."
+		got := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review Loop"}, record.PlanPath, "", model.FlowPromptTemplates{ReviewLoop: template})
+		if strings.Count(got, instruction) != 2 {
+			t.Fatalf("prompt should append completion instruction after earlier occurrence:\n%s", got)
+		}
+		assertFinalFlowDoneInstruction(t, got)
+	})
+
+	t.Run("larger final line still appends standalone instruction", func(t *testing.T) {
+		template := "Continue, then " + instruction
+		got := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review Loop"}, record.PlanPath, "", model.FlowPromptTemplates{ReviewLoop: template})
+		if strings.Count(got, instruction) != 2 {
+			t.Fatalf("prompt should append standalone completion instruction after larger final line:\n%s", got)
+		}
+		assertFinalFlowDoneInstruction(t, got)
+	})
+
+	t.Run("rendered placeholder occurrence still appends final instruction", func(t *testing.T) {
+		template := "Generic body:\n{plan_body}"
+		got := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "qa-check", Title: "QA Check"}, record.PlanPath, instruction, model.FlowPromptTemplates{Generic: template})
+		if strings.Count(got, instruction) != 2 {
+			t.Fatalf("prompt should append completion instruction when only rendered placeholder ends with it:\n%s", got)
+		}
+		assertFinalFlowDoneInstruction(t, got)
+	})
+}
+
+func assertFinalFlowDoneInstruction(t *testing.T, prompt string) {
+	t.Helper()
+	instruction := model.FlowPhaseDoneInstructionForTest()
+	if got := lastNonEmptyLine(prompt); got != instruction {
+		t.Fatalf("last non-empty prompt line = %q, want %q\n%s", got, instruction, prompt)
+	}
+}
+
+func lastNonEmptyLine(text string) string {
+	lines := strings.Split(strings.TrimRight(text, " \t\r\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if trimmed := strings.TrimSpace(lines[i]); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func appendFlowDoneInstructionForTest(prompt string) string {
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + model.FlowPhaseDoneInstructionForTest()
+}

--- a/model/flow_prompts.go
+++ b/model/flow_prompts.go
@@ -91,10 +91,11 @@ func ensureFlowPhaseDoneInstruction(prompt, guardSource string) string {
 }
 
 func lastNonEmptyPromptLine(text string) string {
-	lines := strings.Split(strings.TrimRight(text, " \t\r\n"), "\n")
+	lines := strings.Split(text, "\n")
 	for i := len(lines) - 1; i >= 0; i-- {
-		if trimmed := strings.TrimSpace(lines[i]); trimmed != "" {
-			return trimmed
+		line := strings.TrimSuffix(lines[i], "\r")
+		if strings.TrimSpace(line) != "" {
+			return line
 		}
 	}
 	return ""

--- a/model/flow_prompts.go
+++ b/model/flow_prompts.go
@@ -7,6 +7,8 @@ import (
 	"github.com/brian-bell/wtui/flowstore"
 )
 
+const flowPhaseDoneInstruction = "After completing this phase goal, mark this Flow phase done with wtui-flow."
+
 // FlowPromptTemplates stores optional launch prompt templates for Flow phases.
 // Unknown placeholders are left literal so users can evolve templates safely.
 type FlowPromptTemplates struct {
@@ -75,4 +77,25 @@ func prNumberPlaceholder(number int) string {
 		return ""
 	}
 	return strconv.Itoa(number)
+}
+
+func ensureFlowPhaseDoneInstruction(prompt, guardSource string) string {
+	guard := guardSource
+	if strings.TrimSpace(guard) == "" {
+		guard = prompt
+	}
+	if lastNonEmptyPromptLine(guard) == flowPhaseDoneInstruction {
+		return strings.TrimRight(prompt, " \t\r\n")
+	}
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + flowPhaseDoneInstruction
+}
+
+func lastNonEmptyPromptLine(text string) string {
+	lines := strings.Split(strings.TrimRight(text, " \t\r\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if trimmed := strings.TrimSpace(lines[i]); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -248,12 +248,13 @@ func flowStartPromptRecord(flow flowstore.FlowRecord, req FlowStartRequest, work
 
 func flowPlanPrompt(flow flowstore.FlowRecord, templates FlowPromptTemplates) string {
 	if strings.TrimSpace(templates.Plan) != "" {
-		return renderFlowPromptTemplate(templates.Plan, flow, flowstore.FlowPhase{PhaseID: flowPlanPhaseID, Title: "Plan"}, flow.PlanPath, "")
+		prompt := renderFlowPromptTemplate(templates.Plan, flow, flowstore.FlowPhase{PhaseID: flowPlanPhaseID, Title: "Plan"}, flow.PlanPath, "")
+		return ensureFlowPhaseDoneInstruction(prompt, templates.Plan)
 	}
 	var b strings.Builder
 	b.WriteString("Use the wtui-flow skill for this launch.\n\n")
 	b.WriteString(flow.Instructions)
 	b.WriteString("\n\nProduce a plan only; do not start coding in this phase.")
 	b.WriteString("\nCreate and persist the plan with wtui plan save, link it back with wtui flow plan set, then report Flow persistence failures explicitly before ending.")
-	return b.String()
+	return ensureFlowPhaseDoneInstruction(b.String(), "")
 }

--- a/model/flow_start_test.go
+++ b/model/flow_start_test.go
@@ -194,7 +194,7 @@ func TestFlowStarterStartPlanUsesConfiguredPromptTemplate(t *testing.T) {
 		t.Fatalf("StartPlan returned error: %v", err)
 	}
 
-	want := "Plan flow-1: Build the thing in /dev/alpha-worktrees/flow-plan on flow/plan from abc123; keep {unknown}"
+	want := appendFlowDoneInstructionForTest("Plan flow-1: Build the thing in /dev/alpha-worktrees/flow-plan on flow/plan from abc123; keep {unknown}")
 	if result.LaunchContext.InitialPrompt != want {
 		t.Fatalf("plan prompt = %q, want %q", result.LaunchContext.InitialPrompt, want)
 	}

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1674,7 +1674,7 @@ func TestModel_CtrlJOnFlowPhaseEmbeddedInteractivePrefillSanitizesTerminalContro
 		t.Fatal("expected embedded Flow launch to return repaint/fetch command")
 	}
 
-	wantWrite := "\x1b[200~Alpha\nBeta\tOmegaDone\x1b[201~"
+	wantWrite := "\x1b[200~" + appendFlowDoneInstructionForTest("Alpha\nBeta\tOmegaDone") + "\x1b[201~"
 	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != wantWrite {
 		t.Fatalf("prefill writes = %#v, want exact sanitized bracketed paste %q", fakeTerm.writes, wantWrite)
 	}
@@ -3309,7 +3309,7 @@ func TestModel_CtrlJLaunchesFlowPhaseReadyPlanReviewWithLinkedPlanContext(t *tes
 		!launched.FlowLaunchTracked {
 		t.Fatalf("launch context = %#v", launched)
 	}
-	wantPrompt := strings.Join([]string{
+	wantPrompt := appendFlowDoneInstructionForTest(strings.Join([]string{
 		"Use the review-loop skill to review the saved plan, max 6 loops.",
 		"Use the wtui-flow skill to record the Plan Review verdict before finishing; the phase is not done until the verdict is persisted.",
 		"",
@@ -3317,7 +3317,7 @@ func TestModel_CtrlJLaunchesFlowPhaseReadyPlanReviewWithLinkedPlanContext(t *tes
 		"Worktree: /dev/alpha-worktrees/flow-review",
 		"Branch: flow/review",
 		"Start commit: abc123",
-	}, "\n")
+	}, "\n"))
 	if launched.InitialPrompt != wantPrompt {
 		t.Fatalf("plan-review prompt = %q, want %q", launched.InitialPrompt, wantPrompt)
 	}
@@ -3383,7 +3383,7 @@ func TestModel_FlowPlanReviewPromptTemplateOverridesBuiltInPrompt(t *testing.T) 
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
-	want := "Custom plan-review for flow-1: /state/plans/plan-1/plan.md on flow/template; keep {unknown}"
+	want := appendFlowDoneInstructionForTest("Custom plan-review for flow-1: /state/plans/plan-1/plan.md on flow/template; keep {unknown}")
 	if launched.InitialPrompt != want {
 		t.Fatalf("templated plan-review prompt = %q, want %q", launched.InitialPrompt, want)
 	}
@@ -3453,7 +3453,7 @@ func TestModel_CtrlJLaunchesFlowPhaseImplementationWithMinimalPrompt(t *testing.
 		!launched.FlowLaunchTracked {
 		t.Fatalf("launch context = %#v", launched)
 	}
-	wantPrompt := strings.Join([]string{
+	wantPrompt := appendFlowDoneInstructionForTest(strings.Join([]string{
 		"Implement the approved plan.",
 		"Use the commit skill before completing this phase.",
 		"",
@@ -3461,7 +3461,7 @@ func TestModel_CtrlJLaunchesFlowPhaseImplementationWithMinimalPrompt(t *testing.
 		"Worktree: /dev/alpha-worktrees/flow-implementation",
 		"Branch: flow/implementation",
 		"Start commit: fed321",
-	}, "\n")
+	}, "\n"))
 	if launched.InitialPrompt != wantPrompt {
 		t.Fatalf("implementation prompt = %q, want %q", launched.InitialPrompt, wantPrompt)
 	}
@@ -3587,7 +3587,7 @@ func TestModel_CtrlJLaunchesFlowPhaseImplementationInEmbeddedHeadlessTerminalByD
 	if len(fakeTerm.resizes) == 0 || fakeTerm.resizes[len(fakeTerm.resizes)-1] != wantResizeSize {
 		t.Fatalf("embedded terminal resize calls = %#v, want latest %dx%d", fakeTerm.resizes, wantResizeWidth, wantResizeHeight)
 	}
-	wantPrompt := strings.Join([]string{
+	wantPrompt := appendFlowDoneInstructionForTest(strings.Join([]string{
 		"Implement the approved plan.",
 		"Use the commit skill before completing this phase.",
 		"",
@@ -3595,7 +3595,7 @@ func TestModel_CtrlJLaunchesFlowPhaseImplementationInEmbeddedHeadlessTerminalByD
 		"Worktree: /dev/alpha-worktrees/flow-implementation",
 		"Branch: flow/implementation",
 		"Start commit: fed321",
-	}, "\n")
+	}, "\n"))
 	if started.InitialPrompt != wantPrompt {
 		t.Fatalf("embedded prompt = %q, want %q", started.InitialPrompt, wantPrompt)
 	}
@@ -5445,7 +5445,7 @@ func TestModel_FlowPromptTemplateReplacesSupportedPlaceholders(t *testing.T) {
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
-	want := "Custom implementation for flow-1: /state/plans/plan-1/plan.md @ /dev/alpha-worktrees/flow-template on flow/template from c0ffee; keep {unknown}"
+	want := appendFlowDoneInstructionForTest("Custom implementation for flow-1: /state/plans/plan-1/plan.md @ /dev/alpha-worktrees/flow-template on flow/template from c0ffee; keep {unknown}")
 	if launched.InitialPrompt != want {
 		t.Fatalf("templated flow prompt = %q, want %q", launched.InitialPrompt, want)
 	}
@@ -5563,7 +5563,7 @@ func TestModel_CtrlJLaunchesFlowPhaseReviewLoopWithFirstLevelPrompt(t *testing.T
 	if launched.FlowID != "flow-1" || launched.FlowPhaseID != "review-loop" || launched.PlanID != "plan-1" {
 		t.Fatalf("launch context = %#v", launched)
 	}
-	wantPrompt := strings.Join([]string{
+	wantPrompt := appendFlowDoneInstructionForTest(strings.Join([]string{
 		"Use the review-loop workflow with goal: review-and-revise.",
 		"Use the commit skill when revisions are made.",
 		"Use the wtui-flow skill to record the Review Loop result before finishing; the phase is not done until the result is persisted.",
@@ -5571,7 +5571,7 @@ func TestModel_CtrlJLaunchesFlowPhaseReviewLoopWithFirstLevelPrompt(t *testing.T
 		"Worktree: /dev/alpha-worktrees/flow-review-loop",
 		"Branch: flow/review-loop",
 		"Start commit: def456",
-	}, "\n")
+	}, "\n"))
 	if launched.InitialPrompt != wantPrompt {
 		t.Fatalf("review-loop prompt = %q, want %q", launched.InitialPrompt, wantPrompt)
 	}
@@ -5648,7 +5648,7 @@ func TestModel_FlowReviewLoopPromptTemplateOverridesBuiltInPrompt(t *testing.T) 
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
-	want := "Custom review-loop for flow-1: /dev/alpha-worktrees/flow-review-template on flow/review-template from baddad; plan /state/plans/plan-1/plan.md; keep {unknown}"
+	want := appendFlowDoneInstructionForTest("Custom review-loop for flow-1: /dev/alpha-worktrees/flow-review-template on flow/review-template from baddad; plan /state/plans/plan-1/plan.md; keep {unknown}")
 	if launched.InitialPrompt != want {
 		t.Fatalf("templated review-loop prompt = %q, want %q", launched.InitialPrompt, want)
 	}
@@ -5712,14 +5712,14 @@ func TestModel_CtrlJLaunchesFlowPhasePRCreationWithMinimalPrompt(t *testing.T) {
 	if launched.FlowID != "flow-1" || launched.FlowPhaseID != "pr-creation" || launched.PlanID != "plan-1" {
 		t.Fatalf("launch context = %#v", launched)
 	}
-	wantPrompt := strings.Join([]string{
+	wantPrompt := appendFlowDoneInstructionForTest(strings.Join([]string{
 		"Use the ship skill to create a PR for the changes.",
 		"After the PR exists, run `wtui flow pr set --flow-id flow-1 --provider github --number <number> --url <url> --head flow/pr --base <base>` before completing this phase.",
 		"",
 		"Worktree: /dev/alpha-worktrees/flow-pr",
 		"Branch: flow/pr",
 		"Start commit: abc789",
-	}, "\n")
+	}, "\n"))
 	if launched.InitialPrompt != wantPrompt {
 		t.Fatalf("pr-creation prompt = %q, want %q", launched.InitialPrompt, wantPrompt)
 	}
@@ -5781,14 +5781,14 @@ func TestModel_CtrlJLaunchesFlowPhasePRCreationWithStructuredMetadataPrompt(t *t
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
-	wantPrompt := strings.Join([]string{
+	wantPrompt := appendFlowDoneInstructionForTest(strings.Join([]string{
 		"Use the ship skill to create a PR for the changes.",
 		"After the PR exists, run `wtui flow pr set --flow-id flow-1 --provider github --number <number> --url <url> --head flow/pr --base <base>` before completing this phase.",
 		"",
 		"Worktree: /dev/alpha-worktrees/flow-pr",
 		"Branch: flow/pr",
 		"Start commit: abc789",
-	}, "\n")
+	}, "\n"))
 	if launched.InitialPrompt != wantPrompt {
 		t.Fatalf("pr-creation prompt = %q, want %q", launched.InitialPrompt, wantPrompt)
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1927,24 +1927,27 @@ func flowAutoreviewMissingPRTarget(record flowstore.FlowRecord) bool {
 
 func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string, templates FlowPromptTemplates) string {
 	if template := templates.templateForPhase(phase.PhaseID); strings.TrimSpace(template) != "" {
-		return renderFlowPromptTemplate(template, record, phase, planPath, planBody)
+		prompt := renderFlowPromptTemplate(template, record, phase, planPath, planBody)
+		return ensureFlowPhaseDoneInstruction(prompt, template)
 	}
+	var prompt string
 	switch phase.PhaseID {
 	case "plan-review":
-		return flowPlanReviewPrompt(record, phase, planPath, planBody)
+		prompt = flowPlanReviewPrompt(record, phase, planPath, planBody)
 	case "implementation":
-		return flowImplementationPrompt(record, phase, planPath, planBody)
+		prompt = flowImplementationPrompt(record, phase, planPath, planBody)
 	case "review-loop":
-		return flowReviewLoopPrompt(record, phase, planPath, planBody)
+		prompt = flowReviewLoopPrompt(record, phase, planPath, planBody)
 	case "pr-creation":
-		return flowPRCreationPrompt(record, phase, planPath, planBody)
+		prompt = flowPRCreationPrompt(record, phase, planPath, planBody)
 	case "autoreview":
-		return flowAutoreviewPrompt(record, phase, planPath, planBody)
+		prompt = flowAutoreviewPrompt(record, phase, planPath, planBody)
 	case "merge":
-		return flowMergePrompt(record, phase, planPath, planBody)
+		prompt = flowMergePrompt(record, phase, planPath, planBody)
 	default:
-		return flowGenericPhasePrompt(record, phase, planPath, planBody)
+		prompt = flowGenericPhasePrompt(record, phase, planPath, planBody)
 	}
+	return ensureFlowPhaseDoneInstruction(prompt, "")
 }
 
 func flowPhasePromptNeedsPlanBody(phaseID string) bool {


### PR DESCRIPTION
## Summary
- add a shared Flow prompt completion instruction so launched phase prompts tell agents to persist completion, blocked, or needs-attention status before ending
- keep the completion instruction out of read-only/detail prompts and PR/merge follow-up prompts where it is not appropriate
- document the prompt behavior and add focused model tests for launchable phases and prompt variants

## Verification
- `gofmt -l .` passed
- `make build` passed
- `make test` failed in `embeddedterm`: `TestTmuxBackedTerminalRealTmuxDetachLeavesSessionAlive` timed out after 10m; branch changes do not touch `embeddedterm`