### PR TITLE
Change Flow launch shortcut to g

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ filter matches, or a load failure with details in the status bar.
 | `h` | Cycle to the previous mode outside flows view; toggle Flow headless/interactive command mode in flows view |
 | `E` | Choose and persist reasoning effort for the selected CLI agent in flows view |
 | `enter` | Page diff in `less` (dirty worktree, dirty branch, stash, commit, or reflog entry), resume an inline worktree session, page a session transcript, or expand/collapse plan or Flow phases |
-| `ctrl+j` | Launch the next launchable phase for the selected Flow in flows view |
+| `g` | Launch the next launchable phase for the selected Flow in flows view |
 | `n` | Create a new worktree in worktrees view, a new branch in branches view, or a new Flow in flows view |
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
@@ -327,7 +327,7 @@ worktrees, branches, checked-out code, linked plans, sessions, transcripts, or
 active embedded terminals. Expanded phase rows cannot be deleted with this
 action. On a Flow row or an expanded phase row, `enter` expands or collapses
 the phase list. Press
-`ctrl+j` to launch the first launchable phase in the selected Flow's
+`g` to launch the first launchable phase in the selected Flow's
 canonical phase order. This action
 uses the selected Flow, so a highlighted pending phase row can still launch an
 earlier ready sibling, and nothing is persisted when no phase is launchable.
@@ -339,7 +339,7 @@ existing app thread without extra launch tracking. Press `m` on a Flow row or
 expanded phase row to toggle per-Flow auto mode, which is off by default and
 persisted on that Flow record. When auto mode is on, a successful completed
 phase transition launches the next ready non-merge phase in that same Flow
-through the same launch path as pressing `ctrl+j`. For CLI phases running in an
+through the same launch path as pressing `g`. For CLI phases running in an
 embedded Flow terminal, wtui waits until the completed phase's terminal exits
 normally and auto-closes before launching the next phase; that exit also
 triggers a Flow refresh so completions recorded after the last refresh are
@@ -590,7 +590,7 @@ foundation fields for provider, launch, and agent settings.
 
 ### Agent session hooks
 
-CLI agents launched from wtui with `a`, `N`, Flow `ctrl+j`, or
+CLI agents launched from wtui with `a`, `N`, Flow `g`, or
 session resume `r` are wired automatically: wtui passes Claude Code or Codex a
 session-end hook that calls the current wtui binary, and it exports `WTUI_*`
 metadata so hook records can be associated with the repo, worktree, branch, and

--- a/docs/config.md
+++ b/docs/config.md
@@ -319,7 +319,7 @@ through `wtui flow`. Each record is stored as
 flows pane (mode `8`), which is the startup default. The pane shows linked plan
 IDs when present; press `n` to create a new Flow. On a Flow row or expanded
 phase row, `enter` expands or collapses read-only phase detail rows; `o` opens
-the linked plan body from the selected Flow. Press `ctrl+j` to launch the first
+the linked plan body from the selected Flow. Press `g` to launch the first
 launchable phase for the selected Flow. Press `y` to copy the selected Flow
 worktree path from either a Flow row or one of its expanded phase rows. Press
 `m` to toggle per-Flow auto mode. When auto mode is on, completed CLI phases
@@ -536,7 +536,7 @@ manually afterward.
 
 ## Agent Session Hooks
 
-Agents launched from wtui with `a`, `N`, Flow `ctrl+j`, or session
+Agents launched from wtui with `a`, `N`, Flow `g`, or session
 resume `r` are wired automatically. wtui passes Claude Code or Codex a
 session-end hook that calls the current wtui binary, and it appends the
 environment metadata listed below so the hook can associate the session with
@@ -627,7 +627,7 @@ tmux reattach command, using the detach handoff order described in
 `[terminal]`. Platforms without `$TERMINAL`, `[terminal].command`, or the macOS
 Terminal AppleScript fallback report the handoff error after detach; the agent
 continues in the detached tmux session. When `tmux` is unavailable, wtui uses
-the direct embedded PTY path and reports detach unavailable. Fresh Flow `ctrl+j`
+the direct embedded PTY path and reports detach unavailable. Fresh Flow `g`
 launches and Flow phase-session resumes run CLI agents inside runtime-only
 embedded PTYs in the flows pane; Flow headless mode chooses
 headless provider commands (`codex exec` / `claude --print`) versus interactive

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -2597,6 +2597,58 @@ func TestModel_CtrlJWithLaunchableFlowPhaseDoesNotMutateOrLaunch(t *testing.T) {
 	}
 }
 
+func TestModel_GOutsideFlowsModesDoesNotMutateOrLaunch(t *testing.T) {
+	tests := []struct {
+		name string
+		key  rune
+		mode ui.Mode
+	}{
+		{name: "worktrees", key: '1', mode: ui.ModeWorktrees},
+		{name: "branches", key: '2', mode: ui.ModeBranches},
+		{name: "plans", key: '7', mode: ui.ModePlans},
+		{name: "sessions", key: '6', mode: ui.ModeSessions},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			addLaunchRan := false
+			launchAgentRan := false
+			startEmbeddedRan := false
+			m := model.NewWithOptions(testRepos(), model.Options{
+				AgentCommand: "codex-app",
+				AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+					addLaunchRan = true
+					return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+				},
+				LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+					launchAgentRan = true
+					return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+				},
+				StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+					startEmbeddedRan = true
+					return &fakeEmbeddedTerminal{}, nil
+				},
+			})
+			m = inRightPane(m)
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tc.key}})
+			if m.Mode() != tc.mode {
+				t.Fatalf("starting mode = %d, want %d", m.Mode(), tc.mode)
+			}
+
+			m, cmd := update(m, flowLaunchKey())
+			if cmd != nil {
+				t.Fatalf("g outside flows mode returned command %T, want nil", cmd)
+			}
+			if addLaunchRan || launchAgentRan || startEmbeddedRan {
+				t.Fatalf("g outside flows mode launched phase: add=%v launch=%v embedded=%v", addLaunchRan, launchAgentRan, startEmbeddedRan)
+			}
+			if got := m.TransientError(); got != "" {
+				t.Fatalf("g outside flows mode set status %q, want none", got)
+			}
+		})
+	}
+}
+
 func TestModel_HKeyInFlowsTogglesHeadlessWithoutNavigatingModes(t *testing.T) {
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithPhaseDetails()})
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -388,7 +388,7 @@ func applyFlowResultFollowup(t *testing.T, m model.Model, cmd tea.Cmd) model.Mod
 func prepareSelectedFlowPhaseLaunch(t *testing.T, m model.Model, phaseID string) (model.Model, tea.Cmd) {
 	t.Helper()
 	m = selectFlowPhaseByID(t, m, phaseID)
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	return m, cmd
 }
 
@@ -399,7 +399,7 @@ func prepareSelectedFlowPhaseHeadlessOffLaunch(t *testing.T, m model.Model, phas
 	if cmd != nil {
 		t.Fatalf("h before Flow phase launch returned command %T, want nil", cmd)
 	}
-	m, cmd = update(m, flowCtrlJKey())
+	m, cmd = update(m, flowLaunchKey())
 	return m, cmd
 }
 
@@ -424,12 +424,12 @@ func runPreparedFlowEmbeddedLaunch(t *testing.T, m model.Model, cmd tea.Cmd) mod
 func prepareSelectedFlowPhaseEmbeddedLaunch(t *testing.T, m model.Model, phaseID string) (model.Model, tea.Cmd) {
 	t.Helper()
 	m = selectFlowPhaseByID(t, m, phaseID)
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	return m, cmd
 }
 
-func flowCtrlJKey() tea.KeyMsg {
-	return tea.KeyMsg{Type: tea.KeyCtrlJ}
+func flowLaunchKey() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
 }
 
 func TestModel_MKeyTogglesFlowAutoModeFromFlowRow(t *testing.T) {
@@ -787,7 +787,7 @@ func TestModel_ResetShortcutHiddenWhenMatchingFlowTerminalIsRunning(t *testing.T
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j on ready Flow should prepare embedded terminal launch")
+		t.Fatal("g on ready Flow should prepare embedded terminal launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, model.FlowResultMsg{RepoPath: "/dev/alpha", Flows: []flowstore.FlowRecord{flowWithAwaitingImplementation()}, ListRequest: m.ListRequest(ui.ModeFlows)})
@@ -831,9 +831,9 @@ func TestModel_ResetShortcutHiddenAfterLegacyPhaseIDLaunchNormalizes(t *testing.
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{legacy})
 	m = selectFlowPhaseByID(t, m, "Implementation")
 
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	if started.FlowPhaseID != "implementation" {
@@ -879,7 +879,7 @@ func TestModel_XKeyKeepsFlowTerminalFocusCloseBehavior(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j on ready Flow should prepare embedded terminal launch")
+		t.Fatal("g on ready Flow should prepare embedded terminal launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
@@ -2163,7 +2163,7 @@ func TestModel_EnterOnSelectedFlowPhaseCollapsesWithoutLaunching(t *testing.T) {
 	}
 }
 
-func TestModel_CtrlJOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHeadless(t *testing.T) {
+func TestModel_GOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHeadless(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var started actions.AgentLaunchContext
 	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
@@ -2202,9 +2202,9 @@ func TestModel_CtrlJOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHead
 	}})
 	m = selectFlowPhaseByID(t, m, "review-loop")
 
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare a headless launch")
+		t.Fatal("g should prepare a headless launch")
 	}
 	m, cmd = update(m, cmd())
 	if launchAgentRan {
@@ -2214,7 +2214,7 @@ func TestModel_CtrlJOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHead
 		t.Fatal("expected embedded Flow launch to return repaint/fetch command")
 	}
 	if started.FlowPhaseID != "implementation" || launchUpdate.PhaseID != "implementation" {
-		t.Fatalf("ctrl+j launched %#v with update %#v, want first launchable implementation", started, launchUpdate)
+		t.Fatalf("g launched %#v with update %#v, want first launchable implementation", started, launchUpdate)
 	}
 	if started.Command != "claude" || started.ReasoningEffort != "max" {
 		t.Fatalf("Flow phase launch agent settings = command %q effort %q, want claude/max", started.Command, started.ReasoningEffort)
@@ -2282,7 +2282,57 @@ func TestModel_HeadlessFlowLaunchFromTerminalInputReturnsFocusToList(t *testing.
 	}
 }
 
-func TestModel_CtrlJOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *testing.T) {
+func TestModel_GWithFocusedFlowTerminalWritesInputWithoutLaunchingPhase(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
+	addLaunchRan := false
+	launchAgentRan := false
+	starts := 0
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			addLaunchRan = true
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launchAgentRan = true
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			starts++
+			return fakeTerm, nil
+		},
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return nil, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-selected",
+		Status:       flowstore.StatusInProgress,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady, Order: 1},
+		},
+	}})
+	m, _ = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:     "codex",
+		FlowID:      "flow-1",
+		FlowPhaseID: "implementation",
+	}})
+
+	m, cmd := update(m, flowLaunchKey())
+	if cmd != nil {
+		t.Fatalf("terminal-focused g returned command %T, want nil", cmd)
+	}
+	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "g" {
+		t.Fatalf("terminal-focused g writes = %#v, want forwarded input", fakeTerm.writes)
+	}
+	if addLaunchRan || launchAgentRan || starts != 1 {
+		t.Fatalf("terminal-focused g launched phase: add=%v launch=%v starts=%d", addLaunchRan, launchAgentRan, starts)
+	}
+}
+
+func TestModel_GOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *testing.T) {
 	for _, command := range []string{"codex", "claude"} {
 		t.Run(command, func(t *testing.T) {
 			var launchUpdate flowstore.PhaseLaunchUpdate
@@ -2324,9 +2374,9 @@ func TestModel_CtrlJOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *
 				t.Fatalf("h before Flow phase launch returned command %T, want nil", cmd)
 			}
 
-			m, cmd = update(m, flowCtrlJKey())
+			m, cmd = update(m, flowLaunchKey())
 			if cmd == nil {
-				t.Fatal("ctrl+j should prepare an embedded interactive launch")
+				t.Fatal("g should prepare an embedded interactive launch")
 			}
 			m, cmd = update(m, cmd())
 			if cmd == nil {
@@ -2370,7 +2420,7 @@ func TestModel_CtrlJOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *
 	}
 }
 
-func TestModel_CtrlJOnFlowPhaseEmbeddedInteractivePrefillSanitizesTerminalControls(t *testing.T) {
+func TestModel_GOnFlowPhaseEmbeddedInteractivePrefillSanitizesTerminalControls(t *testing.T) {
 	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -2401,9 +2451,9 @@ func TestModel_CtrlJOnFlowPhaseEmbeddedInteractivePrefillSanitizesTerminalContro
 	if cmd != nil {
 		t.Fatalf("h before Flow phase launch returned command %T, want nil", cmd)
 	}
-	m, cmd = update(m, flowCtrlJKey())
+	m, cmd = update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded interactive launch")
+		t.Fatal("g should prepare an embedded interactive launch")
 	}
 	m, cmd = update(m, cmd())
 	if cmd == nil {
@@ -2416,7 +2466,7 @@ func TestModel_CtrlJOnFlowPhaseEmbeddedInteractivePrefillSanitizesTerminalContro
 	}
 }
 
-func TestModel_CtrlJOnSelectedNonLaunchableFlowPhaseLaunchesFirstReadySibling(t *testing.T) {
+func TestModel_GOnSelectedNonLaunchableFlowPhaseLaunchesFirstReadySibling(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var started actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -2455,17 +2505,17 @@ func TestModel_CtrlJOnSelectedNonLaunchableFlowPhaseLaunchesFirstReadySibling(t 
 	}
 	m = selectFlowPhaseByID(t, m, "implementation")
 
-	m, cmd = update(m, flowCtrlJKey())
+	m, cmd = update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should launch the first launchable sibling")
+		t.Fatal("g should launch the first launchable sibling")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 	if launchUpdate.PhaseID != "review-loop" || started.FlowPhaseID != "review-loop" {
-		t.Fatalf("ctrl+j launched update %#v context %#v, want review-loop", launchUpdate, started)
+		t.Fatalf("g launched update %#v context %#v, want review-loop", launchUpdate, started)
 	}
 }
 
-func TestModel_CtrlJWithNoLaunchableFlowPhaseDoesNotMutateOrLaunch(t *testing.T) {
+func TestModel_GWithNoLaunchableFlowPhaseDoesNotMutateOrLaunch(t *testing.T) {
 	addLaunchRan := false
 	launchAgentRan := false
 	startEmbeddedRan := false
@@ -2496,15 +2546,54 @@ func TestModel_CtrlJWithNoLaunchableFlowPhaseDoesNotMutateOrLaunch(t *testing.T)
 	}})
 	m = selectFlowPhaseByID(t, m, "implementation")
 
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd != nil {
-		t.Fatalf("ctrl+j without a launchable phase returned command %T, want nil", cmd)
+		t.Fatalf("g without a launchable phase returned command %T, want nil", cmd)
 	}
 	if addLaunchRan || launchAgentRan || startEmbeddedRan {
-		t.Fatalf("ctrl+j without launchable phase launched: add=%v launch=%v embedded=%v", addLaunchRan, launchAgentRan, startEmbeddedRan)
+		t.Fatalf("g without launchable phase launched: add=%v launch=%v embedded=%v", addLaunchRan, launchAgentRan, startEmbeddedRan)
 	}
 	if got := m.TransientError(); got != "No launchable Flow phase" {
 		t.Fatalf("status = %q, want no-launchable message", got)
+	}
+}
+
+func TestModel_CtrlJWithLaunchableFlowPhaseDoesNotMutateOrLaunch(t *testing.T) {
+	addLaunchRan := false
+	launchAgentRan := false
+	startEmbeddedRan := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex-app",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			addLaunchRan = true
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			launchAgentRan = true
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			startEmbeddedRan = true
+			return &fakeEmbeddedTerminal{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-selected",
+		Status:       flowstore.StatusInProgress,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady, Order: 1},
+		},
+	}})
+	m = selectFlowPhaseByID(t, m, "implementation")
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyCtrlJ})
+	if cmd != nil {
+		t.Fatalf("ctrl+j with a launchable phase returned command %T, want nil", cmd)
+	}
+	if addLaunchRan || launchAgentRan || startEmbeddedRan {
+		t.Fatalf("ctrl+j launched phase: add=%v launch=%v embedded=%v", addLaunchRan, launchAgentRan, startEmbeddedRan)
 	}
 }
 
@@ -3181,7 +3270,7 @@ func TestModel_FlowDeleteDoesNotTerminateEmbeddedTerminal(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	for i := 0; i < 10 && m.SelectedFlowPhaseID() != ""; i++ {
@@ -3981,7 +4070,7 @@ func TestModel_RKeyOnFlowPhaseResumeStartFailureKeepsSkippedPhase(t *testing.T) 
 	}
 }
 
-func TestModel_CtrlJLaunchesFlowPhaseReadyPlanReviewWithLinkedPlanContext(t *testing.T) {
+func TestModel_GLaunchesFlowPhaseReadyPlanReviewWithLinkedPlanContext(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -4025,7 +4114,7 @@ func TestModel_CtrlJLaunchesFlowPhaseReadyPlanReviewWithLinkedPlanContext(t *tes
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "plan-review")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare a plan-review launch")
+		t.Fatal("g should prepare a plan-review launch")
 	}
 	m = runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -4115,7 +4204,7 @@ func TestModel_FlowPlanReviewPromptTemplateOverridesBuiltInPrompt(t *testing.T) 
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "plan-review")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare a plan-review launch")
+		t.Fatal("g should prepare a plan-review launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -4125,7 +4214,7 @@ func TestModel_FlowPlanReviewPromptTemplateOverridesBuiltInPrompt(t *testing.T) 
 	}
 }
 
-func TestModel_CtrlJLaunchesFlowPhaseImplementationWithMinimalPrompt(t *testing.T) {
+func TestModel_GLaunchesFlowPhaseImplementationWithMinimalPrompt(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -4169,7 +4258,7 @@ func TestModel_CtrlJLaunchesFlowPhaseImplementationWithMinimalPrompt(t *testing.
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an implementation launch")
+		t.Fatal("g should prepare an implementation launch")
 	}
 	m = runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -4216,7 +4305,7 @@ func TestModel_CtrlJLaunchesFlowPhaseImplementationWithMinimalPrompt(t *testing.
 	}
 }
 
-func TestModel_CtrlJLaunchesFlowPhaseImplementationInEmbeddedHeadlessTerminalByDefault(t *testing.T) {
+func TestModel_GLaunchesFlowPhaseImplementationInEmbeddedHeadlessTerminalByDefault(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var started actions.AgentLaunchContext
 	var startWidth, startHeight int
@@ -4266,13 +4355,13 @@ func TestModel_CtrlJLaunchesFlowPhaseImplementationInEmbeddedHeadlessTerminalByD
 	}})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded implementation launch")
+		t.Fatal("g should prepare an embedded implementation launch")
 	}
 	m, cmd = update(m, cmd())
 	if launchAgentRan {
-		t.Fatal("default headless ctrl+j should not call LaunchAgent for CLI providers")
+		t.Fatal("default headless g should not call LaunchAgent for CLI providers")
 	}
 	if cmd == nil {
 		t.Fatal("expected embedded launch to return repaint/fetch command")
@@ -4355,7 +4444,7 @@ func TestModel_FlowEmbeddedTerminalAutoClosesOnExitedTick(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, tickBatch := update(m, cmd())
 	if tickBatch == nil {
@@ -4408,7 +4497,7 @@ func TestModel_FlowEmbeddedTerminalAutoCloseKeepsRunningSessionTickAlive(t *test
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, flowTick := update(m, cmd())
 	if flowTick == nil {
@@ -4467,7 +4556,7 @@ func TestModel_FlowEmbeddedTerminalAutoClosePreservesExitedSessionTerminal(t *te
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, tickBatch := update(m, cmd())
 	if tickBatch == nil {
@@ -4538,7 +4627,7 @@ func TestModel_FlowEmbeddedTerminalAutoCloseRenumbersAndKeepsActiveFlowTerminal(
 		var cmd tea.Cmd
 		m, cmd = prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 		if cmd == nil {
-			t.Fatal("ctrl+j should prepare an embedded launch")
+			t.Fatal("g should prepare an embedded launch")
 		}
 		var tickBatch tea.Cmd
 		m, tickBatch = update(m, cmd())
@@ -4612,7 +4701,7 @@ func TestModel_FlowEmbeddedTerminalAutoCloseKeepsCommandModeForPromotedTerminal(
 		var cmd tea.Cmd
 		m, cmd = prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 		if cmd == nil {
-			t.Fatal("ctrl+j should prepare an embedded launch")
+			t.Fatal("g should prepare an embedded launch")
 		}
 		var nextTick tea.Cmd
 		m, nextTick = update(m, cmd())
@@ -4687,7 +4776,7 @@ func TestModel_FlowEmbeddedTerminalAutoCloseClearsStaleTerminateConfirm(t *testi
 		var cmd tea.Cmd
 		m, cmd = prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 		if cmd == nil {
-			t.Fatal("ctrl+j should prepare an embedded launch")
+			t.Fatal("g should prepare an embedded launch")
 		}
 		var nextTick tea.Cmd
 		m, nextTick = update(m, cmd())
@@ -4748,7 +4837,7 @@ func TestModel_FlowEmbeddedTerminalTickKeepsFailedTerminalVisible(t *testing.T) 
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, tickBatch := update(m, cmd())
 	if tickBatch == nil {
@@ -4796,9 +4885,9 @@ func TestModel_FlowEmbeddedLaunchMarksActiveFlowAndPhaseRows(t *testing.T) {
 	}})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
@@ -4850,9 +4939,9 @@ func TestModel_FlowTerminalActivityFiltersActiveStates(t *testing.T) {
 			}})
 
 			m = selectFlowPhaseByID(t, m, "implementation")
-			m, cmd := update(m, flowCtrlJKey())
+			m, cmd := update(m, flowLaunchKey())
 			if cmd == nil {
-				t.Fatal("ctrl+j should prepare an embedded launch")
+				t.Fatal("g should prepare an embedded launch")
 			}
 			m, _ = update(m, cmd())
 			m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
@@ -4890,9 +4979,9 @@ func TestModel_DismissedFlowTerminalRemovesActiveMarker(t *testing.T) {
 	}})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
@@ -4949,9 +5038,9 @@ func TestModel_FlowTerminalActivityMatchesStructuredFlowAndPhaseIDs(t *testing.T
 	})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
@@ -4992,9 +5081,9 @@ func TestModel_FlowEmbeddedTerminalResizesWhenSearchTogglesShortcutPane(t *testi
 		},
 	}})
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -5079,9 +5168,9 @@ func TestModel_FlowEmbeddedTerminalTinyAllocationClampsPTYSize(t *testing.T) {
 	m, _ = update(m, tea.WindowSizeMsg{Width: width, Height: height})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -5095,7 +5184,7 @@ func TestModel_FlowEmbeddedTerminalTinyAllocationClampsPTYSize(t *testing.T) {
 	}
 }
 
-func TestModel_CtrlJOnFlowPhaseWithCodexAppUsesExternalLaunchRoute(t *testing.T) {
+func TestModel_GOnFlowPhaseWithCodexAppUsesExternalLaunchRoute(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	startEmbeddedRan := false
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -5125,9 +5214,9 @@ func TestModel_CtrlJOnFlowPhaseWithCodexAppUsesExternalLaunchRoute(t *testing.T)
 	}})
 
 	m = selectFlowPhaseByID(t, m, "plan")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an external codex-app launch")
+		t.Fatal("g should prepare an external codex-app launch")
 	}
 	msg := cmd()
 	launchMsg, ok := msg.(model.PlanLaunchRequestedMsg)
@@ -5140,7 +5229,7 @@ func TestModel_CtrlJOnFlowPhaseWithCodexAppUsesExternalLaunchRoute(t *testing.T)
 	}
 	_ = cmd()
 	if startEmbeddedRan {
-		t.Fatal("codex-app ctrl+j should not start an embedded terminal")
+		t.Fatal("codex-app g should not start an embedded terminal")
 	}
 	if launched.Command != "codex-app" || launched.FlowID != "flow-1" || launched.Headless || launched.Embedded {
 		t.Fatalf("codex-app launch context = %#v", launched)
@@ -5150,7 +5239,7 @@ func TestModel_CtrlJOnFlowPhaseWithCodexAppUsesExternalLaunchRoute(t *testing.T)
 	}
 }
 
-func TestModel_CtrlJFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNeedsAttention(t *testing.T) {
+func TestModel_GFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNeedsAttention(t *testing.T) {
 	var phaseUpdate flowstore.PhaseUpdate
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -5177,9 +5266,9 @@ func TestModel_CtrlJFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNeedsAttentio
 	}})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -5194,7 +5283,7 @@ func TestModel_CtrlJFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNeedsAttentio
 	}
 }
 
-func TestModel_CtrlJFlowPhaseEmbeddedInteractivePrefillFailureCleansUpTerminal(t *testing.T) {
+func TestModel_GFlowPhaseEmbeddedInteractivePrefillFailureCleansUpTerminal(t *testing.T) {
 	tests := []struct {
 		name           string
 		term           *fakeEmbeddedTerminal
@@ -5263,9 +5352,9 @@ func TestModel_CtrlJFlowPhaseEmbeddedInteractivePrefillFailureCleansUpTerminal(t
 			if cmd != nil {
 				t.Fatalf("h before Flow phase launch returned command %T, want nil", cmd)
 			}
-			m, cmd = update(m, flowCtrlJKey())
+			m, cmd = update(m, flowLaunchKey())
 			if cmd == nil {
-				t.Fatal("ctrl+j should prepare an embedded launch")
+				t.Fatal("g should prepare an embedded launch")
 			}
 			m, cmd = update(m, cmd())
 			if cmd == nil {
@@ -5327,9 +5416,9 @@ func TestModel_FlowTerminalFocusUsesPersistentCommandModeAndTabReturnsToList(t *
 	})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -5379,9 +5468,9 @@ func TestModel_FlowEffortKeyDoesNotOpenPickerWhileFlowTerminalFocused(t *testing
 		},
 	}})
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -5439,9 +5528,9 @@ func TestModel_FlowTerminalCommandModeCanEnterInputMode(t *testing.T) {
 	})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -5482,9 +5571,9 @@ func TestModel_FlowTerminalInputModeForwardsCtrlGToAgent(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -5525,9 +5614,9 @@ func TestModel_FlowTerminalCommandModeSendsLiteralCommandKey(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -5555,9 +5644,9 @@ func TestModel_FlowTerminalTabLeavesFocusEvenAfterCommandKey(t *testing.T) {
 	})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
@@ -5700,7 +5789,7 @@ func TestModel_FlowEmbeddedTerminalDismissRenumbersTabs(t *testing.T) {
 		var cmd tea.Cmd
 		m, cmd = prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 		if cmd == nil {
-			t.Fatal("ctrl+j should prepare an embedded launch")
+			t.Fatal("g should prepare an embedded launch")
 		}
 		m, _ = update(m, cmd())
 	}
@@ -5752,7 +5841,7 @@ func TestModel_EmbeddedTerminalCloseUsesStableIdentityAcrossScopes(t *testing.T)
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 	if view := m.View(); !strings.Contains(view, "1 codex implementation running") {
@@ -5802,7 +5891,7 @@ func TestModel_EmbeddedTerminalTerminateUsesStableIdentityAcrossScopes(t *testin
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, cmd := prepareSelectedFlowPhaseEmbeddedLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -5857,9 +5946,9 @@ func TestModel_FlowListQuitWithRunningEmbeddedTerminalConfirmsAndTerminates(t *t
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -5897,9 +5986,9 @@ func TestModel_LeftPaneQuitWithRunningEmbeddedTerminalConfirms(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -5913,7 +6002,7 @@ func TestModel_LeftPaneQuitWithRunningEmbeddedTerminalConfirms(t *testing.T) {
 	}
 }
 
-func TestModel_CtrlJOnFlowPhaseAtEmbeddedTerminalCapMarksPhaseNeedsAttention(t *testing.T) {
+func TestModel_GOnFlowPhaseAtEmbeddedTerminalCapMarksPhaseNeedsAttention(t *testing.T) {
 	var phaseUpdates []flowstore.PhaseUpdate
 	starts := 0
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -5935,7 +6024,7 @@ func TestModel_CtrlJOnFlowPhaseAtEmbeddedTerminalCapMarksPhaseNeedsAttention(t *
 
 	for i := 0; i < 9; i++ {
 		var cmd tea.Cmd
-		m, cmd = update(m, flowCtrlJKey())
+		m, cmd = update(m, flowLaunchKey())
 		if cmd == nil {
 			t.Fatalf("launch %d should prepare an embedded launch", i+1)
 		}
@@ -5948,9 +6037,9 @@ func TestModel_CtrlJOnFlowPhaseAtEmbeddedTerminalCapMarksPhaseNeedsAttention(t *
 		t.Fatalf("phase updates before cap = %#v, want none", phaseUpdates)
 	}
 
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j at cap should still prepare a launch attempt")
+		t.Fatal("g at cap should still prepare a launch attempt")
 	}
 	m, _ = update(m, cmd())
 	if starts != 9 {
@@ -6053,9 +6142,9 @@ func TestModel_FlowSplitListScrollKeepsSelectionVisible(t *testing.T) {
 	m = flowsInRightPane(t, m, flows)
 
 	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an embedded launch")
+		t.Fatal("g should prepare an embedded launch")
 	}
 	m, _ = update(m, cmd())
 
@@ -6074,7 +6163,7 @@ func TestModel_FlowSplitListScrollKeepsSelectionVisible(t *testing.T) {
 	}
 }
 
-func TestModel_CtrlJLaunchesFlowPhaseImplementationWithoutLinkedPlanContext(t *testing.T) {
+func TestModel_GLaunchesFlowPhaseImplementationWithoutLinkedPlanContext(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -6112,7 +6201,7 @@ func TestModel_CtrlJLaunchesFlowPhaseImplementationWithoutLinkedPlanContext(t *t
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an implementation launch")
+		t.Fatal("g should prepare an implementation launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -6177,7 +6266,7 @@ func TestModel_FlowPromptTemplateReplacesSupportedPlaceholders(t *testing.T) {
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "implementation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an implementation launch")
+		t.Fatal("g should prepare an implementation launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -6210,12 +6299,12 @@ func TestModel_SelectedReadyFlowPhaseAdvertisesLaunchPhaseAction(t *testing.T) {
 
 	m = selectFlowPhaseByID(t, m, "implementation")
 	view = m.View()
-	if !strings.Contains(view, "ctrl+j") || !strings.Contains(view, "launch next") {
+	if !strings.Contains(view, "g      launch next") && !strings.Contains(view, "g: launch next") {
 		t.Fatalf("selected ready Flow phase should expose next launch action:\n%s", view)
 	}
 }
 
-func TestModel_CtrlJWithoutReadyFlowPhaseShowsNoLaunchableStatus(t *testing.T) {
+func TestModel_GWithoutReadyFlowPhaseShowsNoLaunchableStatus(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: "codex"})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
 		FlowID:       "flow-1",
@@ -6235,7 +6324,7 @@ func TestModel_CtrlJWithoutReadyFlowPhaseShowsNoLaunchableStatus(t *testing.T) {
 		t.Fatalf("gated selected phase should not expose launch action:\n%s", view)
 	}
 
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd != nil {
 		t.Fatalf("not-ready flow launch returned command %T, want nil", cmd)
 	}
@@ -6244,7 +6333,7 @@ func TestModel_CtrlJWithoutReadyFlowPhaseShowsNoLaunchableStatus(t *testing.T) {
 	}
 }
 
-func TestModel_CtrlJLaunchesFlowPhaseReviewLoopWithFirstLevelPrompt(t *testing.T) {
+func TestModel_GLaunchesFlowPhaseReviewLoopWithFirstLevelPrompt(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -6289,7 +6378,7 @@ func TestModel_CtrlJLaunchesFlowPhaseReviewLoopWithFirstLevelPrompt(t *testing.T
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "review-loop")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare a review-loop launch")
+		t.Fatal("g should prepare a review-loop launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -6380,7 +6469,7 @@ func TestModel_FlowReviewLoopPromptTemplateOverridesBuiltInPrompt(t *testing.T) 
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "review-loop")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare a review-loop launch")
+		t.Fatal("g should prepare a review-loop launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -6393,7 +6482,7 @@ func TestModel_FlowReviewLoopPromptTemplateOverridesBuiltInPrompt(t *testing.T) 
 	}
 }
 
-func TestModel_CtrlJLaunchesFlowPhasePRCreationWithMinimalPrompt(t *testing.T) {
+func TestModel_GLaunchesFlowPhasePRCreationWithMinimalPrompt(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -6438,7 +6527,7 @@ func TestModel_CtrlJLaunchesFlowPhasePRCreationWithMinimalPrompt(t *testing.T) {
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "pr-creation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare a pr-creation launch")
+		t.Fatal("g should prepare a pr-creation launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -6474,7 +6563,7 @@ func TestModel_CtrlJLaunchesFlowPhasePRCreationWithMinimalPrompt(t *testing.T) {
 	}
 }
 
-func TestModel_CtrlJLaunchesFlowPhasePRCreationWithStructuredMetadataPrompt(t *testing.T) {
+func TestModel_GLaunchesFlowPhasePRCreationWithStructuredMetadataPrompt(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -6513,7 +6602,7 @@ func TestModel_CtrlJLaunchesFlowPhasePRCreationWithStructuredMetadataPrompt(t *t
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "pr-creation")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare a pr-creation launch")
+		t.Fatal("g should prepare a pr-creation launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -6541,7 +6630,7 @@ func TestModel_CtrlJLaunchesFlowPhasePRCreationWithStructuredMetadataPrompt(t *t
 	}
 }
 
-func TestModel_CtrlJLaunchesFlowPhaseAutoreviewWithPRContext(t *testing.T) {
+func TestModel_GLaunchesFlowPhaseAutoreviewWithPRContext(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -6589,7 +6678,7 @@ func TestModel_CtrlJLaunchesFlowPhaseAutoreviewWithPRContext(t *testing.T) {
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "autoreview")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an autoreview launch")
+		t.Fatal("g should prepare an autoreview launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -6619,7 +6708,7 @@ func TestModel_CtrlJLaunchesFlowPhaseAutoreviewWithPRContext(t *testing.T) {
 	}
 }
 
-func TestModel_CtrlJLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) {
+func TestModel_GLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -6667,7 +6756,7 @@ func TestModel_CtrlJLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) 
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "autoreview")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare an autoreview relaunch")
+		t.Fatal("g should prepare an autoreview relaunch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -6695,7 +6784,7 @@ func TestModel_CtrlJLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) 
 	}
 }
 
-func TestModel_CtrlJDoesNotRelaunchFlowPhaseAutoreviewWithoutPRTarget(t *testing.T) {
+func TestModel_GDoesNotRelaunchFlowPhaseAutoreviewWithoutPRTarget(t *testing.T) {
 	var launchAttempted bool
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -6725,9 +6814,9 @@ func TestModel_CtrlJDoesNotRelaunchFlowPhaseAutoreviewWithoutPRTarget(t *testing
 	}})
 
 	m = selectFlowPhaseByID(t, m, "autoreview")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd != nil {
-		t.Fatal("ctrl+j should not launch blocked autoreview without PR metadata")
+		t.Fatal("g should not launch blocked autoreview without PR metadata")
 	}
 	if launchAttempted {
 		t.Fatal("LaunchAgent() ran without PR metadata")
@@ -6737,7 +6826,7 @@ func TestModel_CtrlJDoesNotRelaunchFlowPhaseAutoreviewWithoutPRTarget(t *testing
 	}
 }
 
-func TestModel_CtrlJDoesNotRelaunchFlowPhaseAutoreviewWhenPredecessorsAreUnsatisfied(t *testing.T) {
+func TestModel_GDoesNotRelaunchFlowPhaseAutoreviewWhenPredecessorsAreUnsatisfied(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
@@ -6774,16 +6863,16 @@ func TestModel_CtrlJDoesNotRelaunchFlowPhaseAutoreviewWhenPredecessorsAreUnsatis
 	}})
 
 	m = selectFlowPhaseByID(t, m, "autoreview")
-	m, cmd := update(m, flowCtrlJKey())
+	m, cmd := update(m, flowLaunchKey())
 	if cmd != nil {
-		t.Fatal("ctrl+j should not launch blocked autoreview while predecessors are unsatisfied")
+		t.Fatal("g should not launch blocked autoreview while predecessors are unsatisfied")
 	}
 	if got := m.TransientError(); got != "No launchable Flow phase" {
 		t.Fatalf("status = %q, want no-launchable message", got)
 	}
 }
 
-func TestModel_CtrlJLaunchesFlowPhaseMergeWithStructuredReportingPrompt(t *testing.T) {
+func TestModel_GLaunchesFlowPhaseMergeWithStructuredReportingPrompt(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -6832,7 +6921,7 @@ func TestModel_CtrlJLaunchesFlowPhaseMergeWithStructuredReportingPrompt(t *testi
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "merge")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare a merge launch")
+		t.Fatal("g should prepare a merge launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -6856,7 +6945,7 @@ func TestModel_CtrlJLaunchesFlowPhaseMergeWithStructuredReportingPrompt(t *testi
 	}
 }
 
-func TestModel_CtrlJUsesFlowPhaseOrderingForReadyLaunch(t *testing.T) {
+func TestModel_GUsesFlowPhaseOrderingForReadyLaunch(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -6890,7 +6979,7 @@ func TestModel_CtrlJUsesFlowPhaseOrderingForReadyLaunch(t *testing.T) {
 
 	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "implementation-api")
 	if cmd == nil {
-		t.Fatal("ctrl+j should prepare a child phase launch")
+		t.Fatal("g should prepare a child phase launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -395,7 +395,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModeFlows {
 			m = m.clearSelectedFlowPhase()
 		}
-	case "ctrl+j":
+	case "g":
 		if m.mode == ui.ModeFlows {
 			return m.handleLaunchNextFlowPhase()
 		}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1216,7 +1216,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 				if sp.FlowPhaseSelected {
 					actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
 					if sp.FlowNextLaunchReady {
-						actions = append(actions, shortcutHint{Key: "ctrl+j", Label: "launch next"})
+						actions = append(actions, shortcutHint{Key: "g", Label: "launch next"})
 					}
 					if sp.FlowPhaseResetReadySelected {
 						actions = append(actions, shortcutHint{Key: "x", Label: "reset ready"})
@@ -1230,7 +1230,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 				} else {
 					actions = append(actions, shortcutHint{Key: "enter", Label: "phases"})
 					if sp.FlowNextLaunchReady {
-						actions = append(actions, shortcutHint{Key: "ctrl+j", Label: "launch next"})
+						actions = append(actions, shortcutHint{Key: "g", Label: "launch next"})
 					}
 					if sp.FlowPlanLinked {
 						actions = append(actions, shortcutHint{Key: "o", Label: "open"})
@@ -1475,12 +1475,12 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 	base := footerHintsForKeys(hints, "tab", "q/esc")
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
-	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "ctrl+j", "d")
-	coreActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "ctrl+j", "d", "m")
-	selectedActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "ctrl+j", "x", "o", "y", "d", "r", "m")
-	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "ctrl+j", "x", "o", "y", "d", "r", "m", "A", "E", "f", "F")
-	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "ctrl+j", "x", "o", "y", "d", "r", "m", "A", "f", "F")
-	actionsWithoutAgentAndEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "ctrl+j", "x", "o", "y", "d", "r", "m", "f", "F")
+	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "g", "d")
+	coreActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "d", "m")
+	selectedActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "x", "o", "y", "d", "r", "m")
+	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "E", "f", "F")
+	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "f", "F")
+	actionsWithoutAgentAndEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "f", "F")
 
 	for _, parts := range [][]string{
 		appendParts(base, upDown, arrow, actions),

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -484,7 +484,7 @@ func TestRender_FlowsModeShortcutSectionsUseFlowGroups(t *testing.T) {
 	for _, want := range []string{
 		"n      new flow",
 		"enter  phases",
-		"ctrl+j launch next",
+		"g      launch next",
 		"o      open",
 		"y      copy path",
 		"d      delete",
@@ -711,7 +711,7 @@ func TestStatusBar_FlowsModeShowsNextLaunchOnlyWhenFlowHasLaunchablePhase(t *tes
 
 	base.FlowNextLaunchReady = true
 	ready := renderStatusBarWithState(base)
-	if !strings.Contains(ready, "ctrl+j: launch next") {
+	if !strings.Contains(ready, "g: launch next") {
 		t.Fatalf("ready selected Flow phase should expose launch action, got %q", ready)
 	}
 	for _, notWant := range []string{"a: launch phase", "a: phase status", "i: embed phase"} {
@@ -848,7 +848,7 @@ func TestRender_FlowsModeShowsLaunchAndHeadlessShortcutForLaunchableSelectedPhas
 	})
 
 	pane := shortcutPaneText(view)
-	for _, want := range []string{"enter  phases", "ctrl+j launch next", "h      headless off", "y      copy path"} {
+	for _, want := range []string{"enter  phases", "g      launch next", "h      headless off", "y      copy path"} {
 		if !strings.Contains(pane, want) {
 			t.Fatalf("launchable selected Flow phase shortcut pane missing %q:\n%s", want, pane)
 		}
@@ -931,7 +931,7 @@ func TestStatusBar_FlowsModeNarrowFooterShowsEnterWithHeadlessHint(t *testing.T)
 		FlowHeadless:        true,
 		FlowNextLaunchReady: true,
 	})
-	for _, want := range []string{"h: headless on", "enter: phases", "ctrl+j: launch next"} {
+	for _, want := range []string{"h: headless on", "enter: phases", "g: launch next"} {
 		if !strings.Contains(bar, want) {
 			t.Fatalf("narrow Flow footer missing %q: %q", want, bar)
 		}


### PR DESCRIPTION
## Summary
- change the Flow phase launch shortcut from Ctrl+J to `g`
- update README/config docs and UI labels to reflect the new shortcut
- expand Flow and non-Flow shortcut coverage so `g` launches ready Flow phases only in the intended context

## Verification
- `gofmt -l .`
- `make test`
- `make build`