### PR TITLE
Fix right-pane Backspace navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ WORKTREE_ROOT=~/projects ./bin/wtui
 The UI has two panes: repos on the left, content on the right. Press `enter`
 or `tab` on a selected repo to focus the content pane, and press `f2` to switch
 pane focus explicitly. Left-pane shortcut hints show `f2/tab` for pane focus
-because `tab` is the left-to-content shortcut; right-pane hints show `f2` unless
-Flow list-specific navigation is available. When a Flow embedded terminal is
-open, `tab` switches focus between the Flow list and that terminal while the
-right pane remains active.
+because `tab` is the left-to-content shortcut; right-pane hints show `bksp`
+for returning to the repo pane. When a Flow embedded terminal is open, `tab`
+switches focus between the Flow list and that terminal while the right pane
+remains active.
 The active pane is highlighted with a blue border.
 
 **Destructive mode:** The app starts in read-only mode — deletion keys are disabled. Press `D` (Shift+D) to toggle destructive mode on/off. When active, the right pane border turns red and delete/drop hints appear in red as a visual warning.
@@ -113,8 +113,7 @@ filter matches, or a load failure with details in the status bar.
 | `e` | Edit selected plan Markdown (plans view) |
 | `i` | Alias for plan implementation launch |
 | `D` | Toggle destructive mode |
-| `f2` | Switch focus to left pane |
-| `bksp` | Switch focus to left pane |
+| `f2`/`bksp` | Switch focus to left pane |
 | `q`/`esc` | Close a prompt/dialog or quit |
 
 The right pane header shows the active mode. Press `1`–`8` or use arrow keys to

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ filter matches, or a load failure with details in the status bar.
 | `i` | Alias for plan implementation launch |
 | `D` | Toggle destructive mode |
 | `f2` | Switch focus to left pane |
-| `⌫` | Switch focus to left pane from the Flow list |
+| `bksp` | Switch focus to left pane |
 | `q`/`esc` | Close a prompt/dialog or quit |
 
 The right pane header shows the active mode. Press `1`–`8` or use arrow keys to
@@ -123,7 +123,7 @@ and flows. Arrow-key view switching clamps at worktrees and flows. Press `V` to
 choose which numbered view wtui opens on future launches; leaving it unset keeps
 the built-in startup default of Flows. Press `enter` or `tab` from the repo
 pane to focus the content pane, or `f2` to switch pane focus explicitly. In the
-Flow list, `⌫` switches focus back to the left repo pane.
+content pane, `bksp` switches focus back to the left repo pane.
 
 When the left repo pane is focused, press `f` to run `git fetch --prune` for
 the currently visible repos. Repo filtering limits the batch to the filtered

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -4542,39 +4542,49 @@ func TestModel_RKeyResumeCLIEmbeddedTerminalShowsTerminalView(t *testing.T) {
 	}
 }
 
-func TestModel_BackspaceForwardsWhenSessionTerminalOwnsKeys(t *testing.T) {
-	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
-	m := model.NewWithOptions(testRepos(), model.Options{
-		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
-			return fakeTerm, nil
-		},
-	})
-	m = inRightPane(m)
-	m, _ = update(m, tea.WindowSizeMsg{Width: 180, Height: 14})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
-	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{{
-		Provider:     sessions.ProviderCodex,
-		SessionID:    "codex-session-1",
-		RepoPath:     "/dev/alpha",
-		WorktreePath: "/dev/alpha-worktrees/feat",
-		CWD:          "/dev/alpha-worktrees/feat",
-		Branch:       "feature/api",
-	}}, ListRequest: m.ListRequest(ui.ModeSessions)})
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
-	if cmd == nil {
-		t.Fatal("embedded session resume should schedule terminal repaint ticks")
-	}
+func TestModel_BackKeysForwardWhenSessionTerminalOwnsKeys(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "backspace", key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{name: "ctrl-h", key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
+			m := model.NewWithOptions(testRepos(), model.Options{
+				StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+					return fakeTerm, nil
+				},
+			})
+			m = inRightPane(m)
+			m, _ = update(m, tea.WindowSizeMsg{Width: 180, Height: 14})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+			m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{{
+				Provider:     sessions.ProviderCodex,
+				SessionID:    "codex-session-1",
+				RepoPath:     "/dev/alpha",
+				WorktreePath: "/dev/alpha-worktrees/feat",
+				CWD:          "/dev/alpha-worktrees/feat",
+				Branch:       "feature/api",
+			}}, ListRequest: m.ListRequest(ui.ModeSessions)})
+			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+			if cmd == nil {
+				t.Fatal("embedded session resume should schedule terminal repaint ticks")
+			}
 
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
+			m, cmd = update(m, tt.key)
 
-	if m.ActivePane() != 1 {
-		t.Fatalf("terminal-owned backspace activePane = %d, want right pane", m.ActivePane())
-	}
-	if cmd != nil {
-		t.Fatalf("terminal-owned backspace returned cmd %T, want nil", cmd)
-	}
-	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "\x7f" {
-		t.Fatalf("terminal input backspace writes = %#v, want delete byte", fakeTerm.writes)
+			if m.ActivePane() != 1 {
+				t.Fatalf("terminal-owned %s activePane = %d, want right pane", tt.name, m.ActivePane())
+			}
+			if cmd != nil {
+				t.Fatalf("terminal-owned %s returned cmd %T, want nil", tt.name, cmd)
+			}
+			if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "\x7f" {
+				t.Fatalf("terminal input %s writes = %#v, want delete byte", tt.name, fakeTerm.writes)
+			}
+		})
 	}
 }
 

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -4542,6 +4542,42 @@ func TestModel_RKeyResumeCLIEmbeddedTerminalShowsTerminalView(t *testing.T) {
 	}
 }
 
+func TestModel_BackspaceForwardsWhenSessionTerminalOwnsKeys(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
+	m := model.NewWithOptions(testRepos(), model.Options{
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return fakeTerm, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 180, Height: 14})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{{
+		Provider:     sessions.ProviderCodex,
+		SessionID:    "codex-session-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/feat",
+		CWD:          "/dev/alpha-worktrees/feat",
+		Branch:       "feature/api",
+	}}, ListRequest: m.ListRequest(ui.ModeSessions)})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("embedded session resume should schedule terminal repaint ticks")
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
+
+	if m.ActivePane() != 1 {
+		t.Fatalf("terminal-owned backspace activePane = %d, want right pane", m.ActivePane())
+	}
+	if cmd != nil {
+		t.Fatalf("terminal-owned backspace returned cmd %T, want nil", cmd)
+	}
+	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "\x7f" {
+		t.Fatalf("terminal input backspace writes = %#v, want delete byte", fakeTerm.writes)
+	}
+}
+
 func TestModel_EmbeddedTerminalViewRendersRealPTYOutput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("pty tests require a Unix-like platform")

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -6533,65 +6533,85 @@ func TestModel_BackspaceFromFlowListReturnsToLeftPaneAndClearsSelectedPhase(t *t
 	}
 }
 
-func TestModel_BackspaceFromActiveFlowsReturnsToLeftPaneAndClearsSelectedPhase(t *testing.T) {
-	flow := flowWithPhaseDetails()
-	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
-	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	for i := 0; i < 50 && model.SelectedActiveFlowPhaseIDForTest(m) != "implementation"; i++ {
-		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
-	}
-	if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "implementation" {
-		t.Fatalf("selected active Flow phase = %q, want implementation before backspace", got)
-	}
-	before := listRequests(m)
+func TestModel_BackKeysFromActiveFlowsReturnToLeftPaneAndClearSelectedPhase(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "backspace", key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{name: "ctrl-h", key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			flow := flowWithPhaseDetails()
+			m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+			m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+			for i := 0; i < 50 && model.SelectedActiveFlowPhaseIDForTest(m) != "implementation"; i++ {
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+			}
+			if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "implementation" {
+				t.Fatalf("selected active Flow phase = %q, want implementation before %s", got, tt.name)
+			}
+			before := listRequests(m)
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyBackspace})
+			m, cmd := update(m, tt.key)
 
-	if m.ActivePane() != 0 {
-		t.Fatalf("active pane = %d, want left pane after backspace", m.ActivePane())
+			if m.ActivePane() != 0 {
+				t.Fatalf("active pane = %d, want left pane after %s", m.ActivePane(), tt.name)
+			}
+			if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "" {
+				t.Fatalf("selected active Flow phase = %q, want cleared", got)
+			}
+			if cmd != nil {
+				t.Fatalf("%s from active Flow list returned cmd %T, want nil", tt.name, cmd)
+			}
+			assertListRequestsUnchanged(t, before, m)
+		})
 	}
-	if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "" {
-		t.Fatalf("selected active Flow phase = %q, want cleared", got)
-	}
-	if cmd != nil {
-		t.Fatalf("backspace from active Flow list returned cmd %T, want nil", cmd)
-	}
-	assertListRequestsUnchanged(t, before, m)
 }
 
-func TestModel_BackspaceForwardsWhenFlowTerminalInputOwnsKeys(t *testing.T) {
-	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
-	m := model.NewWithOptions(testRepos(), model.Options{
-		AgentCommand: "codex",
-		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
-			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
-		},
-		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
-			return fakeTerm, nil
-		},
-	})
-	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
-	m = selectFlowPhaseByID(t, m, "implementation")
-	m, cmd := update(m, flowLaunchKey())
-	if cmd == nil {
-		t.Fatal("g should prepare an embedded launch")
-	}
-	m, _ = update(m, cmd())
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+func TestModel_BackKeysForwardWhenFlowTerminalInputOwnsKeys(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "backspace", key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{name: "ctrl-h", key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
+			m := model.NewWithOptions(testRepos(), model.Options{
+				AgentCommand: "codex",
+				AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+					return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+				},
+				StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+					return fakeTerm, nil
+				},
+			})
+			m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
+			m = selectFlowPhaseByID(t, m, "implementation")
+			m, cmd := update(m, flowLaunchKey())
+			if cmd == nil {
+				t.Fatal("g should prepare an embedded launch")
+			}
+			m, _ = update(m, cmd())
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
 
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
+			m, cmd = update(m, tt.key)
 
-	if m.ActivePane() != 1 {
-		t.Fatalf("terminal-owned backspace activePane = %d, want right pane", m.ActivePane())
-	}
-	if cmd != nil {
-		t.Fatalf("terminal-owned backspace returned cmd %T, want nil", cmd)
-	}
-	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "\x7f" {
-		t.Fatalf("terminal input backspace writes = %#v, want delete byte", fakeTerm.writes)
+			if m.ActivePane() != 1 {
+				t.Fatalf("terminal-owned %s activePane = %d, want right pane", tt.name, m.ActivePane())
+			}
+			if cmd != nil {
+				t.Fatalf("terminal-owned %s returned cmd %T, want nil", tt.name, cmd)
+			}
+			if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "\x7f" {
+				t.Fatalf("terminal input %s writes = %#v, want delete byte", tt.name, fakeTerm.writes)
+			}
+		})
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -6504,7 +6504,7 @@ func TestModel_FlowTerminalFocusUsesPersistentCommandModeAndTabReturnsToList(t *
 	}
 }
 
-func TestModel_BackspaceFromFlowListReturnsToLeftPaneAndClearsSelectedPhase(t *testing.T) {
+func TestModel_BackKeysFromFlowListReturnToLeftPaneAndClearSelectedPhase(t *testing.T) {
 	for _, tt := range []struct {
 		name string
 		key  tea.KeyMsg

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -116,7 +116,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if (key == "backspace" || key == "ctrl+h") && m.activePane == 1 && m.flowSurfaceVisible() && m.flowFocus == flowFocusList {
+	if isPaneBackKey(key) && m.activePane == 1 {
 		m = m.togglePrimaryPaneFocus()
 		return m, nil
 	}
@@ -125,6 +125,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleLeftPaneKey(key)
 	}
 	return m.handleRightPaneKey(key)
+}
+
+func isPaneBackKey(key string) bool {
+	return key == "backspace" || key == "ctrl+h"
 }
 
 func isWorktreeCreateInput(view modal.View) bool {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -621,33 +621,43 @@ func TestModel_F2FromPlansPaneClearsSelectedPhase(t *testing.T) {
 	}
 }
 
-func TestModel_BackspaceFromPlansPaneClearsSelectedPhase(t *testing.T) {
-	m := plansInRightPane(t, model.New(testRepos()), []planstore.PlanRecord{{
-		PlanID:   "plan-1",
-		RepoPath: "/dev/alpha",
-		Title:    "Persist plans",
-		Status:   "draft",
-		Phases:   []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}},
-	}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
-	if got := m.SelectedPlanPhaseID(); got != "p1" {
-		t.Fatalf("selected plan phase = %q, want p1 before backspace", got)
-	}
+func TestModel_BackKeysFromPlansPaneClearSelectedPhase(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "backspace", key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{name: "ctrl-h", key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := plansInRightPane(t, model.New(testRepos()), []planstore.PlanRecord{{
+				PlanID:   "plan-1",
+				RepoPath: "/dev/alpha",
+				Title:    "Persist plans",
+				Status:   "draft",
+				Phases:   []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}},
+			}})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+			if got := m.SelectedPlanPhaseID(); got != "p1" {
+				t.Fatalf("selected plan phase = %q, want p1 before %s", got, tt.name)
+			}
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyBackspace})
+			m, cmd := update(m, tt.key)
 
-	if m.ActivePane() != 0 {
-		t.Fatalf("expected left pane after backspace, got %d", m.ActivePane())
-	}
-	if got := m.SelectedPlanPhaseID(); got != "" {
-		t.Fatalf("selected plan phase = %q, want cleared", got)
-	}
-	if m.Mode() != ui.ModePlans {
-		t.Fatalf("mode = %d, want unchanged plans", m.Mode())
-	}
-	if cmd != nil {
-		t.Fatalf("backspace from plans pane returned cmd %T, want nil", cmd)
+			if m.ActivePane() != 0 {
+				t.Fatalf("expected left pane after %s, got %d", tt.name, m.ActivePane())
+			}
+			if got := m.SelectedPlanPhaseID(); got != "" {
+				t.Fatalf("selected plan phase = %q, want cleared", got)
+			}
+			if m.Mode() != ui.ModePlans {
+				t.Fatalf("mode = %d, want unchanged plans", m.Mode())
+			}
+			if cmd != nil {
+				t.Fatalf("%s from plans pane returned cmd %T, want nil", tt.name, cmd)
+			}
+		})
 	}
 }
 
@@ -723,25 +733,35 @@ func TestModel_BackKeysEditRightPaneSearchInsteadOfSwitchingPanes(t *testing.T) 
 	}
 }
 
-func TestModel_BackspaceEditsModalInputInsteadOfSwitchingPanes(t *testing.T) {
-	m := model.New(testRepos())
-	m = inRightPane(m)
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
-	if cmd != nil {
-		t.Fatalf("opening worktree input produced cmd %T, want nil", cmd)
-	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f', 'e', 'a', 't'}})
+func TestModel_BackKeysEditModalInputInsteadOfSwitchingPanes(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		key  tea.KeyMsg
+	}{
+		{name: "backspace", key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{name: "ctrl-h", key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := model.New(testRepos())
+			m = inRightPane(m)
+			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+			if cmd != nil {
+				t.Fatalf("opening worktree input produced cmd %T, want nil", cmd)
+			}
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f', 'e', 'a', 't'}})
 
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
+			m, cmd = update(m, tt.key)
 
-	if cmd != nil {
-		t.Fatalf("modal backspace returned cmd %T, want nil", cmd)
-	}
-	if m.ActivePane() != 1 {
-		t.Fatalf("active pane = %d, want right pane while modal owns backspace", m.ActivePane())
-	}
-	if got := m.WorktreeInput(); got != "fea" {
-		t.Fatalf("worktree input = %q, want edited value", got)
+			if cmd != nil {
+				t.Fatalf("modal %s returned cmd %T, want nil", tt.name, cmd)
+			}
+			if m.ActivePane() != 1 {
+				t.Fatalf("active pane = %d, want right pane while modal owns %s", m.ActivePane(), tt.name)
+			}
+			if got := m.WorktreeInput(); got != "fea" {
+				t.Fatalf("worktree input = %q, want edited value", got)
+			}
+		})
 	}
 }
 

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -547,6 +547,53 @@ func TestModel_F2FromRightPaneSwitchesToLeftWithoutChangingMode(t *testing.T) {
 	}
 }
 
+func TestModel_BackspaceFromRightPaneSwitchesToLeftAcrossModes(t *testing.T) {
+	for _, tt := range []struct {
+		mode ui.Mode
+		key  tea.KeyMsg
+	}{
+		{mode: ui.ModeWorktrees, key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{mode: ui.ModeBranches, key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{mode: ui.ModeStashes, key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{mode: ui.ModeHistory, key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{mode: ui.ModeReflog, key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{mode: ui.ModeSessions, key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{mode: ui.ModePlans, key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{mode: ui.ModeFlows, key: tea.KeyMsg{Type: tea.KeyBackspace}},
+		{mode: ui.ModeWorktrees, key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+		{mode: ui.ModeBranches, key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+		{mode: ui.ModeStashes, key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+		{mode: ui.ModeHistory, key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+		{mode: ui.ModeReflog, key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+		{mode: ui.ModeSessions, key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+		{mode: ui.ModePlans, key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+		{mode: ui.ModeFlows, key: tea.KeyMsg{Type: tea.KeyCtrlH}},
+	} {
+		t.Run(fmt.Sprintf("mode_%d_%s", tt.mode, tt.key.String()), func(t *testing.T) {
+			m := model.New(testRepos())
+			m = inRightPane(m)
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(fmt.Sprint(int(tt.mode)))})
+			if m.ActivePane() != 1 || m.Mode() != tt.mode {
+				t.Fatalf("setup activePane=%d mode=%d, want right pane mode %d", m.ActivePane(), m.Mode(), tt.mode)
+			}
+			before := listRequests(m)
+
+			m, cmd := update(m, tt.key)
+
+			if m.ActivePane() != 0 {
+				t.Fatalf("active pane = %d, want left pane", m.ActivePane())
+			}
+			if m.Mode() != tt.mode {
+				t.Fatalf("mode = %d, want unchanged %d", m.Mode(), tt.mode)
+			}
+			if cmd != nil {
+				t.Fatalf("back key returned cmd %T, want nil", cmd)
+			}
+			assertListRequestsUnchanged(t, before, m)
+		})
+	}
+}
+
 func TestModel_F2FromPlansPaneClearsSelectedPhase(t *testing.T) {
 	m := plansInRightPane(t, model.New(testRepos()), []planstore.PlanRecord{{
 		PlanID:   "plan-1",
@@ -571,6 +618,36 @@ func TestModel_F2FromPlansPaneClearsSelectedPhase(t *testing.T) {
 	}
 	if m.Mode() != ui.ModePlans {
 		t.Fatalf("mode = %d, want unchanged plans", m.Mode())
+	}
+}
+
+func TestModel_BackspaceFromPlansPaneClearsSelectedPhase(t *testing.T) {
+	m := plansInRightPane(t, model.New(testRepos()), []planstore.PlanRecord{{
+		PlanID:   "plan-1",
+		RepoPath: "/dev/alpha",
+		Title:    "Persist plans",
+		Status:   "draft",
+		Phases:   []planstore.PlanPhase{{PhaseID: "p1", Title: "Tracer bullet", Status: "completed", Order: 1}},
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := m.SelectedPlanPhaseID(); got != "p1" {
+		t.Fatalf("selected plan phase = %q, want p1 before backspace", got)
+	}
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyBackspace})
+
+	if m.ActivePane() != 0 {
+		t.Fatalf("expected left pane after backspace, got %d", m.ActivePane())
+	}
+	if got := m.SelectedPlanPhaseID(); got != "" {
+		t.Fatalf("selected plan phase = %q, want cleared", got)
+	}
+	if m.Mode() != ui.ModePlans {
+		t.Fatalf("mode = %d, want unchanged plans", m.Mode())
+	}
+	if cmd != nil {
+		t.Fatalf("backspace from plans pane returned cmd %T, want nil", cmd)
 	}
 }
 
@@ -620,6 +697,51 @@ func TestModel_F2DoesNotSwitchPanesWhileSearchIsActive(t *testing.T) {
 
 	if m.ActivePane() != 0 {
 		t.Fatalf("active pane = %d, want left pane while search handles f2", m.ActivePane())
+	}
+}
+
+func TestModel_BackKeysEditRightPaneSearchInsteadOfSwitchingPanes(t *testing.T) {
+	for _, key := range []tea.KeyMsg{{Type: tea.KeyBackspace}, {Type: tea.KeyCtrlH}} {
+		t.Run(key.String(), func(t *testing.T) {
+			m := model.New(testRepos())
+			m = inRightPane(m)
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'w'}})
+
+			m, cmd := update(m, key)
+
+			if cmd != nil {
+				t.Fatalf("search back key returned cmd %T, want nil", cmd)
+			}
+			if m.ActivePane() != 1 {
+				t.Fatalf("active pane = %d, want right pane while search owns back key", m.ActivePane())
+			}
+			if m.ItemSearch() != "" || !m.SearchActive() {
+				t.Fatalf("item search query=%q active=%v, want empty active search", m.ItemSearch(), m.SearchActive())
+			}
+		})
+	}
+}
+
+func TestModel_BackspaceEditsModalInputInsteadOfSwitchingPanes(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if cmd != nil {
+		t.Fatalf("opening worktree input produced cmd %T, want nil", cmd)
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f', 'e', 'a', 't'}})
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
+
+	if cmd != nil {
+		t.Fatalf("modal backspace returned cmd %T, want nil", cmd)
+	}
+	if m.ActivePane() != 1 {
+		t.Fatalf("active pane = %d, want right pane while modal owns backspace", m.ActivePane())
+	}
+	if got := m.WorktreeInput(); got != "fea" {
+		t.Fatalf("worktree input = %q, want edited value", got)
 	}
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -142,6 +142,7 @@ const (
 	shortcutKeyColumnWidth = 6
 	shortcutOverflowMarker = "..."
 	paneShortcutKey        = "f2/tab"
+	paneBackShortcutKey    = "bksp"
 )
 
 const (
@@ -1083,9 +1084,6 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	if sp.ActivePane == 1 && !sp.ActiveFlows {
 		navigation = append(navigation, shortcutHint{Key: "←/→", Label: "view", Inline: true})
 	}
-	if flowSurfaceActive && sp.ActivePane == 1 && !sp.EmbeddedTerminalActive {
-		navigation = append(navigation, shortcutHint{Key: "⌫", Label: "pane", Inline: true})
-	}
 	global := []shortcutHint{
 		{Key: paneShortcutKeyForStatus(sp), Label: "pane"},
 		{Key: "q/esc", Label: "quit"},
@@ -1381,8 +1379,9 @@ func muteShortcutSections(sections []shortcutSection) []shortcutSection {
 func shortcutSectionsForPane(sp statusBarParams, height int) []shortcutSection {
 	sections := shortcutSections(sp)
 	if height < 20 && sp.Mode != ModeFlows && !sp.ActiveFlows {
-		sections = prioritizeShortcutInSection(sections, "Global", "V", "f2")
-		sections = prioritizeShortcutInSection(sections, "Global", "A", "q/esc")
+		paneKey := paneShortcutKeyForStatus(sp)
+		sections = prioritizeShortcutInSection(sections, "Global", "V", paneKey)
+		sections = prioritizeShortcutInSection(sections, "Global", "A", paneKey)
 	}
 	if (sp.Mode == ModeFlows || sp.ActiveFlows) && !sp.FlowSelected && height <= 9 {
 		sections = withoutShortcutKeys(sections, "D", "n", "f5")
@@ -1465,7 +1464,7 @@ func paneShortcutKeyForStatus(sp statusBarParams) string {
 	if sp.ActivePane == 0 {
 		return paneShortcutKey
 	}
-	return "f2"
+	return paneBackShortcutKey
 }
 
 func transientStatusStyle(fadeStep int) lipgloss.Style {
@@ -1532,15 +1531,16 @@ func renderGenericFooterShortcuts(sp statusBarParams, sections []shortcutSection
 		{"f5", "f3", "A", "D"},
 		{"f5", "f3", "A", "D", "←/→"},
 		{"f5", "f3", "A", "D", "←/→", "↑/↓"},
-		{"f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc"},
-		{"f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc", paneKey},
+		{"f5", "f3", "A", "D", "←/→", "↑/↓", paneBackShortcutKey},
+		{"f5", "f3", "A", "D", "←/→", "↑/↓", paneBackShortcutKey, paneKey},
+		{"f5", "f3", "A", "D", "←/→", "↑/↓", paneBackShortcutKey, paneKey, "q/esc"},
 	} {
 		candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, drop...)))
 		if lipgloss.Width(candidate) <= sp.Width {
 			return candidate
 		}
 	}
-	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc", paneKey)))
+	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "f3", "A", "D", "←/→", "↑/↓", paneBackShortcutKey, paneKey, "q/esc")))
 	return ansi.Truncate(candidate, sp.Width, "")
 }
 
@@ -1553,11 +1553,15 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 		return full
 	}
 	hints := flattenShortcutHints(sections)
-	base := footerHintsForKeys(hints, paneShortcutKeyForStatus(sp), "⌫", "q/esc")
+	base := footerHintsForKeys(hints, paneShortcutKeyForStatus(sp), "q/esc")
+	compactBase := footerHintsForKeys(hints, paneBackShortcutKey, "q/esc")
+	tinyBase := footerHintsForKeys(hints, "q/esc")
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
 	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "g", "d")
+	coreActionsWithoutSafety := footerHintsForKeys(hints, "h", "enter", "g", "d")
 	coreActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "d", "m")
+	coreActionsWithAutoWithoutSafety := footerHintsForKeys(hints, "h", "enter", "g", "d", "m")
 	selectedActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "x", "o", "y", "d", "r", "m")
 	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "E", "f", "F")
 	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "f", "F")
@@ -1570,14 +1574,21 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 		appendParts(base, upDown, arrow, actionsWithoutAgentAndEffort),
 		appendParts(base, arrow, actionsWithoutAgentAndEffort),
 		appendParts(base, arrow, selectedActionsWithAuto),
-		appendParts(arrow, selectedActionsWithAuto),
+		appendParts(compactBase, selectedActionsWithAuto),
 		appendParts(base, arrow, coreActionsWithAuto),
 		appendParts(base, arrow, coreActions),
+		appendParts(compactBase, coreActionsWithAuto),
+		appendParts(compactBase, coreActions),
+		appendParts(compactBase, coreActionsWithAutoWithoutSafety),
+		appendParts(compactBase, coreActionsWithoutSafety),
+		appendParts(arrow, selectedActionsWithAuto),
 		appendParts(arrow, coreActionsWithAuto),
 		appendParts(arrow, coreActions),
 		appendParts(coreActionsWithAuto),
 		appendParts(coreActions),
 		base,
+		compactBase,
+		tinyBase,
 	} {
 		if candidate, ok := footerCandidate(sp.Width, parts); ok {
 			return candidate

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -83,7 +83,7 @@ func TestRender_ActiveFlowsHeaderAndShortcutLabels(t *testing.T) {
 	if !strings.Contains(pane, "f3") || !strings.Contains(pane, "active flows") {
 		t.Fatalf("active-flow shortcut pane should keep f3 active flows hint:\n%s", pane)
 	}
-	if !strings.Contains(pane, "⌫      pane") {
+	if !strings.Contains(pane, "bksp   pane") {
 		t.Fatalf("active-flow shortcut pane should expose backspace pane hint:\n%s", pane)
 	}
 }
@@ -748,8 +748,7 @@ func TestRender_FlowsModeShortcutSectionsUseFlowGroups(t *testing.T) {
 		"m      auto: on",
 		"A      codex",
 		"E      effort: high",
-		"⌫      pane",
-		"f2     pane",
+		"bksp   pane",
 		"q/esc  quit",
 		"f5     refresh",
 	} {
@@ -859,13 +858,15 @@ func TestStatusBar_FlowsModeFullFooterPreservesSectionOrder(t *testing.T) {
 	enterIndex := strings.Index(bar, "enter: phases")
 	headlessIndex := strings.Index(bar, "h: headless on")
 	agentIndex := strings.Index(bar, "A: codex")
-	backspaceIndex := strings.Index(bar, "⌫ pane")
-	paneIndex := strings.Index(bar, "f2: pane")
-	if enterIndex < 0 || headlessIndex < 0 || agentIndex < 0 || backspaceIndex < 0 || paneIndex < 0 {
+	backspaceIndex := strings.Index(bar, "bksp: pane")
+	if enterIndex < 0 || headlessIndex < 0 || agentIndex < 0 || backspaceIndex < 0 {
 		t.Fatalf("full Flow footer missing expected hints, got %q", bar)
 	}
-	if !(enterIndex < headlessIndex && headlessIndex < agentIndex && agentIndex < backspaceIndex && backspaceIndex < paneIndex) {
+	if !(enterIndex < headlessIndex && headlessIndex < agentIndex && agentIndex < backspaceIndex) {
 		t.Fatalf("full Flow footer should order Actions, Mode, Agent, Global, got %q", bar)
+	}
+	if strings.Contains(bar, "f2: pane") {
+		t.Fatalf("full Flow footer should not duplicate f2 pane hint, got %q", bar)
 	}
 }
 
@@ -1189,7 +1190,7 @@ func TestStatusBar_FlowsModeNarrowFooterShowsEnterWithHeadlessHint(t *testing.T)
 		FlowHeadless:        true,
 		FlowNextLaunchReady: true,
 	})
-	for _, want := range []string{"h: headless on", "enter: phases", "g: launch next"} {
+	for _, want := range []string{"h: headless on", "enter: phases", "g: launch next", "bksp: pane"} {
 		if !strings.Contains(bar, want) {
 			t.Fatalf("narrow Flow footer missing %q: %q", want, bar)
 		}
@@ -1198,6 +1199,24 @@ func TestStatusBar_FlowsModeNarrowFooterShowsEnterWithHeadlessHint(t *testing.T)
 		if strings.Contains(bar, notWant) {
 			t.Fatalf("narrow Flow footer should not include %q: %q", notWant, bar)
 		}
+	}
+}
+
+func TestStatusBar_FlowsModeTinyFooterKeepsQuitOverBackspace(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:               18,
+		Mode:                ModeFlows,
+		ActivePane:          1,
+		RepoSelected:        true,
+		FlowSelected:        true,
+		FlowHeadless:        true,
+		FlowNextLaunchReady: true,
+	})
+	if !strings.Contains(bar, "q/esc: quit") {
+		t.Fatalf("tiny Flow footer should keep quit hint, got %q", bar)
+	}
+	if strings.Contains(bar, "bksp") {
+		t.Fatalf("tiny Flow footer should drop backspace before quit, got %q", bar)
 	}
 }
 

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -143,9 +143,9 @@ func TestStatusBar_StashesModeOmitsIndicatorLegend(t *testing.T) {
 func TestStatusBar_PipeSeparatesLegendAndHints(t *testing.T) {
 	bar := RenderStatusBar(120, 2, 0, 1, true, false, false)
 	upstreamIdx := strings.Index(bar, "no upstream")
-	paneIdx := strings.Index(bar, "f2: pane")
+	paneIdx := strings.Index(bar, "bksp: pane")
 	if upstreamIdx == -1 || paneIdx == -1 {
-		t.Fatalf("expected both 'no upstream' and 'f2: pane' in bar: %q", bar)
+		t.Fatalf("expected both 'no upstream' and 'bksp: pane' in bar: %q", bar)
 	}
 	between := bar[upstreamIdx+len("no upstream") : paneIdx]
 	if !strings.Contains(between, "|") {
@@ -155,13 +155,13 @@ func TestStatusBar_PipeSeparatesLegendAndHints(t *testing.T) {
 
 func TestStatusBar_TabAndQuitBeforeOtherHints(t *testing.T) {
 	bar := RenderStatusBar(160, 2, 0, 1, true, false, false)
-	paneIdx := strings.Index(bar, "f2: pane")
+	paneIdx := strings.Index(bar, "bksp: pane")
 	tIdx := strings.Index(bar, "t: terminal")
 	if paneIdx == -1 || tIdx == -1 {
 		t.Fatalf("expected both hints in bar: %q", bar)
 	}
 	if paneIdx > tIdx {
-		t.Error("f2: pane should appear before t: terminal")
+		t.Error("bksp: pane should appear before t: terminal")
 	}
 	qIdx := strings.Index(bar, "q/esc: quit")
 	if qIdx > tIdx {
@@ -1317,7 +1317,7 @@ func TestStatusBar_LaunchInstructionsOverlayShowsLaunchHint(t *testing.T) {
 func TestStatusBar_KeyHintSpacingIs2(t *testing.T) {
 	bar := RenderStatusBar(160, 2, 0, 1, true, false, false)
 	for _, pair := range [][2]string{
-		{"f2: pane", "q/esc: quit"},
+		{"bksp: pane", "q/esc: quit"},
 		{"d: delete", "f: fetch"},
 		{"t: terminal", "c: code"},
 	} {
@@ -1412,8 +1412,8 @@ func TestRender_WideLayoutReplacesFooterHints(t *testing.T) {
 	if strings.Contains(footer, "f2/tab: pane") || strings.Contains(footer, "q/esc: quit") {
 		t.Fatalf("wide render footer should not carry shortcut hints, got %q", footer)
 	}
-	if !strings.Contains(shortcutPaneText(view), "f2     pane") {
-		t.Fatal("wide render should still expose global shortcuts in the shortcut pane")
+	if !strings.Contains(shortcutPaneText(view), "bksp   pane") {
+		t.Fatal("wide right-pane render should expose backspace pane shortcut")
 	}
 }
 
@@ -1433,6 +1433,28 @@ func TestRender_NarrowLayoutKeepsFooterHints(t *testing.T) {
 	}
 	if strings.Contains(view, "Shortcuts") {
 		t.Fatal("narrow render should not reserve a shortcut pane")
+	}
+}
+
+func TestRender_NarrowRightPaneLayoutKeepsBackspaceAndQuitFooterHints(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:      []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:   0,
+		Width:      80,
+		Height:     18,
+		Mode:       ModeBranches,
+		ActivePane: 1,
+	})
+
+	lines := strings.Split(view, "\n")
+	footer := lines[len(lines)-1]
+	for _, want := range []string{"bksp: pane", "q/esc: quit"} {
+		if !strings.Contains(footer, want) {
+			t.Fatalf("narrow right-pane footer should expose %q, got %q", want, footer)
+		}
+	}
+	if strings.Contains(footer, "⌫") {
+		t.Fatalf("narrow right-pane footer should use bksp label, got %q", footer)
 	}
 }
 
@@ -1538,11 +1560,11 @@ func TestRender_ShortcutPanePrioritizesActions(t *testing.T) {
 	navigate := strings.Index(pane, "Navigate")
 	global := strings.Index(pane, "Global")
 	newWorktree := strings.Index(pane, "new worktree")
-	paneHint := strings.Index(pane, "f2     pane")
+	globalHint := strings.Index(pane, "A      set agent")
 	if actions < 0 || navigate < 0 || global < 0 || !(actions < navigate && navigate < global) {
 		t.Fatalf("shortcut pane should order Actions, Navigate, Global, got:\n%s", pane)
 	}
-	if newWorktree < 0 || paneHint < 0 || newWorktree > paneHint {
+	if newWorktree < 0 || globalHint < 0 || newWorktree > globalHint {
 		t.Fatalf("shortcut pane should show contextual actions before global hints, got:\n%s", pane)
 	}
 }
@@ -1814,8 +1836,8 @@ func TestRender_ShortcutPaneShowsArrowViewHintOnlyForRightPane(t *testing.T) {
 		Mode:       ModeFlows,
 		ActivePane: 1,
 	}, 26, 18))
-	if !strings.Contains(rightPane, "f2") || !strings.Contains(rightPane, "pane") {
-		t.Fatalf("right-pane shortcut pane should include f2 pane hint, got:\n%s", rightPane)
+	if !strings.Contains(rightPane, "bksp") || !strings.Contains(rightPane, "pane") {
+		t.Fatalf("right-pane shortcut pane should include bksp pane hint, got:\n%s", rightPane)
 	}
 	if !strings.Contains(rightPane, "←/→") || !strings.Contains(rightPane, "view") {
 		t.Fatalf("right-pane shortcut pane should include arrow view hint, got:\n%s", rightPane)
@@ -3551,7 +3573,7 @@ func TestStatusBar_StashesModeHintsSpacing(t *testing.T) {
 		}
 	}
 	for _, pair := range [][2]string{
-		{"f2: pane", "q/esc: quit"},
+		{"bksp: pane", "q/esc: quit"},
 		{"↑/↓ select", "←/→ view"},
 		{"←/→ view", "enter: diff"},
 		{"enter: diff", "d: drop"},
@@ -3936,7 +3958,7 @@ func TestWorktreePane_ScrollOffset(t *testing.T) {
 
 func TestStatusBar_GenericFooterKeepsQuitBeforeNavigationWhenTight(t *testing.T) {
 	bar := ansi.Strip(RenderStatusBar(52, 3, 0, 1, true, false, false))
-	for _, want := range []string{"f2: pane", "q/esc: quit"} {
+	for _, want := range []string{"bksp: pane", "q/esc: quit"} {
 		if !strings.Contains(bar, want) {
 			t.Fatalf("tight generic footer should keep %q, got %q", want, bar)
 		}
@@ -3950,7 +3972,7 @@ func TestStatusBar_GenericFooterKeepsQuitBeforeNavigationWhenTight(t *testing.T)
 
 func TestStatusBar_WorktreesModeShowsNavHints(t *testing.T) {
 	bar := RenderStatusBar(160, 1, 0, 1, false, false, false)
-	for _, hint := range []string{"f2: pane", "q/esc: quit", "↑/↓ select", "←/→ view"} {
+	for _, hint := range []string{"bksp: pane", "q/esc: quit", "↑/↓ select", "←/→ view"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("worktrees mode status bar should contain %q", hint)
 		}
@@ -3976,8 +3998,23 @@ func TestStatusBar_HidesArrowViewHintForActiveFlows(t *testing.T) {
 	if strings.Contains(bar, "←/→") || strings.Contains(bar, "pane/view") {
 		t.Fatalf("active Flow status bar should not advertise arrow view navigation, got %q", bar)
 	}
-	if !strings.Contains(bar, "⌫ pane") {
+	if !strings.Contains(bar, "bksp: pane") {
 		t.Fatalf("active Flow status bar should advertise backspace pane navigation, got %q", bar)
+	}
+}
+
+func TestStatusBar_RightPaneShowsBackspacePaneHint(t *testing.T) {
+	bar := RenderStatusBar(120, ModeBranches, OverlayNone, 1, false, false, false)
+	for _, want := range []string{"bksp: pane", "q/esc: quit"} {
+		if !strings.Contains(bar, want) {
+			t.Fatalf("right-pane status bar should advertise %q, got %q", want, bar)
+		}
+	}
+	if strings.Contains(bar, "f2: pane") {
+		t.Fatalf("right-pane status bar should not duplicate f2 pane hint, got %q", bar)
+	}
+	if strings.Contains(bar, "⌫") {
+		t.Fatalf("right-pane status bar should use bksp label, got %q", bar)
 	}
 }
 
@@ -4411,7 +4448,7 @@ func TestReflogDiffOverlay_NonEmptyDiffShowsContent(t *testing.T) {
 
 func TestStatusBar_ReflogModeHints(t *testing.T) {
 	bar := RenderStatusBar(120, 5, 0, 1, false, false, false)
-	for _, hint := range []string{"enter: diff", "y: copy hash", "f2: pane", "q/esc: quit"} {
+	for _, hint := range []string{"enter: diff", "y: copy hash", "bksp: pane", "q/esc: quit"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("reflog status bar should contain %q", hint)
 		}


### PR DESCRIPTION
## Summary
- make Backspace/Ctrl-H return from any right-pane list to the repo pane, matching the documented pane navigation behavior
- keep embedded session and Flow terminals in control of Backspace/Ctrl-H when terminal input owns the keys
- update shortcut hints and README text to advertise `bksp` consistently for right-pane pane navigation

## Verification
- `gofmt -l .`
- `make test`
- `make build`