### PR TITLE
Show repository in active flows

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -2530,6 +2530,9 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 
 func renderFlowPhaseRows(record flowstore.FlowRecord, width int, selectedPhaseID string, active flowTerminalActivitySet, showRepo bool) []string {
 	if len(record.Phases) == 0 {
+		if showRepo {
+			return []string{truncateToWidth(formatFlowColumns(showRepo, flowPhaseRowPrefix(false, false), "", "", "", "No phases", "", "", "", ""), width)}
+		}
 		return []string{truncateToWidth("      No phases", width)}
 	}
 	rows := make([]string, 0, len(record.Phases))

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -596,9 +596,9 @@ func renderApplication(p RenderParams) string {
 	var rightLines []string
 	switch {
 	case flowSurfaceActive && len(p.FlowEmbeddedTerminals) > 0:
-		rightLines = renderFlowSplitPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.FlowEmbeddedTerminals, p.FlowEmbeddedTerminalLines, p.FlowEmbeddedTerminalPrefix, p.ActivePane == 1 && p.FlowTerminalFocused)
+		rightLines = renderFlowSplitPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.FlowEmbeddedTerminals, p.FlowEmbeddedTerminalLines, p.FlowEmbeddedTerminalPrefix, p.ActivePane == 1 && p.FlowTerminalFocused, p.ActiveFlows)
 	case flowSurfaceActive && len(p.Flows) > 0:
-		rightLines = renderFlowPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity)
+		rightLines = renderFlowPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.ActiveFlows)
 	case p.Mode == ModeWorktrees && len(p.Worktrees) > 0:
 		rightLines = renderWorktreePaneWithSessions(p.Worktrees, worktreeSel, p.WorktreeScroll, rightContentWidth, rightContentHeight, p.InlineWorktreeSessions, p.WorktreeSessions, p.WorktreeSessionSelected, p.WorktreeSessionScroll)
 	case p.Mode == ModeBranches && len(p.Branches) > 0:
@@ -2437,6 +2437,7 @@ func planUpdatedLabel(record planstore.PlanRecord) string {
 
 const (
 	flowStatusWidth  = 15
+	flowRepoWidth    = 16
 	flowBranchWidth  = 20
 	flowPhaseWidth   = 34
 	flowPlanWidth    = 12
@@ -2444,14 +2445,14 @@ const (
 	flowUpdatedWidth = 10
 )
 
-func renderFlowSplitPane(records []flowstore.FlowRecord, selected, scroll, width, height int, expandedFlowID, selectedPhaseID string, activity []FlowTerminalActivity, terminals []EmbeddedTerminalTab, terminalLines []string, prefixActive, terminalFocused bool) []string {
+func renderFlowSplitPane(records []flowstore.FlowRecord, selected, scroll, width, height int, expandedFlowID, selectedPhaseID string, activity []FlowTerminalActivity, terminals []EmbeddedTerminalTab, terminalLines []string, prefixActive, terminalFocused, showRepo bool) []string {
 	if height <= 0 {
 		return nil
 	}
 	listHeight, terminalHeight := FlowSplitPanelHeights(height)
 	lines := make([]string, 0, height)
 	if len(records) > 0 {
-		lines = append(lines, renderFlowPane(records, selected, scroll, width, listHeight, expandedFlowID, selectedPhaseID, activity)...)
+		lines = append(lines, renderFlowPane(records, selected, scroll, width, listHeight, expandedFlowID, selectedPhaseID, activity, showRepo)...)
 	} else {
 		lines = append(lines, renderPlaceholderPane(width, listHeight, "No flows")...)
 	}
@@ -2459,11 +2460,11 @@ func renderFlowSplitPane(records []flowstore.FlowRecord, selected, scroll, width
 	return scrollAndPad(lines, 0, height)
 }
 
-func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, height int, expandedFlowID, selectedPhaseID string, activity []FlowTerminalActivity) []string {
+func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, height int, expandedFlowID, selectedPhaseID string, activity []FlowTerminalActivity, showRepo bool) []string {
 	if height <= 0 {
 		return nil
 	}
-	header := truncateToWidth(statusStyle.Render(formatFlowColumns("   ", "Status", "Branch", "Phase", "Plan", "PR", "Updated", "Title")), width)
+	header := truncateToWidth(statusStyle.Render(formatFlowColumns(showRepo, "   ", "Status", "Repo", "Branch", "Phase", "Plan", "PR", "Updated", "Title")), width)
 	rowHeight := height - TableHeaderRows
 	if rowHeight <= 0 {
 		return []string{header}
@@ -2476,6 +2477,10 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 		plan := flowPlanLabel(record)
 		pr := flowPRLabel(record)
 		updated := flowUpdatedLabel(record)
+		repo := ""
+		if showRepo {
+			repo = flowRepoLabel(record)
+		}
 		branch := record.Branch
 		if branch == "" {
 			if record.WorktreePath != "" {
@@ -2486,14 +2491,16 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 		}
 		rowSelected := i == selected && selectedPhaseID == ""
 		statusCell := statusStyle.Render(fitSessionColumn(record.Status, flowStatusWidth))
+		repoCell := statusStyle.Render(fitSessionColumn(repo, flowRepoWidth))
 		branchCell := branchStyle.Render(fitSessionColumn(branch, flowBranchWidth))
 		phaseCell := diffHdrStyle.Render(fitSessionColumn(phase, flowPhaseWidth))
 		planCell := statusStyle.Render(fitSessionColumn(plan, flowPlanWidth))
 		prCell := statusStyle.Render(fitSessionColumn(pr, flowPRWidth))
 		updatedCell := stashDateStyle.Render(fitSessionColumn(updated, flowUpdatedWidth))
 		titleCell := stashMsgStyle.Render(record.Title)
-		line := formatFlowColumns(flowRowPrefix(false, active.hasFlow(record.FlowID)),
+		line := formatFlowColumns(showRepo, flowRowPrefix(false, active.hasFlow(record.FlowID)),
 			statusCell,
+			repoCell,
 			branchCell,
 			phaseCell,
 			planCell,
@@ -2502,8 +2509,9 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 			titleCell,
 		)
 		if rowSelected {
-			line = renderSelectedFlowColumns(selectedFlowRowPrefix(active.hasFlow(record.FlowID)),
+			line = renderSelectedFlowColumns(showRepo, selectedFlowRowPrefix(active.hasFlow(record.FlowID)),
 				record.Status,
+				repo,
 				branch,
 				phase,
 				plan,
@@ -2514,13 +2522,13 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 		}
 		rows = append(rows, truncateToWidth(line, width))
 		if record.FlowID == expandedFlowID {
-			rows = append(rows, renderFlowPhaseRows(record, width, selectedPhaseID, active)...)
+			rows = append(rows, renderFlowPhaseRows(record, width, selectedPhaseID, active, showRepo)...)
 		}
 	}
 	return append([]string{header}, scrollAndPad(rows, scroll, rowHeight)...)
 }
 
-func renderFlowPhaseRows(record flowstore.FlowRecord, width int, selectedPhaseID string, active flowTerminalActivitySet) []string {
+func renderFlowPhaseRows(record flowstore.FlowRecord, width int, selectedPhaseID string, active flowTerminalActivitySet, showRepo bool) []string {
 	if len(record.Phases) == 0 {
 		return []string{truncateToWidth("      No phases", width)}
 	}
@@ -2536,8 +2544,9 @@ func renderFlowPhaseRows(record flowstore.FlowRecord, width int, selectedPhaseID
 			title += "  " + sessionSummary
 		}
 		rowActive := active.hasPhase(record.FlowID, phase.PhaseID)
-		line := formatFlowColumns(flowPhaseRowPrefix(false, rowActive),
+		line := formatFlowColumns(showRepo, flowPhaseRowPrefix(false, rowActive),
 			statusStyle.Render(fitSessionColumn(phase.Status, flowStatusWidth)),
+			"",
 			"",
 			diffHdrStyle.Render(fitSessionColumn(phase.PhaseID+":"+state, flowPhaseWidth)),
 			"",
@@ -2546,8 +2555,9 @@ func renderFlowPhaseRows(record flowstore.FlowRecord, width int, selectedPhaseID
 			stashMsgStyle.Render(title),
 		)
 		if phase.PhaseID == selectedPhaseID {
-			line = renderSelectedFlowColumns(selectedFlowPhaseRowPrefix(rowActive),
+			line = renderSelectedFlowColumns(showRepo, selectedFlowPhaseRowPrefix(rowActive),
 				phase.Status,
+				"",
 				"",
 				phase.PhaseID+":"+state,
 				"",
@@ -2629,7 +2639,20 @@ func selectedFlowRowPrefix(active bool) string {
 	return selectedStyle.Render(">  ")
 }
 
-func formatFlowColumns(prefix, status, branch, phase, plan, pr, updated, title string) string {
+func formatFlowColumns(showRepo bool, prefix, status, repo, branch, phase, plan, pr, updated, title string) string {
+	if showRepo {
+		return fmt.Sprintf("%s%s  %s  %s  %s  %s  %s  %s  %s",
+			prefix,
+			fitSessionColumn(status, flowStatusWidth),
+			fitSessionColumn(repo, flowRepoWidth),
+			fitSessionColumn(branch, flowBranchWidth),
+			fitSessionColumn(phase, flowPhaseWidth),
+			fitSessionColumn(plan, flowPlanWidth),
+			fitSessionColumn(pr, flowPRWidth),
+			fitSessionColumn(updated, flowUpdatedWidth),
+			title,
+		)
+	}
 	return fmt.Sprintf("%s%s  %s  %s  %s  %s  %s  %s",
 		prefix,
 		fitSessionColumn(status, flowStatusWidth),
@@ -2642,10 +2665,14 @@ func formatFlowColumns(prefix, status, branch, phase, plan, pr, updated, title s
 	)
 }
 
-func renderSelectedFlowColumns(prefix, status, branch, phase, plan, pr, updated, title string, width int) string {
+func renderSelectedFlowColumns(showRepo bool, prefix, status, repo, branch, phase, plan, pr, updated, title string, width int) string {
 	line := prefix
 	line += selectedStyle.Render(fitSessionColumn(status, flowStatusWidth))
 	line += selectedStyle.Render("  ")
+	if showRepo {
+		line += selectedStyle.Render(fitSessionColumn(repo, flowRepoWidth))
+		line += selectedStyle.Render("  ")
+	}
 	line += selectedStyle.Render(fitSessionColumn(branch, flowBranchWidth))
 	line += selectedStyle.Render("  ")
 	line += selectedStyle.Render(fitSessionColumn(phase, flowPhaseWidth))
@@ -2658,6 +2685,14 @@ func renderSelectedFlowColumns(prefix, status, branch, phase, plan, pr, updated,
 	line += selectedStyle.Render("  ")
 	line += selectedStyle.Render(title)
 	return renderSelectedRow(line, width)
+}
+
+func flowRepoLabel(record flowstore.FlowRecord) string {
+	repoPath := strings.TrimSpace(record.RepoPath)
+	if repoPath == "" {
+		return ""
+	}
+	return filepath.Base(filepath.Clean(repoPath))
 }
 
 func flowPhaseProgress(record flowstore.FlowRecord) string {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -593,12 +593,13 @@ func renderApplication(p RenderParams) string {
 		selectedFlowPhaseID = ""
 	}
 
+	repoDisplayNames := repoDisplayNamesByPath(p.Repos)
 	var rightLines []string
 	switch {
 	case flowSurfaceActive && len(p.FlowEmbeddedTerminals) > 0:
-		rightLines = renderFlowSplitPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.FlowEmbeddedTerminals, p.FlowEmbeddedTerminalLines, p.FlowEmbeddedTerminalPrefix, p.ActivePane == 1 && p.FlowTerminalFocused, p.ActiveFlows)
+		rightLines = renderFlowSplitPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.FlowEmbeddedTerminals, p.FlowEmbeddedTerminalLines, p.FlowEmbeddedTerminalPrefix, p.ActivePane == 1 && p.FlowTerminalFocused, p.ActiveFlows, repoDisplayNames)
 	case flowSurfaceActive && len(p.Flows) > 0:
-		rightLines = renderFlowPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.ActiveFlows)
+		rightLines = renderFlowPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.ActiveFlows, repoDisplayNames)
 	case p.Mode == ModeWorktrees && len(p.Worktrees) > 0:
 		rightLines = renderWorktreePaneWithSessions(p.Worktrees, worktreeSel, p.WorktreeScroll, rightContentWidth, rightContentHeight, p.InlineWorktreeSessions, p.WorktreeSessions, p.WorktreeSessionSelected, p.WorktreeSessionScroll)
 	case p.Mode == ModeBranches && len(p.Branches) > 0:
@@ -2445,14 +2446,14 @@ const (
 	flowUpdatedWidth = 10
 )
 
-func renderFlowSplitPane(records []flowstore.FlowRecord, selected, scroll, width, height int, expandedFlowID, selectedPhaseID string, activity []FlowTerminalActivity, terminals []EmbeddedTerminalTab, terminalLines []string, prefixActive, terminalFocused, showRepo bool) []string {
+func renderFlowSplitPane(records []flowstore.FlowRecord, selected, scroll, width, height int, expandedFlowID, selectedPhaseID string, activity []FlowTerminalActivity, terminals []EmbeddedTerminalTab, terminalLines []string, prefixActive, terminalFocused, showRepo bool, repoDisplayNames map[string]string) []string {
 	if height <= 0 {
 		return nil
 	}
 	listHeight, terminalHeight := FlowSplitPanelHeights(height)
 	lines := make([]string, 0, height)
 	if len(records) > 0 {
-		lines = append(lines, renderFlowPane(records, selected, scroll, width, listHeight, expandedFlowID, selectedPhaseID, activity, showRepo)...)
+		lines = append(lines, renderFlowPane(records, selected, scroll, width, listHeight, expandedFlowID, selectedPhaseID, activity, showRepo, repoDisplayNames)...)
 	} else {
 		lines = append(lines, renderPlaceholderPane(width, listHeight, "No flows")...)
 	}
@@ -2460,7 +2461,7 @@ func renderFlowSplitPane(records []flowstore.FlowRecord, selected, scroll, width
 	return scrollAndPad(lines, 0, height)
 }
 
-func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, height int, expandedFlowID, selectedPhaseID string, activity []FlowTerminalActivity, showRepo bool) []string {
+func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, height int, expandedFlowID, selectedPhaseID string, activity []FlowTerminalActivity, showRepo bool, repoDisplayNames map[string]string) []string {
 	if height <= 0 {
 		return nil
 	}
@@ -2479,7 +2480,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 		updated := flowUpdatedLabel(record)
 		repo := ""
 		if showRepo {
-			repo = flowRepoLabel(record)
+			repo = flowRepoLabel(record, repoDisplayNames)
 		}
 		branch := record.Branch
 		if branch == "" {
@@ -2690,12 +2691,32 @@ func renderSelectedFlowColumns(showRepo bool, prefix, status, repo, branch, phas
 	return renderSelectedRow(line, width)
 }
 
-func flowRepoLabel(record flowstore.FlowRecord) string {
+func repoDisplayNamesByPath(repos []scanner.Repo) map[string]string {
+	if len(repos) == 0 {
+		return nil
+	}
+	displayNames := make(map[string]string, len(repos))
+	for _, repo := range repos {
+		path := strings.TrimSpace(repo.Path)
+		name := strings.TrimSpace(repo.DisplayName)
+		if path == "" || name == "" {
+			continue
+		}
+		displayNames[filepath.Clean(path)] = name
+	}
+	return displayNames
+}
+
+func flowRepoLabel(record flowstore.FlowRecord, repoDisplayNames map[string]string) string {
 	repoPath := strings.TrimSpace(record.RepoPath)
 	if repoPath == "" {
 		return ""
 	}
-	return filepath.Base(filepath.Clean(repoPath))
+	cleanRepoPath := filepath.Clean(repoPath)
+	if name := repoDisplayNames[cleanRepoPath]; name != "" {
+		return name
+	}
+	return filepath.Base(cleanRepoPath)
 }
 
 func flowPhaseProgress(record flowstore.FlowRecord) string {

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -338,6 +338,34 @@ func TestRender_ActiveFlowsExpandedPhaseRowsKeepRepoColumnAlignment(t *testing.T
 	}
 }
 
+func TestRender_ActiveFlowsExpandedNoPhasesKeepsRepoColumnAlignment(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:       []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:    0,
+		Width:       240,
+		Height:      12,
+		Mode:        ModeSessions,
+		ActiveFlows: true,
+		ActivePane:  1,
+		Flows: []flowstore.FlowRecord{{
+			FlowID:   "flow-1",
+			Title:    "Expanded active repo flow",
+			Status:   flowstore.StatusInProgress,
+			RepoPath: "/dev/wtui",
+			Branch:   "flow/empty-phases",
+		}},
+		FlowSelected:   0,
+		ExpandedFlowID: "flow-1",
+	})
+
+	flowRow := lineContaining(view, "flow/empty-phases")
+	noPhasesRow := lineContaining(view, "No phases")
+	requireOrderedColumns(t, flowRow, flowstore.StatusInProgress, "wtui", "flow/empty-phases")
+	if visibleColumn(noPhasesRow, "No phases") <= visibleColumn(flowRow, "flow/empty-phases") {
+		t.Fatalf("no-phases detail should stay aligned after the active-flow branch column, flow=%q noPhases=%q", flowRow, noPhasesRow)
+	}
+}
+
 func TestRender_FlowsModeMarksActiveTerminalFlowRows(t *testing.T) {
 	flows := []flowstore.FlowRecord{
 		{
@@ -384,6 +412,64 @@ func TestRender_FlowsModeMarksActiveTerminalFlowRows(t *testing.T) {
 	selectedActiveRow := ansi.Strip(lineContaining(view, "flow/active"))
 	if !strings.HasPrefix(selectedActiveRow, ">● in_progress") {
 		t.Fatalf("selected active flow row prefix = %q, want selection and marker:\n%s", selectedActiveRow, view)
+	}
+}
+
+func TestRender_ActiveFlowsSelectedActiveRowsPreserveSelectionAfterRepoColumn(t *testing.T) {
+	previousProfile := lipgloss.ColorProfile()
+	previousDarkBackground := lipgloss.HasDarkBackground()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	lipgloss.SetHasDarkBackground(true)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(previousProfile)
+		lipgloss.SetHasDarkBackground(previousDarkBackground)
+	})
+
+	flows := []flowstore.FlowRecord{{
+		FlowID:   "flow-1",
+		Title:    "Active repo flow",
+		Status:   flowstore.StatusInProgress,
+		RepoPath: "/dev/wtui",
+		Branch:   "flow/active-repo",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning},
+		},
+	}}
+	activity := []FlowTerminalActivity{
+		{FlowID: "flow-1", PhaseID: "implementation"},
+	}
+
+	view := strings.Join(renderFlowPane(flows, 0, 0, 240, 6, "", "", activity, true), "\n")
+	flowRow := rawLineContaining(view, "flow/active-repo")
+	if flowRow == "" {
+		t.Fatalf("active flow row missing:\n%s", view)
+	}
+	strippedFlowRow := ansi.Strip(flowRow)
+	if !strings.HasPrefix(strippedFlowRow, ">● in_progress") {
+		t.Fatalf("selected active flow row prefix = %q, want selection and marker:\n%s", strippedFlowRow, view)
+	}
+	requireOrderedColumns(t, strippedFlowRow, flowstore.StatusInProgress, "wtui", "flow/active-repo")
+	if !strings.Contains(flowRow, selectedSegment(flowTerminalStyle, "●")) {
+		t.Fatalf("selected active flow marker should keep semantic marker style:\n%q", flowRow)
+	}
+	if want := selectedStyle.Render(fitSessionColumn("wtui", flowRepoWidth)); !strings.Contains(flowRow, want) {
+		t.Fatalf("selected active flow row should style repo column after marker:\n%q\nmissing %q", flowRow, want)
+	}
+
+	view = strings.Join(renderFlowPane(flows, 0, 0, 240, 6, "flow-1", "implementation", activity, true), "\n")
+	phaseRow := rawLineContaining(view, "Implementation")
+	if phaseRow == "" {
+		t.Fatalf("active phase row missing:\n%s", view)
+	}
+	strippedPhaseRow := ansi.Strip(phaseRow)
+	if !strings.HasPrefix(strippedPhaseRow, "   >● running") {
+		t.Fatalf("selected active phase row prefix = %q, want phase indent, selection, marker:\n%s", strippedPhaseRow, view)
+	}
+	if visibleColumn(strippedPhaseRow, "implementation:running") <= visibleColumn(strippedFlowRow, "flow/active-repo") {
+		t.Fatalf("selected active phase should stay aligned after active-flow repo and branch columns, flow=%q phase=%q", strippedFlowRow, strippedPhaseRow)
+	}
+	if !strings.Contains(phaseRow, selectedSegment(flowTerminalStyle, "●")) {
+		t.Fatalf("selected active phase marker should keep semantic marker style:\n%q", phaseRow)
 	}
 }
 

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -47,6 +47,10 @@ func TestRender_FlowsModeShowsHeaderAndRows(t *testing.T) {
 	if strings.Contains(view, "Review loop") {
 		t.Fatalf("flow phase detail rows should be collapsed by default:\n%s", view)
 	}
+	header := lineContaining(view, "Status")
+	if strings.Contains(header, "Repo") {
+		t.Fatalf("normal flows header should not include active-flows Repo column:\n%s", header)
+	}
 }
 
 func TestRender_ActiveFlowsHeaderAndShortcutLabels(t *testing.T) {
@@ -79,6 +83,31 @@ func TestRender_ActiveFlowsHeaderAndShortcutLabels(t *testing.T) {
 	if !strings.Contains(pane, "f3") || !strings.Contains(pane, "active flows") {
 		t.Fatalf("active-flow shortcut pane should keep f3 active flows hint:\n%s", pane)
 	}
+}
+
+func TestRender_ActiveFlowsShowsRepoColumnBetweenStatusAndBranch(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:       []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:    0,
+		Width:       220,
+		Height:      12,
+		Mode:        ModeSessions,
+		ActiveFlows: true,
+		ActivePane:  1,
+		Flows: []flowstore.FlowRecord{{
+			FlowID:   "flow-1",
+			Title:    "Active repo flow",
+			Status:   flowstore.StatusInProgress,
+			RepoPath: "/dev/wtui",
+			Branch:   "flow/active-repo",
+		}},
+		FlowSelected: 0,
+	})
+
+	header := lineContaining(view, "Status")
+	row := lineContaining(view, "flow/active-repo")
+	requireOrderedColumns(t, header, "Status", "Repo", "Branch")
+	requireOrderedColumns(t, row, flowstore.StatusInProgress, "wtui", "flow/active-repo")
 }
 
 func TestRender_FlowsModeSplitsListAndEmbeddedTerminal(t *testing.T) {
@@ -130,6 +159,42 @@ func TestRender_FlowsModeSplitsListAndEmbeddedTerminal(t *testing.T) {
 	}
 	if strings.Contains(view, "terminal line 1") || strings.Contains(view, "terminal line 2") {
 		t.Fatalf("split Flow terminal should window old lines after border/header rows:\n%s", view)
+	}
+}
+
+func TestRender_ActiveFlowsSplitPaneShowsRepoColumn(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:       []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:    0,
+		Width:       240,
+		Height:      14,
+		Mode:        ModeSessions,
+		ActiveFlows: true,
+		ActivePane:  1,
+		Flows: []flowstore.FlowRecord{{
+			FlowID:   "flow-1",
+			Title:    "Split active repo flow",
+			Status:   flowstore.StatusInProgress,
+			RepoPath: "/dev/wtui",
+			Branch:   "flow/split-repo",
+		}},
+		FlowSelected: 0,
+		FlowEmbeddedTerminals: []EmbeddedTerminalTab{{
+			Number:   1,
+			Provider: "codex",
+			Identity: "implementation",
+			State:    "running",
+			Active:   true,
+		}},
+		FlowEmbeddedTerminalLines: []string{"terminal line"},
+	})
+
+	header := lineContaining(view, "Status")
+	row := lineContaining(view, "flow/split-repo")
+	requireOrderedColumns(t, header, "Status", "Repo", "Branch")
+	requireOrderedColumns(t, row, flowstore.StatusInProgress, "wtui", "flow/split-repo")
+	if !strings.Contains(view, "terminal line") {
+		t.Fatalf("active-flow split pane should still render terminal content:\n%s", view)
 	}
 }
 
@@ -197,7 +262,7 @@ func TestRenderFlowSplitPaneWrapsOnlyTerminalPanelInBorder(t *testing.T) {
 		Identity: "implementation",
 		State:    "running",
 		Active:   true,
-	}}, terminalLines, false, true))
+	}}, terminalLines, false, true, false))
 
 	if listHeight != 4 || terminalHeight != 6 {
 		t.Fatalf("split heights = %d/%d, want 4/6", listHeight, terminalHeight)
@@ -235,6 +300,44 @@ func TestRenderFlowSplitPaneWrapsOnlyTerminalPanelInBorder(t *testing.T) {
 	}
 }
 
+func TestRender_ActiveFlowsExpandedPhaseRowsKeepRepoColumnAlignment(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:       []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:    0,
+		Width:       240,
+		Height:      12,
+		Mode:        ModeSessions,
+		ActiveFlows: true,
+		ActivePane:  1,
+		Flows: []flowstore.FlowRecord{{
+			FlowID:   "flow-1",
+			Title:    "Expanded active repo flow",
+			Status:   flowstore.StatusInProgress,
+			RepoPath: "/dev/wtui",
+			Branch:   "flow/expanded",
+			Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation",
+				Title:   "Implementation",
+				Status:  flowstore.PhaseReady,
+				Order:   1,
+			}},
+		}},
+		FlowSelected:        0,
+		ExpandedFlowID:      "flow-1",
+		SelectedFlowPhaseID: "implementation",
+	})
+
+	flowRow := lineContaining(view, "flow/expanded")
+	phaseRow := lineContaining(view, "implementation:ready")
+	requireOrderedColumns(t, flowRow, flowstore.StatusInProgress, "wtui", "flow/expanded")
+	if repoColumn := visibleColumn(flowRow, "wtui"); repoColumn >= visibleColumn(phaseRow, "implementation:ready") {
+		t.Fatalf("phase detail should render after the empty repo and branch cells, flow=%q phase=%q", flowRow, phaseRow)
+	}
+	if visibleColumn(phaseRow, "implementation:ready") <= visibleColumn(flowRow, "flow/expanded") {
+		t.Fatalf("phase detail should stay aligned after the branch column, flow=%q phase=%q", flowRow, phaseRow)
+	}
+}
+
 func TestRender_FlowsModeMarksActiveTerminalFlowRows(t *testing.T) {
 	flows := []flowstore.FlowRecord{
 		{
@@ -258,7 +361,7 @@ func TestRender_FlowsModeMarksActiveTerminalFlowRows(t *testing.T) {
 	}
 	view := strings.Join(renderFlowPane(flows, 1, 0, 200, 5, "", "", []FlowTerminalActivity{
 		{FlowID: "flow-1", PhaseID: "implementation"},
-	}), "\n")
+	}, false), "\n")
 
 	activeRow := ansi.Strip(lineContaining(view, "flow/active"))
 	inactiveRow := ansi.Strip(lineContaining(view, "flow/inactive"))
@@ -277,7 +380,7 @@ func TestRender_FlowsModeMarksActiveTerminalFlowRows(t *testing.T) {
 
 	view = strings.Join(renderFlowPane(flows, 0, 0, 200, 5, "", "", []FlowTerminalActivity{
 		{FlowID: "flow-1", PhaseID: "implementation"},
-	}), "\n")
+	}, false), "\n")
 	selectedActiveRow := ansi.Strip(lineContaining(view, "flow/active"))
 	if !strings.HasPrefix(selectedActiveRow, ">● in_progress") {
 		t.Fatalf("selected active flow row prefix = %q, want selection and marker:\n%s", selectedActiveRow, view)
@@ -290,6 +393,24 @@ func visibleColumn(line, needle string) int {
 		return -1
 	}
 	return lipgloss.Width(line[:index])
+}
+
+func requireOrderedColumns(t *testing.T, line string, columns ...string) {
+	t.Helper()
+	if line == "" {
+		t.Fatalf("missing line for ordered columns %v", columns)
+	}
+	previous := -1
+	for _, column := range columns {
+		current := visibleColumn(line, column)
+		if current < 0 {
+			t.Fatalf("line missing column %q: %q", column, line)
+		}
+		if current <= previous {
+			t.Fatalf("line columns out of order %v: %q", columns, line)
+		}
+		previous = current
+	}
 }
 
 func lineWithPrefix(view, prefix string) string {
@@ -334,7 +455,7 @@ func TestRender_FlowsModeSelectedActiveRowsPreserveSelectionAfterMarker(t *testi
 		{FlowID: "flow-1", PhaseID: "implementation"},
 	}
 
-	view := strings.Join(renderFlowPane(flows, 0, 0, 220, 6, "", "", activity), "\n")
+	view := strings.Join(renderFlowPane(flows, 0, 0, 220, 6, "", "", activity, false), "\n")
 
 	flowRow := rawLineContaining(view, "flow/active")
 	if flowRow == "" {
@@ -347,7 +468,7 @@ func TestRender_FlowsModeSelectedActiveRowsPreserveSelectionAfterMarker(t *testi
 		t.Fatalf("selected active flow row should restore selection style after marker:\n%q\nmissing %q", flowRow, want)
 	}
 
-	view = strings.Join(renderFlowPane(flows, 0, 0, 220, 6, "flow-1", "implementation", activity), "\n")
+	view = strings.Join(renderFlowPane(flows, 0, 0, 220, 6, "flow-1", "implementation", activity, false), "\n")
 	phaseRow := rawLineContaining(view, "Implementation")
 	if phaseRow == "" {
 		t.Fatalf("active phase row missing:\n%s", view)
@@ -385,7 +506,7 @@ func TestRender_FlowsModeMarksActiveTerminalExpandedPhaseRows(t *testing.T) {
 	view := strings.Join(renderFlowPane(flows, 0, 0, 220, 8, "flow-1", "implementation", []FlowTerminalActivity{
 		{FlowID: "flow-1", PhaseID: "Implementation"},
 		{FlowID: "flow-2", PhaseID: "review-loop"},
-	}), "\n")
+	}, false), "\n")
 
 	flowRow := ansi.Strip(lineContaining(view, "flow/active"))
 	activePhaseRow := ansi.Strip(lineContaining(view, "Implementation"))
@@ -425,7 +546,7 @@ func TestRender_FlowsModeSplitPaneMarksActiveTerminalRows(t *testing.T) {
 		Identity: "misleading-label",
 		State:    "running",
 		Active:   true,
-	}}, []string{"terminal line"}, false, false)
+	}}, []string{"terminal line"}, false, false, false)
 	view := strings.Join(lines, "\n")
 
 	flowRow := ansi.Strip(lineContaining(view, "flow/split-active"))

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -87,7 +87,10 @@ func TestRender_ActiveFlowsHeaderAndShortcutLabels(t *testing.T) {
 
 func TestRender_ActiveFlowsShowsRepoColumnBetweenStatusAndBranch(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Repos: []scanner.Repo{
+			{Path: "/dev/wtui", DisplayName: "wtui"},
+			{Path: "/dev/client/api", DisplayName: "client/api"},
+		},
 		Selected:    0,
 		Width:       220,
 		Height:      12,
@@ -100,14 +103,25 @@ func TestRender_ActiveFlowsShowsRepoColumnBetweenStatusAndBranch(t *testing.T) {
 			Status:   flowstore.StatusInProgress,
 			RepoPath: "/dev/wtui",
 			Branch:   "flow/active-repo",
+		}, {
+			FlowID:   "flow-2",
+			Title:    "Nested active repo flow",
+			Status:   flowstore.StatusInProgress,
+			RepoPath: "/dev/client/api",
+			Branch:   "flow/nested-repo",
 		}},
 		FlowSelected: 0,
 	})
 
 	header := lineContaining(view, "Status")
 	row := lineContaining(view, "flow/active-repo")
+	nestedRow := lineContaining(view, "flow/nested-repo")
 	requireOrderedColumns(t, header, "Status", "Repo", "Branch")
 	requireOrderedColumns(t, row, flowstore.StatusInProgress, "wtui", "flow/active-repo")
+	requireOrderedColumns(t, nestedRow, flowstore.StatusInProgress, "client/api", "flow/nested-repo")
+	if strings.Contains(nestedRow, " api ") {
+		t.Fatalf("nested active-flow repo label should preserve scanner display context, got basename row: %q", nestedRow)
+	}
 }
 
 func TestRender_FlowsModeSplitsListAndEmbeddedTerminal(t *testing.T) {
@@ -262,7 +276,7 @@ func TestRenderFlowSplitPaneWrapsOnlyTerminalPanelInBorder(t *testing.T) {
 		Identity: "implementation",
 		State:    "running",
 		Active:   true,
-	}}, terminalLines, false, true, false))
+	}}, terminalLines, false, true, false, nil))
 
 	if listHeight != 4 || terminalHeight != 6 {
 		t.Fatalf("split heights = %d/%d, want 4/6", listHeight, terminalHeight)
@@ -389,7 +403,7 @@ func TestRender_FlowsModeMarksActiveTerminalFlowRows(t *testing.T) {
 	}
 	view := strings.Join(renderFlowPane(flows, 1, 0, 200, 5, "", "", []FlowTerminalActivity{
 		{FlowID: "flow-1", PhaseID: "implementation"},
-	}, false), "\n")
+	}, false, nil), "\n")
 
 	activeRow := ansi.Strip(lineContaining(view, "flow/active"))
 	inactiveRow := ansi.Strip(lineContaining(view, "flow/inactive"))
@@ -408,7 +422,7 @@ func TestRender_FlowsModeMarksActiveTerminalFlowRows(t *testing.T) {
 
 	view = strings.Join(renderFlowPane(flows, 0, 0, 200, 5, "", "", []FlowTerminalActivity{
 		{FlowID: "flow-1", PhaseID: "implementation"},
-	}, false), "\n")
+	}, false, nil), "\n")
 	selectedActiveRow := ansi.Strip(lineContaining(view, "flow/active"))
 	if !strings.HasPrefix(selectedActiveRow, ">● in_progress") {
 		t.Fatalf("selected active flow row prefix = %q, want selection and marker:\n%s", selectedActiveRow, view)
@@ -439,7 +453,7 @@ func TestRender_ActiveFlowsSelectedActiveRowsPreserveSelectionAfterRepoColumn(t 
 		{FlowID: "flow-1", PhaseID: "implementation"},
 	}
 
-	view := strings.Join(renderFlowPane(flows, 0, 0, 240, 6, "", "", activity, true), "\n")
+	view := strings.Join(renderFlowPane(flows, 0, 0, 240, 6, "", "", activity, true, nil), "\n")
 	flowRow := rawLineContaining(view, "flow/active-repo")
 	if flowRow == "" {
 		t.Fatalf("active flow row missing:\n%s", view)
@@ -456,7 +470,7 @@ func TestRender_ActiveFlowsSelectedActiveRowsPreserveSelectionAfterRepoColumn(t 
 		t.Fatalf("selected active flow row should style repo column after marker:\n%q\nmissing %q", flowRow, want)
 	}
 
-	view = strings.Join(renderFlowPane(flows, 0, 0, 240, 6, "flow-1", "implementation", activity, true), "\n")
+	view = strings.Join(renderFlowPane(flows, 0, 0, 240, 6, "flow-1", "implementation", activity, true, nil), "\n")
 	phaseRow := rawLineContaining(view, "Implementation")
 	if phaseRow == "" {
 		t.Fatalf("active phase row missing:\n%s", view)
@@ -541,7 +555,7 @@ func TestRender_FlowsModeSelectedActiveRowsPreserveSelectionAfterMarker(t *testi
 		{FlowID: "flow-1", PhaseID: "implementation"},
 	}
 
-	view := strings.Join(renderFlowPane(flows, 0, 0, 220, 6, "", "", activity, false), "\n")
+	view := strings.Join(renderFlowPane(flows, 0, 0, 220, 6, "", "", activity, false, nil), "\n")
 
 	flowRow := rawLineContaining(view, "flow/active")
 	if flowRow == "" {
@@ -554,7 +568,7 @@ func TestRender_FlowsModeSelectedActiveRowsPreserveSelectionAfterMarker(t *testi
 		t.Fatalf("selected active flow row should restore selection style after marker:\n%q\nmissing %q", flowRow, want)
 	}
 
-	view = strings.Join(renderFlowPane(flows, 0, 0, 220, 6, "flow-1", "implementation", activity, false), "\n")
+	view = strings.Join(renderFlowPane(flows, 0, 0, 220, 6, "flow-1", "implementation", activity, false, nil), "\n")
 	phaseRow := rawLineContaining(view, "Implementation")
 	if phaseRow == "" {
 		t.Fatalf("active phase row missing:\n%s", view)
@@ -592,7 +606,7 @@ func TestRender_FlowsModeMarksActiveTerminalExpandedPhaseRows(t *testing.T) {
 	view := strings.Join(renderFlowPane(flows, 0, 0, 220, 8, "flow-1", "implementation", []FlowTerminalActivity{
 		{FlowID: "flow-1", PhaseID: "Implementation"},
 		{FlowID: "flow-2", PhaseID: "review-loop"},
-	}, false), "\n")
+	}, false, nil), "\n")
 
 	flowRow := ansi.Strip(lineContaining(view, "flow/active"))
 	activePhaseRow := ansi.Strip(lineContaining(view, "Implementation"))
@@ -632,7 +646,7 @@ func TestRender_FlowsModeSplitPaneMarksActiveTerminalRows(t *testing.T) {
 		Identity: "misleading-label",
 		State:    "running",
 		Active:   true,
-	}}, []string{"terminal line"}, false, false, false)
+	}}, []string{"terminal line"}, false, false, false, nil)
 	view := strings.Join(lines, "\n")
 
 	flowRow := ansi.Strip(lineContaining(view, "flow/split-active"))


### PR DESCRIPTION
## Summary
- add a Repo column to the active flows view so global flows identify their source repository
- keep the normal per-repo flows view unchanged
- preserve column alignment for selected rows, expanded phase rows, empty phase rows, and split terminal views

## Verification
- gofmt -l .
- make test
- make build