### PR TITLE
Default new Flow plan launches to headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,9 +381,10 @@ headless off runs interactive `codex` or `claude` in the same embedded Flow
 terminal. Headless-off Flow launches prefill the phase prompt without
 submitting it, then focus the Flow terminal in input mode so you can review or
 edit it before pressing enter. Headless launches keep focus on the Flow list.
-Creating a new Flow has its own default-off Headless checkbox for the
-initial Plan launch; that checkbox does not change the selected-phase `h`
-setting. Manual phase launches, auto-launched phases, and new Flow Plan
+Creating a new Flow has its own default-on Headless checkbox for the initial
+Plan launch; uncheck it for an interactive initial Plan launch. That checkbox
+does not change the selected-phase `h` setting. Manual phase launches,
+auto-launched phases, and new Flow Plan
 launches all use the configured agent and that agent's configured effort. Press
 `E` to choose the selected CLI agent's reasoning effort; the shortcut pane shows
 the current value. Codex CLI launches use `--config

--- a/docs/config.md
+++ b/docs/config.md
@@ -359,10 +359,11 @@ inside the flows pane. Press `h` to choose the CLI command mode: headless runs
 `claude` in the same embedded Flow terminal. Headless-off Flow launches prefill
 the phase prompt without submitting it, then focus the Flow terminal in input
 mode so you can review or edit it before pressing enter. Headless launches keep
-focus on the Flow list. Creating a new Flow has its own default-off Headless
-checkbox for the initial Plan launch; that checkbox does not change the
-selected-phase `h` setting. Press `E` to choose the configured CLI agent's
-reasoning effort for future launches; the shortcut pane shows the current value. Manual phase
+focus on the Flow list. Creating a new Flow has its own default-on Headless
+checkbox for the initial Plan launch; uncheck it for an interactive initial
+Plan launch. That checkbox does not change the selected-phase `h` setting.
+Press `E` to choose the configured CLI agent's reasoning effort for future
+launches; the shortcut pane shows the current value. Manual phase
 launches, auto-launched phases, and new Flow Plan launches all use the
 configured agent and that agent's configured effort.
 `codex-app` remains URL/deep-link based, launches externally, and uses

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -8289,8 +8289,8 @@ func TestModel_NewFlowOpensSingleCreationForm(t *testing.T) {
 			t.Fatalf("field %d = %#v, want %#v", i, field, wantField)
 		}
 		if field.Kind == ui.FormCheckbox {
-			if field.Checked {
-				t.Fatalf("field %d initial checked = true, want false", i)
+			if !field.Checked {
+				t.Fatalf("field %d initial checked = false, want true", i)
 			}
 			continue
 		}
@@ -8406,7 +8406,7 @@ func TestModel_NewFlowDelegatesStartAndLaunchesPlanAgent(t *testing.T) {
 				started.LaunchID != "launch-1" ||
 				started.ReasoningEffort != wantEffort ||
 				!started.Embedded ||
-				started.Headless ||
+				!started.Headless ||
 				!started.FlowLaunchTracked {
 				t.Fatalf("embedded launch context = %#v", started)
 			}
@@ -8594,7 +8594,7 @@ func TestModel_NewFlowInteractiveCLIPlanLaunchFocusesTerminalInput(t *testing.T)
 	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 20})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
 
-	m, cmd := submitNewFlowPrompts(t, m, "Interactive Plan", "Write the plan", "main")
+	m, cmd := submitNewFlowPromptsWithOptions(t, m, "Interactive Plan", "Write the plan", "main", false)
 	if cmd == nil {
 		t.Fatal("expected flow creation command")
 	}
@@ -9332,13 +9332,13 @@ func TestModel_FlowAgentResultFailureReportsPhaseUpdateFailure(t *testing.T) {
 
 func submitNewFlowPrompts(t *testing.T, m model.Model, title, instructions, baseRef string) (model.Model, tea.Cmd) {
 	t.Helper()
-	return submitNewFlowPromptsWithOptions(t, m, title, instructions, baseRef, false)
+	return submitNewFlowPromptsWithOptions(t, m, title, instructions, baseRef, true)
 }
 
 func submitNewFlowPromptsWithOptions(t *testing.T, m model.Model, title, instructions, baseRef string, headless bool) (model.Model, tea.Cmd) {
 	t.Helper()
 	m = openNewFlowForm(t, m, title, instructions, baseRef)
-	if headless {
+	if !headless {
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeySpace})
 	}

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -8610,6 +8610,9 @@ func TestModel_NewFlowInteractiveCLIPlanLaunchFocusesTerminalInput(t *testing.T)
 	if started.FlowPhaseID != "plan" || started.Headless || !started.Embedded || !started.FlowLaunchTracked {
 		t.Fatalf("interactive new Flow plan launch context = %#v", started)
 	}
+	if !model.FlowHeadlessForTest(m) {
+		t.Fatal("unchecked create-form headless option should not mutate flows-mode headless toggle")
+	}
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
 	wantPrefill := "\x1b[200~Create and persist the plan.\x1b[201~"

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1229,7 +1229,7 @@ func (m Model) handleNewFlow() (tea.Model, tea.Cmd) {
 			{ID: flowCreateTitleField, Kind: modal.FormText, Label: "Title", Placeholder: ui.FlowTitleInputPlaceholder},
 			{ID: flowCreateInstructionsField, Kind: modal.FormMultilineText, Label: "Instructions", Placeholder: ui.FlowInstructionsInputPlaceholder},
 			{ID: flowCreateBaseRefField, Kind: modal.FormText, Label: "Base ref", Placeholder: ui.FlowBaseRefInputPlaceholder},
-			{ID: flowCreateHeadlessField, Kind: modal.FormCheckbox, Label: "Headless", Checked: false},
+			{ID: flowCreateHeadlessField, Kind: modal.FormCheckbox, Label: "Headless", Checked: true},
 		},
 		Validate: validateFlowCreateForm,
 		Submit: func(values modal.FormValues) tea.Cmd {


### PR DESCRIPTION
## Summary
- default the new Flow creation Headless checkbox to on for the initial Plan launch
- keep explicit interactive new Flow launches available by unchecking the form checkbox
- document the default-on behavior in README and config docs

## Implementation
- initialize the create-flow Headless form field as checked
- update form submission test helpers so default submissions remain headless and explicit interactive submissions uncheck the box
- add coverage that unchecking the create-flow checkbox does not mutate the flows-mode selected-phase headless toggle

## Verification
- gofmt -l .
- go test ./model
- make test
- make build