### PR TITLE
Remove left/right pane swapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ filter matches, or a load failure with details in the status bar.
 | `/` | Fuzzy filter the current item list |
 | `1`/`2`/`3`/`4`/`5`/`6`/`7`/`8` | Switch to worktrees / branches / stashes / history / reflog / sessions / plans / flows |
 | `F3` | Toggle active Flows for the current repo in the middle pane, filtered to non-merged Flow records |
-| `←`/`→`/`l` | Cycle through modes; use arrows or `l` in flows view because `h` toggles Flow headless/interactive command mode |
-| `h` | Cycle to the previous mode outside flows view; toggle Flow headless/interactive command mode in flows view |
+| `←`/`→`/`l` | Switch views in the right pane, clamping at worktrees and flows; use arrows or `l` in flows view because `h` toggles Flow headless/interactive command mode |
+| `h` | Switch to the previous view outside flows view; toggle Flow headless/interactive command mode in flows view |
 | `E` | Choose and persist reasoning effort for the selected CLI agent in flows view |
 | `enter` | Page diff in `less` (dirty worktree, dirty branch, stash, commit, or reflog entry), resume an inline worktree session, page a session transcript, or expand/collapse plan or Flow phases |
 | `g` | Launch the next launchable phase for the selected Flow in flows view |
@@ -108,7 +108,8 @@ filter matches, or a load failure with details in the status bar.
 
 The right pane header shows the active mode. Press `1`–`8` or use arrow keys to
 switch between worktrees, branches, stashes, history, reflog, sessions, plans,
-and flows.
+and flows. Arrow-key view switching clamps at worktrees and flows; use
+`tab`/`f2` to switch pane focus.
 
 When the left repo pane is focused, press `f` to run `git fetch --prune` for
 the currently visible repos. Repo filtering limits the batch to the filtered

--- a/model/flow_refresh_tick_test.go
+++ b/model/flow_refresh_tick_test.go
@@ -173,15 +173,6 @@ func TestModel_FlowRefreshTickScheduledWhenEnteringFlowsModePaths(t *testing.T) 
 			},
 			key: tea.KeyMsg{Type: tea.KeyRight},
 		},
-		{
-			name: "left-pane-wrap",
-			setup: func(m Model) Model {
-				m.activePane = 0
-				m.mode = ui.ModeWorktrees
-				return m
-			},
-			key: tea.KeyMsg{Type: tea.KeyLeft},
-		},
 	}
 
 	for _, tc := range tests {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -199,7 +199,7 @@ func TestModel_F3ActiveFlowRefreshPreparesAutoLaunch(t *testing.T) {
 	}
 }
 
-func TestModel_F3ActiveFlowLKeyNavigatesLikeRightArrow(t *testing.T) {
+func TestModel_F3ActiveFlowLKeyClampsAtFlowSurface(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
@@ -209,15 +209,15 @@ func TestModel_F3ActiveFlowLKeyNavigatesLikeRightArrow(t *testing.T) {
 	if cmd != nil {
 		t.Fatalf("l from active Flow surface returned command %T, want nil", cmd)
 	}
-	if m.ActivePane() != 0 {
-		t.Fatalf("l from active Flow surface left active pane = %d, want left pane", m.ActivePane())
+	if m.ActivePane() != 1 {
+		t.Fatalf("l from active Flow surface active pane = %d, want right pane", m.ActivePane())
 	}
 	if m.Mode() != ui.ModeWorktrees {
 		t.Fatalf("l from active Flow surface changed underlying mode = %d, want worktrees", m.Mode())
 	}
 }
 
-func TestModel_F3ActiveFlowLeftKeyPreservesUnderlyingMode(t *testing.T) {
+func TestModel_F3ActiveFlowLeftKeyClampsAndPreservesUnderlyingMode(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
@@ -227,8 +227,8 @@ func TestModel_F3ActiveFlowLeftKeyPreservesUnderlyingMode(t *testing.T) {
 	if cmd != nil {
 		t.Fatalf("left from active Flow surface returned command %T, want nil", cmd)
 	}
-	if m.ActivePane() != 0 {
-		t.Fatalf("left from active Flow surface left active pane = %d, want left pane", m.ActivePane())
+	if m.ActivePane() != 1 {
+		t.Fatalf("left from active Flow surface active pane = %d, want right pane", m.ActivePane())
 	}
 	if m.Mode() != ui.ModeSessions {
 		t.Fatalf("left from active Flow surface changed underlying mode = %d, want sessions", m.Mode())
@@ -3380,7 +3380,6 @@ func TestModel_SelectedFlowPhaseClearsWhenFlowSelectionChanges(t *testing.T) {
 func TestModel_SelectedFlowPhaseClearsWhenLeavingRightPane(t *testing.T) {
 	for _, key := range []tea.KeyMsg{
 		{Type: tea.KeyTab},
-		{Type: tea.KeyRight},
 	} {
 		m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithPhaseDetails()})
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -3393,6 +3392,27 @@ func TestModel_SelectedFlowPhaseClearsWhenLeavingRightPane(t *testing.T) {
 		if got := m.SelectedFlowPhaseID(); got != "" {
 			t.Fatalf("%s left selected flow phase = %q, want cleared", key.String(), got)
 		}
+	}
+}
+
+func TestModel_SelectedFlowPhasePreservedWhenRightArrowClampsAtFlows(t *testing.T) {
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithPhaseDetails()})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	before := m.SelectedFlowPhaseID()
+	if before == "" {
+		t.Fatal("expected selected flow phase before right arrow")
+	}
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
+	if cmd != nil {
+		t.Fatalf("right from flows returned command %T, want nil", cmd)
+	}
+	if got := m.SelectedFlowPhaseID(); got != before {
+		t.Fatalf("right from flows selected flow phase = %q, want preserved %q", got, before)
+	}
+	if m.ActivePane() != 1 {
+		t.Fatalf("right from flows active pane = %d, want right pane", m.ActivePane())
 	}
 }
 
@@ -3945,8 +3965,8 @@ func TestModel_RightNavigationReachesFlowsWithoutChangingExistingModeNumbers(t *
 	if m.Mode() != ui.ModeFlows {
 		t.Fatalf("right from flows mode = %d, want still flows", m.Mode())
 	}
-	if m.ActivePane() != 0 {
-		t.Fatalf("right from flows active pane = %d, want left pane", m.ActivePane())
+	if m.ActivePane() != 1 {
+		t.Fatalf("right from flows active pane = %d, want right pane", m.ActivePane())
 	}
 	if cmd != nil {
 		t.Fatalf("right from flows mode should not fetch, got %T", cmd)

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -239,6 +239,30 @@ func TestModel_F3ActiveFlowLeftKeyClampsAndPreservesUnderlyingMode(t *testing.T)
 	}
 }
 
+func TestModel_F3ActiveFlowLeftPaneNumberedKeysAreNoOps(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	before := listRequests(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	if cmd != nil {
+		t.Fatalf("left-pane numbered key on active Flow surface returned command %T, want nil", cmd)
+	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("left-pane numbered key activePane = %d, want left pane", m.ActivePane())
+	}
+	if m.Mode() != ui.ModeSessions {
+		t.Fatalf("left-pane numbered key changed underlying mode = %d, want sessions", m.Mode())
+	}
+	if view := ansi.Strip(m.View()); !strings.Contains(view, "Active flows") {
+		t.Fatalf("left-pane numbered key should keep active Flow view visible:\n%s", view)
+	}
+	assertListRequestsUnchanged(t, before, m)
+}
+
 func TestModel_F3ActiveFlowFetchErrorUsesActiveFetchMode(t *testing.T) {
 	m := flowsInRightPane(t, model.New(testRepos()), nil)
 	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 18})

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -257,10 +257,6 @@ func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 	switch key {
 	case "tab":
 		m = m.togglePrimaryPaneFocus()
-	case "left":
-		return m.handleHorizontalNavigation(-1)
-	case "right":
-		return m.handleHorizontalNavigation(1)
 	case "up", "k":
 		if len(m.filteredRepos()) > 0 {
 			m.repos = m.repos.Move(-1, m.repoContentHeight(), ui.LeftPaneWidth-2)
@@ -502,8 +498,6 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 	case "down", "j":
 		return m.handleCursorDown()
 	case "left":
-		m.activePane = 0
-		m = m.clearSelectedFlowPhase()
 		return m, nil
 	case "right", "l":
 		return m.handleHorizontalNavigation(1)
@@ -548,34 +542,11 @@ func (m Model) handleHorizontalNavigation(direction int) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if m.activePane == 0 {
-		m.activePane = 1
-		if m.activeFlowSurfaceVisible() {
-			return m, nil
-		}
-		targetMode := ui.ModeWorktrees
-		if direction < 0 {
-			targetMode = ui.ModeFlows
-		}
-		if m.mode != targetMode {
-			m.mode = targetMode
-			m = m.resetModeCursors()
-			if m.mode == ui.ModeFlows {
-				return m.startFlowsModeFetchWithRefreshTick()
-			}
-			return m.startFetchForMode()
-		}
 		return m, nil
 	}
 
 	if direction > 0 {
-		if m.activeFlowSurfaceVisible() {
-			m.activePane = 0
-			m = m.clearSelectedFlowPhase()
-			return m, nil
-		}
-		if m.mode == ui.ModeFlows {
-			m.activePane = 0
-			m = m.clearSelectedFlowPhase()
+		if m.activeFlowSurfaceVisible() || m.mode == ui.ModeFlows {
 			return m, nil
 		}
 		m.mode++
@@ -587,7 +558,6 @@ func (m Model) handleHorizontalNavigation(direction int) (tea.Model, tea.Cmd) {
 	}
 
 	if m.mode == ui.ModeWorktrees {
-		m.activePane = 0
 		return m, nil
 	}
 	m.mode--

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -53,7 +53,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if key == "f3" {
 		return m.toggleActiveFlowsSurface()
 	}
-	if !m.searchActive && m.activeFlowSurfaceVisible() && isNumberedModeKey(key) {
+	if !m.searchActive && m.activePane == 1 && m.activeFlowSurfaceVisible() && isNumberedModeKey(key) {
 		next, cmd, handled := m.switchModeFromKey(key)
 		if handled {
 			return next, cmd

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -680,14 +680,14 @@ func TestModel_LeftPaneModeKeysAreNoOps(t *testing.T) {
 	}
 }
 
-func TestModel_RightArrowFromLeftPaneMovesToRightPaneWithoutChangingMode(t *testing.T) {
+func TestModel_RightArrowFromLeftPaneIsNoOp(t *testing.T) {
 	m := model.New(testRepos())
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
 
-	if m.ActivePane() != 1 {
-		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
+	if m.ActivePane() != 0 {
+		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
 	}
 	if m.Mode() != ui.ModeWorktrees {
 		t.Fatalf("Mode() = %d, want worktrees", m.Mode())
@@ -698,25 +698,25 @@ func TestModel_RightArrowFromLeftPaneMovesToRightPaneWithoutChangingMode(t *test
 	assertListRequestsUnchanged(t, before, m)
 }
 
-func TestModel_LeftArrowFromLeftPaneWrapsToFlowsMode(t *testing.T) {
+func TestModel_LeftArrowFromLeftPaneIsNoOp(t *testing.T) {
 	m := model.New(testRepos())
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
 
-	if m.ActivePane() != 1 {
-		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
+	if m.ActivePane() != 0 {
+		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
 	}
-	if m.Mode() != ui.ModeFlows {
-		t.Fatalf("Mode() = %d, want flows", m.Mode())
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("Mode() = %d, want worktrees", m.Mode())
 	}
-	if cmd == nil {
-		t.Fatal("left from left pane should fetch flows")
+	if cmd != nil {
+		t.Fatalf("left from left pane produced cmd %T, want nil", cmd)
 	}
-	assertOnlyListRequestAdvanced(t, before, m, ui.ModeFlows)
+	assertListRequestsUnchanged(t, before, m)
 }
 
-func TestModel_RightArrowFromLeftPaneEntersWorktreesFromNonEdgeMode(t *testing.T) {
+func TestModel_RightArrowFromLeftPaneInNonEdgeModeIsNoOp(t *testing.T) {
 	m := model.New(testRepos())
 	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchResultMsg{RepoPath: "/dev/alpha", Branches: []gitquery.Branch{
@@ -728,22 +728,22 @@ func TestModel_RightArrowFromLeftPaneEntersWorktreesFromNonEdgeMode(t *testing.T
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
 
-	if m.ActivePane() != 1 {
-		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
+	if m.ActivePane() != 0 {
+		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
 	}
-	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("Mode() = %d, want worktrees", m.Mode())
+	if m.Mode() != ui.ModeBranches {
+		t.Fatalf("Mode() = %d, want branches", m.Mode())
 	}
-	if m.BranchSelected() != 0 {
-		t.Fatalf("BranchSelected() = %d, want reset cursor 0", m.BranchSelected())
+	if m.BranchSelected() != 1 {
+		t.Fatalf("BranchSelected() = %d, want preserved cursor 1", m.BranchSelected())
 	}
-	if cmd == nil {
-		t.Fatal("right from left pane in branches should fetch worktrees")
+	if cmd != nil {
+		t.Fatalf("right from left pane in branches produced cmd %T, want nil", cmd)
 	}
-	assertOnlyListRequestChanged(t, before, m, ui.ModeWorktrees)
+	assertListRequestsUnchanged(t, before, m)
 }
 
-func TestModel_LeftArrowFromLeftPaneAtFlowsIsPaneOnlyMove(t *testing.T) {
+func TestModel_LeftArrowFromLeftPaneAtFlowsIsNoOp(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := model.New(testRepos())
 	m = inRightPane(m)
@@ -759,8 +759,8 @@ func TestModel_LeftArrowFromLeftPaneAtFlowsIsPaneOnlyMove(t *testing.T) {
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
 
-	if m.ActivePane() != 1 {
-		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
+	if m.ActivePane() != 0 {
+		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
 	}
 	if m.Mode() != ui.ModeFlows {
 		t.Fatalf("Mode() = %d, want flows", m.Mode())
@@ -1573,7 +1573,7 @@ func TestModel_HLSwitchModes(t *testing.T) {
 	}
 }
 
-func TestModel_RightCyclesThroughAllViewsAndWrapsToLeftPane(t *testing.T) {
+func TestModel_RightCyclesThroughAllViewsAndClampsAtFlows(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	if m.Mode() != ui.ModeWorktrees {
@@ -1593,31 +1593,18 @@ func TestModel_RightCyclesThroughAllViewsAndWrapsToLeftPane(t *testing.T) {
 	before := listRequests(m)
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
 	if m.Mode() != ui.ModeFlows {
-		t.Fatalf("Mode() = %d, want flows after wrapping to left pane", m.Mode())
+		t.Fatalf("Mode() = %d, want flows after clamping", m.Mode())
 	}
-	if m.ActivePane() != 0 {
-		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
+	if m.ActivePane() != 1 {
+		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
 	}
 	if cmd != nil {
 		t.Fatalf("right from flows produced cmd %T, want nil", cmd)
 	}
 	assertListRequestsUnchanged(t, before, m)
-
-	before = listRequests(m)
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRight})
-	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("Mode() = %d, want worktrees after re-entering from left pane", m.Mode())
-	}
-	if m.ActivePane() != 1 {
-		t.Fatalf("ActivePane() = %d, want right pane after re-entering from left pane", m.ActivePane())
-	}
-	if cmd == nil {
-		t.Fatal("right from left pane at flows should fetch worktrees")
-	}
-	assertOnlyListRequestChanged(t, before, m, ui.ModeWorktrees)
 }
 
-func TestModel_LeftCyclesBackThroughAllViewsAndWrapsToLeftPane(t *testing.T) {
+func TestModel_LeftCyclesBackThroughAllViewsAndClampsAtWorktrees(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
@@ -1635,31 +1622,18 @@ func TestModel_LeftCyclesBackThroughAllViewsAndWrapsToLeftPane(t *testing.T) {
 	before := listRequests(m)
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
 	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("Mode() = %d, want worktrees after wrapping to left pane", m.Mode())
+		t.Fatalf("Mode() = %d, want worktrees after clamping", m.Mode())
 	}
-	if m.ActivePane() != 0 {
-		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
+	if m.ActivePane() != 1 {
+		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
 	}
 	if cmd != nil {
 		t.Fatalf("left from worktrees produced cmd %T, want nil", cmd)
 	}
 	assertListRequestsUnchanged(t, before, m)
-
-	before = listRequests(m)
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyLeft})
-	if m.Mode() != ui.ModeFlows {
-		t.Fatalf("Mode() = %d, want flows after re-entering from left pane", m.Mode())
-	}
-	if m.ActivePane() != 1 {
-		t.Fatalf("ActivePane() = %d, want right pane after re-entering from left pane", m.ActivePane())
-	}
-	if cmd == nil {
-		t.Fatal("left from left pane at worktrees should fetch flows")
-	}
-	assertOnlyListRequestChanged(t, before, m, ui.ModeFlows)
 }
 
-func TestModel_ArrowNavigationWrapsFromModeEdgesToLeftPane(t *testing.T) {
+func TestModel_ArrowNavigationClampsAtModeEdges(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
@@ -1673,8 +1647,8 @@ func TestModel_ArrowNavigationWrapsFromModeEdgesToLeftPane(t *testing.T) {
 	if m.Mode() != ui.ModeWorktrees {
 		t.Fatalf("Mode() = %d, want worktrees", m.Mode())
 	}
-	if m.ActivePane() != 0 {
-		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
+	if m.ActivePane() != 1 {
+		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
 	}
 	if m.WorktreeSelected() != 1 {
 		t.Fatalf("WorktreeSelected() = %d, want preserved cursor 1", m.WorktreeSelected())
@@ -1685,7 +1659,6 @@ func TestModel_ArrowNavigationWrapsFromModeEdgesToLeftPane(t *testing.T) {
 	assertListRequestsUnchanged(t, before, m)
 
 	flow := flowWithPhaseDetails()
-	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
 	m, _ = update(m, model.FlowResultMsg{RepoPath: "/dev/alpha", Flows: []flowstore.FlowRecord{
 		flow,
@@ -1699,8 +1672,8 @@ func TestModel_ArrowNavigationWrapsFromModeEdgesToLeftPane(t *testing.T) {
 	if m.Mode() != ui.ModeFlows {
 		t.Fatalf("Mode() = %d, want flows", m.Mode())
 	}
-	if m.ActivePane() != 0 {
-		t.Fatalf("ActivePane() = %d, want left pane", m.ActivePane())
+	if m.ActivePane() != 1 {
+		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
 	}
 	if m.FlowSelected() != 1 || m.ExpandedFlowID() != "flow-2" {
 		t.Fatalf("flow state selected=%d expanded=%q, want selected 1 expanded flow-2", m.FlowSelected(), m.ExpandedFlowID())

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1015,7 +1015,7 @@ func sidebarShortcutHints(hints []shortcutHint) []shortcutHint {
 			next := hints[i+1]
 			switch {
 			case hint.Key == "↑/↓" && next.Key == "←/→":
-				grouped = append(grouped, shortcutHint{Key: "↑/↓ ←/→", Label: "select/pane/view", Warning: hint.Warning || next.Warning})
+				grouped = append(grouped, shortcutHint{Key: "↑/↓ ←/→", Label: "select/view", Warning: hint.Warning || next.Warning})
 				i++
 				continue
 			case hint.Key == "f" && next.Key == "F":
@@ -1071,7 +1071,9 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 
 	navigation := []shortcutHint{
 		{Key: "↑/↓", Label: "select", Inline: true},
-		{Key: "←/→", Label: "pane/view", Inline: true},
+	}
+	if sp.ActivePane == 1 {
+		navigation = append(navigation, shortcutHint{Key: "←/→", Label: "view", Inline: true})
 	}
 	global := []shortcutHint{
 		{Key: "f2/tab", Label: "pane"},

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1072,7 +1072,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	navigation := []shortcutHint{
 		{Key: "↑/↓", Label: "select", Inline: true},
 	}
-	if sp.ActivePane == 1 {
+	if sp.ActivePane == 1 && !sp.ActiveFlows {
 		navigation = append(navigation, shortcutHint{Key: "←/→", Label: "view", Inline: true})
 	}
 	global := []shortcutHint{

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -1137,6 +1137,9 @@ func TestRender_ActiveFlowsIgnoreHiddenSessionTerminalForShortcuts(t *testing.T)
 			t.Fatalf("active Flow shortcut pane missing %q:\n%s", want, pane)
 		}
 	}
+	if strings.Contains(pane, "←/→") {
+		t.Fatalf("active Flow shortcut pane should not advertise clamped arrow navigation:\n%s", pane)
+	}
 	if strings.Contains(pane, "ctrl+] commands") || strings.Contains(pane, "Terminal") {
 		t.Fatalf("active Flow shortcut pane should ignore hidden session terminal:\n%s", pane)
 	}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1724,18 +1724,30 @@ func TestRender_LeftPaneShortcutPaneOmitsModeNumberHint(t *testing.T) {
 	}
 }
 
-func TestRender_ShortcutPaneShowsArrowPaneViewHint(t *testing.T) {
-	for _, activePane := range []int{0, 1} {
-		pane := shortcutPaneText(renderShortcutPane(statusBarParams{
-			Mode:       ModeFlows,
-			ActivePane: activePane,
-		}, 26, 18))
-		if !strings.Contains(pane, "f2/tab") || !strings.Contains(pane, "pane") {
-			t.Fatalf("shortcut pane activePane=%d should include f2/tab pane hint, got:\n%s", activePane, pane)
-		}
-		if !strings.Contains(pane, "←/→") || !strings.Contains(pane, "pane/view") {
-			t.Fatalf("shortcut pane activePane=%d should include arrow pane/view hint, got:\n%s", activePane, pane)
-		}
+func TestRender_ShortcutPaneShowsArrowViewHintOnlyForRightPane(t *testing.T) {
+	leftPane := shortcutPaneText(renderShortcutPane(statusBarParams{
+		Mode:       ModeFlows,
+		ActivePane: 0,
+	}, 26, 18))
+	if !strings.Contains(leftPane, "f2/tab") || !strings.Contains(leftPane, "pane") {
+		t.Fatalf("left-pane shortcut pane should include f2/tab pane hint, got:\n%s", leftPane)
+	}
+	if strings.Contains(leftPane, "←/→") || strings.Contains(leftPane, "pane/view") {
+		t.Fatalf("left-pane shortcut pane should not include arrow view hint, got:\n%s", leftPane)
+	}
+
+	rightPane := shortcutPaneText(renderShortcutPane(statusBarParams{
+		Mode:       ModeFlows,
+		ActivePane: 1,
+	}, 26, 18))
+	if !strings.Contains(rightPane, "f2/tab") || !strings.Contains(rightPane, "pane") {
+		t.Fatalf("right-pane shortcut pane should include f2/tab pane hint, got:\n%s", rightPane)
+	}
+	if !strings.Contains(rightPane, "←/→") || !strings.Contains(rightPane, "view") {
+		t.Fatalf("right-pane shortcut pane should include arrow view hint, got:\n%s", rightPane)
+	}
+	if strings.Contains(rightPane, "pane/view") || strings.Contains(rightPane, "select/pane/view") {
+		t.Fatalf("right-pane shortcut pane should not describe arrows as pane navigation, got:\n%s", rightPane)
 	}
 }
 
@@ -3466,8 +3478,8 @@ func TestStatusBar_StashesModeHintsSpacing(t *testing.T) {
 	}
 	for _, pair := range [][2]string{
 		{"f2/tab: pane", "q/esc: quit"},
-		{"↑/↓ select", "←/→ pane/view"},
-		{"←/→ pane/view", "enter: diff"},
+		{"↑/↓ select", "←/→ view"},
+		{"←/→ view", "enter: diff"},
 		{"enter: diff", "d: drop"},
 	} {
 		a := strings.Index(bar, pair[0])
@@ -3855,7 +3867,7 @@ func TestStatusBar_GenericFooterKeepsQuitBeforeNavigationWhenTight(t *testing.T)
 			t.Fatalf("tight generic footer should keep %q, got %q", want, bar)
 		}
 	}
-	for _, notWant := range []string{"↑/↓ select", "←/→ pane/view"} {
+	for _, notWant := range []string{"↑/↓ select", "←/→ view"} {
 		if strings.Contains(bar, notWant) {
 			t.Fatalf("tight generic footer should drop navigation hint %q before quit, got %q", notWant, bar)
 		}
@@ -3864,24 +3876,27 @@ func TestStatusBar_GenericFooterKeepsQuitBeforeNavigationWhenTight(t *testing.T)
 
 func TestStatusBar_WorktreesModeShowsNavHints(t *testing.T) {
 	bar := RenderStatusBar(160, 1, 0, 1, false, false, false)
-	for _, hint := range []string{"f2/tab: pane", "q/esc: quit", "↑/↓ select", "←/→ pane/view"} {
+	for _, hint := range []string{"f2/tab: pane", "q/esc: quit", "↑/↓ select", "←/→ view"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("worktrees mode status bar should contain %q", hint)
 		}
 	}
 }
 
-func TestStatusBar_ShowsArrowPaneViewHintWhenLeftPaneActive(t *testing.T) {
+func TestStatusBar_HidesArrowViewHintWhenLeftPaneActive(t *testing.T) {
 	bar := RenderStatusBar(80, ModeFlows, OverlayNone, 0, false, false, false)
-	if !strings.Contains(bar, "←/→ pane/view") {
-		t.Fatalf("left-pane status bar should advertise arrow pane/view navigation, got %q", bar)
+	if strings.Contains(bar, "←/→") || strings.Contains(bar, "pane/view") {
+		t.Fatalf("left-pane status bar should not advertise arrow view navigation, got %q", bar)
 	}
 }
 
-func TestStatusBar_BranchesModeShowsArrowPaneViewHint(t *testing.T) {
+func TestStatusBar_BranchesModeShowsArrowViewHint(t *testing.T) {
 	bar := RenderStatusBar(120, ModeBranches, OverlayNone, 1, false, false, false)
-	if !strings.Contains(bar, "←/→ pane/view") {
-		t.Fatalf("branches status bar should advertise arrow pane/view navigation, got %q", bar)
+	if !strings.Contains(bar, "←/→ view") {
+		t.Fatalf("branches status bar should advertise arrow view navigation, got %q", bar)
+	}
+	if strings.Contains(bar, "pane/view") {
+		t.Fatalf("branches status bar should not describe arrows as pane navigation, got %q", bar)
 	}
 }
 
@@ -3938,15 +3953,16 @@ func TestStatusBar_BranchesModePrefersActionsOverLegendWhenTight(t *testing.T) {
 	}
 }
 
-func TestStatusBar_ArrowPaneViewHintFitsNarrowFooter(t *testing.T) {
+func TestStatusBar_ArrowViewHintFitsNarrowFooter(t *testing.T) {
 	for _, tc := range []struct {
-		name string
-		mode Mode
-		pane int
+		name      string
+		mode      Mode
+		pane      int
+		wantArrow bool
 	}{
 		{name: "worktrees left pane", mode: ModeWorktrees, pane: 0},
-		{name: "branches", mode: ModeBranches, pane: 1},
-		{name: "flows", mode: ModeFlows, pane: 1},
+		{name: "branches", mode: ModeBranches, pane: 1, wantArrow: true},
+		{name: "flows", mode: ModeFlows, pane: 1, wantArrow: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			bar := RenderStatusBar(80, tc.mode, OverlayNone, tc.pane, false, false, false)
@@ -3957,8 +3973,11 @@ func TestStatusBar_ArrowPaneViewHintFitsNarrowFooter(t *testing.T) {
 			if got := lipgloss.Width(stripped); got > 80 {
 				t.Fatalf("status bar width = %d, want <= 80: %q", got, bar)
 			}
-			if !strings.Contains(bar, "←/→ pane/view") {
-				t.Fatalf("status bar should include arrow pane/view hint, got %q", bar)
+			if tc.wantArrow && !strings.Contains(bar, "←/→ view") {
+				t.Fatalf("status bar should include arrow view hint, got %q", bar)
+			}
+			if !tc.wantArrow && strings.Contains(bar, "←/→") {
+				t.Fatalf("status bar should hide arrow view hint, got %q", bar)
 			}
 		})
 	}
@@ -3971,7 +3990,7 @@ func TestStatusBar_GenericActionModesDoNotWrapNarrowFooter(t *testing.T) {
 		destructive bool
 		wantHints   []string
 	}{
-		{name: "stashes destructive", mode: ModeStashes, destructive: true, wantHints: []string{"←/→ pane/view", "enter: diff", "d: drop"}},
+		{name: "stashes destructive", mode: ModeStashes, destructive: true, wantHints: []string{"←/→ view", "enter: diff", "d: drop"}},
 		{name: "reflog", mode: ModeReflog, wantHints: []string{"q/esc: quit", "enter: diff", "y: copy hash"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -4098,10 +4117,10 @@ func TestStatusBar_WorktreesModeDoesNotWrapNarrowFooter(t *testing.T) {
 		dirty       bool
 		wantHints   []string
 	}{
-		{name: "clean", wantHints: []string{"←/→ pane/view", "n: new worktree", "f: fetch", "F: pull"}},
-		{name: "dirty", dirty: true, wantHints: []string{"←/→ pane/view", "enter: diff"}},
-		{name: "destructive", destructive: true, wantHints: []string{"←/→ pane/view", "d: delete"}},
-		{name: "stale", destructive: true, stale: true, wantHints: []string{"←/→ pane/view", "p: prune"}},
+		{name: "clean", wantHints: []string{"←/→ view", "n: new worktree", "f: fetch", "F: pull"}},
+		{name: "dirty", dirty: true, wantHints: []string{"←/→ view", "enter: diff"}},
+		{name: "destructive", destructive: true, wantHints: []string{"←/→ view", "d: delete"}},
+		{name: "stale", destructive: true, stale: true, wantHints: []string{"←/→ view", "p: prune"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			bar := RenderStatusBar(80, ModeWorktrees, OverlayNone, 1, tc.destructive, tc.stale, tc.dirty)

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -3890,6 +3890,20 @@ func TestStatusBar_HidesArrowViewHintWhenLeftPaneActive(t *testing.T) {
 	}
 }
 
+func TestStatusBar_HidesArrowViewHintForActiveFlows(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:        120,
+		Mode:         ModeSessions,
+		ActiveFlows:  true,
+		ActivePane:   1,
+		RepoSelected: true,
+		FlowSelected: true,
+	})
+	if strings.Contains(bar, "←/→") || strings.Contains(bar, "pane/view") {
+		t.Fatalf("active Flow status bar should not advertise arrow view navigation, got %q", bar)
+	}
+}
+
 func TestStatusBar_BranchesModeShowsArrowViewHint(t *testing.T) {
 	bar := RenderStatusBar(120, ModeBranches, OverlayNone, 1, false, false, false)
 	if !strings.Contains(bar, "←/→ view") {


### PR DESCRIPTION
## Summary
- Stop left/right arrows from moving focus between the repo pane and content pane.
- Keep right-pane arrow navigation within views, clamped at worktrees and flows while preserving selection and Flow terminal command-mode behavior.
- Update shortcut hints, README guidance, and regression coverage for the revised navigation behavior.

## Verification
- gofmt -l .
- git diff --check
- go test ./model ./ui
- make test
- make build