### PR TITLE
Move active flows to view 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,14 @@ filter matches, or a load failure with details in the status bar.
 | `⌫` | Switch focus to left pane from the Flow list |
 | `q`/`esc` | Close a prompt/dialog or quit |
 
-The right pane header shows the active mode. Press `1`–`8` or use arrow keys to
+The right pane header shows the active mode. Press `1`–`9` or use arrow keys to
 switch between worktrees, branches, stashes, history, reflog, sessions, plans,
-and flows. Arrow-key view switching clamps at worktrees and flows. Press `V` to
-choose which numbered view wtui opens on future launches; leaving it unset keeps
-the built-in startup default of Flows. Press `enter` or `tab` from the repo
-pane to focus the content pane, or `f2` to switch pane focus explicitly. In the
-Flow list, `⌫` switches focus back to the left repo pane.
+flows, and active flows. Horizontal view switching wraps between worktrees and
+active flows. Press `V` to choose which numbered view wtui opens on future
+launches; leaving it unset keeps the built-in startup default of Flows. Press
+`enter` or `tab` from the repo pane to focus the content pane, or `f2` to switch
+pane focus explicitly. In the Flow list, `⌫` switches focus back to the left
+repo pane.
 
 When the left repo pane is focused, press `f` to run `git fetch --prune` for
 the currently visible repos. Repo filtering limits the batch to the filtered

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ filter matches, or a load failure with details in the status bar.
 | `↓`/`j` | Select next repo |
 | `/` | Fuzzy filter repos |
 | `A` | Choose and persist the coding agent from a picker (`codex`, `codex-app`, or `claude`) |
-| `V` | Choose and persist the startup default view (`1` through `8`) |
+| `V` | Choose and persist the startup default view (`1` through `9`) |
 | `D` | Toggle destructive mode |
 | `f` | Fetch all currently visible repos with `--prune` |
 | `n` | Create a new local repo under the scan root, optionally creating a GitHub repo and wiring `origin` |
@@ -84,9 +84,8 @@ filter matches, or a load failure with details in the status bar.
 | `↑`/`k` | Move selection up |
 | `↓`/`j` | Move selection down |
 | `/` | Fuzzy filter the current item list |
-| `1`/`2`/`3`/`4`/`5`/`6`/`7`/`8` | Switch to worktrees / branches / stashes / history / reflog / sessions / plans / flows |
-| `F3` | Toggle global active Flows in the middle pane, filtered to non-merged Flow records |
-| `←`/`→`/`l` | Switch views in the right pane, clamping at worktrees and flows; use arrows or `l` in flows view because `h` toggles Flow headless/interactive command mode |
+| `1`/`2`/`3`/`4`/`5`/`6`/`7`/`8`/`9` | Switch to worktrees / branches / stashes / history / reflog / sessions / plans / flows / active flows |
+| `←`/`→`/`l` | Switch views in the right pane, wrapping between worktrees and active flows; use arrows or `l` in flows view because `h` toggles Flow headless/interactive command mode |
 | `h` | Switch to the previous view outside flows view; toggle Flow headless/interactive command mode in flows view |
 | `E` | Choose and persist reasoning effort for the selected CLI agent in flows view |
 | `enter` | Page diff in `less` (dirty worktree, dirty branch, stash, commit, or reflog entry), resume an inline worktree session, page a session transcript, or expand/collapse plan or Flow phases |
@@ -96,7 +95,7 @@ filter matches, or a load failure with details in the status bar.
 | `N` | Create a new worktree and launch the selected coding agent |
 | `m` | Move or rename a linked worktree (worktrees view), or toggle auto mode for the selected Flow (flows view) |
 | `A` | Choose and persist the coding agent from a picker (`codex`, `codex-app`, or `claude`) |
-| `V` | Choose and persist the startup default view (`1` through `8`) |
+| `V` | Choose and persist the startup default view (`1` through `9`) |
 | `a` | Launch the selected coding agent in the selected worktree, or launch the selected plan or plan phase |
 | `d` | Delete worktree/branch, drop stash, or delete Flow data — requires destructive mode |
 | `p` | Prune stale worktree — requires destructive mode (worktrees view) |
@@ -365,13 +364,13 @@ missing-PR-metadata states do not auto-launch. Automation stops before Merge:
 if Autoreview completes and Merge becomes ready, wtui keeps auto mode on and
 requires the existing manual Merge launch.
 
-Press `F3` from any middle-pane view to keep the current numbered mode selected
-while showing active Flows across all repos. This active view hides merged Flow
-records; moving focus to the left repo pane temporarily filters the visible
-active rows to the selected repo, and returning focus to the middle pane restores
-the global list. Normal Flow actions, phase launches, attached-session resumes,
-auto-mode toggles, and embedded Flow terminals work from the visible active Flow
-rows.
+### Active Flows view (mode 9)
+
+Browse active Flow records across all repos. This view hides merged Flow records;
+moving focus to the left repo pane temporarily filters the visible active rows to
+the selected repo, and returning focus to the middle pane restores the global
+list. Normal Flow actions, phase launches, attached-session resumes, auto-mode
+toggles, and embedded Flow terminals work from the visible active Flow rows.
 
 Flow headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in a runtime-only embedded
@@ -599,7 +598,7 @@ for compatibility. The same root is resolved to an absolute path when used as
 the parent directory for left-pane repo creation.
 `[agent].codex_reasoning_effort` and `[agent].claude_reasoning_effort`
 configure provider-specific effort for new CLI agent launches; empty or
-`default` keeps provider defaults. `[ui].default_view` accepts `1` through `8`
+`default` keeps provider defaults. `[ui].default_view` accepts `1` through `9`
 and controls the startup view; omitting it keeps the built-in Flows default.
 `[agent].plan_prompt` customizes the
 editable instructions shown before launching an agent from the plans pane, while

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -418,6 +418,7 @@ func TestModelOptionsFromConfigMapsDefaultView(t *testing.T) {
 		{name: "missing uses flows", want: ui.ModeFlows},
 		{name: "view 1", view: intPtr(1), want: ui.ModeWorktrees},
 		{name: "view 8", view: intPtr(8), want: ui.ModeFlows},
+		{name: "view 9", view: intPtr(9), want: ui.ModeActiveFlows},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			sessionStore, planStore, flowStore := testArtifactStores(t)

--- a/config/config.go
+++ b/config/config.go
@@ -231,8 +231,8 @@ func defaultConfig() Config {
 }
 
 func validateDefaultView(view int) error {
-	if view < 1 || view > 8 {
-		return fmt.Errorf("ui.default_view must be between 1 and 8")
+	if view < 1 || view > 9 {
+		return fmt.Errorf("ui.default_view must be between 1 and 9")
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -194,8 +194,8 @@ func TestLoadFrom_DefaultViewAbsentIsUnset(t *testing.T) {
 	}
 }
 
-func TestLoadFrom_AcceptsDefaultViewOneThroughEight(t *testing.T) {
-	for view := 1; view <= 8; view++ {
+func TestLoadFrom_AcceptsDefaultViewOneThroughNine(t *testing.T) {
+	for view := 1; view <= 9; view++ {
 		t.Run(fmt.Sprintf("view_%d", view), func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "config.toml")
 			if err := os.WriteFile(path, []byte(fmt.Sprintf("[ui]\ndefault_view = %d\n", view)), 0o644); err != nil {
@@ -219,9 +219,9 @@ func TestLoadFrom_RejectsInvalidDefaultView(t *testing.T) {
 		body string
 		want string
 	}{
-		{name: "zero", body: "[ui]\ndefault_view = 0\n", want: "ui.default_view must be between 1 and 8"},
-		{name: "negative", body: "[ui]\ndefault_view = -1\n", want: "ui.default_view must be between 1 and 8"},
-		{name: "too high", body: "[ui]\ndefault_view = 9\n", want: "ui.default_view must be between 1 and 8"},
+		{name: "zero", body: "[ui]\ndefault_view = 0\n", want: "ui.default_view must be between 1 and 9"},
+		{name: "negative", body: "[ui]\ndefault_view = -1\n", want: "ui.default_view must be between 1 and 9"},
+		{name: "too high", body: "[ui]\ndefault_view = 10\n", want: "ui.default_view must be between 1 and 9"},
 		{name: "string", body: "[ui]\ndefault_view = \"8\"\n", want: "toml"},
 		{name: "float", body: "[ui]\ndefault_view = 8.0\n", want: "toml"},
 	}
@@ -853,7 +853,7 @@ func TestSaveDefaultView_InsertsBeforeArrayTable(t *testing.T) {
 }
 
 func TestSaveDefaultView_RejectsInvalidValueWithoutWriting(t *testing.T) {
-	for _, view := range []int{0, -1, 9} {
+	for _, view := range []int{0, -1, 10} {
 		t.Run(fmt.Sprintf("view_%d", view), func(t *testing.T) {
 			xdg := t.TempDir()
 			path := filepath.Join(xdg, "wtui", "config.toml")

--- a/docs/config.md
+++ b/docs/config.md
@@ -123,10 +123,10 @@ Stores user-interface preferences.
 
 | Key | Type | Description |
 |-----|------|-------------|
-| `default_view` | integer | Optional startup view number. Valid values are `1` worktrees, `2` branches, `3` stashes, `4` history, `5` reflog, `6` sessions, `7` plans, and `8` flows. Omitted keeps the built-in Flows startup default. |
+| `default_view` | integer | Optional startup view number. Valid values are `1` worktrees, `2` branches, `3` stashes, `4` history, `5` reflog, `6` sessions, `7` plans, `8` flows, and `9` active flows. Omitted keeps the built-in Flows startup default. |
 
 Press `V` in wtui to choose and persist this value from a picker. The picker
-changes future launches only; use `1` through `8`, arrows, `h`, or `l` to switch
+changes future launches only; use `1` through `9`, arrows, `h`, or `l` to switch
 the current view.
 
 ### `[editor]`
@@ -345,11 +345,10 @@ terminal exits normally and auto-closes; terminal exit also triggers a Flow
 refresh so newly persisted completion state is discovered without waiting for
 unrelated UI activity. Auto mode still skips non-completed outcomes and stops
 before Merge.
-Press `F3` from any middle-pane view to keep the current numbered mode selected
-while showing active Flows across all repos. This active view hides merged Flow
-records; moving focus to the left repo pane temporarily filters the visible
-active rows to the selected repo, and returning focus to the middle pane restores
-the global list. It supports the same Flow actions, phase launches,
+The active flows pane (mode `9`) shows active Flows across all repos and hides
+merged Flow records. Moving focus to the left repo pane temporarily filters the
+visible active rows to the selected repo, and returning focus to the middle pane
+restores the global list. It supports the same Flow actions, phase launches,
 attached-session resumes, auto-mode toggles, and embedded Flow terminal
 management as the flows pane.
 Headless mode is on by default:

--- a/model/export_test.go
+++ b/model/export_test.go
@@ -26,6 +26,11 @@ func ActiveFlowSelectedForTest(m Model) int {
 	return m.activeFlows.SelectedIndex()
 }
 
+func ActiveFlowsForTest(m Model) []flowstore.FlowRecord {
+	flows, _, _ := m.activeFlows.View()
+	return flows
+}
+
 func SelectedActiveFlowPhaseIDForTest(m Model) string {
 	return m.selectedActiveFlowPhaseID
 }

--- a/model/flow_refresh_tick.go
+++ b/model/flow_refresh_tick.go
@@ -26,11 +26,13 @@ func (m Model) flowRefreshTickCmd() tea.Cmd {
 
 func (m Model) startFlowsModeFetchWithRefreshTick() (Model, tea.Cmd) {
 	m.flowRefreshInFlight = 0
+	m.flowRefreshInFlightMode = 0
 	return m.startFlowRefreshFetch()
 }
 
 func (m Model) startActiveFlowsFetchWithRefreshTick() (Model, tea.Cmd) {
 	m.flowRefreshInFlight = 0
+	m.flowRefreshInFlightMode = 0
 	return m.startActiveFlowRefreshFetch()
 }
 
@@ -75,10 +77,14 @@ func (m Model) startActiveFlowRefreshFetch() (Model, tea.Cmd) {
 }
 
 func (m Model) finishFlowRefreshFetch(mode ui.Mode, request uint64) (Model, tea.Cmd) {
-	if mode != ui.ModeFlows || request == 0 || request != m.flowRefreshInFlight {
+	if (mode != ui.ModeFlows && mode != ui.ModeActiveFlows) || request == 0 || request != m.flowRefreshInFlight {
+		return m, nil
+	}
+	if mode != m.flowRefreshInFlightMode {
 		return m, nil
 	}
 	m.flowRefreshInFlight = 0
+	m.flowRefreshInFlightMode = 0
 	if !m.flowSurfaceVisible() {
 		return m, nil
 	}

--- a/model/flow_refresh_tick_test.go
+++ b/model/flow_refresh_tick_test.go
@@ -186,15 +186,6 @@ func TestModel_FlowRefreshTickScheduledWhenEnteringFlowsModePaths(t *testing.T) 
 			},
 			key: tea.KeyMsg{Type: tea.KeyRight},
 		},
-		{
-			name: "left-arrow-wrap",
-			setup: func(m Model) Model {
-				m.activePane = 1
-				m.mode = ui.ModeWorktrees
-				return m
-			},
-			key: tea.KeyMsg{Type: tea.KeyLeft},
-		},
 	}
 
 	for _, tc := range tests {
@@ -255,8 +246,8 @@ func TestModel_FlowRefreshTickFetchesAndSchedulesNextTick(t *testing.T) {
 	before := m.ListRequest(ui.ModeFlows)
 
 	m, cmd := updateFlowRefreshTest(m, flowRefreshTickMsg{Generation: m.flowRefreshTickGen})
-	if got := m.ListRequest(ui.ModeFlows); got != before+1 {
-		t.Fatalf("flows list request = %d, want %d", got, before+1)
+	if got := m.ListRequest(ui.ModeFlows); got == before {
+		t.Fatalf("flows list request = %d, want changed from %d", got, before)
 	}
 	if m.flowRefreshInFlight != m.ListRequest(ui.ModeFlows) {
 		t.Fatalf("flow refresh in-flight request = %d, want %d", m.flowRefreshInFlight, m.ListRequest(ui.ModeFlows))
@@ -299,7 +290,7 @@ func TestModel_ActiveFlowRefreshTickUsesGlobalFetchAndPreservesNormalFlowCache(t
 	m, _ = updateFlowRefreshTest(m, flowResultFromCommand(t, m.Init()))
 	m.activePane = 1
 
-	m, cmd := updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, cmd := updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 	m, cmd = updateFlowRefreshTest(m, activeFlowResultFromRefreshCommand(t, cmd))
 	if cmd == nil {
 		t.Fatal("expected active Flow result to schedule refresh tick")
@@ -311,8 +302,8 @@ func TestModel_ActiveFlowRefreshTickUsesGlobalFetchAndPreservesNormalFlowCache(t
 
 	m, cmd = updateFlowRefreshTest(m, flowRefreshTickMsg{Generation: m.flowRefreshTickGen})
 	result := activeFlowResultFromRefreshCommand(t, cmd)
-	if result.ListRequest != m.ListRequest(ui.ModeFlows) {
-		t.Fatalf("ActiveFlowResultMsg.ListRequest = %d, want %d", result.ListRequest, m.ListRequest(ui.ModeFlows))
+	if result.ListRequest != m.ListRequest(ui.ModeActiveFlows) {
+		t.Fatalf("ActiveFlowResultMsg.ListRequest = %d, want %d", result.ListRequest, m.ListRequest(ui.ModeActiveFlows))
 	}
 	if len(filters) != 1 || filters[0].RepoPath != "" {
 		t.Fatalf("active Flow tick filters = %#v, want one global fetch", filters)
@@ -458,7 +449,7 @@ func TestModel_ActiveFlowRefreshRepoChangeKeepsInFlightGlobalFetch(t *testing.T)
 	})
 	m.activePane = 1
 	var activeCmd tea.Cmd
-	m, activeCmd = updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, activeCmd = updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 	if activeCmd == nil {
 		t.Fatal("expected active Flow surface entry to fetch flows")
 	}
@@ -473,8 +464,8 @@ func TestModel_ActiveFlowRefreshRepoChangeKeepsInFlightGlobalFetch(t *testing.T)
 	if cmd != nil {
 		t.Fatalf("repo change returned command %T, want nil local filter", cmd)
 	}
-	if got := m.ListRequest(ui.ModeFlows); got != globalRequest {
-		t.Fatalf("flows list request = %d, want unchanged global request %d", got, globalRequest)
+	if got := m.ListRequest(ui.ModeActiveFlows); got != globalRequest {
+		t.Fatalf("active flows list request = %d, want unchanged global request %d", got, globalRequest)
 	}
 	if m.flowRefreshInFlight != globalRequest {
 		t.Fatalf("flow refresh in-flight request = %d, want global request %d", m.flowRefreshInFlight, globalRequest)
@@ -513,23 +504,23 @@ func TestModel_ActiveFlowEntrySupersedesStaleInFlightFetch(t *testing.T) {
 	}
 	m.activePane = 1
 
-	m, cmd = updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, cmd = updateFlowRefreshTest(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 	if cmd == nil {
-		t.Fatal("expected F3 entry to supersede stale in-flight Flow fetch")
+		t.Fatal("expected view 9 entry to supersede stale in-flight Flow fetch")
 	}
-	if got := m.ListRequest(ui.ModeFlows); got == alphaRequest {
-		t.Fatalf("flows list request = %d, want changed from alpha request %d", got, alphaRequest)
+	if got := m.ListRequest(ui.ModeActiveFlows); got == 0 {
+		t.Fatalf("active flows list request = %d, want non-zero", got)
 	}
-	if m.flowRefreshInFlight != m.ListRequest(ui.ModeFlows) {
-		t.Fatalf("flow refresh in-flight request = %d, want F3 entry request %d", m.flowRefreshInFlight, m.ListRequest(ui.ModeFlows))
+	if m.flowRefreshInFlight != m.ListRequest(ui.ModeActiveFlows) {
+		t.Fatalf("flow refresh in-flight request = %d, want active flows entry request %d", m.flowRefreshInFlight, m.ListRequest(ui.ModeActiveFlows))
 	}
 	msg := cmd()
 	result, ok := msg.(ActiveFlowResultMsg)
 	if !ok {
 		t.Fatalf("active Flow command returned %T, want ActiveFlowResultMsg", msg)
 	}
-	if result.ListRequest != m.ListRequest(ui.ModeFlows) {
-		t.Fatalf("ActiveFlowResultMsg.ListRequest = %d, want %d", result.ListRequest, m.ListRequest(ui.ModeFlows))
+	if result.ListRequest != m.ListRequest(ui.ModeActiveFlows) {
+		t.Fatalf("ActiveFlowResultMsg.ListRequest = %d, want %d", result.ListRequest, m.ListRequest(ui.ModeActiveFlows))
 	}
 }
 

--- a/model/flow_surface.go
+++ b/model/flow_surface.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (m Model) activeFlowSurfaceVisible() bool {
-	return m.contentSurface == surfaceActiveFlows
+	return m.mode == ui.ModeActiveFlows
 }
 
 func (m Model) flowSurfaceVisible() bool {
@@ -18,13 +18,14 @@ func (m Model) flowSurfaceVisible() bool {
 
 func (m Model) activeContentFetchMode() ui.Mode {
 	if m.activeFlowSurfaceVisible() {
-		return ui.ModeFlows
+		return ui.ModeActiveFlows
 	}
 	return m.mode
 }
 
 func (m Model) enterActiveFlowsSurface() (Model, tea.Cmd) {
-	m.contentSurface = surfaceActiveFlows
+	m.mode = ui.ModeActiveFlows
+	m.contentSurface = surfaceModeContent
 	m.flowFocus = flowFocusList
 	m.terminalPrefixActive = false
 	m = m.syncActiveFlowsFromCache()
@@ -217,7 +218,7 @@ func (m Model) reflowActiveFlows() Model {
 }
 
 func isNumberedModeKey(key string) bool {
-	return key >= "1" && key <= "8"
+	return key >= "1" && key <= "9"
 }
 
 func modeForNumberedKey(key string) (ui.Mode, bool) {
@@ -232,14 +233,18 @@ func (m Model) switchModeFromKey(key string) (Model, tea.Cmd, bool) {
 	if !ok {
 		return m, nil, false
 	}
-	m = m.exitActiveFlowsSurface()
 	if m.mode == mode {
 		return m, nil, true
 	}
+	previousMode := m.mode
 	m.mode = mode
-	m = m.resetModeCursors()
+	m = m.resetModeCursorsForSwitch(previousMode, m.mode)
 	if m.mode == ui.ModeFlows {
 		next, cmd := m.startFlowsModeFetchWithRefreshTick()
+		return next, cmd, true
+	}
+	if m.mode == ui.ModeActiveFlows {
+		next, cmd := m.startActiveFlowsFetchWithRefreshTick()
 		return next, cmd, true
 	}
 	next, cmd := m.startFetchMode(mode)

--- a/model/flow_surface.go
+++ b/model/flow_surface.go
@@ -23,31 +23,6 @@ func (m Model) activeContentFetchMode() ui.Mode {
 	return m.mode
 }
 
-func (m Model) enterActiveFlowsSurface() (Model, tea.Cmd) {
-	m.mode = ui.ModeActiveFlows
-	m.contentSurface = surfaceModeContent
-	m.flowFocus = flowFocusList
-	m.terminalPrefixActive = false
-	m = m.syncActiveFlowsFromCache()
-	return m.startActiveFlowsFetchWithRefreshTick()
-}
-
-func (m Model) exitActiveFlowsSurface() Model {
-	m.contentSurface = surfaceModeContent
-	if m.flowFocus == flowFocusTerminal {
-		m.flowFocus = flowFocusList
-		m.terminalPrefixActive = false
-	}
-	return m
-}
-
-func (m Model) toggleActiveFlowsSurface() (Model, tea.Cmd) {
-	if m.activeFlowSurfaceVisible() {
-		return m.exitActiveFlowsSurface(), nil
-	}
-	return m.enterActiveFlowsSurface()
-}
-
 func (m Model) syncActiveFlowsFromCache() Model {
 	selectedFlowID := m.selectedActiveFlowID()
 	expandedFlowID := m.expandedActiveFlowID

--- a/model/mode_fetch.go
+++ b/model/mode_fetch.go
@@ -135,6 +135,9 @@ func listFetchDescriptorForMode(mode ui.Mode) (listFetchDescriptor, bool) {
 }
 
 func (m Model) startFetchMode(mode ui.Mode) (Model, tea.Cmd) {
+	if mode == ui.ModeActiveFlows {
+		return m.startFetchActiveFlows()
+	}
 	desc, ok := listFetchDescriptorForMode(mode)
 	if !ok {
 		return m, nil
@@ -147,27 +150,34 @@ func (m Model) startFetchMode(mode ui.Mode) (Model, tea.Cmd) {
 	if desc.mode == ui.ModeFlows && m.flowSurfaceVisible() {
 		m.flowRefreshTickGen++
 		m.flowRefreshInFlight = 0
+		m.flowRefreshInFlightMode = 0
 		if cmd != nil {
 			m.flowRefreshInFlight = request
+			m.flowRefreshInFlightMode = desc.mode
 		}
 	}
 	return m, cmd
 }
 
 func (m Model) startFetchActiveFlows() (Model, tea.Cmd) {
-	m, request := m.nextListFetchRequest(ui.ModeFlows)
+	m, request := m.nextListFetchRequest(ui.ModeActiveFlows)
 	cmd := m.fetchActiveFlows(request)
 	if m.flowSurfaceVisible() {
 		m.flowRefreshTickGen++
 		m.flowRefreshInFlight = 0
+		m.flowRefreshInFlightMode = 0
 		if cmd != nil {
 			m.flowRefreshInFlight = request
+			m.flowRefreshInFlightMode = ui.ModeActiveFlows
 		}
 	}
 	return m, cmd
 }
 
 func (m Model) fetchMode(mode ui.Mode, request uint64) tea.Cmd {
+	if mode == ui.ModeActiveFlows {
+		return m.fetchActiveFlows(request)
+	}
 	desc, ok := listFetchDescriptorForMode(mode)
 	if !ok {
 		return nil
@@ -183,7 +193,7 @@ func (m Model) fetchActiveFlows(request uint64) tea.Cmd {
 				Pane:        "active-flows",
 				Err:         fmt.Sprintf("failed to load active flows: %v", err),
 				Kind:        FetchList,
-				Mode:        ui.ModeFlows,
+				Mode:        ui.ModeActiveFlows,
 				ListRequest: request,
 			}
 		}

--- a/model/model.go
+++ b/model/model.go
@@ -22,7 +22,7 @@ import (
 	"github.com/brian-bell/wtui/ui"
 )
 
-const listRequestSlots = int(ui.ModeFlows) + 1
+const listRequestSlots = int(ui.ModeActiveFlows) + 1
 
 type contentSurface int
 
@@ -130,6 +130,7 @@ type Model struct {
 	embeddedTerminalTickGen    uint64
 	flowRefreshTickGen         uint64
 	flowRefreshInFlight        uint64
+	flowRefreshInFlightMode    ui.Mode
 	terminalPrefixActive       bool
 	terminalConfirmID          embeddedTerminalID
 	terminalConfirmScope       embeddedTerminalScope
@@ -442,20 +443,25 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		bootstrapHookForRepo:     bootstrapHookForRepo,
 		runBootstrapHook:         runBootstrapHook,
 	}
-	for mode := ui.ModeWorktrees; mode <= ui.ModeFlows; mode++ {
+	for mode := ui.ModeWorktrees; mode <= ui.ModeActiveFlows; mode++ {
 		m.listRequestSeq++
 		m.listRequests[int(mode)] = m.listRequestSeq
 	}
 	if m.mode == ui.ModeFlows {
 		if _, ok := m.currentRepoPath(); ok {
 			m.flowRefreshInFlight = m.currentListRequest(ui.ModeFlows)
+			m.flowRefreshInFlightMode = ui.ModeFlows
 		}
+	}
+	if m.mode == ui.ModeActiveFlows {
+		m.flowRefreshInFlight = m.currentListRequest(ui.ModeActiveFlows)
+		m.flowRefreshInFlightMode = ui.ModeActiveFlows
 	}
 	return m
 }
 
 func startupMode(mode ui.Mode) ui.Mode {
-	if mode >= ui.ModeWorktrees && mode <= ui.ModeFlows {
+	if mode >= ui.ModeWorktrees && mode <= ui.ModeActiveFlows {
 		return mode
 	}
 	return ui.ModeWorktrees
@@ -818,6 +824,8 @@ func (m Model) activeItemCounts(filteredWorktrees, filteredBranches, filteredSta
 		return m.plans.ItemCount(), filteredPlans
 	case ui.ModeFlows:
 		return m.flows.ItemCount(), filteredFlows
+	case ui.ModeActiveFlows:
+		return m.activeFlows.ItemCount(), filteredFlows
 	default:
 		return 0, 0
 	}
@@ -841,6 +849,8 @@ func modeDataName(mode ui.Mode) string {
 		return "plans"
 	case ui.ModeFlows:
 		return "flows"
+	case ui.ModeActiveFlows:
+		return "active flows"
 	default:
 		return "items"
 	}
@@ -863,6 +873,8 @@ func modeResultName(mode ui.Mode) string {
 	case ui.ModePlans:
 		return "plan"
 	case ui.ModeFlows:
+		return "flow"
+	case ui.ModeActiveFlows:
 		return "flow"
 	default:
 		return "item"
@@ -1128,7 +1140,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return next, batchNonNil(refreshCmd, autoLaunchCmd)
 	case ActiveFlowResultMsg:
 		next, autoLaunchCmd := m.handleActiveFlowResult(msg)
-		next, refreshCmd := next.finishFlowRefreshFetch(ui.ModeFlows, msg.ListRequest)
+		next, refreshCmd := next.finishFlowRefreshFetch(ui.ModeActiveFlows, msg.ListRequest)
 		return next, batchNonNil(refreshCmd, autoLaunchCmd)
 	case FlowAutoModeSetMsg:
 		return m.handleFlowAutoModeSet(msg), nil

--- a/model/model.go
+++ b/model/model.go
@@ -24,13 +24,6 @@ import (
 
 const listRequestSlots = int(ui.ModeActiveFlows) + 1
 
-type contentSurface int
-
-const (
-	surfaceModeContent contentSurface = iota
-	surfaceActiveFlows
-)
-
 // Model is the bubbletea application model.
 type Model struct {
 	repos                      pane.Pane[scanner.Repo]
@@ -54,7 +47,6 @@ type Model struct {
 	selectedPlanPhaseID        string
 	selectedFlowPhaseID        string
 	selectedActiveFlowPhaseID  string
-	contentSurface             contentSurface
 	flowHeadless               bool
 	modal                      modal.Modal
 	diffRequestSeq             uint64

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3415,7 +3415,7 @@ func TestModel_ShiftVOpensDefaultViewSelectFromBothPanes(t *testing.T) {
 				t.Fatalf("expected select overlay, got %d", m.Overlay())
 			}
 			view := m.View()
-			for _, want := range []string{"Choose default view", "1 worktrees", "2 branches", "3 stashes", "4 history", "5 reflog", "6 sessions", "7 plans", "8 flows"} {
+			for _, want := range []string{"Choose default view", "1 worktrees", "2 branches", "3 stashes", "4 history", "5 reflog", "6 sessions", "7 plans", "8 flows", "9 active flows"} {
 				if !strings.Contains(view, want) {
 					t.Fatalf("expected default view select to contain %q:\n%s", want, view)
 				}
@@ -3430,17 +3430,16 @@ func TestModel_ShiftVOpensDefaultViewSelectFromBothPanes(t *testing.T) {
 	}
 }
 
-func TestModel_ShiftVOpensDefaultViewSelectFromActiveFlowsSurface(t *testing.T) {
-	m := model.NewWithOptions(testRepos(), model.Options{StartupMode: ui.ModeBranches})
+func TestModel_ShiftVOpensDefaultViewSelectFromActiveFlowsMode(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{StartupMode: ui.ModeActiveFlows})
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'V'}})
 
 	if m.Overlay() != ui.OverlaySelect {
 		t.Fatalf("expected default view select overlay, got %d", m.Overlay())
 	}
-	if !strings.Contains(m.View(), "> 2 branches") {
-		t.Fatalf("expected branches default preselected:\n%s", m.View())
+	if !strings.Contains(m.View(), "> 9 active flows") {
+		t.Fatalf("expected active flows default preselected:\n%s", m.View())
 	}
 	if cmd != nil {
 		t.Fatalf("expected nil cmd opening default view select, got %T", cmd)
@@ -3457,7 +3456,7 @@ func TestModel_DefaultViewSelectSavesAndUpdatesSessionChoice(t *testing.T) {
 		},
 	})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'V'}})
-	for range 7 {
+	for range 8 {
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	}
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -3468,11 +3467,11 @@ func TestModel_DefaultViewSelectSavesAndUpdatesSessionChoice(t *testing.T) {
 		t.Fatal("expected save default view command")
 	}
 	m, _ = update(m, cmd())
-	if saved != ui.ModeFlows {
-		t.Fatalf("saved default view = %v, want flows", saved)
+	if saved != ui.ModeActiveFlows {
+		t.Fatalf("saved default view = %v, want active flows", saved)
 	}
-	if m.DefaultView() != ui.ModeFlows {
-		t.Fatalf("session default view = %v, want flows", m.DefaultView())
+	if m.DefaultView() != ui.ModeActiveFlows {
+		t.Fatalf("session default view = %v, want active flows", m.DefaultView())
 	}
 	if m.Mode() != ui.ModeWorktrees {
 		t.Fatalf("selecting default view should not switch current mode, got %v", m.Mode())
@@ -3531,8 +3530,8 @@ func TestModel_ShiftVDoesNotReplaceExistingModal(t *testing.T) {
 
 func TestModel_ViewChoicesCoverNumberedViews(t *testing.T) {
 	choices := model.ViewChoices()
-	if len(choices) != 8 {
-		t.Fatalf("ViewChoices length = %d, want 8", len(choices))
+	if len(choices) != 9 {
+		t.Fatalf("ViewChoices length = %d, want 9", len(choices))
 	}
 	for _, choice := range choices {
 		mode, ok := model.ModeForViewNumber(choice.Number)
@@ -3547,6 +3546,16 @@ func TestModel_ViewChoicesCoverNumberedViews(t *testing.T) {
 		if label != want {
 			t.Fatalf("ViewChoiceLabel(%v) = %q, want %q", choice.Mode, label, want)
 		}
+	}
+	mode, ok := model.ModeForViewNumber(9)
+	if !ok || mode != ui.ModeActiveFlows {
+		t.Fatalf("ModeForViewNumber(9) = %v, %v; want active flows, true", mode, ok)
+	}
+	if number, ok := model.ViewNumber(ui.ModeActiveFlows); !ok || number != 9 {
+		t.Fatalf("ViewNumber(ModeActiveFlows) = %d, %v; want 9, true", number, ok)
+	}
+	if label := model.ViewChoiceLabel(ui.ModeActiveFlows); label != "9 active flows" {
+		t.Fatalf("ViewChoiceLabel(ModeActiveFlows) = %q, want %q", label, "9 active flows")
 	}
 }
 

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -76,7 +76,7 @@ func (m Model) startGlobalRefresh() (Model, tea.Cmd) {
 
 func (m Model) fetchForMode() tea.Cmd {
 	if m.activeFlowSurfaceVisible() {
-		return m.fetchActiveFlows(m.currentListRequest(ui.ModeFlows))
+		return m.fetchActiveFlows(m.currentListRequest(ui.ModeActiveFlows))
 	}
 	mode := m.activeContentFetchMode()
 	return m.fetchMode(mode, m.currentListRequest(mode))

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -49,8 +49,14 @@ func (m Model) startGlobalRefresh() (Model, tea.Cmd) {
 	}
 
 	cmds := []tea.Cmd{scanCmd}
-	if repoPath, ok := m.currentRepoPath(); ok {
-		fetchMode := m.activeContentFetchMode()
+	fetchMode := m.activeContentFetchMode()
+	if fetchMode == ui.ModeActiveFlows {
+		var fetchCmd tea.Cmd
+		m, fetchCmd = m.startFetchForMode()
+		if fetchCmd != nil {
+			cmds = append(cmds, fetchCmd)
+		}
+	} else if repoPath, ok := m.currentRepoPath(); ok {
 		if _, ok := listFetchDescriptorForMode(fetchMode); ok {
 			inlineWorktreePath := ""
 			if fetchMode == ui.ModeWorktrees && m.inlineWorktreeSessionPath != "" {

--- a/model/model_filter.go
+++ b/model/model_filter.go
@@ -203,10 +203,7 @@ func (m Model) clampSelectionsAfterFilter() Model {
 	m = m.reflowPlans()
 	m = m.reflowFlows()
 	m = m.reflowActiveFlows()
-	if m.mode == ui.ModeFlows && m.activePane == 1 && m.flowFocus != flowFocusTerminal {
-		m = m.syncActiveFlowTerminalToSelectedFlow()
-	}
-	if m.activeFlowSurfaceVisible() && m.activePane == 1 && m.flowFocus != flowFocusTerminal {
+	if m.flowSurfaceVisible() && m.activePane == 1 && m.flowFocus != flowFocusTerminal {
 		m = m.syncActiveFlowTerminalToSelectedFlow()
 	}
 	return m

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -230,11 +230,19 @@ func TestModel_ActiveFlowsGlobalFetchErrorSurvivesRepoMove(t *testing.T) {
 }
 
 func TestModel_ActiveFlowsLeftPaneEnterShowsGlobalActiveFlows(t *testing.T) {
+	alpha := flowWithPhaseDetails()
+	alpha.FlowID = "alpha-flow"
+	alpha.Title = "Alpha Flow"
+	bravo := flowWithPhaseDetails()
+	bravo.FlowID = "bravo-flow"
+	bravo.RepoPath = "/dev/bravo"
+	bravo.Title = "Bravo Flow"
+
 	var filters []flowstore.FlowFilter
 	m := model.NewWithOptions(testRepos(), model.Options{
 		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			filters = append(filters, filter)
-			return []flowstore.FlowRecord{{FlowID: "flow", RepoPath: filter.RepoPath, Title: "Repo Flow", Status: flowstore.StatusPending}}, nil
+			return []flowstore.FlowRecord{alpha, bravo}, nil
 		},
 	})
 	m = inRightPane(m)
@@ -246,6 +254,9 @@ func TestModel_ActiveFlowsLeftPaneEnterShowsGlobalActiveFlows(t *testing.T) {
 	m, _ = update(m, activeFlowResultFromCommand(t, cmd))
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	if got := model.ActiveFlowsForTest(m); len(got) != 1 || got[0].FlowID != "bravo-flow" {
+		t.Fatalf("left-pane active flows = %#v, want repo-filtered bravo", got)
+	}
 
 	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	if cmd != nil {
@@ -254,6 +265,9 @@ func TestModel_ActiveFlowsLeftPaneEnterShowsGlobalActiveFlows(t *testing.T) {
 	view := ansi.Strip(m.View())
 	if !strings.Contains(view, "Shortcuts  Active flows") {
 		t.Fatalf("left-pane enter should keep active flows visible:\n%s", view)
+	}
+	if got := model.ActiveFlowsForTest(m); len(got) != 2 || got[0].FlowID != "alpha-flow" || got[1].FlowID != "bravo-flow" {
+		t.Fatalf("left-pane enter active flows = %#v, want global alpha and bravo", got)
 	}
 	if len(filters) != 2 || filters[len(filters)-1].RepoPath != "" {
 		t.Fatalf("flow filters = %#v, want no repo-scoped fetch on left-pane enter", filters)

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -52,8 +52,11 @@ func activeFlowResultFromCommand(t *testing.T, cmd tea.Cmd) model.ActiveFlowResu
 
 func enterActiveFlowsWithRecords(t *testing.T, m model.Model, records []flowstore.FlowRecord) model.Model {
 	t.Helper()
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
-	m, _ = update(m, model.ActiveFlowResultMsg{Flows: records, ListRequest: m.ListRequest(ui.ModeFlows)})
+	if m.ActivePane() == 0 {
+		m = inRightPane(m)
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
+	m, _ = update(m, model.ActiveFlowResultMsg{Flows: records, ListRequest: m.ListRequest(ui.ModeActiveFlows)})
 	return m
 }
 
@@ -72,7 +75,7 @@ func flowWithPhaseDetails() flowstore.FlowRecord {
 	}
 }
 
-func TestModel_F3ShowsGlobalActiveFlowsWithoutPollutingFlowsCache(t *testing.T) {
+func TestModel_Key9ShowsGlobalActiveFlowsWithoutPollutingFlowsCache(t *testing.T) {
 	alpha := flowWithPhaseDetails()
 	alpha.FlowID = "alpha-flow"
 	alpha.Title = "Alpha Flow"
@@ -96,25 +99,28 @@ func TestModel_F3ShowsGlobalActiveFlowsWithoutPollutingFlowsCache(t *testing.T) 
 	m, _ = update(m, tea.WindowSizeMsg{Width: 220, Height: 30})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
 	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("mode = %v, want worktrees before F3", m.Mode())
+		t.Fatalf("mode = %v, want worktrees before view 9", m.Mode())
 	}
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 	if cmd == nil {
-		t.Fatal("F3 should start or continue a Flow refresh")
+		t.Fatal("view 9 should start or continue a Flow refresh")
 	}
 	m, _ = update(m, activeFlowResultFromCommand(t, cmd))
 	if gotFilter.RepoPath != "" {
 		t.Fatalf("active Flow filter RepoPath = %q, want global", gotFilter.RepoPath)
 	}
-	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("mode = %v, want preserved worktrees mode", m.Mode())
+	if m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("mode = %v, want active flows", m.Mode())
 	}
 	view := ansi.Strip(m.View())
-	for _, want := range []string{"active flows", "Alpha Flow", "Bravo Flow", "f3"} {
+	for _, want := range []string{"active flows", "Alpha Flow", "Bravo Flow"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("active-flow view missing %q:\n%s", want, view)
 		}
+	}
+	if strings.Contains(view, "f3") {
+		t.Fatalf("active-flow view should not advertise f3:\n%s", view)
 	}
 	if strings.Contains(view, "Merged Flow") {
 		t.Fatalf("active-flow view should filter merged flows:\n%s", view)
@@ -123,14 +129,14 @@ func TestModel_F3ShowsGlobalActiveFlowsWithoutPollutingFlowsCache(t *testing.T) 
 		t.Fatalf("normal Flows() cache = %#v, want original repo-scoped alpha flow", got)
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
 	view = ansi.Strip(m.View())
 	if !strings.Contains(view, "worktrees") || strings.Contains(view, "Bravo Flow") {
-		t.Fatalf("second F3 should restore worktrees pane:\n%s", view)
+		t.Fatalf("view 1 should restore worktrees pane:\n%s", view)
 	}
 }
 
-func TestModel_F3GlobalResultSurvivesRepoMoveAndUsesLeftPaneFilter(t *testing.T) {
+func TestModel_ActiveFlowsGlobalResultSurvivesRepoMoveAndUsesLeftPaneFilter(t *testing.T) {
 	alpha := flowWithPhaseDetails()
 	alpha.FlowID = "alpha-flow"
 	alpha.Title = "Alpha Flow"
@@ -149,7 +155,7 @@ func TestModel_F3GlobalResultSurvivesRepoMoveAndUsesLeftPaneFilter(t *testing.T)
 	m = inRightPane(m)
 	m, _ = update(m, tea.WindowSizeMsg{Width: 220, Height: 24})
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 	result := activeFlowResultFromCommand(t, cmd)
 	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	if cmd != nil {
@@ -176,7 +182,7 @@ func TestModel_F3GlobalResultSurvivesRepoMoveAndUsesLeftPaneFilter(t *testing.T)
 	}
 }
 
-func TestModel_F3LeftPaneFilterCleansRepoPath(t *testing.T) {
+func TestModel_ActiveFlowsLeftPaneFilterCleansRepoPath(t *testing.T) {
 	alpha := flowWithPhaseDetails()
 	alpha.FlowID = "alpha-flow"
 	alpha.Title = "Alpha Flow"
@@ -197,7 +203,7 @@ func TestModel_F3LeftPaneFilterCleansRepoPath(t *testing.T) {
 	}
 }
 
-func TestModel_F3GlobalFetchErrorSurvivesRepoMove(t *testing.T) {
+func TestModel_ActiveFlowsGlobalFetchErrorSurvivesRepoMove(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return nil, errors.New("state unavailable")
@@ -206,7 +212,7 @@ func TestModel_F3GlobalFetchErrorSurvivesRepoMove(t *testing.T) {
 	m = inRightPane(m)
 	m, _ = update(m, tea.WindowSizeMsg{Width: 180, Height: 18})
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 	if cmd == nil {
 		t.Fatal("expected active Flow fetch command")
 	}
@@ -223,7 +229,7 @@ func TestModel_F3GlobalFetchErrorSurvivesRepoMove(t *testing.T) {
 	}
 }
 
-func TestModel_F3LeftPaneEnterExitsToSelectedRepoMode(t *testing.T) {
+func TestModel_ActiveFlowsLeftPaneEnterShowsGlobalActiveFlows(t *testing.T) {
 	var filters []flowstore.FlowFilter
 	m := model.NewWithOptions(testRepos(), model.Options{
 		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
@@ -236,29 +242,28 @@ func TestModel_F3LeftPaneEnterExitsToSelectedRepoMode(t *testing.T) {
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
 	m, _ = update(m, flowResultFromCommand(t, cmd))
 
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 	m, _ = update(m, activeFlowResultFromCommand(t, cmd))
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
 	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	if cmd == nil {
-		t.Fatal("expected normal Flow-mode fetch after left-pane enter")
+	if cmd != nil {
+		t.Fatalf("left-pane enter in active flows returned command %T, want nil", cmd)
 	}
-	m, _ = update(m, flowResultFromCommand(t, cmd))
 	view := ansi.Strip(m.View())
-	if strings.Contains(view, "Shortcuts  Active flows") {
-		t.Fatalf("left-pane enter should exit active flows:\n%s", view)
+	if !strings.Contains(view, "Shortcuts  Active flows") {
+		t.Fatalf("left-pane enter should keep active flows visible:\n%s", view)
 	}
-	if len(filters) < 3 || filters[len(filters)-1].RepoPath != "/dev/bravo" {
-		t.Fatalf("flow filters = %#v, want final normal fetch for selected bravo repo", filters)
+	if len(filters) != 2 || filters[len(filters)-1].RepoPath != "" {
+		t.Fatalf("flow filters = %#v, want no repo-scoped fetch on left-pane enter", filters)
 	}
-	if m.ActivePane() != 0 || m.Mode() != ui.ModeFlows {
-		t.Fatalf("active pane/mode = %d/%d, want left pane in flows mode", m.ActivePane(), m.Mode())
+	if m.ActivePane() != 1 || m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("active pane/mode = %d/%d, want right pane in active flows", m.ActivePane(), m.Mode())
 	}
 }
 
-func TestModel_F3UsesSeparateActiveFlowSelectionForActions(t *testing.T) {
+func TestModel_ActiveFlowsUsesSeparateActiveFlowSelectionForActions(t *testing.T) {
 	activeOne := flowWithPhaseDetails()
 	activeOne.FlowID = "active-one"
 	activeOne.Title = "Active One"
@@ -310,14 +315,14 @@ func TestModel_F3UsesSeparateActiveFlowSelectionForActions(t *testing.T) {
 		t.Fatalf("launch update = %#v, want active-two implementation", launched)
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
 	view = ansi.Strip(m.View())
 	if m.Mode() != ui.ModeFlows || m.FlowSelected() != 1 || !strings.Contains(view, "Merged Flow") {
-		t.Fatalf("normal Flow mode should retain merged selection after F3 exit; selected=%d view:\n%s", m.FlowSelected(), view)
+		t.Fatalf("normal Flow mode should retain merged selection after switching to view 8; selected=%d view:\n%s", m.FlowSelected(), view)
 	}
 }
 
-func TestModel_F3ActiveFlowRefreshPreparesAutoLaunch(t *testing.T) {
+func TestModel_ActiveFlowsRefreshPreparesAutoLaunch(t *testing.T) {
 	previous := autoFlowWithPhaseStatuses(map[string]string{
 		"plan":           flowstore.PhaseCompleted,
 		"plan-review":    flowstore.PhaseRunning,
@@ -349,7 +354,7 @@ func TestModel_F3ActiveFlowRefreshPreparesAutoLaunch(t *testing.T) {
 
 	_, cmd := update(m, model.ActiveFlowResultMsg{
 		Flows:       []flowstore.FlowRecord{current},
-		ListRequest: m.ListRequest(ui.ModeFlows),
+		ListRequest: m.ListRequest(ui.ModeActiveFlows),
 	})
 	if cmd == nil {
 		t.Fatal("active Flow refresh should return auto-launch command")
@@ -371,7 +376,7 @@ func TestModel_F3ActiveFlowRefreshPreparesAutoLaunch(t *testing.T) {
 	}
 }
 
-func TestModel_F3ActiveFlowRightNavigationKeysClampAtFlowSurface(t *testing.T) {
+func TestModel_ActiveFlowsRightNavigationWrapsToWorktrees(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		key  tea.KeyMsg
@@ -387,25 +392,25 @@ func TestModel_F3ActiveFlowRightNavigationKeysClampAtFlowSurface(t *testing.T) {
 			before := listRequests(m)
 
 			m, cmd := update(m, tc.key)
-			if cmd != nil {
-				t.Fatalf("%s from active Flow surface returned command %T, want nil", tc.name, cmd)
+			if cmd == nil {
+				t.Fatalf("%s from active Flow surface returned nil command, want worktrees fetch", tc.name)
 			}
 			if m.ActivePane() != 1 {
 				t.Fatalf("%s from active Flow surface active pane = %d, want right pane", tc.name, m.ActivePane())
 			}
 			if m.Mode() != ui.ModeWorktrees {
-				t.Fatalf("%s from active Flow surface changed underlying mode = %d, want worktrees", tc.name, m.Mode())
+				t.Fatalf("%s from active Flow surface mode = %d, want worktrees", tc.name, m.Mode())
 			}
 			view := ansi.Strip(m.View())
-			if !strings.Contains(view, "Active flows") {
-				t.Fatalf("%s from active Flow surface should keep active Flow view visible:\n%s", tc.name, view)
+			if strings.Contains(view, "Active flows") {
+				t.Fatalf("%s from active Flow surface should switch away from active Flow view:\n%s", tc.name, view)
 			}
-			assertListRequestsUnchanged(t, before, m)
+			assertOnlyListRequestChanged(t, before, m, ui.ModeWorktrees)
 		})
 	}
 }
 
-func TestModel_F3ActiveFlowLeftKeyClampsAndPreservesUnderlyingMode(t *testing.T) {
+func TestModel_ActiveFlowsLeftNavigationMovesToFlows(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
@@ -413,27 +418,27 @@ func TestModel_F3ActiveFlowLeftKeyClampsAndPreservesUnderlyingMode(t *testing.T)
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
-	if cmd != nil {
-		t.Fatalf("left from active Flow surface returned command %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("left from active Flow surface returned nil command, want flows fetch")
 	}
 	if m.ActivePane() != 1 {
 		t.Fatalf("left from active Flow surface active pane = %d, want right pane", m.ActivePane())
 	}
-	if m.Mode() != ui.ModeSessions {
-		t.Fatalf("left from active Flow surface changed underlying mode = %d, want sessions", m.Mode())
+	if m.Mode() != ui.ModeFlows {
+		t.Fatalf("left from active Flow surface mode = %d, want flows", m.Mode())
 	}
 	view := ansi.Strip(m.View())
-	if !strings.Contains(view, "Active flows") {
-		t.Fatalf("left from active Flow surface should keep active Flow view visible:\n%s", view)
+	if strings.Contains(view, "Active flows") {
+		t.Fatalf("left from active Flow surface should switch to normal flows:\n%s", view)
 	}
-	assertListRequestsUnchanged(t, before, m)
+	assertOnlyListRequestChanged(t, before, m, ui.ModeFlows)
 }
 
-func TestModel_F3ActiveFlowTabWithoutTerminalKeepsFlowSurfaceFocused(t *testing.T) {
+func TestModel_ActiveFlowsTabWithoutTerminalKeepsFlowSurfaceFocused(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyTab})
@@ -443,8 +448,8 @@ func TestModel_F3ActiveFlowTabWithoutTerminalKeepsFlowSurfaceFocused(t *testing.
 	if m.ActivePane() != 1 {
 		t.Fatalf("tab from active Flow surface active pane = %d, want right pane", m.ActivePane())
 	}
-	if m.Mode() != ui.ModeSessions {
-		t.Fatalf("tab from active Flow surface changed underlying mode = %d, want sessions", m.Mode())
+	if m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("tab from active Flow surface mode = %d, want active flows", m.Mode())
 	}
 	if view := ansi.Strip(m.View()); !strings.Contains(view, "Active flows") {
 		t.Fatalf("tab from active Flow surface should keep active Flow view visible:\n%s", view)
@@ -452,7 +457,7 @@ func TestModel_F3ActiveFlowTabWithoutTerminalKeepsFlowSurfaceFocused(t *testing.
 	assertListRequestsUnchanged(t, before, m)
 }
 
-func TestModel_F3ActiveFlowTabWithTerminalSwitchesBetweenListAndTerminal(t *testing.T) {
+func TestModel_ActiveFlowsTabWithTerminalSwitchesBetweenListAndTerminal(t *testing.T) {
 	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
 	flowOne := flowWithPhaseDetails()
 	flowTwo := flowWithPhaseDetails()
@@ -510,7 +515,7 @@ func TestModel_F3ActiveFlowTabWithTerminalSwitchesBetweenListAndTerminal(t *test
 	}
 }
 
-func TestModel_F3ActiveFlowF2ClearsSelectedPhaseWhenLeavingRightPane(t *testing.T) {
+func TestModel_ActiveFlowsF2ClearsSelectedPhaseWhenLeavingRightPane(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
@@ -529,15 +534,15 @@ func TestModel_F3ActiveFlowF2ClearsSelectedPhaseWhenLeavingRightPane(t *testing.
 	if m.ActivePane() != 0 {
 		t.Fatalf("F2 from active Flow surface active pane = %d, want left pane", m.ActivePane())
 	}
-	if m.Mode() != ui.ModeSessions {
-		t.Fatalf("F2 from active Flow surface changed underlying mode = %d, want sessions", m.Mode())
+	if m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("F2 from active Flow surface mode = %d, want active flows", m.Mode())
 	}
 	if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "" {
 		t.Fatalf("F2 from active Flow surface left selected phase = %q, want cleared", got)
 	}
 }
 
-func TestModel_F3ActiveFlowLeftPaneNumberedKeysAreNoOps(t *testing.T) {
+func TestModel_ActiveFlowsLeftPaneNumberedKeysAreNoOps(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
@@ -552,8 +557,8 @@ func TestModel_F3ActiveFlowLeftPaneNumberedKeysAreNoOps(t *testing.T) {
 	if m.ActivePane() != 0 {
 		t.Fatalf("left-pane numbered key activePane = %d, want left pane", m.ActivePane())
 	}
-	if m.Mode() != ui.ModeSessions {
-		t.Fatalf("left-pane numbered key changed underlying mode = %d, want sessions", m.Mode())
+	if m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("left-pane numbered key changed mode = %d, want active flows", m.Mode())
 	}
 	if view := ansi.Strip(m.View()); !strings.Contains(view, "Active flows") {
 		t.Fatalf("left-pane numbered key should keep active Flow view visible:\n%s", view)
@@ -561,7 +566,7 @@ func TestModel_F3ActiveFlowLeftPaneNumberedKeysAreNoOps(t *testing.T) {
 	assertListRequestsUnchanged(t, before, m)
 }
 
-func TestModel_F3ActiveFlowFetchErrorUsesActiveFetchMode(t *testing.T) {
+func TestModel_ActiveFlowsFetchErrorUsesActiveFetchMode(t *testing.T) {
 	m := flowsInRightPane(t, model.New(testRepos()), nil)
 	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 18})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
@@ -571,20 +576,20 @@ func TestModel_F3ActiveFlowFetchErrorUsesActiveFetchMode(t *testing.T) {
 		Pane:        "active-flows",
 		Err:         "failed to load active flows: boom",
 		Kind:        model.FetchList,
-		Mode:        ui.ModeFlows,
-		ListRequest: m.ListRequest(ui.ModeFlows),
+		Mode:        ui.ModeActiveFlows,
+		ListRequest: m.ListRequest(ui.ModeActiveFlows),
 	})
 
 	view := ansi.Strip(m.View())
 	if !strings.Contains(view, "failed to load active flows: boom") {
 		t.Fatalf("active Flow surface should show Flow fetch failure in status bar:\n%s", view)
 	}
-	if !strings.Contains(view, "Could not load flows; see status bar") {
+	if !strings.Contains(view, "Could not load active flows; see status bar") {
 		t.Fatalf("empty active Flow surface should show Flow fetch failure placeholder:\n%s", view)
 	}
 }
 
-func TestModel_F3ActiveFlowSearchAcceptsDigits(t *testing.T) {
+func TestModel_ActiveFlowsSearchAcceptsDigits(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	flow.Title = "Release Flow 123"
 	flow.Branch = "release/123"
@@ -606,7 +611,7 @@ func TestModel_F3ActiveFlowSearchAcceptsDigits(t *testing.T) {
 	}
 }
 
-func TestModel_F3ActiveFlowPullDoesNotTargetHiddenWorktree(t *testing.T) {
+func TestModel_ActiveFlowsPullDoesNotTargetHiddenWorktree(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	flow.WorktreePath = "/dev/alpha-worktrees/visible-flow"
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
@@ -675,9 +680,9 @@ func TestModel_ActiveFlowRefreshPreservesNormalFlowSelection(t *testing.T) {
 
 	m, _ = update(m, model.ActiveFlowResultMsg{
 		Flows:       []flowstore.FlowRecord{activeOne, activeTwo},
-		ListRequest: m.ListRequest(ui.ModeFlows),
+		ListRequest: m.ListRequest(ui.ModeActiveFlows),
 	})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
 	if got := m.FlowSelected(); got != 1 {
 		t.Fatalf("normal Flow selection after active refresh = %d, want preserved active-two", got)
 	}
@@ -3766,7 +3771,7 @@ func TestModel_SelectedFlowPhaseClearsWhenLeavingRightPane(t *testing.T) {
 	}
 }
 
-func TestModel_SelectedFlowPhaseClearsWhenRightArrowWrapsFromFlows(t *testing.T) {
+func TestModel_RightArrowFromFlowsMovesToActiveFlows(t *testing.T) {
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
@@ -3777,21 +3782,18 @@ func TestModel_SelectedFlowPhaseClearsWhenRightArrowWrapsFromFlows(t *testing.T)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
 	if cmd == nil {
-		t.Fatal("right from flows returned nil command, want worktrees fetch")
-	}
-	if got := m.SelectedFlowPhaseID(); got != "" {
-		t.Fatalf("right from flows selected flow phase = %q, want cleared", got)
+		t.Fatal("right from flows returned nil command, want active flows fetch")
 	}
 	if m.ActivePane() != 1 {
 		t.Fatalf("right from flows active pane = %d, want right pane", m.ActivePane())
 	}
-	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("right from flows mode = %d, want worktrees", m.Mode())
+	if m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("right from flows mode = %d, want active flows", m.Mode())
 	}
-	assertOnlyListRequestChanged(t, beforeRequests, m, ui.ModeWorktrees)
+	assertOnlyListRequestChanged(t, beforeRequests, m, ui.ModeActiveFlows)
 	msgs := runBatchCmd(t, cmd)
-	if !hasListFetchForMode(msgs, ui.ModeWorktrees, m.ListRequest(ui.ModeWorktrees)) {
-		t.Fatalf("right from flows command messages = %#v, want worktrees fetch for request %d", msgs, m.ListRequest(ui.ModeWorktrees))
+	if !hasListFetchForMode(msgs, ui.ModeActiveFlows, m.ListRequest(ui.ModeActiveFlows)) {
+		t.Fatalf("right from flows command messages = %#v, want active flows fetch for request %d", msgs, m.ListRequest(ui.ModeActiveFlows))
 	}
 }
 
@@ -4060,7 +4062,7 @@ func TestModel_ActiveFlowDeleteWithNoVisibleFlowIgnoresUnderlyingStash(t *testin
 		}},
 		ListRequest: m.ListRequest(ui.ModeStashes),
 	})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF3})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
@@ -4355,7 +4357,7 @@ func TestModel_FlowDeleteDoesNotTerminateEmbeddedTerminal(t *testing.T) {
 	}
 }
 
-func TestModel_RightNavigationWrapsFromFlowsWithoutChangingExistingModeNumbers(t *testing.T) {
+func TestModel_RightNavigationMovesFromFlowsToActiveFlowsWithoutChangingExistingModeNumbers(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) { return nil, nil },
 	})
@@ -4372,19 +4374,19 @@ func TestModel_RightNavigationWrapsFromFlowsWithoutChangingExistingModeNumbers(t
 	}
 	before := listRequests(m)
 	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRight})
-	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("right from flows mode = %d, want worktrees", m.Mode())
+	if m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("right from flows mode = %d, want active flows", m.Mode())
 	}
 	if m.ActivePane() != 1 {
 		t.Fatalf("right from flows active pane = %d, want right pane", m.ActivePane())
 	}
 	if cmd == nil {
-		t.Fatal("right from flows returned nil command, want worktrees fetch")
+		t.Fatal("right from flows returned nil command, want active flows fetch")
 	}
-	assertOnlyListRequestChanged(t, before, m, ui.ModeWorktrees)
+	assertOnlyListRequestChanged(t, before, m, ui.ModeActiveFlows)
 	msgs := runBatchCmd(t, cmd)
-	if !hasListFetchForMode(msgs, ui.ModeWorktrees, m.ListRequest(ui.ModeWorktrees)) {
-		t.Fatalf("right from flows command messages = %#v, want worktrees fetch for request %d", msgs, m.ListRequest(ui.ModeWorktrees))
+	if !hasListFetchForMode(msgs, ui.ModeActiveFlows, m.ListRequest(ui.ModeActiveFlows)) {
+		t.Fatalf("right from flows command messages = %#v, want active flows fetch for request %d", msgs, m.ListRequest(ui.ModeActiveFlows))
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -2958,6 +2958,54 @@ func TestModel_FlowAutoModeDoesNotLaunchAfterLeavingFlowsMode(t *testing.T) {
 	}
 }
 
+func TestModel_FlowAutoModeDoesNotLaunchAfterSwitchingToActiveFlowsMode(t *testing.T) {
+	previous := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseRunning,
+		"implementation": flowstore.PhasePending,
+	})
+	current := autoFlowWithPhaseStatuses(map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	var updates []flowstore.PhaseLaunchUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			return current, nil
+		},
+		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{current}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{previous})
+	request := m.ListRequest(ui.ModeFlows)
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
+	if cmd == nil {
+		t.Fatal("switching to active flows returned nil command, want active flows fetch")
+	}
+
+	m, cmd = update(m, model.FlowResultMsg{
+		RepoPath:    "/dev/alpha",
+		Flows:       []flowstore.FlowRecord{current},
+		ListRequest: request,
+	})
+	if cmd != nil {
+		t.Fatalf("accepted FlowResultMsg in active flows mode returned command %T, want nil", cmd)
+	}
+	if len(updates) != 0 {
+		t.Fatalf("launch updates = %#v, want none after switching to active flows mode", updates)
+	}
+	if m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("Mode() = %d, want active flows", m.Mode())
+	}
+	if got := m.Flows(); len(got) != 1 || phaseByID(got[0], "implementation").Status != flowstore.PhaseReady {
+		t.Fatalf("Flows() = %#v, want accepted refresh without auto launch", got)
+	}
+}
+
 func TestModel_StartsInFlowsModeAndFetchesSelectedRepoFlows(t *testing.T) {
 	var gotFilter flowstore.FlowFilter
 	want := []flowstore.FlowRecord{

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -51,10 +51,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return next, cmd
 	}
 
-	if key == "f3" {
-		return m.toggleActiveFlowsSurface()
-	}
-	if !m.searchActive && m.activePane == 1 && m.activeFlowSurfaceVisible() && isNumberedModeKey(key) {
+	if !m.searchActive && m.activePane == 1 && isNumberedModeKey(key) {
 		next, cmd, handled := m.switchModeFromKey(key)
 		if handled {
 			return next, cmd
@@ -265,10 +262,6 @@ func (m Model) setSearchActive(active bool) Model {
 func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 	switch key {
 	case "enter":
-		if m.activeFlowSurfaceVisible() {
-			m = m.exitActiveFlowsSurface()
-			return m.startFetchForMode()
-		}
 		if len(m.filteredRepos()) > 0 {
 			m.activePane = 1
 		}
@@ -329,11 +322,15 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			return m.startFetchForMode()
 		}
 	case "l":
-		if m.mode < ui.ModeFlows {
+		if m.mode < ui.ModeActiveFlows {
+			previousMode := m.mode
 			m.mode++
-			m = m.resetModeCursors()
+			m = m.resetModeCursorsForSwitch(previousMode, m.mode)
 			if m.mode == ui.ModeFlows {
 				return m.startFlowsModeFetchWithRefreshTick()
+			}
+			if m.mode == ui.ModeActiveFlows {
+				return m.startActiveFlowsFetchWithRefreshTick()
 			}
 			return m.startFetchForMode()
 		}
@@ -385,6 +382,12 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			m = m.resetModeCursors()
 			return m.startFlowsModeFetchWithRefreshTick()
 		}
+	case "9":
+		if m.mode != ui.ModeActiveFlows {
+			m.mode = ui.ModeActiveFlows
+			m = m.resetModeCursors()
+			return m.startActiveFlowsFetchWithRefreshTick()
+		}
 	case "y":
 		if m.mode == ui.ModePlans {
 			return m.handleCopyPlanPath()
@@ -392,19 +395,19 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModeSessions {
 			return m.handleCopySessionID()
 		}
-		if m.mode == ui.ModeFlows {
+		if m.flowSurfaceVisible() {
 			return m.handleCopyFlowWorktreePath()
 		}
 		return m.handleCopyHash()
 	case "s":
 		return m.handleShowSessionSummary()
 	case "r":
-		if m.mode == ui.ModeFlows {
+		if m.flowSurfaceVisible() {
 			return m.handleResumeFlowPhaseSession()
 		}
 		return m.handleResumeSession()
 	case "E":
-		if m.mode == ui.ModeFlows {
+		if m.flowSurfaceVisible() {
 			return m.handleSetReasoningEffort()
 		}
 	case "i":
@@ -418,17 +421,17 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModePlans {
 			return m.handleTogglePlanPhases()
 		}
-		if m.mode == ui.ModeFlows {
+		if m.flowSurfaceVisible() {
 			return m.handleResetSelectedFlowPhase()
 		}
 	case "tab":
-		if m.mode == ui.ModeFlows && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
+		if m.flowSurfaceVisible() && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
 			m.flowFocus = flowFocusTerminal
 			m.terminalPrefixActive = true
 			return m, nil
 		}
 	case "g":
-		if m.mode == ui.ModeFlows {
+		if m.flowSurfaceVisible() {
 			return m.handleLaunchNextFlowPhase()
 		}
 	case "enter":
@@ -454,7 +457,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModePlans {
 			return m.handleOpenPlanText()
 		}
-		if m.mode == ui.ModeFlows {
+		if m.flowSurfaceVisible() {
 			return m.handleOpenFlowPlanText()
 		}
 	case "e":
@@ -465,7 +468,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModeWorktrees {
 			return m.handleMoveWorktree()
 		}
-		if m.mode == ui.ModeFlows {
+		if m.flowSurfaceVisible() {
 			return m.handleToggleFlowAutoMode()
 		}
 	case "N":
@@ -476,7 +479,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModePlans {
 			return m.handleImplementPlan()
 		}
-		if m.mode == ui.ModeFlows {
+		if m.flowSurfaceVisible() {
 			return m, nil
 		}
 		return m.handleOpenAgent()
@@ -529,7 +532,7 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 	case "down", "j":
 		return m.handleCursorDown()
 	case "left":
-		return m, nil
+		return m.handleHorizontalNavigation(-1)
 	case "right", "l":
 		return m.handleHorizontalNavigation(1)
 	case "h":
@@ -573,31 +576,31 @@ func (m Model) handleHorizontalNavigation(direction int) (tea.Model, tea.Cmd) {
 	if m.activePane == 0 {
 		return m, nil
 	}
-	if m.activeFlowSurfaceVisible() {
-		return m, nil
-	}
-
 	nextMode := modeAfterHorizontalNavigation(m.mode, direction)
 	if nextMode == m.mode {
 		return m, nil
 	}
+	previousMode := m.mode
 	m.mode = nextMode
-	m = m.resetModeCursors()
+	m = m.resetModeCursorsForSwitch(previousMode, m.mode)
 	if m.mode == ui.ModeFlows {
 		return m.startFlowsModeFetchWithRefreshTick()
+	}
+	if m.mode == ui.ModeActiveFlows {
+		return m.startActiveFlowsFetchWithRefreshTick()
 	}
 	return m.startFetchForMode()
 }
 
 func modeAfterHorizontalNavigation(current ui.Mode, direction int) ui.Mode {
 	if direction > 0 {
-		if current == ui.ModeFlows {
+		if current == ui.ModeActiveFlows {
 			return ui.ModeWorktrees
 		}
 		return current + 1
 	}
 	if current == ui.ModeWorktrees {
-		return ui.ModeFlows
+		return ui.ModeActiveFlows
 	}
 	return current - 1
 }
@@ -743,7 +746,7 @@ func (m Model) handleEnter() (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	}
-	if m.mode == ui.ModeFlows {
+	if m.flowSurfaceVisible() {
 		return m.handleFlowEnter()
 	}
 	return m, nil
@@ -873,8 +876,9 @@ func (m Model) handleOpenFlowPlanText() (tea.Model, tea.Cmd) {
 		m = m.setStatus(statusOther, "Flow has no linked plan")
 		return m, nil
 	}
-	m = m.startViewRequest(FetchPlanText, ui.ModeFlows)
-	return m, m.fetchPlanTextByID(record.PlanID, ui.ModeFlows)
+	mode := m.activeContentFetchMode()
+	m = m.startViewRequest(FetchPlanText, mode)
+	return m, m.fetchPlanTextByID(record.PlanID, mode)
 }
 
 func (m Model) handleEditPlan() (tea.Model, tea.Cmd) {
@@ -1457,7 +1461,7 @@ func (m Model) pathForOpenAction() (string, bool) {
 }
 
 func (m Model) handleOpenAgent() (tea.Model, tea.Cmd) {
-	if m.mode == ui.ModeFlows {
+	if m.flowSurfaceVisible() {
 		return m, nil
 	}
 	path, ok := m.agentTargetPath()
@@ -2388,6 +2392,19 @@ func (m Model) resetModeCursors() Model {
 	return m
 }
 
+func (m Model) resetModeCursorsForSwitch(from, to ui.Mode) Model {
+	if isFlowMode(from) && isFlowMode(to) {
+		m.flowFocus = flowFocusList
+		m.terminalPrefixActive = false
+		return m.invalidateViewRequest()
+	}
+	return m.resetModeCursors()
+}
+
+func isFlowMode(mode ui.Mode) bool {
+	return mode == ui.ModeFlows || mode == ui.ModeActiveFlows
+}
+
 func (m Model) resetRightPaneCursors() Model {
 	m = m.invalidateListRequests()
 	m.pendingBranchSelection = ""
@@ -2496,6 +2513,8 @@ func (m Model) contentHeightForMode() int {
 	case ui.ModePlans:
 		return m.planContentHeight()
 	case ui.ModeFlows:
+		return m.flowContentHeight()
+	case ui.ModeActiveFlows:
 		return m.flowContentHeight()
 	default:
 		return m.rightContentHeight()

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -51,14 +51,14 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return next, cmd
 	}
 
+	m = m.clearAnyStatus()
+
 	if !m.searchActive && m.activePane == 1 && isNumberedModeKey(key) {
 		next, cmd, handled := m.switchModeFromKey(key)
 		if handled {
 			return next, cmd
 		}
 	}
-
-	m = m.clearAnyStatus()
 
 	if m.searchActive {
 		return m.handleSearchKey(msg)

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -269,6 +269,9 @@ func (m Model) handleLeftPaneKey(key string) (tea.Model, tea.Cmd) {
 	case "enter":
 		if len(m.filteredRepos()) > 0 {
 			m.activePane = 1
+			if m.activeFlowSurfaceVisible() {
+				return m.syncActiveFlowsFromCache(), nil
+			}
 		}
 	case "up", "k":
 		if len(m.filteredRepos()) > 0 {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -525,10 +525,10 @@ func (m Model) acceptListResult(repoPath string, mode ui.Mode, request uint64) (
 }
 
 func (m Model) acceptActiveFlowResult(request uint64) (Model, bool) {
-	if !m.activeFlowSurfaceVisible() || !m.isCurrentListRequest(ui.ModeFlows, request) {
+	if !m.activeFlowSurfaceVisible() || !m.isCurrentListRequest(ui.ModeActiveFlows, request) {
 		return m, false
 	}
-	return m.clearFetchListStatus(ui.ModeFlows), true
+	return m.clearFetchListStatus(ui.ModeActiveFlows), true
 }
 
 func (m Model) clearAnyStatus() Model {
@@ -1160,7 +1160,7 @@ func (m Model) handleForceDeleteFailed(msg ForceDeleteFailedMsg) Model {
 }
 
 func (m Model) handleFetchError(msg FetchErrorMsg) Model {
-	if m.activeFlowSurfaceVisible() && msg.Kind == FetchList && msg.Mode == ui.ModeFlows && msg.Pane == "active-flows" {
+	if m.activeFlowSurfaceVisible() && msg.Kind == FetchList && msg.Mode == ui.ModeActiveFlows && msg.Pane == "active-flows" {
 		if next, ok := m.acceptActiveFlowResult(msg.ListRequest); ok {
 			return next.setFetchStatus(msg)
 		}
@@ -1611,6 +1611,9 @@ func (m Model) currentPlanTextTargetMatches(mode ui.Mode, planID string) bool {
 		record, ok := m.selectedPlan()
 		return ok && record.PlanID == planID
 	case ui.ModeFlows:
+		record, ok := m.selectedFlow()
+		return ok && record.PlanID == planID
+	case ui.ModeActiveFlows:
 		record, ok := m.selectedFlow()
 		return ok && record.PlanID == planID
 	default:

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1266,7 +1266,7 @@ func (m Model) handleFlowResult(msg FlowResultMsg) (Model, tea.Cmd) {
 	m = m.restoreExpandedFlowSelection(expandedFlowID, selectedFlowPhaseID)
 	m = m.syncActiveFlowsFromCache()
 	m = m.clampSelectionsAfterFilter()
-	if !m.flowSurfaceVisible() {
+	if m.mode != ui.ModeFlows {
 		return m, nil
 	}
 	if m.flowFocus != flowFocusTerminal {

--- a/model/model_refresh_test.go
+++ b/model/model_refresh_test.go
@@ -511,6 +511,8 @@ func hasListFetchForMode(msgs []tea.Msg, mode ui.Mode, request uint64) bool {
 			return mode == ui.ModePlans && msg.ListRequest == request
 		case model.FlowResultMsg:
 			return mode == ui.ModeFlows && msg.ListRequest == request
+		case model.ActiveFlowResultMsg:
+			return mode == ui.ModeActiveFlows && msg.ListRequest == request
 		case model.FetchErrorMsg:
 			return msg.Kind == model.FetchList && msg.Mode == mode && msg.ListRequest == request
 		}

--- a/model/model_refresh_test.go
+++ b/model/model_refresh_test.go
@@ -26,6 +26,7 @@ func TestModel_F5RefreshesReposAndCurrentFetchBackedMode(t *testing.T) {
 		ui.ModeSessions,
 		ui.ModePlans,
 		ui.ModeFlows,
+		ui.ModeActiveFlows,
 	}
 
 	for _, mode := range modes {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -72,6 +72,11 @@ func stampListRequest(m model.Model, msg tea.Msg) tea.Msg {
 			msg.ListRequest = m.ListRequest(ui.ModeFlows)
 		}
 		return msg
+	case model.ActiveFlowResultMsg:
+		if msg.ListRequest == 0 {
+			msg.ListRequest = m.ListRequest(ui.ModeActiveFlows)
+		}
+		return msg
 	case model.FetchErrorMsg:
 		if msg.Kind == model.FetchList && msg.ListRequest == 0 {
 			msg.ListRequest = m.ListRequest(msg.Mode)
@@ -83,8 +88,8 @@ func stampListRequest(m model.Model, msg tea.Msg) tea.Msg {
 }
 
 func listRequests(m model.Model) map[ui.Mode]uint64 {
-	requests := make(map[ui.Mode]uint64, int(ui.ModeFlows))
-	for mode := ui.ModeWorktrees; mode <= ui.ModeFlows; mode++ {
+	requests := make(map[ui.Mode]uint64, int(ui.ModeActiveFlows))
+	for mode := ui.ModeWorktrees; mode <= ui.ModeActiveFlows; mode++ {
 		requests[mode] = m.ListRequest(mode)
 	}
 	return requests
@@ -604,8 +609,8 @@ func TestModel_TabFromLeftPaneReturnsToActiveFlowsWithoutChangingMode(t *testing
 	if m.ActivePane() != 1 {
 		t.Fatalf("active pane = %d, want right pane after tab", m.ActivePane())
 	}
-	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("mode = %d, want unchanged underlying worktrees mode", m.Mode())
+	if m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("mode = %d, want active flows", m.Mode())
 	}
 	if cmd != nil {
 		t.Fatalf("tab from left pane with active flows returned cmd %T, want nil", cmd)
@@ -1642,7 +1647,7 @@ func TestModel_RightCyclesThroughAllViewsAndWrapsToWorktrees(t *testing.T) {
 		t.Fatalf("expected starting mode worktrees, got %d", m.Mode())
 	}
 
-	for want := ui.ModeBranches; want <= ui.ModeFlows; want++ {
+	for want := ui.ModeBranches; want <= ui.ModeActiveFlows; want++ {
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRight})
 		if m.Mode() != want {
 			t.Fatalf("mode after right = %d, want %d", m.Mode(), want)
@@ -1673,9 +1678,9 @@ func TestModel_RightCyclesThroughAllViewsAndWrapsToWorktrees(t *testing.T) {
 func TestModel_LeftCyclesBackThroughAllViewsAndWrapsToFlows(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 
-	for want := ui.ModePlans; want >= ui.ModeWorktrees; want-- {
+	for want := ui.ModeFlows; want >= ui.ModeWorktrees; want-- {
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyLeft})
 		if m.Mode() != want {
 			t.Fatalf("mode after left = %d, want %d", m.Mode(), want)
@@ -1687,19 +1692,19 @@ func TestModel_LeftCyclesBackThroughAllViewsAndWrapsToFlows(t *testing.T) {
 
 	before := listRequests(m)
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
-	if m.Mode() != ui.ModeFlows {
-		t.Fatalf("Mode() = %d, want flows after wrapping", m.Mode())
+	if m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("Mode() = %d, want active flows after wrapping", m.Mode())
 	}
 	if m.ActivePane() != 1 {
 		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
 	}
 	if cmd == nil {
-		t.Fatal("left from worktrees produced nil cmd, want flows fetch")
+		t.Fatal("left from worktrees produced nil cmd, want active flows fetch")
 	}
-	assertOnlyListRequestChanged(t, before, m, ui.ModeFlows)
+	assertOnlyListRequestChanged(t, before, m, ui.ModeActiveFlows)
 	msgs := runBatchCmd(t, cmd)
-	if !hasListFetchForMode(msgs, ui.ModeFlows, m.ListRequest(ui.ModeFlows)) {
-		t.Fatalf("left from worktrees command messages = %#v, want flows fetch for request %d", msgs, m.ListRequest(ui.ModeFlows))
+	if !hasListFetchForMode(msgs, ui.ModeActiveFlows, m.ListRequest(ui.ModeActiveFlows)) {
+		t.Fatalf("left from worktrees command messages = %#v, want active flows fetch for request %d", msgs, m.ListRequest(ui.ModeActiveFlows))
 	}
 }
 
@@ -1714,8 +1719,8 @@ func TestModel_ArrowNavigationWrapsAtModeEdges(t *testing.T) {
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
-	if m.Mode() != ui.ModeFlows {
-		t.Fatalf("Mode() = %d, want flows after wrapping", m.Mode())
+	if m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("Mode() = %d, want active flows after wrapping", m.Mode())
 	}
 	if m.ActivePane() != 1 {
 		t.Fatalf("ActivePane() = %d, want right pane", m.ActivePane())
@@ -1724,12 +1729,12 @@ func TestModel_ArrowNavigationWrapsAtModeEdges(t *testing.T) {
 		t.Fatalf("WorktreeSelected() = %d, want preserved cursor 1", m.WorktreeSelected())
 	}
 	if cmd == nil {
-		t.Fatal("left from worktrees produced nil cmd, want flows fetch")
+		t.Fatal("left from worktrees produced nil cmd, want active flows fetch")
 	}
-	assertOnlyListRequestChanged(t, before, m, ui.ModeFlows)
+	assertOnlyListRequestChanged(t, before, m, ui.ModeActiveFlows)
 	msgs := runBatchCmd(t, cmd)
-	if !hasListFetchForMode(msgs, ui.ModeFlows, m.ListRequest(ui.ModeFlows)) {
-		t.Fatalf("left from worktrees command messages = %#v, want flows fetch for request %d", msgs, m.ListRequest(ui.ModeFlows))
+	if !hasListFetchForMode(msgs, ui.ModeActiveFlows, m.ListRequest(ui.ModeActiveFlows)) {
+		t.Fatalf("left from worktrees command messages = %#v, want active flows fetch for request %d", msgs, m.ListRequest(ui.ModeActiveFlows))
 	}
 
 	flow := flowWithPhaseDetails()
@@ -1778,13 +1783,13 @@ func TestModel_HLClampAtModeEdges(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
 	before = listRequests(m)
 	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
-	if m.ActivePane() != 1 || m.Mode() != ui.ModeFlows {
-		t.Fatalf("l at flows activePane=%d mode=%d, want right pane flows", m.ActivePane(), m.Mode())
+	if m.ActivePane() != 1 || m.Mode() != ui.ModeActiveFlows {
+		t.Fatalf("l at flows activePane=%d mode=%d, want right pane active flows", m.ActivePane(), m.Mode())
 	}
-	if cmd != nil {
-		t.Fatalf("l at flows produced cmd %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("l at flows produced nil cmd, want active flows fetch")
 	}
-	assertListRequestsUnchanged(t, before, m)
+	assertOnlyListRequestChanged(t, before, m, ui.ModeActiveFlows)
 }
 
 func TestModel_RightFromStashesGoesToHistory(t *testing.T) {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1675,6 +1675,20 @@ func TestModel_RightCyclesThroughAllViewsAndWrapsToWorktrees(t *testing.T) {
 	}
 }
 
+func TestModel_NumberedModeSwitchClearsStatus(t *testing.T) {
+	m := model.New(testRepos())
+	m = inRightPane(m)
+	m, _ = update(m, model.ActionFailedMsg{RepoPath: "/dev/alpha", Err: "operation failed"})
+	if got := m.TransientError(); got != "operation failed" {
+		t.Fatalf("TransientError() = %q, want operation failed", got)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
+	if got := m.TransientError(); got != "" {
+		t.Fatalf("numbered mode switch left status %q, want cleared", got)
+	}
+}
+
 func TestModel_LeftCyclesBackThroughAllViewsAndWrapsToFlows(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)

--- a/model/view_choices.go
+++ b/model/view_choices.go
@@ -21,6 +21,7 @@ var viewChoices = []ViewChoice{
 	{Number: 6, Mode: ui.ModeSessions, Label: "sessions"},
 	{Number: 7, Mode: ui.ModePlans, Label: "plans"},
 	{Number: 8, Mode: ui.ModeFlows, Label: "flows"},
+	{Number: 9, Mode: ui.ModeActiveFlows, Label: "active flows"},
 }
 
 func ViewChoices() []ViewChoice {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -130,6 +130,7 @@ const (
 	ModeSessions
 	ModePlans
 	ModeFlows
+	ModeActiveFlows
 )
 
 const LeftPaneWidth = 30
@@ -447,8 +448,9 @@ func renderApplication(p RenderParams) string {
 	stashSelected := p.Mode == ModeStashes && p.StashSelected >= 0 && p.StashSelected < len(p.Stashes)
 	commitSelected := p.Mode == ModeHistory && p.CommitSelected >= 0 && p.CommitSelected < len(p.Commits)
 	reflogSelected := p.Mode == ModeReflog && p.ReflogSelected >= 0 && p.ReflogSelected < len(p.Reflogs)
-	embeddedTerminalActive := p.Mode == ModeSessions && !p.ActiveFlows && len(p.EmbeddedTerminals) > 0
-	flowSurfaceActive := p.Mode == ModeFlows || p.ActiveFlows
+	activeFlows := p.ActiveFlows || p.Mode == ModeActiveFlows
+	embeddedTerminalActive := p.Mode == ModeSessions && !activeFlows && len(p.EmbeddedTerminals) > 0
+	flowSurfaceActive := p.Mode == ModeFlows || activeFlows
 	flowEmbeddedTerminalActive := flowSurfaceActive && len(p.FlowEmbeddedTerminals) > 0
 	terminalShortcutsActive := embeddedTerminalActive || (flowEmbeddedTerminalActive && p.FlowTerminalFocused)
 	sessionSelected := p.Mode == ModeSessions && !embeddedTerminalActive && p.SessionSelected >= 0 && p.SessionSelected < len(p.Sessions)
@@ -478,7 +480,7 @@ func renderApplication(p RenderParams) string {
 	status := statusBarParams{
 		Width:                       p.Width,
 		Mode:                        p.Mode,
-		ActiveFlows:                 p.ActiveFlows,
+		ActiveFlows:                 activeFlows,
 		Overlay:                     p.Overlay,
 		InputMode:                   inputRenderParamsFrom(p).mode,
 		FormHasMultiline:            formHasMultilineField(p.Form),
@@ -565,9 +567,6 @@ func renderApplication(p RenderParams) string {
 	rightContentWidth := RightContentWidth(p.Width, p.Height, activeStatusQuery)
 
 	modeHeader := renderModeHeader(p.Mode, rightContentWidth)
-	if p.ActiveFlows {
-		modeHeader = renderActiveFlowsHeader(rightContentWidth)
-	}
 	rightContentHeight := p.Height - BranchContentOverhead
 
 	// Hide cursor in right pane when left pane is active
@@ -600,9 +599,9 @@ func renderApplication(p RenderParams) string {
 	var rightLines []string
 	switch {
 	case flowSurfaceActive && len(p.FlowEmbeddedTerminals) > 0:
-		rightLines = renderFlowSplitPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.FlowEmbeddedTerminals, p.FlowEmbeddedTerminalLines, p.FlowEmbeddedTerminalPrefix, p.ActivePane == 1 && p.FlowTerminalFocused, p.ActiveFlows, repoDisplayNames)
+		rightLines = renderFlowSplitPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.FlowEmbeddedTerminals, p.FlowEmbeddedTerminalLines, p.FlowEmbeddedTerminalPrefix, p.ActivePane == 1 && p.FlowTerminalFocused, activeFlows, repoDisplayNames)
 	case flowSurfaceActive && len(p.Flows) > 0:
-		rightLines = renderFlowPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, p.ActiveFlows, repoDisplayNames)
+		rightLines = renderFlowPane(p.Flows, flowSel, p.FlowScroll, rightContentWidth, rightContentHeight, p.ExpandedFlowID, selectedFlowPhaseID, p.FlowTerminalActivity, activeFlows, repoDisplayNames)
 	case p.Mode == ModeWorktrees && len(p.Worktrees) > 0:
 		rightLines = renderWorktreePaneWithSessions(p.Worktrees, worktreeSel, p.WorktreeScroll, rightContentWidth, rightContentHeight, p.InlineWorktreeSessions, p.WorktreeSessions, p.WorktreeSessionSelected, p.WorktreeSessionScroll)
 	case p.Mode == ModeBranches && len(p.Branches) > 0:
@@ -698,6 +697,7 @@ func renderModeHeader(mode Mode, width int) string {
 		{ModeSessions, "sessions"},
 		{ModePlans, "plans"},
 		{ModeFlows, "flows"},
+		{ModeActiveFlows, "active flows"},
 	}
 
 	var parts []string
@@ -930,7 +930,7 @@ func renderShortcutPane(sp statusBarParams, width, height int) string {
 	title := titleStyle.Render("Shortcuts") + "  " + modeStyle.Render(modeShortcutTitleForStatus(sp))
 	lines = append(lines, ansi.Truncate(" "+title, width, ""))
 	compact := height <= 3
-	flowSurfaceActive := sp.Mode == ModeFlows || sp.ActiveFlows
+	flowSurfaceActive := sp.Mode == ModeFlows || sp.Mode == ModeActiveFlows || sp.ActiveFlows
 	tight := height <= 7 || (flowSurfaceActive && height <= 14)
 	if !compact && !tight {
 		lines = append(lines, strings.Repeat(" ", width))
@@ -1047,7 +1047,7 @@ func padShortcutKey(key string, width int) string {
 }
 
 func shortcutSections(sp statusBarParams) []shortcutSection {
-	flowSurfaceActive := sp.Mode == ModeFlows || sp.ActiveFlows
+	flowSurfaceActive := sp.Mode == ModeFlows || sp.Mode == ModeActiveFlows || sp.ActiveFlows
 	if (sp.Mode == ModeSessions || flowSurfaceActive) && sp.EmbeddedTerminalActive {
 		hints := []shortcutHint{{Key: "ctrl+]", Label: "commands"}}
 		if sp.EmbeddedTerminalPrefix {
@@ -1080,7 +1080,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	if sp.ActivePane == 0 && sp.RepoSelected {
 		navigation = append(navigation, shortcutHint{Key: "enter", Label: "pane", Inline: true})
 	}
-	if sp.ActivePane == 1 && !sp.ActiveFlows {
+	if sp.ActivePane == 1 {
 		navigation = append(navigation, shortcutHint{Key: "←/→", Label: "view", Inline: true})
 	}
 	if flowSurfaceActive && sp.ActivePane == 1 && !sp.EmbeddedTerminalActive {
@@ -1090,7 +1090,6 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 		{Key: paneShortcutKeyForStatus(sp), Label: "pane"},
 		{Key: "q/esc", Label: "quit"},
 		{Key: "f5", Label: "refresh"},
-		{Key: "f3", Label: "active flows"},
 	}
 	if !flowSurfaceActive {
 		global = slices.Insert(global, 2, shortcutHint{Key: "A", Label: "set agent"})
@@ -1348,7 +1347,7 @@ func flowAgentShortcut(value string) (string, bool) {
 }
 
 func shortcutsMuted(sp statusBarParams) bool {
-	return (sp.Mode == ModeSessions || sp.Mode == ModeFlows || sp.ActiveFlows) && sp.EmbeddedTerminalActive && !sp.EmbeddedTerminalPrefix
+	return (sp.Mode == ModeSessions || sp.Mode == ModeFlows || sp.Mode == ModeActiveFlows || sp.ActiveFlows) && sp.EmbeddedTerminalActive && !sp.EmbeddedTerminalPrefix
 }
 
 func flowReasoningEffortShortcutLabel(value string) string {
@@ -1380,11 +1379,11 @@ func muteShortcutSections(sections []shortcutSection) []shortcutSection {
 
 func shortcutSectionsForPane(sp statusBarParams, height int) []shortcutSection {
 	sections := shortcutSections(sp)
-	if height < 20 && sp.Mode != ModeFlows && !sp.ActiveFlows {
+	if height < 20 && sp.Mode != ModeFlows && sp.Mode != ModeActiveFlows && !sp.ActiveFlows {
 		sections = prioritizeShortcutInSection(sections, "Global", "V", "f2")
 		sections = prioritizeShortcutInSection(sections, "Global", "A", "q/esc")
 	}
-	if (sp.Mode == ModeFlows || sp.ActiveFlows) && !sp.FlowSelected && height <= 9 {
+	if (sp.Mode == ModeFlows || sp.Mode == ModeActiveFlows || sp.ActiveFlows) && !sp.FlowSelected && height <= 9 {
 		sections = withoutShortcutKeys(sections, "D", "n", "f5")
 	}
 	if height < 20 {
@@ -1455,7 +1454,7 @@ func renderFooterShortcuts(sp statusBarParams, sections []shortcutSection) strin
 	if sp.Mode == ModeBranches {
 		return renderBranchFooterShortcuts(sp, sections)
 	}
-	if sp.Mode == ModeFlows || sp.ActiveFlows {
+	if sp.Mode == ModeFlows || sp.Mode == ModeActiveFlows || sp.ActiveFlows {
 		return renderFlowFooterShortcuts(sp, sections)
 	}
 	return renderGenericFooterShortcuts(sp, sections)
@@ -1527,20 +1526,20 @@ func renderGenericFooterShortcuts(sp statusBarParams, sections []shortcutSection
 	paneKey := paneShortcutKeyForStatus(sp)
 	for _, drop := range [][]string{
 		{},
-		{"f5", "f3"},
-		{"f5", "f3", "A"},
-		{"f5", "f3", "A", "D"},
-		{"f5", "f3", "A", "D", "←/→"},
-		{"f5", "f3", "A", "D", "←/→", "↑/↓"},
-		{"f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc"},
-		{"f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc", paneKey},
+		{"f5"},
+		{"f5", "A"},
+		{"f5", "A", "D"},
+		{"f5", "A", "D", "←/→"},
+		{"f5", "A", "D", "←/→", "↑/↓"},
+		{"f5", "A", "D", "←/→", "↑/↓", "q/esc"},
+		{"f5", "A", "D", "←/→", "↑/↓", "q/esc", paneKey},
 	} {
 		candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, drop...)))
 		if lipgloss.Width(candidate) <= sp.Width {
 			return candidate
 		}
 	}
-	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "f3", "A", "D", "←/→", "↑/↓", "q/esc", paneKey)))
+	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "A", "D", "←/→", "↑/↓", "q/esc", paneKey)))
 	return ansi.Truncate(candidate, sp.Width, "")
 }
 
@@ -1876,13 +1875,15 @@ func modeShortcutTitle(mode Mode) string {
 		return "Plans"
 	case ModeFlows:
 		return "Flows"
+	case ModeActiveFlows:
+		return "Active flows"
 	default:
 		return "Items"
 	}
 }
 
 func modeShortcutTitleForStatus(sp statusBarParams) string {
-	if sp.ActiveFlows {
+	if sp.ActiveFlows || sp.Mode == ModeActiveFlows {
 		return "Active flows"
 	}
 	return modeShortcutTitle(sp.Mode)

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -80,8 +80,11 @@ func TestRender_ActiveFlowsHeaderAndShortcutLabels(t *testing.T) {
 		FlowSelected: 0,
 	})
 	pane := shortcutPaneText(ansi.Strip(view))
-	if !strings.Contains(pane, "f3") || !strings.Contains(pane, "active flows") {
-		t.Fatalf("active-flow shortcut pane should keep f3 active flows hint:\n%s", pane)
+	if strings.Contains(pane, "f3") {
+		t.Fatalf("active-flow shortcut pane should not advertise f3 active flows:\n%s", pane)
+	}
+	if !strings.Contains(pane, "Active flows") {
+		t.Fatalf("active-flow shortcut pane should identify Active flows:\n%s", pane)
 	}
 	if !strings.Contains(pane, "⌫      pane") {
 		t.Fatalf("active-flow shortcut pane should expose backspace pane hint:\n%s", pane)

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -3964,17 +3964,16 @@ func TestStatusBar_HidesArrowViewHintWhenLeftPaneActive(t *testing.T) {
 	}
 }
 
-func TestStatusBar_HidesArrowViewHintForActiveFlows(t *testing.T) {
+func TestStatusBar_ShowsArrowViewHintForActiveFlows(t *testing.T) {
 	bar := renderStatusBarWithState(statusBarParams{
 		Width:        120,
-		Mode:         ModeSessions,
-		ActiveFlows:  true,
+		Mode:         ModeActiveFlows,
 		ActivePane:   1,
 		RepoSelected: true,
 		FlowSelected: true,
 	})
-	if strings.Contains(bar, "←/→") || strings.Contains(bar, "pane/view") {
-		t.Fatalf("active Flow status bar should not advertise arrow view navigation, got %q", bar)
+	if !strings.Contains(bar, "←/→ view") {
+		t.Fatalf("active Flow status bar should advertise arrow view navigation, got %q", bar)
 	}
 	if !strings.Contains(bar, "⌫ pane") {
 		t.Fatalf("active Flow status bar should advertise backspace pane navigation, got %q", bar)


### PR DESCRIPTION
## Summary
- Move Active Flows from its dedicated F3 shortcut into numbered view 9.
- Add Active Flows to the default view picker and related config/docs.
- Remove obsolete active-flow overlay state and tighten refresh behavior for flows and active flows.

## Verification
- make test
- make build
- gofmt -l .
- git diff --check
