### PR TITLE
Refine Flow pane navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ WORKTREE_ROOT=~/projects ./bin/wtui
 
 ### Keys
 
-The UI has two panes: repos on the left, content on the right. `tab` or `f2` switches focus between them. When a Flow embedded terminal is open, `tab` also switches focus between the Flow list and that terminal while the right pane remains active. The active pane is highlighted with a blue border.
+The UI has two panes: repos on the left, content on the right. Press `enter`
+on a selected repo to focus the content pane, and press `f2` to switch pane
+focus explicitly. When a Flow embedded terminal is open, `tab` switches focus
+between the Flow list and that terminal while the right pane remains active.
+The active pane is highlighted with a blue border.
 
 **Destructive mode:** The app starts in read-only mode — deletion keys are disabled. Press `D` (Shift+D) to toggle destructive mode on/off. When active, the right pane border turns red and delete/drop hints appear in red as a visual warning.
 
@@ -65,7 +69,8 @@ filter matches, or a load failure with details in the status bar.
 | `D` | Toggle destructive mode |
 | `f` | Fetch all currently visible repos with `--prune` |
 | `n` | Create a new local repo under the scan root, optionally creating a GitHub repo and wiring `origin` |
-| `tab`/`f2` | Switch focus to right pane |
+| `enter` | Switch focus to right pane |
+| `f2` | Switch pane focus |
 | `q`/`esc` | Quit |
 
 **Right pane (content)**
@@ -103,13 +108,14 @@ filter matches, or a load failure with details in the status bar.
 | `e` | Edit selected plan Markdown (plans view) |
 | `i` | Alias for plan implementation launch |
 | `D` | Toggle destructive mode |
-| `tab`/`f2` | Switch focus to left pane |
+| `f2` | Switch focus to left pane |
 | `q`/`esc` | Close a prompt/dialog or quit |
 
 The right pane header shows the active mode. Press `1`–`8` or use arrow keys to
 switch between worktrees, branches, stashes, history, reflog, sessions, plans,
-and flows. Arrow-key view switching clamps at worktrees and flows; use
-`tab`/`f2` to switch pane focus.
+and flows. Arrow-key view switching clamps at worktrees and flows. Press
+`enter` from the repo pane to focus the content pane, or `f2` to switch pane
+focus explicitly.
 
 When the left repo pane is focused, press `f` to run `git fetch --prune` for
 the currently visible repos. Repo filtering limits the batch to the filtered

--- a/model/export_test.go
+++ b/model/export_test.go
@@ -22,6 +22,14 @@ func ActiveFlowCreateForTest(m Model) uint64 {
 	return m.activeFlowCreate
 }
 
+func ActiveFlowSelectedForTest(m Model) int {
+	return m.activeFlows.SelectedIndex()
+}
+
+func SelectedActiveFlowPhaseIDForTest(m Model) string {
+	return m.selectedActiveFlowPhaseID
+}
+
 func FlowHeadlessForTest(m Model) bool {
 	return m.flowHeadless
 }

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -1907,7 +1907,7 @@ func TestModel_DestructivePersistsAcrossRepoSwitch(t *testing.T) {
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 	// Switch to left pane and navigate to a different repo
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if !m.Destructive() {
 		t.Error("expected destructive to persist after repo switch")
@@ -2756,7 +2756,7 @@ func TestModel_BranchCreatedPendingSelectionClearsOnRepoSwitch(t *testing.T) {
 	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchCreatedMsg{RepoPath: "/dev/alpha", Name: "feature/one"})
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})  // left pane
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})   // left pane
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown}) // repo bravo
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/bravo",
@@ -3992,7 +3992,7 @@ func TestModel_ChangingRepoRefetchesSessionsMode(t *testing.T) {
 		t.Fatalf("initial Sessions() = %#v", got)
 	}
 
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	if cmd != nil {
 		t.Fatalf("expected nil cmd switching to repo pane, got %T", cmd)
 	}

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -262,6 +262,91 @@ func TestModel_F3ActiveFlowTabWithoutTerminalKeepsFlowSurfaceFocused(t *testing.
 	assertListRequestsUnchanged(t, before, m)
 }
 
+func TestModel_F3ActiveFlowTabWithTerminalSwitchesBetweenListAndTerminal(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
+	flowOne := flowWithPhaseDetails()
+	flowTwo := flowWithPhaseDetails()
+	flowTwo.FlowID = "flow-2"
+	flowTwo.Title = "Second active flow"
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updated := flowOne
+			for i := range updated.Phases {
+				if updated.Phases[i].PhaseID == update.PhaseID {
+					updated.Phases[i].Status = flowstore.PhaseRunning
+					updated.Phases[i].LaunchIDs = append(updated.Phases[i].LaunchIDs, update.LaunchID)
+				}
+			}
+			return updated, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return fakeTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowOne, flowTwo})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, cmd := update(m, flowLaunchKey())
+	if cmd == nil {
+		t.Fatal("g on active Flow should prepare an embedded launch")
+	}
+	m, _ = update(m, cmd())
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	if len(fakeTerm.writes) != 0 {
+		t.Fatalf("active Flow terminal command mode should not forward unknown command bytes: %#v", fakeTerm.writes)
+	}
+	if got := m.TransientError(); !strings.Contains(got, "Unknown terminal prefix command") {
+		t.Fatalf("status = %q, want unknown terminal command", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlCloseBracket})
+	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "\x1d" {
+		t.Fatalf("ctrl+] in active Flow terminal command mode should send literal ctrl+], writes = %#v", fakeTerm.writes)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if len(fakeTerm.writes) != 1 {
+		t.Fatalf("active Flow list focus should not forward j to terminal: %#v", fakeTerm.writes)
+	}
+	if m.FlowSelected() != 0 {
+		t.Fatalf("normal Flow selection = %d, want unchanged while active Flow list moves", m.FlowSelected())
+	}
+	if got := model.ActiveFlowSelectedForTest(m); got != 1 {
+		t.Fatalf("active Flow selection = %d, want list focus to move to second flow", got)
+	}
+}
+
+func TestModel_F3ActiveFlowF2ClearsSelectedPhaseWhenLeavingRightPane(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "plan" {
+		t.Fatalf("selected active Flow phase = %q, want plan before leaving right pane", got)
+	}
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF2})
+	if cmd != nil {
+		t.Fatalf("F2 from active Flow surface returned command %T, want nil", cmd)
+	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("F2 from active Flow surface active pane = %d, want left pane", m.ActivePane())
+	}
+	if m.Mode() != ui.ModeSessions {
+		t.Fatalf("F2 from active Flow surface changed underlying mode = %d, want sessions", m.Mode())
+	}
+	if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "" {
+		t.Fatalf("F2 from active Flow surface left selected phase = %q, want cleared", got)
+	}
+}
+
 func TestModel_F3ActiveFlowLeftPaneNumberedKeysAreNoOps(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -239,12 +239,35 @@ func TestModel_F3ActiveFlowLeftKeyClampsAndPreservesUnderlyingMode(t *testing.T)
 	}
 }
 
+func TestModel_F3ActiveFlowTabWithoutTerminalKeepsFlowSurfaceFocused(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	before := listRequests(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if cmd != nil {
+		t.Fatalf("tab from active Flow surface returned command %T, want nil", cmd)
+	}
+	if m.ActivePane() != 1 {
+		t.Fatalf("tab from active Flow surface active pane = %d, want right pane", m.ActivePane())
+	}
+	if m.Mode() != ui.ModeSessions {
+		t.Fatalf("tab from active Flow surface changed underlying mode = %d, want sessions", m.Mode())
+	}
+	if view := ansi.Strip(m.View()); !strings.Contains(view, "Active flows") {
+		t.Fatalf("tab from active Flow surface should keep active Flow view visible:\n%s", view)
+	}
+	assertListRequestsUnchanged(t, before, m)
+}
+
 func TestModel_F3ActiveFlowLeftPaneNumberedKeysAreNoOps(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
@@ -3403,7 +3426,7 @@ func TestModel_SelectedFlowPhaseClearsWhenFlowSelectionChanges(t *testing.T) {
 
 func TestModel_SelectedFlowPhaseClearsWhenLeavingRightPane(t *testing.T) {
 	for _, key := range []tea.KeyMsg{
-		{Type: tea.KeyTab},
+		{Type: tea.KeyF2},
 	} {
 		m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithPhaseDetails()})
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -3548,7 +3571,7 @@ func TestModel_ChangingRepoRefetchesFlowsMode(t *testing.T) {
 		t.Fatalf("initial Flows() = %#v", got)
 	}
 
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	if cmd != nil {
 		t.Fatalf("expected nil cmd switching to repo pane, got %T", cmd)
 	}
@@ -8302,7 +8325,7 @@ func TestModel_NewFlowCodexAppStaleLaunchIgnoredAfterRepoChange(t *testing.T) {
 		t.Fatal("expected flow creation command")
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	staleMsg := createCmd()
 	if launchMsg, ok := staleMsg.(model.PlanLaunchRequestedMsg); !ok || launchMsg.Request == 0 {
@@ -8405,7 +8428,7 @@ func TestModel_NewFlowStaleLaunchIgnoredAfterRepoChange(t *testing.T) {
 		t.Fatal("expected flow creation command")
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	staleMsg := createCmd()
 	if launchMsg, ok := staleMsg.(model.FlowEmbeddedLaunchRequestedMsg); !ok || launchMsg.Request == 0 {
@@ -8520,7 +8543,7 @@ func TestModel_NewFlowStaleStartFailureIgnoredAfterRepoChange(t *testing.T) {
 		t.Fatal("flow create failure should be tagged with the active create request")
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	next, cmd := update(m, staleMsg)
 	if cmd != nil {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -486,7 +486,7 @@ func (m Model) togglePrimaryPaneFocus() Model {
 	if m.mode == ui.ModePlans {
 		m = m.clearSelectedPlanPhase()
 	}
-	if m.mode == ui.ModeFlows {
+	if m.mode == ui.ModeFlows || m.activeFlowSurfaceVisible() {
 		m = m.clearSelectedFlowPhase()
 	}
 	return m

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -255,8 +255,10 @@ func (m Model) setSearchActive(active bool) Model {
 
 func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 	switch key {
-	case "tab":
-		m = m.togglePrimaryPaneFocus()
+	case "enter":
+		if len(m.filteredRepos()) > 0 {
+			m.activePane = 1
+		}
 	case "up", "k":
 		if len(m.filteredRepos()) > 0 {
 			m.repos = m.repos.Move(-1, m.repoContentHeight(), ui.LeftPaneWidth-2)
@@ -402,7 +404,6 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			m.terminalPrefixActive = true
 			return m, nil
 		}
-		m = m.togglePrimaryPaneFocus()
 	case "g":
 		if m.mode == ui.ModeFlows {
 			return m.handleLaunchNextFlowPhase()
@@ -509,8 +510,6 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 			m.terminalPrefixActive = true
 			return m, nil
 		}
-		m.activePane = 0
-		m = m.clearSelectedFlowPhase()
 	case "g":
 		return m.handleLaunchNextFlowPhase()
 	case "enter":

--- a/model/model_plan_overlay_test.go
+++ b/model/model_plan_overlay_test.go
@@ -449,7 +449,7 @@ func TestModel_CollapsingExpandedPlanResumesPlanMovement(t *testing.T) {
 	}
 }
 
-func TestModel_TabbingAwayFromPlansClearsSelectedPhase(t *testing.T) {
+func TestModel_F2AwayFromPlansClearsSelectedPhase(t *testing.T) {
 	m := model.New(testRepos())
 	m = plansInRightPane(t, m, []planstore.PlanRecord{
 		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft",
@@ -462,12 +462,12 @@ func TestModel_TabbingAwayFromPlansClearsSelectedPhase(t *testing.T) {
 		t.Fatalf("selected phase = %q, want p1", got)
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	if got := m.SelectedPlanPhaseID(); got != "" {
 		t.Fatalf("selected phase should clear when focus leaves plans pane, got %q", got)
 	}
 	if view := m.View(); !strings.Contains(view, "Phase 1") {
-		t.Fatalf("tabbing away should preserve phase expansion:\n%s", view)
+		t.Fatalf("leaving plans should preserve phase expansion:\n%s", view)
 	}
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})

--- a/model/model_plan_overlay_test.go
+++ b/model/model_plan_overlay_test.go
@@ -449,7 +449,7 @@ func TestModel_CollapsingExpandedPlanResumesPlanMovement(t *testing.T) {
 	}
 }
 
-func TestModel_F2AwayFromPlansClearsSelectedPhase(t *testing.T) {
+func TestModel_F2AwayFromPlansAndBackKeepsSelectedPhaseCleared(t *testing.T) {
 	m := model.New(testRepos())
 	m = plansInRightPane(t, m, []planstore.PlanRecord{
 		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft",
@@ -463,6 +463,9 @@ func TestModel_F2AwayFromPlansClearsSelectedPhase(t *testing.T) {
 	}
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	if got := m.ActivePane(); got != 0 {
+		t.Fatalf("F2 should move focus to repo pane, got active pane %d", got)
+	}
 	if got := m.SelectedPlanPhaseID(); got != "" {
 		t.Fatalf("selected phase should clear when focus leaves plans pane, got %q", got)
 	}
@@ -470,7 +473,10 @@ func TestModel_F2AwayFromPlansClearsSelectedPhase(t *testing.T) {
 		t.Fatalf("leaving plans should preserve phase expansion:\n%s", view)
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	if got := m.ActivePane(); got != 1 {
+		t.Fatalf("F2 should return focus to plans pane, got active pane %d", got)
+	}
 	if got := m.SelectedPlanPhaseID(); got != "" {
 		t.Fatalf("selected phase should not restore when focus returns, got %q", got)
 	}

--- a/model/model_plan_test.go
+++ b/model/model_plan_test.go
@@ -72,7 +72,7 @@ func TestModel_ChangingRepoRefetchesPlansMode(t *testing.T) {
 		t.Fatalf("initial Plans() = %#v", got)
 	}
 
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	if cmd != nil {
 		t.Fatalf("expected nil cmd switching to repo pane, got %T", cmd)
 	}
@@ -640,7 +640,7 @@ func TestModel_IKeyMissingPlanLaunchPathShowsStatus(t *testing.T) {
 		AgentCommand:     "codex",
 		PlanMarkdownPath: func(string) (string, error) { return "/state/plans/plan-1/plan.md", nil },
 	})
-	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
 	m, _ = update(m, model.PlanResultMsg{Plans: []planstore.PlanRecord{
 		{PlanID: "plan-1", Title: "Implement plans", Status: "approved"},

--- a/model/model_refresh_test.go
+++ b/model/model_refresh_test.go
@@ -407,7 +407,7 @@ func TestModel_RepoSelectionResetInvalidatesStaleNonCurrentPaneResults(t *testin
 	}
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
 	m, _ = update(m, stalePlan)

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -133,7 +133,7 @@ func assertOnlyListRequestChanged(t *testing.T, before map[ui.Mode]uint64, after
 
 // inRightPane switches focus to the right pane.
 func inRightPane(m model.Model) model.Model {
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	return m
 }
 
@@ -446,24 +446,57 @@ func TestModel_QuitKeys(t *testing.T) {
 
 // --- Pane switching ---
 
-func TestModel_TabFromRightPaneSwitchesToLeft(t *testing.T) {
+func TestModel_TabFromRightPaneDoesNotSwitchToLeft(t *testing.T) {
 	m := model.New(testRepos())
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab}) // left → right
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab}) // right → left
-	if m.ActivePane() != 0 {
-		t.Errorf("expected left pane (0) after second tab, got %d", m.ActivePane())
-	}
-}
+	m = inRightPane(m)
+	before := listRequests(m)
 
-func TestModel_TabTogglesPaneFocus(t *testing.T) {
-	m := model.New(testRepos())
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyTab})
+
 	if m.ActivePane() != 1 {
 		t.Errorf("expected right pane after tab, got %d", m.ActivePane())
 	}
-	// TAB does not change repo selection
+	if cmd != nil {
+		t.Fatalf("tab from right pane produced cmd %T, want nil", cmd)
+	}
+	assertListRequestsUnchanged(t, before, m)
+}
+
+func TestModel_TabFromLeftPaneDoesNotSwitchPanes(t *testing.T) {
+	m := model.New(testRepos())
+	before := listRequests(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyTab})
+
+	if m.ActivePane() != 0 {
+		t.Errorf("expected left pane after tab, got %d", m.ActivePane())
+	}
 	if m.Selected() != 0 {
 		t.Errorf("expected selected unchanged at 0, got %d", m.Selected())
+	}
+	if cmd != nil {
+		t.Fatalf("tab from left pane produced cmd %T, want nil", cmd)
+	}
+	assertListRequestsUnchanged(t, before, m)
+}
+
+func TestModel_EnterFromLeftPaneSwitchesToRightWithoutChangingSelectionOrMode(t *testing.T) {
+	m := model.New(testRepos())
+	m = selectBravo(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.ActivePane() != 1 {
+		t.Fatalf("expected right pane after enter, got %d", m.ActivePane())
+	}
+	if m.Selected() != 1 {
+		t.Fatalf("selected repo = %d, want unchanged 1", m.Selected())
+	}
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("mode = %d, want unchanged worktrees", m.Mode())
+	}
+	if cmd != nil {
+		t.Fatalf("enter from left pane produced cmd %T, want nil", cmd)
 	}
 }
 
@@ -485,17 +518,20 @@ func TestModel_F2FromLeftPaneSwitchesToRightWithoutChangingSelectionOrMode(t *te
 
 func TestModel_TabDoesNotChangeMode(t *testing.T) {
 	m := model.New(testRepos())
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // left → right
+	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // mode 3 (stashes)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // right → left
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 	if m.Mode() != 3 {
 		t.Errorf("expected mode unchanged at 3, got %d", m.Mode())
+	}
+	if m.ActivePane() != 1 {
+		t.Errorf("expected active pane unchanged at right pane, got %d", m.ActivePane())
 	}
 }
 
 func TestModel_F2FromRightPaneSwitchesToLeftWithoutChangingMode(t *testing.T) {
 	m := model.New(testRepos())
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // left → right
+	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // mode 3 (stashes)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})                        // right → left
 
@@ -575,7 +611,7 @@ func TestModel_LeftPaneDownFiresFetchInBranchMode(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}) // branches
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // back to left pane
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})                        // back to left pane
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if cmd == nil {
 		t.Error("expected fetch cmd after repo navigation in branches mode, got nil")
@@ -651,7 +687,7 @@ func TestModel_LeftPaneDownResetsRightPaneCursors(t *testing.T) {
 	}})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown}) // move branch cursor
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown}) // branchSelected=2
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})  // back to left pane
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})   // back to left pane
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown}) // navigate to bravo
 	if m.BranchSelected() != 0 {
 		t.Errorf("expected branchSelected reset to 0, got %d", m.BranchSelected())
@@ -723,7 +759,7 @@ func TestModel_RightArrowFromLeftPaneInNonEdgeModeIsNoOp(t *testing.T) {
 		{Name: "main"}, {Name: "feature"},
 	}})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
@@ -754,7 +790,7 @@ func TestModel_LeftArrowFromLeftPaneAtFlowsIsNoOp(t *testing.T) {
 	}, ListRequest: m.ListRequest(ui.ModeFlows)})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
@@ -1534,7 +1570,7 @@ func TestModel_PressingCurrentModeKeyNoFetch(t *testing.T) {
 func TestModel_ModeSwitchPreservesSelection(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})                      // select bravo (left pane)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})                       // switch to right pane
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})                     // switch to right pane
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // mode 3 (stashes)
 	if m.Selected() != 1 {
 		t.Errorf("expected selection preserved at 1, got %d", m.Selected())
@@ -1939,7 +1975,7 @@ func TestModel_RepoSwitchClearsCommits(t *testing.T) {
 	if len(m.Commits()) != 3 {
 		t.Fatal("expected 3 commits")
 	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab}) // switch to left pane
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2}) // switch to left pane
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if len(m.Commits()) != 0 {
 		t.Errorf("expected commits cleared on repo switch, got %d", len(m.Commits()))
@@ -2107,7 +2143,7 @@ func TestModel_RepoSwitchClearsReflogs(t *testing.T) {
 		t.Fatalf("expected 3 reflogs loaded, got %d", len(m.Reflogs()))
 	}
 	// Switch to left pane and navigate down
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if len(m.Reflogs()) != 0 {
 		t.Errorf("expected reflogs cleared on repo switch, got %d", len(m.Reflogs()))

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -342,8 +342,8 @@ func TestModel_ViewStatusBarShowsKeyHints(t *testing.T) {
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 
 	view := m.View()
-	if !strings.Contains(view, "f2/tab pane") {
-		t.Error("view should contain 'f2/tab pane' shortcut")
+	if !strings.Contains(view, "f2     pane") {
+		t.Error("view should contain 'f2 pane' shortcut")
 	}
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1072,11 +1072,14 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	navigation := []shortcutHint{
 		{Key: "↑/↓", Label: "select", Inline: true},
 	}
+	if sp.ActivePane == 0 && sp.RepoSelected {
+		navigation = append(navigation, shortcutHint{Key: "enter", Label: "pane", Inline: true})
+	}
 	if sp.ActivePane == 1 && !sp.ActiveFlows {
 		navigation = append(navigation, shortcutHint{Key: "←/→", Label: "view", Inline: true})
 	}
 	global := []shortcutHint{
-		{Key: "f2/tab", Label: "pane"},
+		{Key: "f2", Label: "pane"},
 		{Key: "q/esc", Label: "quit"},
 		{Key: "f5", Label: "refresh"},
 		{Key: "f3", Label: "active flows"},
@@ -1446,7 +1449,7 @@ func transientStatusStyle(fadeStep int) lipgloss.Style {
 
 func renderWorktreeFooterShortcuts(sp statusBarParams, sections []shortcutSection) string {
 	hints := flattenShortcutHints(sections)
-	base := footerHintsForKeys(hints, "f2/tab", "q/esc")
+	base := footerHintsForKeys(hints, "f2", "q/esc")
 	agent := footerHintsForKeys(hints, "A")
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
@@ -1497,14 +1500,14 @@ func renderGenericFooterShortcuts(sp statusBarParams, sections []shortcutSection
 		{"f5", "f3", "A", "D", "←/→"},
 		{"f5", "f3", "A", "D", "←/→", "↑/↓"},
 		{"f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc"},
-		{"f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc", "f2/tab"},
+		{"f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc", "f2"},
 	} {
 		candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, drop...)))
 		if lipgloss.Width(candidate) <= sp.Width {
 			return candidate
 		}
 	}
-	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc", "f2/tab")))
+	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc", "f2")))
 	return ansi.Truncate(candidate, sp.Width, "")
 }
 
@@ -1517,7 +1520,7 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 		return full
 	}
 	hints := flattenShortcutHints(sections)
-	base := footerHintsForKeys(hints, "f2/tab", "q/esc")
+	base := footerHintsForKeys(hints, "f2", "q/esc")
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
 	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "g", "d")
@@ -1555,14 +1558,14 @@ func renderBranchFooterShortcuts(sp statusBarParams, sections []shortcutSection)
 	legend, rest := splitLegendSection(sections)
 	rest = branchFooterSectionOrder(rest)
 	hints := flattenShortcutHints(rest)
-	base := footerHintsForKeys(hints, "f2/tab", "q/esc")
+	base := footerHintsForKeys(hints, "f2", "q/esc")
 	nav := footerHintsForKeys(hints, "↑/↓", "←/→")
 	actions := footerHintsForKeys(hints, "D", "n", "enter", "d", "f", "F", "t", "c", "a")
 
 	full := append(append(append([]string{}, base...), actions...), nav...)
 	baseActions := append(append([]string{}, base...), actions...)
 	baseNav := append(append([]string{}, base...), nav...)
-	baseArrow := footerHintsForKeys(hints, "f2/tab", "q/esc", "←/→")
+	baseArrow := footerHintsForKeys(hints, "f2", "q/esc", "←/→")
 
 	for _, parts := range [][]string{full, baseActions} {
 		if candidate, ok := branchFooterCandidateWithLegend(sp.Width, legend, parts); ok {

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -492,7 +492,7 @@ func TestRender_FlowsModeShortcutSectionsUseFlowGroups(t *testing.T) {
 		"m      auto: on",
 		"A      codex",
 		"E      effort: high",
-		"f2/tab pane",
+		"f2     pane",
 		"q/esc  quit",
 		"f5     refresh",
 	} {
@@ -602,7 +602,7 @@ func TestStatusBar_FlowsModeFullFooterPreservesSectionOrder(t *testing.T) {
 	enterIndex := strings.Index(bar, "enter: phases")
 	headlessIndex := strings.Index(bar, "h: headless on")
 	agentIndex := strings.Index(bar, "A: codex")
-	tabIndex := strings.Index(bar, "f2/tab: pane")
+	tabIndex := strings.Index(bar, "f2: pane")
 	if enterIndex < 0 || headlessIndex < 0 || agentIndex < 0 || tabIndex < 0 {
 		t.Fatalf("full Flow footer missing expected hints, got %q", bar)
 	}

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -142,9 +142,9 @@ func TestStatusBar_StashesModeOmitsIndicatorLegend(t *testing.T) {
 func TestStatusBar_PipeSeparatesLegendAndHints(t *testing.T) {
 	bar := RenderStatusBar(120, 2, 0, 1, true, false, false)
 	upstreamIdx := strings.Index(bar, "no upstream")
-	tabIdx := strings.Index(bar, "f2/tab: pane")
+	tabIdx := strings.Index(bar, "f2: pane")
 	if upstreamIdx == -1 || tabIdx == -1 {
-		t.Fatalf("expected both 'no upstream' and 'f2/tab: pane' in bar: %q", bar)
+		t.Fatalf("expected both 'no upstream' and 'f2: pane' in bar: %q", bar)
 	}
 	between := bar[upstreamIdx+len("no upstream") : tabIdx]
 	if !strings.Contains(between, "|") {
@@ -154,13 +154,13 @@ func TestStatusBar_PipeSeparatesLegendAndHints(t *testing.T) {
 
 func TestStatusBar_TabAndQuitBeforeOtherHints(t *testing.T) {
 	bar := RenderStatusBar(160, 2, 0, 1, true, false, false)
-	tabIdx := strings.Index(bar, "f2/tab: pane")
+	tabIdx := strings.Index(bar, "f2: pane")
 	tIdx := strings.Index(bar, "t: terminal")
 	if tabIdx == -1 || tIdx == -1 {
 		t.Fatalf("expected both hints in bar: %q", bar)
 	}
 	if tabIdx > tIdx {
-		t.Error("f2/tab: pane should appear before t: terminal")
+		t.Error("f2: pane should appear before t: terminal")
 	}
 	qIdx := strings.Index(bar, "q/esc: quit")
 	if qIdx > tIdx {
@@ -176,7 +176,7 @@ func TestStatusBar_ActionHintsHiddenWhenLeftPaneActive(t *testing.T) {
 		}
 	}
 	// Pane switching and q/esc should still appear.
-	for _, hint := range []string{"f2/tab: pane", "q/esc: quit"} {
+	for _, hint := range []string{"f2: pane", "q/esc: quit"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("hint %q should appear even when left pane is active", hint)
 		}
@@ -1243,7 +1243,7 @@ func TestStatusBar_LaunchInstructionsOverlayShowsLaunchHint(t *testing.T) {
 func TestStatusBar_KeyHintSpacingIs2(t *testing.T) {
 	bar := RenderStatusBar(160, 2, 0, 1, true, false, false)
 	for _, pair := range [][2]string{
-		{"f2/tab: pane", "q/esc: quit"},
+		{"f2: pane", "q/esc: quit"},
 		{"d: delete", "f: fetch"},
 		{"t: terminal", "c: code"},
 	} {
@@ -1335,10 +1335,10 @@ func TestRender_WideLayoutReplacesFooterHints(t *testing.T) {
 
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	if strings.Contains(footer, "f2/tab: pane") || strings.Contains(footer, "q/esc: quit") {
+	if strings.Contains(footer, "f2: pane") || strings.Contains(footer, "q/esc: quit") {
 		t.Fatalf("wide render footer should not carry shortcut hints, got %q", footer)
 	}
-	if !strings.Contains(shortcutPaneText(view), "f2/tab pane") {
+	if !strings.Contains(shortcutPaneText(view), "f2     pane") {
 		t.Fatal("wide render should still expose global shortcuts in the shortcut pane")
 	}
 }
@@ -1354,8 +1354,8 @@ func TestRender_NarrowLayoutKeepsFooterHints(t *testing.T) {
 
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	if !strings.Contains(footer, "f2/tab: pane") {
-		t.Fatalf("narrow render should expose f2/tab pane hint, got %q", footer)
+	if !strings.Contains(footer, "f2: pane") {
+		t.Fatalf("narrow render should expose f2 pane hint, got %q", footer)
 	}
 	if strings.Contains(view, "Shortcuts") {
 		t.Fatal("narrow render should not reserve a shortcut pane")
@@ -1386,7 +1386,7 @@ func TestRender_ShortWideLayoutKeepsClippedShortcutPane(t *testing.T) {
 	}
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	for _, forbidden := range []string{"f2/tab: pane", "n: new worktree", "F: pull", "c: code"} {
+	for _, forbidden := range []string{"f2: pane", "n: new worktree", "F: pull", "c: code"} {
 		if strings.Contains(footer, forbidden) {
 			t.Fatalf("short wide footer should not carry shortcut hint %q, got %q", forbidden, footer)
 		}
@@ -1464,7 +1464,7 @@ func TestRender_ShortcutPanePrioritizesActions(t *testing.T) {
 	navigate := strings.Index(pane, "Navigate")
 	global := strings.Index(pane, "Global")
 	newWorktree := strings.Index(pane, "new worktree")
-	tabPane := strings.Index(pane, "f2/tab pane")
+	tabPane := strings.Index(pane, "f2     pane")
 	if actions < 0 || navigate < 0 || global < 0 || !(actions < navigate && navigate < global) {
 		t.Fatalf("shortcut pane should order Actions, Navigate, Global, got:\n%s", pane)
 	}
@@ -1729,8 +1729,8 @@ func TestRender_ShortcutPaneShowsArrowViewHintOnlyForRightPane(t *testing.T) {
 		Mode:       ModeFlows,
 		ActivePane: 0,
 	}, 26, 18))
-	if !strings.Contains(leftPane, "f2/tab") || !strings.Contains(leftPane, "pane") {
-		t.Fatalf("left-pane shortcut pane should include f2/tab pane hint, got:\n%s", leftPane)
+	if !strings.Contains(leftPane, "f2") || !strings.Contains(leftPane, "pane") {
+		t.Fatalf("left-pane shortcut pane should include f2 pane hint, got:\n%s", leftPane)
 	}
 	if strings.Contains(leftPane, "←/→") || strings.Contains(leftPane, "pane/view") {
 		t.Fatalf("left-pane shortcut pane should not include arrow view hint, got:\n%s", leftPane)
@@ -1740,8 +1740,8 @@ func TestRender_ShortcutPaneShowsArrowViewHintOnlyForRightPane(t *testing.T) {
 		Mode:       ModeFlows,
 		ActivePane: 1,
 	}, 26, 18))
-	if !strings.Contains(rightPane, "f2/tab") || !strings.Contains(rightPane, "pane") {
-		t.Fatalf("right-pane shortcut pane should include f2/tab pane hint, got:\n%s", rightPane)
+	if !strings.Contains(rightPane, "f2") || !strings.Contains(rightPane, "pane") {
+		t.Fatalf("right-pane shortcut pane should include f2 pane hint, got:\n%s", rightPane)
 	}
 	if !strings.Contains(rightPane, "←/→") || !strings.Contains(rightPane, "view") {
 		t.Fatalf("right-pane shortcut pane should include arrow view hint, got:\n%s", rightPane)
@@ -1782,7 +1782,7 @@ func TestRender_BranchShortcutPaneKeepsLegend(t *testing.T) {
 	}
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	if strings.Contains(footer, "f2/tab: pane") || strings.Contains(footer, "no upstream") {
+	if strings.Contains(footer, "f2: pane") || strings.Contains(footer, "no upstream") {
 		t.Fatalf("branch wide footer should not duplicate shortcut or legend hints, got %q", footer)
 	}
 }
@@ -3477,7 +3477,7 @@ func TestStatusBar_StashesModeHintsSpacing(t *testing.T) {
 		}
 	}
 	for _, pair := range [][2]string{
-		{"f2/tab: pane", "q/esc: quit"},
+		{"f2: pane", "q/esc: quit"},
 		{"↑/↓ select", "←/→ view"},
 		{"←/→ view", "enter: diff"},
 		{"enter: diff", "d: drop"},
@@ -3861,8 +3861,8 @@ func TestWorktreePane_ScrollOffset(t *testing.T) {
 }
 
 func TestStatusBar_GenericFooterKeepsQuitBeforeNavigationWhenTight(t *testing.T) {
-	bar := ansi.Strip(RenderStatusBar(60, 3, 0, 1, true, false, false))
-	for _, want := range []string{"f2/tab: pane", "q/esc: quit"} {
+	bar := ansi.Strip(RenderStatusBar(52, 3, 0, 1, true, false, false))
+	for _, want := range []string{"f2: pane", "q/esc: quit"} {
 		if !strings.Contains(bar, want) {
 			t.Fatalf("tight generic footer should keep %q, got %q", want, bar)
 		}
@@ -3876,7 +3876,7 @@ func TestStatusBar_GenericFooterKeepsQuitBeforeNavigationWhenTight(t *testing.T)
 
 func TestStatusBar_WorktreesModeShowsNavHints(t *testing.T) {
 	bar := RenderStatusBar(160, 1, 0, 1, false, false, false)
-	for _, hint := range []string{"f2/tab: pane", "q/esc: quit", "↑/↓ select", "←/→ view"} {
+	for _, hint := range []string{"f2: pane", "q/esc: quit", "↑/↓ select", "←/→ view"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("worktrees mode status bar should contain %q", hint)
 		}
@@ -4334,7 +4334,7 @@ func TestReflogDiffOverlay_NonEmptyDiffShowsContent(t *testing.T) {
 
 func TestStatusBar_ReflogModeHints(t *testing.T) {
 	bar := RenderStatusBar(120, 5, 0, 1, false, false, false)
-	for _, hint := range []string{"enter: diff", "y: copy hash", "f2/tab: pane", "q/esc: quit"} {
+	for _, hint := range []string{"enter: diff", "y: copy hash", "f2: pane", "q/esc: quit"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("reflog status bar should contain %q", hint)
 		}


### PR DESCRIPTION
## Summary
- Make Flow mode pane navigation use tab/backtab instead of left/right pane swapping.
- Keep active Flow focus cleanup consistent when expanded phases or terminal panes change.
- Update Flow/navigation tests and README shortcut docs for the new behavior.

## Verification
- `gofmt -l .`
- `make test`
- `make build`