### PR TITLE
Add F3 active flows view

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ filter matches, or a load failure with details in the status bar.
 | `↓`/`j` | Move selection down |
 | `/` | Fuzzy filter the current item list |
 | `1`/`2`/`3`/`4`/`5`/`6`/`7`/`8` | Switch to worktrees / branches / stashes / history / reflog / sessions / plans / flows |
+| `F3` | Toggle active Flows for the current repo in the middle pane, filtered to non-merged Flow records |
 | `←`/`→`/`l` | Cycle through modes; use arrows or `l` in flows view because `h` toggles Flow headless/interactive command mode |
 | `h` | Cycle to the previous mode outside flows view; toggle Flow headless/interactive command mode in flows view |
 | `E` | Choose and persist reasoning effort for the selected CLI agent in flows view |
@@ -346,7 +347,15 @@ triggers a Flow refresh so completions recorded after the last refresh are
 picked up promptly. Skipped, blocked, needs-attention, failed-launch, or
 missing-PR-metadata states do not auto-launch. Automation stops before Merge:
 if Autoreview completes and Merge becomes ready, wtui keeps auto mode on and
-requires the existing manual Merge launch. Flow headless mode is on by default:
+requires the existing manual Merge launch.
+
+Press `F3` from any middle-pane view to keep the current numbered mode selected
+while showing active Flows for the selected repo. This active view is scoped to
+the current repo and hides merged Flow records; normal Flow actions, phase
+launches, attached-session resumes, auto-mode toggles, and embedded Flow
+terminals work from the visible active Flow rows.
+
+Flow headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in a runtime-only embedded
 terminal inside the flows pane. Press `h` to choose the CLI command mode:
 headless runs `codex exec` or `claude --print`, while

--- a/docs/config.md
+++ b/docs/config.md
@@ -328,6 +328,11 @@ terminal exits normally and auto-closes; terminal exit also triggers a Flow
 refresh so newly persisted completion state is discovered without waiting for
 unrelated UI activity. Auto mode still skips non-completed outcomes and stops
 before Merge.
+Press `F3` from any middle-pane view to keep the current numbered mode selected
+while showing active Flows for the selected repo. This active view is current
+repo scoped, hides merged Flow records, and supports the same Flow actions,
+phase launches, attached-session resumes, auto-mode toggles, and embedded Flow
+terminal management as the flows pane.
 Headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in an embedded terminal
 inside the flows pane. Press `h` to choose the CLI command mode: headless runs

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -242,7 +242,7 @@ func (m Model) activeTerminalRepoPaths() map[string]bool {
 }
 
 func (m Model) syncActiveFlowTerminalToSelectedFlow() Model {
-	if m.mode != ui.ModeFlows {
+	if !m.flowSurfaceVisible() {
 		return m
 	}
 	flowID := m.selectedFlowID()
@@ -625,11 +625,11 @@ func (m Model) cycleEmbeddedTerminalForScope(scope embeddedTerminalScope, direct
 }
 
 func (m Model) handleEmbeddedTerminalKey(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
-	if m.mode == ui.ModeSessions && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeSession) {
-		return m.handleEmbeddedTerminalKeyForScope(msg, embeddedTerminalScopeSession)
-	}
 	if m.flowSurfaceVisible() && m.activePane == 1 && m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
 		return m.handleEmbeddedTerminalKeyForScope(msg, embeddedTerminalScopeFlow)
+	}
+	if m.mode == ui.ModeSessions && !m.activeFlowSurfaceVisible() && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeSession) {
+		return m.handleEmbeddedTerminalKeyForScope(msg, embeddedTerminalScopeSession)
 	}
 	return m, nil, false
 }
@@ -880,7 +880,7 @@ func (m Model) dismissEmbeddedTerminal(id embeddedTerminalID) Model {
 	prefixScope, prefixActive := m.embeddedTerminalPrefixScope()
 	activeID := m.activeEmbeddedTerminalIDForScope(embeddedTerminalScopeSession)
 	activeFlowID := m.activeEmbeddedTerminalIDForScope(embeddedTerminalScopeFlow)
-	flowTerminalFocused := m.mode == ui.ModeFlows && m.activePane == 1 && m.flowFocus == flowFocusTerminal
+	flowTerminalFocused := m.flowSurfaceVisible() && m.activePane == 1 && m.flowFocus == flowFocusTerminal
 	next := m.embeddedTerminals[:0]
 	for _, slot := range m.embeddedTerminals {
 		if slot.ID != id {
@@ -947,7 +947,7 @@ func (m Model) embeddedTerminalPrefixScope() (embeddedTerminalScope, bool) {
 	if m.mode == ui.ModeSessions && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeSession) {
 		return embeddedTerminalScopeSession, true
 	}
-	if m.mode == ui.ModeFlows && m.activePane == 1 && m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
+	if m.flowSurfaceVisible() && m.activePane == 1 && m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
 		return embeddedTerminalScopeFlow, true
 	}
 	return "", false

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -628,7 +628,7 @@ func (m Model) handleEmbeddedTerminalKey(msg tea.KeyMsg) (Model, tea.Cmd, bool) 
 	if m.mode == ui.ModeSessions && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeSession) {
 		return m.handleEmbeddedTerminalKeyForScope(msg, embeddedTerminalScopeSession)
 	}
-	if m.mode == ui.ModeFlows && m.activePane == 1 && m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
+	if m.flowSurfaceVisible() && m.activePane == 1 && m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
 		return m.handleEmbeddedTerminalKeyForScope(msg, embeddedTerminalScopeFlow)
 	}
 	return m, nil, false

--- a/model/flow_refresh_tick.go
+++ b/model/flow_refresh_tick.go
@@ -47,7 +47,7 @@ func (m Model) finishFlowRefreshFetch(mode ui.Mode, request uint64) (Model, tea.
 		return m, nil
 	}
 	m.flowRefreshInFlight = 0
-	if m.mode != ui.ModeFlows {
+	if !m.flowSurfaceVisible() {
 		return m, nil
 	}
 	return m, m.flowRefreshTickCmd()

--- a/model/flow_refresh_tick_test.go
+++ b/model/flow_refresh_tick_test.go
@@ -422,6 +422,46 @@ func TestModel_ActiveFlowRefreshRepoChangeSupersedesInFlightFetch(t *testing.T) 
 	}
 }
 
+func TestModel_ActiveFlowEntrySupersedesStaleInFlightFetch(t *testing.T) {
+	repos := []scanner.Repo{
+		{Path: "/dev/alpha", DisplayName: "alpha"},
+		{Path: "/dev/bravo", DisplayName: "bravo"},
+	}
+	m := NewWithOptions(repos, Options{
+		StartupMode: ui.ModeFlows,
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{flowForRefreshTest("flow-" + filter.RepoPath)}, nil
+		},
+	})
+	alphaRequest := m.flowRefreshInFlight
+	if alphaRequest == 0 {
+		t.Fatal("expected startup Flow fetch to be in flight")
+	}
+	m.mode = ui.ModeWorktrees
+	m.activePane = 0
+	var cmd tea.Cmd
+	m, cmd = updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyDown})
+	if cmd == nil {
+		t.Fatal("expected repo change in worktrees mode to fetch worktrees")
+	}
+	m.activePane = 1
+
+	m, cmd = updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyF3})
+	if cmd == nil {
+		t.Fatal("expected F3 entry to supersede stale in-flight Flow fetch")
+	}
+	if got := m.ListRequest(ui.ModeFlows); got == alphaRequest {
+		t.Fatalf("flows list request = %d, want changed from alpha request %d", got, alphaRequest)
+	}
+	if m.flowRefreshInFlight != m.ListRequest(ui.ModeFlows) {
+		t.Fatalf("flow refresh in-flight request = %d, want F3 entry request %d", m.flowRefreshInFlight, m.ListRequest(ui.ModeFlows))
+	}
+	result := flowResultFromCommand(t, cmd)
+	if result.RepoPath != "/dev/bravo" {
+		t.Fatalf("FlowResultMsg.RepoPath = %q, want /dev/bravo", result.RepoPath)
+	}
+}
+
 func TestModel_FlowRefreshTracksActionRefetchBeforePendingTick(t *testing.T) {
 	m := NewWithOptions(flowRefreshTestRepos(), Options{
 		StartupMode: ui.ModeFlows,

--- a/model/flow_refresh_tick_test.go
+++ b/model/flow_refresh_tick_test.go
@@ -384,6 +384,44 @@ func TestModel_FlowRefreshTracksRepoChangeRefetchBeforePendingTick(t *testing.T)
 	}
 }
 
+func TestModel_ActiveFlowRefreshRepoChangeSupersedesInFlightFetch(t *testing.T) {
+	repos := []scanner.Repo{
+		{Path: "/dev/alpha", DisplayName: "alpha"},
+		{Path: "/dev/bravo", DisplayName: "bravo"},
+	}
+	m := NewWithOptions(repos, Options{
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{flowForRefreshTest("flow-" + filter.RepoPath)}, nil
+		},
+	})
+	m.activePane = 1
+	var cmd tea.Cmd
+	m, cmd = updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyF3})
+	if cmd == nil {
+		t.Fatal("expected active Flow surface entry to fetch flows")
+	}
+	alphaRequest := m.flowRefreshInFlight
+	if alphaRequest == 0 {
+		t.Fatal("expected alpha active Flow fetch to be in flight")
+	}
+	m.activePane = 0
+
+	m, cmd = updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyDown})
+	if cmd == nil {
+		t.Fatal("expected repo change to supersede in-flight active Flow fetch")
+	}
+	if got := m.ListRequest(ui.ModeFlows); got == alphaRequest {
+		t.Fatalf("flows list request = %d, want changed from alpha request %d", got, alphaRequest)
+	}
+	if m.flowRefreshInFlight != m.ListRequest(ui.ModeFlows) {
+		t.Fatalf("flow refresh in-flight request = %d, want repo-change request %d", m.flowRefreshInFlight, m.ListRequest(ui.ModeFlows))
+	}
+	result := flowResultFromCommand(t, cmd)
+	if result.RepoPath != "/dev/bravo" {
+		t.Fatalf("FlowResultMsg.RepoPath = %q, want /dev/bravo", result.RepoPath)
+	}
+}
+
 func TestModel_FlowRefreshTracksActionRefetchBeforePendingTick(t *testing.T) {
 	m := NewWithOptions(flowRefreshTestRepos(), Options{
 		StartupMode: ui.ModeFlows,

--- a/model/flow_surface.go
+++ b/model/flow_surface.go
@@ -1,0 +1,246 @@
+package model
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/model/pane"
+	"github.com/brian-bell/wtui/ui"
+)
+
+func (m Model) activeFlowSurfaceVisible() bool {
+	return m.contentSurface == surfaceActiveFlows
+}
+
+func (m Model) flowSurfaceVisible() bool {
+	return m.mode == ui.ModeFlows || m.activeFlowSurfaceVisible()
+}
+
+func (m Model) activeContentFetchMode() ui.Mode {
+	if m.activeFlowSurfaceVisible() {
+		return ui.ModeFlows
+	}
+	return m.mode
+}
+
+func (m Model) enterActiveFlowsSurface() (Model, tea.Cmd) {
+	m.contentSurface = surfaceActiveFlows
+	m.flowFocus = flowFocusList
+	m.terminalPrefixActive = false
+	m = m.syncActiveFlowsFromCache()
+	return m.startFlowRefreshFetch()
+}
+
+func (m Model) exitActiveFlowsSurface() Model {
+	m.contentSurface = surfaceModeContent
+	if m.flowFocus == flowFocusTerminal {
+		m.flowFocus = flowFocusList
+		m.terminalPrefixActive = false
+	}
+	return m
+}
+
+func (m Model) toggleActiveFlowsSurface() (Model, tea.Cmd) {
+	if m.activeFlowSurfaceVisible() {
+		return m.exitActiveFlowsSurface(), nil
+	}
+	return m.enterActiveFlowsSurface()
+}
+
+func (m Model) syncActiveFlowsFromCache() Model {
+	selectedFlowID := m.selectedActiveFlowID()
+	expandedFlowID := m.expandedActiveFlowID
+	selectedPhaseID := m.selectedActiveFlowPhaseID
+	m.activeFlows = m.activeFlows.SetItems(activeFlowRecords(m.flows.Items()))
+	if selectedFlowID != "" {
+		m.activeFlows = m.activeFlows.SelectFunc(func(record flowstore.FlowRecord) bool {
+			return record.FlowID == selectedFlowID
+		})
+	}
+	m = m.restoreActiveExpandedFlowSelection(expandedFlowID, selectedPhaseID)
+	return m.reflowActiveFlows()
+}
+
+func activeFlowRecords(records []flowstore.FlowRecord) []flowstore.FlowRecord {
+	active := make([]flowstore.FlowRecord, 0, len(records))
+	for _, record := range records {
+		if record.Status == flowstore.StatusMerged {
+			continue
+		}
+		active = append(active, record)
+	}
+	return active
+}
+
+func (m Model) selectedActiveFlow() (flowstore.FlowRecord, bool) {
+	if _, ok := m.currentRepoPath(); !ok {
+		return flowstore.FlowRecord{}, false
+	}
+	return m.activeFlows.Selected()
+}
+
+func (m Model) selectedActiveFlowID() string {
+	record, ok := m.selectedActiveFlow()
+	if !ok {
+		return ""
+	}
+	return record.FlowID
+}
+
+func (m Model) currentFlowPane() pane.Pane[flowstore.FlowRecord] {
+	if m.activeFlowSurfaceVisible() {
+		return m.activeFlows
+	}
+	return m.flows
+}
+
+func (m Model) currentFlowSelectedIndex() int {
+	if m.activeFlowSurfaceVisible() {
+		return m.activeFlows.SelectedIndex()
+	}
+	return m.flows.SelectedIndex()
+}
+
+func (m Model) currentFlowScroll() int {
+	if m.activeFlowSurfaceVisible() {
+		return m.activeFlows.Scroll()
+	}
+	return m.flows.Scroll()
+}
+
+func (m Model) currentExpandedFlowID() string {
+	if m.activeFlowSurfaceVisible() {
+		return m.expandedActiveFlowID
+	}
+	return m.expandedFlowID
+}
+
+func (m Model) currentSelectedFlowPhaseID() string {
+	if m.activeFlowSurfaceVisible() {
+		return m.selectedActiveFlowPhaseID
+	}
+	return m.selectedFlowPhaseID
+}
+
+func (m Model) setCurrentSelectedFlowPhaseID(phaseID string) Model {
+	if m.activeFlowSurfaceVisible() {
+		m.selectedActiveFlowPhaseID = phaseID
+		return m
+	}
+	m.selectedFlowPhaseID = phaseID
+	return m
+}
+
+func (m Model) currentFilteredFlows() []flowstore.FlowRecord {
+	if len(m.filteredRepos()) == 0 {
+		return nil
+	}
+	flows, _, _ := m.currentFlowPane().View()
+	return flows
+}
+
+func (m Model) flowSurfaceContentHeight() int {
+	return m.flowContentHeight()
+}
+
+func (m Model) flowSurfaceItemHeight(expandedFlowID string) pane.ItemHeight[flowstore.FlowRecord] {
+	return flowItemHeight(expandedFlowID)
+}
+
+func (m Model) setCurrentFlowPane(p pane.Pane[flowstore.FlowRecord]) Model {
+	if m.activeFlowSurfaceVisible() {
+		m.activeFlows = p
+		return m
+	}
+	m.flows = p
+	return m
+}
+
+func (m Model) restoreActiveExpandedFlowSelection(flowID, phaseID string) Model {
+	if flowID == "" {
+		m.expandedActiveFlowID = ""
+		m.selectedActiveFlowPhaseID = ""
+		m.activeFlows = m.activeFlows.SetItemHeight(flowItemHeight(""))
+		return m
+	}
+	record, ok := m.selectedActiveFlow()
+	if !ok || record.FlowID != flowID {
+		m.expandedActiveFlowID = ""
+		m.selectedActiveFlowPhaseID = ""
+		m.activeFlows = m.activeFlows.SetItemHeight(flowItemHeight(""))
+		return m
+	}
+	if phaseID != "" {
+		phase, ok := flowRecordPhaseByID(record, phaseID)
+		if !ok {
+			m.expandedActiveFlowID = ""
+			m.selectedActiveFlowPhaseID = ""
+			m.activeFlows = m.activeFlows.SetItemHeight(flowItemHeight(""))
+			return m
+		}
+		phaseID = phase.PhaseID
+	}
+	m.expandedActiveFlowID = flowID
+	m.selectedActiveFlowPhaseID = phaseID
+	m.activeFlows = m.activeFlows.SetItemHeight(flowItemHeight(flowID))
+	return m
+}
+
+func (m Model) reflowActiveFlows() Model {
+	m.activeFlows = m.activeFlows.Reflow(m.flowContentHeight(), m.contentWidth())
+	if m.activeFlowSurfaceVisible() {
+		if m.selectedActiveFlowPhaseID != "" {
+			return m.ensureSelectedFlowPhaseVisible()
+		}
+		if m.expandedActiveFlowID != "" {
+			return m.reflowExpandedFlow()
+		}
+	}
+	return m
+}
+
+func isNumberedModeKey(key string) bool {
+	return key >= "1" && key <= "8"
+}
+
+func modeForNumberedKey(key string) (ui.Mode, bool) {
+	switch key {
+	case "1":
+		return ui.ModeWorktrees, true
+	case "2":
+		return ui.ModeBranches, true
+	case "3":
+		return ui.ModeStashes, true
+	case "4":
+		return ui.ModeHistory, true
+	case "5":
+		return ui.ModeReflog, true
+	case "6":
+		return ui.ModeSessions, true
+	case "7":
+		return ui.ModePlans, true
+	case "8":
+		return ui.ModeFlows, true
+	default:
+		return ui.ModeWorktrees, false
+	}
+}
+
+func (m Model) switchModeFromKey(key string) (Model, tea.Cmd, bool) {
+	mode, ok := modeForNumberedKey(key)
+	if !ok {
+		return m, nil, false
+	}
+	m = m.exitActiveFlowsSurface()
+	if m.mode == mode {
+		return m, nil, true
+	}
+	m.mode = mode
+	m = m.resetModeCursors()
+	if m.mode == ui.ModeFlows {
+		next, cmd := m.startFlowsModeFetchWithRefreshTick()
+		return next, cmd, true
+	}
+	next, cmd := m.startFetchMode(mode)
+	return next, cmd, true
+}

--- a/model/flow_surface.go
+++ b/model/flow_surface.go
@@ -28,7 +28,7 @@ func (m Model) enterActiveFlowsSurface() (Model, tea.Cmd) {
 	m.flowFocus = flowFocusList
 	m.terminalPrefixActive = false
 	m = m.syncActiveFlowsFromCache()
-	return m.startFlowRefreshFetch()
+	return m.startFlowsModeFetchWithRefreshTick()
 }
 
 func (m Model) exitActiveFlowsSurface() Model {

--- a/model/mode_fetch.go
+++ b/model/mode_fetch.go
@@ -144,7 +144,7 @@ func (m Model) startFetchMode(mode ui.Mode) (Model, tea.Cmd) {
 		m = desc.beforeStart(m)
 	}
 	cmd := m.fetchList(desc, request)
-	if desc.mode == ui.ModeFlows && m.mode == ui.ModeFlows {
+	if desc.mode == ui.ModeFlows && m.flowSurfaceVisible() {
 		m.flowRefreshTickGen++
 		m.flowRefreshInFlight = 0
 		if cmd != nil {

--- a/model/model.go
+++ b/model/model.go
@@ -1033,7 +1033,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, batchNonNil(cmds...)
 	case flowRefreshTickMsg:
-		if msg.Generation != m.flowRefreshTickGen || m.mode != ui.ModeFlows {
+		if msg.Generation != m.flowRefreshTickGen || !m.flowSurfaceVisible() {
 			return m, nil
 		}
 		return m.startFlowRefreshFetch()
@@ -1182,7 +1182,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m = m.clearFlowCreateRequest(msg.Request)
 		next, launchCmd := m.launchAgentWithContext(msg.LaunchContext)
-		if msg.LaunchContext.FlowID != "" && next.mode == ui.ModeFlows {
+		if msg.LaunchContext.FlowID != "" && next.flowSurfaceVisible() {
 			next, fetchCmd := next.startFetchMode(ui.ModeFlows)
 			return next, tea.Batch(fetchCmd, launchCmd)
 		}
@@ -1195,7 +1195,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m = m.clearFlowCreateRequest(msg.Request)
 		}
 		next, launchCmd := m.launchFlowEmbeddedWithContext(msg.LaunchContext)
-		if msg.LaunchContext.FlowID != "" && next.mode == ui.ModeFlows {
+		if msg.LaunchContext.FlowID != "" && next.flowSurfaceVisible() {
 			next, fetchCmd := next.startFetchMode(ui.ModeFlows)
 			return next, tea.Batch(fetchCmd, launchCmd)
 		}
@@ -1219,7 +1219,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if resultErr != "" {
 			m, resultErr = m.markFlowLaunchNeedsAttention(msg.LaunchContext, resultErr)
 			m = m.setStatus(statusOther, resultErr)
-			if msg.LaunchContext.FlowID != "" && m.mode == ui.ModeFlows {
+			if msg.LaunchContext.FlowID != "" && m.flowSurfaceVisible() {
 				return m.startFetchMode(ui.ModeFlows)
 			}
 		} else if msg.Detached {
@@ -1235,7 +1235,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return next.finishFlowRefreshFetch(msg.Mode, msg.ListRequest)
 	case ActionFailedMsg:
 		next := m.handleActionFailed(msg)
-		if next.mode == ui.ModeFlows && next.isCurrentRepo(msg.RepoPath) {
+		if next.flowSurfaceVisible() && next.isCurrentRepo(msg.RepoPath) {
 			return next.startFetchMode(ui.ModeFlows)
 		}
 		return next, nil

--- a/model/model.go
+++ b/model/model.go
@@ -24,6 +24,13 @@ import (
 
 const listRequestSlots = int(ui.ModeFlows) + 1
 
+type contentSurface int
+
+const (
+	surfaceModeContent contentSurface = iota
+	surfaceActiveFlows
+)
+
 // Model is the bubbletea application model.
 type Model struct {
 	repos                      pane.Pane[scanner.Repo]
@@ -39,10 +46,14 @@ type Model struct {
 	sessions                   pane.Pane[sessions.SessionRecord]
 	plans                      pane.Pane[planstore.PlanRecord]
 	flows                      pane.Pane[flowstore.FlowRecord]
+	activeFlows                pane.Pane[flowstore.FlowRecord]
 	expandedPlanID             string
 	expandedFlowID             string
+	expandedActiveFlowID       string
 	selectedPlanPhaseID        string
 	selectedFlowPhaseID        string
+	selectedActiveFlowPhaseID  string
+	contentSurface             contentSurface
 	flowHeadless               bool
 	modal                      modal.Modal
 	diffRequestSeq             uint64
@@ -381,6 +392,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		sessions:                 newSessionPane(),
 		plans:                    newPlanPane(),
 		flows:                    newFlowPane(),
+		activeFlows:              newFlowPane(),
 		flowHeadless:             true,
 		flowRefreshTickGen:       1,
 		mode:                     startupMode(opts.StartupMode),
@@ -616,6 +628,9 @@ func (m Model) View() string {
 	sessions, sessionSelected, sessionScroll := m.sessions.View()
 	plans, planSelected, planScroll := m.plans.View()
 	flows, flowSelected, flowScroll := m.flows.View()
+	if m.activeFlowSurfaceVisible() {
+		flows, flowSelected, flowScroll = m.activeFlows.View()
+	}
 	flowAutoModeSelected := false
 	if flowSelected >= 0 && flowSelected < len(flows) {
 		flowAutoModeSelected = flows[flowSelected].AutoMode
@@ -640,6 +655,7 @@ func (m Model) View() string {
 		Width:                       m.width,
 		Height:                      m.height,
 		Mode:                        m.mode,
+		ActiveFlows:                 m.activeFlowSurfaceVisible(),
 		Branches:                    rows,
 		Stashes:                     stashes,
 		BranchSelected:              branchSelected,
@@ -702,9 +718,9 @@ func (m Model) View() string {
 		FlowTerminalActivity:        m.flowTerminalActivity(),
 		FlowTerminalFocused:         m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow),
 		ExpandedPlanID:              m.expandedPlanID,
-		ExpandedFlowID:              m.expandedFlowID,
+		ExpandedFlowID:              m.currentExpandedFlowID(),
 		SelectedPlanPhaseID:         m.selectedPlanPhaseID,
-		SelectedFlowPhaseID:         m.selectedFlowPhaseID,
+		SelectedFlowPhaseID:         m.currentSelectedFlowPhaseID(),
 		FlowHeadless:                m.flowHeadless,
 		FlowAutoModeSelected:        flowAutoModeSelected,
 		FlowAgentLabel:              m.flowAgentShortcutLabel(),
@@ -754,15 +770,24 @@ func (m Model) rightEmptyMessage(filteredRepos, filteredWorktrees, filteredBranc
 	}
 	sourceCount, filteredCount := m.activeItemCounts(filteredWorktrees, filteredBranches, filteredStashes, filteredCommits, filteredReflogs, filteredSessions, filteredPlans, filteredFlows)
 	if m.activeItemPaneQuery() != "" && sourceCount > 0 && filteredCount == 0 {
+		if m.activeFlowSurfaceVisible() {
+			return "No flow results for " + m.activeItemPaneQuery()
+		}
 		return "No " + modeResultName(m.mode) + " results for " + m.activeItemPaneQuery()
 	}
-	if m.status.Source == statusFetch && m.status.FetchKind == FetchList && m.status.Mode == m.mode {
-		return "Could not load " + modeDataName(m.mode) + "; see status bar"
+	if m.status.Source == statusFetch && m.status.FetchKind == FetchList && m.status.Mode == m.activeContentFetchMode() {
+		return "Could not load " + modeDataName(m.activeContentFetchMode()) + "; see status bar"
+	}
+	if m.activeFlowSurfaceVisible() {
+		return "No active flows"
 	}
 	return modeEmptyMessage(m.mode)
 }
 
 func (m Model) activeItemCounts(filteredWorktrees, filteredBranches, filteredStashes, filteredCommits, filteredReflogs, filteredSessions, filteredPlans, filteredFlows int) (int, int) {
+	if m.activeFlowSurfaceVisible() {
+		return m.activeFlows.ItemCount(), filteredFlows
+	}
 	switch m.mode {
 	case ui.ModeWorktrees:
 		return m.worktrees.ItemCount(), filteredWorktrees
@@ -1280,6 +1305,9 @@ func (m Model) selectedFlow() (flowstore.FlowRecord, bool) {
 	if _, ok := m.currentRepoPath(); !ok {
 		return flowstore.FlowRecord{}, false
 	}
+	if m.activeFlowSurfaceVisible() {
+		return m.activeFlows.Selected()
+	}
 	return m.flows.Selected()
 }
 
@@ -1327,18 +1355,22 @@ func (m Model) selectedPlanPhaseIndex() (int, bool) {
 
 func (m Model) selectedFlowPhase() (flowstore.FlowPhase, bool) {
 	record, ok := m.selectedFlow()
-	if !ok || record.FlowID == "" || record.FlowID != m.expandedFlowID || m.selectedFlowPhaseID == "" {
+	expandedFlowID := m.currentExpandedFlowID()
+	selectedPhaseID := m.currentSelectedFlowPhaseID()
+	if !ok || record.FlowID == "" || record.FlowID != expandedFlowID || selectedPhaseID == "" {
 		return flowstore.FlowPhase{}, false
 	}
-	return flowRecordPhaseByID(record, m.selectedFlowPhaseID)
+	return flowRecordPhaseByID(record, selectedPhaseID)
 }
 
 func (m Model) selectedFlowPhaseIndex() (int, bool) {
 	record, ok := m.selectedFlow()
-	if !ok || record.FlowID == "" || record.FlowID != m.expandedFlowID || m.selectedFlowPhaseID == "" {
+	expandedFlowID := m.currentExpandedFlowID()
+	selectedPhaseID := m.currentSelectedFlowPhaseID()
+	if !ok || record.FlowID == "" || record.FlowID != expandedFlowID || selectedPhaseID == "" {
 		return 0, false
 	}
-	index, _, ok := flowRecordPhaseIndexByID(record, m.selectedFlowPhaseID)
+	index, _, ok := flowRecordPhaseIndexByID(record, selectedPhaseID)
 	return index, ok
 }
 
@@ -1424,6 +1456,10 @@ func (m Model) clearSelectedPlanPhase() Model {
 }
 
 func (m Model) clearSelectedFlowPhase() Model {
+	if m.activeFlowSurfaceVisible() {
+		m.selectedActiveFlowPhaseID = ""
+		return m
+	}
 	m.selectedFlowPhaseID = ""
 	return m
 }
@@ -1440,6 +1476,12 @@ func (m Model) setExpandedPlanID(planID string) Model {
 }
 
 func (m Model) setExpandedFlowID(flowID string) Model {
+	if m.activeFlowSurfaceVisible() {
+		m.expandedActiveFlowID = flowID
+		m.selectedActiveFlowPhaseID = ""
+		m.activeFlows = m.activeFlows.SetItemHeight(flowItemHeight(flowID))
+		return m.reflowActiveFlows()
+	}
 	m.expandedFlowID = flowID
 	m.selectedFlowPhaseID = ""
 	m.flows = m.flows.SetItemHeight(flowItemHeight(flowID))
@@ -1475,24 +1517,25 @@ func (m Model) canScrollExpandedPlan(delta, viewHeight int) bool {
 }
 
 func (m Model) canScrollExpandedFlow(delta, viewHeight int) bool {
-	if m.expandedFlowID == "" || m.selectedFlowID() != m.expandedFlowID {
+	expandedFlowID := m.currentExpandedFlowID()
+	if expandedFlowID == "" || m.selectedFlowID() != expandedFlowID {
 		return false
 	}
 	if viewHeight <= 0 {
 		viewHeight = 1
 	}
-	flows := m.filteredFlows()
-	selected := m.FlowSelected()
+	flows := m.currentFilteredFlows()
+	selected := m.currentFlowSelectedIndex()
 	if selected < 0 || selected >= len(flows) {
 		return false
 	}
 
 	line := 0
 	for i := 0; i < selected; i++ {
-		line += flowVisualHeight(flows[i], m.expandedFlowID)
+		line += flowVisualHeight(flows[i], expandedFlowID)
 	}
-	height := flowVisualHeight(flows[selected], m.expandedFlowID)
-	scroll := m.FlowScroll()
+	height := flowVisualHeight(flows[selected], expandedFlowID)
+	scroll := m.currentFlowScroll()
 	if delta > 0 {
 		return line+height > scroll+viewHeight
 	}
@@ -1532,19 +1575,20 @@ func (m Model) reflowExpandedPlan() Model {
 }
 
 func (m Model) reflowExpandedFlow() Model {
-	flows := m.filteredFlows()
-	selected := m.FlowSelected()
+	flows := m.currentFilteredFlows()
+	selected := m.currentFlowSelectedIndex()
 	if selected < 0 || selected >= len(flows) {
 		return m
 	}
 
 	viewHeight := m.flowContentHeight()
+	expandedFlowID := m.currentExpandedFlowID()
 	line := 0
 	for i := 0; i < selected; i++ {
-		line += flowVisualHeight(flows[i], m.expandedFlowID)
+		line += flowVisualHeight(flows[i], expandedFlowID)
 	}
-	height := flowVisualHeight(flows[selected], m.expandedFlowID)
-	scroll := m.FlowScroll()
+	height := flowVisualHeight(flows[selected], expandedFlowID)
+	scroll := m.currentFlowScroll()
 	target := scroll
 	if scroll > line {
 		target = line
@@ -1555,7 +1599,7 @@ func (m Model) reflowExpandedFlow() Model {
 		target = line
 	}
 	if target != scroll {
-		m.flows = m.flows.ScrollBy(target-scroll, viewHeight, m.contentWidth())
+		m = m.setCurrentFlowPane(m.currentFlowPane().ScrollBy(target-scroll, viewHeight, m.contentWidth()))
 	}
 	return m
 }
@@ -1600,7 +1644,8 @@ func (m Model) moveSelectedPlanPhase(delta int) (Model, bool) {
 }
 
 func (m Model) moveSelectedFlowPhase(delta int) (Model, bool) {
-	if m.mode != ui.ModeFlows || m.expandedFlowID == "" || m.selectedFlowID() != m.expandedFlowID {
+	expandedFlowID := m.currentExpandedFlowID()
+	if !m.flowSurfaceVisible() || expandedFlowID == "" || m.selectedFlowID() != expandedFlowID {
 		return m, false
 	}
 	record, ok := m.selectedFlow()
@@ -1612,7 +1657,7 @@ func (m Model) moveSelectedFlowPhase(delta int) (Model, bool) {
 	index, hasPhase := m.selectedFlowPhaseIndex()
 	if !hasPhase {
 		if delta > 0 {
-			m.selectedFlowPhaseID = phases[0].PhaseID
+			m = m.setCurrentSelectedFlowPhaseID(phases[0].PhaseID)
 			return m.ensureSelectedFlowPhaseVisible(), true
 		}
 		return m, false
@@ -1624,11 +1669,11 @@ func (m Model) moveSelectedFlowPhase(delta int) (Model, bool) {
 		return m.reflowExpandedFlow(), true
 	}
 	if nextIndex >= len(phases) {
-		if m.flows.Len() <= 1 {
+		if m.currentFlowPane().Len() <= 1 {
 			return m.ensureSelectedFlowPhaseVisible(), true
 		}
 		before := m.selectedFlowID()
-		m.flows = m.flows.Move(delta, m.contentHeightForMode(), m.contentWidth())
+		m = m.setCurrentFlowPane(m.currentFlowPane().Move(delta, m.contentHeightForMode(), m.contentWidth()))
 		if after := m.selectedFlowID(); before != "" && after != before {
 			m = m.clearSelectedFlowPhase()
 			m = m.setExpandedFlowID("")
@@ -1636,7 +1681,7 @@ func (m Model) moveSelectedFlowPhase(delta int) (Model, bool) {
 		}
 		return m, true
 	}
-	m.selectedFlowPhaseID = phases[nextIndex].PhaseID
+	m = m.setCurrentSelectedFlowPhaseID(phases[nextIndex].PhaseID)
 	return m.ensureSelectedFlowPhaseVisible(), true
 }
 
@@ -1682,7 +1727,7 @@ func (m Model) ensureSelectedFlowPhaseVisible() Model {
 	if viewHeight <= 0 {
 		viewHeight = 1
 	}
-	scroll := m.FlowScroll()
+	scroll := m.currentFlowScroll()
 	target := scroll
 	if line < target {
 		target = line
@@ -1691,7 +1736,7 @@ func (m Model) ensureSelectedFlowPhaseVisible() Model {
 		target = line - viewHeight + 1
 	}
 	if target != scroll {
-		m.flows = m.flows.ScrollBy(target-scroll, viewHeight, m.contentWidth())
+		m = m.setCurrentFlowPane(m.currentFlowPane().ScrollBy(target-scroll, viewHeight, m.contentWidth()))
 	}
 	return m
 }
@@ -1710,14 +1755,15 @@ func (m Model) selectedPlanVisualLine() (int, bool) {
 }
 
 func (m Model) selectedFlowVisualLine() (int, bool) {
-	flows := m.filteredFlows()
-	selected := m.FlowSelected()
+	flows := m.currentFilteredFlows()
+	selected := m.currentFlowSelectedIndex()
 	if selected < 0 || selected >= len(flows) {
 		return 0, false
 	}
+	expandedFlowID := m.currentExpandedFlowID()
 	line := 0
 	for i := 0; i < selected; i++ {
-		line += flowVisualHeight(flows[i], m.expandedFlowID)
+		line += flowVisualHeight(flows[i], expandedFlowID)
 	}
 	return line, true
 }
@@ -1785,6 +1831,9 @@ func (m Model) reflowPlans() Model {
 
 func (m Model) reflowFlows() Model {
 	m.flows = m.flows.Reflow(m.flowContentHeight(), m.contentWidth())
+	if m.activeFlowSurfaceVisible() {
+		return m
+	}
 	if m.selectedFlowPhaseID != "" {
 		return m.ensureSelectedFlowPhaseVisible()
 	}

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -24,7 +24,7 @@ const visibleRepoFetchFadeStepDuration = 1 * time.Second
 
 func (m Model) startFetchForMode() (Model, tea.Cmd) {
 	if m.activeFlowSurfaceVisible() {
-		return m.startFlowRefreshFetch()
+		return m.startFlowsModeFetchWithRefreshTick()
 	}
 	return m.startFetchMode(m.mode)
 }

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -23,6 +23,9 @@ const visibleRepoFetchStatusTTL = 3 * time.Second
 const visibleRepoFetchFadeStepDuration = 1 * time.Second
 
 func (m Model) startFetchForMode() (Model, tea.Cmd) {
+	if m.activeFlowSurfaceVisible() {
+		return m.startFlowRefreshFetch()
+	}
 	return m.startFetchMode(m.mode)
 }
 
@@ -47,9 +50,10 @@ func (m Model) startGlobalRefresh() (Model, tea.Cmd) {
 
 	cmds := []tea.Cmd{scanCmd}
 	if repoPath, ok := m.currentRepoPath(); ok {
-		if _, ok := listFetchDescriptorForMode(m.mode); ok {
+		fetchMode := m.activeContentFetchMode()
+		if _, ok := listFetchDescriptorForMode(fetchMode); ok {
 			inlineWorktreePath := ""
-			if m.mode == ui.ModeWorktrees && m.inlineWorktreeSessionPath != "" {
+			if fetchMode == ui.ModeWorktrees && m.inlineWorktreeSessionPath != "" {
 				inlineWorktreePath = m.inlineWorktreeSessionPath
 			}
 			var fetchCmd tea.Cmd
@@ -71,7 +75,8 @@ func (m Model) startGlobalRefresh() (Model, tea.Cmd) {
 }
 
 func (m Model) fetchForMode() tea.Cmd {
-	return m.fetchMode(m.mode, m.currentListRequest(m.mode))
+	mode := m.activeContentFetchMode()
+	return m.fetchMode(mode, m.currentListRequest(mode))
 }
 
 func (m Model) currentListRequest(mode ui.Mode) uint64 {

--- a/model/model_filter.go
+++ b/model/model_filter.go
@@ -116,6 +116,9 @@ func (m Model) activeSearchQuery() string {
 }
 
 func (m Model) activeItemPaneQuery() string {
+	if m.activeFlowSurfaceVisible() {
+		return m.activeFlows.Query()
+	}
 	switch m.mode {
 	case ui.ModeWorktrees:
 		return m.worktrees.Query()
@@ -142,6 +145,12 @@ func (m Model) setActiveSearchQuery(query string) Model {
 	if m.activePane == 0 {
 		m.repos = m.repos.SetQuery(query)
 		return m.reflowRepos()
+	}
+
+	if m.activeFlowSurfaceVisible() {
+		m.activeFlows = m.activeFlows.SetQuery(query)
+		m = m.setExpandedFlowID("")
+		return m
 	}
 
 	m.worktrees = m.worktrees.SetQueryPreserveIndex(query)
@@ -193,7 +202,11 @@ func (m Model) clampSelectionsAfterFilter() Model {
 	m = m.reflowSessions()
 	m = m.reflowPlans()
 	m = m.reflowFlows()
+	m = m.reflowActiveFlows()
 	if m.mode == ui.ModeFlows && m.activePane == 1 && m.flowFocus != flowFocusTerminal {
+		m = m.syncActiveFlowTerminalToSelectedFlow()
+	}
+	if m.activeFlowSurfaceVisible() && m.activePane == 1 && m.flowFocus != flowFocusTerminal {
 		m = m.syncActiveFlowTerminalToSelectedFlow()
 	}
 	return m

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -263,6 +263,31 @@ func TestModel_F3ActiveFlowSearchAcceptsDigits(t *testing.T) {
 	}
 }
 
+func TestModel_F3ActiveFlowPullDoesNotTargetHiddenWorktree(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	flow.WorktreePath = "/dev/alpha-worktrees/visible-flow"
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	m, _ = update(m, model.WorktreeResultMsg{
+		RepoPath: "/dev/alpha",
+		Worktrees: []gitquery.Worktree{{
+			Path:       "/dev/alpha-worktrees/hidden-worktree",
+			BranchName: "hidden",
+		}},
+		ListRequest: m.ListRequest(ui.ModeWorktrees),
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'F'}})
+	if cmd != nil {
+		t.Fatalf("F from active Flow surface returned command %T, want nil to avoid hidden worktree pull", cmd)
+	}
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Active flows") {
+		t.Fatalf("F from active Flow surface should leave active Flow view visible:\n%s", view)
+	}
+}
+
 func TestModel_EnterTogglesActiveFlowPhaseRows(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -44,6 +44,105 @@ func flowWithPhaseDetails() flowstore.FlowRecord {
 	}
 }
 
+func TestModel_F3ShowsActiveFlowsFromCurrentRepoCache(t *testing.T) {
+	active := flowWithPhaseDetails()
+	active.FlowID = "active-flow"
+	active.Title = "Active Flow"
+	merged := flowWithPhaseDetails()
+	merged.FlowID = "merged-flow"
+	merged.Title = "Merged Flow"
+	merged.Status = flowstore.StatusMerged
+
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{active, merged})
+	m, _ = update(m, tea.WindowSizeMsg{Width: 220, Height: 18})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("mode = %v, want worktrees before F3", m.Mode())
+	}
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF3})
+	if cmd == nil {
+		t.Fatal("F3 should start or continue a Flow refresh")
+	}
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("mode = %v, want preserved worktrees mode", m.Mode())
+	}
+	view := ansi.Strip(m.View())
+	for _, want := range []string{"Active flows", "Active Flow", "F3"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("active-flow view missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "Merged Flow") {
+		t.Fatalf("active-flow view should filter merged flows:\n%s", view)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	view = ansi.Strip(m.View())
+	if !strings.Contains(view, "worktrees") || strings.Contains(view, "Active Flow") {
+		t.Fatalf("second F3 should restore worktrees pane:\n%s", view)
+	}
+}
+
+func TestModel_F3UsesSeparateActiveFlowSelectionForActions(t *testing.T) {
+	activeOne := flowWithPhaseDetails()
+	activeOne.FlowID = "active-one"
+	activeOne.Title = "Active One"
+	activeTwo := flowWithPhaseDetails()
+	activeTwo.FlowID = "active-two"
+	activeTwo.Title = "Active Two"
+	merged := flowWithPhaseDetails()
+	merged.FlowID = "merged-flow"
+	merged.Title = "Merged Flow"
+	merged.Status = flowstore.StatusMerged
+
+	var launched flowstore.PhaseLaunchUpdate
+	m := flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			launched = update
+			updated := activeTwo
+			for i := range updated.Phases {
+				if updated.Phases[i].PhaseID == update.PhaseID {
+					updated.Phases[i].Status = flowstore.PhaseRunning
+					updated.Phases[i].LaunchIDs = append(updated.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return updated, nil
+		},
+	}), []flowstore.FlowRecord{activeOne, merged, activeTwo})
+	m, _ = update(m, tea.WindowSizeMsg{Width: 220, Height: 18})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.FlowSelected(); got != 1 {
+		t.Fatalf("normal Flow selection = %d, want merged row index 1", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Active Two") || strings.Contains(view, "Merged Flow") {
+		t.Fatalf("active-flow surface should select among non-merged rows only:\n%s", view)
+	}
+
+	m, cmd := update(m, flowCtrlJKey())
+	if cmd == nil {
+		t.Fatal("expected active Flow launch command")
+	}
+	launches := flowEmbeddedLaunchesFromCommand(t, cmd)
+	if len(launches) != 1 || launches[0].LaunchContext.FlowID != "active-two" {
+		t.Fatalf("launches = %#v, want active-two", launches)
+	}
+	if launched.FlowID != "active-two" || launched.PhaseID != "implementation" {
+		t.Fatalf("launch update = %#v, want active-two implementation", launched)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	view = ansi.Strip(m.View())
+	if m.Mode() != ui.ModeFlows || m.FlowSelected() != 1 || !strings.Contains(view, "Merged Flow") {
+		t.Fatalf("normal Flow mode should retain merged selection after F3 exit; selected=%d view:\n%s", m.FlowSelected(), view)
+	}
+}
+
 func flowWithAwaitingImplementation() flowstore.FlowRecord {
 	flow := flowWithPhaseDetails()
 	for i := range flow.Phases {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -3477,6 +3477,31 @@ func TestModel_ActiveFlowDeleteUsesVisibleFlowOverUnderlyingStash(t *testing.T) 
 	}
 }
 
+func TestModel_ActiveFlowDeleteWithNoVisibleFlowIgnoresUnderlyingStash(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{})
+	m = flowsInRightPane(t, m, nil)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.StashResultMsg{
+		RepoPath: "/dev/alpha",
+		Stashes: []gitquery.Stash{{
+			Index:   0,
+			Date:    "2026-06-14 12:00:00 -0400",
+			Message: "hidden stash",
+		}},
+		ListRequest: m.ListRequest(ui.ModeStashes),
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if cmd != nil {
+		t.Fatalf("d with no visible active Flow returned command %T, want nil", cmd)
+	}
+	if prompt := m.ConfirmPrompt(); prompt != "" {
+		t.Fatalf("d with no visible active Flow opened hidden-pane confirmation %q", prompt)
+	}
+}
+
 func TestModel_FlowDeleteCancelDoesNotCallDeleteAdapter(t *testing.T) {
 	deleted := false
 	m := model.NewWithOptions(testRepos(), model.Options{

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/brian-bell/wtui/actions"
 	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/model"
 	"github.com/brian-bell/wtui/sessions"
 	"github.com/brian-bell/wtui/ui"
@@ -237,6 +238,28 @@ func TestModel_F3ActiveFlowFetchErrorUsesActiveFetchMode(t *testing.T) {
 	}
 	if !strings.Contains(view, "Could not load flows; see status bar") {
 		t.Fatalf("empty active Flow surface should show Flow fetch failure placeholder:\n%s", view)
+	}
+}
+
+func TestModel_F3ActiveFlowSearchAcceptsDigits(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	flow.Title = "Release Flow 123"
+	flow.Branch = "release/123"
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	if cmd != nil {
+		t.Fatalf("digit in active Flow search returned command %T, want nil", cmd)
+	}
+	if got := m.ItemSearch(); got != "1" {
+		t.Fatalf("active Flow search query = %q, want 1", got)
+	}
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Active flows") || !strings.Contains(view, "release/123") {
+		t.Fatalf("digit search should keep active Flow surface visible and filtered:\n%s", view)
 	}
 }
 
@@ -3370,6 +3393,40 @@ func TestModel_FlowDeleteRequiresDestructiveMode(t *testing.T) {
 	}
 	if deleted {
 		t.Fatal("DeleteFlow should not run while destructive mode is disabled")
+	}
+}
+
+func TestModel_ActiveFlowDeleteUsesVisibleFlowOverUnderlyingStash(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:   "flow-1",
+		RepoPath: "/dev/alpha",
+		Title:    "Delete visible Flow",
+		Status:   flowstore.StatusPending,
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m, _ = update(m, model.StashResultMsg{
+		RepoPath: "/dev/alpha",
+		Stashes: []gitquery.Stash{{
+			Index:   0,
+			Date:    "2026-06-14 12:00:00 -0400",
+			Message: "hidden stash",
+		}},
+		ListRequest: m.ListRequest(ui.ModeStashes),
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	if cmd != nil {
+		t.Fatalf("opening active Flow delete confirm returned command %T, want nil", cmd)
+	}
+	prompt := m.ConfirmPrompt()
+	if !strings.Contains(prompt, "Delete Flow Delete visible Flow (flow-1)") {
+		t.Fatalf("active Flow delete prompt = %q, want visible Flow delete confirmation", prompt)
+	}
+	if strings.Contains(prompt, "hidden stash") {
+		t.Fatalf("active Flow delete should not target hidden stash: %q", prompt)
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -198,6 +198,24 @@ func TestModel_F3ActiveFlowRefreshPreparesAutoLaunch(t *testing.T) {
 	}
 }
 
+func TestModel_F3ActiveFlowLKeyNavigatesLikeRightArrow(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if cmd != nil {
+		t.Fatalf("l from active Flow surface returned command %T, want nil", cmd)
+	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("l from active Flow surface left active pane = %d, want left pane", m.ActivePane())
+	}
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("l from active Flow surface changed underlying mode = %d, want worktrees", m.Mode())
+	}
+}
+
 func TestModel_EnterTogglesActiveFlowPhaseRows(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -143,6 +143,217 @@ func TestModel_F3UsesSeparateActiveFlowSelectionForActions(t *testing.T) {
 	}
 }
 
+func TestModel_EnterTogglesActiveFlowPhaseRows(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.WindowSizeMsg{Width: 220, Height: 18})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("enter on active Flow row returned command %T, want nil", cmd)
+	}
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Plan Review") || !strings.Contains(view, "Implementation") {
+		t.Fatalf("enter should expand active Flow phase rows:\n%s", view)
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("second enter on active Flow row returned command %T, want nil", cmd)
+	}
+	view = ansi.Strip(m.View())
+	if strings.Contains(view, "Plan Review") || strings.Contains(view, "Implementation") {
+		t.Fatalf("second enter should collapse active Flow phase rows:\n%s", view)
+	}
+}
+
+func TestModel_ActiveFlowRefreshPreservesNormalFlowSelection(t *testing.T) {
+	activeOne := flowWithPhaseDetails()
+	activeOne.FlowID = "active-one"
+	activeOne.Title = "Active One"
+	activeTwo := flowWithPhaseDetails()
+	activeTwo.FlowID = "active-two"
+	activeTwo.Title = "Active Two"
+
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{activeOne, activeTwo})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.FlowSelected(); got != 1 {
+		t.Fatalf("normal Flow selection = %d, want active-two", got)
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
+
+	m, _ = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{activeOne, activeTwo},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	if got := m.FlowSelected(); got != 1 {
+		t.Fatalf("normal Flow selection after active refresh = %d, want preserved active-two", got)
+	}
+}
+
+func TestModel_RKeyResumesActiveFlowPhaseSession(t *testing.T) {
+	var launchUpdate flowstore.PhaseLaunchUpdate
+	var started actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:     "codex",
+		SessionStateRoot: "/state/wtui",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			launchUpdate = update
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
+			started = ctx
+			return &fakeEmbeddedTerminal{state: "running"}, nil
+		},
+	})
+	flow := flowWithPhaseDetails()
+	flow.WorktreePath = "/dev/alpha-worktrees/active-resume"
+	flow.Phases = []flowstore.FlowPhase{{
+		PhaseID: "review-loop",
+		Title:   "Review loop",
+		Status:  flowstore.PhaseCompleted,
+		Sessions: []flowstore.Session{
+			{Provider: "codex", SessionID: "codex-review", Status: "ended", StartedAt: time.Date(2026, 6, 7, 11, 0, 0, 0, time.UTC)},
+		},
+	}}
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("expected active Flow phase resume command")
+	}
+	if started.ResumeSessionID != "codex-review" ||
+		started.FlowID != "flow-1" ||
+		started.FlowPhaseID != "review-loop" ||
+		started.WorktreePath != "/dev/alpha-worktrees/active-resume" ||
+		!started.Embedded ||
+		started.Headless ||
+		!started.FlowLaunchTracked {
+		t.Fatalf("unexpected active Flow phase resume context: %#v", started)
+	}
+	if launchUpdate.FlowID != "flow-1" || launchUpdate.PhaseID != "review-loop" || !launchUpdate.Resume {
+		t.Fatalf("launch update = %#v, want tracked resume for review-loop", launchUpdate)
+	}
+}
+
+func TestModel_InteractiveActiveFlowLaunchFocusesEmbeddedTerminal(t *testing.T) {
+	var started actions.AgentLaunchContext
+	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
+	flow := flowWithPhaseDetails()
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updated := flow
+			for i := range updated.Phases {
+				if updated.Phases[i].PhaseID == update.PhaseID {
+					updated.Phases[i].Status = flowstore.PhaseRunning
+					updated.Phases[i].LaunchIDs = append(updated.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return updated, nil
+		},
+		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
+			started = ctx
+			return fakeTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	m, cmd := update(m, flowCtrlJKey())
+	if cmd == nil {
+		t.Fatal("expected active Flow launch command")
+	}
+	msg := cmd()
+	launchMsg, ok := msg.(model.FlowEmbeddedLaunchRequestedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want FlowEmbeddedLaunchRequestedMsg", msg)
+	}
+	m, _ = update(m, launchMsg)
+	if started.FlowID != "flow-1" || started.FlowPhaseID != "implementation" || started.Headless {
+		t.Fatalf("unexpected active Flow launch context: %#v", started)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	if len(fakeTerm.writes) == 0 || fakeTerm.writes[len(fakeTerm.writes)-1] != "z" {
+		t.Fatalf("interactive active Flow launch should focus terminal input and forward z: %#v", fakeTerm.writes)
+	}
+}
+
+func TestModel_ActiveFlowLaunchOverSessionsUsesFlowTerminal(t *testing.T) {
+	var sessionTerm *fakeEmbeddedTerminal
+	var flowTerm *fakeEmbeddedTerminal
+	flow := flowWithPhaseDetails()
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updated := flow
+			for i := range updated.Phases {
+				if updated.Phases[i].PhaseID == update.PhaseID {
+					updated.Phases[i].Status = flowstore.PhaseRunning
+					updated.Phases[i].LaunchIDs = append(updated.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return updated, nil
+		},
+		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
+			if ctx.FlowID == "" {
+				sessionTerm = &fakeEmbeddedTerminal{state: "running", lines: []string{"session-terminal"}}
+				return sessionTerm, nil
+			}
+			flowTerm = &fakeEmbeddedTerminal{state: "running"}
+			return flowTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{
+		{Provider: sessions.ProviderCodex, SessionID: "codex-session-1", RepoPath: "/dev/alpha", WorktreePath: "/dev/alpha-worktrees/session"},
+	}, ListRequest: m.ListRequest(ui.ModeSessions)})
+	m, sessionTick := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if sessionTick == nil || sessionTerm == nil {
+		t.Fatal("expected session resume to start a session embedded terminal")
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "flow/with-phases") || strings.Contains(view, "session-terminal") {
+		t.Fatalf("active flows should visually override session terminal:\n%s", view)
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	m, cmd := update(m, flowCtrlJKey())
+	if cmd == nil {
+		t.Fatal("expected active Flow launch command over Sessions")
+	}
+	msg := cmd()
+	launchMsg, ok := msg.(model.FlowEmbeddedLaunchRequestedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want FlowEmbeddedLaunchRequestedMsg", msg)
+	}
+	m, _ = update(m, launchMsg)
+	if flowTerm == nil {
+		t.Fatal("expected active Flow launch to start a flow embedded terminal")
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	if len(flowTerm.writes) == 0 || flowTerm.writes[len(flowTerm.writes)-1] != "z" {
+		t.Fatalf("active Flow input over Sessions should go to flow terminal: %#v", flowTerm.writes)
+	}
+	if len(sessionTerm.writes) != 0 {
+		t.Fatalf("active Flow input over Sessions should not go to session terminal: %#v", sessionTerm.writes)
+	}
+}
+
 func flowWithAwaitingImplementation() flowstore.FlowRecord {
 	flow := flowWithPhaseDetails()
 	for i := range flow.Phases {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -143,6 +143,61 @@ func TestModel_F3UsesSeparateActiveFlowSelectionForActions(t *testing.T) {
 	}
 }
 
+func TestModel_F3ActiveFlowRefreshPreparesAutoLaunch(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	var updates []flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			launched := current
+			for i := range launched.Phases {
+				if launched.Phases[i].PhaseID == update.PhaseID {
+					launched.Phases[i].Status = flowstore.PhaseRunning
+					launched.Phases[i].LaunchIDs = append(launched.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return launched, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+
+	_, cmd := update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+	if cmd == nil {
+		t.Fatal("active Flow refresh should return auto-launch command")
+	}
+	launches := flowEmbeddedLaunchesFromCommand(t, cmd)
+	if len(launches) != 1 {
+		t.Fatalf("active Flow refresh returned %d embedded launches, want 1", len(launches))
+	}
+	if len(updates) != 1 || !updates[0].AutoLaunch || updates[0].FlowID != "flow-1" || updates[0].PhaseID != "implementation" || updates[0].LaunchID == "" {
+		t.Fatalf("launch updates = %#v, want implementation auto launch", updates)
+	}
+	launch := launches[0]
+	if launch.LaunchContext.FlowID != "flow-1" ||
+		launch.LaunchContext.FlowPhaseID != "implementation" ||
+		!launch.LaunchContext.Embedded ||
+		!launch.LaunchContext.Headless ||
+		!launch.LaunchContext.FlowLaunchTracked {
+		t.Fatalf("active Flow launch context = %#v", launch.LaunchContext)
+	}
+}
+
 func TestModel_EnterTogglesActiveFlowPhaseRows(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -217,6 +217,28 @@ func TestModel_F3ActiveFlowLKeyNavigatesLikeRightArrow(t *testing.T) {
 	}
 }
 
+func TestModel_F3ActiveFlowLeftKeyPreservesUnderlyingMode(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
+	if cmd != nil {
+		t.Fatalf("left from active Flow surface returned command %T, want nil", cmd)
+	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("left from active Flow surface left active pane = %d, want left pane", m.ActivePane())
+	}
+	if m.Mode() != ui.ModeSessions {
+		t.Fatalf("left from active Flow surface changed underlying mode = %d, want sessions", m.Mode())
+	}
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Active flows") {
+		t.Fatalf("left from active Flow surface should keep active Flow view visible:\n%s", view)
+	}
+}
+
 func TestModel_F3ActiveFlowFetchErrorUsesActiveFetchMode(t *testing.T) {
 	m := flowsInRightPane(t, model.New(testRepos()), nil)
 	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 18})

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -216,6 +216,30 @@ func TestModel_F3ActiveFlowLKeyNavigatesLikeRightArrow(t *testing.T) {
 	}
 }
 
+func TestModel_F3ActiveFlowFetchErrorUsesActiveFetchMode(t *testing.T) {
+	m := flowsInRightPane(t, model.New(testRepos()), nil)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 18})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath:    "/dev/alpha",
+		Pane:        "flows",
+		Err:         "failed to load flows: boom",
+		Kind:        model.FetchList,
+		Mode:        ui.ModeFlows,
+		ListRequest: m.ListRequest(ui.ModeFlows),
+	})
+
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "failed to load flows: boom") {
+		t.Fatalf("active Flow surface should show Flow fetch failure in status bar:\n%s", view)
+	}
+	if !strings.Contains(view, "Could not load flows; see status bar") {
+		t.Fatalf("empty active Flow surface should show Flow fetch failure placeholder:\n%s", view)
+	}
+}
+
 func TestModel_EnterTogglesActiveFlowPhaseRows(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
@@ -363,8 +387,54 @@ func TestModel_InteractiveActiveFlowLaunchFocusesEmbeddedTerminal(t *testing.T) 
 	}
 }
 
+func TestModel_F3PassesThroughFocusedActiveFlowTerminal(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
+	flow := flowWithPhaseDetails()
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updated := flow
+			for i := range updated.Phases {
+				if updated.Phases[i].PhaseID == update.PhaseID {
+					updated.Phases[i].Status = flowstore.PhaseRunning
+					updated.Phases[i].LaunchIDs = append(updated.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return updated, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return fakeTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	m, cmd := update(m, flowCtrlJKey())
+	if cmd == nil {
+		t.Fatal("expected active Flow launch command")
+	}
+	launchMsg, ok := cmd().(model.FlowEmbeddedLaunchRequestedMsg)
+	if !ok {
+		t.Fatalf("command returned non-launch message")
+	}
+	m, _ = update(m, launchMsg)
+	writeCount := len(fakeTerm.writes)
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	if cmd != nil {
+		t.Fatalf("F3 in focused active Flow terminal returned command %T, want nil", cmd)
+	}
+	if len(fakeTerm.writes) != writeCount+1 || fakeTerm.writes[len(fakeTerm.writes)-1] != "\x1bOR" {
+		t.Fatalf("focused active Flow terminal F3 writes = %#v, want F3 escape sequence", fakeTerm.writes)
+	}
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Active flows") {
+		t.Fatalf("F3 in focused active Flow terminal should not toggle active Flow surface:\n%s", view)
+	}
+}
+
 func TestModel_ActiveFlowLaunchOverSessionsUsesFlowTerminal(t *testing.T) {
-	var sessionTerm *fakeEmbeddedTerminal
 	var flowTerm *fakeEmbeddedTerminal
 	flow := flowWithPhaseDetails()
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -380,10 +450,6 @@ func TestModel_ActiveFlowLaunchOverSessionsUsesFlowTerminal(t *testing.T) {
 			return updated, nil
 		},
 		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
-			if ctx.FlowID == "" {
-				sessionTerm = &fakeEmbeddedTerminal{state: "running", lines: []string{"session-terminal"}}
-				return sessionTerm, nil
-			}
 			flowTerm = &fakeEmbeddedTerminal{state: "running"}
 			return flowTerm, nil
 		},
@@ -393,15 +459,11 @@ func TestModel_ActiveFlowLaunchOverSessionsUsesFlowTerminal(t *testing.T) {
 	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{
 		{Provider: sessions.ProviderCodex, SessionID: "codex-session-1", RepoPath: "/dev/alpha", WorktreePath: "/dev/alpha-worktrees/session"},
 	}, ListRequest: m.ListRequest(ui.ModeSessions)})
-	m, sessionTick := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
-	if sessionTick == nil || sessionTerm == nil {
-		t.Fatal("expected session resume to start a session embedded terminal")
-	}
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
 	view := ansi.Strip(m.View())
-	if !strings.Contains(view, "flow/with-phases") || strings.Contains(view, "session-terminal") {
-		t.Fatalf("active flows should visually override session terminal:\n%s", view)
+	if !strings.Contains(view, "flow/with-phases") || strings.Contains(view, "codex-session-1") {
+		t.Fatalf("active flows should visually override sessions mode:\n%s", view)
 	}
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
 	m, cmd := update(m, flowCtrlJKey())
@@ -421,9 +483,6 @@ func TestModel_ActiveFlowLaunchOverSessionsUsesFlowTerminal(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
 	if len(flowTerm.writes) == 0 || flowTerm.writes[len(flowTerm.writes)-1] != "z" {
 		t.Fatalf("active Flow input over Sessions should go to flow terminal: %#v", flowTerm.writes)
-	}
-	if len(sessionTerm.writes) != 0 {
-		t.Fatalf("active Flow input over Sessions should not go to session terminal: %#v", sessionTerm.writes)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -885,8 +885,11 @@ func (m Model) handleDelete() (tea.Model, tea.Cmd) {
 	if !m.destructive {
 		return m, nil
 	}
-	if m.flowSurfaceVisible() && len(m.currentFilteredFlows()) > 0 && len(m.filteredRepos()) > 0 {
-		return m.confirmFlowDelete()
+	if m.flowSurfaceVisible() {
+		if len(m.currentFilteredFlows()) > 0 && len(m.filteredRepos()) > 0 {
+			return m.confirmFlowDelete()
+		}
+		return m, nil
 	}
 	if m.mode == ui.ModeHistory || m.mode == ui.ModeReflog {
 		return m, nil

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -488,7 +488,9 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 	case "down", "j":
 		return m.handleCursorDown()
 	case "left":
-		return m.handleHorizontalNavigation(-1)
+		m.activePane = 0
+		m = m.clearSelectedFlowPhase()
+		return m, nil
 	case "right", "l":
 		return m.handleHorizontalNavigation(1)
 	case "h":

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -53,7 +53,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if key == "f3" {
 		return m.toggleActiveFlowsSurface()
 	}
-	if m.activeFlowSurfaceVisible() && isNumberedModeKey(key) {
+	if !m.searchActive && m.activeFlowSurfaceVisible() && isNumberedModeKey(key) {
 		next, cmd, handled := m.switchModeFromKey(key)
 		if handled {
 			return next, cmd
@@ -891,14 +891,14 @@ func (m Model) handleDelete() (tea.Model, tea.Cmd) {
 	if !m.destructive {
 		return m, nil
 	}
+	if m.flowSurfaceVisible() && len(m.currentFilteredFlows()) > 0 && len(m.filteredRepos()) > 0 {
+		return m.confirmFlowDelete()
+	}
 	if m.mode == ui.ModeHistory || m.mode == ui.ModeReflog {
 		return m, nil
 	}
 	if m.mode == ui.ModeStashes && len(m.filteredStashes()) > 0 && len(m.filteredRepos()) > 0 {
 		return m.confirmStashDrop()
-	}
-	if m.flowSurfaceVisible() && len(m.currentFilteredFlows()) > 0 && len(m.filteredRepos()) > 0 {
-		return m.confirmFlowDelete()
 	}
 	if m.mode == ui.ModeBranches && len(m.filteredRepos()) > 0 {
 		return m.confirmBranchDelete()

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -600,8 +600,9 @@ func (m Model) handleCursorDown() (tea.Model, tea.Cmd) {
 // moveCursor moves the selected item in the active right-pane view by delta
 // (-1 for up, +1 for down) and keeps the new selection visible.
 func (m Model) moveCursor(delta int) Model {
-	h, w := m.contentHeightForMode(), m.contentWidth()
+	w := m.contentWidth()
 	if m.activeFlowSurfaceVisible() {
+		h := m.flowSurfaceContentHeight()
 		if next, ok := m.moveSelectedFlowPhase(delta); ok {
 			return next
 		}
@@ -620,6 +621,7 @@ func (m Model) moveCursor(delta int) Model {
 		m = m.syncActiveFlowTerminalToSelectedFlow()
 		return m
 	}
+	h := m.contentHeightForMode()
 	switch m.mode {
 	case ui.ModeWorktrees:
 		if m.inlineWorktreeSessionPath != "" {
@@ -768,7 +770,7 @@ func (m Model) handleToggleFlowPhases() (tea.Model, tea.Cmd) {
 	if flowID == "" {
 		return m, nil
 	}
-	if m.expandedFlowID == flowID {
+	if m.currentExpandedFlowID() == flowID {
 		m = m.setExpandedFlowID("")
 	} else {
 		m = m.setExpandedFlowID(flowID)
@@ -1180,7 +1182,7 @@ func (m Model) handleFlowCreateFailed(msg FlowCreateFailedMsg) (Model, tea.Cmd) 
 		errText = "Unable to create flow"
 	}
 	m = m.setStatus(statusOther, errText)
-	if m.mode == ui.ModeFlows {
+	if m.flowSurfaceVisible() {
 		return m.startFetchMode(ui.ModeFlows)
 	}
 	return m, nil
@@ -1326,7 +1328,7 @@ func (m Model) canLaunchAgent() bool {
 	if m.activePane != 1 {
 		return false
 	}
-	if m.mode == ui.ModeFlows {
+	if m.flowSurfaceVisible() {
 		_, ok := m.selectedFlow()
 		return ok
 	}
@@ -1579,11 +1581,11 @@ func (m Model) handleResumeSession() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleResumeFlowPhaseSession() (tea.Model, tea.Cmd) {
-	if m.mode != ui.ModeFlows {
+	if !m.flowSurfaceVisible() {
 		return m, nil
 	}
 	record, ok := m.selectedFlow()
-	if !ok || record.FlowID == "" || record.FlowID != m.expandedFlowID || m.selectedFlowPhaseID == "" {
+	if !ok || record.FlowID == "" || record.FlowID != m.currentExpandedFlowID() || m.currentSelectedFlowPhaseID() == "" {
 		return m, nil
 	}
 	phase, ok := m.selectedFlowPhase()
@@ -1883,7 +1885,7 @@ func (m Model) launchFlowEmbeddedWithContext(ctx actions.AgentLaunchContext) (Mo
 }
 
 func (m Model) updateFlowTerminalFocusAfterLaunch(ctx actions.AgentLaunchContext) Model {
-	if m.mode != ui.ModeFlows {
+	if !m.flowSurfaceVisible() {
 		return m
 	}
 	if ctx.Headless {
@@ -1927,7 +1929,7 @@ func (m Model) launchTrackedFlowPhaseResumeWithContext(ctx actions.AgentLaunchCo
 		}
 		next, errText = next.markFlowLaunchNeedsAttention(ctx, errText)
 		next = next.setStatus(statusOther, errText)
-		if next.mode == ui.ModeFlows {
+		if next.flowSurfaceVisible() {
 			next, fetchCmd := next.startFetchMode(ui.ModeFlows)
 			return next, fetchCmd
 		}
@@ -1938,7 +1940,7 @@ func (m Model) launchTrackedFlowPhaseResumeWithContext(ctx actions.AgentLaunchCo
 	if needsTick {
 		next, launchCmd = next.startEmbeddedTerminalTick()
 	}
-	if next.mode == ui.ModeFlows {
+	if next.flowSurfaceVisible() {
 		next, fetchCmd := next.startFetchMode(ui.ModeFlows)
 		return next, tea.Batch(fetchCmd, launchCmd)
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -46,6 +46,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
+	if key == "f3" {
+		return m.toggleActiveFlowsSurface()
+	}
+	if m.activeFlowSurfaceVisible() && isNumberedModeKey(key) {
+		next, cmd, handled := m.switchModeFromKey(key)
+		if handled {
+			return next, cmd
+		}
+	}
+
 	if next, cmd, handled := m.handleEmbeddedTerminalKey(msg); handled {
 		return next, cmd
 	}
@@ -271,6 +281,9 @@ func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
+	if m.activeFlowSurfaceVisible() {
+		return m.handleActiveFlowSurfaceKey(key)
+	}
 	switch key {
 	case "up", "k":
 		return m.handleCursorUp()
@@ -468,12 +481,69 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
+	switch key {
+	case "up", "k":
+		return m.handleCursorUp()
+	case "down", "j":
+		return m.handleCursorDown()
+	case "left":
+		return m.handleHorizontalNavigation(-1)
+	case "right":
+		return m.handleHorizontalNavigation(1)
+	case "h":
+		return m.handleToggleFlowHeadless()
+	case "tab":
+		if m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
+			m.flowFocus = flowFocusTerminal
+			m.terminalPrefixActive = true
+			return m, nil
+		}
+		m.activePane = 0
+		m = m.clearSelectedFlowPhase()
+	case "ctrl+j":
+		return m.handleLaunchNextFlowPhase()
+	case "enter":
+		return m.handleFlowEnter()
+	case "n":
+		return m.handleNewFlow()
+	case "o":
+		return m.handleOpenFlowPlanText()
+	case "m":
+		return m.handleToggleFlowAutoMode()
+	case "y":
+		return m.handleCopyFlowWorktreePath()
+	case "r":
+		return m.handleResumeFlowPhaseSession()
+	case "E":
+		return m.handleSetReasoningEffort()
+	case "x":
+		return m.handleResetSelectedFlowPhase()
+	case "d":
+		return m.handleDelete()
+	case "f":
+		return m.handleFetch()
+	case "F":
+		return m.handlePull()
+	case "t":
+		return m.handleOpenTerminal()
+	case "c":
+		return m.handleOpenCode()
+	case "q", "ctrl+c", "esc":
+		return m.handleEmbeddedTerminalQuitPrefix()
+	}
+	return m, nil
+}
+
 func (m Model) handleHorizontalNavigation(direction int) (tea.Model, tea.Cmd) {
 	if direction == 0 {
 		return m, nil
 	}
 	if m.activePane == 0 {
 		m.activePane = 1
+		if m.activeFlowSurfaceVisible() {
+			return m, nil
+		}
 		targetMode := ui.ModeWorktrees
 		if direction < 0 {
 			targetMode = ui.ModeFlows
@@ -490,6 +560,11 @@ func (m Model) handleHorizontalNavigation(direction int) (tea.Model, tea.Cmd) {
 	}
 
 	if direction > 0 {
+		if m.activeFlowSurfaceVisible() {
+			m.activePane = 0
+			m = m.clearSelectedFlowPhase()
+			return m, nil
+		}
 		if m.mode == ui.ModeFlows {
 			m.activePane = 0
 			m = m.clearSelectedFlowPhase()
@@ -526,6 +601,25 @@ func (m Model) handleCursorDown() (tea.Model, tea.Cmd) {
 // (-1 for up, +1 for down) and keeps the new selection visible.
 func (m Model) moveCursor(delta int) Model {
 	h, w := m.contentHeightForMode(), m.contentWidth()
+	if m.activeFlowSurfaceVisible() {
+		if next, ok := m.moveSelectedFlowPhase(delta); ok {
+			return next
+		}
+		if m.canScrollExpandedFlow(delta, h) {
+			m.activeFlows = m.activeFlows.ScrollBy(delta, h, w)
+			return m
+		}
+		if m.activeFlows.Len() <= 1 {
+			return m
+		}
+		before := m.selectedFlowID()
+		m.activeFlows = m.activeFlows.Move(delta, h, w)
+		if after := m.selectedFlowID(); before != "" && after != before {
+			m = m.setExpandedFlowID("")
+		}
+		m = m.syncActiveFlowTerminalToSelectedFlow()
+		return m
+	}
 	switch m.mode {
 	case ui.ModeWorktrees:
 		if m.inlineWorktreeSessionPath != "" {
@@ -643,7 +737,7 @@ func (m Model) handleFlowEnter() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleToggleFlowHeadless() (tea.Model, tea.Cmd) {
-	if m.mode != ui.ModeFlows {
+	if !m.flowSurfaceVisible() {
 		return m, nil
 	}
 	m.flowHeadless = !m.flowHeadless
@@ -667,7 +761,7 @@ func (m Model) handleTogglePlanPhases() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleToggleFlowPhases() (tea.Model, tea.Cmd) {
-	if m.mode != ui.ModeFlows || len(m.filteredFlows()) == 0 {
+	if !m.flowSurfaceVisible() || len(m.currentFilteredFlows()) == 0 {
 		return m, nil
 	}
 	flowID := m.selectedFlowID()
@@ -683,7 +777,7 @@ func (m Model) handleToggleFlowPhases() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleToggleFlowAutoMode() (tea.Model, tea.Cmd) {
-	if m.mode != ui.ModeFlows || len(m.filteredFlows()) == 0 {
+	if !m.flowSurfaceVisible() || len(m.currentFilteredFlows()) == 0 {
 		return m, nil
 	}
 	record, ok := m.selectedFlow()
@@ -751,7 +845,7 @@ func (m Model) handleOpenPlanText() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleOpenFlowPlanText() (tea.Model, tea.Cmd) {
-	if m.mode != ui.ModeFlows || len(m.filteredFlows()) == 0 {
+	if !m.flowSurfaceVisible() || len(m.currentFilteredFlows()) == 0 {
 		return m, nil
 	}
 	record, ok := m.selectedFlow()
@@ -801,7 +895,7 @@ func (m Model) handleDelete() (tea.Model, tea.Cmd) {
 	if m.mode == ui.ModeStashes && len(m.filteredStashes()) > 0 && len(m.filteredRepos()) > 0 {
 		return m.confirmStashDrop()
 	}
-	if m.mode == ui.ModeFlows && len(m.filteredFlows()) > 0 && len(m.filteredRepos()) > 0 {
+	if m.flowSurfaceVisible() && len(m.currentFilteredFlows()) > 0 && len(m.filteredRepos()) > 0 {
 		return m.confirmFlowDelete()
 	}
 	if m.mode == ui.ModeBranches && len(m.filteredRepos()) > 0 {
@@ -2129,7 +2223,7 @@ func (m Model) confirmWorktreeDelete() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) confirmFlowDelete() (tea.Model, tea.Cmd) {
-	if m.mode != ui.ModeFlows {
+	if !m.flowSurfaceVisible() {
 		return m, nil
 	}
 	if _, ok := m.selectedFlowPhase(); ok {
@@ -2201,8 +2295,14 @@ func (m Model) resetModeCursors() Model {
 	m.sessions = m.sessions.ResetSelection()
 	m.plans = m.plans.ResetSelection()
 	m.flows = m.flows.ResetSelection()
+	m.activeFlows = m.activeFlows.ResetSelection()
 	m = m.setExpandedPlanID("")
-	m = m.setExpandedFlowID("")
+	m.expandedFlowID = ""
+	m.selectedFlowPhaseID = ""
+	m.flows = m.flows.SetItemHeight(flowItemHeight(""))
+	m.expandedActiveFlowID = ""
+	m.selectedActiveFlowPhaseID = ""
+	m.activeFlows = m.activeFlows.SetItemHeight(flowItemHeight(""))
 	m.flowFocus = flowFocusList
 	m.terminalPrefixActive = false
 	m = m.clearInlineWorktreeSessions()
@@ -2222,8 +2322,14 @@ func (m Model) resetRightPaneCursors() Model {
 	m.sessions = m.sessions.SetItems(nil).ResetSelection()
 	m.plans = m.plans.SetItems(nil).ResetSelection()
 	m.flows = m.flows.SetItems(nil).ResetSelection()
+	m.activeFlows = m.activeFlows.SetItems(nil).ResetSelection()
 	m = m.setExpandedPlanID("")
-	m = m.setExpandedFlowID("")
+	m.expandedFlowID = ""
+	m.selectedFlowPhaseID = ""
+	m.flows = m.flows.SetItemHeight(flowItemHeight(""))
+	m.expandedActiveFlowID = ""
+	m.selectedActiveFlowPhaseID = ""
+	m.activeFlows = m.activeFlows.SetItemHeight(flowItemHeight(""))
 	m.flowFocus = flowFocusList
 	m.terminalPrefixActive = false
 	m = m.clearInlineWorktreeSessions()

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -521,14 +521,6 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleResetSelectedFlowPhase()
 	case "d":
 		return m.handleDelete()
-	case "f":
-		return m.handleFetch()
-	case "F":
-		return m.handlePull()
-	case "t":
-		return m.handleOpenTerminal()
-	case "c":
-		return m.handleOpenCode()
 	case "q", "ctrl+c", "esc":
 		return m.handleEmbeddedTerminalQuitPrefix()
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -489,7 +489,7 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleCursorDown()
 	case "left":
 		return m.handleHorizontalNavigation(-1)
-	case "right":
+	case "right", "l":
 		return m.handleHorizontalNavigation(1)
 	case "h":
 		return m.handleToggleFlowHeadless()

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -46,6 +46,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 
+	if next, cmd, handled := m.handleEmbeddedTerminalKey(msg); handled {
+		return next, cmd
+	}
+
 	if key == "f3" {
 		return m.toggleActiveFlowsSurface()
 	}
@@ -54,10 +58,6 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if handled {
 			return next, cmd
 		}
-	}
-
-	if next, cmd, handled := m.handleEmbeddedTerminalKey(msg); handled {
-		return next, cmd
 	}
 
 	m = m.clearAnyStatus()

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1228,9 +1228,6 @@ func (m Model) handleFlowResult(msg FlowResultMsg) (Model, tea.Cmd) {
 	if m.flowFocus != flowFocusTerminal {
 		m = m.syncActiveFlowTerminalToSelectedFlow()
 	}
-	if m.activeFlowSurfaceVisible() {
-		return m, nil
-	}
 	var cmds []tea.Cmd
 	var autoCmd tea.Cmd
 	m, autoCmd = m.prepareAutoFlowPhaseLaunch(previousFlows, msg.Flows)

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1475,7 +1475,7 @@ func (m Model) fetchErrorMatchesCurrentTarget(msg FetchErrorMsg) bool {
 				msg.ListRequest == m.activeWorktreeSessionReq &&
 				msg.WorktreePath == m.inlineWorktreeSessionPath
 		}
-		return msg.Mode == m.mode && m.isCurrentListRequest(msg.Mode, msg.ListRequest)
+		return msg.Mode == m.activeContentFetchMode() && m.isCurrentListRequest(msg.Mode, msg.ListRequest)
 	case FetchWorktreeDiff:
 		if !m.activeViewMatches(FetchWorktreeDiff, ui.ModeWorktrees, msg.DiffRequest) {
 			return false

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1207,7 +1207,10 @@ func (m Model) handleFlowResult(msg FlowResultMsg) (Model, tea.Cmd) {
 		return m, nil
 	}
 	previousFlows := append([]flowstore.FlowRecord(nil), m.flows.Items()...)
-	selectedFlowID := m.selectedFlowID()
+	selectedFlowID := ""
+	if record, ok := m.flows.Selected(); ok {
+		selectedFlowID = record.FlowID
+	}
 	expandedFlowID := m.expandedFlowID
 	selectedFlowPhaseID := m.selectedFlowPhaseID
 	m.flows = m.flows.SetItems(msg.Flows)
@@ -1260,7 +1263,10 @@ func (m Model) replaceFlowRecord(flow flowstore.FlowRecord) Model {
 	if flow.FlowID == "" {
 		return m
 	}
-	selectedFlowID := m.selectedFlowID()
+	selectedFlowID := ""
+	if record, ok := m.flows.Selected(); ok {
+		selectedFlowID = record.FlowID
+	}
 	expandedFlowID := m.expandedFlowID
 	selectedFlowPhaseID := m.selectedFlowPhaseID
 	items := append([]flowstore.FlowRecord(nil), m.flows.Items()...)
@@ -1614,7 +1620,7 @@ func (m Model) handleCopyPlanPath() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleCopyFlowWorktreePath() (tea.Model, tea.Cmd) {
-	if m.mode != ui.ModeFlows {
+	if !m.flowSurfaceVisible() {
 		return m, nil
 	}
 	flow, ok := m.selectedFlow()

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1217,12 +1217,16 @@ func (m Model) handleFlowResult(msg FlowResultMsg) (Model, tea.Cmd) {
 		})
 	}
 	m = m.restoreExpandedFlowSelection(expandedFlowID, selectedFlowPhaseID)
+	m = m.syncActiveFlowsFromCache()
 	m = m.clampSelectionsAfterFilter()
-	if m.mode != ui.ModeFlows {
+	if !m.flowSurfaceVisible() {
 		return m, nil
 	}
 	if m.flowFocus != flowFocusTerminal {
 		m = m.syncActiveFlowTerminalToSelectedFlow()
+	}
+	if m.activeFlowSurfaceVisible() {
+		return m, nil
 	}
 	var cmds []tea.Cmd
 	var autoCmd tea.Cmd
@@ -1278,6 +1282,7 @@ func (m Model) replaceFlowRecord(flow flowstore.FlowRecord) Model {
 		})
 	}
 	m = m.restoreExpandedFlowSelection(expandedFlowID, selectedFlowPhaseID)
+	m = m.syncActiveFlowsFromCache()
 	return m.clampSelectionsAfterFilter()
 }
 
@@ -1335,10 +1340,20 @@ func (m Model) clearDeletedFlowState(flowID string) Model {
 		return m
 	}
 	if m.expandedFlowID == flowID {
-		m = m.setExpandedFlowID("")
+		m.expandedFlowID = ""
+		m.selectedFlowPhaseID = ""
+		m.flows = m.flows.SetItemHeight(flowItemHeight(""))
 	}
-	if selectedID := m.selectedFlowID(); selectedID == flowID {
-		m = m.clearSelectedFlowPhase()
+	if m.expandedActiveFlowID == flowID {
+		m.expandedActiveFlowID = ""
+		m.selectedActiveFlowPhaseID = ""
+		m.activeFlows = m.activeFlows.SetItemHeight(flowItemHeight(""))
+	}
+	if record, ok := m.flows.Selected(); ok && record.FlowID == flowID {
+		m.selectedFlowPhaseID = ""
+	}
+	if record, ok := m.activeFlows.Selected(); ok && record.FlowID == flowID {
+		m.selectedActiveFlowPhaseID = ""
 	}
 	return m
 }
@@ -1356,22 +1371,34 @@ func flowDisplayName(title, flowID string) string {
 
 func (m Model) restoreExpandedFlowSelection(flowID, phaseID string) Model {
 	if flowID == "" {
-		return m.setExpandedFlowID("")
+		m.expandedFlowID = ""
+		m.selectedFlowPhaseID = ""
+		m.flows = m.flows.SetItemHeight(flowItemHeight(""))
+		return m
 	}
-	record, ok := m.selectedFlow()
+	record, ok := m.flows.Selected()
 	if !ok || record.FlowID != flowID {
-		return m.setExpandedFlowID("")
+		m.expandedFlowID = ""
+		m.selectedFlowPhaseID = ""
+		m.flows = m.flows.SetItemHeight(flowItemHeight(""))
+		return m
 	}
 	if phaseID != "" {
 		phase, ok := flowRecordPhaseByID(record, phaseID)
 		if !ok {
-			return m.setExpandedFlowID("")
+			m.expandedFlowID = ""
+			m.selectedFlowPhaseID = ""
+			m.flows = m.flows.SetItemHeight(flowItemHeight(""))
+			return m
 		}
 		phaseID = phase.PhaseID
 	}
 	m.expandedFlowID = flowID
 	m.selectedFlowPhaseID = phaseID
 	m.flows = m.flows.SetItemHeight(flowItemHeight(flowID))
+	if m.activeFlowSurfaceVisible() {
+		return m
+	}
 	return m.reflowFlows()
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -220,6 +220,7 @@ type RenderParams struct {
 	Width                       int
 	Height                      int
 	Mode                        Mode
+	ActiveFlows                 bool
 	Branches                    []gitquery.BranchRow
 	Stashes                     []gitquery.Stash
 	BranchSelected              int
@@ -445,11 +446,12 @@ func renderApplication(p RenderParams) string {
 	commitSelected := p.Mode == ModeHistory && p.CommitSelected >= 0 && p.CommitSelected < len(p.Commits)
 	reflogSelected := p.Mode == ModeReflog && p.ReflogSelected >= 0 && p.ReflogSelected < len(p.Reflogs)
 	embeddedTerminalActive := p.Mode == ModeSessions && len(p.EmbeddedTerminals) > 0
-	flowEmbeddedTerminalActive := p.Mode == ModeFlows && len(p.FlowEmbeddedTerminals) > 0
+	flowSurfaceActive := p.Mode == ModeFlows || p.ActiveFlows
+	flowEmbeddedTerminalActive := flowSurfaceActive && len(p.FlowEmbeddedTerminals) > 0
 	terminalShortcutsActive := embeddedTerminalActive || (flowEmbeddedTerminalActive && p.FlowTerminalFocused)
 	sessionSelected := p.Mode == ModeSessions && !embeddedTerminalActive && p.SessionSelected >= 0 && p.SessionSelected < len(p.Sessions)
 	planSelected := p.Mode == ModePlans && p.PlanSelected >= 0 && p.PlanSelected < len(p.Plans)
-	flowSelected := p.Mode == ModeFlows && p.FlowSelected >= 0 && p.FlowSelected < len(p.Flows)
+	flowSelected := flowSurfaceActive && p.FlowSelected >= 0 && p.FlowSelected < len(p.Flows)
 	flowPlanLinked := false
 	flowWorktreePathSelected := false
 	flowAutoModeSelected := false
@@ -474,6 +476,7 @@ func renderApplication(p RenderParams) string {
 	status := statusBarParams{
 		Width:                       p.Width,
 		Mode:                        p.Mode,
+		ActiveFlows:                 p.ActiveFlows,
 		Overlay:                     p.Overlay,
 		InputMode:                   inputRenderParamsFrom(p).mode,
 		FormHasMultiline:            formHasMultilineField(p.Form),
@@ -559,6 +562,9 @@ func renderApplication(p RenderParams) string {
 	rightContentWidth := RightContentWidth(p.Width, p.Height, activeStatusQuery)
 
 	modeHeader := renderModeHeader(p.Mode, rightContentWidth)
+	if p.ActiveFlows {
+		modeHeader = renderActiveFlowsHeader(rightContentWidth)
+	}
 	rightContentHeight := p.Height - BranchContentOverhead
 
 	// Hide cursor in right pane when left pane is active
@@ -605,9 +611,9 @@ func renderApplication(p RenderParams) string {
 		rightLines = renderSessionPane(p.Sessions, sessionSel, p.SessionScroll, rightContentWidth, rightContentHeight)
 	case p.Mode == ModePlans && len(p.Plans) > 0:
 		rightLines = renderPlanPane(p.Plans, planSel, p.PlanScroll, rightContentWidth, rightContentHeight, p.ExpandedPlanID, selectedPlanPhaseID)
-	case p.Mode == ModeFlows && len(p.FlowEmbeddedTerminals) > 0:
+	case flowSurfaceActive && len(p.FlowEmbeddedTerminals) > 0:
 		rightLines = renderFlowSplitPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.FlowEmbeddedTerminals, p.FlowEmbeddedTerminalLines, p.FlowEmbeddedTerminalPrefix, p.ActivePane == 1 && p.FlowTerminalFocused)
-	case p.Mode == ModeFlows && len(p.Flows) > 0:
+	case flowSurfaceActive && len(p.Flows) > 0:
 		rightLines = renderFlowPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity)
 	default:
 		rightLines = renderPlaceholderPane(rightContentWidth, rightContentHeight, p.RightEmptyMessage)
@@ -703,6 +709,12 @@ func renderModeHeader(mode Mode, width int) string {
 	return line + "\n" + separator
 }
 
+func renderActiveFlowsHeader(width int) string {
+	line := ansi.Truncate(" "+activeModeStyle.Render("F3 Active flows")+statusStyle.Render("  current repo, non-merged"), width, "")
+	separator := strings.Repeat("─", width)
+	return line + "\n" + separator
+}
+
 // RenderStatusBar produces the bottom status bar (hints only, no mode tabs).
 func RenderStatusBar(width int, mode Mode, overlay OverlayState, activePane int, destructive, staleSelected, dirtySelected bool) string {
 	fetchAvailable := activePane == 1 && (mode == ModeWorktrees || mode == ModeBranches)
@@ -740,6 +752,7 @@ func RenderStatusBar(width int, mode Mode, overlay OverlayState, activePane int,
 type statusBarParams struct {
 	Width                       int
 	Mode                        Mode
+	ActiveFlows                 bool
 	Overlay                     OverlayState
 	InputMode                   InputMode
 	FormHasMultiline            bool
@@ -909,10 +922,11 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 		modeStyle = statusStyle
 		groupStyle = statusStyle
 	}
-	title := titleStyle.Render("Shortcuts") + "  " + modeStyle.Render(modeShortcutTitle(sp.Mode))
+	title := titleStyle.Render("Shortcuts") + "  " + modeStyle.Render(modeShortcutTitleForStatus(sp))
 	lines = append(lines, ansi.Truncate(" "+title, width, ""))
 	compact := height <= 3
-	tight := height <= 7 || (sp.Mode == ModeFlows && height <= 14)
+	flowSurfaceActive := sp.Mode == ModeFlows || sp.ActiveFlows
+	tight := height <= 7 || (flowSurfaceActive && height <= 14)
 	if !compact && !tight {
 		lines = append(lines, strings.Repeat(" ", width))
 	}
@@ -1028,7 +1042,8 @@ func padShortcutKey(key string, width int) string {
 }
 
 func shortcutSections(sp statusBarParams) []shortcutSection {
-	if (sp.Mode == ModeSessions || sp.Mode == ModeFlows) && sp.EmbeddedTerminalActive {
+	flowSurfaceActive := sp.Mode == ModeFlows || sp.ActiveFlows
+	if (sp.Mode == ModeSessions || flowSurfaceActive) && sp.EmbeddedTerminalActive {
 		hints := []shortcutHint{{Key: "ctrl+]", Label: "commands"}}
 		if sp.EmbeddedTerminalPrefix {
 			hints = []shortcutHint{
@@ -1062,19 +1077,21 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 		{Key: "tab", Label: "pane"},
 		{Key: "q/esc", Label: "quit"},
 		{Key: "f5", Label: "refresh"},
+		{Key: "f3", Label: "active flows"},
 	}
-	if sp.Mode != ModeFlows {
+	if !flowSurfaceActive {
 		global = slices.Insert(global, 2, shortcutHint{Key: "A", Label: "set agent"})
 	}
 
 	var actions []shortcutHint
-	var flowModeControls []shortcutHint
-	var flowAgentControls []shortcutHint
 	if sp.ActivePane == 0 && sp.FetchVisibleAvailable {
 		actions = append(actions, shortcutHint{Key: "f", Label: "fetch visible"})
 	}
 	if sp.ActivePane == 0 && sp.RepoCreateAvailable {
 		actions = append(actions, shortcutHint{Key: "n", Label: "new repo"})
+	}
+	if flowSurfaceActive {
+		return flowShortcutSections(sp, actions, navigation, global)
 	}
 	switch sp.Mode {
 	case ModeWorktrees:
@@ -1202,56 +1219,8 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 				shortcutHint{Key: "y", Label: "copy path"},
 			)
 		}
-	case ModeFlows:
-		if sp.ActivePane == 1 && sp.RepoSelected {
-			actions = append(actions, shortcutHint{Key: "n", Label: "new flow"})
-			headlessLabel := "headless off"
-			headlessSuccessSuffix := ""
-			if sp.FlowHeadless {
-				headlessLabel = "headless on"
-				headlessSuccessSuffix = "on"
-			}
-			flowModeControls = append(flowModeControls, shortcutHint{Key: "h", Label: headlessLabel, SuccessSuffix: headlessSuccessSuffix})
-			if sp.FlowSelected {
-				if sp.FlowPhaseSelected {
-					actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
-					if sp.FlowNextLaunchReady {
-						actions = append(actions, shortcutHint{Key: "ctrl+j", Label: "launch next"})
-					}
-					if sp.FlowPhaseResetReadySelected {
-						actions = append(actions, shortcutHint{Key: "x", Label: "reset ready"})
-					}
-					if sp.FlowWorktreePathSelected {
-						actions = append(actions, shortcutHint{Key: "y", Label: "copy path"})
-					}
-					if sp.FlowPhaseResumableSelected {
-						actions = append(actions, shortcutHint{Key: "r", Label: "resume"})
-					}
-				} else {
-					actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
-					if sp.FlowNextLaunchReady {
-						actions = append(actions, shortcutHint{Key: "ctrl+j", Label: "launch next"})
-					}
-					if sp.FlowPlanLinked {
-						actions = append(actions, shortcutHint{Key: "o", Label: "open"})
-					}
-					if sp.FlowWorktreePathSelected {
-						actions = append(actions, shortcutHint{Key: "y", Label: "copy path"})
-					}
-					if sp.Destructive && sp.FlowDeletableSelected {
-						actions = append(actions, shortcutHint{Key: "d", Label: "delete", Warning: true})
-					}
-				}
-				flowModeControls = append(flowModeControls, flowAutoModeShortcutHint(sp.FlowAutoModeSelected))
-			}
-		}
-		agentLabel, agentConfigured := flowAgentShortcut(sp.FlowAgentLabel)
-		flowAgentControls = append(flowAgentControls, shortcutHint{Key: "A", Label: agentLabel})
-		if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); agentConfigured && effortLabel != "" {
-			flowAgentControls = append(flowAgentControls, shortcutHint{Key: "E", Label: effortLabel})
-		}
 	}
-	if sp.ActivePane == 1 && sp.Mode != ModeWorktrees && sp.Mode != ModeBranches {
+	if sp.ActivePane == 1 && sp.Mode != ModeWorktrees && sp.Mode != ModeBranches && !sp.ActiveFlows {
 		if sp.FetchAvailable {
 			actions = append(actions, shortcutHint{Key: "f", Label: "fetch"})
 		}
@@ -1259,22 +1228,8 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 			actions = append(actions, shortcutHint{Key: "F", Label: "pull"})
 		}
 	}
-	if !sp.Destructive && (sp.Mode == ModeWorktrees || sp.Mode == ModeBranches || sp.Mode == ModeStashes || sp.Mode == ModeFlows) {
+	if !sp.Destructive && (sp.Mode == ModeWorktrees || sp.Mode == ModeBranches || sp.Mode == ModeStashes) {
 		actions = append([]shortcutHint{{Key: "D", Label: "destructive mode"}}, actions...)
-	}
-	if sp.Mode == ModeFlows {
-		var sections []shortcutSection
-		if len(actions) > 0 {
-			sections = append(sections, shortcutSection{Title: "Actions", Hints: actions})
-		}
-		if len(flowModeControls) > 0 {
-			sections = append(sections, shortcutSection{Title: "Mode", Hints: flowModeControls})
-		}
-		if len(flowAgentControls) > 0 {
-			sections = append(sections, shortcutSection{Title: "Agent", Hints: flowAgentControls})
-		}
-		sections = append(sections, shortcutSection{Title: "Global", Hints: append(navigation, global...)})
-		return sections
 	}
 	var sections []shortcutSection
 	if len(actions) > 0 {
@@ -1304,6 +1259,63 @@ func flowAutoModeShortcutHint(enabled bool) shortcutHint {
 	return shortcutHint{Key: "m", Label: "auto: off"}
 }
 
+func flowShortcutSections(sp statusBarParams, actions, navigation, global []shortcutHint) []shortcutSection {
+	var flowModeControls []shortcutHint
+	var flowAgentControls []shortcutHint
+	if sp.ActivePane == 1 && sp.RepoSelected {
+		actions = append(actions, shortcutHint{Key: "n", Label: "new flow"})
+		headlessLabel := "headless off"
+		headlessSuccessSuffix := ""
+		if sp.FlowHeadless {
+			headlessLabel = "headless on"
+			headlessSuccessSuffix = "on"
+		}
+		flowModeControls = append(flowModeControls, shortcutHint{Key: "h", Label: headlessLabel, SuccessSuffix: headlessSuccessSuffix})
+		if sp.FlowSelected {
+			actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
+			if sp.FlowNextLaunchReady {
+				actions = append(actions, shortcutHint{Key: "ctrl+j", Label: "launch next"})
+			}
+			if sp.FlowPhaseSelected && sp.FlowPhaseResetReadySelected {
+				actions = append(actions, shortcutHint{Key: "x", Label: "reset ready"})
+			}
+			if !sp.FlowPhaseSelected && sp.FlowPlanLinked {
+				actions = append(actions, shortcutHint{Key: "o", Label: "open"})
+			}
+			if sp.FlowWorktreePathSelected {
+				actions = append(actions, shortcutHint{Key: "y", Label: "copy path"})
+			}
+			if sp.FlowPhaseSelected && sp.FlowPhaseResumableSelected {
+				actions = append(actions, shortcutHint{Key: "r", Label: "resume"})
+			}
+			if !sp.FlowPhaseSelected && sp.Destructive && sp.FlowDeletableSelected {
+				actions = append(actions, shortcutHint{Key: "d", Label: "delete", Warning: true})
+			}
+			flowModeControls = append(flowModeControls, flowAutoModeShortcutHint(sp.FlowAutoModeSelected))
+		}
+	}
+	if !sp.Destructive {
+		actions = append([]shortcutHint{{Key: "D", Label: "destructive mode"}}, actions...)
+	}
+	agentLabel, agentConfigured := flowAgentShortcut(sp.FlowAgentLabel)
+	flowAgentControls = append(flowAgentControls, shortcutHint{Key: "A", Label: agentLabel})
+	if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); agentConfigured && effortLabel != "" {
+		flowAgentControls = append(flowAgentControls, shortcutHint{Key: "E", Label: effortLabel})
+	}
+	var sections []shortcutSection
+	if len(actions) > 0 {
+		sections = append(sections, shortcutSection{Title: "Actions", Hints: actions})
+	}
+	if len(flowModeControls) > 0 {
+		sections = append(sections, shortcutSection{Title: "Mode", Hints: flowModeControls})
+	}
+	if len(flowAgentControls) > 0 {
+		sections = append(sections, shortcutSection{Title: "Agent", Hints: flowAgentControls})
+	}
+	sections = append(sections, shortcutSection{Title: "Global", Hints: append(navigation, global...)})
+	return sections
+}
+
 const flowChooseAgentLabel = "choose agent"
 
 func flowAgentShortcut(value string) (string, bool) {
@@ -1315,7 +1327,7 @@ func flowAgentShortcut(value string) (string, bool) {
 }
 
 func shortcutsMuted(sp statusBarParams) bool {
-	return (sp.Mode == ModeSessions || sp.Mode == ModeFlows) && sp.EmbeddedTerminalActive && !sp.EmbeddedTerminalPrefix
+	return (sp.Mode == ModeSessions || sp.Mode == ModeFlows || sp.ActiveFlows) && sp.EmbeddedTerminalActive && !sp.EmbeddedTerminalPrefix
 }
 
 func flowReasoningEffortShortcutLabel(value string) string {
@@ -1339,11 +1351,42 @@ func muteShortcutSections(sections []shortcutSection) []shortcutSection {
 
 func shortcutSectionsForPane(sp statusBarParams, height int) []shortcutSection {
 	sections := shortcutSections(sp)
-	if sp.Mode == ModeFlows && !sp.FlowSelected && height <= 9 {
+	if height < 20 && sp.Mode != ModeFlows && !sp.ActiveFlows {
+		sections = prioritizeShortcutInSection(sections, "Global", "A", "q/esc")
+	}
+	if (sp.Mode == ModeFlows || sp.ActiveFlows) && !sp.FlowSelected && height <= 9 {
 		sections = withoutShortcutKeys(sections, "D", "n", "f5")
 	}
 	if height < 20 {
 		return withoutShortcutKey(sections, "f5")
+	}
+	return sections
+}
+
+func prioritizeShortcutInSection(sections []shortcutSection, title, key, beforeKey string) []shortcutSection {
+	for si, section := range sections {
+		if section.Title != title {
+			continue
+		}
+		keyIndex := -1
+		beforeIndex := -1
+		for i, hint := range section.Hints {
+			if hint.Key == key {
+				keyIndex = i
+			}
+			if hint.Key == beforeKey {
+				beforeIndex = i
+			}
+		}
+		if keyIndex < 0 || beforeIndex < 0 || keyIndex < beforeIndex {
+			return sections
+		}
+		hint := section.Hints[keyIndex]
+		hints := append([]shortcutHint{}, section.Hints[:keyIndex]...)
+		hints = append(hints, section.Hints[keyIndex+1:]...)
+		hints = slices.Insert(hints, beforeIndex, hint)
+		sections[si].Hints = hints
+		return sections
 	}
 	return sections
 }
@@ -1382,7 +1425,7 @@ func renderFooterShortcuts(sp statusBarParams, sections []shortcutSection) strin
 	if sp.Mode == ModeBranches {
 		return renderBranchFooterShortcuts(sp, sections)
 	}
-	if sp.Mode == ModeFlows {
+	if sp.Mode == ModeFlows || sp.ActiveFlows {
 		return renderFlowFooterShortcuts(sp, sections)
 	}
 	return renderGenericFooterShortcuts(sp, sections)
@@ -1446,20 +1489,20 @@ func renderWorktreeFooterShortcuts(sp statusBarParams, sections []shortcutSectio
 func renderGenericFooterShortcuts(sp statusBarParams, sections []shortcutSection) string {
 	for _, drop := range [][]string{
 		{},
-		{"f5"},
-		{"f5", "A"},
-		{"f5", "A", "D"},
-		{"f5", "A", "D", "←/→"},
-		{"f5", "A", "D", "←/→", "↑/↓"},
-		{"f5", "A", "D", "←/→", "↑/↓", "q/esc"},
-		{"f5", "A", "D", "←/→", "↑/↓", "q/esc", "tab"},
+		{"f5", "f3"},
+		{"f5", "f3", "A"},
+		{"f5", "f3", "A", "D"},
+		{"f5", "f3", "A", "D", "←/→"},
+		{"f5", "f3", "A", "D", "←/→", "↑/↓"},
+		{"f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc"},
+		{"f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc", "tab"},
 	} {
 		candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, drop...)))
 		if lipgloss.Width(candidate) <= sp.Width {
 			return candidate
 		}
 	}
-	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "A", "D", "←/→", "↑/↓", "q/esc", "tab")))
+	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc", "tab")))
 	return ansi.Truncate(candidate, sp.Width, "")
 }
 
@@ -1798,6 +1841,13 @@ func modeShortcutTitle(mode Mode) string {
 	default:
 		return "Items"
 	}
+}
+
+func modeShortcutTitleForStatus(sp statusBarParams) string {
+	if sp.ActiveFlows {
+		return "Active flows"
+	}
+	return modeShortcutTitle(sp.Mode)
 }
 
 func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, emptyMessage string, activeTerminalRepoPaths map[string]bool) []string {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1053,7 +1053,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 				{Key: "q/esc", Label: "quit"},
 				{Key: "1-9", Label: "switch"},
 			}
-			if sp.Mode == ModeSessions {
+			if sp.Mode == ModeSessions && !flowSurfaceActive {
 				hints = slices.Insert(hints, 1, shortcutHint{Key: "l", Label: "sessions"})
 			} else {
 				hints = slices.Insert(hints, 1,

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -595,6 +595,10 @@ func renderApplication(p RenderParams) string {
 
 	var rightLines []string
 	switch {
+	case flowSurfaceActive && len(p.FlowEmbeddedTerminals) > 0:
+		rightLines = renderFlowSplitPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.FlowEmbeddedTerminals, p.FlowEmbeddedTerminalLines, p.FlowEmbeddedTerminalPrefix, p.ActivePane == 1 && p.FlowTerminalFocused)
+	case flowSurfaceActive && len(p.Flows) > 0:
+		rightLines = renderFlowPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity)
 	case p.Mode == ModeWorktrees && len(p.Worktrees) > 0:
 		rightLines = renderWorktreePaneWithSessions(p.Worktrees, worktreeSel, p.WorktreeScroll, rightContentWidth, rightContentHeight, p.InlineWorktreeSessions, p.WorktreeSessions, p.WorktreeSessionSelected, p.WorktreeSessionScroll)
 	case p.Mode == ModeBranches && len(p.Branches) > 0:
@@ -611,10 +615,6 @@ func renderApplication(p RenderParams) string {
 		rightLines = renderSessionPane(p.Sessions, sessionSel, p.SessionScroll, rightContentWidth, rightContentHeight)
 	case p.Mode == ModePlans && len(p.Plans) > 0:
 		rightLines = renderPlanPane(p.Plans, planSel, p.PlanScroll, rightContentWidth, rightContentHeight, p.ExpandedPlanID, selectedPlanPhaseID)
-	case flowSurfaceActive && len(p.FlowEmbeddedTerminals) > 0:
-		rightLines = renderFlowSplitPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.FlowEmbeddedTerminals, p.FlowEmbeddedTerminalLines, p.FlowEmbeddedTerminalPrefix, p.ActivePane == 1 && p.FlowTerminalFocused)
-	case flowSurfaceActive && len(p.Flows) > 0:
-		rightLines = renderFlowPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity)
 	default:
 		rightLines = renderPlaceholderPane(rightContentWidth, rightContentHeight, p.RightEmptyMessage)
 	}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -445,7 +445,7 @@ func renderApplication(p RenderParams) string {
 	stashSelected := p.Mode == ModeStashes && p.StashSelected >= 0 && p.StashSelected < len(p.Stashes)
 	commitSelected := p.Mode == ModeHistory && p.CommitSelected >= 0 && p.CommitSelected < len(p.Commits)
 	reflogSelected := p.Mode == ModeReflog && p.ReflogSelected >= 0 && p.ReflogSelected < len(p.Reflogs)
-	embeddedTerminalActive := p.Mode == ModeSessions && len(p.EmbeddedTerminals) > 0
+	embeddedTerminalActive := p.Mode == ModeSessions && !p.ActiveFlows && len(p.EmbeddedTerminals) > 0
 	flowSurfaceActive := p.Mode == ModeFlows || p.ActiveFlows
 	flowEmbeddedTerminalActive := flowSurfaceActive && len(p.FlowEmbeddedTerminals) > 0
 	terminalShortcutsActive := embeddedTerminalActive || (flowEmbeddedTerminalActive && p.FlowTerminalFocused)

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -1079,6 +1079,25 @@ func TestRender_FlowsEmbeddedTerminalShortcutsAreActiveByDefault(t *testing.T) {
 	}
 }
 
+func TestRender_ActiveFlowsOverSessionsUsesFlowTerminalPrefixShortcuts(t *testing.T) {
+	pane := renderShortcutPane(statusBarParams{
+		Mode:                   ModeSessions,
+		ActiveFlows:            true,
+		ActivePane:             1,
+		EmbeddedTerminalActive: true,
+		EmbeddedTerminalPrefix: true,
+	}, 34, 12)
+	text := ansi.Strip(pane)
+	for _, want := range []string{"ctrl+] send", "i      input", "left/right terminal", "d      detach", "x      close", "q/esc  quit", "1-9    switch"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("active Flow terminal shortcut pane missing %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "l      sessions") {
+		t.Fatalf("active Flow terminal shortcut pane should not show session prefix command:\n%s", text)
+	}
+}
+
 func TestRender_ActiveFlowsIgnoreHiddenSessionTerminalForShortcuts(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:       []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -1079,6 +1079,50 @@ func TestRender_FlowsEmbeddedTerminalShortcutsAreActiveByDefault(t *testing.T) {
 	}
 }
 
+func TestRender_ActiveFlowsIgnoreHiddenSessionTerminalForShortcuts(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:       []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:    0,
+		Width:       180,
+		Height:      18,
+		Mode:        ModeSessions,
+		ActiveFlows: true,
+		Flows: []flowstore.FlowRecord{{
+			FlowID:       "flow-1",
+			Title:        "Active Flow",
+			Status:       flowstore.StatusInProgress,
+			WorktreePath: "/dev/wtui-worktrees/active-flow",
+			Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation",
+				Title:   "Implementation",
+				Status:  flowstore.PhaseReady,
+				Order:   1,
+			}},
+		}},
+		EmbeddedTerminals: []EmbeddedTerminalTab{{
+			Number:   1,
+			Provider: "codex",
+			Identity: "hidden-session-terminal",
+			State:    "running",
+			Active:   true,
+		}},
+		ActivePane:          1,
+		FlowSelected:        0,
+		FlowNextLaunchReady: true,
+		FlowHeadless:        true,
+	})
+
+	pane := shortcutPaneText(view)
+	for _, want := range []string{"Actions", "ctrl+j launch next", "Mode", "h      headless on"} {
+		if !strings.Contains(pane, want) {
+			t.Fatalf("active Flow shortcut pane missing %q:\n%s", want, pane)
+		}
+	}
+	if strings.Contains(pane, "ctrl+] commands") || strings.Contains(pane, "Terminal") {
+		t.Fatalf("active Flow shortcut pane should ignore hidden session terminal:\n%s", pane)
+	}
+}
+
 func TestRender_FlowsModeIgnoresStaleSelectedPhaseForCopyShortcut(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},


### PR DESCRIPTION
## Summary
- add an F3 Active Flows pane that surfaces flows needing attention and pending ready work
- wire active-flow refresh, filtering, mode transitions, and key handling through the model
- update UI rendering and documentation for the new active-flow surface

## Implementation
- adds flow-surface state and refresh plumbing across model messages, fetches, filters, and key handling
- keeps embedded terminal focus and flow launch interactions coherent when moving between flow views
- extends model tests for active-flow navigation, filtering, refresh behavior, and launch interactions

## Verification
- gofmt -l .
- make test
- make build