### PR TITLE
Update Flow review and PR phase order

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,8 +353,8 @@ normally and auto-closes before launching the next phase; that exit also
 triggers a Flow refresh so completions recorded after the last refresh are
 picked up promptly. Skipped, blocked, needs-attention, failed-launch, or
 missing-PR-metadata states do not auto-launch. Automation stops before Merge:
-if Autoreview completes and Merge becomes ready, wtui keeps auto mode on and
-requires the existing manual Merge launch.
+if PR Creation completes with structured PR metadata and Merge becomes ready,
+wtui keeps auto mode on and requires the existing manual Merge launch.
 
 Press `F3` from any middle-pane view to keep the current numbered mode selected
 while showing active Flows across all repos. This active view hides merged Flow
@@ -396,8 +396,8 @@ mode, keys pass through to the PTY (including agent shortcuts like `ctrl+g`)
 and `ctrl+]` returns to command mode. When
 Implementation is still gated by Plan Review, wtui reports the Plan Review state
 and notes instead of launching. When PR Creation is complete but structured PR
-metadata is missing, Autoreview remains pending and the Flow row shows
-`autoreview:missing-pr`.
+metadata is missing, Merge remains pending and the Flow row shows
+`merge:missing-pr`.
 Expanded phase rows group child implementation phases directly under
 Implementation.
 
@@ -407,7 +407,7 @@ shows `recover-worktree`, a running phase with a recorded launch but no attached
 session yet shows `await-session`, a phase with an attached session whose
 launch ID does not match the phase's launch attempts shows `session-mismatch`,
 and an attached session that lacks a provider session ID shows
-`missing-session-id`. A pending Autoreview phase whose PR Creation predecessor
+`missing-session-id`. A pending Merge phase whose PR Creation predecessor
 completed without structured PR metadata shows `missing-pr`.
 
 When an expanded phase row shows `await-session`, and no running or starting
@@ -439,7 +439,7 @@ wtui flow plan set --flow-id "$FLOW_ID" --plan-id "$PLAN_ID"
 # print JSON with the updated phase and the next actionable phase state. For
 # Plan Review, complete defaults to approved, needs-attention defaults to
 # changes_requested, and block defaults to blocked unless --outcome is supplied.
-# Autoreview defaults are passed, needs_attention, and blocked.
+# review-loop-2 defaults are passed, needs_attention, and blocked.
 wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan --summary "Saved plan"
 wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review \
   --notes "Revise the rollout section"
@@ -489,31 +489,32 @@ marks the Flow phase `needs_attention` and reports the persistence error.
 Repeating `completed` for an already-completed Flow phase preserves that
 completed state even if the linked-plan sync later fails.
 
-Child implementation phases gate downstream readiness in phase order: review
-loop and PR creation remain pending until required implementation children are
-completed or explicitly skipped with notes. Flow phase launch prompts stay
-minimal: Plan Review and Implementation point to the saved plan artifact, while
-Review Loop and PR Creation include only the worktree, branch, and start commit
-metadata needed to inspect the changes. Built-in prompts tell Plan to produce
-only a plan, Plan Review to use the review-loop skill with max 6 loops,
-Implementation to use the `commit` skill, Review Loop to use the review-loop
-workflow with goal `review-and-revise` and `commit` when revisions are made,
-PR Creation to use the `ship` skill, and Autoreview to use `ship` when fixes
-require commits or pushes without embedding phase-restart recipes. All Flow
-phase launch prompts also end with:
+Child implementation phases gate downstream readiness in phase order:
+review-loop-1, review-loop-2, and PR creation remain pending until required
+implementation children are completed or explicitly skipped with notes. Flow
+phase launch prompts stay minimal: Plan Review and Implementation point to the
+saved plan artifact, while review-loop-1, review-loop-2, and PR Creation
+include only the worktree, branch, and start commit metadata needed to inspect
+the changes. Built-in prompts tell Plan to produce only a plan, Plan Review to
+use the review-loop skill with max 6 loops, Implementation to use the `commit`
+skill, review-loop-1 to use the review-loop workflow with goal
+`review-and-revise` and `commit` when revisions are made, review-loop-2 to run
+a second-level local worktree autoreview and use `commit` when revisions are
+made, and PR Creation to use the `ship` skill. All Flow phase launch prompts
+also end with:
 `After completing this phase goal, mark this Flow phase done with wtui-flow.`
 Use `wtui flow phase restart` to rerun a blocked or needs-attention phase as
 `running`; if notes are omitted, wtui records a standard rerun note.
 
-For example, after addressing Autoreview findings:
+For example, after addressing review-loop-2 findings:
 
 ```bash
-wtui flow phase restart --flow-id "$FLOW_ID" --phase-id autoreview
+wtui flow phase restart --flow-id "$FLOW_ID" --phase-id review-loop-2
 ```
 
-Autoreview is ready only after PR Creation is complete and
-`wtui flow pr set` has recorded provider, PR number, URL, head branch, and base
-branch metadata. Merge stays an explicit phase:
+PR Creation is ready only after review-loop-2 is complete. Merge is ready only
+after PR Creation is complete and `wtui flow pr set` has recorded provider, PR
+number, URL, head branch, and base branch metadata. Merge stays an explicit phase:
 agents must record both the Merge phase update and structured merge metadata
 through `wtui flow merge set`; `--status merged` requires existing PR metadata,
 a merge commit, and an RFC3339 merge timestamp. If merge is blocked, record a

--- a/agent-skills/skill_docs_test.go
+++ b/agent-skills/skill_docs_test.go
@@ -35,9 +35,9 @@ func TestWtuiFlowSkillDocumentsAgentContract(t *testing.T) {
 		"plan",
 		"plan-review",
 		"implementation",
-		"review-loop",
+		"review-loop-1",
+		"review-loop-2",
 		"pr-creation",
-		"autoreview",
 		"merge",
 	})
 	requireContainsAll(t, "agent-facing phase statuses", skill, []string{

--- a/agent-skills/wtui-flow/SKILL.md
+++ b/agent-skills/wtui-flow/SKILL.md
@@ -70,7 +70,7 @@ Use `wtui flow phase block --notes "..."` for blockers and
 For Plan Review, those wrappers fill default outcomes when omitted:
 `complete` => `approved`, `needs-attention` => `changes_requested`, and
 `block` => `blocked`. The `complete` wrapper can still take an explicit
-Plan Review outcome such as `approved_with_concerns`. For Autoreview, the
+Plan Review outcome such as `approved_with_concerns`. For review-loop-2, the
 wrappers fill `complete` => `passed`, `needs-attention` =>
 `needs_attention`, and `block` => `blocked`. Use `wtui flow phase restart`
 for reruns, and use the lower-level `wtui flow phase set` command for
@@ -281,21 +281,51 @@ workflow proceeds. If verification or persistence fails, do not report
 Implementation as completed; use `needs_attention` or `blocked` and include the
 failure in `--summary` or `--notes`.
 
-## Review Loop Phase
+## review-loop-1 Phase
 
-Goal: critique the implementation and drive revisions before PR creation.
+Goal: critique the implementation and drive revisions before second-level
+local worktree autoreview.
 
-Run the requested review loop. Record `completed` when blocking findings are
-fixed, `needs_attention` when non-blocking concerns remain for the user, and
-`blocked` when the branch cannot be reviewed or fixed.
+Run the requested first review loop. Record `completed` when blocking findings
+are fixed, `needs_attention` when non-blocking concerns remain for the user,
+and `blocked` when the branch cannot be reviewed or fixed.
 
 ```bash
 wtui flow phase set \
   --flow-id "$WTUI_FLOW_ID" \
-  --phase-id review-loop \
+  --phase-id review-loop-1 \
   --status completed \
   --outcome "completed" \
   --summary "Review loop passed after revisions." \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+## review-loop-2 Phase
+
+Goal: perform a second-level local worktree autoreview before PR creation.
+
+Review the local worktree, branch, and start commit. Do not require or wait for
+PR metadata in this phase; that metadata belongs to PR Creation after this
+phase completes. Record `completed` when blocking findings are fixed,
+`needs_attention` when non-blocking concerns remain for the user, and `blocked`
+when the branch cannot be reviewed or fixed.
+
+If review-loop-2 is already `needs_attention` or `blocked`, do not mark it
+`completed` directly. First restart the phase as `running`, then complete it
+after the rerun succeeds:
+
+```bash
+wtui flow phase restart \
+  --flow-id "$WTUI_FLOW_ID" \
+  --phase-id review-loop-2 \
+  "${FLOW_STATE_ARGS[@]}"
+```
+
+```bash
+wtui flow phase complete \
+  --flow-id "$WTUI_FLOW_ID" \
+  --phase-id review-loop-2 \
+  --summary "Second-level local worktree autoreview passed; no blocking findings remain." \
   "${FLOW_STATE_ARGS[@]}"
 ```
 
@@ -305,9 +335,9 @@ Goal: commit, push, and open or update the pull request.
 
 After the PR exists, record the PR provider, positive PR number, URL, head
 branch, base branch, and status through `wtui flow pr set`. Recording this
-structured PR metadata is a required part of PR Creation, not optional
-bookkeeping. The command currently supports `--provider github`; the PR head
-branch must match the Flow branch.
+structured PR metadata is a required part of PR Creation because it gates
+Merge, not optional bookkeeping. The command currently supports `--provider
+github`; the PR head branch must match the Flow branch.
 
 ```bash
 wtui flow pr set \
@@ -332,36 +362,6 @@ wtui flow phase set \
 If `wtui flow pr set` fails, do not mark PR Creation completed; report the
 command error. If a PR cannot be created, use `blocked` with notes explaining
 what failed.
-
-## Autoreview Phase
-
-Goal: perform a second-level review against the PR or pushed branch.
-
-Read the Flow first and verify the top-level `pr` object contains provider,
-number, URL, head branch, and base branch. If PR metadata is missing, do not run
-Autoreview and do not try to advance the pending Autoreview phase. Return to PR
-Creation by recording the missing metadata with `wtui flow pr set`; if a PR does
-not exist or cannot be recovered, rerun PR Creation as `running` with notes and
-then mark PR Creation `blocked` with notes.
-
-If Autoreview is already `needs_attention` or `blocked`, do not mark it
-`completed` directly. First restart the phase as `running`, then
-complete it after the rerun succeeds:
-
-```bash
-wtui flow phase restart \
-  --flow-id "$WTUI_FLOW_ID" \
-  --phase-id autoreview \
-  "${FLOW_STATE_ARGS[@]}"
-```
-
-```bash
-wtui flow phase complete \
-  --flow-id "$WTUI_FLOW_ID" \
-  --phase-id autoreview \
-  --summary "Autoreview passed; no blocking findings remain." \
-  "${FLOW_STATE_ARGS[@]}"
-```
 
 ## Merge Phase
 

--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/internal/artifacts"
 )
 
 // runFlow handles `wtui flow ...` subcommands. It may load config to resolve
@@ -73,7 +74,7 @@ Examples:
   wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan --summary "Saved plan"
   wtui flow phase block --flow-id "$FLOW_ID" --phase-id implementation --notes "Waiting on review"
   wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review --notes "Revise scope"
-  wtui flow phase restart --flow-id "$FLOW_ID" --phase-id autoreview
+  wtui flow phase restart --flow-id "$FLOW_ID" --phase-id review-loop-2
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan --status completed --summary "Plan saved"
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan-review --status completed --outcome approved
   wtui flow pr set --flow-id "$FLOW_ID" --provider github --number 155 --url "$PR_URL" --head "$BRANCH" --base main
@@ -345,7 +346,7 @@ Examples:
   wtui flow phase complete --flow-id "$FLOW_ID" --phase-id plan --summary "Saved plan"
   wtui flow phase block --flow-id "$FLOW_ID" --phase-id implementation --notes "Waiting on review"
   wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan-review --outcome changes_requested --notes "Revise scope"
-  wtui flow phase restart --flow-id "$FLOW_ID" --phase-id autoreview
+  wtui flow phase restart --flow-id "$FLOW_ID" --phase-id review-loop-2
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id implementation --status blocked --notes "Waiting on review"
   wtui flow phase add-child --flow-id "$FLOW_ID" --parent-phase-id implementation --phase-id api --title "API work" --order 1
 
@@ -508,7 +509,8 @@ func defaultFlowPhaseActionOutcome(phaseID string, spec flowPhaseActionSpec) str
 	switch phaseID {
 	case "plan-review":
 		return spec.defaultOutcome
-	case "autoreview":
+	}
+	if flowPhaseIDUsesAutoreviewOutcomes(phaseID) {
 		switch spec.status {
 		case flowstore.PhaseCompleted:
 			return "passed"
@@ -519,6 +521,15 @@ func defaultFlowPhaseActionOutcome(phaseID string, spec flowPhaseActionSpec) str
 		}
 	}
 	return ""
+}
+
+func flowPhaseIDUsesAutoreviewOutcomes(phaseID string) bool {
+	switch artifacts.NormalizePhaseID(phaseID) {
+	case "autoreview", "review-loop-2":
+		return true
+	default:
+		return false
+	}
 }
 
 func runFlowPhaseRestart(args []string, deps runDeps) error {
@@ -667,7 +678,7 @@ Common flags:
   --state-root PATH
 
 Examples:
-  wtui flow phase restart --flow-id "$FLOW_ID" --phase-id autoreview
+  wtui flow phase restart --flow-id "$FLOW_ID" --phase-id review-loop-2
   wtui flow phase restart --flow-id "$FLOW_ID" --phase-id implementation --notes "Rerunning after fixing review findings."
 `)
 }

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -520,7 +520,7 @@ func TestRunFlowPlanSetValidatesInputsAndKeepsRecordUnchanged(t *testing.T) {
 	}
 }
 
-func TestRunFlowPRSetPrintsJSONRecordAndUngatesAutoreview(t *testing.T) {
+func TestRunFlowPRSetPrintsJSONRecordAndUngatesMerge(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")
 	created := mustRunFlow(t, []string{
@@ -532,7 +532,7 @@ func TestRunFlowPRSetPrintsJSONRecordAndUngatesAutoreview(t *testing.T) {
 		"--json",
 		"--state-root", root,
 	})
-	for _, phaseID := range []string{"plan", "plan-review", "implementation", "review-loop", "pr-creation"} {
+	for _, phaseID := range []string{"plan", "plan-review", "implementation", "review-loop-1", "review-loop-2", "pr-creation"} {
 		outcome := ""
 		if phaseID == "plan-review" {
 			outcome = flowstore.OutcomeApproved
@@ -568,8 +568,8 @@ func TestRunFlowPRSetPrintsJSONRecordAndUngatesAutoreview(t *testing.T) {
 		updated.PR.Status != "open" {
 		t.Fatalf("PR metadata = %#v", updated.PR)
 	}
-	if got := phaseByID(updated, "autoreview").Status; got != flowstore.PhaseReady {
-		t.Fatalf("autoreview status = %q, want ready", got)
+	if got := phaseByID(updated, "merge").Status; got != flowstore.PhaseReady {
+		t.Fatalf("merge status = %q, want ready", got)
 	}
 }
 
@@ -627,7 +627,7 @@ func TestRunFlowMergeSetPrintsJSONRecord(t *testing.T) {
 		"--json",
 		"--state-root", root,
 	})
-	for _, phaseID := range []string{"plan", "plan-review", "implementation", "review-loop", "pr-creation"} {
+	for _, phaseID := range []string{"plan", "plan-review", "implementation", "review-loop-1", "review-loop-2", "pr-creation"} {
 		outcome := ""
 		if phaseID == "plan-review" {
 			outcome = flowstore.OutcomeApproved
@@ -645,7 +645,7 @@ func TestRunFlowMergeSetPrintsJSONRecord(t *testing.T) {
 		"--status", "open",
 		"--state-root", root,
 	})
-	mustSetFlowPhase(t, root, created.FlowID, "autoreview", flowstore.PhaseCompleted, "passed", "", "")
+	mustSetFlowPhase(t, root, created.FlowID, "review-loop-2", flowstore.PhaseCompleted, "passed", "", "")
 	mustSetFlowPhase(t, root, created.FlowID, "merge", flowstore.PhaseCompleted, "merged", "", "")
 
 	var stdout bytes.Buffer
@@ -817,8 +817,8 @@ func TestRunFlowPhaseSetImplementationOutcomesAfterApprovedReview(t *testing.T) 
 			if phaseByID(updated, "implementation").Status != tc.status {
 				t.Fatalf("implementation phase = %#v", phaseByID(updated, "implementation"))
 			}
-			if phaseByID(updated, "review-loop").Status != tc.wantReviewStatus {
-				t.Fatalf("review-loop status = %q, want %q", phaseByID(updated, "review-loop").Status, tc.wantReviewStatus)
+			if phaseByID(updated, "review-loop-1").Status != tc.wantReviewStatus {
+				t.Fatalf("review-loop-1 status = %q, want %q", phaseByID(updated, "review-loop-1").Status, tc.wantReviewStatus)
 			}
 		})
 	}
@@ -966,7 +966,7 @@ func TestRunFlowPhaseActionsDefaultPlanReviewOutcomes(t *testing.T) {
 	}
 }
 
-func TestRunFlowPhaseActionsDefaultAutoreviewOutcomes(t *testing.T) {
+func TestRunFlowPhaseActionsDefaultReviewLoop2Outcomes(t *testing.T) {
 	root := t.TempDir()
 	for _, tc := range []struct {
 		name        string
@@ -980,13 +980,13 @@ func TestRunFlowPhaseActionsDefaultAutoreviewOutcomes(t *testing.T) {
 		{name: "block", command: "block", notes: "Autoreview cannot inspect the PR.", wantStatus: flowstore.PhaseBlocked, wantOutcome: flowstore.OutcomeBlocked},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			branch := "flow/autoreview-" + strings.ReplaceAll(tc.name, " ", "-")
-			created := mustRunFlowReadyForAutoreview(t, root, tc.name, branch)
+			branch := "flow/review-loop-2-" + strings.ReplaceAll(tc.name, " ", "-")
+			created := mustRunFlowReadyForReviewLoop2(t, root, tc.name, branch)
 
 			args := []string{
 				"wtui", "flow", "phase", tc.command,
 				"--flow-id", created.FlowID,
-				"--phase-id", "autoreview",
+				"--phase-id", "review-loop-2",
 				"--state-root", root,
 			}
 			if tc.notes != "" {
@@ -1002,9 +1002,9 @@ func TestRunFlowPhaseActionsDefaultAutoreviewOutcomes(t *testing.T) {
 			if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 				t.Fatalf("output is not JSON action result: %v\n%s", err, stdout.String())
 			}
-			autoreview := result.UpdatedPhase
-			if autoreview.Status != tc.wantStatus || autoreview.Outcome != tc.wantOutcome {
-				t.Fatalf("autoreview = %#v, want status %q outcome %q", autoreview, tc.wantStatus, tc.wantOutcome)
+			review := result.UpdatedPhase
+			if review.Status != tc.wantStatus || review.Outcome != tc.wantOutcome {
+				t.Fatalf("review-loop-2 = %#v, want status %q outcome %q", review, tc.wantStatus, tc.wantOutcome)
 			}
 		})
 	}
@@ -1033,14 +1033,14 @@ func TestRunFlowPhaseRestartRerunsAttentionAndBlockedPhases(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			branch := "flow/restart-" + strings.ReplaceAll(tc.name, " ", "-")
-			created := mustRunFlowReadyForAutoreview(t, root, tc.name, branch)
-			mustSetFlowPhase(t, root, created.FlowID, "autoreview", tc.startStatus, tc.startOutcome, tc.startNotes, "")
+			created := mustRunFlowReadyForReviewLoop2(t, root, tc.name, branch)
+			mustSetFlowPhase(t, root, created.FlowID, "review-loop-2", tc.startStatus, tc.startOutcome, tc.startNotes, "")
 
 			var stdout bytes.Buffer
 			err := run([]string{
 				"wtui", "flow", "phase", "restart",
 				"--flow-id", created.FlowID,
-				"--phase-id", "autoreview",
+				"--phase-id", "review-loop-2",
 				"--state-root", root,
 			}, noScanDeps(t, runDeps{stdout: &stdout}))
 			if err != nil {
@@ -1051,12 +1051,12 @@ func TestRunFlowPhaseRestartRerunsAttentionAndBlockedPhases(t *testing.T) {
 			if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
 				t.Fatalf("output is not JSON action result: %v\n%s", err, stdout.String())
 			}
-			autoreview := result.UpdatedPhase
-			if autoreview.Status != flowstore.PhaseRunning || autoreview.Outcome != "" {
-				t.Fatalf("autoreview = %#v, want running with cleared outcome", autoreview)
+			review := result.UpdatedPhase
+			if review.Status != flowstore.PhaseRunning || review.Outcome != "" {
+				t.Fatalf("review-loop-2 = %#v, want running with cleared outcome", review)
 			}
-			if !strings.Contains(autoreview.Notes, "Rerunning Autoreview after addressing prior findings.") {
-				t.Fatalf("autoreview notes = %q, want default rerun note", autoreview.Notes)
+			if !strings.Contains(review.Notes, "Rerunning Review Loop 2 after addressing prior findings.") {
+				t.Fatalf("review-loop-2 notes = %q, want default rerun note", review.Notes)
 			}
 		})
 	}
@@ -1086,23 +1086,23 @@ func TestRunFlowPhaseRestartRejectsNonRecoveryStates(t *testing.T) {
 		{
 			name: "ready",
 			prepare: func(t *testing.T) flowstore.FlowRecord {
-				return mustRunFlowReadyForAutoreview(t, root, "ready restart", "flow/restart-ready")
+				return mustRunFlowReadyForReviewLoop2(t, root, "ready restart", "flow/restart-ready")
 			},
 			wantCurrent: "ready",
 		},
 		{
 			name: "completed",
 			prepare: func(t *testing.T) flowstore.FlowRecord {
-				record := mustRunFlowReadyForAutoreview(t, root, "completed restart", "flow/restart-completed")
-				return mustSetFlowPhase(t, root, record.FlowID, "autoreview", flowstore.PhaseCompleted, "passed", "", "")
+				record := mustRunFlowReadyForReviewLoop2(t, root, "completed restart", "flow/restart-completed")
+				return mustSetFlowPhase(t, root, record.FlowID, "review-loop-2", flowstore.PhaseCompleted, "passed", "", "")
 			},
 			wantCurrent: "completed",
 		},
 		{
 			name: "skipped",
 			prepare: func(t *testing.T) flowstore.FlowRecord {
-				record := mustRunFlowReadyForAutoreview(t, root, "skipped restart", "flow/restart-skipped")
-				return mustSetFlowPhase(t, root, record.FlowID, "autoreview", flowstore.PhaseSkipped, "", "", "Autoreview intentionally skipped.")
+				record := mustRunFlowReadyForReviewLoop2(t, root, "skipped restart", "flow/restart-skipped")
+				return mustSetFlowPhase(t, root, record.FlowID, "review-loop-2", flowstore.PhaseSkipped, "", "", "Review loop 2 intentionally skipped.")
 			},
 			wantCurrent: "skipped",
 		},
@@ -1112,7 +1112,7 @@ func TestRunFlowPhaseRestartRejectsNonRecoveryStates(t *testing.T) {
 			err := run([]string{
 				"wtui", "flow", "phase", "restart",
 				"--flow-id", record.FlowID,
-				"--phase-id", "autoreview",
+				"--phase-id", "review-loop-2",
 				"--state-root", root,
 			}, noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
 			if err == nil {
@@ -1120,7 +1120,7 @@ func TestRunFlowPhaseRestartRejectsNonRecoveryStates(t *testing.T) {
 			}
 			for _, want := range []string{
 				"flow phase restart requires current status needs_attention or blocked",
-				"autoreview is " + tc.wantCurrent,
+				"review-loop-2 is " + tc.wantCurrent,
 			} {
 				if !strings.Contains(err.Error(), want) {
 					t.Fatalf("restart error = %q, want %q", err.Error(), want)
@@ -1509,7 +1509,7 @@ func mustRunFlow(t *testing.T, args []string) flowstore.FlowRecord {
 	return record
 }
 
-func mustRunFlowReadyForAutoreview(t *testing.T, root, title, branch string) flowstore.FlowRecord {
+func mustRunFlowReadyForReviewLoop2(t *testing.T, root, title, branch string) flowstore.FlowRecord {
 	t.Helper()
 	created := mustRunFlow(t, []string{
 		"wtui", "flow", "create",
@@ -1520,13 +1520,27 @@ func mustRunFlowReadyForAutoreview(t *testing.T, root, title, branch string) flo
 		"--json",
 		"--state-root", root,
 	})
-	for _, phaseID := range []string{"plan", "plan-review", "implementation", "review-loop", "pr-creation"} {
+	for _, phaseID := range []string{"plan", "plan-review", "implementation", "review-loop-1"} {
 		outcome := ""
 		if phaseID == "plan-review" {
 			outcome = flowstore.OutcomeApproved
 		}
 		mustSetFlowPhase(t, root, created.FlowID, phaseID, flowstore.PhaseCompleted, outcome, "", "")
 	}
+	return created
+}
+
+func mustRunFlowReadyForPRCreation(t *testing.T, root, title, branch string) flowstore.FlowRecord {
+	t.Helper()
+	created := mustRunFlowReadyForReviewLoop2(t, root, title, branch)
+	mustSetFlowPhase(t, root, created.FlowID, "review-loop-2", flowstore.PhaseCompleted, "passed", "", "")
+	return created
+}
+
+func mustRunFlowReadyForMerge(t *testing.T, root, title, branch string) flowstore.FlowRecord {
+	t.Helper()
+	created := mustRunFlowReadyForPRCreation(t, root, title, branch)
+	mustSetFlowPhase(t, root, created.FlowID, "pr-creation", flowstore.PhaseCompleted, "", "", "")
 	return mustRunFlow(t, []string{
 		"wtui", "flow", "pr", "set",
 		"--flow-id", created.FlowID,

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -977,7 +977,7 @@ func TestRunFlowPhaseActionsDefaultReviewLoop2Outcomes(t *testing.T) {
 	}{
 		{name: "complete", command: "complete", wantStatus: flowstore.PhaseCompleted, wantOutcome: "passed"},
 		{name: "needs attention", command: "needs-attention", notes: "Follow-up concern remains.", wantStatus: flowstore.PhaseNeedsAttention, wantOutcome: "needs_attention"},
-		{name: "block", command: "block", notes: "Autoreview cannot inspect the PR.", wantStatus: flowstore.PhaseBlocked, wantOutcome: flowstore.OutcomeBlocked},
+		{name: "block", command: "block", notes: "Autoreview could not complete.", wantStatus: flowstore.PhaseBlocked, wantOutcome: flowstore.OutcomeBlocked},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			branch := "flow/review-loop-2-" + strings.ReplaceAll(tc.name, " ", "-")

--- a/docs/config.md
+++ b/docs/config.md
@@ -71,7 +71,7 @@ plan = "Produce a plan only for: {instructions}"
 implementation = "Implement {plan_path} in {worktree_path}, then use the commit skill before completing."
 review_loop = "Use review-loop for {branch}; use commit if revisions are made."
 pr_creation = "Use ship for {branch}; record PR metadata for flow {flow_id}."
-autoreview = "Autoreview {pr_url}; use ship when fixes require commits or pushes."
+autoreview = "Autoreview local worktree {worktree_path}; use commit if revisions are made."
 
 [sessions]
 root = "~/.local/state/wtui/sessions/v1"
@@ -476,12 +476,12 @@ inspect the changes. Built-in prompts tell Plan to produce only a plan,
 Plan Review to use the review-loop skill with max 6 loops, Implementation to
 use the `commit` skill, Review Loop to use the review-loop workflow with goal
 `review-and-revise` and `commit` when revisions are made, PR Creation to use
-the `ship` skill, and Autoreview to use `ship` when fixes require commits or
-pushes. All Flow phase launch prompts also end with:
+the `ship` skill, and Autoreview to review the local worktree and use `commit`
+when revisions are made. All Flow phase launch prompts also end with:
 `After completing this phase goal, mark this Flow phase done with wtui-flow.`
-Autoreview launch prompts include the PR target metadata but leave detailed
-completion, needs-attention, blocked, and restart mechanics to the high-level
-Flow phase commands.
+Autoreview launch prompts include worktree, branch, and start commit metadata
+but leave detailed completion, needs-attention, blocked, and restart mechanics
+to the high-level Flow phase commands.
 Override `[flow_prompts]` keys to customize those phase templates; wtui still
 appends the common phase-done instruction to custom templates.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -71,7 +71,7 @@ plan = "Produce a plan only for: {instructions}"
 implementation = "Implement {plan_path} in {worktree_path}, then use the commit skill before completing."
 review_loop = "Use review-loop for {branch}; use commit if revisions are made."
 pr_creation = "Use ship for {branch}; record PR metadata for flow {flow_id}."
-autoreview = "Autoreview local worktree {worktree_path}; use commit if revisions are made."
+autoreview = "Second-level local worktree autoreview for {branch}; use commit if revisions are made."
 
 [sessions]
 root = "~/.local/state/wtui/sessions/v1"
@@ -216,23 +216,23 @@ ends with that exact standalone instruction.
 | `plan` | string | Template for the initial Plan phase launch. |
 | `plan_review` | string | Template for Plan Review. |
 | `implementation` | string | Template for Implementation. |
-| `review_loop` | string | Template for Review Loop. |
+| `review_loop` | string | Template for review-loop-1. |
 | `pr_creation` | string | Template for PR Creation. |
-| `autoreview` | string | Template for Autoreview. |
+| `autoreview` | string | Template for review-loop-2, the second-level local worktree autoreview. |
 | `merge` | string | Template for Merge. |
 | `generic` | string | Template for non-standard Flow phase IDs. |
 
 `review-loop-1` uses the Review Loop prompt/template. `review-loop-2` uses the
-Autoreview prompt/template.
+autoreview prompt/template.
 
 Supported Flow placeholders are `{flow_id}`, `{flow_title}`,
 `{instructions}`, `{phase_id}`, `{phase_title}`, `{plan_id}`, `{plan_path}`,
 `{plan_body}`, `{repo_path}`, `{worktree_path}`, `{branch}`, `{commit}`,
 `{base_ref}`, `{pr_provider}`, `{pr_number}`, `{pr_url}`, `{pr_head}`,
-`{pr_base}`, and `{pr_status}`. Standard Plan Review, Implementation, Review
-Loop, PR Creation, Autoreview, and Merge launches do not pre-read the linked
-plan body, so `{plan_body}` is empty for those built-in phase types unless a
-future phase path explicitly supplies it.
+`{pr_base}`, and `{pr_status}`. Standard Plan Review, Implementation,
+`review-loop-1`, `review-loop-2`, PR Creation, and Merge launches do not
+pre-read the linked plan body, so `{plan_body}` is empty for those built-in
+phase types unless a future phase path explicitly supplies it.
 
 ### `[sessions]`
 
@@ -416,8 +416,8 @@ completed state even if the linked-plan sync later fails.
 Flow IDs use the same safe single-path-segment shape as plans:
 `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`. Generated IDs use
 `YYYYMMDDTHHMMSSZ-<title-slug>` with a numeric suffix on collision. New flows
-start with a default phase graph: plan, plan review, implementation, review
-loop, PR creation, autoreview, and merge.
+start with a default phase graph: plan, plan review, implementation,
+review-loop-1, review-loop-2, PR creation, and merge.
 
 Flow statuses are derived from phase and merge state. Flow statuses include
 `pending`, `in_progress`, `needs_attention`, `blocked`, `completed`, `merged`,
@@ -432,8 +432,7 @@ metadata, `await-session` when a running phase has a launch attempt but no
 attached provider session yet, `session-mismatch` when a phase's attached
 session launch ID does not match the phase launch IDs, `missing-session-id`
 when an attached session lacks a provider session ID, and `missing-pr` on a
-pending Autoreview phase when PR Creation completed without structured PR
-metadata.
+pending Merge phase when PR Creation completed without structured PR metadata.
 
 On a selected `await-session` phase row, `x` offers a confirmed reset back to
 derived `ready` only when no running or starting embedded Flow terminal is
@@ -455,7 +454,7 @@ actionable phase state, and allowed statuses for that next action. Notes
 requirements are still enforced by the same store rules as `phase set`. Plan
 Review wrappers fill the unambiguous outcomes when omitted: `complete` uses
 `approved`, `block` uses `blocked`, and `needs-attention` uses
-`changes_requested`. Autoreview wrappers fill `passed`, `blocked`, and
+`changes_requested`. `review-loop-2` wrappers fill `passed`, `blocked`, and
 `needs_attention` for the matching common outcomes. Use
 `wtui flow phase restart` to rerun a blocked or needs-attention phase as
 `running`; if `--notes` is omitted, wtui records a standard rerun note. Use
@@ -468,20 +467,21 @@ and lowercased): re-running the command with the same logical id -- including
 case or whitespace variants -- updates the same child instead of duplicating
 it, and updates collapse duplicate rows left by older records. `wtui flow phase
 set` resolves phase ids the same way. Child phases currently belong
-under `implementation`; they gate review loop and PR creation until completed or
-skipped with notes. Flow phase launch prompts stay minimal: Plan Review and
-Implementation point to the saved plan artifact, while Review Loop and PR
-Creation include only the worktree, branch, and start commit metadata needed to
-inspect the changes. Built-in prompts tell Plan to produce only a plan,
-Plan Review to use the review-loop skill with max 6 loops, Implementation to
-use the `commit` skill, Review Loop to use the review-loop workflow with goal
-`review-and-revise` and `commit` when revisions are made, PR Creation to use
-the `ship` skill, and Autoreview to review the local worktree and use `commit`
-when revisions are made. All Flow phase launch prompts also end with:
+under `implementation`; they gate review-loop-1, review-loop-2, and PR
+creation until completed or skipped with notes. Flow phase launch prompts stay
+minimal: Plan Review and Implementation point to the saved plan artifact, while
+review-loop-1, review-loop-2, and PR Creation include only the worktree,
+branch, and start commit metadata needed to inspect the changes. Built-in
+prompts tell Plan to produce only a plan, Plan Review to use the review-loop
+skill with max 6 loops, Implementation to use the `commit` skill,
+review-loop-1 to use the review-loop workflow with goal `review-and-revise`
+and `commit` when revisions are made, review-loop-2 to run a second-level
+local worktree autoreview and use `commit` when revisions are made, and PR
+Creation to use the `ship` skill. All Flow phase launch prompts also end with:
 `After completing this phase goal, mark this Flow phase done with wtui-flow.`
-Autoreview launch prompts include worktree, branch, and start commit metadata
-but leave detailed completion, needs-attention, blocked, and restart mechanics
-to the high-level Flow phase commands.
+`review-loop-2` launch prompts include worktree, branch, and start commit
+metadata but leave detailed completion, needs-attention, blocked, and restart
+mechanics to the high-level Flow phase commands.
 Override `[flow_prompts]` keys to customize those phase templates; wtui still
 appends the common phase-done instruction to custom templates.
 
@@ -489,7 +489,7 @@ The PR Creation phase should record structured PR metadata with
 `wtui flow pr set` after a pull request exists. The command currently supports
 GitHub PRs and validates the provider, absolute http(s) URL, positive PR
 number, required head/base branches, and that the head branch matches the Flow
-branch. Autoreview stays pending when PR Creation is complete but this PR target
+branch. Merge stays pending when PR Creation is complete but this PR target
 metadata is missing.
 
 The flow state root is resolved as: `--state-root` >

--- a/docs/config.md
+++ b/docs/config.md
@@ -222,6 +222,9 @@ ends with that exact standalone instruction.
 | `merge` | string | Template for Merge. |
 | `generic` | string | Template for non-standard Flow phase IDs. |
 
+`review-loop-1` uses the Review Loop prompt/template. `review-loop-2` uses the
+Autoreview prompt/template.
+
 Supported Flow placeholders are `{flow_id}`, `{flow_title}`,
 `{instructions}`, `{phase_id}`, `{phase_title}`, `{plan_id}`, `{plan_path}`,
 `{plan_body}`, `{repo_path}`, `{worktree_path}`, `{branch}`, `{commit}`,

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -94,6 +94,11 @@ standard graph; hand-authored records without one keep their stored statuses
 until a phase-affecting mutation touches them. Agents never need to know which
 phase becomes ready next; they only report their own phase.
 
+The standard graph order is `plan -> plan-review -> implementation ->
+review-loop-1 -> review-loop-2 -> pr-creation -> merge`. `review-loop-1` is
+the first implementation review loop. `review-loop-2` is the second-level local
+worktree autoreview.
+
 Walking phases in order, a `pending` phase becomes `ready` once every
 predecessor satisfies its downstream gate:
 
@@ -103,13 +108,13 @@ predecessor satisfies its downstream gate:
   Implementation `pending`. The high-level Plan Review wrappers fill the
   unambiguous outcomes when omitted: `complete` uses `approved`,
   `needs-attention` uses `changes_requested`, and `block` uses `blocked`.
-- **Autoreview**: the high-level wrappers fill the unambiguous outcomes when
-  omitted: `complete` uses `passed`, `needs-attention` uses
+- **review-loop-2**: the high-level wrappers fill the unambiguous outcomes
+  when omitted: `complete` uses `passed`, `needs-attention` uses
   `needs_attention`, and `block` uses `blocked`.
 - **PR Creation**: `completed` *and* structured PR metadata recorded via
   `wtui flow pr set` (provider, positive number, valid URL, head/base
-  branches). Completion alone does not unlock Autoreview; a skipped PR
-  Creation never unlocks it.
+  branches). Completion alone does not unlock Merge; a skipped PR Creation
+  never unlocks it.
 - **Implementation children**: every child phase under Implementation must be
   `completed` or `skipped` with notes before phases after Implementation can
   become ready.
@@ -161,7 +166,7 @@ The flows pane renders the persisted status, or the phase outcome when one is
 recorded (for example `plan-review:approved`). Recovery labels for partial
 states (`recover-worktree`, `await-session`, `session-mismatch`,
 `missing-session-id`, `missing-pr`) are layered on top, rendered prefixed
-with the phase ID like any phase state (for example `autoreview:missing-pr`),
+with the phase ID like any phase state (for example `merge:missing-pr`),
 and are display-only; they never change persisted phase status. See
 `docs/config.md` for the pane behavior.
 

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -55,7 +55,7 @@ are already implemented and should be treated as the baseline product:
   filtering, linked-plan body opening, expanded-phase session resume, and
   recoverable partial-state labels for missing worktree metadata, pending
   session attachment, launch/session mismatch, missing provider session IDs,
-  and missing Autoreview PR metadata.
+  and missing Merge PR metadata.
 - Cross-platform hash copy for history and reflog entries.
 - GoReleaser release configuration, GitHub release workflow, release snapshot
   CI job, version metadata, and Homebrew cask publishing.

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -1278,7 +1278,7 @@ func PhasePredecessorsSatisfied(record FlowRecord, phaseID string) bool {
 }
 
 // HasPRTarget reports whether PR metadata contains enough target context for
-// downstream Autoreview work.
+// downstream merge work.
 func HasPRTarget(pr PullRequest) bool {
 	if strings.ToLower(strings.TrimSpace(pr.Provider)) != "github" ||
 		pr.Number <= 0 ||
@@ -1508,9 +1508,9 @@ func defaultPhases(createdAt, updatedAt time.Time) []FlowPhase {
 		{"plan", "Plan", "plan"},
 		{"plan-review", "Plan Review", "plan_review"},
 		{"implementation", "Implementation", "implementation"},
-		{"review-loop", "Review loop", "review_loop"},
+		{"review-loop-1", "Review loop 1", "review_loop"},
+		{"review-loop-2", "Review loop 2", "autoreview"},
 		{"pr-creation", "PR creation", "pr_creation"},
-		{"autoreview", "Autoreview", "autoreview"},
 		{"merge", "Merge", "merge"},
 	}
 	phases := make([]FlowPhase, 0, len(specs))

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -60,6 +60,7 @@ func TestStoreCreatePersistsDefaultFlowRecord(t *testing.T) {
 	if record.Phases[0].PhaseID != "plan" || record.Phases[0].Status != flowstore.PhaseReady {
 		t.Fatalf("first phase = %#v, want ready plan", record.Phases[0])
 	}
+	assertPhaseOrder(t, record, []string{"plan", "plan-review", "implementation", "review-loop-1", "review-loop-2", "pr-creation", "merge"})
 	for _, phase := range record.Phases[1:] {
 		if phase.Status != flowstore.PhasePending {
 			t.Fatalf("phase %q status = %q, want pending", phase.PhaseID, phase.Status)
@@ -452,15 +453,15 @@ func TestStoreSetPhaseDoesNotAddMissingLinkedPlanPhase(t *testing.T) {
 
 	completed, err := store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "review-loop",
+		PhaseID: "review-loop-1",
 		Status:  flowstore.PhaseCompleted,
 		Summary: "Review loop passed.",
 	})
 	if err != nil {
-		t.Fatalf("SetPhase(review-loop completed) error = %v", err)
+		t.Fatalf("SetPhase(review-loop-1 completed) error = %v", err)
 	}
-	if got := phaseByID(t, completed, "review-loop").Status; got != flowstore.PhaseCompleted {
-		t.Fatalf("flow review-loop status = %q, want completed", got)
+	if got := phaseByID(t, completed, "review-loop-1").Status; got != flowstore.PhaseCompleted {
+		t.Fatalf("flow review-loop-1 status = %q, want completed", got)
 	}
 
 	plans, err := planStore.List(planstore.PlanFilter{RepoPath: repoPath})
@@ -470,8 +471,8 @@ func TestStoreSetPhaseDoesNotAddMissingLinkedPlanPhase(t *testing.T) {
 	if len(plans) != 1 {
 		t.Fatalf("plan List() returned %d records, want 1: %#v", len(plans), plans)
 	}
-	if _, ok := maybePlanPhaseByID(plans[0], "review-loop"); ok {
-		t.Fatalf("linked plan unexpectedly gained review-loop phase: %#v", plans[0].Phases)
+	if _, ok := maybePlanPhaseByID(plans[0], "review-loop-1"); ok {
+		t.Fatalf("linked plan unexpectedly gained review-loop-1 phase: %#v", plans[0].Phases)
 	}
 }
 
@@ -1189,7 +1190,7 @@ func TestStoreSetPhaseExplainsNeedsAttentionRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop-1")
 	record, err = store.SetPR(flowstore.PRUpdate{
 		FlowID:     record.FlowID,
 		Provider:   "github",
@@ -1204,7 +1205,7 @@ func TestStoreSetPhaseExplainsNeedsAttentionRecovery(t *testing.T) {
 	}
 	record, err = store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "autoreview",
+		PhaseID: "review-loop-2",
 		Status:  flowstore.PhaseNeedsAttention,
 		Outcome: "needs_attention",
 		Notes:   "Follow-up findings remain.",
@@ -1215,7 +1216,7 @@ func TestStoreSetPhaseExplainsNeedsAttentionRecovery(t *testing.T) {
 
 	_, err = store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "autoreview",
+		PhaseID: "review-loop-2",
 		Status:  flowstore.PhaseCompleted,
 		Outcome: "passed",
 	})
@@ -1233,19 +1234,19 @@ func TestStoreSetPhaseExplainsNeedsAttentionRecovery(t *testing.T) {
 
 	record, err = store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "autoreview",
+		PhaseID: "review-loop-2",
 		Status:  flowstore.PhaseRunning,
 		Notes:   "Rerunning autoreview after addressing prior findings.",
 	})
 	if err != nil {
 		t.Fatalf("SetPhase(needs_attention -> running) error = %v", err)
 	}
-	if got := phaseByID(t, record, "autoreview").Status; got != flowstore.PhaseRunning {
+	if got := phaseByID(t, record, "review-loop-2").Status; got != flowstore.PhaseRunning {
 		t.Fatalf("autoreview status = %q, want running", got)
 	}
 	_, err = store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "autoreview",
+		PhaseID: "review-loop-2",
 		Status:  flowstore.PhaseCompleted,
 		Outcome: "passed",
 		Summary: "Autoreview passed after rerun.",
@@ -1270,7 +1271,7 @@ func TestStoreRestartPhaseAtomicallyRequiresRecoveryState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop-1")
 	record, err = store.SetPR(flowstore.PRUpdate{
 		FlowID:     record.FlowID,
 		Provider:   "github",
@@ -1285,16 +1286,16 @@ func TestStoreRestartPhaseAtomicallyRequiresRecoveryState(t *testing.T) {
 
 	_, err = store.RestartPhase(flowstore.PhaseRestartUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "autoreview",
+		PhaseID: "review-loop-2",
 		Notes:   "Rerunning Autoreview after addressing prior findings.",
 	})
-	if err == nil || !strings.Contains(err.Error(), "autoreview is ready") {
+	if err == nil || !strings.Contains(err.Error(), "review-loop-2 is ready") {
 		t.Fatalf("RestartPhase(ready) error = %v, want ready rejection", err)
 	}
 
 	record, err = store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "autoreview",
+		PhaseID: "review-loop-2",
 		Status:  flowstore.PhaseNeedsAttention,
 		Outcome: "needs_attention",
 		Notes:   "Follow-up concern remains.",
@@ -1304,13 +1305,13 @@ func TestStoreRestartPhaseAtomicallyRequiresRecoveryState(t *testing.T) {
 	}
 	record, err = store.RestartPhase(flowstore.PhaseRestartUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "autoreview",
+		PhaseID: "review-loop-2",
 		Notes:   "Rerunning Autoreview after addressing prior findings.",
 	})
 	if err != nil {
 		t.Fatalf("RestartPhase(needs_attention) error = %v", err)
 	}
-	phase := phaseByID(t, record, "autoreview")
+	phase := phaseByID(t, record, "review-loop-2")
 	if phase.Status != flowstore.PhaseRunning || phase.Outcome != "" {
 		t.Fatalf("autoreview after restart = %#v, want running with cleared outcome", phase)
 	}
@@ -1331,7 +1332,7 @@ func TestStoreRestartPhaseClearsBlockedMergeMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop-1", "review-loop-2", "pr-creation")
 	record, err = store.SetPR(flowstore.PRUpdate{
 		FlowID:     record.FlowID,
 		Provider:   "github",
@@ -1343,7 +1344,6 @@ func TestStoreRestartPhaseClearsBlockedMergeMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetPR() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "autoreview")
 	record, err = store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
 		PhaseID: "merge",
@@ -1399,7 +1399,7 @@ func TestStoreAddPhaseLaunchIDRestartsNeedsAttentionPhase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop-1")
 	record, err = store.SetPR(flowstore.PRUpdate{
 		FlowID:     record.FlowID,
 		Provider:   "github",
@@ -1414,7 +1414,7 @@ func TestStoreAddPhaseLaunchIDRestartsNeedsAttentionPhase(t *testing.T) {
 	}
 	record, err = store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "autoreview",
+		PhaseID: "review-loop-2",
 		Status:  flowstore.PhaseNeedsAttention,
 		Outcome: "needs_attention",
 		Notes:   "Follow-up findings remain.",
@@ -1425,14 +1425,14 @@ func TestStoreAddPhaseLaunchIDRestartsNeedsAttentionPhase(t *testing.T) {
 
 	relaunched, err := store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
 		FlowID:   record.FlowID,
-		PhaseID:  "autoreview",
+		PhaseID:  "review-loop-2",
 		LaunchID: "launch-autoreview-2",
 	})
 	if err != nil {
 		t.Fatalf("AddPhaseLaunchID(autoreview) error = %v", err)
 	}
 
-	phase := phaseByID(t, relaunched, "autoreview")
+	phase := phaseByID(t, relaunched, "review-loop-2")
 	if phase.Status != flowstore.PhaseRunning || phase.Outcome != "" {
 		t.Fatalf("autoreview after relaunch = %#v, want running with cleared outcome", phase)
 	}
@@ -1462,36 +1462,36 @@ func TestStoreAddPhaseLaunchIDResumePreservesCompletedPhase(t *testing.T) {
 	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation")
 	record, err = store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "review-loop",
+		PhaseID: "review-loop-1",
 		Status:  flowstore.PhaseCompleted,
 		Outcome: flowstore.OutcomeApproved,
 	})
 	if err != nil {
-		t.Fatalf("SetPhase(review-loop completed) error = %v", err)
+		t.Fatalf("SetPhase(review-loop-1 completed) error = %v", err)
 	}
-	if got := phaseByID(t, record, "pr-creation").Status; got != flowstore.PhaseReady {
-		t.Fatalf("pr-creation status before resume = %q, want ready", got)
+	if got := phaseByID(t, record, "review-loop-2").Status; got != flowstore.PhaseReady {
+		t.Fatalf("review-loop-2 status before resume = %q, want ready", got)
 	}
 
 	resumed, err := store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
 		FlowID:   record.FlowID,
-		PhaseID:  "review-loop",
+		PhaseID:  "review-loop-1",
 		LaunchID: "launch-resume-1",
 		Resume:   true,
 	})
 	if err != nil {
-		t.Fatalf("AddPhaseLaunchID(review-loop resume) error = %v", err)
+		t.Fatalf("AddPhaseLaunchID(review-loop-1 resume) error = %v", err)
 	}
 
-	phase := phaseByID(t, resumed, "review-loop")
+	phase := phaseByID(t, resumed, "review-loop-1")
 	if phase.Status != flowstore.PhaseCompleted || phase.Outcome != flowstore.OutcomeApproved {
-		t.Fatalf("review-loop after resume = %#v, want completed with approved outcome", phase)
+		t.Fatalf("review-loop-1 after resume = %#v, want completed with approved outcome", phase)
 	}
 	if len(phase.LaunchIDs) != 1 || phase.LaunchIDs[0] != "launch-resume-1" {
 		t.Fatalf("launch ids = %#v", phase.LaunchIDs)
 	}
-	if got := phaseByID(t, resumed, "pr-creation").Status; got != flowstore.PhaseReady {
-		t.Fatalf("pr-creation status after resume = %q, want ready", got)
+	if got := phaseByID(t, resumed, "review-loop-2").Status; got != flowstore.PhaseReady {
+		t.Fatalf("review-loop-2 status after resume = %q, want ready", got)
 	}
 }
 
@@ -1513,27 +1513,27 @@ func TestStoreAddPhaseLaunchIDResumePreservesSkippedPhase(t *testing.T) {
 	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation")
 	record, err = store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "review-loop",
+		PhaseID: "review-loop-1",
 		Status:  flowstore.PhaseSkipped,
 		Notes:   "Review covered during implementation.",
 	})
 	if err != nil {
-		t.Fatalf("SetPhase(review-loop skipped) error = %v", err)
+		t.Fatalf("SetPhase(review-loop-1 skipped) error = %v", err)
 	}
 
 	resumed, err := store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
 		FlowID:   record.FlowID,
-		PhaseID:  "review-loop",
+		PhaseID:  "review-loop-1",
 		LaunchID: "launch-resume-1",
 		Resume:   true,
 	})
 	if err != nil {
-		t.Fatalf("AddPhaseLaunchID(review-loop resume) error = %v", err)
+		t.Fatalf("AddPhaseLaunchID(review-loop-1 resume) error = %v", err)
 	}
 
-	phase := phaseByID(t, resumed, "review-loop")
+	phase := phaseByID(t, resumed, "review-loop-1")
 	if phase.Status != flowstore.PhaseSkipped || phase.Notes != "Review covered during implementation." {
-		t.Fatalf("review-loop after resume = %#v, want skipped with original notes", phase)
+		t.Fatalf("review-loop-1 after resume = %#v, want skipped with original notes", phase)
 	}
 	if len(phase.LaunchIDs) != 1 || phase.LaunchIDs[0] != "launch-resume-1" {
 		t.Fatalf("launch ids = %#v", phase.LaunchIDs)
@@ -2532,7 +2532,7 @@ func TestStoreSetPhaseChildPhasesGateDownstreamReadiness(t *testing.T) {
 	}
 }
 
-func TestStoreSetPRPersistsMetadataAndUngatesAutoreview(t *testing.T) {
+func TestStoreSetPRPersistsMetadataAndUngatesMerge(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
 	if err != nil {
@@ -2547,7 +2547,7 @@ func TestStoreSetPRPersistsMetadataAndUngatesAutoreview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	for _, phaseID := range []string{"plan", "plan-review", "implementation", "review-loop", "pr-creation"} {
+	for _, phaseID := range []string{"plan", "plan-review", "implementation", "review-loop-1", "review-loop-2", "pr-creation"} {
 		update := flowstore.PhaseUpdate{
 			FlowID:  record.FlowID,
 			PhaseID: phaseID,
@@ -2561,8 +2561,8 @@ func TestStoreSetPRPersistsMetadataAndUngatesAutoreview(t *testing.T) {
 			t.Fatalf("SetPhase(%s completed) error = %v", phaseID, err)
 		}
 	}
-	if got := phaseByID(t, record, "autoreview").Status; got != flowstore.PhasePending {
-		t.Fatalf("autoreview status before PR metadata = %q, want pending", got)
+	if got := phaseByID(t, record, "merge").Status; got != flowstore.PhasePending {
+		t.Fatalf("merge status before PR metadata = %q, want pending", got)
 	}
 
 	updated, err := store.SetPR(flowstore.PRUpdate{
@@ -2586,12 +2586,12 @@ func TestStoreSetPRPersistsMetadataAndUngatesAutoreview(t *testing.T) {
 		updated.PR.Status != "open" {
 		t.Fatalf("PR metadata = %#v", updated.PR)
 	}
-	if got := phaseByID(t, updated, "autoreview").Status; got != flowstore.PhaseReady {
-		t.Fatalf("autoreview status after PR metadata = %q, want ready", got)
+	if got := phaseByID(t, updated, "merge").Status; got != flowstore.PhaseReady {
+		t.Fatalf("merge status after PR metadata = %q, want ready", got)
 	}
 }
 
-func TestStoreSetPhaseSkippedPRCreationDoesNotUngateAutoreview(t *testing.T) {
+func TestStoreSetPhaseSkippedPRCreationDoesNotUngateMerge(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
 	if err != nil {
@@ -2599,14 +2599,14 @@ func TestStoreSetPhaseSkippedPRCreationDoesNotUngateAutoreview(t *testing.T) {
 	}
 	record, err := store.Create(flowstore.FlowRecord{
 		Title:        "Skipped PR gate",
-		Instructions: "pr creation cannot be skipped into autoreview",
+		Instructions: "pr creation cannot be skipped into merge",
 		RepoPath:     filepath.Join(root, "repo"),
 		Branch:       "flow/skipped-pr",
 	})
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop")
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop-1", "review-loop-2")
 
 	updated, err := store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
@@ -2618,8 +2618,8 @@ func TestStoreSetPhaseSkippedPRCreationDoesNotUngateAutoreview(t *testing.T) {
 		t.Fatalf("SetPhase(pr-creation skipped) error = %v", err)
 	}
 
-	if got := phaseByID(t, updated, "autoreview").Status; got != flowstore.PhasePending {
-		t.Fatalf("autoreview status = %q, want pending without PR metadata", got)
+	if got := phaseByID(t, updated, "merge").Status; got != flowstore.PhasePending {
+		t.Fatalf("merge status = %q, want pending without PR metadata", got)
 	}
 }
 
@@ -2745,7 +2745,7 @@ func TestStoreSetMergePersistsMergedMetadataAndCompletesFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop-1", "review-loop-2", "pr-creation")
 	record, err = store.SetPR(flowstore.PRUpdate{
 		FlowID:     record.FlowID,
 		Provider:   "github",
@@ -2758,7 +2758,7 @@ func TestStoreSetMergePersistsMergedMetadataAndCompletesFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetPR() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "autoreview", "merge")
+	mustCompleteFlowPhases(t, store, &record, "merge")
 
 	updated, err := store.SetMerge(flowstore.MergeUpdate{
 		FlowID:   record.FlowID,
@@ -2880,7 +2880,7 @@ func TestStoreSetMergeValidatesMergedMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Create() error = %v", err)
 			}
-			mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+			mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop-1", "review-loop-2", "pr-creation")
 			if tc.withPR {
 				record, err = store.SetPR(flowstore.PRUpdate{
 					FlowID:     record.FlowID,
@@ -2898,7 +2898,7 @@ func TestStoreSetMergeValidatesMergedMetadata(t *testing.T) {
 			if tc.blockPhase {
 				record, err = store.SetPhase(flowstore.PhaseUpdate{
 					FlowID:  record.FlowID,
-					PhaseID: "autoreview",
+					PhaseID: "review-loop-2",
 					Status:  flowstore.PhaseCompleted,
 					Outcome: "passed",
 				})
@@ -3001,7 +3001,7 @@ func TestStoreSetPhaseReopeningMergeClearsTerminalMergeMetadata(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Create() error = %v", err)
 			}
-			mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+			mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop-1", "review-loop-2", "pr-creation")
 			record, err = store.SetPR(flowstore.PRUpdate{
 				FlowID:     record.FlowID,
 				Provider:   "github",
@@ -3016,7 +3016,7 @@ func TestStoreSetPhaseReopeningMergeClearsTerminalMergeMetadata(t *testing.T) {
 			}
 			record, err = store.SetPhase(flowstore.PhaseUpdate{
 				FlowID:  record.FlowID,
-				PhaseID: "autoreview",
+				PhaseID: "review-loop-2",
 				Status:  flowstore.PhaseCompleted,
 				Outcome: "passed",
 			})
@@ -3076,7 +3076,7 @@ func TestStoreAddPhaseLaunchIDReopeningMergeClearsTerminalMergeMetadata(t *testi
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop-1", "review-loop-2", "pr-creation")
 	record, err = store.SetPR(flowstore.PRUpdate{
 		FlowID:     record.FlowID,
 		Provider:   "github",
@@ -3089,7 +3089,7 @@ func TestStoreAddPhaseLaunchIDReopeningMergeClearsTerminalMergeMetadata(t *testi
 	if err != nil {
 		t.Fatalf("SetPR() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "autoreview", "merge")
+	mustCompleteFlowPhases(t, store, &record, "merge")
 	record, err = store.SetMerge(flowstore.MergeUpdate{
 		FlowID:   record.FlowID,
 		Status:   flowstore.MergeMerged,
@@ -3131,7 +3131,7 @@ func TestStoreAddPhaseLaunchIDResumePreservesTerminalMergeMetadata(t *testing.T)
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop-1", "review-loop-2", "pr-creation")
 	record, err = store.SetPR(flowstore.PRUpdate{
 		FlowID:     record.FlowID,
 		Provider:   "github",
@@ -3144,7 +3144,7 @@ func TestStoreAddPhaseLaunchIDResumePreservesTerminalMergeMetadata(t *testing.T)
 	if err != nil {
 		t.Fatalf("SetPR() error = %v", err)
 	}
-	mustCompleteFlowPhases(t, store, &record, "autoreview", "merge")
+	mustCompleteFlowPhases(t, store, &record, "merge")
 	mergedAt := time.Date(2026, 6, 12, 11, 12, 13, 0, time.UTC)
 	record, err = store.SetMerge(flowstore.MergeUpdate{
 		FlowID:   record.FlowID,
@@ -3196,6 +3196,7 @@ func TestStoreAddChildImplementationPhasePersistsIdempotentlyAndGatesDownstream(
 		time.Date(2026, 6, 7, 12, 0, 6, 0, time.UTC),
 		time.Date(2026, 6, 7, 12, 0, 7, 0, time.UTC),
 		time.Date(2026, 6, 7, 12, 0, 8, 0, time.UTC),
+		time.Date(2026, 6, 7, 12, 0, 9, 0, time.UTC),
 	}
 	i := 0
 	store, err := flowstore.NewStore(flowstore.StoreOptions{
@@ -3229,8 +3230,8 @@ func TestStoreAddChildImplementationPhasePersistsIdempotentlyAndGatesDownstream(
 	if err != nil {
 		t.Fatalf("SetPhase(implementation completed) error = %v", err)
 	}
-	if got := phaseByID(t, record, "review-loop").Status; got != flowstore.PhaseReady {
-		t.Fatalf("review-loop before child = %q, want ready", got)
+	if got := phaseByID(t, record, "review-loop-1").Status; got != flowstore.PhaseReady {
+		t.Fatalf("review-loop-1 before child = %q, want ready", got)
 	}
 
 	added, err := store.AddChildPhase(flowstore.ChildPhaseUpdate{
@@ -3253,8 +3254,8 @@ func TestStoreAddChildImplementationPhasePersistsIdempotentlyAndGatesDownstream(
 		child.UpdatedAt != times[5] {
 		t.Fatalf("child phase = %#v", child)
 	}
-	if got := phaseByID(t, added, "review-loop").Status; got != flowstore.PhasePending {
-		t.Fatalf("review-loop after child add = %q, want pending", got)
+	if got := phaseByID(t, added, "review-loop-1").Status; got != flowstore.PhasePending {
+		t.Fatalf("review-loop-1 after child add = %q, want pending", got)
 	}
 	if got := phaseByID(t, added, "pr-creation").Status; got != flowstore.PhasePending {
 		t.Fatalf("pr-creation after child add = %q, want pending", got)
@@ -3286,25 +3287,38 @@ func TestStoreAddChildImplementationPhasePersistsIdempotentlyAndGatesDownstream(
 	if err != nil {
 		t.Fatalf("SetPhase(child completed) error = %v", err)
 	}
-	if got := phaseByID(t, completed, "review-loop").Status; got != flowstore.PhaseReady {
-		t.Fatalf("review-loop after child completion = %q, want ready", got)
+	if got := phaseByID(t, completed, "review-loop-1").Status; got != flowstore.PhaseReady {
+		t.Fatalf("review-loop-1 after child completion = %q, want ready", got)
 	}
 	if got := phaseByID(t, completed, "pr-creation").Status; got != flowstore.PhasePending {
-		t.Fatalf("pr-creation after child completion = %q, want pending until review-loop is done", got)
+		t.Fatalf("pr-creation after child completion = %q, want pending until both review loops are done", got)
 	}
 
 	reviewed, err := store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  record.FlowID,
-		PhaseID: "review-loop",
+		PhaseID: "review-loop-1",
 		Status:  flowstore.PhaseCompleted,
 		Outcome: "completed",
 		Summary: "Review loop passed.",
 	})
 	if err != nil {
-		t.Fatalf("SetPhase(review-loop completed) error = %v", err)
+		t.Fatalf("SetPhase(review-loop-1 completed) error = %v", err)
+	}
+	if got := phaseByID(t, reviewed, "review-loop-2").Status; got != flowstore.PhaseReady {
+		t.Fatalf("review-loop-2 after review-loop-1 completion = %q, want ready", got)
+	}
+	reviewed, err = store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "review-loop-2",
+		Status:  flowstore.PhaseCompleted,
+		Outcome: "passed",
+		Summary: "Second review passed.",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(review-loop-2 completed) error = %v", err)
 	}
 	if got := phaseByID(t, reviewed, "pr-creation").Status; got != flowstore.PhaseReady {
-		t.Fatalf("pr-creation after review-loop completion = %q, want ready", got)
+		t.Fatalf("pr-creation after review-loop-2 completion = %q, want ready", got)
 	}
 }
 
@@ -3344,7 +3358,7 @@ func TestStoreAddChildImplementationPhaseOrdersAndUpdatesExistingChildren(t *tes
 		t.Fatalf("AddChildPhase(cli) error = %v", err)
 	}
 
-	assertPhaseOrder(t, record, []string{"implementation", "implementation-cli", "implementation-api", "review-loop"})
+	assertPhaseOrder(t, record, []string{"implementation", "implementation-cli", "implementation-api", "review-loop-1"})
 
 	updated, err := store.AddChildPhase(flowstore.ChildPhaseUpdate{
 		FlowID:        record.FlowID,
@@ -3356,7 +3370,7 @@ func TestStoreAddChildImplementationPhaseOrdersAndUpdatesExistingChildren(t *tes
 	if err != nil {
 		t.Fatalf("AddChildPhase(update api) error = %v", err)
 	}
-	assertPhaseOrder(t, updated, []string{"implementation", "implementation-api", "implementation-cli", "review-loop"})
+	assertPhaseOrder(t, updated, []string{"implementation", "implementation-api", "implementation-cli", "review-loop-1"})
 	if child := phaseByID(t, updated, "implementation-api"); child.Title != "API and store integration" || child.Order != 5 {
 		t.Fatalf("updated child = %#v", child)
 	}

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -528,17 +528,3 @@ func flowPhaseStatusDetail(phase flowstore.FlowPhase) string {
 	}
 	return detail
 }
-
-func flowAutoreviewMissingPRTarget(record flowstore.FlowRecord) bool {
-	if flowstore.HasPRTarget(record.PR) {
-		return false
-	}
-	prCreation, hasPRCreation := flowPhaseByID(record, "pr-creation")
-	autoreview, hasAutoreview := flowPhaseByID(record, "autoreview")
-	if !hasPRCreation || !hasAutoreview || prCreation.Status != flowstore.PhaseCompleted {
-		return false
-	}
-	return autoreview.Status == flowstore.PhasePending ||
-		autoreview.Status == flowstore.PhaseNeedsAttention ||
-		autoreview.Status == flowstore.PhaseBlocked
-}

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -504,10 +504,13 @@ func flowPhaseCanLaunch(record flowstore.FlowRecord, phase flowstore.FlowPhase) 
 	if phase.Status == flowstore.PhaseReady {
 		return true
 	}
-	return artifacts.NormalizePhaseID(phase.PhaseID) == "autoreview" &&
+	return flowPhaseUsesAutoreviewRecovery(phase.PhaseID) &&
 		(phase.Status == flowstore.PhaseNeedsAttention || phase.Status == flowstore.PhaseBlocked) &&
-		flowstore.HasPRTarget(record.PR) &&
 		flowstore.PhasePredecessorsSatisfied(record, phase.PhaseID)
+}
+
+func flowPhaseUsesAutoreviewRecovery(phaseID string) bool {
+	return canonicalFlowPromptPhaseID(phaseID) == "autoreview"
 }
 
 func flowPhaseStatusDetail(phase flowstore.FlowPhase) string {

--- a/model/flow_prompt_completion_test.go
+++ b/model/flow_prompt_completion_test.go
@@ -128,6 +128,62 @@ func TestFlowPromptTemplatesAppendPhaseDoneInstruction(t *testing.T) {
 	}
 }
 
+func TestFlowPromptAliasesUseCanonicalReviewPrompts(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		PlanPath:     "/state/plans/plan-1/plan.md",
+		WorktreePath: "/dev/alpha-worktrees/flow-review",
+		Branch:       "flow/review",
+		Commit:       "abc123",
+		PR: flowstore.PullRequest{
+			Provider:   "github",
+			Number:     42,
+			URL:        "https://github.com/brian-bell/wtui/pull/42",
+			HeadBranch: "flow/review",
+			BaseBranch: "main",
+			Status:     "open",
+		},
+	}
+
+	reviewLoopPrompt := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review Loop"}, record.PlanPath, "", model.FlowPromptTemplates{})
+	reviewLoop1Prompt := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "review-loop-1", Title: "Review Loop 1"}, record.PlanPath, "", model.FlowPromptTemplates{})
+	if reviewLoop1Prompt != reviewLoopPrompt {
+		t.Fatalf("review-loop-1 prompt = %q, want canonical review-loop prompt %q", reviewLoop1Prompt, reviewLoopPrompt)
+	}
+
+	autoreviewPrompt := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "autoreview", Title: "Autoreview"}, record.PlanPath, "", model.FlowPromptTemplates{})
+	reviewLoop2Prompt := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "review-loop-2", Title: "Review Loop 2"}, record.PlanPath, "", model.FlowPromptTemplates{})
+	if reviewLoop2Prompt != autoreviewPrompt {
+		t.Fatalf("review-loop-2 prompt = %q, want canonical autoreview prompt %q", reviewLoop2Prompt, autoreviewPrompt)
+	}
+}
+
+func TestFlowPromptAliasesUseCanonicalTemplates(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		PlanPath:     "/state/plans/plan-1/plan.md",
+		WorktreePath: "/dev/alpha-worktrees/flow-review",
+		Branch:       "flow/review",
+		Commit:       "abc123",
+	}
+	templates := model.FlowPromptTemplates{
+		ReviewLoop: "Review loop template for {phase_id}",
+		Autoreview: "Autoreview template for {phase_id}",
+	}
+
+	reviewLoop1Prompt := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "review-loop-1", Title: "Review Loop 1"}, record.PlanPath, "", templates)
+	wantReviewLoop1 := "Review loop template for review-loop-1\n\n" + model.FlowPhaseDoneInstructionForTest()
+	if reviewLoop1Prompt != wantReviewLoop1 {
+		t.Fatalf("review-loop-1 templated prompt = %q, want %q", reviewLoop1Prompt, wantReviewLoop1)
+	}
+
+	reviewLoop2Prompt := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "review-loop-2", Title: "Review Loop 2"}, record.PlanPath, "", templates)
+	wantReviewLoop2 := "Autoreview template for review-loop-2\n\n" + model.FlowPhaseDoneInstructionForTest()
+	if reviewLoop2Prompt != wantReviewLoop2 {
+		t.Fatalf("review-loop-2 templated prompt = %q, want %q", reviewLoop2Prompt, wantReviewLoop2)
+	}
+}
+
 func TestFlowPromptPhaseDoneInstructionDuplicateGuard(t *testing.T) {
 	instruction := model.FlowPhaseDoneInstructionForTest()
 	record := flowstore.FlowRecord{

--- a/model/flow_prompts.go
+++ b/model/flow_prompts.go
@@ -203,7 +203,7 @@ func flowMinimalArtifactPrompt(instruction, planPath string, record flowstore.Fl
 func flowAutoreviewPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
 	var b strings.Builder
 	b.WriteString("Use the autoreview skill for this second-level review.\n")
-	b.WriteString("Review the local worktree changes, not the pull request.\n")
+	b.WriteString("Review the local worktree changes.\n")
 	b.WriteString("Use the commit skill when local revisions are made.\n")
 	b.WriteString("Use the wtui-flow skill to record the Autoreview result before finishing; the phase is not done until the result is persisted.\n\n")
 	writeFlowChangeMetadata(&b, record)

--- a/model/flow_prompts.go
+++ b/model/flow_prompts.go
@@ -25,7 +25,7 @@ type FlowPromptTemplates struct {
 }
 
 func (templates FlowPromptTemplates) templateForPhase(phaseID string) string {
-	switch artifacts.NormalizePhaseID(phaseID) {
+	switch canonicalFlowPromptPhaseID(phaseID) {
 	case "plan":
 		return templates.Plan
 	case "plan-review":
@@ -42,6 +42,17 @@ func (templates FlowPromptTemplates) templateForPhase(phaseID string) string {
 		return templates.Merge
 	default:
 		return templates.Generic
+	}
+}
+
+func canonicalFlowPromptPhaseID(phaseID string) string {
+	switch normalized := artifacts.NormalizePhaseID(phaseID); normalized {
+	case "review-loop-1":
+		return "review-loop"
+	case "review-loop-2":
+		return "autoreview"
+	default:
+		return normalized
 	}
 }
 
@@ -109,7 +120,7 @@ func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, pla
 		return ensureFlowPhaseDoneInstruction(prompt, template)
 	}
 	var prompt string
-	switch artifacts.NormalizePhaseID(phase.PhaseID) {
+	switch canonicalFlowPromptPhaseID(phase.PhaseID) {
 	case "plan-review":
 		prompt = flowPlanReviewPrompt(record, phase, planPath, planBody)
 	case "implementation":
@@ -129,7 +140,7 @@ func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, pla
 }
 
 func flowPhasePromptNeedsPlanBody(phaseID string) bool {
-	switch artifacts.NormalizePhaseID(phaseID) {
+	switch canonicalFlowPromptPhaseID(phaseID) {
 	case "plan-review", "implementation", "review-loop", "pr-creation", "autoreview", "merge":
 		return false
 	default:

--- a/model/flow_prompts.go
+++ b/model/flow_prompts.go
@@ -203,17 +203,10 @@ func flowMinimalArtifactPrompt(instruction, planPath string, record flowstore.Fl
 func flowAutoreviewPrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {
 	var b strings.Builder
 	b.WriteString("Use the autoreview skill for this second-level review.\n")
-	b.WriteString("Use the ship skill when fixes require commits or pushes.\n")
+	b.WriteString("Review the local worktree changes, not the pull request.\n")
+	b.WriteString("Use the commit skill when local revisions are made.\n")
 	b.WriteString("Use the wtui-flow skill to record the Autoreview result before finishing; the phase is not done until the result is persisted.\n\n")
 	writeFlowChangeMetadata(&b, record)
-	if flowstore.HasPRTarget(record.PR) {
-		fmt.Fprintf(&b, "\nPR target:\n- PR: %s #%d\n- URL: %s\n- Head: %s\n- Base: %s", record.PR.Provider, record.PR.Number, record.PR.URL, record.PR.HeadBranch, record.PR.BaseBranch)
-		if record.PR.Status != "" {
-			fmt.Fprintf(&b, "\n- Status: %s", record.PR.Status)
-		}
-	} else {
-		b.WriteString("\nPR target: missing. Do not run Autoreview until `wtui flow pr set` records provider, number, URL, head, and base.\n")
-	}
 	return b.String()
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -7761,12 +7761,12 @@ func TestModel_GLaunchesFlowPhasePRCreationWithStructuredMetadataPrompt(t *testi
 	}
 }
 
-func TestModel_GLaunchesFlowPhaseAutoreviewWithPRContext(t *testing.T) {
+func TestModel_GLaunchesFlowPhaseAutoreviewWithLocalWorktreePrompt(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
 		ReadPlan: func(planID string) (string, error) {
-			t.Fatalf("Autoreview launch should pass PR metadata without pre-reading %q", planID)
+			t.Fatalf("Autoreview launch should pass worktree metadata without pre-reading %q", planID)
 			return "", nil
 		},
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
@@ -7816,23 +7816,30 @@ func TestModel_GLaunchesFlowPhaseAutoreviewWithPRContext(t *testing.T) {
 	prompt := strings.ToLower(launched.InitialPrompt)
 	for _, want := range []string{
 		"second-level review",
-		"use the ship skill when fixes require commits or pushes",
+		"review the local worktree changes",
+		"use the commit skill when local revisions are made",
 		"use the wtui-flow skill to record the autoreview result before finishing",
 		"worktree: /dev/alpha-worktrees/flow-pr",
 		"branch: flow/pr",
 		"start commit: ghi789",
-		"pr target:",
-		"github #115",
-		"https://github.com/brian-bell/wtui/pull/115",
-		"head: flow/pr",
-		"base: main",
-		"status: open",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("autoreview prompt missing %q:\n%s", want, launched.InitialPrompt)
 		}
 	}
-	for _, unwanted := range []string{"saved plan body", "wtui flow phase", "--status completed", "--status needs_attention", "--status blocked"} {
+	for _, unwanted := range []string{
+		"saved plan body",
+		"pr target",
+		"github #115",
+		"https://github.com/brian-bell/wtui/pull/115",
+		"head: flow/pr",
+		"base: main",
+		"status: open",
+		"wtui flow phase",
+		"--status completed",
+		"--status needs_attention",
+		"--status blocked",
+	} {
 		if strings.Contains(prompt, unwanted) {
 			t.Fatalf("autoreview prompt should not include %q:\n%s", unwanted, launched.InitialPrompt)
 		}
@@ -7844,7 +7851,7 @@ func TestModel_GLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
 		ReadPlan: func(planID string) (string, error) {
-			t.Fatalf("Autoreview recovery launch should pass PR metadata without pre-reading %q", planID)
+			t.Fatalf("Autoreview recovery launch should pass worktree metadata without pre-reading %q", planID)
 			return "", nil
 		},
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
@@ -7894,21 +7901,28 @@ func TestModel_GLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) {
 	prompt := strings.ToLower(launched.InitialPrompt)
 	for _, want := range []string{
 		"second-level review",
-		"use the ship skill when fixes require commits or pushes",
+		"review the local worktree changes",
+		"use the commit skill when local revisions are made",
 		"use the wtui-flow skill to record the autoreview result before finishing",
 		"worktree: /dev/alpha-worktrees/flow-pr",
 		"branch: flow/pr",
 		"start commit: ghi789",
-		"github #115",
-		"head: flow/pr",
-		"base: main",
-		"status: open",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("autoreview recovery prompt missing %q:\n%s", want, launched.InitialPrompt)
 		}
 	}
-	for _, unwanted := range []string{"restart required", "--status running", "rerunning autoreview", "wtui flow phase"} {
+	for _, unwanted := range []string{
+		"pr target",
+		"github #115",
+		"head: flow/pr",
+		"base: main",
+		"status: open",
+		"restart required",
+		"--status running",
+		"rerunning autoreview",
+		"wtui flow phase",
+	} {
 		if strings.Contains(prompt, unwanted) {
 			t.Fatalf("autoreview recovery prompt should not include %q:\n%s", unwanted, launched.InitialPrompt)
 		}

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -897,9 +897,9 @@ func autoFlowWithPhaseStatuses(statuses map[string]string) flowstore.FlowRecord 
 		{id: "plan", title: "Plan", order: 1},
 		{id: "plan-review", title: "Plan Review", order: 2},
 		{id: "implementation", title: "Implementation", order: 3},
-		{id: "review-loop", title: "Review loop", order: 4},
-		{id: "pr-creation", title: "PR creation", order: 5},
-		{id: "autoreview", title: "Autoreview", order: 6},
+		{id: "review-loop-1", title: "Review loop 1", order: 4},
+		{id: "review-loop-2", title: "Review loop 2", order: 5},
+		{id: "pr-creation", title: "PR creation", order: 6},
 		{id: "merge", title: "Merge", order: 7},
 	}
 	phases := make([]flowstore.FlowPhase, 0, len(statuses))
@@ -2643,22 +2643,24 @@ func TestModel_FlowAutoModeLaunchesNextImplementationChildOrReviewLoop(t *testin
 	}
 }
 
-func TestModel_FlowAutoModeLaunchesAutoreviewAfterPRCreationCompletesWithPRMetadata(t *testing.T) {
+func TestModel_FlowAutoModeDoesNotLaunchMergeAfterPRCreationCompletesWithPRMetadata(t *testing.T) {
 	previous := autoFlowWithPhaseStatuses(map[string]string{
 		"plan":           flowstore.PhaseCompleted,
 		"plan-review":    flowstore.PhaseCompleted,
 		"implementation": flowstore.PhaseCompleted,
-		"review-loop":    flowstore.PhaseCompleted,
+		"review-loop-1":  flowstore.PhaseCompleted,
+		"review-loop-2":  flowstore.PhaseCompleted,
 		"pr-creation":    flowstore.PhaseRunning,
-		"autoreview":     flowstore.PhasePending,
+		"merge":          flowstore.PhasePending,
 	})
 	current := autoFlowWithPhaseStatuses(map[string]string{
 		"plan":           flowstore.PhaseCompleted,
 		"plan-review":    flowstore.PhaseCompleted,
 		"implementation": flowstore.PhaseCompleted,
-		"review-loop":    flowstore.PhaseCompleted,
+		"review-loop-1":  flowstore.PhaseCompleted,
+		"review-loop-2":  flowstore.PhaseCompleted,
 		"pr-creation":    flowstore.PhaseCompleted,
-		"autoreview":     flowstore.PhaseReady,
+		"merge":          flowstore.PhaseReady,
 	})
 	current.Branch = "flow/auto"
 	current.PR = flowstore.PullRequest{
@@ -2669,12 +2671,12 @@ func TestModel_FlowAutoModeLaunchesAutoreviewAfterPRCreationCompletesWithPRMetad
 		BaseBranch: "main",
 	}
 
-	launchMsg, updates := autoLaunchFromFlowRefresh(t, previous, current)
-	if len(updates) != 1 || updates[0].PhaseID != "autoreview" {
-		t.Fatalf("launch updates = %#v, want autoreview", updates)
+	cmd, updates := autoLaunchCommandFromFlowRefresh(t, previous, current)
+	if cmd != nil {
+		t.Fatalf("pr-creation completion returned auto-launch command %T, want nil", cmd)
 	}
-	if launchMsg.LaunchContext.FlowPhaseID != "autoreview" {
-		t.Fatalf("launched phase = %q, want autoreview", launchMsg.LaunchContext.FlowPhaseID)
+	if len(*updates) != 0 {
+		t.Fatalf("launch updates = %#v, want none", updates)
 	}
 }
 
@@ -7761,12 +7763,12 @@ func TestModel_GLaunchesFlowPhasePRCreationWithStructuredMetadataPrompt(t *testi
 	}
 }
 
-func TestModel_GLaunchesFlowPhaseAutoreviewWithLocalWorktreePrompt(t *testing.T) {
+func TestModel_GLaunchesFlowPhaseReviewLoop2WithLocalWorktreePrompt(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
 		ReadPlan: func(planID string) (string, error) {
-			t.Fatalf("Autoreview launch should pass worktree metadata without pre-reading %q", planID)
+			t.Fatalf("Review Loop 2 launch should pass worktree metadata without pre-reading %q", planID)
 			return "", nil
 		},
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
@@ -7789,27 +7791,19 @@ func TestModel_GLaunchesFlowPhaseAutoreviewWithLocalWorktreePrompt(t *testing.T)
 		Commit:       "ghi789",
 		PlanID:       "plan-1",
 		Status:       flowstore.StatusInProgress,
-		PR: flowstore.PullRequest{
-			Provider:   "github",
-			Number:     115,
-			URL:        "https://github.com/brian-bell/wtui/pull/115",
-			HeadBranch: "flow/pr",
-			BaseBranch: "main",
-			Status:     "open",
-		},
 		Phases: []flowstore.FlowPhase{
 			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
 			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
 			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted},
-			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseCompleted},
-			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhaseCompleted},
-			{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseReady},
+			{PhaseID: "review-loop-1", Title: "Review loop 1", Status: flowstore.PhaseCompleted},
+			{PhaseID: "review-loop-2", Title: "Review Loop 2", Status: flowstore.PhaseReady},
+			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhasePending},
 		},
 	}})
 
-	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "autoreview")
+	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "review-loop-2")
 	if cmd == nil {
-		t.Fatal("g should prepare an autoreview launch")
+		t.Fatal("g should prepare a review-loop-2 launch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -7824,7 +7818,7 @@ func TestModel_GLaunchesFlowPhaseAutoreviewWithLocalWorktreePrompt(t *testing.T)
 		"start commit: ghi789",
 	} {
 		if !strings.Contains(prompt, want) {
-			t.Fatalf("autoreview prompt missing %q:\n%s", want, launched.InitialPrompt)
+			t.Fatalf("review-loop-2 prompt missing %q:\n%s", want, launched.InitialPrompt)
 		}
 	}
 	for _, unwanted := range []string{
@@ -7842,17 +7836,17 @@ func TestModel_GLaunchesFlowPhaseAutoreviewWithLocalWorktreePrompt(t *testing.T)
 		"--status blocked",
 	} {
 		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("autoreview prompt should not include %q:\n%s", unwanted, launched.InitialPrompt)
+			t.Fatalf("review-loop-2 prompt should not include %q:\n%s", unwanted, launched.InitialPrompt)
 		}
 	}
 }
 
-func TestModel_GLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) {
+func TestModel_GLaunchesFlowPhaseReviewLoop2WithRecoveryPrompt(t *testing.T) {
 	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
 		ReadPlan: func(planID string) (string, error) {
-			t.Fatalf("Autoreview recovery launch should pass worktree metadata without pre-reading %q", planID)
+			t.Fatalf("Review Loop 2 recovery launch should pass worktree metadata without pre-reading %q", planID)
 			return "", nil
 		},
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
@@ -7875,27 +7869,19 @@ func TestModel_GLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) {
 		Commit:       "ghi789",
 		PlanID:       "plan-1",
 		Status:       flowstore.StatusNeedsAttention,
-		PR: flowstore.PullRequest{
-			Provider:   "github",
-			Number:     115,
-			URL:        "https://github.com/brian-bell/wtui/pull/115",
-			HeadBranch: "flow/pr",
-			BaseBranch: "main",
-			Status:     "open",
-		},
 		Phases: []flowstore.FlowPhase{
 			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
 			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
 			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted},
-			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseCompleted},
-			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhaseCompleted},
-			{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseNeedsAttention, Outcome: "needs_attention", Notes: "Non-blocking concern remains."},
+			{PhaseID: "review-loop-1", Title: "Review loop 1", Status: flowstore.PhaseCompleted},
+			{PhaseID: "review-loop-2", Title: "Review Loop 2", Status: flowstore.PhaseNeedsAttention, Outcome: "needs_attention", Notes: "Non-blocking concern remains."},
+			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhasePending},
 		},
 	}})
 
-	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "autoreview")
+	m, cmd := prepareSelectedFlowPhaseHeadlessOffLaunch(t, m, "review-loop-2")
 	if cmd == nil {
-		t.Fatal("g should prepare an autoreview relaunch")
+		t.Fatal("g should prepare a review-loop-2 relaunch")
 	}
 	runPreparedFlowEmbeddedLaunch(t, m, cmd)
 
@@ -7910,7 +7896,7 @@ func TestModel_GLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) {
 		"start commit: ghi789",
 	} {
 		if !strings.Contains(prompt, want) {
-			t.Fatalf("autoreview recovery prompt missing %q:\n%s", want, launched.InitialPrompt)
+			t.Fatalf("review-loop-2 recovery prompt missing %q:\n%s", want, launched.InitialPrompt)
 		}
 	}
 	for _, unwanted := range []string{
@@ -7926,22 +7912,33 @@ func TestModel_GLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) {
 		"wtui flow phase",
 	} {
 		if strings.Contains(prompt, unwanted) {
-			t.Fatalf("autoreview recovery prompt should not include %q:\n%s", unwanted, launched.InitialPrompt)
+			t.Fatalf("review-loop-2 recovery prompt should not include %q:\n%s", unwanted, launched.InitialPrompt)
 		}
 	}
 }
 
-func TestModel_GDoesNotRelaunchFlowPhaseAutoreviewWithoutPRTarget(t *testing.T) {
-	var launchAttempted bool
+func TestModel_GRelaunchesFlowPhaseReviewLoop2WithoutPRTarget(t *testing.T) {
+	var launched actions.AgentLaunchContext
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
-			t.Fatalf("AddFlowPhaseLaunchID() should not run without PR metadata: %#v", update)
-			return flowstore.FlowRecord{}, nil
+			if update.PhaseID != "review-loop-2" {
+				t.Fatalf("AddFlowPhaseLaunchID() phase = %q, want review-loop-2", update.PhaseID)
+			}
+			return flowstore.FlowRecord{
+				FlowID: update.FlowID,
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "review-loop-2", Title: "Review Loop 2", Status: flowstore.PhaseRunning, LaunchIDs: []string{update.LaunchID}},
+				},
+			}, nil
 		},
 		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
-			launchAttempted = true
-			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+			t.Fatalf("Flow phase CLI launch should start an embedded terminal, not LaunchAgent: %#v", ctx)
+			return actions.TerminalLaunchSpec{}, nil
+		},
+		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
+			launched = ctx
+			return &fakeEmbeddedTerminal{state: "running"}, nil
 		},
 	})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
@@ -7954,26 +7951,24 @@ func TestModel_GDoesNotRelaunchFlowPhaseAutoreviewWithoutPRTarget(t *testing.T) 
 			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
 			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
 			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted},
-			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseCompleted},
-			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhaseCompleted},
-			{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseBlocked, Outcome: "blocked", Notes: "PR target missing."},
+			{PhaseID: "review-loop-1", Title: "Review loop 1", Status: flowstore.PhaseCompleted},
+			{PhaseID: "review-loop-2", Title: "Review Loop 2", Status: flowstore.PhaseBlocked, Outcome: "blocked", Notes: "Needs another review."},
+			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhasePending},
 		},
 	}})
 
-	m = selectFlowPhaseByID(t, m, "autoreview")
+	m = selectFlowPhaseByID(t, m, "review-loop-2")
 	m, cmd := update(m, flowLaunchKey())
-	if cmd != nil {
-		t.Fatal("g should not launch blocked autoreview without PR metadata")
+	if cmd == nil {
+		t.Fatal("g should launch blocked review-loop-2 without PR metadata")
 	}
-	if launchAttempted {
-		t.Fatal("LaunchAgent() ran without PR metadata")
-	}
-	if got := m.TransientError(); got != "No launchable Flow phase" {
-		t.Fatalf("status = %q, want no-launchable message", got)
+	runPreparedFlowEmbeddedLaunch(t, m, cmd)
+	if launched.FlowPhaseID != "review-loop-2" {
+		t.Fatalf("launched phase = %q, want review-loop-2", launched.FlowPhaseID)
 	}
 }
 
-func TestModel_GDoesNotRelaunchFlowPhaseAutoreviewWhenPredecessorsAreUnsatisfied(t *testing.T) {
+func TestModel_GDoesNotRelaunchFlowPhaseReviewLoop2WhenPredecessorsAreUnsatisfied(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
@@ -7991,28 +7986,20 @@ func TestModel_GDoesNotRelaunchFlowPhaseAutoreviewWhenPredecessorsAreUnsatisfied
 		WorktreePath: "/dev/alpha-worktrees/flow-pr",
 		Branch:       "flow/pr",
 		Status:       flowstore.StatusBlocked,
-		PR: flowstore.PullRequest{
-			Provider:   "github",
-			Number:     115,
-			URL:        "https://github.com/brian-bell/wtui/pull/115",
-			HeadBranch: "flow/pr",
-			BaseBranch: "main",
-			Status:     "open",
-		},
 		Phases: []flowstore.FlowPhase{
 			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
 			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
 			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning},
-			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhasePending},
+			{PhaseID: "review-loop-1", Title: "Review loop 1", Status: flowstore.PhasePending},
+			{PhaseID: "review-loop-2", Title: "Review Loop 2", Status: flowstore.PhaseBlocked, Outcome: "blocked", Notes: "Needs another review."},
 			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhasePending},
-			{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseBlocked, Outcome: "blocked", Notes: "Needs another review."},
 		},
 	}})
 
-	m = selectFlowPhaseByID(t, m, "autoreview")
+	m = selectFlowPhaseByID(t, m, "review-loop-2")
 	m, cmd := update(m, flowLaunchKey())
 	if cmd != nil {
-		t.Fatal("g should not launch blocked autoreview while predecessors are unsatisfied")
+		t.Fatal("g should not launch blocked review-loop-2 while predecessors are unsatisfied")
 	}
 	if got := m.TransientError(); got != "No launchable Flow phase" {
 		t.Fatalf("status = %q, want no-launchable message", got)

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -7829,6 +7829,7 @@ func TestModel_GLaunchesFlowPhaseAutoreviewWithLocalWorktreePrompt(t *testing.T)
 	}
 	for _, unwanted := range []string{
 		"saved plan body",
+		"not the pull request",
 		"pr target",
 		"github #115",
 		"https://github.com/brian-bell/wtui/pull/115",
@@ -7913,6 +7914,7 @@ func TestModel_GLaunchesFlowPhaseAutoreviewWithRecoveryPrompt(t *testing.T) {
 		}
 	}
 	for _, unwanted := range []string{
+		"not the pull request",
 		"pr target",
 		"github #115",
 		"head: flow/pr",

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -2760,7 +2760,7 @@ func flowPhaseState(record flowstore.FlowRecord, phase flowstore.FlowPhase) stri
 	if session, ok := flowstore.LatestPhaseSession(phase, false); ok && strings.TrimSpace(session.SessionID) == "" {
 		return "missing-session-id"
 	}
-	if phase.PhaseID == "autoreview" && flowMissingPRTarget(record) && phaseCanReportMissingPR(phase) {
+	if phase.PhaseID == "merge" && flowMissingPRTarget(record) && phaseCanReportMissingPR(phase) {
 		return "missing-pr"
 	}
 	return flowBasePhaseState(phase)

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -1770,7 +1770,7 @@ func TestRender_FlowsModeShowsPlanReviewGateState(t *testing.T) {
 	}
 }
 
-func TestRender_FlowsModeShowsAutoreviewMissingPRMetadata(t *testing.T) {
+func TestRender_FlowsModeShowsMergeMissingPRMetadata(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
 		Selected: 0,
@@ -1786,16 +1786,17 @@ func TestRender_FlowsModeShowsAutoreviewMissingPRMetadata(t *testing.T) {
 				{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
 				{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
 				{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted},
-				{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseCompleted},
+				{PhaseID: "review-loop-1", Title: "Review loop 1", Status: flowstore.PhaseCompleted},
+				{PhaseID: "review-loop-2", Title: "Review loop 2", Status: flowstore.PhaseCompleted},
 				{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhaseCompleted},
-				{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhasePending},
+				{PhaseID: "merge", Title: "Merge", Status: flowstore.PhasePending},
 			},
 		}},
 		ActivePane:   1,
 		FlowSelected: 0,
 	})
 
-	for _, want := range []string{"autoreview:missing-pr", "missing", "Needs PR metadata"} {
+	for _, want := range []string{"merge:missing-pr", "missing", "Needs PR metadata"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("missing PR metadata view missing %q:\n%s", want, view)
 		}
@@ -1907,7 +1908,7 @@ func TestRender_FlowRecoveryWarningsPreservePhaseSpecificStates(t *testing.T) {
 		Phases: []flowstore.FlowPhase{
 			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted, Order: 1},
 			{PhaseID: "pr-creation", Title: "PR Creation", Status: flowstore.PhaseCompleted, Order: 2},
-			{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhasePending, Order: 3},
+			{PhaseID: "merge", Title: "Merge", Status: flowstore.PhasePending, Order: 3},
 		},
 	}
 	view := Render(RenderParams{
@@ -1922,7 +1923,7 @@ func TestRender_FlowRecoveryWarningsPreservePhaseSpecificStates(t *testing.T) {
 		ExpandedFlowID: flow.FlowID,
 	})
 
-	for _, want := range []string{"autoreview:missing-pr", "plan:completed"} {
+	for _, want := range []string{"merge:missing-pr", "plan:completed"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("recovery precedence view missing %q:\n%s", want, view)
 		}
@@ -1943,8 +1944,8 @@ func TestRender_FlowRecoveryWarningsPreservePhaseSpecificStates(t *testing.T) {
 		FlowSelected:   0,
 		ExpandedFlowID: flow.FlowID,
 	})
-	if !strings.Contains(view, "autoreview:completed") || strings.Contains(view, "autoreview:missing-pr") {
-		t.Fatalf("completed autoreview history should not be overwritten by missing PR recovery:\n%s", view)
+	if !strings.Contains(view, "merge:completed") || strings.Contains(view, "merge:missing-pr") {
+		t.Fatalf("completed merge history should not be overwritten by missing PR recovery:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Update the default Flow graph to run review-loop-1, then review-loop-2, then PR Creation, then Merge.
- Keep review-loop-1 on the standard review-loop prompt/template and review-loop-2 on the second-level local worktree Autoreview prompt/template.
- Move structured PR metadata gating from Autoreview readiness to Merge readiness after PR Creation.
- Update the TUI missing-PR recovery label so missing PR metadata appears on merge:missing-pr.
- Refresh README, config docs, Flow phase semantics, and the wtui-flow agent skill for the new phase order.

## Implementation Notes
- Added canonical phase prompt classification so review-loop-1 maps to Review Loop behavior and review-loop-2 maps to Autoreview behavior.
- Changed the seeded Flow phases to plan -> plan-review -> implementation -> review-loop-1 -> review-loop-2 -> pr-creation -> merge.
- Updated CLI phase action defaults so review-loop-2 uses passed / needs_attention / blocked outcomes.
- Allowed review-loop-2 recovery launches without requiring PR metadata, since PR Creation now happens afterward.
- Updated store, model, CLI, UI, and skill-doc tests for the new order and gating behavior.

## Verification
- make test
- make build
- gofmt -l .