### PR TITLE
Add F2 pane switching shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ WORKTREE_ROOT=~/projects ./bin/wtui
 
 ### Keys
 
-The UI has two panes: repos on the left, content on the right. `tab` switches focus between them. When a Flow embedded terminal is open, `tab` also switches focus between the Flow list and that terminal while the right pane remains active. The active pane is highlighted with a blue border.
+The UI has two panes: repos on the left, content on the right. `tab` or `f2` switches focus between them. When a Flow embedded terminal is open, `tab` also switches focus between the Flow list and that terminal while the right pane remains active. The active pane is highlighted with a blue border.
 
 **Destructive mode:** The app starts in read-only mode — deletion keys are disabled. Press `D` (Shift+D) to toggle destructive mode on/off. When active, the right pane border turns red and delete/drop hints appear in red as a visual warning.
 
@@ -65,7 +65,7 @@ filter matches, or a load failure with details in the status bar.
 | `D` | Toggle destructive mode |
 | `f` | Fetch all currently visible repos with `--prune` |
 | `n` | Create a new local repo under the scan root, optionally creating a GitHub repo and wiring `origin` |
-| `tab` | Switch focus to right pane |
+| `tab`/`f2` | Switch focus to right pane |
 | `q`/`esc` | Quit |
 
 **Right pane (content)**
@@ -102,7 +102,7 @@ filter matches, or a load failure with details in the status bar.
 | `e` | Edit selected plan Markdown (plans view) |
 | `i` | Alias for plan implementation launch |
 | `D` | Toggle destructive mode |
-| `tab` | Switch focus to left pane |
+| `tab`/`f2` | Switch focus to left pane |
 | `q`/`esc` | Close a prompt/dialog or quit |
 
 The right pane header shows the active mode. Press `1`–`8` or use arrow keys to

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -5357,6 +5357,79 @@ func TestModel_FlowTerminalFocusUsesPersistentCommandModeAndTabReturnsToList(t *
 	}
 }
 
+func TestModel_F2SwitchesPaneWithoutFocusingInactiveFlowTerminal(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return fakeTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{
+		flowWithPhaseDetails(),
+		{FlowID: "flow-2", RepoPath: "/dev/alpha", Title: "Second flow", Status: flowstore.StatusInProgress},
+	})
+
+	m = selectFlowPhaseByID(t, m, "implementation")
+	m, cmd := update(m, flowCtrlJKey())
+	if cmd == nil {
+		t.Fatal("ctrl+j should prepare an embedded launch")
+	}
+	m, _ = update(m, cmd())
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	if m.ActivePane() != 0 {
+		t.Fatalf("f2 with inactive Flow terminal activePane = %d, want left pane", m.ActivePane())
+	}
+	if len(fakeTerm.writes) != 0 {
+		t.Fatalf("inactive Flow terminal should not receive f2 writes: %#v", fakeTerm.writes)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if len(fakeTerm.writes) != 0 {
+		t.Fatalf("returning from f2 should keep Flow list focus, not terminal focus: %#v", fakeTerm.writes)
+	}
+	if got := m.SelectedFlowPhaseID(); got != "plan" {
+		t.Fatalf("selected Flow phase = %q, want list focus to move to first phase", got)
+	}
+}
+
+func TestModel_F2ForwardsWhenFlowTerminalInputOwnsKeys(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return fakeTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
+
+	m = selectFlowPhaseByID(t, m, "implementation")
+	m, cmd := update(m, flowCtrlJKey())
+	if cmd == nil {
+		t.Fatal("ctrl+j should prepare an embedded launch")
+	}
+	m, _ = update(m, cmd())
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+
+	if m.ActivePane() != 1 {
+		t.Fatalf("terminal-owned f2 activePane = %d, want right pane", m.ActivePane())
+	}
+	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "\x1bOQ" {
+		t.Fatalf("terminal input f2 writes = %#v, want F2 escape sequence", fakeTerm.writes)
+	}
+}
+
 func TestModel_FlowEffortKeyDoesNotOpenPickerWhileFlowTerminalFocused(t *testing.T) {
 	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
 	m := model.NewWithOptions(testRepos(), model.Options{

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -94,6 +94,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.startGlobalRefresh()
 	}
 
+	if key == "f2" {
+		m = m.togglePrimaryPaneFocus()
+		return m, nil
+	}
+
 	if m.activePane == 0 {
 		return m.handleLeftPaneKey(key)
 	}
@@ -241,7 +246,7 @@ func (m Model) setSearchActive(active bool) Model {
 func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 	switch key {
 	case "tab":
-		m.activePane = 1
+		m = m.togglePrimaryPaneFocus()
 	case "left":
 		return m.handleHorizontalNavigation(-1)
 	case "right":
@@ -388,13 +393,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			m.terminalPrefixActive = true
 			return m, nil
 		}
-		m.activePane = 0
-		if m.mode == ui.ModePlans {
-			m = m.clearSelectedPlanPhase()
-		}
-		if m.mode == ui.ModeFlows {
-			m = m.clearSelectedFlowPhase()
-		}
+		m = m.togglePrimaryPaneFocus()
 	case "ctrl+j":
 		if m.mode == ui.ModeFlows {
 			return m.handleLaunchNextFlowPhase()
@@ -466,6 +465,21 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleEmbeddedTerminalQuitPrefix()
 	}
 	return m, nil
+}
+
+func (m Model) togglePrimaryPaneFocus() Model {
+	if m.activePane == 0 {
+		m.activePane = 1
+		return m
+	}
+	m.activePane = 0
+	if m.mode == ui.ModePlans {
+		m = m.clearSelectedPlanPhase()
+	}
+	if m.mode == ui.ModeFlows {
+		m = m.clearSelectedFlowPhase()
+	}
+	return m
 }
 
 func (m Model) handleHorizontalNavigation(direction int) (tea.Model, tea.Cmd) {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -891,7 +891,7 @@ func TestModel_SearchActiveSuppressesHorizontalArrowNavigation(t *testing.T) {
 	}
 }
 
-func TestModel_ModalSuppressesHorizontalArrowNavigation(t *testing.T) {
+func TestModel_ModalSuppressesPaneNavigationKeys(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
@@ -902,7 +902,7 @@ func TestModel_ModalSuppressesHorizontalArrowNavigation(t *testing.T) {
 		t.Fatalf("Overlay() = %d, want worktree input", m.Overlay())
 	}
 
-	for _, key := range []tea.KeyMsg{{Type: tea.KeyLeft}, {Type: tea.KeyRight}} {
+	for _, key := range []tea.KeyMsg{{Type: tea.KeyLeft}, {Type: tea.KeyRight}, {Type: tea.KeyF2}} {
 		before := listRequests(m)
 		m2, cmd := update(m, key)
 		if cmd != nil {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/model"
+	"github.com/brian-bell/wtui/planstore"
 	"github.com/brian-bell/wtui/scanner"
 	"github.com/brian-bell/wtui/ui"
 )
@@ -466,6 +467,22 @@ func TestModel_TabTogglesPaneFocus(t *testing.T) {
 	}
 }
 
+func TestModel_F2FromLeftPaneSwitchesToRightWithoutChangingSelectionOrMode(t *testing.T) {
+	m := model.New(testRepos())
+	m = selectBravo(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+
+	if m.ActivePane() != 1 {
+		t.Fatalf("expected right pane after f2, got %d", m.ActivePane())
+	}
+	if m.Selected() != 1 {
+		t.Fatalf("selected repo = %d, want unchanged 1", m.Selected())
+	}
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("mode = %d, want unchanged worktrees", m.Mode())
+	}
+}
+
 func TestModel_TabDoesNotChangeMode(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // left → right
@@ -473,6 +490,74 @@ func TestModel_TabDoesNotChangeMode(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // right → left
 	if m.Mode() != 3 {
 		t.Errorf("expected mode unchanged at 3, got %d", m.Mode())
+	}
+}
+
+func TestModel_F2FromRightPaneSwitchesToLeftWithoutChangingMode(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // left → right
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // mode 3 (stashes)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})                        // right → left
+
+	if m.ActivePane() != 0 {
+		t.Fatalf("expected left pane after f2, got %d", m.ActivePane())
+	}
+	if m.Mode() != ui.ModeStashes {
+		t.Fatalf("mode = %d, want unchanged stashes", m.Mode())
+	}
+}
+
+func TestModel_F2FromPlansPaneClearsSelectedPhase(t *testing.T) {
+	m := plansInRightPane(t, model.New(testRepos()), []planstore.PlanRecord{{
+		PlanID:   "plan-1",
+		RepoPath: "/dev/alpha",
+		Title:    "Persist plans",
+		Status:   "draft",
+		Phases:   []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.SelectedPlanPhaseID(); got != "p1" {
+		t.Fatalf("selected plan phase = %q, want p1 before f2", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+
+	if m.ActivePane() != 0 {
+		t.Fatalf("expected left pane after f2, got %d", m.ActivePane())
+	}
+	if got := m.SelectedPlanPhaseID(); got != "" {
+		t.Fatalf("selected plan phase = %q, want cleared", got)
+	}
+	if m.Mode() != ui.ModePlans {
+		t.Fatalf("mode = %d, want unchanged plans", m.Mode())
+	}
+}
+
+func TestModel_F2FromFlowsPaneClearsSelectedPhase(t *testing.T) {
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithPhaseDetails()})
+	m = selectFlowPhaseByID(t, m, "implementation")
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+
+	if m.ActivePane() != 0 {
+		t.Fatalf("expected left pane after f2, got %d", m.ActivePane())
+	}
+	if got := m.SelectedFlowPhaseID(); got != "" {
+		t.Fatalf("selected flow phase = %q, want cleared", got)
+	}
+	if m.Mode() != ui.ModeFlows {
+		t.Fatalf("mode = %d, want unchanged flows", m.Mode())
+	}
+}
+
+func TestModel_F2DoesNotSwitchPanesWhileSearchIsActive(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+
+	if m.ActivePane() != 0 {
+		t.Fatalf("active pane = %d, want left pane while search handles f2", m.ActivePane())
 	}
 }
 

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -342,8 +342,8 @@ func TestModel_ViewStatusBarShowsKeyHints(t *testing.T) {
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 
 	view := m.View()
-	if !strings.Contains(view, "tab    pane") {
-		t.Error("view should contain 'tab    pane' shortcut")
+	if !strings.Contains(view, "f2/tab pane") {
+		t.Error("view should contain 'f2/tab pane' shortcut")
 	}
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1449,10 +1449,10 @@ func renderGenericFooterShortcuts(sp statusBarParams, sections []shortcutSection
 		{"f5"},
 		{"f5", "A"},
 		{"f5", "A", "D"},
-		{"f5", "A", "D", "↑/↓"},
-		{"f5", "A", "D", "↑/↓", "q/esc"},
-		{"f5", "A", "D", "↑/↓", "q/esc", "←/→"},
-		{"f5", "A", "D", "↑/↓", "q/esc", "←/→", "f2/tab"},
+		{"f5", "A", "D", "←/→"},
+		{"f5", "A", "D", "←/→", "↑/↓"},
+		{"f5", "A", "D", "←/→", "↑/↓", "q/esc"},
+		{"f5", "A", "D", "←/→", "↑/↓", "q/esc", "f2/tab"},
 	} {
 		candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, drop...)))
 		if lipgloss.Width(candidate) <= sp.Width {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1059,7 +1059,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 		{Key: "←/→", Label: "pane/view", Inline: true},
 	}
 	global := []shortcutHint{
-		{Key: "tab", Label: "pane"},
+		{Key: "f2/tab", Label: "pane"},
 		{Key: "q/esc", Label: "quit"},
 		{Key: "f5", Label: "refresh"},
 	}
@@ -1401,7 +1401,7 @@ func transientStatusStyle(fadeStep int) lipgloss.Style {
 
 func renderWorktreeFooterShortcuts(sp statusBarParams, sections []shortcutSection) string {
 	hints := flattenShortcutHints(sections)
-	base := footerHintsForKeys(hints, "tab", "q/esc")
+	base := footerHintsForKeys(hints, "f2/tab", "q/esc")
 	agent := footerHintsForKeys(hints, "A")
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
@@ -1449,17 +1449,17 @@ func renderGenericFooterShortcuts(sp statusBarParams, sections []shortcutSection
 		{"f5"},
 		{"f5", "A"},
 		{"f5", "A", "D"},
-		{"f5", "A", "D", "←/→"},
-		{"f5", "A", "D", "←/→", "↑/↓"},
-		{"f5", "A", "D", "←/→", "↑/↓", "q/esc"},
-		{"f5", "A", "D", "←/→", "↑/↓", "q/esc", "tab"},
+		{"f5", "A", "D", "↑/↓"},
+		{"f5", "A", "D", "↑/↓", "q/esc"},
+		{"f5", "A", "D", "↑/↓", "q/esc", "←/→"},
+		{"f5", "A", "D", "↑/↓", "q/esc", "←/→", "f2/tab"},
 	} {
 		candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, drop...)))
 		if lipgloss.Width(candidate) <= sp.Width {
 			return candidate
 		}
 	}
-	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "A", "D", "←/→", "↑/↓", "q/esc", "tab")))
+	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "A", "D", "←/→", "↑/↓", "q/esc", "f2/tab")))
 	return ansi.Truncate(candidate, sp.Width, "")
 }
 
@@ -1472,7 +1472,7 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 		return full
 	}
 	hints := flattenShortcutHints(sections)
-	base := footerHintsForKeys(hints, "tab", "q/esc")
+	base := footerHintsForKeys(hints, "f2/tab", "q/esc")
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
 	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "ctrl+j", "d")
@@ -1510,14 +1510,14 @@ func renderBranchFooterShortcuts(sp statusBarParams, sections []shortcutSection)
 	legend, rest := splitLegendSection(sections)
 	rest = branchFooterSectionOrder(rest)
 	hints := flattenShortcutHints(rest)
-	base := footerHintsForKeys(hints, "tab", "q/esc")
+	base := footerHintsForKeys(hints, "f2/tab", "q/esc")
 	nav := footerHintsForKeys(hints, "↑/↓", "←/→")
 	actions := footerHintsForKeys(hints, "D", "n", "enter", "d", "f", "F", "t", "c", "a")
 
 	full := append(append(append([]string{}, base...), actions...), nav...)
 	baseActions := append(append([]string{}, base...), actions...)
 	baseNav := append(append([]string{}, base...), nav...)
-	baseArrow := footerHintsForKeys(hints, "tab", "q/esc", "←/→")
+	baseArrow := footerHintsForKeys(hints, "f2/tab", "q/esc", "←/→")
 
 	for _, parts := range [][]string{full, baseActions} {
 		if candidate, ok := branchFooterCandidateWithLegend(sp.Width, legend, parts); ok {

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -492,7 +492,7 @@ func TestRender_FlowsModeShortcutSectionsUseFlowGroups(t *testing.T) {
 		"m      auto: on",
 		"A      codex",
 		"E      effort: high",
-		"tab    pane",
+		"f2/tab pane",
 		"q/esc  quit",
 		"f5     refresh",
 	} {

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -602,7 +602,7 @@ func TestStatusBar_FlowsModeFullFooterPreservesSectionOrder(t *testing.T) {
 	enterIndex := strings.Index(bar, "enter: phases")
 	headlessIndex := strings.Index(bar, "h: headless on")
 	agentIndex := strings.Index(bar, "A: codex")
-	tabIndex := strings.Index(bar, "tab: pane")
+	tabIndex := strings.Index(bar, "f2/tab: pane")
 	if enterIndex < 0 || headlessIndex < 0 || agentIndex < 0 || tabIndex < 0 {
 		t.Fatalf("full Flow footer missing expected hints, got %q", bar)
 	}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -142,9 +142,9 @@ func TestStatusBar_StashesModeOmitsIndicatorLegend(t *testing.T) {
 func TestStatusBar_PipeSeparatesLegendAndHints(t *testing.T) {
 	bar := RenderStatusBar(120, 2, 0, 1, true, false, false)
 	upstreamIdx := strings.Index(bar, "no upstream")
-	tabIdx := strings.Index(bar, "tab: pane")
+	tabIdx := strings.Index(bar, "f2/tab: pane")
 	if upstreamIdx == -1 || tabIdx == -1 {
-		t.Fatalf("expected both 'no upstream' and 'tab: pane' in bar: %q", bar)
+		t.Fatalf("expected both 'no upstream' and 'f2/tab: pane' in bar: %q", bar)
 	}
 	between := bar[upstreamIdx+len("no upstream") : tabIdx]
 	if !strings.Contains(between, "|") {
@@ -154,13 +154,13 @@ func TestStatusBar_PipeSeparatesLegendAndHints(t *testing.T) {
 
 func TestStatusBar_TabAndQuitBeforeOtherHints(t *testing.T) {
 	bar := RenderStatusBar(160, 2, 0, 1, true, false, false)
-	tabIdx := strings.Index(bar, "tab: pane")
+	tabIdx := strings.Index(bar, "f2/tab: pane")
 	tIdx := strings.Index(bar, "t: terminal")
 	if tabIdx == -1 || tIdx == -1 {
 		t.Fatalf("expected both hints in bar: %q", bar)
 	}
 	if tabIdx > tIdx {
-		t.Error("tab: pane should appear before t: terminal")
+		t.Error("f2/tab: pane should appear before t: terminal")
 	}
 	qIdx := strings.Index(bar, "q/esc: quit")
 	if qIdx > tIdx {
@@ -175,8 +175,8 @@ func TestStatusBar_ActionHintsHiddenWhenLeftPaneActive(t *testing.T) {
 			t.Errorf("hint %q should be hidden when left pane is active", hint)
 		}
 	}
-	// tab and q/esc should still appear
-	for _, hint := range []string{"tab: pane", "q/esc: quit"} {
+	// Pane switching and q/esc should still appear.
+	for _, hint := range []string{"f2/tab: pane", "q/esc: quit"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("hint %q should appear even when left pane is active", hint)
 		}
@@ -1243,7 +1243,7 @@ func TestStatusBar_LaunchInstructionsOverlayShowsLaunchHint(t *testing.T) {
 func TestStatusBar_KeyHintSpacingIs2(t *testing.T) {
 	bar := RenderStatusBar(160, 2, 0, 1, true, false, false)
 	for _, pair := range [][2]string{
-		{"tab: pane", "q/esc: quit"},
+		{"f2/tab: pane", "q/esc: quit"},
 		{"d: delete", "f: fetch"},
 		{"t: terminal", "c: code"},
 	} {
@@ -1335,7 +1335,7 @@ func TestRender_WideLayoutReplacesFooterHints(t *testing.T) {
 
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	if strings.Contains(footer, "tab: pane") || strings.Contains(footer, "q/esc: quit") {
+	if strings.Contains(footer, "f2/tab: pane") || strings.Contains(footer, "q/esc: quit") {
 		t.Fatalf("wide render footer should not carry shortcut hints, got %q", footer)
 	}
 	if !strings.Contains(shortcutPaneText(view), "f2/tab pane") {
@@ -1356,9 +1356,6 @@ func TestRender_NarrowLayoutKeepsFooterHints(t *testing.T) {
 	footer := lines[len(lines)-1]
 	if !strings.Contains(footer, "f2/tab: pane") {
 		t.Fatalf("narrow render should expose f2/tab pane hint, got %q", footer)
-	}
-	if !strings.Contains(footer, "tab: pane") {
-		t.Fatalf("narrow render should keep footer hints, got %q", footer)
 	}
 	if strings.Contains(view, "Shortcuts") {
 		t.Fatal("narrow render should not reserve a shortcut pane")
@@ -1389,7 +1386,7 @@ func TestRender_ShortWideLayoutKeepsClippedShortcutPane(t *testing.T) {
 	}
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	for _, forbidden := range []string{"tab: pane", "n: new worktree", "F: pull", "c: code"} {
+	for _, forbidden := range []string{"f2/tab: pane", "n: new worktree", "F: pull", "c: code"} {
 		if strings.Contains(footer, forbidden) {
 			t.Fatalf("short wide footer should not carry shortcut hint %q, got %q", forbidden, footer)
 		}
@@ -1773,7 +1770,7 @@ func TestRender_BranchShortcutPaneKeepsLegend(t *testing.T) {
 	}
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	if strings.Contains(footer, "tab: pane") || strings.Contains(footer, "no upstream") {
+	if strings.Contains(footer, "f2/tab: pane") || strings.Contains(footer, "no upstream") {
 		t.Fatalf("branch wide footer should not duplicate shortcut or legend hints, got %q", footer)
 	}
 }
@@ -3468,7 +3465,7 @@ func TestStatusBar_StashesModeHintsSpacing(t *testing.T) {
 		}
 	}
 	for _, pair := range [][2]string{
-		{"tab: pane", "q/esc: quit"},
+		{"f2/tab: pane", "q/esc: quit"},
 		{"↑/↓ select", "←/→ pane/view"},
 		{"←/→ pane/view", "enter: diff"},
 		{"enter: diff", "d: drop"},
@@ -3851,9 +3848,23 @@ func TestWorktreePane_ScrollOffset(t *testing.T) {
 	}
 }
 
+func TestStatusBar_GenericFooterKeepsQuitBeforeNavigationWhenTight(t *testing.T) {
+	bar := ansi.Strip(RenderStatusBar(60, 3, 0, 1, true, false, false))
+	for _, want := range []string{"f2/tab: pane", "q/esc: quit"} {
+		if !strings.Contains(bar, want) {
+			t.Fatalf("tight generic footer should keep %q, got %q", want, bar)
+		}
+	}
+	for _, notWant := range []string{"↑/↓ select", "←/→ pane/view"} {
+		if strings.Contains(bar, notWant) {
+			t.Fatalf("tight generic footer should drop navigation hint %q before quit, got %q", notWant, bar)
+		}
+	}
+}
+
 func TestStatusBar_WorktreesModeShowsNavHints(t *testing.T) {
 	bar := RenderStatusBar(160, 1, 0, 1, false, false, false)
-	for _, hint := range []string{"tab: pane", "q/esc: quit", "↑/↓ select", "←/→ pane/view"} {
+	for _, hint := range []string{"f2/tab: pane", "q/esc: quit", "↑/↓ select", "←/→ pane/view"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("worktrees mode status bar should contain %q", hint)
 		}
@@ -3961,7 +3972,7 @@ func TestStatusBar_GenericActionModesDoNotWrapNarrowFooter(t *testing.T) {
 		wantHints   []string
 	}{
 		{name: "stashes destructive", mode: ModeStashes, destructive: true, wantHints: []string{"←/→ pane/view", "enter: diff", "d: drop"}},
-		{name: "reflog", mode: ModeReflog, wantHints: []string{"←/→ pane/view", "enter: diff", "y: copy hash"}},
+		{name: "reflog", mode: ModeReflog, wantHints: []string{"q/esc: quit", "enter: diff", "y: copy hash"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			bar := RenderStatusBar(80, tc.mode, OverlayNone, 1, tc.destructive, false, false)
@@ -4290,7 +4301,7 @@ func TestReflogDiffOverlay_NonEmptyDiffShowsContent(t *testing.T) {
 
 func TestStatusBar_ReflogModeHints(t *testing.T) {
 	bar := RenderStatusBar(120, 5, 0, 1, false, false, false)
-	for _, hint := range []string{"enter: diff", "y: copy hash", "tab: pane", "q/esc: quit"} {
+	for _, hint := range []string{"enter: diff", "y: copy hash", "f2/tab: pane", "q/esc: quit"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("reflog status bar should contain %q", hint)
 		}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1338,7 +1338,7 @@ func TestRender_WideLayoutReplacesFooterHints(t *testing.T) {
 	if strings.Contains(footer, "tab: pane") || strings.Contains(footer, "q/esc: quit") {
 		t.Fatalf("wide render footer should not carry shortcut hints, got %q", footer)
 	}
-	if !strings.Contains(shortcutPaneText(view), "tab    pane") {
+	if !strings.Contains(shortcutPaneText(view), "f2/tab pane") {
 		t.Fatal("wide render should still expose global shortcuts in the shortcut pane")
 	}
 }
@@ -1354,6 +1354,9 @@ func TestRender_NarrowLayoutKeepsFooterHints(t *testing.T) {
 
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
+	if !strings.Contains(footer, "f2/tab: pane") {
+		t.Fatalf("narrow render should expose f2/tab pane hint, got %q", footer)
+	}
 	if !strings.Contains(footer, "tab: pane") {
 		t.Fatalf("narrow render should keep footer hints, got %q", footer)
 	}
@@ -1464,7 +1467,7 @@ func TestRender_ShortcutPanePrioritizesActions(t *testing.T) {
 	navigate := strings.Index(pane, "Navigate")
 	global := strings.Index(pane, "Global")
 	newWorktree := strings.Index(pane, "new worktree")
-	tabPane := strings.Index(pane, "tab    pane")
+	tabPane := strings.Index(pane, "f2/tab pane")
 	if actions < 0 || navigate < 0 || global < 0 || !(actions < navigate && navigate < global) {
 		t.Fatalf("shortcut pane should order Actions, Navigate, Global, got:\n%s", pane)
 	}
@@ -1730,6 +1733,9 @@ func TestRender_ShortcutPaneShowsArrowPaneViewHint(t *testing.T) {
 			Mode:       ModeFlows,
 			ActivePane: activePane,
 		}, 26, 18))
+		if !strings.Contains(pane, "f2/tab") || !strings.Contains(pane, "pane") {
+			t.Fatalf("shortcut pane activePane=%d should include f2/tab pane hint, got:\n%s", activePane, pane)
+		}
 		if !strings.Contains(pane, "←/→") || !strings.Contains(pane, "pane/view") {
 			t.Fatalf("shortcut pane activePane=%d should include arrow pane/view hint, got:\n%s", activePane, pane)
 		}


### PR DESCRIPTION
## Summary
- add F2 as a global pane-switching shortcut alongside Tab
- keep Flow embedded terminal input ownership intact by forwarding F2 only when the terminal owns keys
- update status bar, shortcut pane, README, and regression coverage for the new hint

## Verification
- gofmt -l .
- make test
- make build