### PR TITLE
Wrap arrow navigation at pane edges

### DIFF
--- a/model/flow_refresh_tick_test.go
+++ b/model/flow_refresh_tick_test.go
@@ -173,6 +173,15 @@ func TestModel_FlowRefreshTickScheduledWhenEnteringFlowsModePaths(t *testing.T) 
 			},
 			key: tea.KeyMsg{Type: tea.KeyRight},
 		},
+		{
+			name: "left-arrow-wrap",
+			setup: func(m Model) Model {
+				m.activePane = 1
+				m.mode = ui.ModeWorktrees
+				return m
+			},
+			key: tea.KeyMsg{Type: tea.KeyLeft},
+		},
 	}
 
 	for _, tc := range tests {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -199,21 +199,33 @@ func TestModel_F3ActiveFlowRefreshPreparesAutoLaunch(t *testing.T) {
 	}
 }
 
-func TestModel_F3ActiveFlowLKeyClampsAtFlowSurface(t *testing.T) {
-	flow := flowWithPhaseDetails()
-	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+func TestModel_F3ActiveFlowRightNavigationKeysClampAtFlowSurface(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "right arrow", key: tea.KeyMsg{Type: tea.KeyRight}},
+		{name: "l", key: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flow := flowWithPhaseDetails()
+			m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+			before := listRequests(m)
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
-	if cmd != nil {
-		t.Fatalf("l from active Flow surface returned command %T, want nil", cmd)
-	}
-	if m.ActivePane() != 1 {
-		t.Fatalf("l from active Flow surface active pane = %d, want right pane", m.ActivePane())
-	}
-	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("l from active Flow surface changed underlying mode = %d, want worktrees", m.Mode())
+			m, cmd := update(m, tc.key)
+			if cmd != nil {
+				t.Fatalf("%s from active Flow surface returned command %T, want nil", tc.name, cmd)
+			}
+			if m.ActivePane() != 1 {
+				t.Fatalf("%s from active Flow surface active pane = %d, want right pane", tc.name, m.ActivePane())
+			}
+			if m.Mode() != ui.ModeWorktrees {
+				t.Fatalf("%s from active Flow surface changed underlying mode = %d, want worktrees", tc.name, m.Mode())
+			}
+			assertListRequestsUnchanged(t, before, m)
+		})
 	}
 }
 
@@ -222,6 +234,7 @@ func TestModel_F3ActiveFlowLeftKeyClampsAndPreservesUnderlyingMode(t *testing.T)
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
 	if cmd != nil {
@@ -237,6 +250,7 @@ func TestModel_F3ActiveFlowLeftKeyClampsAndPreservesUnderlyingMode(t *testing.T)
 	if !strings.Contains(view, "Active flows") {
 		t.Fatalf("left from active Flow surface should keep active Flow view visible:\n%s", view)
 	}
+	assertListRequestsUnchanged(t, before, m)
 }
 
 func TestModel_F3ActiveFlowLeftPaneNumberedKeysAreNoOps(t *testing.T) {
@@ -3419,24 +3433,32 @@ func TestModel_SelectedFlowPhaseClearsWhenLeavingRightPane(t *testing.T) {
 	}
 }
 
-func TestModel_SelectedFlowPhasePreservedWhenRightArrowClampsAtFlows(t *testing.T) {
+func TestModel_SelectedFlowPhaseClearsWhenRightArrowWrapsFromFlows(t *testing.T) {
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
-	before := m.SelectedFlowPhaseID()
-	if before == "" {
+	if before := m.SelectedFlowPhaseID(); before == "" {
 		t.Fatal("expected selected flow phase before right arrow")
 	}
+	beforeRequests := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
-	if cmd != nil {
-		t.Fatalf("right from flows returned command %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("right from flows returned nil command, want worktrees fetch")
 	}
-	if got := m.SelectedFlowPhaseID(); got != before {
-		t.Fatalf("right from flows selected flow phase = %q, want preserved %q", got, before)
+	if got := m.SelectedFlowPhaseID(); got != "" {
+		t.Fatalf("right from flows selected flow phase = %q, want cleared", got)
 	}
 	if m.ActivePane() != 1 {
 		t.Fatalf("right from flows active pane = %d, want right pane", m.ActivePane())
+	}
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("right from flows mode = %d, want worktrees", m.Mode())
+	}
+	assertOnlyListRequestChanged(t, beforeRequests, m, ui.ModeWorktrees)
+	msgs := runBatchCmd(t, cmd)
+	if !hasListFetchForMode(msgs, ui.ModeWorktrees, m.ListRequest(ui.ModeWorktrees)) {
+		t.Fatalf("right from flows command messages = %#v, want worktrees fetch for request %d", msgs, m.ListRequest(ui.ModeWorktrees))
 	}
 }
 
@@ -3970,7 +3992,7 @@ func TestModel_FlowDeleteDoesNotTerminateEmbeddedTerminal(t *testing.T) {
 	}
 }
 
-func TestModel_RightNavigationReachesFlowsWithoutChangingExistingModeNumbers(t *testing.T) {
+func TestModel_RightNavigationWrapsFromFlowsWithoutChangingExistingModeNumbers(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) { return nil, nil },
 	})
@@ -3985,15 +4007,21 @@ func TestModel_RightNavigationReachesFlowsWithoutChangingExistingModeNumbers(t *
 	if m.Mode() != ui.ModeFlows || cmd == nil {
 		t.Fatalf("key 8 mode=%d cmd=%v, want flows fetch", m.Mode(), cmd)
 	}
+	before := listRequests(m)
 	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRight})
-	if m.Mode() != ui.ModeFlows {
-		t.Fatalf("right from flows mode = %d, want still flows", m.Mode())
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("right from flows mode = %d, want worktrees", m.Mode())
 	}
 	if m.ActivePane() != 1 {
 		t.Fatalf("right from flows active pane = %d, want right pane", m.ActivePane())
 	}
-	if cmd != nil {
-		t.Fatalf("right from flows mode should not fetch, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("right from flows returned nil command, want worktrees fetch")
+	}
+	assertOnlyListRequestChanged(t, before, m, ui.ModeWorktrees)
+	msgs := runBatchCmd(t, cmd)
+	if !hasListFetchForMode(msgs, ui.ModeWorktrees, m.ListRequest(ui.ModeWorktrees)) {
+		t.Fatalf("right from flows command messages = %#v, want worktrees fetch for request %d", msgs, m.ListRequest(ui.ModeWorktrees))
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -224,6 +224,10 @@ func TestModel_F3ActiveFlowRightNavigationKeysClampAtFlowSurface(t *testing.T) {
 			if m.Mode() != ui.ModeWorktrees {
 				t.Fatalf("%s from active Flow surface changed underlying mode = %d, want worktrees", tc.name, m.Mode())
 			}
+			view := ansi.Strip(m.View())
+			if !strings.Contains(view, "Active flows") {
+				t.Fatalf("%s from active Flow surface should keep active Flow view visible:\n%s", tc.name, view)
+			}
 			assertListRequestsUnchanged(t, before, m)
 		})
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -544,25 +544,33 @@ func (m Model) handleHorizontalNavigation(direction int) (tea.Model, tea.Cmd) {
 	if m.activePane == 0 {
 		return m, nil
 	}
-
-	if direction > 0 {
-		if m.activeFlowSurfaceVisible() || m.mode == ui.ModeFlows {
-			return m, nil
-		}
-		m.mode++
-		m = m.resetModeCursors()
-		if m.mode == ui.ModeFlows {
-			return m.startFlowsModeFetchWithRefreshTick()
-		}
-		return m.startFetchForMode()
-	}
-
-	if m.mode == ui.ModeWorktrees {
+	if m.activeFlowSurfaceVisible() {
 		return m, nil
 	}
-	m.mode--
+
+	nextMode := modeAfterHorizontalNavigation(m.mode, direction)
+	if nextMode == m.mode {
+		return m, nil
+	}
+	m.mode = nextMode
 	m = m.resetModeCursors()
+	if m.mode == ui.ModeFlows {
+		return m.startFlowsModeFetchWithRefreshTick()
+	}
 	return m.startFetchForMode()
+}
+
+func modeAfterHorizontalNavigation(current ui.Mode, direction int) ui.Mode {
+	if direction > 0 {
+		if current == ui.ModeFlows {
+			return ui.ModeWorktrees
+		}
+		return current + 1
+	}
+	if current == ui.ModeWorktrees {
+		return ui.ModeFlows
+	}
+	return current - 1
 }
 
 // --- Cursor navigation ---

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1573,7 +1573,7 @@ func TestModel_HLSwitchModes(t *testing.T) {
 	}
 }
 
-func TestModel_RightCyclesThroughAllViewsAndClampsAtFlows(t *testing.T) {
+func TestModel_RightCyclesThroughAllViewsAndWrapsToWorktrees(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	if m.Mode() != ui.ModeWorktrees {
@@ -1592,19 +1592,23 @@ func TestModel_RightCyclesThroughAllViewsAndClampsAtFlows(t *testing.T) {
 
 	before := listRequests(m)
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
-	if m.Mode() != ui.ModeFlows {
-		t.Fatalf("Mode() = %d, want flows after clamping", m.Mode())
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("Mode() = %d, want worktrees after wrapping", m.Mode())
 	}
 	if m.ActivePane() != 1 {
 		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
 	}
-	if cmd != nil {
-		t.Fatalf("right from flows produced cmd %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("right from flows produced nil cmd, want worktrees fetch")
 	}
-	assertListRequestsUnchanged(t, before, m)
+	assertOnlyListRequestChanged(t, before, m, ui.ModeWorktrees)
+	msgs := runBatchCmd(t, cmd)
+	if !hasListFetchForMode(msgs, ui.ModeWorktrees, m.ListRequest(ui.ModeWorktrees)) {
+		t.Fatalf("right from flows command messages = %#v, want worktrees fetch for request %d", msgs, m.ListRequest(ui.ModeWorktrees))
+	}
 }
 
-func TestModel_LeftCyclesBackThroughAllViewsAndClampsAtWorktrees(t *testing.T) {
+func TestModel_LeftCyclesBackThroughAllViewsAndWrapsToFlows(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
@@ -1621,19 +1625,23 @@ func TestModel_LeftCyclesBackThroughAllViewsAndClampsAtWorktrees(t *testing.T) {
 
 	before := listRequests(m)
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
-	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("Mode() = %d, want worktrees after clamping", m.Mode())
+	if m.Mode() != ui.ModeFlows {
+		t.Fatalf("Mode() = %d, want flows after wrapping", m.Mode())
 	}
 	if m.ActivePane() != 1 {
 		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
 	}
-	if cmd != nil {
-		t.Fatalf("left from worktrees produced cmd %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("left from worktrees produced nil cmd, want flows fetch")
 	}
-	assertListRequestsUnchanged(t, before, m)
+	assertOnlyListRequestChanged(t, before, m, ui.ModeFlows)
+	msgs := runBatchCmd(t, cmd)
+	if !hasListFetchForMode(msgs, ui.ModeFlows, m.ListRequest(ui.ModeFlows)) {
+		t.Fatalf("left from worktrees command messages = %#v, want flows fetch for request %d", msgs, m.ListRequest(ui.ModeFlows))
+	}
 }
 
-func TestModel_ArrowNavigationClampsAtModeEdges(t *testing.T) {
+func TestModel_ArrowNavigationWrapsAtModeEdges(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	m, _ = update(m, model.WorktreeResultMsg{RepoPath: "/dev/alpha", Worktrees: []gitquery.Worktree{
@@ -1644,8 +1652,8 @@ func TestModel_ArrowNavigationClampsAtModeEdges(t *testing.T) {
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
-	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("Mode() = %d, want worktrees", m.Mode())
+	if m.Mode() != ui.ModeFlows {
+		t.Fatalf("Mode() = %d, want flows after wrapping", m.Mode())
 	}
 	if m.ActivePane() != 1 {
 		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
@@ -1653,13 +1661,16 @@ func TestModel_ArrowNavigationClampsAtModeEdges(t *testing.T) {
 	if m.WorktreeSelected() != 1 {
 		t.Fatalf("WorktreeSelected() = %d, want preserved cursor 1", m.WorktreeSelected())
 	}
-	if cmd != nil {
-		t.Fatalf("left from worktrees produced cmd %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("left from worktrees produced nil cmd, want flows fetch")
 	}
-	assertListRequestsUnchanged(t, before, m)
+	assertOnlyListRequestChanged(t, before, m, ui.ModeFlows)
+	msgs := runBatchCmd(t, cmd)
+	if !hasListFetchForMode(msgs, ui.ModeFlows, m.ListRequest(ui.ModeFlows)) {
+		t.Fatalf("left from worktrees command messages = %#v, want flows fetch for request %d", msgs, m.ListRequest(ui.ModeFlows))
+	}
 
 	flow := flowWithPhaseDetails()
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
 	m, _ = update(m, model.FlowResultMsg{RepoPath: "/dev/alpha", Flows: []flowstore.FlowRecord{
 		flow,
 		{FlowID: "flow-2", RepoPath: "/dev/alpha", Title: "Second flow", Status: flowstore.StatusPending},
@@ -1669,19 +1680,23 @@ func TestModel_ArrowNavigationClampsAtModeEdges(t *testing.T) {
 	before = listRequests(m)
 
 	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRight})
-	if m.Mode() != ui.ModeFlows {
-		t.Fatalf("Mode() = %d, want flows", m.Mode())
+	if m.Mode() != ui.ModeWorktrees {
+		t.Fatalf("Mode() = %d, want worktrees after wrapping", m.Mode())
 	}
 	if m.ActivePane() != 1 {
 		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
 	}
-	if m.FlowSelected() != 1 || m.ExpandedFlowID() != "flow-2" {
-		t.Fatalf("flow state selected=%d expanded=%q, want selected 1 expanded flow-2", m.FlowSelected(), m.ExpandedFlowID())
+	if m.FlowSelected() != 0 || m.ExpandedFlowID() != "" {
+		t.Fatalf("flow state selected=%d expanded=%q, want reset after leaving flows", m.FlowSelected(), m.ExpandedFlowID())
 	}
-	if cmd != nil {
-		t.Fatalf("right from flows produced cmd %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("right from flows produced nil cmd, want worktrees fetch")
 	}
-	assertListRequestsUnchanged(t, before, m)
+	assertOnlyListRequestChanged(t, before, m, ui.ModeWorktrees)
+	msgs = runBatchCmd(t, cmd)
+	if !hasListFetchForMode(msgs, ui.ModeWorktrees, m.ListRequest(ui.ModeWorktrees)) {
+		t.Fatalf("right from flows command messages = %#v, want worktrees fetch for request %d", msgs, m.ListRequest(ui.ModeWorktrees))
+	}
 }
 
 func TestModel_HLClampAtModeEdges(t *testing.T) {


### PR DESCRIPTION
## Summary
- Wrap left/right view navigation when selection moves past the first or last available view
- Keep arrow navigation in sync across repos, branches, sessions, plans, and flows panes
- Add regression coverage for pane-edge wrapping and refresh behavior

## Verification
- gofmt -l .
- make test
- make build