### PR TITLE
Block new Flow shortcut in active flows

### DIFF
--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -429,6 +429,39 @@ func TestModel_F3ActiveFlowLeftKeyClampsAndPreservesUnderlyingMode(t *testing.T)
 	assertListRequestsUnchanged(t, before, m)
 }
 
+func TestModel_F3ActiveFlowNewFlowKeyIsIgnored(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	m := flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		StartFlowPlan: func(model.FlowStartRequest) (model.FlowStartResult, error) {
+			t.Fatal("StartFlowPlan should not be called from active flows")
+			return model.FlowStartResult{}, nil
+		},
+	}), []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
+	before := listRequests(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if cmd != nil {
+		t.Fatalf("n from active Flow surface returned command %T, want nil", cmd)
+	}
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("n from active Flow surface opened overlay %d, want none", m.Overlay())
+	}
+	if m.Mode() != ui.ModeSessions {
+		t.Fatalf("n from active Flow surface changed underlying mode = %d, want sessions", m.Mode())
+	}
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Active flows") {
+		t.Fatalf("n from active Flow surface should keep active Flow view visible:\n%s", view)
+	}
+	if strings.Contains(view, "New flow") || strings.Contains(view, ui.FlowTitleInputPlaceholder) {
+		t.Fatalf("n from active Flow surface should not open new Flow form:\n%s", view)
+	}
+	assertListRequestsUnchanged(t, before, m)
+}
+
 func TestModel_F3ActiveFlowTabWithoutTerminalKeepsFlowSurfaceFocused(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -544,8 +544,6 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleLaunchNextFlowPhase()
 	case "enter":
 		return m.handleFlowEnter()
-	case "n":
-		return m.handleNewFlow()
 	case "o":
 		return m.handleOpenFlowPlanText()
 	case "m":

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1281,7 +1281,9 @@ func flowShortcutSections(sp statusBarParams, actions, navigation, global []shor
 	var flowModeControls []shortcutHint
 	var flowAgentControls []shortcutHint
 	if sp.ActivePane == 1 && sp.RepoSelected {
-		actions = append(actions, shortcutHint{Key: "n", Label: "new flow"})
+		if !sp.ActiveFlows {
+			actions = append(actions, shortcutHint{Key: "n", Label: "new flow"})
+		}
 		headlessLabel := "headless off"
 		headlessSuccessSuffix := ""
 		if sp.FlowHeadless {

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -677,6 +677,29 @@ func TestStatusBar_FlowsModeShowsNewFlowHint(t *testing.T) {
 	}
 }
 
+func TestStatusBar_ActiveFlowsHidesNewFlowHint(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:                    240,
+		Mode:                     ModeFlows,
+		ActiveFlows:              true,
+		ActivePane:               1,
+		RepoSelected:             true,
+		FlowSelected:             true,
+		FlowWorktreePathSelected: true,
+		FlowPlanLinked:           true,
+		FlowHeadless:             true,
+		FlowNextLaunchReady:      true,
+	})
+	if strings.Contains(bar, "n: new flow") {
+		t.Fatalf("active Flow status bar should not expose new flow, got %q", bar)
+	}
+	for _, want := range []string{"enter: phases", "g: launch next", "h: headless on", "o: open", "y: copy path"} {
+		if !strings.Contains(bar, want) {
+			t.Fatalf("active Flow status bar missing %q, got %q", want, bar)
+		}
+	}
+}
+
 func TestRender_FlowsModeShowsReasoningEffortShortcut(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:               []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -762,6 +762,60 @@ func TestRender_FlowsModeShortcutSectionsUseFlowGroups(t *testing.T) {
 	}
 }
 
+func TestRender_ActiveFlowsShortcutSectionsHideNewFlow(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:       []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:    0,
+		Width:       180,
+		Height:      28,
+		Mode:        ModeFlows,
+		ActiveFlows: true,
+		Flows: []flowstore.FlowRecord{{
+			FlowID:       "flow-1",
+			Title:        "Grouped shortcuts",
+			Status:       flowstore.StatusInProgress,
+			Branch:       "flow/grouped-shortcuts",
+			WorktreePath: "/dev/wtui-worktrees/flow-grouped-shortcuts",
+			PlanID:       "plan-1",
+			AutoMode:     true,
+			Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation",
+				Title:   "Implementation",
+				Status:  flowstore.PhaseReady,
+			}},
+		}},
+		ActivePane:                 1,
+		Destructive:                true,
+		FlowSelected:               0,
+		FlowHeadless:               true,
+		FlowAutoModeSelected:       true,
+		FlowNextLaunchReady:        true,
+		FlowAgentLabel:             "codex",
+		FlowReasoningEffort:        "effort: high",
+		FlowPhaseResumableSelected: true,
+	})
+
+	pane := shortcutPaneText(view)
+	if strings.Contains(pane, "n      new flow") {
+		t.Fatalf("active Flow shortcut pane should not expose new flow:\n%s", pane)
+	}
+	for _, want := range []string{
+		"enter  phases",
+		"g      launch next",
+		"o      open",
+		"y      copy path",
+		"h      headless on",
+		"m      auto: on",
+		"A      codex",
+		"E      effort: high",
+		"f3     active flows",
+	} {
+		if !strings.Contains(pane, want) {
+			t.Fatalf("active Flow shortcut pane missing %q:\n%s", want, pane)
+		}
+	}
+}
+
 func shortcutSectionTitles(pane string) []string {
 	known := map[string]bool{
 		"Actions":  true,


### PR DESCRIPTION
## Summary
- Block the `n` shortcut from opening the new Flow modal while the Flow pane is showing active flows.
- Keep `n` available in the normal Flow list and update the active-flow status bar shortcut labels.
- Add model and UI coverage for active-flow shortcut behavior and status bar rendering.

## Verification
- go test ./model ./ui
- gofmt -l .
- make test
- make build