### PR TITLE
Make active flows global

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ filter matches, or a load failure with details in the status bar.
 | `↓`/`j` | Move selection down |
 | `/` | Fuzzy filter the current item list |
 | `1`/`2`/`3`/`4`/`5`/`6`/`7`/`8` | Switch to worktrees / branches / stashes / history / reflog / sessions / plans / flows |
-| `F3` | Toggle active Flows for the current repo in the middle pane, filtered to non-merged Flow records |
+| `F3` | Toggle global active Flows in the middle pane, filtered to non-merged Flow records |
 | `←`/`→`/`l` | Switch views in the right pane, clamping at worktrees and flows; use arrows or `l` in flows view because `h` toggles Flow headless/interactive command mode |
 | `h` | Switch to the previous view outside flows view; toggle Flow headless/interactive command mode in flows view |
 | `E` | Choose and persist reasoning effort for the selected CLI agent in flows view |
@@ -351,10 +351,12 @@ if Autoreview completes and Merge becomes ready, wtui keeps auto mode on and
 requires the existing manual Merge launch.
 
 Press `F3` from any middle-pane view to keep the current numbered mode selected
-while showing active Flows for the selected repo. This active view is scoped to
-the current repo and hides merged Flow records; normal Flow actions, phase
-launches, attached-session resumes, auto-mode toggles, and embedded Flow
-terminals work from the visible active Flow rows.
+while showing active Flows across all repos. This active view hides merged Flow
+records; moving focus to the left repo pane temporarily filters the visible
+active rows to the selected repo, and returning focus to the middle pane restores
+the global list. Normal Flow actions, phase launches, attached-session resumes,
+auto-mode toggles, and embedded Flow terminals work from the visible active Flow
+rows.
 
 Flow headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in a runtime-only embedded

--- a/docs/config.md
+++ b/docs/config.md
@@ -329,10 +329,12 @@ refresh so newly persisted completion state is discovered without waiting for
 unrelated UI activity. Auto mode still skips non-completed outcomes and stops
 before Merge.
 Press `F3` from any middle-pane view to keep the current numbered mode selected
-while showing active Flows for the selected repo. This active view is current
-repo scoped, hides merged Flow records, and supports the same Flow actions,
-phase launches, attached-session resumes, auto-mode toggles, and embedded Flow
-terminal management as the flows pane.
+while showing active Flows across all repos. This active view hides merged Flow
+records; moving focus to the left repo pane temporarily filters the visible
+active rows to the selected repo, and returning focus to the middle pane restores
+the global list. It supports the same Flow actions, phase launches,
+attached-session resumes, auto-mode toggles, and embedded Flow terminal
+management as the flows pane.
 Headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in an embedded terminal
 inside the flows pane. Press `h` to choose the CLI command mode: headless runs

--- a/model/flow_refresh_tick.go
+++ b/model/flow_refresh_tick.go
@@ -29,12 +29,37 @@ func (m Model) startFlowsModeFetchWithRefreshTick() (Model, tea.Cmd) {
 	return m.startFlowRefreshFetch()
 }
 
+func (m Model) startActiveFlowsFetchWithRefreshTick() (Model, tea.Cmd) {
+	m.flowRefreshInFlight = 0
+	return m.startActiveFlowRefreshFetch()
+}
+
+func (m Model) startFlowSurfaceFetch() (Model, tea.Cmd) {
+	if m.activeFlowSurfaceVisible() {
+		return m.startActiveFlowsFetchWithRefreshTick()
+	}
+	return m.startFetchMode(ui.ModeFlows)
+}
+
 func (m Model) startFlowRefreshFetch() (Model, tea.Cmd) {
 	if m.flowRefreshInFlight != 0 {
 		return m, nil
 	}
 	var fetchCmd tea.Cmd
 	m, fetchCmd = m.startFetchMode(ui.ModeFlows)
+	if fetchCmd == nil {
+		m.flowRefreshTickGen++
+		return m, m.flowRefreshTickCmd()
+	}
+	return m, fetchCmd
+}
+
+func (m Model) startActiveFlowRefreshFetch() (Model, tea.Cmd) {
+	if m.flowRefreshInFlight != 0 {
+		return m, nil
+	}
+	var fetchCmd tea.Cmd
+	m, fetchCmd = m.startFetchActiveFlows()
 	if fetchCmd == nil {
 		m.flowRefreshTickGen++
 		return m, m.flowRefreshTickCmd()

--- a/model/flow_refresh_tick.go
+++ b/model/flow_refresh_tick.go
@@ -41,6 +41,13 @@ func (m Model) startFlowSurfaceFetch() (Model, tea.Cmd) {
 	return m.startFetchMode(ui.ModeFlows)
 }
 
+func (m Model) startFlowSurfaceRefreshFetch() (Model, tea.Cmd) {
+	if m.activeFlowSurfaceVisible() {
+		return m.startActiveFlowRefreshFetch()
+	}
+	return m.startFlowRefreshFetch()
+}
+
 func (m Model) startFlowRefreshFetch() (Model, tea.Cmd) {
 	if m.flowRefreshInFlight != 0 {
 		return m, nil

--- a/model/flow_refresh_tick_test.go
+++ b/model/flow_refresh_tick_test.go
@@ -375,7 +375,7 @@ func TestModel_FlowRefreshTracksRepoChangeRefetchBeforePendingTick(t *testing.T)
 	}
 }
 
-func TestModel_ActiveFlowRefreshRepoChangeSupersedesInFlightFetch(t *testing.T) {
+func TestModel_ActiveFlowRefreshRepoChangeKeepsInFlightGlobalFetch(t *testing.T) {
 	repos := []scanner.Repo{
 		{Path: "/dev/alpha", DisplayName: "alpha"},
 		{Path: "/dev/bravo", DisplayName: "bravo"},
@@ -386,30 +386,35 @@ func TestModel_ActiveFlowRefreshRepoChangeSupersedesInFlightFetch(t *testing.T) 
 		},
 	})
 	m.activePane = 1
-	var cmd tea.Cmd
-	m, cmd = updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyF3})
-	if cmd == nil {
+	var activeCmd tea.Cmd
+	m, activeCmd = updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyF3})
+	if activeCmd == nil {
 		t.Fatal("expected active Flow surface entry to fetch flows")
 	}
-	alphaRequest := m.flowRefreshInFlight
-	if alphaRequest == 0 {
-		t.Fatal("expected alpha active Flow fetch to be in flight")
+	globalRequest := m.flowRefreshInFlight
+	if globalRequest == 0 {
+		t.Fatal("expected global active Flow fetch to be in flight")
 	}
 	m.activePane = 0
 
+	var cmd tea.Cmd
 	m, cmd = updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyDown})
-	if cmd == nil {
-		t.Fatal("expected repo change to supersede in-flight active Flow fetch")
+	if cmd != nil {
+		t.Fatalf("repo change returned command %T, want nil local filter", cmd)
 	}
-	if got := m.ListRequest(ui.ModeFlows); got == alphaRequest {
-		t.Fatalf("flows list request = %d, want changed from alpha request %d", got, alphaRequest)
+	if got := m.ListRequest(ui.ModeFlows); got != globalRequest {
+		t.Fatalf("flows list request = %d, want unchanged global request %d", got, globalRequest)
 	}
-	if m.flowRefreshInFlight != m.ListRequest(ui.ModeFlows) {
-		t.Fatalf("flow refresh in-flight request = %d, want repo-change request %d", m.flowRefreshInFlight, m.ListRequest(ui.ModeFlows))
+	if m.flowRefreshInFlight != globalRequest {
+		t.Fatalf("flow refresh in-flight request = %d, want global request %d", m.flowRefreshInFlight, globalRequest)
 	}
-	result := flowResultFromCommand(t, cmd)
-	if result.RepoPath != "/dev/bravo" {
-		t.Fatalf("FlowResultMsg.RepoPath = %q, want /dev/bravo", result.RepoPath)
+	msg := activeCmd()
+	result, ok := msg.(ActiveFlowResultMsg)
+	if !ok {
+		t.Fatalf("active Flow command returned %T, want ActiveFlowResultMsg", msg)
+	}
+	if result.ListRequest != globalRequest {
+		t.Fatalf("ActiveFlowResultMsg.ListRequest = %d, want %d", result.ListRequest, globalRequest)
 	}
 }
 
@@ -447,9 +452,13 @@ func TestModel_ActiveFlowEntrySupersedesStaleInFlightFetch(t *testing.T) {
 	if m.flowRefreshInFlight != m.ListRequest(ui.ModeFlows) {
 		t.Fatalf("flow refresh in-flight request = %d, want F3 entry request %d", m.flowRefreshInFlight, m.ListRequest(ui.ModeFlows))
 	}
-	result := flowResultFromCommand(t, cmd)
-	if result.RepoPath != "/dev/bravo" {
-		t.Fatalf("FlowResultMsg.RepoPath = %q, want /dev/bravo", result.RepoPath)
+	msg := cmd()
+	result, ok := msg.(ActiveFlowResultMsg)
+	if !ok {
+		t.Fatalf("active Flow command returned %T, want ActiveFlowResultMsg", msg)
+	}
+	if result.ListRequest != m.ListRequest(ui.ModeFlows) {
+		t.Fatalf("ActiveFlowResultMsg.ListRequest = %d, want %d", result.ListRequest, m.ListRequest(ui.ModeFlows))
 	}
 }
 

--- a/model/flow_refresh_tick_test.go
+++ b/model/flow_refresh_tick_test.go
@@ -40,6 +40,19 @@ func flowResultFromCommand(t *testing.T, cmd tea.Cmd) FlowResultMsg {
 	return result
 }
 
+func activeFlowResultFromRefreshCommand(t *testing.T, cmd tea.Cmd) ActiveFlowResultMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected active Flow command")
+	}
+	msg := cmd()
+	result, ok := msg.(ActiveFlowResultMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want ActiveFlowResultMsg", msg)
+	}
+	return result
+}
+
 func flowResultFromBatchCommand(t *testing.T, cmd tea.Cmd) FlowResultMsg {
 	t.Helper()
 	if cmd == nil {
@@ -252,6 +265,55 @@ func TestModel_FlowRefreshTickFetchesAndSchedulesNextTick(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("expected completed refresh fetch to schedule next tick")
+	}
+}
+
+func TestModel_ActiveFlowRefreshTickUsesGlobalFetchAndPreservesNormalFlowCache(t *testing.T) {
+	repos := []scanner.Repo{
+		{Path: "/dev/alpha", DisplayName: "alpha"},
+		{Path: "/dev/bravo", DisplayName: "bravo"},
+	}
+	alphaFlow := flowForRefreshTest("alpha-flow")
+	bravoFlow := flowForRefreshTest("bravo-flow")
+	bravoFlow.RepoPath = "/dev/bravo"
+	var filters []flowstore.FlowFilter
+	m := NewWithOptions(repos, Options{
+		StartupMode: ui.ModeFlows,
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			filters = append(filters, filter)
+			if filter.RepoPath != "" {
+				return []flowstore.FlowRecord{alphaFlow}, nil
+			}
+			return []flowstore.FlowRecord{alphaFlow, bravoFlow}, nil
+		},
+	})
+	m, _ = updateFlowRefreshTest(m, flowResultFromCommand(t, m.Init()))
+	m.activePane = 1
+
+	m, cmd := updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, cmd = updateFlowRefreshTest(m, activeFlowResultFromRefreshCommand(t, cmd))
+	if cmd == nil {
+		t.Fatal("expected active Flow result to schedule refresh tick")
+	}
+	if got := m.Flows(); len(got) != 1 || got[0].FlowID != "alpha-flow" {
+		t.Fatalf("normal Flows() cache before tick = %#v, want repo-scoped alpha-flow", got)
+	}
+	filters = nil
+
+	m, cmd = updateFlowRefreshTest(m, flowRefreshTickMsg{Generation: m.flowRefreshTickGen})
+	result := activeFlowResultFromRefreshCommand(t, cmd)
+	if result.ListRequest != m.ListRequest(ui.ModeFlows) {
+		t.Fatalf("ActiveFlowResultMsg.ListRequest = %d, want %d", result.ListRequest, m.ListRequest(ui.ModeFlows))
+	}
+	if len(filters) != 1 || filters[0].RepoPath != "" {
+		t.Fatalf("active Flow tick filters = %#v, want one global fetch", filters)
+	}
+	m, _ = updateFlowRefreshTest(m, result)
+	if got := m.Flows(); len(got) != 1 || got[0].FlowID != "alpha-flow" {
+		t.Fatalf("normal Flows() cache after active Flow tick = %#v, want unchanged alpha-flow", got)
+	}
+	if len(m.activeFlowRecords) != 2 {
+		t.Fatalf("active Flow global cache has %d records, want 2", len(m.activeFlowRecords))
 	}
 }
 

--- a/model/flow_surface.go
+++ b/model/flow_surface.go
@@ -69,7 +69,7 @@ func (m Model) visibleActiveFlowRecords() []flowstore.FlowRecord {
 		}
 		records := make([]flowstore.FlowRecord, 0, len(m.activeFlowRecords))
 		for _, record := range m.activeFlowRecords {
-			if record.RepoPath == repoPath {
+			if sameRepoPath(record.RepoPath, repoPath) {
 				records = append(records, record)
 			}
 		}

--- a/model/flow_surface.go
+++ b/model/flow_surface.go
@@ -28,7 +28,7 @@ func (m Model) enterActiveFlowsSurface() (Model, tea.Cmd) {
 	m.flowFocus = flowFocusList
 	m.terminalPrefixActive = false
 	m = m.syncActiveFlowsFromCache()
-	return m.startFlowsModeFetchWithRefreshTick()
+	return m.startActiveFlowsFetchWithRefreshTick()
 }
 
 func (m Model) exitActiveFlowsSurface() Model {
@@ -51,7 +51,7 @@ func (m Model) syncActiveFlowsFromCache() Model {
 	selectedFlowID := m.selectedActiveFlowID()
 	expandedFlowID := m.expandedActiveFlowID
 	selectedPhaseID := m.selectedActiveFlowPhaseID
-	m.activeFlows = m.activeFlows.SetItems(activeFlowRecords(m.flows.Items()))
+	m.activeFlows = m.activeFlows.SetItems(activeFlowRecords(m.visibleActiveFlowRecords()))
 	if selectedFlowID != "" {
 		m.activeFlows = m.activeFlows.SelectFunc(func(record flowstore.FlowRecord) bool {
 			return record.FlowID == selectedFlowID
@@ -59,6 +59,23 @@ func (m Model) syncActiveFlowsFromCache() Model {
 	}
 	m = m.restoreActiveExpandedFlowSelection(expandedFlowID, selectedPhaseID)
 	return m.reflowActiveFlows()
+}
+
+func (m Model) visibleActiveFlowRecords() []flowstore.FlowRecord {
+	if m.activeFlowSurfaceVisible() && m.activePane == 0 {
+		repoPath, ok := m.currentRepoPath()
+		if !ok {
+			return nil
+		}
+		records := make([]flowstore.FlowRecord, 0, len(m.activeFlowRecords))
+		for _, record := range m.activeFlowRecords {
+			if record.RepoPath == repoPath {
+				records = append(records, record)
+			}
+		}
+		return records
+	}
+	return m.activeFlowRecords
 }
 
 func activeFlowRecords(records []flowstore.FlowRecord) []flowstore.FlowRecord {

--- a/model/mode_fetch.go
+++ b/model/mode_fetch.go
@@ -154,12 +154,41 @@ func (m Model) startFetchMode(mode ui.Mode) (Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m Model) startFetchActiveFlows() (Model, tea.Cmd) {
+	m, request := m.nextListFetchRequest(ui.ModeFlows)
+	cmd := m.fetchActiveFlows(request)
+	if m.flowSurfaceVisible() {
+		m.flowRefreshTickGen++
+		m.flowRefreshInFlight = 0
+		if cmd != nil {
+			m.flowRefreshInFlight = request
+		}
+	}
+	return m, cmd
+}
+
 func (m Model) fetchMode(mode ui.Mode, request uint64) tea.Cmd {
 	desc, ok := listFetchDescriptorForMode(mode)
 	if !ok {
 		return nil
 	}
 	return m.fetchList(desc, request)
+}
+
+func (m Model) fetchActiveFlows(request uint64) tea.Cmd {
+	return func() tea.Msg {
+		records, err := m.listFlows(flowstore.FlowFilter{})
+		if err != nil {
+			return FetchErrorMsg{
+				Pane:        "active-flows",
+				Err:         fmt.Sprintf("failed to load active flows: %v", err),
+				Kind:        FetchList,
+				Mode:        ui.ModeFlows,
+				ListRequest: request,
+			}
+		}
+		return ActiveFlowResultMsg{Flows: records, ListRequest: request}
+	}
 }
 
 func (m Model) fetchList(desc listFetchDescriptor, request uint64) tea.Cmd {

--- a/model/model.go
+++ b/model/model.go
@@ -46,6 +46,7 @@ type Model struct {
 	sessions                   pane.Pane[sessions.SessionRecord]
 	plans                      pane.Pane[planstore.PlanRecord]
 	flows                      pane.Pane[flowstore.FlowRecord]
+	activeFlowRecords          []flowstore.FlowRecord
 	activeFlows                pane.Pane[flowstore.FlowRecord]
 	expandedPlanID             string
 	expandedFlowID             string
@@ -1113,6 +1114,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		next, autoLaunchCmd := m.handleFlowResult(msg)
 		next, refreshCmd := next.finishFlowRefreshFetch(ui.ModeFlows, msg.ListRequest)
 		return next, batchNonNil(refreshCmd, autoLaunchCmd)
+	case ActiveFlowResultMsg:
+		next, autoLaunchCmd := m.handleActiveFlowResult(msg)
+		next, refreshCmd := next.finishFlowRefreshFetch(ui.ModeFlows, msg.ListRequest)
+		return next, batchNonNil(refreshCmd, autoLaunchCmd)
 	case FlowAutoModeSetMsg:
 		return m.handleFlowAutoModeSet(msg), nil
 	case FlowAutoModeSetFailedMsg:
@@ -1183,7 +1188,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m = m.clearFlowCreateRequest(msg.Request)
 		next, launchCmd := m.launchAgentWithContext(msg.LaunchContext)
 		if msg.LaunchContext.FlowID != "" && next.flowSurfaceVisible() {
-			next, fetchCmd := next.startFetchMode(ui.ModeFlows)
+			next, fetchCmd := next.startFlowSurfaceFetch()
 			return next, tea.Batch(fetchCmd, launchCmd)
 		}
 		return next, launchCmd
@@ -1196,7 +1201,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		next, launchCmd := m.launchFlowEmbeddedWithContext(msg.LaunchContext)
 		if msg.LaunchContext.FlowID != "" && next.flowSurfaceVisible() {
-			next, fetchCmd := next.startFetchMode(ui.ModeFlows)
+			next, fetchCmd := next.startFlowSurfaceFetch()
 			return next, tea.Batch(fetchCmd, launchCmd)
 		}
 		return next, launchCmd
@@ -1220,7 +1225,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m, resultErr = m.markFlowLaunchNeedsAttention(msg.LaunchContext, resultErr)
 			m = m.setStatus(statusOther, resultErr)
 			if msg.LaunchContext.FlowID != "" && m.flowSurfaceVisible() {
-				return m.startFetchMode(ui.ModeFlows)
+				return m.startFlowSurfaceFetch()
 			}
 		} else if msg.Detached {
 			m = m.setStatus(statusOther, agentLaunchedStatus(msg.LaunchContext.Command))
@@ -1235,8 +1240,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return next.finishFlowRefreshFetch(msg.Mode, msg.ListRequest)
 	case ActionFailedMsg:
 		next := m.handleActionFailed(msg)
-		if next.flowSurfaceVisible() && next.isCurrentRepo(msg.RepoPath) {
-			return next.startFetchMode(ui.ModeFlows)
+		if next.flowSurfaceVisible() && (next.activeFlowSurfaceVisible() || next.isCurrentRepo(msg.RepoPath)) {
+			return next.startFlowSurfaceFetch()
 		}
 		return next, nil
 	}
@@ -1404,7 +1409,7 @@ func (m Model) selectedFlowPhaseResettable() bool {
 }
 
 func (m Model) flowPhaseByID(flowID, phaseID string) (flowstore.FlowRecord, flowstore.FlowPhase, bool) {
-	for _, record := range m.flows.Items() {
+	for _, record := range m.flowLookupRecords() {
 		if record.FlowID != flowID {
 			continue
 		}
@@ -1417,12 +1422,19 @@ func (m Model) flowPhaseByID(flowID, phaseID string) (flowstore.FlowRecord, flow
 }
 
 func (m Model) flowByID(flowID string) (flowstore.FlowRecord, bool) {
-	for _, record := range m.flows.Items() {
+	for _, record := range m.flowLookupRecords() {
 		if record.FlowID == flowID {
 			return record, true
 		}
 	}
 	return flowstore.FlowRecord{}, false
+}
+
+func (m Model) flowLookupRecords() []flowstore.FlowRecord {
+	if m.activeFlowSurfaceVisible() {
+		return m.activeFlowRecords
+	}
+	return m.flows.Items()
 }
 
 func flowRecordPhaseByID(record flowstore.FlowRecord, phaseID string) (flowstore.FlowPhase, bool) {

--- a/model/model.go
+++ b/model/model.go
@@ -1026,7 +1026,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmds []tea.Cmd
 		if len(exitedFlowTerminals) > 0 {
 			var refreshCmd tea.Cmd
-			m, refreshCmd = m.startFlowRefreshFetch()
+			m, refreshCmd = m.startFlowSurfaceRefreshFetch()
 			cmds = append(cmds, refreshCmd)
 		}
 		if m.hasRunningEmbeddedTerminal() {
@@ -1037,7 +1037,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Generation != m.flowRefreshTickGen || !m.flowSurfaceVisible() {
 			return m, nil
 		}
-		return m.startFlowRefreshFetch()
+		return m.startFlowSurfaceRefreshFetch()
 	case BranchResultMsg:
 		return m.handleBranchResult(msg), nil
 	case StashResultMsg:

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -24,7 +24,7 @@ const visibleRepoFetchFadeStepDuration = 1 * time.Second
 
 func (m Model) startFetchForMode() (Model, tea.Cmd) {
 	if m.activeFlowSurfaceVisible() {
-		return m.startFlowsModeFetchWithRefreshTick()
+		return m.startActiveFlowsFetchWithRefreshTick()
 	}
 	return m.startFetchMode(m.mode)
 }
@@ -75,6 +75,9 @@ func (m Model) startGlobalRefresh() (Model, tea.Cmd) {
 }
 
 func (m Model) fetchForMode() tea.Cmd {
+	if m.activeFlowSurfaceVisible() {
+		return m.fetchActiveFlows(m.currentListRequest(ui.ModeFlows))
+	}
 	mode := m.activeContentFetchMode()
 	return m.fetchMode(mode, m.currentListRequest(mode))
 }

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -30,6 +30,26 @@ func flowsInRightPane(t *testing.T, m model.Model, records []flowstore.FlowRecor
 	return m
 }
 
+func activeFlowResultFromCommand(t *testing.T, cmd tea.Cmd) model.ActiveFlowResultMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected active Flow fetch command")
+	}
+	msg := cmd()
+	result, ok := msg.(model.ActiveFlowResultMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want ActiveFlowResultMsg", msg)
+	}
+	return result
+}
+
+func enterActiveFlowsWithRecords(t *testing.T, m model.Model, records []flowstore.FlowRecord) model.Model {
+	t.Helper()
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, model.ActiveFlowResultMsg{Flows: records, ListRequest: m.ListRequest(ui.ModeFlows)})
+	return m
+}
+
 func flowWithPhaseDetails() flowstore.FlowRecord {
 	return flowstore.FlowRecord{
 		FlowID:   "flow-1",
@@ -45,17 +65,28 @@ func flowWithPhaseDetails() flowstore.FlowRecord {
 	}
 }
 
-func TestModel_F3ShowsActiveFlowsFromCurrentRepoCache(t *testing.T) {
-	active := flowWithPhaseDetails()
-	active.FlowID = "active-flow"
-	active.Title = "Active Flow"
+func TestModel_F3ShowsGlobalActiveFlowsWithoutPollutingFlowsCache(t *testing.T) {
+	alpha := flowWithPhaseDetails()
+	alpha.FlowID = "alpha-flow"
+	alpha.Title = "Alpha Flow"
+	bravo := flowWithPhaseDetails()
+	bravo.FlowID = "bravo-flow"
+	bravo.RepoPath = "/dev/bravo"
+	bravo.Title = "Bravo Flow"
 	merged := flowWithPhaseDetails()
 	merged.FlowID = "merged-flow"
+	merged.RepoPath = "/dev/bravo"
 	merged.Title = "Merged Flow"
 	merged.Status = flowstore.StatusMerged
 
-	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{active, merged})
-	m, _ = update(m, tea.WindowSizeMsg{Width: 220, Height: 18})
+	var gotFilter flowstore.FlowFilter
+	m := flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			gotFilter = filter
+			return []flowstore.FlowRecord{alpha, bravo, merged}, nil
+		},
+	}), []flowstore.FlowRecord{alpha})
+	m, _ = update(m, tea.WindowSizeMsg{Width: 220, Height: 30})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
 	if m.Mode() != ui.ModeWorktrees {
 		t.Fatalf("mode = %v, want worktrees before F3", m.Mode())
@@ -65,11 +96,15 @@ func TestModel_F3ShowsActiveFlowsFromCurrentRepoCache(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("F3 should start or continue a Flow refresh")
 	}
+	m, _ = update(m, activeFlowResultFromCommand(t, cmd))
+	if gotFilter.RepoPath != "" {
+		t.Fatalf("active Flow filter RepoPath = %q, want global", gotFilter.RepoPath)
+	}
 	if m.Mode() != ui.ModeWorktrees {
 		t.Fatalf("mode = %v, want preserved worktrees mode", m.Mode())
 	}
 	view := ansi.Strip(m.View())
-	for _, want := range []string{"Active flows", "Active Flow", "F3"} {
+	for _, want := range []string{"active flows", "Alpha Flow", "Bravo Flow", "f3"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("active-flow view missing %q:\n%s", want, view)
 		}
@@ -77,11 +112,121 @@ func TestModel_F3ShowsActiveFlowsFromCurrentRepoCache(t *testing.T) {
 	if strings.Contains(view, "Merged Flow") {
 		t.Fatalf("active-flow view should filter merged flows:\n%s", view)
 	}
+	if got := m.Flows(); len(got) != 1 || got[0].FlowID != "alpha-flow" {
+		t.Fatalf("normal Flows() cache = %#v, want original repo-scoped alpha flow", got)
+	}
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
 	view = ansi.Strip(m.View())
-	if !strings.Contains(view, "worktrees") || strings.Contains(view, "Active Flow") {
+	if !strings.Contains(view, "worktrees") || strings.Contains(view, "Bravo Flow") {
 		t.Fatalf("second F3 should restore worktrees pane:\n%s", view)
+	}
+}
+
+func TestModel_F3GlobalResultSurvivesRepoMoveAndUsesLeftPaneFilter(t *testing.T) {
+	alpha := flowWithPhaseDetails()
+	alpha.FlowID = "alpha-flow"
+	alpha.Title = "Alpha Flow"
+	bravo := flowWithPhaseDetails()
+	bravo.FlowID = "bravo-flow"
+	bravo.RepoPath = "/dev/bravo"
+	bravo.Title = "Bravo Flow"
+
+	var filters []flowstore.FlowFilter
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			filters = append(filters, filter)
+			return []flowstore.FlowRecord{alpha, bravo}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 220, Height: 24})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF3})
+	result := activeFlowResultFromCommand(t, cmd)
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if cmd != nil {
+		t.Fatalf("switching active flows to repo pane returned command %T, want nil", cmd)
+	}
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if cmd != nil {
+		t.Fatalf("repo movement in active flows returned command %T, want local filter only", cmd)
+	}
+
+	m, _ = update(m, result)
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Bravo Flow") || strings.Contains(view, "Alpha Flow") {
+		t.Fatalf("left-pane active-flow filter should show only bravo after stale-safe result:\n%s", view)
+	}
+	if len(filters) != 1 || filters[0].RepoPath != "" {
+		t.Fatalf("active Flow filters = %#v, want one global fetch", filters)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	view = ansi.Strip(m.View())
+	if !strings.Contains(view, "Alpha Flow") || !strings.Contains(view, "Bravo Flow") {
+		t.Fatalf("returning focus to content pane should restore global active flows:\n%s", view)
+	}
+}
+
+func TestModel_F3GlobalFetchErrorSurvivesRepoMove(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return nil, errors.New("state unavailable")
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 180, Height: 18})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF3})
+	if cmd == nil {
+		t.Fatal("expected active Flow fetch command")
+	}
+	msg := cmd()
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, repoMoveCmd := update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if repoMoveCmd != nil {
+		t.Fatalf("repo movement in active flows returned command %T, want nil", repoMoveCmd)
+	}
+
+	m, _ = update(m, msg)
+	if got := m.TransientError(); !strings.Contains(got, "failed to load active flows") || !strings.Contains(got, "state unavailable") {
+		t.Fatalf("status = %q, want active-flow fetch error after repo move", got)
+	}
+}
+
+func TestModel_F3LeftPaneEnterExitsToSelectedRepoMode(t *testing.T) {
+	var filters []flowstore.FlowFilter
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			filters = append(filters, filter)
+			return []flowstore.FlowRecord{{FlowID: "flow", RepoPath: filter.RepoPath, Title: "Repo Flow", Status: flowstore.StatusPending}}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 180, Height: 18})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+	m, _ = update(m, flowResultFromCommand(t, cmd))
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, activeFlowResultFromCommand(t, cmd))
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected normal Flow-mode fetch after left-pane enter")
+	}
+	m, _ = update(m, flowResultFromCommand(t, cmd))
+	view := ansi.Strip(m.View())
+	if strings.Contains(view, "Shortcuts  Active flows") {
+		t.Fatalf("left-pane enter should exit active flows:\n%s", view)
+	}
+	if len(filters) < 3 || filters[len(filters)-1].RepoPath != "/dev/bravo" {
+		t.Fatalf("flow filters = %#v, want final normal fetch for selected bravo repo", filters)
+	}
+	if m.ActivePane() != 0 || m.Mode() != ui.ModeFlows {
+		t.Fatalf("active pane/mode = %d/%d, want left pane in flows mode", m.ActivePane(), m.Mode())
 	}
 }
 
@@ -118,7 +263,7 @@ func TestModel_F3UsesSeparateActiveFlowSelectionForActions(t *testing.T) {
 		t.Fatalf("normal Flow selection = %d, want merged row index 1", got)
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{activeOne, merged, activeTwo})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	view := ansi.Strip(m.View())
 	if !strings.Contains(view, "Active Two") || strings.Contains(view, "Merged Flow") {
@@ -172,10 +317,9 @@ func TestModel_F3ActiveFlowRefreshPreparesAutoLaunch(t *testing.T) {
 	})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{previous})
 
-	_, cmd := update(m, model.FlowResultMsg{
-		RepoPath:    "/dev/alpha",
+	_, cmd := update(m, model.ActiveFlowResultMsg{
 		Flows:       []flowstore.FlowRecord{current},
 		ListRequest: m.ListRequest(ui.ModeFlows),
 	})
@@ -203,7 +347,7 @@ func TestModel_F3ActiveFlowLKeyClampsAtFlowSurface(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
 	if cmd != nil {
@@ -221,7 +365,7 @@ func TestModel_F3ActiveFlowLeftKeyClampsAndPreservesUnderlyingMode(t *testing.T)
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
 	if cmd != nil {
@@ -243,7 +387,7 @@ func TestModel_F3ActiveFlowLeftPaneNumberedKeysAreNoOps(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 	before := listRequests(m)
 
@@ -267,19 +411,18 @@ func TestModel_F3ActiveFlowFetchErrorUsesActiveFetchMode(t *testing.T) {
 	m := flowsInRightPane(t, model.New(testRepos()), nil)
 	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 18})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, nil)
 
 	m, _ = update(m, model.FetchErrorMsg{
-		RepoPath:    "/dev/alpha",
-		Pane:        "flows",
-		Err:         "failed to load flows: boom",
+		Pane:        "active-flows",
+		Err:         "failed to load active flows: boom",
 		Kind:        model.FetchList,
 		Mode:        ui.ModeFlows,
 		ListRequest: m.ListRequest(ui.ModeFlows),
 	})
 
 	view := ansi.Strip(m.View())
-	if !strings.Contains(view, "failed to load flows: boom") {
+	if !strings.Contains(view, "failed to load active flows: boom") {
 		t.Fatalf("active Flow surface should show Flow fetch failure in status bar:\n%s", view)
 	}
 	if !strings.Contains(view, "Could not load flows; see status bar") {
@@ -293,7 +436,7 @@ func TestModel_F3ActiveFlowSearchAcceptsDigits(t *testing.T) {
 	flow.Branch = "release/123"
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
@@ -304,7 +447,7 @@ func TestModel_F3ActiveFlowSearchAcceptsDigits(t *testing.T) {
 		t.Fatalf("active Flow search query = %q, want 1", got)
 	}
 	view := ansi.Strip(m.View())
-	if !strings.Contains(view, "Active flows") || !strings.Contains(view, "release/123") {
+	if !strings.Contains(view, "active flows") || !strings.Contains(view, "release/123") {
 		t.Fatalf("digit search should keep active Flow surface visible and filtered:\n%s", view)
 	}
 }
@@ -322,7 +465,7 @@ func TestModel_F3ActiveFlowPullDoesNotTargetHiddenWorktree(t *testing.T) {
 		}},
 		ListRequest: m.ListRequest(ui.ModeWorktrees),
 	})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'F'}})
 	if cmd != nil {
@@ -339,7 +482,7 @@ func TestModel_EnterTogglesActiveFlowPhaseRows(t *testing.T) {
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.WindowSizeMsg{Width: 220, Height: 18})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd != nil {
@@ -373,11 +516,10 @@ func TestModel_ActiveFlowRefreshPreservesNormalFlowSelection(t *testing.T) {
 	if got := m.FlowSelected(); got != 1 {
 		t.Fatalf("normal Flow selection = %d, want active-two", got)
 	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{activeOne, activeTwo})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
 
-	m, _ = update(m, model.FlowResultMsg{
-		RepoPath:    "/dev/alpha",
+	m, _ = update(m, model.ActiveFlowResultMsg{
 		Flows:       []flowstore.FlowRecord{activeOne, activeTwo},
 		ListRequest: m.ListRequest(ui.ModeFlows),
 	})
@@ -414,7 +556,7 @@ func TestModel_RKeyResumesActiveFlowPhaseSession(t *testing.T) {
 	}}
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
@@ -459,7 +601,7 @@ func TestModel_InteractiveActiveFlowLaunchFocusesEmbeddedTerminal(t *testing.T) 
 	})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
 	if cmd == nil {
@@ -502,7 +644,7 @@ func TestModel_F3PassesThroughFocusedActiveFlowTerminal(t *testing.T) {
 	})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
 	if cmd == nil {
@@ -554,7 +696,7 @@ func TestModel_ActiveFlowLaunchOverSessionsUsesFlowTerminal(t *testing.T) {
 		{Provider: sessions.ProviderCodex, SessionID: "codex-session-1", RepoPath: "/dev/alpha", WorktreePath: "/dev/alpha-worktrees/session"},
 	}, ListRequest: m.ListRequest(ui.ModeSessions)})
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 	view := ansi.Strip(m.View())
 	if !strings.Contains(view, "flow/with-phases") || strings.Contains(view, "codex-session-1") {
 		t.Fatalf("active flows should visually override sessions mode:\n%s", view)
@@ -3629,13 +3771,14 @@ func TestModel_FlowDeleteRequiresDestructiveMode(t *testing.T) {
 }
 
 func TestModel_ActiveFlowDeleteUsesVisibleFlowOverUnderlyingStash(t *testing.T) {
-	m := model.NewWithOptions(testRepos(), model.Options{})
-	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+	flow := flowstore.FlowRecord{
 		FlowID:   "flow-1",
 		RepoPath: "/dev/alpha",
 		Title:    "Delete visible Flow",
 		Status:   flowstore.StatusPending,
-	}})
+	}
+	m := model.NewWithOptions(testRepos(), model.Options{})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	m, _ = update(m, model.StashResultMsg{
 		RepoPath: "/dev/alpha",
@@ -3646,7 +3789,7 @@ func TestModel_ActiveFlowDeleteUsesVisibleFlowOverUnderlyingStash(t *testing.T) 
 		}},
 		ListRequest: m.ListRequest(ui.ModeStashes),
 	})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -176,6 +176,27 @@ func TestModel_F3GlobalResultSurvivesRepoMoveAndUsesLeftPaneFilter(t *testing.T)
 	}
 }
 
+func TestModel_F3LeftPaneFilterCleansRepoPath(t *testing.T) {
+	alpha := flowWithPhaseDetails()
+	alpha.FlowID = "alpha-flow"
+	alpha.Title = "Alpha Flow"
+	bravo := flowWithPhaseDetails()
+	bravo.FlowID = "bravo-flow"
+	bravo.RepoPath = "/dev/bravo/"
+	bravo.Title = "Bravo Flow"
+
+	m := inRightPane(model.New(testRepos()))
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{alpha, bravo})
+	m, _ = update(m, tea.WindowSizeMsg{Width: 220, Height: 24})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Bravo Flow") || strings.Contains(view, "Alpha Flow") {
+		t.Fatalf("left-pane active-flow filter should clean repo paths:\n%s", view)
+	}
+}
+
 func TestModel_F3GlobalFetchErrorSurvivesRepoMove(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -36,11 +36,18 @@ func activeFlowResultFromCommand(t *testing.T, cmd tea.Cmd) model.ActiveFlowResu
 		t.Fatal("expected active Flow fetch command")
 	}
 	msg := cmd()
-	result, ok := msg.(model.ActiveFlowResultMsg)
-	if !ok {
-		t.Fatalf("command returned %T, want ActiveFlowResultMsg", msg)
+	if result, ok := msg.(model.ActiveFlowResultMsg); ok {
+		return result
 	}
-	return result
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, subcmd := range batch {
+			if result, ok := subcmd().(model.ActiveFlowResultMsg); ok {
+				return result
+			}
+		}
+	}
+	t.Fatalf("command returned %T, want ActiveFlowResultMsg", msg)
+	return model.ActiveFlowResultMsg{}
 }
 
 func enterActiveFlowsWithRecords(t *testing.T, m model.Model, records []flowstore.FlowRecord) model.Model {
@@ -1894,6 +1901,57 @@ func TestModel_FlowAutoModeRefreshesOnSourceTerminalExitBeforeCompletionObserved
 		!launches[0].LaunchContext.Embedded ||
 		!launches[0].LaunchContext.FlowLaunchTracked {
 		t.Fatalf("launch context = %#v", launches[0].LaunchContext)
+	}
+}
+
+func TestModel_ActiveFlowAutoCloseRefreshUsesGlobalFetch(t *testing.T) {
+	normalFlow := flowWithPhaseDetails()
+	normalFlow.FlowID = "alpha-flow"
+	normalFlow.Title = "Alpha Flow"
+	activeFlow := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	activeFlow.FlowID = "bravo-flow"
+	activeFlow.RepoPath = "/dev/bravo"
+	activeFlow.Title = "Bravo Flow"
+	sourceTerm := &fakeEmbeddedTerminal{lines: []string{"source output"}, state: "running"}
+	var filters []flowstore.FlowFilter
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			filters = append(filters, filter)
+			return []flowstore.FlowRecord{activeFlow}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return sourceTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{normalFlow})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{activeFlow})
+
+	m, cmd := update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:      "codex",
+		RepoPath:     "/dev/bravo",
+		WorktreePath: "/dev/bravo-worktrees/flow-auto",
+		FlowID:       "bravo-flow",
+		FlowPhaseID:  "plan-review",
+	}})
+	m, _ = update(m, activeFlowResultFromCommand(t, cmd))
+	filters = nil
+	sourceTerm.state = "exited"
+
+	m, cmd = update(m, model.EmbeddedTerminalTickMsgForTest(m))
+	if cmd == nil {
+		t.Fatal("active Flow source terminal auto-close should refresh active flows")
+	}
+	m, _ = update(m, activeFlowResultFromCommand(t, cmd))
+	if len(filters) != 1 || filters[0].RepoPath != "" {
+		t.Fatalf("active Flow auto-close filters = %#v, want one global fetch", filters)
+	}
+	if got := m.Flows(); len(got) != 1 || got[0].FlowID != "alpha-flow" {
+		t.Fatalf("normal Flows() cache after active Flow auto-close = %#v, want unchanged alpha-flow", got)
 	}
 }
 
@@ -3802,6 +3860,35 @@ func TestModel_ActiveFlowDeleteUsesVisibleFlowOverUnderlyingStash(t *testing.T) 
 	}
 	if strings.Contains(prompt, "hidden stash") {
 		t.Fatalf("active Flow delete should not target hidden stash: %q", prompt)
+	}
+}
+
+func TestModel_ActiveFlowActionFailureShowsCrossRepoErrorAndRefreshesGlobally(t *testing.T) {
+	bravoFlow := flowstore.FlowRecord{
+		FlowID:   "bravo-flow",
+		RepoPath: "/dev/bravo",
+		Title:    "Bravo Flow",
+		Status:   flowstore.StatusPending,
+	}
+	var filters []flowstore.FlowFilter
+	m := model.NewWithOptions(testRepos(), model.Options{
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			filters = append(filters, filter)
+			return []flowstore.FlowRecord{bravoFlow}, nil
+		},
+	})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{bravoFlow})
+
+	m, cmd := update(m, model.ActionFailedMsg{RepoPath: "/dev/bravo", Err: "failed to launch bravo Flow"})
+	if cmd == nil {
+		t.Fatal("active Flow action failure should refresh global active flows")
+	}
+	if got := m.TransientError(); !strings.Contains(got, "failed to launch bravo Flow") {
+		t.Fatalf("active Flow cross-repo action failure status = %q, want error text", got)
+	}
+	m, _ = update(m, activeFlowResultFromCommand(t, cmd))
+	if len(filters) != 1 || filters[0].RepoPath != "" {
+		t.Fatalf("active Flow action failure filters = %#v, want one global fetch", filters)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -82,10 +82,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.activePane == 0 {
 			newRepoPath, ok := m.currentRepoPath()
 			if oldRepoPath != newRepoPath {
-				m = m.resetRightPaneCursors()
-				if ok {
-					return m.startFetchForMode()
-				}
+				return m.handleRepoSelectionChanged(ok)
 			}
 		}
 		return m, nil
@@ -234,10 +231,7 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.activePane == 0 {
 		newRepoPath, ok := m.currentRepoPath()
 		if oldRepoPath != newRepoPath {
-			m = m.resetRightPaneCursors()
-			if ok {
-				return m.startFetchForMode()
-			}
+			return m.handleRepoSelectionChanged(ok)
 		}
 	}
 	return m, nil
@@ -257,19 +251,22 @@ func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 	switch key {
 	case "tab":
 		m = m.togglePrimaryPaneFocus()
+	case "enter":
+		if m.activeFlowSurfaceVisible() {
+			m = m.exitActiveFlowsSurface()
+			return m.startFetchForMode()
+		}
 	case "up", "k":
 		if len(m.filteredRepos()) > 0 {
 			m.repos = m.repos.Move(-1, m.repoContentHeight(), ui.LeftPaneWidth-2)
 			m.pendingRepoSelection = ""
-			m = m.resetRightPaneCursors()
-			return m.startFetchForMode()
+			return m.handleRepoSelectionChanged(true)
 		}
 	case "down", "j":
 		if len(m.filteredRepos()) > 0 {
 			m.repos = m.repos.Move(1, m.repoContentHeight(), ui.LeftPaneWidth-2)
 			m.pendingRepoSelection = ""
-			m = m.resetRightPaneCursors()
-			return m.startFetchForMode()
+			return m.handleRepoSelectionChanged(true)
 		}
 	case "f":
 		return m.startFetchVisibleRepos()
@@ -277,6 +274,18 @@ func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleNewRepo()
 	case "q", "ctrl+c", "esc":
 		return m.handleEmbeddedTerminalQuitPrefix()
+	}
+	return m, nil
+}
+
+func (m Model) handleRepoSelectionChanged(repoSelected bool) (tea.Model, tea.Cmd) {
+	if m.activeFlowSurfaceVisible() {
+		m = m.syncActiveFlowsFromCache()
+		return m, nil
+	}
+	m = m.resetRightPaneCursors()
+	if repoSelected {
+		return m.startFetchForMode()
 	}
 	return m, nil
 }
@@ -479,9 +488,15 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 func (m Model) togglePrimaryPaneFocus() Model {
 	if m.activePane == 0 {
 		m.activePane = 1
+		if m.activeFlowSurfaceVisible() {
+			return m.syncActiveFlowsFromCache()
+		}
 		return m
 	}
 	m.activePane = 0
+	if m.activeFlowSurfaceVisible() {
+		return m.syncActiveFlowsFromCache()
+	}
 	if m.mode == ui.ModePlans {
 		m = m.clearSelectedPlanPhase()
 	}
@@ -511,6 +526,7 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 		}
 		m.activePane = 0
 		m = m.clearSelectedFlowPhase()
+		m = m.syncActiveFlowsFromCache()
 	case "g":
 		return m.handleLaunchNextFlowPhase()
 	case "enter":
@@ -1164,7 +1180,7 @@ func (m Model) handleFlowCreateFailed(msg FlowCreateFailedMsg) (Model, tea.Cmd) 
 	}
 	m = m.setStatus(statusOther, errText)
 	if m.flowSurfaceVisible() {
-		return m.startFetchMode(ui.ModeFlows)
+		return m.startFlowSurfaceFetch()
 	}
 	return m, nil
 }
@@ -1507,7 +1523,7 @@ func flowEmbeddedTerminalSlotMatchesPhaseLaunch(slot embeddedTerminalSlot, flowI
 }
 
 func (m Model) handleFlowPhaseResetConfirmed(msg flowPhaseResetConfirmedMsg) (Model, tea.Cmd) {
-	if !m.isCurrentRepo(msg.RepoPath) {
+	if !m.activeFlowSurfaceVisible() && !m.isCurrentRepo(msg.RepoPath) {
 		return m, nil
 	}
 	if m.hasRunningFlowEmbeddedTerminalForPhase(msg.FlowID, msg.PhaseID) {
@@ -1911,7 +1927,7 @@ func (m Model) launchTrackedFlowPhaseResumeWithContext(ctx actions.AgentLaunchCo
 		next, errText = next.markFlowLaunchNeedsAttention(ctx, errText)
 		next = next.setStatus(statusOther, errText)
 		if next.flowSurfaceVisible() {
-			next, fetchCmd := next.startFetchMode(ui.ModeFlows)
+			next, fetchCmd := next.startFlowSurfaceFetch()
 			return next, fetchCmd
 		}
 		return next, nil
@@ -1922,7 +1938,7 @@ func (m Model) launchTrackedFlowPhaseResumeWithContext(ctx actions.AgentLaunchCo
 		next, launchCmd = next.startEmbeddedTerminalTick()
 	}
 	if next.flowSurfaceVisible() {
-		next, fetchCmd := next.startFetchMode(ui.ModeFlows)
+		next, fetchCmd := next.startFlowSurfaceFetch()
 		return next, tea.Batch(fetchCmd, launchCmd)
 	}
 	return next, launchCmd
@@ -2216,8 +2232,11 @@ func (m Model) confirmFlowDelete() (tea.Model, tea.Cmd) {
 	if !ok || record.FlowID == "" {
 		return m, nil
 	}
-	repoPath, ok := m.currentRepoPath()
-	if !ok {
+	repoPath := record.RepoPath
+	if repoPath == "" {
+		repoPath, _ = m.currentRepoPath()
+	}
+	if repoPath == "" {
 		return m, nil
 	}
 	flowID := record.FlowID

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -262,6 +262,11 @@ type FlowResultMsg struct {
 	ListRequest uint64
 }
 
+type ActiveFlowResultMsg struct {
+	Flows       []flowstore.FlowRecord
+	ListRequest uint64
+}
+
 type FlowAutoModeSetMsg struct {
 	RepoPath string
 	FlowID   string
@@ -508,6 +513,13 @@ func (m Model) acceptListResult(repoPath string, mode ui.Mode, request uint64) (
 		return m, false
 	}
 	return m.clearFetchListStatus(mode), true
+}
+
+func (m Model) acceptActiveFlowResult(request uint64) (Model, bool) {
+	if !m.activeFlowSurfaceVisible() || !m.isCurrentListRequest(ui.ModeFlows, request) {
+		return m, false
+	}
+	return m.clearFetchListStatus(ui.ModeFlows), true
 }
 
 func (m Model) clearAnyStatus() Model {
@@ -1122,6 +1134,12 @@ func (m Model) handleForceDeleteFailed(msg ForceDeleteFailedMsg) Model {
 }
 
 func (m Model) handleFetchError(msg FetchErrorMsg) Model {
+	if m.activeFlowSurfaceVisible() && msg.Kind == FetchList && msg.Mode == ui.ModeFlows && msg.Pane == "active-flows" {
+		if next, ok := m.acceptActiveFlowResult(msg.ListRequest); ok {
+			return next.setFetchStatus(msg)
+		}
+		return m
+	}
 	if !m.isCurrentRepo(msg.RepoPath) {
 		return m
 	}
@@ -1238,15 +1256,38 @@ func (m Model) handleFlowResult(msg FlowResultMsg) (Model, tea.Cmd) {
 	return m, batchNonNil(cmds...)
 }
 
+func (m Model) handleActiveFlowResult(msg ActiveFlowResultMsg) (Model, tea.Cmd) {
+	var ok bool
+	m, ok = m.acceptActiveFlowResult(msg.ListRequest)
+	if !ok {
+		return m, nil
+	}
+	previousFlows := append([]flowstore.FlowRecord(nil), m.activeFlowRecords...)
+	m.activeFlowRecords = append([]flowstore.FlowRecord(nil), msg.Flows...)
+	m = m.syncActiveFlowsFromCache()
+	m = m.clampSelectionsAfterFilter()
+	if m.flowFocus != flowFocusTerminal {
+		m = m.syncActiveFlowTerminalToSelectedFlow()
+	}
+	var cmds []tea.Cmd
+	var autoCmd tea.Cmd
+	m, autoCmd = m.prepareAutoFlowPhaseLaunch(previousFlows, msg.Flows)
+	cmds = append(cmds, autoCmd)
+	var deferredCmd tea.Cmd
+	m, deferredCmd = m.prepareDeferredAutoFlowPhaseLaunches()
+	cmds = append(cmds, deferredCmd)
+	return m, batchNonNil(cmds...)
+}
+
 func (m Model) handleFlowAutoModeSet(msg FlowAutoModeSetMsg) Model {
-	if !m.isCurrentRepo(msg.RepoPath) || msg.FlowID == "" {
+	if msg.FlowID == "" || (!m.activeFlowSurfaceVisible() && !m.isCurrentRepo(msg.RepoPath)) {
 		return m
 	}
 	return m.replaceFlowRecord(msg.Flow)
 }
 
 func (m Model) handleFlowAutoModeSetFailed(msg FlowAutoModeSetFailedMsg) Model {
-	if !m.isCurrentRepo(msg.RepoPath) {
+	if !m.activeFlowSurfaceVisible() && !m.isCurrentRepo(msg.RepoPath) {
 		return m
 	}
 	errText := strings.TrimSpace(msg.Err)
@@ -1267,38 +1308,54 @@ func (m Model) replaceFlowRecord(flow flowstore.FlowRecord) Model {
 	expandedFlowID := m.expandedFlowID
 	selectedFlowPhaseID := m.selectedFlowPhaseID
 	items := append([]flowstore.FlowRecord(nil), m.flows.Items()...)
-	replaced := false
+	replacedFlows := false
 	for i := range items {
 		if items[i].FlowID == flow.FlowID {
 			items[i] = flow
-			replaced = true
+			replacedFlows = true
 			break
 		}
 	}
-	if !replaced {
-		return m
+	if replacedFlows {
+		m.flows = m.flows.SetItems(items)
 	}
-	m.flows = m.flows.SetItems(items)
-	if selectedFlowID != "" {
+	if replacedFlows && selectedFlowID != "" {
 		m.flows = m.flows.SelectFunc(func(record flowstore.FlowRecord) bool {
 			return record.FlowID == selectedFlowID
 		})
 	}
-	m = m.restoreExpandedFlowSelection(expandedFlowID, selectedFlowPhaseID)
+	if replacedFlows {
+		m = m.restoreExpandedFlowSelection(expandedFlowID, selectedFlowPhaseID)
+	}
+	activeRecords := append([]flowstore.FlowRecord(nil), m.activeFlowRecords...)
+	replacedActive := false
+	for i := range activeRecords {
+		if activeRecords[i].FlowID == flow.FlowID {
+			activeRecords[i] = flow
+			replacedActive = true
+			break
+		}
+	}
+	if replacedActive {
+		m.activeFlowRecords = activeRecords
+	}
+	if !replacedFlows && !replacedActive {
+		return m
+	}
 	m = m.syncActiveFlowsFromCache()
 	return m.clampSelectionsAfterFilter()
 }
 
 func (m Model) handleFlowDeleted(msg FlowDeletedMsg) (tea.Model, tea.Cmd) {
-	if !m.isCurrentRepo(msg.RepoPath) {
+	if !m.activeFlowSurfaceVisible() && !m.isCurrentRepo(msg.RepoPath) {
 		return m, nil
 	}
 	m = m.clearDeletedFlowState(msg.FlowID)
-	return m.startFetchMode(ui.ModeFlows)
+	return m.startFlowSurfaceFetch()
 }
 
 func (m Model) handleFlowPhaseReset(msg flowPhaseResetMsg) (tea.Model, tea.Cmd) {
-	if !m.isCurrentRepo(msg.RepoPath) {
+	if !m.activeFlowSurfaceVisible() && !m.isCurrentRepo(msg.RepoPath) {
 		return m, nil
 	}
 	phaseID := strings.TrimSpace(msg.PhaseID)
@@ -1306,11 +1363,11 @@ func (m Model) handleFlowPhaseReset(msg flowPhaseResetMsg) (tea.Model, tea.Cmd) 
 		phaseID = "phase"
 	}
 	m = m.setStatus(statusOther, fmt.Sprintf("Reset Flow phase %s to ready", phaseID))
-	return m.startFetchMode(ui.ModeFlows)
+	return m.startFlowSurfaceFetch()
 }
 
 func (m Model) handleFlowPhaseResetFailed(msg flowPhaseResetFailedMsg) (tea.Model, tea.Cmd) {
-	if !m.isCurrentRepo(msg.RepoPath) {
+	if !m.activeFlowSurfaceVisible() && !m.isCurrentRepo(msg.RepoPath) {
 		return m, nil
 	}
 	errText := strings.TrimSpace(msg.Err)
@@ -1322,13 +1379,13 @@ func (m Model) handleFlowPhaseResetFailed(msg flowPhaseResetFailedMsg) (tea.Mode
 }
 
 func (m Model) handleFlowDeleteFailed(msg FlowDeleteFailedMsg) (tea.Model, tea.Cmd) {
-	if !m.isCurrentRepo(msg.RepoPath) {
+	if !m.activeFlowSurfaceVisible() && !m.isCurrentRepo(msg.RepoPath) {
 		return m, nil
 	}
 	if msg.NotFound {
 		m = m.clearDeletedFlowState(msg.FlowID)
 		m = m.setStatus(statusOther, fmt.Sprintf("Flow already deleted: %s", flowDisplayName(msg.Title, msg.FlowID)))
-		return m.startFetchMode(ui.ModeFlows)
+		return m.startFlowSurfaceFetch()
 	}
 	errText := msg.Err
 	if strings.TrimSpace(errText) == "" {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1151,7 +1151,7 @@ func (m Model) handleFetchError(msg FetchErrorMsg) Model {
 }
 
 func (m Model) handleActionFailed(msg ActionFailedMsg) Model {
-	if m.isCurrentRepo(msg.RepoPath) {
+	if m.activeFlowSurfaceVisible() || m.isCurrentRepo(msg.RepoPath) {
 		m = m.setStatus(statusOther, msg.Err)
 	}
 	return m

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -710,7 +710,7 @@ func renderModeHeader(mode Mode, width int) string {
 }
 
 func renderActiveFlowsHeader(width int) string {
-	line := ansi.Truncate(" "+activeModeStyle.Render("F3 Active flows")+statusStyle.Render("  current repo, non-merged"), width, "")
+	line := ansi.Truncate(" "+activeModeStyle.Render("active flows"), width, "")
 	separator := strings.Repeat("─", width)
 	return line + "\n" + separator
 }

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -49,6 +49,38 @@ func TestRender_FlowsModeShowsHeaderAndRows(t *testing.T) {
 	}
 }
 
+func TestRender_ActiveFlowsHeaderAndShortcutLabels(t *testing.T) {
+	header := ansi.Strip(renderActiveFlowsHeader(80))
+	if !strings.Contains(header, "active flows") {
+		t.Fatalf("active-flow header missing lowercase title:\n%s", header)
+	}
+	for _, notWant := range []string{"F3", "Active flows", "current repo"} {
+		if strings.Contains(header, notWant) {
+			t.Fatalf("active-flow header should not contain %q:\n%s", notWant, header)
+		}
+	}
+
+	view := Render(RenderParams{
+		Repos:       []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:    0,
+		Width:       180,
+		Height:      24,
+		Mode:        ModeSessions,
+		ActiveFlows: true,
+		ActivePane:  1,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "Active flow",
+			Status: flowstore.StatusPending,
+		}},
+		FlowSelected: 0,
+	})
+	pane := shortcutPaneText(ansi.Strip(view))
+	if !strings.Contains(pane, "f3") || !strings.Contains(pane, "active flows") {
+		t.Fatalf("active-flow shortcut pane should keep f3 active flows hint:\n%s", pane)
+	}
+}
+
 func TestRender_FlowsModeSplitsListAndEmbeddedTerminal(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},


### PR DESCRIPTION
## Summary
- Make the F3 active-flows surface load active Flow records globally instead of only from the selected repo.
- Apply repo filtering locally only while focus is in the left repo pane, and exit active flows into the selected repo when pressing enter from that pane.
- Refresh active-flow results through the new global path after timer ticks, terminal auto-close, and action failures.
- Relabel the active-flow view title while keeping the F3 shortcut hint.

## Verification
- go test ./model
- gofmt -l .
- make test
- make build