### PR TITLE
Default new flows to auto mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,8 @@ attached provider session to resume that session; CLI resumes are recorded as a
 fresh Flow phase launch attempt, while `codex-app` resumes navigate to the
 existing app thread without extra launch tracking. Press `m` on a Flow row or
 expanded phase row to toggle per-Flow auto mode, which is on by default for new
-Flows and persisted on that Flow record. When auto mode is on, a successful
+Flows and persisted on that Flow record. Flows created before this field existed
+remain manual until auto mode is toggled on. When auto mode is on, a successful
 completed phase transition launches the next ready non-merge phase in that same
 Flow through the same launch path as pressing `g`. For CLI phases running in an
 embedded Flow terminal, wtui waits until the completed phase's terminal exits

--- a/README.md
+++ b/README.md
@@ -349,10 +349,10 @@ of its expanded phase rows. Press `r` on an expanded phase row with an
 attached provider session to resume that session; CLI resumes are recorded as a
 fresh Flow phase launch attempt, while `codex-app` resumes navigate to the
 existing app thread without extra launch tracking. Press `m` on a Flow row or
-expanded phase row to toggle per-Flow auto mode, which is off by default and
-persisted on that Flow record. When auto mode is on, a successful completed
-phase transition launches the next ready non-merge phase in that same Flow
-through the same launch path as pressing `g`. For CLI phases running in an
+expanded phase row to toggle per-Flow auto mode, which is on by default for new
+Flows and persisted on that Flow record. When auto mode is on, a successful
+completed phase transition launches the next ready non-merge phase in that same
+Flow through the same launch path as pressing `g`. For CLI phases running in an
 embedded Flow terminal, wtui waits until the completed phase's terminal exits
 normally and auto-closes before launching the next phase; that exit also
 triggers a Flow refresh so completions recorded after the last refresh are

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -348,6 +348,7 @@ func TestRunFlowCreatePrintsJSONRecord(t *testing.T) {
 		record.Branch != "flow/add-flow-mode" ||
 		record.BaseRef != "main" ||
 		record.Status != flowstore.StatusPending ||
+		!record.AutoMode ||
 		len(record.Phases) != 7 {
 		t.Fatalf("unexpected flow record: %#v", record)
 	}

--- a/docs/config.md
+++ b/docs/config.md
@@ -322,12 +322,13 @@ phase row, `enter` expands or collapses read-only phase detail rows; `o` opens
 the linked plan body from the selected Flow. Press `g` to launch the first
 launchable phase for the selected Flow. Press `y` to copy the selected Flow
 worktree path from either a Flow row or one of its expanded phase rows. Press
-`m` to toggle per-Flow auto mode. When auto mode is on, completed CLI phases
-running in an embedded Flow terminal advance only after the completed phase's
-terminal exits normally and auto-closes; terminal exit also triggers a Flow
-refresh so newly persisted completion state is discovered without waiting for
-unrelated UI activity. Auto mode still skips non-completed outcomes and stops
-before Merge.
+`m` to toggle per-Flow auto mode. New Flow records start with auto mode on, and
+the toggle is persisted on each Flow. When auto mode is on, completed CLI
+phases running in an embedded Flow terminal advance only after the completed
+phase's terminal exits normally and auto-closes; terminal exit also triggers a
+Flow refresh so newly persisted completion state is discovered without waiting
+for unrelated UI activity. Auto mode still skips non-completed outcomes and
+stops before Merge.
 Press `F3` from any middle-pane view to keep the current numbered mode selected
 while showing active Flows across all repos. This active view hides merged Flow
 records; moving focus to the left repo pane temporarily filters the visible

--- a/docs/config.md
+++ b/docs/config.md
@@ -323,12 +323,13 @@ the linked plan body from the selected Flow. Press `g` to launch the first
 launchable phase for the selected Flow. Press `y` to copy the selected Flow
 worktree path from either a Flow row or one of its expanded phase rows. Press
 `m` to toggle per-Flow auto mode. New Flow records start with auto mode on, and
-the toggle is persisted on each Flow. When auto mode is on, completed CLI
-phases running in an embedded Flow terminal advance only after the completed
+the toggle is persisted on each Flow. Flows created before this field existed
+remain manual until auto mode is toggled on. When auto mode is on, completed
+CLI phases running in an embedded Flow terminal advance only after the completed
 phase's terminal exits normally and auto-closes; terminal exit also triggers a
 Flow refresh so newly persisted completion state is discovered without waiting
 for unrelated UI activity. Auto mode still skips non-completed outcomes and
-stops before Merge.
+stops before Merge; Merge still requires a manual launch.
 Press `F3` from any middle-pane view to keep the current numbered mode selected
 while showing active Flows across all repos. This active view hides merged Flow
 records; moving focus to the left repo pane temporarily filters the visible

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -292,6 +292,8 @@ func DefaultRoot() (string, error) {
 }
 
 // Create writes a new flow record with the default Flow phase graph.
+// New records always start with auto mode enabled; callers that need manual
+// mode should create the Flow, then opt out with SetAutoMode(false).
 func (s *Store) Create(record FlowRecord) (FlowRecord, error) {
 	if strings.TrimSpace(record.Title) == "" {
 		return FlowRecord{}, fmt.Errorf("flow title is required")

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -329,6 +329,7 @@ func (s *Store) Create(record FlowRecord) (FlowRecord, error) {
 	record.SchemaVersion = schemaVersion
 	record.CreatedAt = defaultTime(record.CreatedAt, now)
 	record.UpdatedAt = defaultTime(record.UpdatedAt, now)
+	record.AutoMode = true
 	if len(record.Phases) == 0 {
 		record.Phases = defaultPhases(record.CreatedAt, record.UpdatedAt)
 	}

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -133,6 +133,54 @@ func TestStoreCreateDefaultsAutoModeOnEvenWhenCallerPassesFalse(t *testing.T) {
 	}
 }
 
+func TestStoreSetAutoModeDisablesNewlyCreatedFlow(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Manual Follow Up",
+		Instructions: "Let the user opt out after creation.",
+		RepoPath:     repoPath,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if !record.AutoMode {
+		t.Fatal("Create().AutoMode = false, want new flow to start with auto mode enabled")
+	}
+
+	updated, err := store.SetAutoMode(flowstore.AutoModeUpdate{
+		FlowID:  record.FlowID,
+		Enabled: false,
+	})
+	if err != nil {
+		t.Fatalf("SetAutoMode(false) error = %v", err)
+	}
+	if updated.AutoMode {
+		t.Fatalf("SetAutoMode(false).AutoMode = true: %#v", updated)
+	}
+
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.AutoMode {
+		t.Fatalf("Read().AutoMode = true after disable: %#v", read)
+	}
+
+	records, err := store.List(flowstore.FlowFilter{RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(records) != 1 || records[0].AutoMode {
+		t.Fatalf("List() = %#v, want one disabled flow", records)
+	}
+}
+
 func TestStoreReadPreservesLegacyOmittedAutoModeAsDisabled(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -51,6 +51,9 @@ func TestStoreCreatePersistsDefaultFlowRecord(t *testing.T) {
 	if record.SchemaVersion != 1 {
 		t.Fatalf("SchemaVersion = %d, want 1", record.SchemaVersion)
 	}
+	if !record.AutoMode {
+		t.Fatal("AutoMode = false, want new flows to default to auto mode enabled")
+	}
 	if record.CreatedAt != now || record.UpdatedAt != now {
 		t.Fatalf("timestamps = %s/%s, want %s", record.CreatedAt, record.UpdatedAt, now)
 	}
@@ -77,7 +80,8 @@ func TestStoreCreatePersistsDefaultFlowRecord(t *testing.T) {
 		read.WorktreePath != filepath.Join(root, "repo-worktrees", "flow-add-flow-mode") ||
 		read.Branch != "flow/add-flow-mode" ||
 		read.BaseRef != "main" ||
-		read.Commit != "abc123" {
+		read.Commit != "abc123" ||
+		!read.AutoMode {
 		t.Fatalf("record did not round-trip: %#v", read)
 	}
 
@@ -104,6 +108,94 @@ func TestStoreCreatePersistsDefaultFlowRecord(t *testing.T) {
 	}
 	if dirInfo.Mode().Perm() != 0o700 {
 		t.Fatalf("flow dir mode = %o, want 0700", dirInfo.Mode().Perm())
+	}
+}
+
+func TestStoreCreateDefaultsAutoModeOnEvenWhenCallerPassesFalse(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Default Automation",
+		Instructions: "Start the pipeline.",
+		RepoPath:     filepath.Join(root, "repo"),
+		AutoMode:     false,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if !record.AutoMode {
+		t.Fatal("AutoMode = false, want Create to default every new flow to auto mode enabled")
+	}
+}
+
+func TestStoreReadPreservesLegacyOmittedAutoModeAsDisabled(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{
+		Root: root,
+		Now:  func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	flowID := "20260607T120000Z-legacy-flow"
+	meta := filepath.Join(root, "flows", flowID, "meta.json")
+	if err := os.MkdirAll(filepath.Dir(meta), 0o700); err != nil {
+		t.Fatalf("create legacy flow dir: %v", err)
+	}
+	legacy := map[string]any{
+		"schema_version": 1,
+		"flow_id":        flowID,
+		"title":          "Legacy Flow",
+		"instructions":   "Existing automation preference should stay off.",
+		"status":         flowstore.StatusPending,
+		"repo_path":      repoPath,
+		"merge": map[string]any{
+			"status": flowstore.MergePending,
+		},
+		"phases": []map[string]any{
+			{
+				"phase_id":   "plan",
+				"title":      "Plan",
+				"kind":       "plan",
+				"status":     flowstore.PhaseReady,
+				"order":      1,
+				"created_at": now.Format(time.RFC3339Nano),
+				"updated_at": now.Format(time.RFC3339Nano),
+			},
+		},
+		"created_at": now.Format(time.RFC3339Nano),
+		"updated_at": now.Format(time.RFC3339Nano),
+	}
+	data, err := json.MarshalIndent(legacy, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal legacy record: %v", err)
+	}
+	if err := os.WriteFile(meta, data, 0o600); err != nil {
+		t.Fatalf("write legacy meta.json: %v", err)
+	}
+
+	read, err := store.Read(flowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.AutoMode {
+		t.Fatalf("Read().AutoMode = true for legacy omitted field: %#v", read)
+	}
+
+	records, err := store.List(flowstore.FlowFilter{RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(records) != 1 || records[0].AutoMode {
+		t.Fatalf("List() = %#v, want one legacy flow with auto mode disabled", records)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Default newly created Flows to auto mode so generated Flow records start with automation enabled.
- Document the new default and clarify how to disable auto mode from the CLI.
- Add coverage for persisted auto-mode defaults and explicit override behavior.

## Implementation
- Applies the default in `flowstore.Store.Create` when `AutoMode` is omitted.
- Extends flow creation and store tests around default, enabled, and disabled auto-mode paths.
- Updates README and config docs to describe the default behavior.

## Verification
- `gofmt -l .`
- `make test`
- `make build`