### PR TITLE
Add Plan Now option for new Flow creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,10 +334,14 @@ ID when present, PR number or label, updated date, and title. Use `/` to filter
 by title, instructions, status, branch, worktree basename, plan metadata, PR
 metadata, phase titles/statuses/summaries, and linked session metadata. Press
 `n` to create a new Flow with one form for title, multiline instructions, and
-optional base ref plus a Headless checkbox for the initial Plan launch; use
-`alt+enter` for instruction newlines. On a Flow row, `enter` expands or
-collapses phase detail rows; `o` pages the linked plan body in `less -R`, and
-wtui shows a status message when the selected Flow has no linked plan. With
+optional base ref plus Headless and Plan Now checkboxes; use `alt+enter` for
+instruction newlines. Plan Now is checked by default and immediately launches
+the initial Plan phase after creating the Flow. Uncheck it to create a parked
+Flow with its instructions, worktree, branch, and start commit saved; the ready
+Plan phase can be launched later from the Flow row. On a Flow row, `enter`
+expands or collapses phase detail rows; `o` pages the linked plan body in
+`less -R`, and wtui shows a status message when the selected Flow has no linked
+plan. With
 destructive mode enabled (`D`), `d` deletes only the selected top-level Flow
 record under the Flow artifact store; it does not remove repositories,
 worktrees, branches, checked-out code, linked plans, sessions, transcripts, or
@@ -382,9 +386,10 @@ terminal. Headless-off Flow launches prefill the phase prompt without
 submitting it, then focus the Flow terminal in input mode so you can review or
 edit it before pressing enter. Headless launches keep focus on the Flow list.
 Creating a new Flow has its own default-off Headless checkbox for the
-initial Plan launch; that checkbox does not change the selected-phase `h`
-setting. Manual phase launches, auto-launched phases, and new Flow Plan
-launches all use the configured agent and that agent's configured effort. Press
+initial Plan launch; that checkbox is ignored when Plan Now is off and does
+not change the selected-phase `h` setting. Manual phase launches,
+auto-launched phases, and new Flow Plan launches all use the configured agent
+and that agent's configured effort. Press
 `E` to choose the selected CLI agent's reasoning effort; the shortcut pane shows
 the current value. Codex CLI launches use `--config
 model_reasoning_effort=<effort>`, Claude launches use `--effort <effort>`, and

--- a/model/flow_phase_launch_test.go
+++ b/model/flow_phase_launch_test.go
@@ -155,8 +155,16 @@ func TestFlowPhaseLauncherLaunchesParkedPlanPhaseFromSavedFlow(t *testing.T) {
 		!ctx.FlowLaunchTracked {
 		t.Fatalf("launch result = route %d context %#v", result.Route, ctx)
 	}
-	if !strings.Contains(ctx.InitialPrompt, "Write the initial plan later") {
-		t.Fatalf("prompt missing saved instructions: %q", ctx.InitialPrompt)
+	for _, want := range []string{
+		"Use the wtui-flow skill for this launch.",
+		"Write the initial plan later",
+		"Produce a plan only; do not start coding in this phase.",
+		"wtui plan save",
+		"wtui flow plan set",
+	} {
+		if !strings.Contains(ctx.InitialPrompt, want) {
+			t.Fatalf("prompt missing %q: %q", want, ctx.InitialPrompt)
+		}
 	}
 }
 

--- a/model/flow_phase_launch_test.go
+++ b/model/flow_phase_launch_test.go
@@ -98,6 +98,68 @@ func TestFlowPhaseLauncherPrepareManualReadyPhaseLaunch(t *testing.T) {
 	}
 }
 
+func TestFlowPhaseLauncherLaunchesParkedPlanPhaseFromSavedFlow(t *testing.T) {
+	phase := flowstore.FlowPhase{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseReady}
+	record := flowstore.FlowRecord{
+		FlowID:       "flow-parked",
+		Title:        "Parked Flow",
+		Instructions: "Write the initial plan later",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-parked",
+		Branch:       "flow/parked",
+		BaseRef:      "main",
+		Commit:       "abc123",
+		Phases:       []flowstore.FlowPhase{phase},
+	}
+	persistedPhase := phase
+	persistedPhase.Status = flowstore.PhaseRunning
+	persistedPhase.LaunchIDs = []string{"launch-parked"}
+	var updates []flowstore.PhaseLaunchUpdate
+	launcher := model.FlowPhaseLauncher{
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			return flowstore.FlowRecord{FlowID: record.FlowID, Phases: []flowstore.FlowPhase{persistedPhase}}, nil
+		},
+		NewLaunchID:      func() string { return "launch-parked" },
+		SessionStateRoot: "/state/wtui/sessions/v1",
+		AgentCommand:     "codex",
+		ReasoningEffort:  "high",
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: phase, Headless: true})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	result, err := launcher.Prepare(prepared)
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+
+	if len(updates) != 1 {
+		t.Fatalf("launch updates = %#v, want one", updates)
+	}
+	if update := updates[0]; update.FlowID != "flow-parked" || update.PhaseID != "plan" || update.LaunchID != "launch-parked" || update.AutoLaunch {
+		t.Fatalf("launch update = %#v", update)
+	}
+	ctx := result.Context
+	if result.Route != model.FlowPhaseLaunchEmbedded ||
+		ctx.LaunchID != "launch-parked" ||
+		ctx.RepoPath != record.RepoPath ||
+		ctx.WorktreePath != record.WorktreePath ||
+		ctx.Branch != record.Branch ||
+		ctx.Commit != record.Commit ||
+		ctx.FlowID != record.FlowID ||
+		ctx.FlowPhaseID != "plan" ||
+		!ctx.Embedded ||
+		!ctx.Headless ||
+		!ctx.FlowLaunchTracked {
+		t.Fatalf("launch result = route %d context %#v", result.Route, ctx)
+	}
+	if !strings.Contains(ctx.InitialPrompt, "Write the initial plan later") {
+		t.Fatalf("prompt missing saved instructions: %q", ctx.InitialPrompt)
+	}
+}
+
 func TestFlowPhaseLauncherStandardTemplateDoesNotReadPlanBody(t *testing.T) {
 	phase := flowstore.FlowPhase{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady}
 	record := flowstore.FlowRecord{

--- a/model/flow_prompts.go
+++ b/model/flow_prompts.go
@@ -110,6 +110,8 @@ func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, pla
 	}
 	var prompt string
 	switch artifacts.NormalizePhaseID(phase.PhaseID) {
+	case "plan":
+		prompt = flowPlanPrompt(record, templates)
 	case "plan-review":
 		prompt = flowPlanReviewPrompt(record, phase, planPath, planBody)
 	case "implementation":
@@ -130,7 +132,7 @@ func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, pla
 
 func flowPhasePromptNeedsPlanBody(phaseID string) bool {
 	switch artifacts.NormalizePhaseID(phaseID) {
-	case "plan-review", "implementation", "review-loop", "pr-creation", "autoreview", "merge":
+	case "plan", "plan-review", "implementation", "review-loop", "pr-creation", "autoreview", "merge":
 		return false
 	default:
 		return true

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -11,7 +11,7 @@ import (
 const flowPlanPhaseID = "plan"
 
 // FlowStartRequest contains the user operation inputs needed to create a Flow
-// and prepare the initial plan-phase agent launch.
+// and optionally prepare the initial plan-phase agent launch.
 type FlowStartRequest struct {
 	RepoPath         string
 	Title            string

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -25,7 +25,7 @@ type FlowStartRequest struct {
 	PlanPhaseStatus  string
 }
 
-// FlowStartResult is the launch-ready result of starting a new Flow plan phase.
+// FlowStartResult is the prepared or launch-ready result of creating a new Flow.
 type FlowStartResult struct {
 	Flow          flowstore.FlowRecord
 	Worktree      actions.FlowWorktreeCreateResult
@@ -119,38 +119,13 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 		phaseID = flowPlanPhaseID
 	}
 
-	flow, err := s.createFlow(flowstore.FlowRecord{
-		Title:        req.Title,
-		Instructions: req.Instructions,
-		RepoPath:     req.RepoPath,
-		BaseRef:      req.BaseRef,
-	})
+	result, err := s.PrepareFlow(req)
 	if err != nil {
-		return FlowStartResult{}, err
+		return result, err
 	}
-
-	worktree, err := s.createWorktree(req.RepoPath, req.Title, req.BaseRef)
-	if err != nil {
-		return FlowStartResult{}, s.blockPlanPhase(flow.FlowID, phaseID, "Worktree creation failed: "+err.Error(), err.Error())
-	}
-
-	commit := s.resolveCommit(worktree.WorktreePath)
-	startedFlow, err := s.setStartMetadata(flowstore.StartMetadataUpdate{
-		FlowID:       flow.FlowID,
-		WorktreePath: worktree.WorktreePath,
-		Branch:       worktree.Branch,
-		BaseRef:      req.BaseRef,
-		Commit:       commit,
-	})
-	if err != nil {
-		return FlowStartResult{}, err
-	}
-	flow = startedFlow
-
-	if err := s.runBootstrap(req.RepoPath, worktree); err != nil {
-		errText := "Bootstrap hook failed: " + err.Error()
-		return FlowStartResult{}, s.blockPlanPhase(flow.FlowID, phaseID, errText, errText)
-	}
+	flow := result.Flow
+	worktree := result.Worktree
+	commit := result.Commit
 
 	launchID := s.newLaunchID()
 	launchedFlow, err := s.addPhaseLaunchID(flowstore.PhaseLaunchUpdate{
@@ -159,9 +134,11 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 		LaunchID: launchID,
 	})
 	if err != nil {
-		return FlowStartResult{}, err
+		return result, err
 	}
 	flow = launchedFlow
+	result.Flow = flow
+	result.LaunchID = launchID
 
 	phaseTitle := req.PlanPhaseTitle
 	if phaseTitle == "" {
@@ -171,7 +148,7 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 	if phaseStatus == "" {
 		phaseStatus = flowstore.PhaseRunning
 	}
-	ctx := actions.AgentLaunchContext{
+	result.LaunchContext = actions.AgentLaunchContext{
 		Command:          req.AgentCommand,
 		ReasoningEffort:  req.ReasoningEffort,
 		LaunchID:         launchID,
@@ -187,13 +164,53 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 		FlowPhaseID:      phaseID,
 		InitialPrompt:    flowPlanPrompt(flowStartPromptRecord(flow, req, worktree, commit), s.flowPromptTemplates),
 	}
-	return FlowStartResult{
-		Flow:          flow,
-		Worktree:      worktree,
-		Commit:        commit,
-		LaunchID:      launchID,
-		LaunchContext: ctx,
-	}, nil
+	return result, nil
+}
+
+func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) {
+	phaseID := req.PlanPhaseID
+	if phaseID == "" {
+		phaseID = flowPlanPhaseID
+	}
+
+	flow, err := s.createFlow(flowstore.FlowRecord{
+		Title:        req.Title,
+		Instructions: req.Instructions,
+		RepoPath:     req.RepoPath,
+		BaseRef:      req.BaseRef,
+	})
+	if err != nil {
+		return FlowStartResult{}, err
+	}
+	result := FlowStartResult{Flow: flow}
+
+	worktree, err := s.createWorktree(req.RepoPath, req.Title, req.BaseRef)
+	if err != nil {
+		return result, s.blockPlanPhase(flow.FlowID, phaseID, "Worktree creation failed: "+err.Error(), err.Error())
+	}
+	result.Worktree = worktree
+
+	commit := s.resolveCommit(worktree.WorktreePath)
+	result.Commit = commit
+	startedFlow, err := s.setStartMetadata(flowstore.StartMetadataUpdate{
+		FlowID:       flow.FlowID,
+		WorktreePath: worktree.WorktreePath,
+		Branch:       worktree.Branch,
+		BaseRef:      req.BaseRef,
+		Commit:       commit,
+	})
+	if err != nil {
+		return result, err
+	}
+	flow = startedFlow
+	result.Flow = flow
+
+	if err := s.runBootstrap(req.RepoPath, worktree); err != nil {
+		errText := "Bootstrap hook failed: " + err.Error()
+		return result, s.blockPlanPhase(flow.FlowID, phaseID, errText, errText)
+	}
+
+	return result, nil
 }
 
 func (s FlowStarter) runBootstrap(repoPath string, worktree actions.FlowWorktreeCreateResult) error {

--- a/model/flow_start_test.go
+++ b/model/flow_start_test.go
@@ -150,6 +150,87 @@ func TestFlowStarterStartPlanRequiresCreateFlow(t *testing.T) {
 	}
 }
 
+func TestFlowStarterPrepareFlowCreatesLaunchableFlowWithoutLaunchID(t *testing.T) {
+	var calls []string
+	var created flowstore.FlowRecord
+	var startUpdate flowstore.StartMetadataUpdate
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			calls = append(calls, "create-flow")
+			created = record
+			record.FlowID = "flow-1"
+			record.Phases = []flowstore.FlowPhase{{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseReady}}
+			return record, nil
+		},
+		CreateWorktree: func(repoPath, title, baseRef string) (actions.FlowWorktreeCreateResult, error) {
+			calls = append(calls, "create-worktree")
+			return actions.FlowWorktreeCreateResult{WorktreePath: "/dev/alpha-worktrees/flow-parked", Branch: "flow/parked"}, nil
+		},
+		ResolveCommit: func(path string) string {
+			calls = append(calls, "resolve-commit")
+			return "abc123"
+		},
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			calls = append(calls, "set-start")
+			startUpdate = update
+			return flowstore.FlowRecord{
+				FlowID:       update.FlowID,
+				Title:        "Parked Flow",
+				Instructions: "Plan later",
+				RepoPath:     "/dev/alpha",
+				WorktreePath: update.WorktreePath,
+				Branch:       update.Branch,
+				BaseRef:      update.BaseRef,
+				Commit:       update.Commit,
+				Phases:       []flowstore.FlowPhase{{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseReady}},
+			}, nil
+		},
+		AddPhaseLaunchID: func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			t.Fatal("PrepareFlow should not allocate a launch ID")
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+
+	result, err := starter.PrepareFlow(model.FlowStartRequest{
+		RepoPath:     "/dev/alpha",
+		Title:        "Parked Flow",
+		Instructions: "Plan later",
+		BaseRef:      "main",
+	})
+	if err != nil {
+		t.Fatalf("PrepareFlow returned error: %v", err)
+	}
+
+	if strings.Join(calls, ",") != "create-flow,create-worktree,resolve-commit,set-start" {
+		t.Fatalf("call order = %#v", calls)
+	}
+	if created.Title != "Parked Flow" || created.Instructions != "Plan later" || created.RepoPath != "/dev/alpha" || created.BaseRef != "main" {
+		t.Fatalf("created record = %#v", created)
+	}
+	if startUpdate.FlowID != "flow-1" ||
+		startUpdate.WorktreePath != "/dev/alpha-worktrees/flow-parked" ||
+		startUpdate.Branch != "flow/parked" ||
+		startUpdate.BaseRef != "main" ||
+		startUpdate.Commit != "abc123" {
+		t.Fatalf("start update = %#v", startUpdate)
+	}
+	if result.Flow.FlowID != "flow-1" ||
+		result.Flow.WorktreePath != "/dev/alpha-worktrees/flow-parked" ||
+		result.Flow.Branch != "flow/parked" ||
+		result.Flow.Commit != "abc123" ||
+		result.LaunchID != "" ||
+		result.LaunchContext.FlowID != "" {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(result.Flow.Phases) != 1 ||
+		result.Flow.Phases[0].PhaseID != "plan" ||
+		result.Flow.Phases[0].Status != flowstore.PhaseReady ||
+		len(result.Flow.Phases[0].LaunchIDs) != 0 {
+		t.Fatalf("plan phase = %#v", result.Flow.Phases)
+	}
+}
+
 func TestFlowStarterStartPlanUsesConfiguredPromptTemplate(t *testing.T) {
 	starter := model.NewFlowStarter(model.FlowStarterOptions{
 		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {

--- a/model/model.go
+++ b/model/model.go
@@ -102,6 +102,7 @@ type Model struct {
 	readTranscript             func(sessions.Provider, string) ([]sessions.TranscriptEvent, error)
 	listPlans                  func(planstore.PlanFilter) ([]planstore.PlanRecord, error)
 	listFlows                  func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error)
+	createFlow                 func(FlowStartRequest) (FlowStartResult, error)
 	startFlowPlan              func(FlowStartRequest) (FlowStartResult, error)
 	setFlowPhase               func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
 	setFlowAutoMode            func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
@@ -183,6 +184,7 @@ type Options struct {
 	ReadTranscript           func(sessions.Provider, string) ([]sessions.TranscriptEvent, error)
 	ListPlans                func(planstore.PlanFilter) ([]planstore.PlanRecord, error)
 	ListFlows                func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error)
+	CreateFlow               func(FlowStartRequest) (FlowStartResult, error)
 	StartFlowPlan            func(FlowStartRequest) (FlowStartResult, error)
 	SetFlowPhase             func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
 	SetFlowAutoMode          func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
@@ -354,8 +356,9 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if runBootstrapHook == nil {
 		runBootstrapHook = actions.RunBootstrapHook
 	}
+	createFlowForRepo := opts.CreateFlow
 	startFlowPlan := opts.StartFlowPlan
-	if startFlowPlan == nil {
+	if createFlowForRepo == nil || startFlowPlan == nil {
 		root := opts.SessionStateRoot
 		createFlow := func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
 			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
@@ -383,7 +386,12 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 			NewLaunchID:          newLaunchID,
 			FlowPromptTemplates:  opts.FlowPromptTemplates,
 		})
-		startFlowPlan = starter.StartPlan
+		if createFlowForRepo == nil {
+			createFlowForRepo = starter.PrepareFlow
+		}
+		if startFlowPlan == nil {
+			startFlowPlan = starter.StartPlan
+		}
 	}
 	finalizeAgentSession := opts.FinalizeAgentSession
 	if finalizeAgentSession == nil {
@@ -419,6 +427,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		readTranscript:           readTranscript,
 		listPlans:                listPlans,
 		listFlows:                listFlows,
+		createFlow:               createFlowForRepo,
 		startFlowPlan:            startFlowPlan,
 		setFlowPhase:             setFlowPhase,
 		setFlowAutoMode:          setFlowAutoMode,
@@ -1221,6 +1230,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return next, tea.Batch(fetchCmd, launchCmd)
 		}
 		return next, launchCmd
+	case FlowCreatedMsg:
+		return m.handleFlowCreated(msg)
 	case FlowCreateFailedMsg:
 		return m.handleFlowCreateFailed(msg)
 	case AgentResultMsg:

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -486,9 +486,25 @@ func (m Model) createFlowAndLaunchPlanForRepo(repoPath, title, instructions, bas
 			PlanPhaseStatus:  flowstore.PhaseRunning,
 		})
 		if err != nil {
-			return FlowCreateFailedMsg{RepoPath: repoPath, Title: title, Err: err.Error()}
+			return FlowCreateFailedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title, Err: err.Error()}
 		}
 		return flowPlanLaunchMessage(result.LaunchContext, headless)
+	}
+}
+
+func (m Model) createFlowForRepo(repoPath, title, instructions, baseRef string) tea.Cmd {
+	return func() tea.Msg {
+		result, err := m.createFlow(FlowStartRequest{
+			RepoPath:     repoPath,
+			Title:        title,
+			Instructions: instructions,
+			BaseRef:      baseRef,
+			PlanPhaseID:  flowPlanPhaseID,
+		})
+		if err != nil {
+			return FlowCreateFailedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title, Err: err.Error()}
+		}
+		return FlowCreatedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title}
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -8269,19 +8269,21 @@ func TestModel_NewFlowOpensSingleCreationForm(t *testing.T) {
 	if form.FocusIndex != 0 {
 		t.Fatalf("focus index = %d, want title field", form.FocusIndex)
 	}
-	if len(form.Fields) != 4 {
-		t.Fatalf("fields = %#v, want title, instructions, base ref, headless", form.Fields)
+	if len(form.Fields) != 5 {
+		t.Fatalf("fields = %#v, want title, instructions, base ref, headless, plan now", form.Fields)
 	}
 	want := []struct {
 		id          string
 		kind        ui.FormFieldKind
 		label       string
 		placeholder string
+		checked     bool
 	}{
 		{id: "title", kind: ui.FormText, label: "Title", placeholder: ui.FlowTitleInputPlaceholder},
 		{id: "instructions", kind: ui.FormMultilineText, label: "Instructions", placeholder: ui.FlowInstructionsInputPlaceholder},
 		{id: "base-ref", kind: ui.FormText, label: "Base ref", placeholder: ui.FlowBaseRefInputPlaceholder},
 		{id: "headless", kind: ui.FormCheckbox, label: "Headless"},
+		{id: "plan-now", kind: ui.FormCheckbox, label: "Plan Now", checked: true},
 	}
 	for i, wantField := range want {
 		field := form.Fields[i]
@@ -8289,8 +8291,8 @@ func TestModel_NewFlowOpensSingleCreationForm(t *testing.T) {
 			t.Fatalf("field %d = %#v, want %#v", i, field, wantField)
 		}
 		if field.Kind == ui.FormCheckbox {
-			if field.Checked {
-				t.Fatalf("field %d initial checked = true, want false", i)
+			if field.Checked != wantField.checked {
+				t.Fatalf("field %d initial checked = %v, want %v", i, field.Checked, wantField.checked)
 			}
 			continue
 		}
@@ -8428,6 +8430,85 @@ func TestModel_NewFlowDelegatesStartAndLaunchesPlanAgent(t *testing.T) {
 				t.Fatalf("flow terminal view missing agent output:\n%s", view)
 			}
 		})
+	}
+}
+
+func TestModel_NewFlowPlanNowOffCreatesFlowWithoutLaunch(t *testing.T) {
+	var createRequest model.FlowStartRequest
+	embeddedCalls := 0
+	externalCalls := 0
+	listed := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+			createRequest = req
+			return model.FlowStartResult{Flow: flowstore.FlowRecord{
+				FlowID:       "flow-parked",
+				Title:        req.Title,
+				Instructions: req.Instructions,
+				RepoPath:     req.RepoPath,
+				WorktreePath: "/dev/alpha-worktrees/flow-parked",
+				Branch:       "flow/parked",
+				Commit:       "abc123",
+				Phases:       []flowstore.FlowPhase{{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseReady}},
+			}}, nil
+		},
+		StartFlowPlan: func(model.FlowStartRequest) (model.FlowStartResult, error) {
+			t.Fatal("Plan Now off should not start the plan phase")
+			return model.FlowStartResult{}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			externalCalls++
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			embeddedCalls++
+			return &fakeEmbeddedTerminal{}, nil
+		},
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			listed = true
+			if filter.RepoPath != "/dev/alpha" {
+				t.Fatalf("flow filter = %#v", filter)
+			}
+			return []flowstore.FlowRecord{{FlowID: "flow-parked", RepoPath: filter.RepoPath, Title: "Parked Flow"}}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+
+	m, cmd := submitNewFlowPromptsWithCreateOptions(t, m, "Parked Flow", "Plan later", "main", true, false)
+	if cmd == nil {
+		t.Fatal("expected flow creation command")
+	}
+	msg := cmd()
+	created, ok := msg.(model.FlowCreatedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want FlowCreatedMsg", msg)
+	}
+	if created.Request == 0 {
+		t.Fatal("created message should be tagged with active create request")
+	}
+	m, cmd = update(m, created)
+	if cmd == nil {
+		t.Fatal("expected flow refresh command after parked Flow creation")
+	}
+	_ = cmd()
+
+	if createRequest.RepoPath != "/dev/alpha" ||
+		createRequest.Title != "Parked Flow" ||
+		createRequest.Instructions != "Plan later" ||
+		createRequest.BaseRef != "main" ||
+		createRequest.AgentCommand != "" ||
+		createRequest.PlanPhaseStatus != "" {
+		t.Fatalf("create request = %#v", createRequest)
+	}
+	if embeddedCalls != 0 || externalCalls != 0 {
+		t.Fatalf("Plan Now off should not launch; embedded=%d external=%d", embeddedCalls, externalCalls)
+	}
+	if got := model.ActiveFlowCreateForTest(m); got != 0 {
+		t.Fatalf("active create request = %d, want cleared", got)
+	}
+	if !listed {
+		t.Fatal("expected Flow surface refresh")
 	}
 }
 
@@ -8930,7 +9011,55 @@ func TestModel_NewFlowStaleLaunchIgnoredAfterRepoChange(t *testing.T) {
 	}
 }
 
-func TestModel_NewFlowWarnsWhenNoAgentConfigured(t *testing.T) {
+func TestModel_NewFlowStaleParkedCreateIgnoredAfterRepoChange(t *testing.T) {
+	listCalls := 0
+	m := model.NewWithOptions(testRepos(), model.Options{
+		CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+			if req.RepoPath != "/dev/alpha" {
+				t.Fatalf("CreateFlow repo = %q, want /dev/alpha", req.RepoPath)
+			}
+			return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "flow-parked", RepoPath: req.RepoPath, Title: req.Title}}, nil
+		},
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			listCalls++
+			return nil, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			t.Fatal("stale parked Flow creation should not launch an external agent")
+			return actions.TerminalLaunchSpec{}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			t.Fatal("stale parked Flow creation should not start an embedded terminal")
+			return &fakeEmbeddedTerminal{}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+
+	m, createCmd := submitNewFlowPromptsWithCreateOptions(t, m, "Stale Parked", "Plan later", "main", false, false)
+	if createCmd == nil {
+		t.Fatal("expected parked Flow creation command")
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	staleMsg := createCmd()
+	if created, ok := staleMsg.(model.FlowCreatedMsg); !ok || created.Request == 0 {
+		t.Fatalf("creation command returned %#v, want tagged FlowCreatedMsg", staleMsg)
+	}
+	next, cmd := update(m, staleMsg)
+	if cmd != nil {
+		t.Fatalf("stale parked create returned command %T, want nil", cmd)
+	}
+	if got := model.ActiveFlowCreateForTest(next); got == 0 {
+		t.Fatal("stale parked create should leave current create request untouched")
+	}
+	if listCalls != 0 {
+		t.Fatalf("list calls = %d, want stale result ignored", listCalls)
+	}
+}
+
+func TestModel_NewFlowPlanNowOnRequiresAgentAtSubmit(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{})
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
@@ -8940,11 +9069,52 @@ func TestModel_NewFlowWarnsWhenNoAgentConfigured(t *testing.T) {
 	if cmd != nil {
 		t.Fatalf("expected no command, got %T", cmd)
 	}
-	if m.Overlay() != ui.OverlayNone {
-		t.Fatalf("overlay = %d, want none", m.Overlay())
+	if m.Overlay() != ui.OverlayForm {
+		t.Fatalf("overlay = %d, want form", m.Overlay())
+	}
+
+	m = fillNewFlowForm(t, m, "Needs Agent", "Plan now", "main")
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("submit without agent returned command %T, want nil", cmd)
+	}
+	if m.Overlay() != ui.OverlayForm {
+		t.Fatalf("overlay after validation = %d, want form", m.Overlay())
 	}
 	if !strings.Contains(m.View(), "Press A to choose") {
-		t.Fatalf("expected missing-agent warning in view:\n%s", m.View())
+		t.Fatalf("expected missing-agent guidance in form:\n%s", m.View())
+	}
+}
+
+func TestModel_NewFlowPlanNowOffAllowsNoAgentConfigured(t *testing.T) {
+	var createRequest model.FlowStartRequest
+	m := model.NewWithOptions(testRepos(), model.Options{
+		CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+			createRequest = req
+			return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "flow-parked", RepoPath: req.RepoPath, Title: req.Title}}, nil
+		},
+		StartFlowPlan: func(model.FlowStartRequest) (model.FlowStartResult, error) {
+			t.Fatal("Plan Now off should not validate or start an agent")
+			return model.FlowStartResult{}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+
+	m, cmd := submitNewFlowPromptsWithCreateOptions(t, m, "No Agent Parked", "Plan later", "main", false, false)
+	if cmd == nil {
+		t.Fatal("expected parked Flow creation command")
+	}
+	msg := cmd()
+	created, ok := msg.(model.FlowCreatedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want FlowCreatedMsg", msg)
+	}
+	if created.FlowID != "flow-parked" {
+		t.Fatalf("created FlowID = %q, want flow-parked", created.FlowID)
+	}
+	if createRequest.AgentCommand != "" || createRequest.ReasoningEffort != "" {
+		t.Fatalf("create request should not include agent settings: %#v", createRequest)
 	}
 }
 
@@ -9337,9 +9507,18 @@ func submitNewFlowPrompts(t *testing.T, m model.Model, title, instructions, base
 
 func submitNewFlowPromptsWithOptions(t *testing.T, m model.Model, title, instructions, baseRef string, headless bool) (model.Model, tea.Cmd) {
 	t.Helper()
+	return submitNewFlowPromptsWithCreateOptions(t, m, title, instructions, baseRef, headless, true)
+}
+
+func submitNewFlowPromptsWithCreateOptions(t *testing.T, m model.Model, title, instructions, baseRef string, headless, planNow bool) (model.Model, tea.Cmd) {
+	t.Helper()
 	m = openNewFlowForm(t, m, title, instructions, baseRef)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 	if headless {
-		m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeySpace})
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if !planNow {
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeySpace})
 	}
 	return update(m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -9351,6 +9530,11 @@ func openNewFlowForm(t *testing.T, m model.Model, title, instructions, baseRef s
 	if m.Overlay() != ui.OverlayForm {
 		t.Fatalf("overlay = %d, want new Flow form", m.Overlay())
 	}
+	return fillNewFlowForm(t, m, title, instructions, baseRef)
+}
+
+func fillNewFlowForm(t *testing.T, m model.Model, title, instructions, baseRef string) model.Model {
+	t.Helper()
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(title)})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 	lines := strings.Split(instructions, "\n")

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -201,6 +201,11 @@ func tagFlowCreateRequest(cmd tea.Cmd, request uint64) tea.Cmd {
 				msg.Request = request
 			}
 			return msg
+		case FlowCreatedMsg:
+			if msg.Request == 0 {
+				msg.Request = request
+			}
+			return msg
 		case FlowCreateFailedMsg:
 			if msg.Request == 0 {
 				msg.Request = request
@@ -1086,6 +1091,7 @@ const (
 	flowCreateInstructionsField = "instructions"
 	flowCreateBaseRefField      = "base-ref"
 	flowCreateHeadlessField     = "headless"
+	flowCreatePlanNowField      = "plan-now"
 )
 
 func (m Model) handleNewRepo() (tea.Model, tea.Cmd) {
@@ -1218,10 +1224,6 @@ func (m Model) handleNewFlow() (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	if m.agentCommand == "" {
-		m = m.setStatus(statusOther, "Press A to choose "+ui.AgentInputPlaceholder+" before launching a flow")
-		return m, nil
-	}
 	m.modal = modal.OpenForm(modal.FormSpec{
 		Purpose: flowCreateFormPurpose,
 		Title:   "New flow",
@@ -1230,9 +1232,20 @@ func (m Model) handleNewFlow() (tea.Model, tea.Cmd) {
 			{ID: flowCreateInstructionsField, Kind: modal.FormMultilineText, Label: "Instructions", Placeholder: ui.FlowInstructionsInputPlaceholder},
 			{ID: flowCreateBaseRefField, Kind: modal.FormText, Label: "Base ref", Placeholder: ui.FlowBaseRefInputPlaceholder},
 			{ID: flowCreateHeadlessField, Kind: modal.FormCheckbox, Label: "Headless", Checked: false},
+			{ID: flowCreatePlanNowField, Kind: modal.FormCheckbox, Label: "Plan Now", Checked: true},
 		},
-		Validate: validateFlowCreateForm,
+		Validate: func(values modal.FormValues) error {
+			return m.validateFlowCreateForm(values)
+		},
 		Submit: func(values modal.FormValues) tea.Cmd {
+			if !values.Checked[flowCreatePlanNowField] {
+				return m.createFlowForRepo(
+					repoPath,
+					values.Text[flowCreateTitleField],
+					values.Text[flowCreateInstructionsField],
+					values.Text[flowCreateBaseRefField],
+				)
+			}
 			return m.createFlowAndLaunchPlanForRepo(
 				repoPath,
 				values.Text[flowCreateTitleField],
@@ -1261,6 +1274,22 @@ func (m Model) handleFlowCreateFailed(msg FlowCreateFailedMsg) (Model, tea.Cmd) 
 	return m, nil
 }
 
+func (m Model) handleFlowCreated(msg FlowCreatedMsg) (Model, tea.Cmd) {
+	if !m.isCurrentRepo(msg.RepoPath) || (msg.Request != 0 && !m.isCurrentFlowCreateRequest(msg.Request)) {
+		return m, nil
+	}
+	m = m.clearFlowCreateRequest(msg.Request)
+	title := strings.TrimSpace(msg.Title)
+	if title == "" {
+		title = "Flow"
+	}
+	m = m.setStatus(statusOther, "Created flow: "+title)
+	if m.flowSurfaceVisible() {
+		return m.startFlowSurfaceFetch()
+	}
+	return m, nil
+}
+
 func validateFlowCreateForm(values modal.FormValues) error {
 	if err := validateFlowTitleInput(values.Text[flowCreateTitleField]); err != nil {
 		return err
@@ -1269,6 +1298,16 @@ func validateFlowCreateForm(values modal.FormValues) error {
 		return err
 	}
 	return validateFlowBaseRefInput(values.Text[flowCreateBaseRefField])
+}
+
+func (m Model) validateFlowCreateForm(values modal.FormValues) error {
+	if err := validateFlowCreateForm(values); err != nil {
+		return err
+	}
+	if values.Checked[flowCreatePlanNowField] && m.agentCommand == "" {
+		return fmt.Errorf("Press A to choose %s before launching a flow", ui.AgentInputPlaceholder)
+	}
+	return nil
 }
 
 func validateWorktreeInput(input string) error {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -362,8 +362,16 @@ type FlowEmbeddedLaunchRequestedMsg struct {
 	Request       uint64
 }
 
+type FlowCreatedMsg struct {
+	RepoPath string
+	FlowID   string
+	Title    string
+	Request  uint64
+}
+
 type FlowCreateFailedMsg struct {
 	RepoPath string
+	FlowID   string
 	Title    string
 	Err      string
 	Request  uint64


### PR DESCRIPTION
## Summary
- Add a default-on Plan Now checkbox to the new Flow form.
- When Plan Now is off, create a parked Flow with the initial prompt saved without launching the Plan phase.
- Preserve manual Plan launch behavior for parked Flows and keep new Flow Headless default-on after syncing with main.

## Verification
- gofmt -l .
- make test
- make build