### PR TITLE
Trigger Flow auto mode after terminal exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,13 +339,17 @@ existing app thread without extra launch tracking. Press `m` on a Flow row or
 expanded phase row to toggle per-Flow auto mode, which is off by default and
 persisted on that Flow record. When auto mode is on, a successful completed
 phase transition launches the next ready non-merge phase in that same Flow
-through the same launch path as pressing `ctrl+j`; skipped, blocked, needs-attention,
-failed-launch, or missing-PR-metadata states do not auto-launch. Automation
-stops before Merge: if Autoreview completes and Merge becomes ready, wtui keeps
-auto mode on and requires the existing manual Merge launch. Flow headless mode
-is on by default: selected CLI `codex` and `claude` phase launches run in a
-runtime-only embedded terminal inside the flows pane. Press `h` to choose the
-CLI command mode: headless runs `codex exec` or `claude --print`, while
+through the same launch path as pressing `ctrl+j`. For CLI phases running in an
+embedded Flow terminal, wtui waits until the completed phase's terminal exits
+normally and auto-closes before launching the next phase; that exit also
+triggers a Flow refresh so completions recorded after the last refresh are
+picked up promptly. Skipped, blocked, needs-attention, failed-launch, or
+missing-PR-metadata states do not auto-launch. Automation stops before Merge:
+if Autoreview completes and Merge becomes ready, wtui keeps auto mode on and
+requires the existing manual Merge launch. Flow headless mode is on by default:
+selected CLI `codex` and `claude` phase launches run in a runtime-only embedded
+terminal inside the flows pane. Press `h` to choose the CLI command mode:
+headless runs `codex exec` or `claude --print`, while
 headless off runs interactive `codex` or `claude` in the same embedded Flow
 terminal. Headless-off Flow launches prefill the phase prompt without
 submitting it, then focus the Flow terminal in input mode so you can review or

--- a/docs/config.md
+++ b/docs/config.md
@@ -318,7 +318,12 @@ IDs when present; press `n` to create a new Flow. On a Flow row or expanded
 phase row, `enter` expands or collapses read-only phase detail rows; `o` opens
 the linked plan body from the selected Flow. Press `ctrl+j` to launch the first
 launchable phase for the selected Flow. Press `y` to copy the selected Flow
-worktree path from either a Flow row or one of its expanded phase rows.
+worktree path from either a Flow row or one of its expanded phase rows. Press
+`m` to toggle per-Flow auto mode. When auto mode is on, completed CLI phases
+advance only after the completed phase's embedded Flow terminal exits normally
+and auto-closes; terminal exit also triggers a Flow refresh so newly persisted
+completion state is discovered without waiting for unrelated UI activity.
+Auto mode still skips non-completed outcomes and stops before Merge.
 Headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in an embedded terminal
 inside the flows pane. Press `h` to choose the CLI command mode: headless runs

--- a/docs/config.md
+++ b/docs/config.md
@@ -320,10 +320,11 @@ the linked plan body from the selected Flow. Press `ctrl+j` to launch the first
 launchable phase for the selected Flow. Press `y` to copy the selected Flow
 worktree path from either a Flow row or one of its expanded phase rows. Press
 `m` to toggle per-Flow auto mode. When auto mode is on, completed CLI phases
-advance only after the completed phase's embedded Flow terminal exits normally
-and auto-closes; terminal exit also triggers a Flow refresh so newly persisted
-completion state is discovered without waiting for unrelated UI activity.
-Auto mode still skips non-completed outcomes and stops before Merge.
+running in an embedded Flow terminal advance only after the completed phase's
+terminal exits normally and auto-closes; terminal exit also triggers a Flow
+refresh so newly persisted completion state is discovered without waiting for
+unrelated UI activity. Auto mode still skips non-completed outcomes and stops
+before Merge.
 Headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in an embedded terminal
 inside the flows pane. Press `h` to choose the CLI command mode: headless runs

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -87,6 +87,7 @@ type embeddedTerminalSlot struct {
 	WorkingDir   string
 	FlowID       string
 	FlowPhaseID  string
+	LaunchID     string
 	Terminal     EmbeddedTerminal
 	ID           embeddedTerminalID
 }
@@ -395,6 +396,7 @@ func (m Model) openEmbeddedTerminalWithLabel(ctx actions.AgentLaunchContext, sco
 		WorkingDir:   cleanEmbeddedTerminalPath(ctx.WorkingDir),
 		FlowID:       flowID,
 		FlowPhaseID:  flowPhaseID,
+		LaunchID:     strings.TrimSpace(ctx.LaunchID),
 		Terminal:     term,
 		ID:           embeddedTerminalID(m.nextEmbeddedTerminalID),
 	})
@@ -884,6 +886,7 @@ func (m Model) dismissEmbeddedTerminal(id embeddedTerminalID) Model {
 		if slot.ID != id {
 			next = append(next, slot)
 		} else {
+			m = m.clearDeferredAutoFlowLaunchForTerminal(slot)
 			removedScope = slot.Scope
 			removed = true
 		}

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -838,6 +838,23 @@ func (m Model) dismissExitedFlowEmbeddedTerminals() Model {
 	return m
 }
 
+func (m Model) exitedFlowEmbeddedTerminalAutoCloseKeys() []deferredAutoFlowLaunchKey {
+	keys := make([]deferredAutoFlowLaunchKey, 0)
+	for _, slot := range m.embeddedTerminals {
+		if slot.Scope != embeddedTerminalScopeFlow || slot.Terminal == nil {
+			continue
+		}
+		if !flowEmbeddedTerminalAutoCloses(slot.Terminal.State()) {
+			continue
+		}
+		key, ok := newDeferredAutoFlowLaunchKey(slot.FlowID, slot.FlowPhaseID)
+		if ok {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
 func flowEmbeddedTerminalAutoCloses(state string) bool {
 	return state == "exited"
 }

--- a/model/export_test.go
+++ b/model/export_test.go
@@ -24,3 +24,11 @@ func ActiveFlowCreateForTest(m Model) uint64 {
 func FlowHeadlessForTest(m Model) bool {
 	return m.flowHeadless
 }
+
+func EmbeddedTerminalTickMsgForTest(m Model) any {
+	return embeddedTerminalTickMsg{Generation: m.embeddedTerminalTickGen}
+}
+
+func HasRunningFlowEmbeddedTerminalForPhaseForTest(m Model, flowID, phaseID string) bool {
+	return m.hasRunningFlowEmbeddedTerminalForPhase(flowID, phaseID)
+}

--- a/model/model.go
+++ b/model/model.go
@@ -111,6 +111,7 @@ type Model struct {
 	activeEmbeddedTerminalNum int
 	activeFlowTerminalNum     int
 	flowFocus                 flowFocus
+	deferredAutoFlowLaunches  map[deferredAutoFlowLaunchKey]struct{}
 	embeddedTerminalTickGen   uint64
 	flowRefreshTickGen        uint64
 	flowRefreshInFlight       uint64
@@ -993,11 +994,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Generation != m.embeddedTerminalTickGen {
 			return m, nil
 		}
+		exitedFlowTerminals := m.exitedFlowEmbeddedTerminalAutoCloseKeys()
 		m = m.dismissExitedFlowEmbeddedTerminals()
-		if m.hasRunningEmbeddedTerminal() {
-			return m, m.embeddedTerminalTickCmd()
+		var cmds []tea.Cmd
+		var deferredCmd tea.Cmd
+		m, deferredCmd = m.prepareDeferredAutoFlowPhaseLaunches(exitedFlowTerminals)
+		cmds = append(cmds, deferredCmd)
+		if len(exitedFlowTerminals) > 0 {
+			var refreshCmd tea.Cmd
+			m, refreshCmd = m.startFlowRefreshFetch()
+			cmds = append(cmds, refreshCmd)
 		}
-		return m, nil
+		if m.hasRunningEmbeddedTerminal() {
+			cmds = append(cmds, m.embeddedTerminalTickCmd())
+		}
+		return m, batchNonNil(cmds...)
 	case flowRefreshTickMsg:
 		if msg.Generation != m.flowRefreshTickGen || m.mode != ui.ModeFlows {
 			return m, nil
@@ -1386,6 +1397,15 @@ func (m Model) flowPhaseByID(flowID, phaseID string) (flowstore.FlowRecord, flow
 		return record, flowstore.FlowPhase{}, false
 	}
 	return flowstore.FlowRecord{}, flowstore.FlowPhase{}, false
+}
+
+func (m Model) flowByID(flowID string) (flowstore.FlowRecord, bool) {
+	for _, record := range m.flows.Items() {
+		if record.FlowID == flowID {
+			return record, true
+		}
+	}
+	return flowstore.FlowRecord{}, false
 }
 
 func flowRecordPhaseByID(record flowstore.FlowRecord, phaseID string) (flowstore.FlowPhase, bool) {

--- a/model/model.go
+++ b/model/model.go
@@ -26,102 +26,103 @@ const listRequestSlots = int(ui.ModeFlows) + 1
 
 // Model is the bubbletea application model.
 type Model struct {
-	repos                     pane.Pane[scanner.Repo]
-	width                     int
-	height                    int
-	mode                      ui.Mode
-	rows                      pane.Pane[gitquery.BranchRow]
-	stashes                   pane.Pane[gitquery.Stash]
-	worktrees                 pane.Pane[gitquery.Worktree]
-	worktreeSessions          pane.Pane[sessions.SessionRecord]
-	commits                   pane.Pane[gitquery.Commit]
-	reflogs                   pane.Pane[gitquery.ReflogEntry]
-	sessions                  pane.Pane[sessions.SessionRecord]
-	plans                     pane.Pane[planstore.PlanRecord]
-	flows                     pane.Pane[flowstore.FlowRecord]
-	expandedPlanID            string
-	expandedFlowID            string
-	selectedPlanPhaseID       string
-	selectedFlowPhaseID       string
-	flowHeadless              bool
-	modal                     modal.Modal
-	diffRequestSeq            uint64
-	activeViewRequest         uint64
-	activeViewKind            FetchKind
-	activeViewMode            ui.Mode
-	listRequestSeq            uint64
-	worktreeSessionRequestSeq uint64
-	activeWorktreeSessionReq  uint64
-	inlineWorktreeSessionRepo string
-	inlineWorktreeSessionPath string
-	pendingInlineSessionRepo  string
-	pendingInlineSessionPath  string
-	pendingInlineSessionList  uint64
-	worktreeCreateSeq         uint64
-	activeWorktreeCreate      uint64
-	repoCreateSeq             uint64
-	activeRepoCreate          uint64
-	flowCreateSeq             uint64
-	activeFlowCreate          uint64
-	repoRefreshSeq            uint64
-	activeRepoRefresh         uint64
-	pendingRepoSelection      string
-	listRequests              [listRequestSlots]uint64
-	activePane                int // 0=left (repos), 1=right (content)
-	destructive               bool
-	status                    statusError
-	visibleRepoFetchSeq       uint64
-	visibleRepoFetchStatusSeq uint64
-	visibleRepoFetch          visibleRepoFetchState
-	searchActive              bool
-	pendingBranchSelection    string
-	pendingWorktreeSelection  string
-	agentCommand              string
-	codexReasoningEffort      string
-	claudeReasoningEffort     string
-	planPromptTemplate        string
-	flowPromptTemplates       FlowPromptTemplates
-	repoCreateRoot            string
-	scanRepos                 func() ([]scanner.Repo, error)
-	createRepo                func(actions.RepoCreateOptions) (actions.RepoCreateResult, error)
-	fetchRepo                 func(string) error
-	listSessions              func(sessions.SessionFilter) ([]sessions.SessionRecord, error)
-	readTranscript            func(sessions.Provider, string) ([]sessions.TranscriptEvent, error)
-	listPlans                 func(planstore.PlanFilter) ([]planstore.PlanRecord, error)
-	listFlows                 func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error)
-	startFlowPlan             func(FlowStartRequest) (FlowStartResult, error)
-	setFlowPhase              func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
-	setFlowAutoMode           func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
-	addFlowPhaseLaunchID      func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
-	resetFlowPhase            func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error)
-	deleteFlow                func(string) error
-	readPlan                  func(string) (string, error)
-	planMarkdownPath          func(string) (string, error)
-	copyToClipboard           func(string) error
-	pageText                  func(string) (actions.TerminalLaunchSpec, error)
-	editFile                  func(string) (actions.TerminalLaunchSpec, error)
-	saveAgent                 func(string) error
-	saveAgentReasoningEffort  func(string, string) error
-	launchTerminal            func(string) (actions.TerminalLaunchSpec, error)
-	launchDetachedTerminal    func(string, string) (actions.TerminalLaunchSpec, error)
-	launchAgent               func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error)
-	startEmbeddedTerminal     EmbeddedTerminalStarter
-	embeddedTerminals         []embeddedTerminalSlot
-	nextEmbeddedTerminalID    int
-	activeEmbeddedTerminalNum int
-	activeFlowTerminalNum     int
-	flowFocus                 flowFocus
-	deferredAutoFlowLaunches  map[deferredAutoFlowLaunchKey]struct{}
-	embeddedTerminalTickGen   uint64
-	flowRefreshTickGen        uint64
-	flowRefreshInFlight       uint64
-	terminalPrefixActive      bool
-	terminalConfirmID         embeddedTerminalID
-	terminalConfirmScope      embeddedTerminalScope
-	finalizeAgentSession      func(actions.AgentLaunchContext) error
-	sessionStateRoot          string
-	bootstrapHookForRepo      func(string) (actions.BootstrapHook, bool)
-	runBootstrapHook          func(actions.BootstrapContext, actions.BootstrapHook) error
+	repos                      pane.Pane[scanner.Repo]
+	width                      int
+	height                     int
+	mode                       ui.Mode
+	rows                       pane.Pane[gitquery.BranchRow]
+	stashes                    pane.Pane[gitquery.Stash]
+	worktrees                  pane.Pane[gitquery.Worktree]
+	worktreeSessions           pane.Pane[sessions.SessionRecord]
+	commits                    pane.Pane[gitquery.Commit]
+	reflogs                    pane.Pane[gitquery.ReflogEntry]
+	sessions                   pane.Pane[sessions.SessionRecord]
+	plans                      pane.Pane[planstore.PlanRecord]
+	flows                      pane.Pane[flowstore.FlowRecord]
+	expandedPlanID             string
+	expandedFlowID             string
+	selectedPlanPhaseID        string
+	selectedFlowPhaseID        string
+	flowHeadless               bool
+	modal                      modal.Modal
+	diffRequestSeq             uint64
+	activeViewRequest          uint64
+	activeViewKind             FetchKind
+	activeViewMode             ui.Mode
+	listRequestSeq             uint64
+	worktreeSessionRequestSeq  uint64
+	activeWorktreeSessionReq   uint64
+	inlineWorktreeSessionRepo  string
+	inlineWorktreeSessionPath  string
+	pendingInlineSessionRepo   string
+	pendingInlineSessionPath   string
+	pendingInlineSessionList   uint64
+	worktreeCreateSeq          uint64
+	activeWorktreeCreate       uint64
+	repoCreateSeq              uint64
+	activeRepoCreate           uint64
+	flowCreateSeq              uint64
+	activeFlowCreate           uint64
+	repoRefreshSeq             uint64
+	activeRepoRefresh          uint64
+	pendingRepoSelection       string
+	listRequests               [listRequestSlots]uint64
+	activePane                 int // 0=left (repos), 1=right (content)
+	destructive                bool
+	status                     statusError
+	visibleRepoFetchSeq        uint64
+	visibleRepoFetchStatusSeq  uint64
+	visibleRepoFetch           visibleRepoFetchState
+	searchActive               bool
+	pendingBranchSelection     string
+	pendingWorktreeSelection   string
+	agentCommand               string
+	codexReasoningEffort       string
+	claudeReasoningEffort      string
+	planPromptTemplate         string
+	flowPromptTemplates        FlowPromptTemplates
+	repoCreateRoot             string
+	scanRepos                  func() ([]scanner.Repo, error)
+	createRepo                 func(actions.RepoCreateOptions) (actions.RepoCreateResult, error)
+	fetchRepo                  func(string) error
+	listSessions               func(sessions.SessionFilter) ([]sessions.SessionRecord, error)
+	readTranscript             func(sessions.Provider, string) ([]sessions.TranscriptEvent, error)
+	listPlans                  func(planstore.PlanFilter) ([]planstore.PlanRecord, error)
+	listFlows                  func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error)
+	startFlowPlan              func(FlowStartRequest) (FlowStartResult, error)
+	setFlowPhase               func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
+	setFlowAutoMode            func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
+	addFlowPhaseLaunchID       func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
+	resetFlowPhase             func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error)
+	deleteFlow                 func(string) error
+	readPlan                   func(string) (string, error)
+	planMarkdownPath           func(string) (string, error)
+	copyToClipboard            func(string) error
+	pageText                   func(string) (actions.TerminalLaunchSpec, error)
+	editFile                   func(string) (actions.TerminalLaunchSpec, error)
+	saveAgent                  func(string) error
+	saveAgentReasoningEffort   func(string, string) error
+	launchTerminal             func(string) (actions.TerminalLaunchSpec, error)
+	launchDetachedTerminal     func(string, string) (actions.TerminalLaunchSpec, error)
+	launchAgent                func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error)
+	startEmbeddedTerminal      EmbeddedTerminalStarter
+	embeddedTerminals          []embeddedTerminalSlot
+	nextEmbeddedTerminalID     int
+	activeEmbeddedTerminalNum  int
+	activeFlowTerminalNum      int
+	flowFocus                  flowFocus
+	deferredAutoFlowLaunches   map[deferredAutoFlowLaunchKey]struct{}
+	suppressedAutoFlowLaunches map[suppressedAutoFlowLaunchKey]struct{}
+	embeddedTerminalTickGen    uint64
+	flowRefreshTickGen         uint64
+	flowRefreshInFlight        uint64
+	terminalPrefixActive       bool
+	terminalConfirmID          embeddedTerminalID
+	terminalConfirmScope       embeddedTerminalScope
+	finalizeAgentSession       func(actions.AgentLaunchContext) error
+	sessionStateRoot           string
+	bootstrapHookForRepo       func(string) (actions.BootstrapHook, bool)
+	runBootstrapHook           func(actions.BootstrapContext, actions.BootstrapHook) error
 }
 
 type statusSource int
@@ -997,9 +998,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		exitedFlowTerminals := m.exitedFlowEmbeddedTerminalAutoCloseKeys()
 		m = m.dismissExitedFlowEmbeddedTerminals()
 		var cmds []tea.Cmd
-		var deferredCmd tea.Cmd
-		m, deferredCmd = m.prepareDeferredAutoFlowPhaseLaunches(exitedFlowTerminals)
-		cmds = append(cmds, deferredCmd)
 		if len(exitedFlowTerminals) > 0 {
 			var refreshCmd tea.Cmd
 			m, refreshCmd = m.startFlowRefreshFetch()

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1626,6 +1626,90 @@ func TestModel_FlowAutoModeSuppressionDoesNotBlockLaterLaunchID(t *testing.T) {
 	}
 }
 
+func TestModel_FlowAutoModeStaleTerminalDoesNotBlockLaterLaunchID(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	previous.Phases[1].LaunchIDs = []string{"launch-old"}
+	rerun := previous
+	rerun.Phases = append([]flowstore.FlowPhase(nil), previous.Phases...)
+	rerun.Phases[1].LaunchIDs = []string{"launch-old", "launch-new"}
+	completed := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	completed.Phases[1].Outcome = flowstore.OutcomeApproved
+	completed.Phases[1].LaunchIDs = []string{"launch-old", "launch-new"}
+	staleTerm := &fakeEmbeddedTerminal{lines: []string{"old failed output"}, state: "running"}
+	var updates []flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			launched := completed
+			for i := range launched.Phases {
+				if launched.Phases[i].PhaseID == update.PhaseID {
+					launched.Phases[i].Status = flowstore.PhaseRunning
+					launched.Phases[i].LaunchIDs = append(launched.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return launched, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return staleTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	var cmd tea.Cmd
+	m, cmd = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:      "codex",
+		LaunchID:     "launch-old",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-auto",
+		FlowID:       "flow-1",
+		FlowPhaseID:  "plan-review",
+	}})
+	if cmd == nil {
+		t.Fatal("starting the stale Flow terminal should schedule refresh and repaint")
+	}
+	m, _ = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{previous},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	staleTerm.state = "failed"
+
+	m, cmd = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{rerun},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd != nil {
+		t.Fatalf("new launch running refresh returned command %T, want nil", cmd)
+	}
+	m, cmd = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{completed},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd == nil {
+		t.Fatal("completion for newer launch ID should auto-launch next phase despite stale terminal")
+	}
+	launches := flowEmbeddedLaunchesFromCommand(t, cmd)
+	if len(launches) != 1 {
+		t.Fatalf("new launch completion returned %d embedded launches, want 1", len(launches))
+	}
+	if len(updates) != 1 || !updates[0].AutoLaunch || updates[0].PhaseID != "implementation" {
+		t.Fatalf("launch updates after newer completion = %#v, want implementation auto launch", updates)
+	}
+	if !strings.Contains(m.View(), "old failed output") {
+		t.Fatalf("stale failed terminal should remain visible:\n%s", m.View())
+	}
+}
+
 func TestModel_FlowAutoModeLaunchesNextImplementationChildOrReviewLoop(t *testing.T) {
 	for _, tc := range []struct {
 		name        string

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -146,6 +146,28 @@ func autoLaunchCommandFromFlowRefresh(t *testing.T, previous, current flowstore.
 	return cmd, &updates
 }
 
+func flowEmbeddedLaunchesFromCommand(t *testing.T, cmd tea.Cmd) []model.FlowEmbeddedLaunchRequestedMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected command")
+	}
+	msg := cmd()
+	msgs := []tea.Msg{msg}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		msgs = msgs[:0]
+		for _, subcmd := range batch {
+			msgs = append(msgs, subcmd())
+		}
+	}
+	launches := make([]model.FlowEmbeddedLaunchRequestedMsg, 0)
+	for _, msg := range msgs {
+		if launch, ok := msg.(model.FlowEmbeddedLaunchRequestedMsg); ok {
+			launches = append(launches, launch)
+		}
+	}
+	return launches
+}
+
 func TestModel_FlowAutoLaunchUsesConfiguredCLIAgentAndEffort(t *testing.T) {
 	previous := autoFlowWithPhaseStatuses(map[string]string{
 		"plan":           flowstore.PhaseCompleted,
@@ -347,6 +369,20 @@ func flowResultFromCommand(t *testing.T, cmd tea.Cmd) model.FlowResultMsg {
 		t.Fatalf("flow fetch command returned %T, want FlowResultMsg", msg)
 	}
 	return result
+}
+
+func applyFlowResultFollowup(t *testing.T, m model.Model, cmd tea.Cmd) model.Model {
+	t.Helper()
+	if cmd == nil {
+		return m
+	}
+	msg := cmd()
+	result, ok := msg.(model.FlowResultMsg)
+	if !ok {
+		t.Fatalf("follow-up command returned %T, want FlowResultMsg", msg)
+	}
+	m, _ = update(m, result)
+	return m
 }
 
 func prepareSelectedFlowPhaseLaunch(t *testing.T, m model.Model, phaseID string) (model.Model, tea.Cmd) {
@@ -971,6 +1007,324 @@ func TestModel_FlowAutoModeLaunchesImplementationAfterPlanReviewCompletes(t *tes
 		!launchMsg.LaunchContext.FlowLaunchTracked ||
 		!launchMsg.LaunchContext.Embedded {
 		t.Fatalf("launch context = %#v, want embedded implementation launch", launchMsg.LaunchContext)
+	}
+}
+
+func TestModel_FlowAutoModeDefersLaunchWhileCompletedPhaseTerminalRuns(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+		"review-loop":    flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+		"review-loop":    flowstore.PhasePending,
+	})
+	current.Phases[1].Outcome = flowstore.OutcomeApproved
+	var updates []flowstore.PhaseLaunchUpdate
+	sourceTerm := &fakeEmbeddedTerminal{lines: []string{"source output"}, state: "running"}
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			launched := current
+			for i := range launched.Phases {
+				if launched.Phases[i].PhaseID == update.PhaseID {
+					launched.Phases[i].Status = flowstore.PhaseRunning
+					launched.Phases[i].LaunchIDs = append(launched.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return launched, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return sourceTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	var cmd tea.Cmd
+	m, cmd = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:      "codex",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-auto",
+		FlowID:       "flow-1",
+		FlowPhaseID:  "plan-review",
+	}})
+	if cmd == nil {
+		t.Fatal("starting the source Flow terminal should schedule refresh and repaint")
+	}
+	if !model.HasRunningFlowEmbeddedTerminalForPhaseForTest(m, "flow-1", "plan-review") {
+		t.Fatal("test setup should attach a running Flow terminal to plan-review")
+	}
+	m, _ = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{previous},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+
+	m, cmd = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd != nil {
+		t.Fatalf("completed phase with running terminal returned auto-launch command %T, want nil", cmd)
+	}
+	if len(updates) != 0 {
+		t.Fatalf("launch updates = %#v, want none while source terminal runs", updates)
+	}
+
+	sourceTerm.state = "exited"
+	m, cmd = update(m, model.EmbeddedTerminalTickMsgForTest(m))
+	if cmd == nil {
+		t.Fatal("exiting the deferred source terminal should prepare the next auto launch")
+	}
+	launches := flowEmbeddedLaunchesFromCommand(t, cmd)
+	if len(launches) != 1 {
+		t.Fatalf("deferred launch command returned %d embedded launches, want 1", len(launches))
+	}
+	launchMsg := launches[0]
+	if len(updates) != 1 || !updates[0].AutoLaunch || updates[0].FlowID != "flow-1" || updates[0].PhaseID != "implementation" || updates[0].LaunchID == "" {
+		t.Fatalf("launch updates after source terminal exit = %#v, want implementation auto launch", updates)
+	}
+	if launchMsg.LaunchContext.FlowID != "flow-1" ||
+		launchMsg.LaunchContext.FlowPhaseID != "implementation" ||
+		!launchMsg.LaunchContext.Embedded ||
+		!launchMsg.LaunchContext.Headless ||
+		!launchMsg.LaunchContext.FlowLaunchTracked {
+		t.Fatalf("deferred launch context = %#v", launchMsg.LaunchContext)
+	}
+	if strings.Contains(m.View(), "source output") || model.HasRunningFlowEmbeddedTerminalForPhaseForTest(m, "flow-1", "plan-review") {
+		t.Fatalf("source terminal should be dismissed after exited tick:\n%s", m.View())
+	}
+}
+
+func TestModel_FlowAutoModeRefreshesOnSourceTerminalExitBeforeCompletionObserved(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	current.Phases[1].Outcome = flowstore.OutcomeApproved
+	sourceTerm := &fakeEmbeddedTerminal{lines: []string{"source output"}, state: "running"}
+	listCalls := 0
+	var updates []flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			listCalls++
+			if filter.RepoPath != "/dev/alpha" {
+				t.Fatalf("FlowFilter.RepoPath = %q, want /dev/alpha", filter.RepoPath)
+			}
+			return []flowstore.FlowRecord{current}, nil
+		},
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			launched := current
+			for i := range launched.Phases {
+				if launched.Phases[i].PhaseID == update.PhaseID {
+					launched.Phases[i].Status = flowstore.PhaseRunning
+					launched.Phases[i].LaunchIDs = append(launched.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return launched, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return sourceTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	var cmd tea.Cmd
+	m, cmd = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:      "codex",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-auto",
+		FlowID:       "flow-1",
+		FlowPhaseID:  "plan-review",
+	}})
+	if cmd == nil {
+		t.Fatal("starting the source Flow terminal should schedule refresh and repaint")
+	}
+	m, _ = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{previous},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+
+	sourceTerm.state = "exited"
+	m, cmd = update(m, model.EmbeddedTerminalTickMsgForTest(m))
+	if cmd == nil {
+		t.Fatal("exiting a Flow terminal should schedule a Flow refresh")
+	}
+	refresh := flowResultFromCommand(t, cmd)
+	if listCalls != 1 {
+		t.Fatalf("ListFlows calls after exit tick command = %d, want 1", listCalls)
+	}
+
+	m, cmd = update(m, refresh)
+	if cmd == nil {
+		t.Fatal("exit-triggered refresh should prepare auto launch after observing completion")
+	}
+	launches := flowEmbeddedLaunchesFromCommand(t, cmd)
+	if len(launches) != 1 {
+		t.Fatalf("exit-triggered refresh returned %d embedded launches, want 1", len(launches))
+	}
+	if len(updates) != 1 || !updates[0].AutoLaunch || updates[0].PhaseID != "implementation" {
+		t.Fatalf("launch updates = %#v, want implementation auto launch", updates)
+	}
+	if launches[0].LaunchContext.FlowID != "flow-1" ||
+		launches[0].LaunchContext.FlowPhaseID != "implementation" ||
+		!launches[0].LaunchContext.Embedded ||
+		!launches[0].LaunchContext.FlowLaunchTracked {
+		t.Fatalf("launch context = %#v", launches[0].LaunchContext)
+	}
+}
+
+func TestModel_FlowAutoModeDeferredLaunchNoopsAfterAutoModeDisabled(t *testing.T) {
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	current.Title = "Stale deferred auto command"
+	current.Instructions = "do not launch after auto mode off"
+	current.RepoPath = "/dev/alpha"
+	current.AutoMode = true
+	current, err = store.Create(current)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	previous := current
+	previous.Phases = append([]flowstore.FlowPhase(nil), current.Phases...)
+	for i := range previous.Phases {
+		switch previous.Phases[i].PhaseID {
+		case "plan-review":
+			previous.Phases[i].Status = flowstore.PhaseRunning
+		case "implementation":
+			previous.Phases[i].Status = flowstore.PhasePending
+		}
+	}
+	sourceTerm := &fakeEmbeddedTerminal{state: "running"}
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:         "codex",
+		AddFlowPhaseLaunchID: store.AddPhaseLaunchID,
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return sourceTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	var cmd tea.Cmd
+	m, cmd = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:      "codex",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-auto",
+		FlowID:       current.FlowID,
+		FlowPhaseID:  "plan-review",
+	}})
+	if cmd == nil {
+		t.Fatal("starting the source Flow terminal should schedule refresh and repaint")
+	}
+	m, _ = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{previous},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	m, cmd = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd != nil {
+		t.Fatalf("deferred completion returned command %T, want nil", cmd)
+	}
+	if _, err := store.SetAutoMode(flowstore.AutoModeUpdate{FlowID: current.FlowID, Enabled: false}); err != nil {
+		t.Fatalf("SetAutoMode(false) error = %v", err)
+	}
+
+	sourceTerm.state = "exited"
+	m, cmd = update(m, model.EmbeddedTerminalTickMsgForTest(m))
+	if cmd == nil {
+		t.Fatal("exiting the deferred source terminal should attempt stale auto launch")
+	}
+	if launches := flowEmbeddedLaunchesFromCommand(t, cmd); len(launches) != 0 {
+		t.Fatalf("stale deferred launch produced %#v, want none", launches)
+	}
+	read, err := store.Read(current.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(read, "implementation").Status; got != flowstore.PhaseReady {
+		t.Fatalf("implementation status = %q, want ready after stale deferred command", got)
+	}
+}
+
+func TestModel_FlowAutoModeDeferredLaunchWaitsOnFailedSourceTerminal(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	sourceTerm := &fakeEmbeddedTerminal{lines: []string{"failed output"}, state: "running"}
+	var updates []flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			return current, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return sourceTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	var cmd tea.Cmd
+	m, cmd = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:      "codex",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-auto",
+		FlowID:       "flow-1",
+		FlowPhaseID:  "plan-review",
+	}})
+	if cmd == nil {
+		t.Fatal("starting the source Flow terminal should schedule refresh and repaint")
+	}
+	m, _ = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{previous},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	m, _ = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+
+	sourceTerm.state = "failed"
+	m, cmd = update(m, model.EmbeddedTerminalTickMsgForTest(m))
+	if cmd != nil {
+		t.Fatalf("failed source terminal returned command %T, want nil", cmd)
+	}
+	if len(updates) != 0 {
+		t.Fatalf("launch updates = %#v, want none after failed source terminal", updates)
+	}
+	if !strings.Contains(m.View(), "failed output") || !strings.Contains(m.View(), "plan-review failed") {
+		t.Fatalf("failed source terminal should remain visible:\n%s", m.View())
 	}
 }
 
@@ -3637,7 +3991,7 @@ func TestModel_FlowEmbeddedTerminalAutoClosesOnExitedTick(t *testing.T) {
 			continue
 		}
 		if followup != nil {
-			t.Fatalf("exited Flow terminal should not reschedule repaint, got %T", followup)
+			m = applyFlowResultFollowup(t, m, followup)
 		}
 	}
 
@@ -3751,7 +4105,7 @@ func TestModel_FlowEmbeddedTerminalAutoClosePreservesExitedSessionTerminal(t *te
 		var followup tea.Cmd
 		m, followup = update(m, msg)
 		if followup != nil {
-			t.Fatalf("all-exited terminals should stop repaint loop, got %T", followup)
+			m = applyFlowResultFollowup(t, m, followup)
 		}
 	}
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1025,9 +1025,17 @@ func TestModel_FlowAutoModeDefersLaunchWhileCompletedPhaseTerminalRuns(t *testin
 	})
 	current.Phases[1].Outcome = flowstore.OutcomeApproved
 	var updates []flowstore.PhaseLaunchUpdate
+	listCalls := 0
 	sourceTerm := &fakeEmbeddedTerminal{lines: []string{"source output"}, state: "running"}
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			listCalls++
+			if filter.RepoPath != "/dev/alpha" {
+				t.Fatalf("FlowFilter.RepoPath = %q, want /dev/alpha", filter.RepoPath)
+			}
+			return []flowstore.FlowRecord{current}, nil
+		},
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
 			updates = append(updates, update)
 			launched := current
@@ -1077,9 +1085,36 @@ func TestModel_FlowAutoModeDefersLaunchWhileCompletedPhaseTerminalRuns(t *testin
 	}
 
 	sourceTerm.state = "exited"
+	m, cmd = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd != nil {
+		t.Fatalf("refresh before exited terminal auto-closes returned command %T, want nil", cmd)
+	}
+	if len(updates) != 0 {
+		t.Fatalf("launch updates before exited terminal auto-closes = %#v, want none", updates)
+	}
+
 	m, cmd = update(m, model.EmbeddedTerminalTickMsgForTest(m))
 	if cmd == nil {
-		t.Fatal("exiting the deferred source terminal should prepare the next auto launch")
+		t.Fatal("exiting the deferred source terminal should schedule a refresh")
+	}
+	refresh := flowResultFromCommand(t, cmd)
+	if listCalls != 1 {
+		t.Fatalf("ListFlows calls after exit tick command = %d, want 1", listCalls)
+	}
+	if len(updates) != 0 {
+		t.Fatalf("launch updates before exit-triggered refresh = %#v, want none", updates)
+	}
+	if strings.Contains(m.View(), "source output") || model.HasRunningFlowEmbeddedTerminalForPhaseForTest(m, "flow-1", "plan-review") {
+		t.Fatalf("source terminal should be dismissed after exited tick:\n%s", m.View())
+	}
+
+	m, cmd = update(m, refresh)
+	if cmd == nil {
+		t.Fatal("exit-triggered refresh should prepare the deferred auto launch")
 	}
 	launches := flowEmbeddedLaunchesFromCommand(t, cmd)
 	if len(launches) != 1 {
@@ -1095,9 +1130,6 @@ func TestModel_FlowAutoModeDefersLaunchWhileCompletedPhaseTerminalRuns(t *testin
 		!launchMsg.LaunchContext.Headless ||
 		!launchMsg.LaunchContext.FlowLaunchTracked {
 		t.Fatalf("deferred launch context = %#v", launchMsg.LaunchContext)
-	}
-	if strings.Contains(m.View(), "source output") || model.HasRunningFlowEmbeddedTerminalForPhaseForTest(m, "flow-1", "plan-review") {
-		t.Fatalf("source terminal should be dismissed after exited tick:\n%s", m.View())
 	}
 }
 
@@ -1187,6 +1219,160 @@ func TestModel_FlowAutoModeRefreshesOnSourceTerminalExitBeforeCompletionObserved
 	}
 }
 
+func TestModel_FlowAutoModeDefersWhenCompletionObservedAfterSourceTerminalExits(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	current.Phases[1].Outcome = flowstore.OutcomeApproved
+	sourceTerm := &fakeEmbeddedTerminal{lines: []string{"source output"}, state: "running"}
+	listCalls := 0
+	var updates []flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			listCalls++
+			if filter.RepoPath != "/dev/alpha" {
+				t.Fatalf("FlowFilter.RepoPath = %q, want /dev/alpha", filter.RepoPath)
+			}
+			return []flowstore.FlowRecord{current}, nil
+		},
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			launched := current
+			for i := range launched.Phases {
+				if launched.Phases[i].PhaseID == update.PhaseID {
+					launched.Phases[i].Status = flowstore.PhaseRunning
+					launched.Phases[i].LaunchIDs = append(launched.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return launched, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return sourceTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	var cmd tea.Cmd
+	m, cmd = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:      "codex",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-auto",
+		FlowID:       "flow-1",
+		FlowPhaseID:  "plan-review",
+	}})
+	if cmd == nil {
+		t.Fatal("starting the source Flow terminal should schedule refresh and repaint")
+	}
+	m, _ = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{previous},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+
+	sourceTerm.state = "exited"
+	m, cmd = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd != nil {
+		t.Fatalf("completion observed before exited terminal auto-closes returned command %T, want nil", cmd)
+	}
+	if len(updates) != 0 {
+		t.Fatalf("launch updates before exited terminal auto-closes = %#v, want none", updates)
+	}
+
+	m, cmd = update(m, model.EmbeddedTerminalTickMsgForTest(m))
+	if cmd == nil {
+		t.Fatal("auto-closing exited source terminal should schedule refresh")
+	}
+	refresh := flowResultFromCommand(t, cmd)
+	if listCalls != 1 {
+		t.Fatalf("ListFlows calls after exit tick command = %d, want 1", listCalls)
+	}
+	m, cmd = update(m, refresh)
+	if cmd == nil {
+		t.Fatal("refresh after source terminal auto-close should prepare deferred launch")
+	}
+	launches := flowEmbeddedLaunchesFromCommand(t, cmd)
+	if len(launches) != 1 {
+		t.Fatalf("deferred launch command returned %d embedded launches, want 1", len(launches))
+	}
+	if len(updates) != 1 || !updates[0].AutoLaunch || updates[0].PhaseID != "implementation" {
+		t.Fatalf("launch updates after auto-close refresh = %#v, want implementation auto launch", updates)
+	}
+	if launches[0].LaunchContext.FlowPhaseID != "implementation" || !launches[0].LaunchContext.FlowLaunchTracked {
+		t.Fatalf("launch context = %#v", launches[0].LaunchContext)
+	}
+}
+
+func TestModel_FlowAutoModeSuppressesWhenCompletionObservedWithNonAutoClosingSourceTerminal(t *testing.T) {
+	for _, state := range []string{"failed", "terminated"} {
+		t.Run(state, func(t *testing.T) {
+			previous := autoFlowWithPhaseStatuses(map[string]string{
+				"plan":           flowstore.PhaseCompleted,
+				"plan-review":    flowstore.PhaseRunning,
+				"implementation": flowstore.PhasePending,
+			})
+			current := autoFlowWithPhaseStatuses(map[string]string{
+				"plan":           flowstore.PhaseCompleted,
+				"plan-review":    flowstore.PhaseCompleted,
+				"implementation": flowstore.PhaseReady,
+			})
+			current.Phases[1].Outcome = flowstore.OutcomeApproved
+			sourceTerm := &fakeEmbeddedTerminal{lines: []string{"source output"}, state: "running"}
+			var updates []flowstore.PhaseLaunchUpdate
+			m := model.NewWithOptions(testRepos(), model.Options{
+				AgentCommand: "codex",
+				AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+					updates = append(updates, update)
+					return current, nil
+				},
+				StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+					return sourceTerm, nil
+				},
+			})
+			m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+			var cmd tea.Cmd
+			m, cmd = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+				Command:      "codex",
+				RepoPath:     "/dev/alpha",
+				WorktreePath: "/dev/alpha-worktrees/flow-auto",
+				FlowID:       "flow-1",
+				FlowPhaseID:  "plan-review",
+			}})
+			if cmd == nil {
+				t.Fatal("starting the source Flow terminal should schedule refresh and repaint")
+			}
+			m, _ = update(m, model.FlowResultMsg{
+				RepoPath:    "/dev/alpha",
+				Flows:       []flowstore.FlowRecord{previous},
+				ListRequest: m.ListRequest(ui.ModeFlows),
+			})
+
+			sourceTerm.state = state
+			m, cmd = update(m, model.FlowResultMsg{
+				RepoPath:    "/dev/alpha",
+				Flows:       []flowstore.FlowRecord{current},
+				ListRequest: m.ListRequest(ui.ModeFlows),
+			})
+			if cmd != nil {
+				t.Fatalf("completion observed with %s source terminal returned command %T, want nil", state, cmd)
+			}
+			if len(updates) != 0 {
+				t.Fatalf("launch updates with %s source terminal = %#v, want none", state, updates)
+			}
+		})
+	}
+}
+
 func TestModel_FlowAutoModeDeferredLaunchNoopsAfterAutoModeDisabled(t *testing.T) {
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: t.TempDir()})
 	if err != nil {
@@ -1217,8 +1403,21 @@ func TestModel_FlowAutoModeDeferredLaunchNoopsAfterAutoModeDisabled(t *testing.T
 	}
 	sourceTerm := &fakeEmbeddedTerminal{state: "running"}
 	m := model.NewWithOptions(testRepos(), model.Options{
-		AgentCommand:         "codex",
-		AddFlowPhaseLaunchID: store.AddPhaseLaunchID,
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			t.Fatalf("AddFlowPhaseLaunchID() should not run after auto mode is disabled: %#v", update)
+			return flowstore.FlowRecord{}, nil
+		},
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			if filter.RepoPath != "/dev/alpha" {
+				t.Fatalf("FlowFilter.RepoPath = %q, want /dev/alpha", filter.RepoPath)
+			}
+			flow, err := store.Read(current.FlowID)
+			if err != nil {
+				t.Fatalf("Read(%q) error = %v", current.FlowID, err)
+			}
+			return []flowstore.FlowRecord{flow}, nil
+		},
 		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
 			return sourceTerm, nil
 		},
@@ -1255,11 +1454,10 @@ func TestModel_FlowAutoModeDeferredLaunchNoopsAfterAutoModeDisabled(t *testing.T
 	sourceTerm.state = "exited"
 	m, cmd = update(m, model.EmbeddedTerminalTickMsgForTest(m))
 	if cmd == nil {
-		t.Fatal("exiting the deferred source terminal should attempt stale auto launch")
+		t.Fatal("exiting the deferred source terminal should schedule refresh")
 	}
-	if launches := flowEmbeddedLaunchesFromCommand(t, cmd); len(launches) != 0 {
-		t.Fatalf("stale deferred launch produced %#v, want none", launches)
-	}
+	refresh := flowResultFromCommand(t, cmd)
+	m, cmd = update(m, refresh)
 	read, err := store.Read(current.FlowID)
 	if err != nil {
 		t.Fatalf("Read() error = %v", err)
@@ -1309,11 +1507,6 @@ func TestModel_FlowAutoModeDeferredLaunchWaitsOnFailedSourceTerminal(t *testing.
 		Flows:       []flowstore.FlowRecord{previous},
 		ListRequest: m.ListRequest(ui.ModeFlows),
 	})
-	m, _ = update(m, model.FlowResultMsg{
-		RepoPath:    "/dev/alpha",
-		Flows:       []flowstore.FlowRecord{current},
-		ListRequest: m.ListRequest(ui.ModeFlows),
-	})
 
 	sourceTerm.state = "failed"
 	m, cmd = update(m, model.EmbeddedTerminalTickMsgForTest(m))
@@ -1325,6 +1518,111 @@ func TestModel_FlowAutoModeDeferredLaunchWaitsOnFailedSourceTerminal(t *testing.
 	}
 	if !strings.Contains(m.View(), "failed output") || !strings.Contains(m.View(), "plan-review failed") {
 		t.Fatalf("failed source terminal should remain visible:\n%s", m.View())
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlCloseBracket})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd != nil {
+		t.Fatalf("closing failed source terminal returned command %T, want nil", cmd)
+	}
+	if strings.Contains(m.View(), "failed output") {
+		t.Fatalf("failed source terminal should be dismissed before refresh:\n%s", m.View())
+	}
+	m, cmd = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd != nil {
+		t.Fatalf("refresh while source terminal is failed returned command %T, want nil", cmd)
+	}
+	if len(updates) != 0 {
+		t.Fatalf("launch updates after failed-terminal refresh = %#v, want none", updates)
+	}
+}
+
+func TestModel_FlowAutoModeSuppressionDoesNotBlockLaterLaunchID(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	previous.Phases[1].LaunchIDs = []string{"launch-old"}
+	rerun := previous
+	rerun.Phases = append([]flowstore.FlowPhase(nil), previous.Phases...)
+	rerun.Phases[1].LaunchIDs = []string{"launch-old", "launch-new"}
+	completed := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	completed.Phases[1].Outcome = flowstore.OutcomeApproved
+	completed.Phases[1].LaunchIDs = []string{"launch-old", "launch-new"}
+	sourceTerm := &fakeEmbeddedTerminal{lines: []string{"old failed output"}, state: "running"}
+	var updates []flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			launched := completed
+			for i := range launched.Phases {
+				if launched.Phases[i].PhaseID == update.PhaseID {
+					launched.Phases[i].Status = flowstore.PhaseRunning
+					launched.Phases[i].LaunchIDs = append(launched.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return launched, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return sourceTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	var cmd tea.Cmd
+	m, cmd = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:      "codex",
+		LaunchID:     "launch-old",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-auto",
+		FlowID:       "flow-1",
+		FlowPhaseID:  "plan-review",
+	}})
+	if cmd == nil {
+		t.Fatal("starting the source Flow terminal should schedule refresh and repaint")
+	}
+	m, _ = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{previous},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	sourceTerm.state = "failed"
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlCloseBracket})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if cmd != nil {
+		t.Fatalf("closing old failed source terminal returned command %T, want nil", cmd)
+	}
+
+	m, cmd = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{rerun},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd != nil {
+		t.Fatalf("new launch running refresh returned command %T, want nil", cmd)
+	}
+	m, cmd = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{completed},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd == nil {
+		t.Fatal("completion for newer launch ID should auto-launch next phase")
+	}
+	launches := flowEmbeddedLaunchesFromCommand(t, cmd)
+	if len(launches) != 1 {
+		t.Fatalf("new launch completion returned %d embedded launches, want 1", len(launches))
+	}
+	if len(updates) != 1 || !updates[0].AutoLaunch || updates[0].PhaseID != "implementation" {
+		t.Fatalf("launch updates after newer completion = %#v, want implementation auto launch", updates)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1338,13 +1338,23 @@ func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstor
 		}
 		completedPhase, ok := newlyCompletedFlowPhase(previous, record)
 		if !ok {
+			m = m.clearResolvedSuppressedAutoFlowLaunches(record)
 			continue
 		}
 		if artifacts.NormalizePhaseID(completedPhase.PhaseID) == "autoreview" {
 			continue
 		}
-		if m.hasRunningFlowEmbeddedTerminalForPhase(record.FlowID, completedPhase.PhaseID) {
+		if m.isAutoFlowLaunchSuppressed(record.FlowID, completedPhase) {
+			m = m.clearSuppressedAutoFlowLaunch(record.FlowID, completedPhase)
+			continue
+		}
+		if m.hasRunningFlowEmbeddedTerminalForPhase(record.FlowID, completedPhase.PhaseID) ||
+			m.hasAutoClosingFlowEmbeddedTerminalForPhase(record.FlowID, completedPhase.PhaseID) {
 			m = m.deferAutoFlowPhaseLaunch(record.FlowID, completedPhase.PhaseID)
+			continue
+		}
+		if m.hasFlowEmbeddedTerminalForPhase(record.FlowID, completedPhase.PhaseID) {
+			m = m.suppressAutoFlowPhaseLaunch(record.FlowID, completedPhase.PhaseID, flowstore.LatestPhaseLaunchID(completedPhase))
 			continue
 		}
 		phase, ok := nextAutoLaunchPhase(record)
@@ -1365,6 +1375,12 @@ type deferredAutoFlowLaunchKey struct {
 	PhaseID string
 }
 
+type suppressedAutoFlowLaunchKey struct {
+	FlowID   string
+	PhaseID  string
+	LaunchID string
+}
+
 func (m Model) deferAutoFlowPhaseLaunch(flowID, phaseID string) Model {
 	key, ok := newDeferredAutoFlowLaunchKey(flowID, phaseID)
 	if !ok {
@@ -1374,6 +1390,80 @@ func (m Model) deferAutoFlowPhaseLaunch(flowID, phaseID string) Model {
 		m.deferredAutoFlowLaunches = make(map[deferredAutoFlowLaunchKey]struct{})
 	}
 	m.deferredAutoFlowLaunches[key] = struct{}{}
+	return m
+}
+
+func (m Model) suppressAutoFlowPhaseLaunch(flowID, phaseID, launchID string) Model {
+	key, ok := newSuppressedAutoFlowLaunchKey(flowID, phaseID, launchID)
+	if !ok {
+		return m
+	}
+	if m.suppressedAutoFlowLaunches == nil {
+		m.suppressedAutoFlowLaunches = make(map[suppressedAutoFlowLaunchKey]struct{})
+	}
+	m.suppressedAutoFlowLaunches[key] = struct{}{}
+	deferredKey, ok := newDeferredAutoFlowLaunchKey(flowID, phaseID)
+	if ok {
+		m = m.clearDeferredAutoFlowLaunch(deferredKey)
+	}
+	return m
+}
+
+func newSuppressedAutoFlowLaunchKey(flowID, phaseID, launchID string) (suppressedAutoFlowLaunchKey, bool) {
+	phaseID = artifacts.NormalizePhaseID(phaseID)
+	launchID = strings.TrimSpace(launchID)
+	if flowID == "" || phaseID == "" {
+		return suppressedAutoFlowLaunchKey{}, false
+	}
+	return suppressedAutoFlowLaunchKey{FlowID: flowID, PhaseID: phaseID, LaunchID: launchID}, true
+}
+
+func suppressedAutoFlowLaunchKeyForPhase(flowID string, phase flowstore.FlowPhase) (suppressedAutoFlowLaunchKey, bool) {
+	return newSuppressedAutoFlowLaunchKey(flowID, phase.PhaseID, flowstore.LatestPhaseLaunchID(phase))
+}
+
+func (m Model) isAutoFlowLaunchSuppressed(flowID string, phase flowstore.FlowPhase) bool {
+	key, ok := suppressedAutoFlowLaunchKeyForPhase(flowID, phase)
+	if !ok {
+		return false
+	}
+	_, suppressed := m.suppressedAutoFlowLaunches[key]
+	return suppressed
+}
+
+func (m Model) clearSuppressedAutoFlowLaunch(flowID string, phase flowstore.FlowPhase) Model {
+	key, ok := suppressedAutoFlowLaunchKeyForPhase(flowID, phase)
+	if !ok || len(m.suppressedAutoFlowLaunches) == 0 {
+		return m
+	}
+	delete(m.suppressedAutoFlowLaunches, key)
+	if len(m.suppressedAutoFlowLaunches) == 0 {
+		m.suppressedAutoFlowLaunches = nil
+	}
+	return m
+}
+
+func (m Model) clearResolvedSuppressedAutoFlowLaunches(record flowstore.FlowRecord) Model {
+	if len(m.suppressedAutoFlowLaunches) == 0 || record.FlowID == "" {
+		return m
+	}
+	for _, phase := range record.Phases {
+		if phase.Status == flowstore.PhaseRunning || phase.Status == flowstore.PhaseCompleted {
+			continue
+		}
+		m = m.clearSuppressedAutoFlowLaunch(record.FlowID, phase)
+	}
+	return m
+}
+
+func (m Model) clearDeferredAutoFlowLaunch(key deferredAutoFlowLaunchKey) Model {
+	if len(m.deferredAutoFlowLaunches) == 0 {
+		return m
+	}
+	delete(m.deferredAutoFlowLaunches, key)
+	if len(m.deferredAutoFlowLaunches) == 0 {
+		m.deferredAutoFlowLaunches = nil
+	}
 	return m
 }
 
@@ -1401,15 +1491,19 @@ func (m Model) prepareAutoFlowPhaseLaunchForRecord(record flowstore.FlowRecord, 
 	}
 }
 
-func (m Model) prepareDeferredAutoFlowPhaseLaunches(exited []deferredAutoFlowLaunchKey) (Model, tea.Cmd) {
+func (m Model) prepareDeferredAutoFlowPhaseLaunches() (Model, tea.Cmd) {
 	var cmds []tea.Cmd
-	for _, key := range exited {
-		if _, ok := m.deferredAutoFlowLaunches[key]; !ok {
-			continue
-		}
+	for key := range m.deferredAutoFlowLaunches {
 		delete(m.deferredAutoFlowLaunches, key)
 		if m.hasRunningFlowEmbeddedTerminalForPhase(key.FlowID, key.PhaseID) {
 			m.deferredAutoFlowLaunches[key] = struct{}{}
+			continue
+		}
+		if m.hasAutoClosingFlowEmbeddedTerminalForPhase(key.FlowID, key.PhaseID) {
+			m.deferredAutoFlowLaunches[key] = struct{}{}
+			continue
+		}
+		if m.hasFlowEmbeddedTerminalForPhase(key.FlowID, key.PhaseID) {
 			continue
 		}
 		record, ok := m.flowByID(key.FlowID)
@@ -1533,14 +1627,53 @@ func (m Model) hasRunningFlowEmbeddedTerminalForPhase(flowID, phaseID string) bo
 		return false
 	}
 	for _, slot := range m.embeddedTerminals {
-		if slot.Scope == embeddedTerminalScopeFlow &&
-			slot.FlowID == flowID &&
-			artifacts.NormalizePhaseID(slot.FlowPhaseID) == wantPhaseID &&
+		if flowEmbeddedTerminalSlotMatchesPhase(slot, flowID, wantPhaseID) &&
 			embeddedTerminalRunning(slot.Terminal) {
 			return true
 		}
 	}
 	return false
+}
+
+func (m Model) hasFlowEmbeddedTerminalForPhase(flowID, phaseID string) bool {
+	wantPhaseID := artifacts.NormalizePhaseID(phaseID)
+	if wantPhaseID == "" {
+		return false
+	}
+	for _, slot := range m.embeddedTerminals {
+		if flowEmbeddedTerminalSlotMatchesPhase(slot, flowID, wantPhaseID) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m Model) hasAutoClosingFlowEmbeddedTerminalForPhase(flowID, phaseID string) bool {
+	wantPhaseID := artifacts.NormalizePhaseID(phaseID)
+	if wantPhaseID == "" {
+		return false
+	}
+	for _, slot := range m.embeddedTerminals {
+		if flowEmbeddedTerminalSlotMatchesPhase(slot, flowID, wantPhaseID) &&
+			flowEmbeddedTerminalAutoCloses(slot.Terminal.State()) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m Model) clearDeferredAutoFlowLaunchForTerminal(slot embeddedTerminalSlot) Model {
+	if slot.Scope != embeddedTerminalScopeFlow || slot.Terminal == nil || flowEmbeddedTerminalAutoCloses(slot.Terminal.State()) {
+		return m
+	}
+	return m.suppressAutoFlowPhaseLaunch(slot.FlowID, slot.FlowPhaseID, slot.LaunchID)
+}
+
+func flowEmbeddedTerminalSlotMatchesPhase(slot embeddedTerminalSlot, flowID, normalizedPhaseID string) bool {
+	return slot.Scope == embeddedTerminalScopeFlow &&
+		slot.FlowID == flowID &&
+		artifacts.NormalizePhaseID(slot.FlowPhaseID) == normalizedPhaseID &&
+		slot.Terminal != nil
 }
 
 func (m Model) handleFlowPhaseResetConfirmed(msg flowPhaseResetConfirmedMsg) (Model, tea.Cmd) {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1343,23 +1343,92 @@ func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstor
 		if artifacts.NormalizePhaseID(completedPhase.PhaseID) == "autoreview" {
 			continue
 		}
+		if m.hasRunningFlowEmbeddedTerminalForPhase(record.FlowID, completedPhase.PhaseID) {
+			m = m.deferAutoFlowPhaseLaunch(record.FlowID, completedPhase.PhaseID)
+			continue
+		}
 		phase, ok := nextAutoLaunchPhase(record)
 		if !ok {
 			continue
 		}
-		target, ok, next := m.flowPhaseLaunchTarget(record, phase)
-		m = next
+		var cmd tea.Cmd
+		m, cmd = m.prepareAutoFlowPhaseLaunchForRecord(record, phase)
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	return m, batchNonNil(cmds...)
+}
+
+type deferredAutoFlowLaunchKey struct {
+	FlowID  string
+	PhaseID string
+}
+
+func (m Model) deferAutoFlowPhaseLaunch(flowID, phaseID string) Model {
+	key, ok := newDeferredAutoFlowLaunchKey(flowID, phaseID)
+	if !ok {
+		return m
+	}
+	if m.deferredAutoFlowLaunches == nil {
+		m.deferredAutoFlowLaunches = make(map[deferredAutoFlowLaunchKey]struct{})
+	}
+	m.deferredAutoFlowLaunches[key] = struct{}{}
+	return m
+}
+
+func newDeferredAutoFlowLaunchKey(flowID, phaseID string) (deferredAutoFlowLaunchKey, bool) {
+	phaseID = artifacts.NormalizePhaseID(phaseID)
+	if flowID == "" || phaseID == "" {
+		return deferredAutoFlowLaunchKey{}, false
+	}
+	return deferredAutoFlowLaunchKey{FlowID: flowID, PhaseID: phaseID}, true
+}
+
+func (m Model) prepareAutoFlowPhaseLaunchForRecord(record flowstore.FlowRecord, phase flowstore.FlowPhase) (Model, tea.Cmd) {
+	target, ok, next := m.flowPhaseLaunchTarget(record, phase)
+	m = next
+	if !ok {
+		return m, nil
+	}
+	launchID := newLaunchID()
+	command, _ := next.flowLaunchAgentSettings()
+	switch command {
+	case agent.CommandCodex, agent.CommandClaude:
+		return m, next.prepareAutoFlowPhaseEmbeddedLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID, next.flowHeadless)
+	default:
+		return m, next.prepareAutoFlowPhaseLaunchCmd(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID)
+	}
+}
+
+func (m Model) prepareDeferredAutoFlowPhaseLaunches(exited []deferredAutoFlowLaunchKey) (Model, tea.Cmd) {
+	var cmds []tea.Cmd
+	for _, key := range exited {
+		if _, ok := m.deferredAutoFlowLaunches[key]; !ok {
+			continue
+		}
+		delete(m.deferredAutoFlowLaunches, key)
+		if m.hasRunningFlowEmbeddedTerminalForPhase(key.FlowID, key.PhaseID) {
+			m.deferredAutoFlowLaunches[key] = struct{}{}
+			continue
+		}
+		record, ok := m.flowByID(key.FlowID)
 		if !ok {
 			continue
 		}
-		launchID := newLaunchID()
-		command, _ := next.flowLaunchAgentSettings()
-		switch command {
-		case agent.CommandCodex, agent.CommandClaude:
-			cmds = append(cmds, next.prepareAutoFlowPhaseEmbeddedLaunch(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID, next.flowHeadless))
+		if !record.AutoMode {
 			continue
 		}
-		cmds = append(cmds, next.prepareAutoFlowPhaseLaunchCmd(target.record, target.phase, target.repoPath, target.worktreePath, target.planPath, launchID))
+		if phase, ok := nextAutoLaunchPhase(record); ok {
+			var cmd tea.Cmd
+			m, cmd = m.prepareAutoFlowPhaseLaunchForRecord(record, phase)
+			if cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
+	}
+	if len(m.deferredAutoFlowLaunches) == 0 {
+		m.deferredAutoFlowLaunches = nil
 	}
 	return m, batchNonNil(cmds...)
 }

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1348,13 +1348,14 @@ func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstor
 			m = m.clearSuppressedAutoFlowLaunch(record.FlowID, completedPhase)
 			continue
 		}
-		if m.hasRunningFlowEmbeddedTerminalForPhase(record.FlowID, completedPhase.PhaseID) ||
-			m.hasAutoClosingFlowEmbeddedTerminalForPhase(record.FlowID, completedPhase.PhaseID) {
+		sourceLaunchID := flowstore.LatestPhaseLaunchID(completedPhase)
+		if m.hasRunningFlowEmbeddedTerminalForPhaseLaunch(record.FlowID, completedPhase.PhaseID, sourceLaunchID) ||
+			m.hasAutoClosingFlowEmbeddedTerminalForPhaseLaunch(record.FlowID, completedPhase.PhaseID, sourceLaunchID) {
 			m = m.deferAutoFlowPhaseLaunch(record.FlowID, completedPhase.PhaseID)
 			continue
 		}
-		if m.hasFlowEmbeddedTerminalForPhase(record.FlowID, completedPhase.PhaseID) {
-			m = m.suppressAutoFlowPhaseLaunch(record.FlowID, completedPhase.PhaseID, flowstore.LatestPhaseLaunchID(completedPhase))
+		if m.hasFlowEmbeddedTerminalForPhaseLaunch(record.FlowID, completedPhase.PhaseID, sourceLaunchID) {
+			m = m.suppressAutoFlowPhaseLaunch(record.FlowID, completedPhase.PhaseID, sourceLaunchID)
 			continue
 		}
 		phase, ok := nextAutoLaunchPhase(record)
@@ -1495,22 +1496,24 @@ func (m Model) prepareDeferredAutoFlowPhaseLaunches() (Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	for key := range m.deferredAutoFlowLaunches {
 		delete(m.deferredAutoFlowLaunches, key)
-		if m.hasRunningFlowEmbeddedTerminalForPhase(key.FlowID, key.PhaseID) {
-			m.deferredAutoFlowLaunches[key] = struct{}{}
-			continue
-		}
-		if m.hasAutoClosingFlowEmbeddedTerminalForPhase(key.FlowID, key.PhaseID) {
-			m.deferredAutoFlowLaunches[key] = struct{}{}
-			continue
-		}
-		if m.hasFlowEmbeddedTerminalForPhase(key.FlowID, key.PhaseID) {
-			continue
-		}
 		record, ok := m.flowByID(key.FlowID)
 		if !ok {
 			continue
 		}
 		if !record.AutoMode {
+			continue
+		}
+		sourcePhase, sourcePhaseOK := flowRecordPhaseByID(record, key.PhaseID)
+		sourceLaunchID := flowstore.LatestPhaseLaunchID(sourcePhase)
+		if sourcePhaseOK && m.hasRunningFlowEmbeddedTerminalForPhaseLaunch(key.FlowID, key.PhaseID, sourceLaunchID) {
+			m.deferredAutoFlowLaunches[key] = struct{}{}
+			continue
+		}
+		if sourcePhaseOK && m.hasAutoClosingFlowEmbeddedTerminalForPhaseLaunch(key.FlowID, key.PhaseID, sourceLaunchID) {
+			m.deferredAutoFlowLaunches[key] = struct{}{}
+			continue
+		}
+		if sourcePhaseOK && m.hasFlowEmbeddedTerminalForPhaseLaunch(key.FlowID, key.PhaseID, sourceLaunchID) {
 			continue
 		}
 		if phase, ok := nextAutoLaunchPhase(record); ok {
@@ -1622,12 +1625,16 @@ func (m Model) flowPhaseResettable(record flowstore.FlowRecord, phase flowstore.
 }
 
 func (m Model) hasRunningFlowEmbeddedTerminalForPhase(flowID, phaseID string) bool {
+	return m.hasRunningFlowEmbeddedTerminalForPhaseLaunch(flowID, phaseID, "")
+}
+
+func (m Model) hasRunningFlowEmbeddedTerminalForPhaseLaunch(flowID, phaseID, launchID string) bool {
 	wantPhaseID := artifacts.NormalizePhaseID(phaseID)
 	if wantPhaseID == "" {
 		return false
 	}
 	for _, slot := range m.embeddedTerminals {
-		if flowEmbeddedTerminalSlotMatchesPhase(slot, flowID, wantPhaseID) &&
+		if flowEmbeddedTerminalSlotMatchesPhaseLaunch(slot, flowID, wantPhaseID, launchID) &&
 			embeddedTerminalRunning(slot.Terminal) {
 			return true
 		}
@@ -1636,12 +1643,16 @@ func (m Model) hasRunningFlowEmbeddedTerminalForPhase(flowID, phaseID string) bo
 }
 
 func (m Model) hasFlowEmbeddedTerminalForPhase(flowID, phaseID string) bool {
+	return m.hasFlowEmbeddedTerminalForPhaseLaunch(flowID, phaseID, "")
+}
+
+func (m Model) hasFlowEmbeddedTerminalForPhaseLaunch(flowID, phaseID, launchID string) bool {
 	wantPhaseID := artifacts.NormalizePhaseID(phaseID)
 	if wantPhaseID == "" {
 		return false
 	}
 	for _, slot := range m.embeddedTerminals {
-		if flowEmbeddedTerminalSlotMatchesPhase(slot, flowID, wantPhaseID) {
+		if flowEmbeddedTerminalSlotMatchesPhaseLaunch(slot, flowID, wantPhaseID, launchID) {
 			return true
 		}
 	}
@@ -1649,12 +1660,16 @@ func (m Model) hasFlowEmbeddedTerminalForPhase(flowID, phaseID string) bool {
 }
 
 func (m Model) hasAutoClosingFlowEmbeddedTerminalForPhase(flowID, phaseID string) bool {
+	return m.hasAutoClosingFlowEmbeddedTerminalForPhaseLaunch(flowID, phaseID, "")
+}
+
+func (m Model) hasAutoClosingFlowEmbeddedTerminalForPhaseLaunch(flowID, phaseID, launchID string) bool {
 	wantPhaseID := artifacts.NormalizePhaseID(phaseID)
 	if wantPhaseID == "" {
 		return false
 	}
 	for _, slot := range m.embeddedTerminals {
-		if flowEmbeddedTerminalSlotMatchesPhase(slot, flowID, wantPhaseID) &&
+		if flowEmbeddedTerminalSlotMatchesPhaseLaunch(slot, flowID, wantPhaseID, launchID) &&
 			flowEmbeddedTerminalAutoCloses(slot.Terminal.State()) {
 			return true
 		}
@@ -1674,6 +1689,14 @@ func flowEmbeddedTerminalSlotMatchesPhase(slot embeddedTerminalSlot, flowID, nor
 		slot.FlowID == flowID &&
 		artifacts.NormalizePhaseID(slot.FlowPhaseID) == normalizedPhaseID &&
 		slot.Terminal != nil
+}
+
+func flowEmbeddedTerminalSlotMatchesPhaseLaunch(slot embeddedTerminalSlot, flowID, normalizedPhaseID, launchID string) bool {
+	if !flowEmbeddedTerminalSlotMatchesPhase(slot, flowID, normalizedPhaseID) {
+		return false
+	}
+	launchID = strings.TrimSpace(launchID)
+	return launchID == "" || strings.TrimSpace(slot.LaunchID) == launchID
 }
 
 func (m Model) handleFlowPhaseResetConfirmed(msg flowPhaseResetConfirmedMsg) (Model, tea.Cmd) {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1224,7 +1224,14 @@ func (m Model) handleFlowResult(msg FlowResultMsg) (Model, tea.Cmd) {
 	if m.flowFocus != flowFocusTerminal {
 		m = m.syncActiveFlowTerminalToSelectedFlow()
 	}
-	return m.prepareAutoFlowPhaseLaunch(previousFlows, msg.Flows)
+	var cmds []tea.Cmd
+	var autoCmd tea.Cmd
+	m, autoCmd = m.prepareAutoFlowPhaseLaunch(previousFlows, msg.Flows)
+	cmds = append(cmds, autoCmd)
+	var deferredCmd tea.Cmd
+	m, deferredCmd = m.prepareDeferredAutoFlowPhaseLaunches()
+	cmds = append(cmds, deferredCmd)
+	return m, batchNonNil(cmds...)
 }
 
 func (m Model) handleFlowAutoModeSet(msg FlowAutoModeSetMsg) Model {


### PR DESCRIPTION
## Summary
- trigger Flow auto mode only after a completed CLI phase's embedded terminal exits and auto-closes
- refresh Flow state on terminal exit so persisted phase completion is discovered promptly
- track deferred auto-launches by Flow/phase and clear them when terminals are dismissed or superseded
- document the auto-mode terminal-exit behavior in the README and config docs

## Verification
- `gofmt -l .`
- `make test`
- `make build`
