### PR TITLE
Add prompt template editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,9 @@ WORKTREE_ROOT=~/projects ./bin/wtui
 ### Keys
 
 The UI has two panes: repos on the left, content on the right. Press `enter`
-or `tab` on a selected repo to focus the content pane, and press `f2` to switch
-pane focus explicitly. Left-pane shortcut hints show `f2/tab` for pane focus
-because `tab` is the left-to-content shortcut; right-pane hints show `bksp`
-for returning to the repo pane. When a Flow embedded terminal is open, `tab`
+or `tab` on a selected repo to focus the content pane; from the content pane,
+`bksp` returns focus to the repo pane. Press `f2` to open the prompt-template
+editor for plan and Flow launch prompts. When a Flow embedded terminal is open, `tab`
 switches focus between the Flow list and that terminal while the right pane
 remains active.
 The active pane is highlighted with a blue border.
@@ -74,7 +73,8 @@ filter matches, or a load failure with details in the status bar.
 | `f` | Fetch all currently visible repos with `--prune` |
 | `n` | Create a new local repo under the scan root, optionally creating a GitHub repo and wiring `origin` |
 | `enter` | Switch focus to right pane |
-| `f2`/`tab` | Switch pane focus |
+| `tab` | Switch focus to right pane |
+| `f2` | Edit prompt templates |
 | `q`/`esc` | Quit |
 
 **Right pane (content)**
@@ -112,7 +112,8 @@ filter matches, or a load failure with details in the status bar.
 | `e` | Edit selected plan Markdown (plans view) |
 | `i` | Alias for plan implementation launch |
 | `D` | Toggle destructive mode |
-| `f2`/`bksp` | Switch focus to left pane |
+| `bksp` | Switch focus to left pane |
+| `f2` | Edit prompt templates |
 | `q`/`esc` | Close a prompt/dialog or quit |
 
 The right pane header shows the active mode. Press `1`–`9` or use arrow keys to
@@ -120,9 +121,10 @@ switch between worktrees, branches, stashes, history, reflog, sessions, plans,
 flows, and active flows. Horizontal view switching wraps between worktrees and
 active flows. Press `V` to choose which numbered view wtui opens on future
 launches; leaving it unset keeps the built-in startup default of Flows. Press
-`enter` or `tab` from the repo pane to focus the content pane, or `f2` to switch
-pane focus explicitly. In the content pane, `bksp` switches focus back to the
-left repo pane.
+`enter` or `tab` from the repo pane to focus the content pane. In the content
+pane, `bksp` switches focus back to the left repo pane. Press `f2` from normal
+TUI views to edit the `[agent].plan_prompt` and `[flow_prompts]` templates;
+Flow terminal input focus passes F2 through to the embedded agent.
 
 When the left repo pane is focused, press `f` to run `git fetch --prune` for
 the currently visible repos. Repo filtering limits the batch to the filtered

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -376,6 +376,12 @@ func modelOptionsFromConfig(cfg config.Config, scanRepos func() ([]scanner.Repo,
 			}
 			return config.SaveDefaultView(number)
 		},
+		SavePromptTemplate: func(section, key, value string) error {
+			return config.SavePromptTemplate(section, key, value)
+		},
+		ResetPromptTemplate: func(section, key string) error {
+			return config.ResetPromptTemplate(section, key)
+		},
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -514,7 +514,11 @@ func patchSectionAssignment(data []byte, section, key, assignmentLine string) []
 			continue
 		}
 		if inSection && isSectionAssignment(line, key) {
+			end := sectionAssignmentEnd(lines, i)
 			lines[i] = replaceSectionAssignment(line, assignmentLine)
+			if end > i+1 {
+				lines = append(lines[:i+1], lines[end:]...)
+			}
 			return []byte(strings.Join(lines, ""))
 		}
 	}
@@ -553,7 +557,8 @@ func removeSectionAssignment(data []byte, section, key string) []byte {
 			continue
 		}
 		if inSection && isSectionAssignment(line, key) {
-			lines = append(lines[:i], lines[i+1:]...)
+			end := sectionAssignmentEnd(lines, i)
+			lines = append(lines[:i], lines[end:]...)
 			return []byte(strings.Join(lines, ""))
 		}
 	}
@@ -607,6 +612,42 @@ func replaceSectionAssignment(line, assignmentLine string) string {
 	ending := line[len(body):]
 	indent := body[:len(body)-len(strings.TrimLeft(body, " \t"))]
 	return indent + strings.TrimSuffix(assignmentLine, "\n") + ending
+}
+
+func sectionAssignmentEnd(lines []string, start int) int {
+	if start < 0 || start >= len(lines) {
+		return start + 1
+	}
+	line := strings.TrimRight(lines[start], "\r\n")
+	eq := strings.Index(line, "=")
+	if eq == -1 {
+		return start + 1
+	}
+	value := strings.TrimSpace(line[eq+1:])
+	delim, ok := multilineStringDelimiter(value)
+	if !ok {
+		return start + 1
+	}
+	if strings.Contains(value[len(delim):], delim) {
+		return start + 1
+	}
+	for i := start + 1; i < len(lines); i++ {
+		if strings.Contains(lines[i], delim) {
+			return i + 1
+		}
+	}
+	return len(lines)
+}
+
+func multilineStringDelimiter(value string) (string, bool) {
+	switch {
+	case strings.HasPrefix(value, `"""`):
+		return `"""`, true
+	case strings.HasPrefix(value, `'''`):
+		return `'''`, true
+	default:
+		return "", false
+	}
 }
 
 func agentCommandLine(command string) string {

--- a/config/config.go
+++ b/config/config.go
@@ -498,7 +498,8 @@ func patchSectionAssignment(data []byte, section, key, assignmentLine string) []
 	lines := strings.SplitAfter(string(data), "\n")
 	inSection := false
 	sectionHeader := -1
-	for i, line := range lines {
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
 		trimmed := strings.TrimSpace(strings.TrimRight(line, "\r\n"))
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
@@ -520,6 +521,11 @@ func patchSectionAssignment(data []byte, section, key, assignmentLine string) []
 				lines = append(lines[:i+1], lines[end:]...)
 			}
 			return []byte(strings.Join(lines, ""))
+		}
+		if inSection {
+			if end := sectionAssignmentEnd(lines, i); end > i+1 {
+				i = end - 1
+			}
 		}
 	}
 
@@ -544,7 +550,8 @@ func removeSectionAssignment(data []byte, section, key string) []byte {
 
 	lines := strings.SplitAfter(string(data), "\n")
 	inSection := false
-	for i, line := range lines {
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
 		trimmed := strings.TrimSpace(strings.TrimRight(line, "\r\n"))
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
@@ -560,6 +567,11 @@ func removeSectionAssignment(data []byte, section, key string) []byte {
 			end := sectionAssignmentEnd(lines, i)
 			lines = append(lines[:i], lines[end:]...)
 			return []byte(strings.Join(lines, ""))
+		}
+		if inSection {
+			if end := sectionAssignmentEnd(lines, i); end > i+1 {
+				i = end - 1
+			}
 		}
 	}
 	return data

--- a/config/config.go
+++ b/config/config.go
@@ -343,6 +343,58 @@ func SaveDefaultView(view int, options ...Option) error {
 	return saveDefaultViewTo(path, view, options...)
 }
 
+// SavePromptTemplate persists a configurable prompt template to wtui's default
+// config file. plan_prompt is stored under [agent]; Flow phase prompt keys are
+// stored under [flow_prompts].
+func SavePromptTemplate(section, key, value string, options ...Option) error {
+	section, key, err := normalizePromptTemplateTarget(section, key)
+	if err != nil {
+		return err
+	}
+
+	opts := defaultOptions(options...)
+	path, err := writableDefaultPath(opts)
+	if err != nil {
+		return err
+	}
+	return savePromptTemplateTo(path, section, key, value, options...)
+}
+
+// ResetPromptTemplate removes a configurable prompt template override from
+// wtui's default config file. Missing assignments are treated as already reset.
+func ResetPromptTemplate(section, key string, options ...Option) error {
+	section, key, err := normalizePromptTemplateTarget(section, key)
+	if err != nil {
+		return err
+	}
+
+	opts := defaultOptions(options...)
+	path, err := writableDefaultPath(opts)
+	if err != nil {
+		return err
+	}
+	return resetPromptTemplateTo(path, section, key, options...)
+}
+
+func normalizePromptTemplateTarget(section, key string) (string, string, error) {
+	section = strings.TrimSpace(section)
+	key = strings.TrimSpace(key)
+	switch key {
+	case "plan_prompt":
+		if section != "" && section != "agent" {
+			return "", "", fmt.Errorf("prompt template %s belongs to [agent]", key)
+		}
+		return "agent", key, nil
+	case "plan", "plan_review", "implementation", "review_loop", "pr_creation", "autoreview", "merge", "generic":
+		if section != "" && section != "flow_prompts" {
+			return "", "", fmt.Errorf("prompt template %s belongs to [flow_prompts]", key)
+		}
+		return "flow_prompts", key, nil
+	default:
+		return "", "", fmt.Errorf("unsupported prompt template key %q", key)
+	}
+}
+
 func writableDefaultPath(opts loadOptions) (string, error) {
 	paths, err := defaultPaths(opts)
 	if err != nil {
@@ -378,6 +430,35 @@ func saveDefaultViewTo(path string, view int, options ...Option) error {
 	return saveAgentConfigTo(path, options, func(data []byte) []byte {
 		return patchSectionAssignment(data, "ui", "default_view", fmt.Sprintf("default_view = %d\n", view))
 	})
+}
+
+func savePromptTemplateTo(path, section, key, value string, options ...Option) error {
+	return saveAgentConfigTo(path, options, func(data []byte) []byte {
+		return patchSectionAssignment(data, section, key, fmt.Sprintf("%s = %s\n", key, escapeTOMLString(value)))
+	})
+}
+
+func resetPromptTemplateTo(path, section, key string, options ...Option) error {
+	opts := defaultOptions(options...)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read config %s: %w", path, err)
+	}
+	if _, err := parseConfigData(path, data, opts); err != nil {
+		return err
+	}
+
+	patched := removeSectionAssignment(data, section, key)
+	if bytes.Equal(patched, data) {
+		return nil
+	}
+	if err := os.WriteFile(path, patched, 0o644); err != nil {
+		return fmt.Errorf("write config %s: %w", path, err)
+	}
+	return nil
 }
 
 func saveAgentConfigTo(path string, options []Option, patch func([]byte) []byte) error {
@@ -452,6 +533,33 @@ func patchSectionAssignment(data []byte, section, key, assignmentLine string) []
 	return []byte(text + "[" + section + "]\n" + assignmentLine)
 }
 
+func removeSectionAssignment(data []byte, section, key string) []byte {
+	if len(data) == 0 {
+		return data
+	}
+
+	lines := strings.SplitAfter(string(data), "\n")
+	inSection := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(strings.TrimRight(line, "\r\n"))
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if header, ok := tableHeaderName(trimmed); ok {
+			if inSection {
+				return data
+			}
+			inSection = header == section
+			continue
+		}
+		if inSection && isSectionAssignment(line, key) {
+			lines = append(lines[:i], lines[i+1:]...)
+			return []byte(strings.Join(lines, ""))
+		}
+	}
+	return data
+}
+
 func tableHeaderName(line string) (string, bool) {
 	if strings.HasPrefix(line, "[[") {
 		end := strings.Index(line, "]]")
@@ -507,6 +615,37 @@ func agentCommandLine(command string) string {
 
 func agentReasoningEffortLine(key, effort string) string {
 	return fmt.Sprintf("%s = %q\n", key, effort)
+}
+
+func escapeTOMLString(value string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range value {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\b':
+			b.WriteString(`\b`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\f':
+			b.WriteString(`\f`)
+		case '\r':
+			b.WriteString(`\r`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				fmt.Fprintf(&b, `\u%04X`, r)
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }
 
 func insertLine(lines []string, index int, line string) []string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -929,6 +929,52 @@ func TestSavePromptTemplate_RoundTripsEscapedMultilineTemplates(t *testing.T) {
 	}
 }
 
+func TestSavePromptTemplate_ReplacesExistingMultilineStringAssignment(t *testing.T) {
+	xdg := t.TempDir()
+	path := filepath.Join(xdg, "wtui", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initial := "[flow_prompts]\nplan = \"\"\"old line 1\nold line 2\"\"\"\nimplementation = \"keep implementation\"\n"
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := config.SavePromptTemplate("flow_prompts", "plan", "new prompt",
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return t.TempDir(), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("SavePromptTemplate returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if strings.Contains(text, "old line") || strings.Contains(text, `"""`) {
+		t.Fatalf("expected old multiline prompt assignment fully replaced, got:\n%s", text)
+	}
+	if !strings.Contains(text, `plan = "new prompt"`) || !strings.Contains(text, `implementation = "keep implementation"`) {
+		t.Fatalf("expected new prompt and sibling assignment preserved, got:\n%s", text)
+	}
+	cfg, err := config.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if cfg.FlowPrompts.Plan != "new prompt" || cfg.FlowPrompts.Implementation != "keep implementation" {
+		t.Fatalf("loaded flow prompts = %#v", cfg.FlowPrompts)
+	}
+}
+
 func TestResetPromptTemplate_RemovesOnlySelectedAssignment(t *testing.T) {
 	xdg := t.TempDir()
 	path := filepath.Join(xdg, "wtui", "config.toml")
@@ -967,6 +1013,52 @@ func TestResetPromptTemplate_RemovesOnlySelectedAssignment(t *testing.T) {
 	}
 	if strings.Contains(text, `plan = "custom flow"`) {
 		t.Fatalf("expected flow plan prompt removed, got:\n%s", text)
+	}
+}
+
+func TestResetPromptTemplate_RemovesExistingMultilineStringAssignment(t *testing.T) {
+	xdg := t.TempDir()
+	path := filepath.Join(xdg, "wtui", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initial := "[flow_prompts]\nplan = '''old line 1\nold line 2'''\nimplementation = \"keep implementation\"\n"
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := config.ResetPromptTemplate("flow_prompts", "plan",
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return t.TempDir(), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("ResetPromptTemplate returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if strings.Contains(text, "old line") || strings.Contains(text, `'''`) || strings.Contains(text, "plan =") {
+		t.Fatalf("expected old multiline prompt assignment fully removed, got:\n%s", text)
+	}
+	if !strings.Contains(text, `implementation = "keep implementation"`) {
+		t.Fatalf("expected sibling assignment preserved, got:\n%s", text)
+	}
+	cfg, err := config.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if cfg.FlowPrompts.Plan != "" || cfg.FlowPrompts.Implementation != "keep implementation" {
+		t.Fatalf("loaded flow prompts = %#v", cfg.FlowPrompts)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -975,6 +975,54 @@ func TestSavePromptTemplate_ReplacesExistingMultilineStringAssignment(t *testing
 	}
 }
 
+func TestSavePromptTemplate_SkipsOtherMultilineStringBodiesBeforeTarget(t *testing.T) {
+	xdg := t.TempDir()
+	path := filepath.Join(xdg, "wtui", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initial := "[flow_prompts]\nplan = \"\"\"\nDocument an example:\nimplementation = \"not the real assignment\"\n\"\"\"\nimplementation = \"old implementation\"\n"
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := config.SavePromptTemplate("flow_prompts", "implementation", "new implementation",
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return t.TempDir(), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("SavePromptTemplate returned error: %v", err)
+	}
+
+	cfg, err := config.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if !strings.Contains(cfg.FlowPrompts.Plan, `implementation = "not the real assignment"`) {
+		t.Fatalf("plan prompt body was not preserved: %q", cfg.FlowPrompts.Plan)
+	}
+	if cfg.FlowPrompts.Implementation != "new implementation" {
+		t.Fatalf("implementation prompt = %q, want new implementation", cfg.FlowPrompts.Implementation)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, `implementation = "not the real assignment"`) ||
+		!strings.Contains(text, `implementation = "new implementation"`) ||
+		strings.Contains(text, `implementation = "old implementation"`) {
+		t.Fatalf("expected multiline body preserved and real assignment replaced, got:\n%s", text)
+	}
+}
+
 func TestResetPromptTemplate_RemovesOnlySelectedAssignment(t *testing.T) {
 	xdg := t.TempDir()
 	path := filepath.Join(xdg, "wtui", "config.toml")
@@ -1059,6 +1107,53 @@ func TestResetPromptTemplate_RemovesExistingMultilineStringAssignment(t *testing
 	}
 	if cfg.FlowPrompts.Plan != "" || cfg.FlowPrompts.Implementation != "keep implementation" {
 		t.Fatalf("loaded flow prompts = %#v", cfg.FlowPrompts)
+	}
+}
+
+func TestResetPromptTemplate_SkipsOtherMultilineStringBodiesBeforeTarget(t *testing.T) {
+	xdg := t.TempDir()
+	path := filepath.Join(xdg, "wtui", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initial := "[flow_prompts]\nplan = '''\nDocument an example:\nimplementation = \"not the real assignment\"\n'''\nimplementation = \"old implementation\"\n"
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := config.ResetPromptTemplate("flow_prompts", "implementation",
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return t.TempDir(), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("ResetPromptTemplate returned error: %v", err)
+	}
+
+	cfg, err := config.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if !strings.Contains(cfg.FlowPrompts.Plan, `implementation = "not the real assignment"`) {
+		t.Fatalf("plan prompt body was not preserved: %q", cfg.FlowPrompts.Plan)
+	}
+	if cfg.FlowPrompts.Implementation != "" {
+		t.Fatalf("implementation prompt = %q, want reset default", cfg.FlowPrompts.Implementation)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, `implementation = "not the real assignment"`) ||
+		strings.Contains(text, `implementation = "old implementation"`) {
+		t.Fatalf("expected multiline body preserved and real assignment removed, got:\n%s", text)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -890,6 +890,111 @@ func TestSaveDefaultView_RejectsInvalidValueWithoutWriting(t *testing.T) {
 	}
 }
 
+func TestSavePromptTemplate_RoundTripsEscapedMultilineTemplates(t *testing.T) {
+	xdg := t.TempDir()
+	home := t.TempDir()
+	value := "Line 1\nLine 2 with \"quotes\" and \\ slash\tend\x01"
+
+	err := config.SavePromptTemplate("flow_prompts", "plan", value,
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return home, nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("SavePromptTemplate returned error: %v", err)
+	}
+
+	path := filepath.Join(xdg, "wtui", "config.toml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, `[flow_prompts]`) || !strings.Contains(text, `plan = "Line 1\nLine 2 with \"quotes\" and \\ slash\tend\u0001"`) {
+		t.Fatalf("expected escaped single-line flow prompt, got:\n%s", text)
+	}
+
+	cfg, err := config.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if cfg.FlowPrompts.Plan != value {
+		t.Fatalf("saved flow prompt = %q, want %q", cfg.FlowPrompts.Plan, value)
+	}
+}
+
+func TestResetPromptTemplate_RemovesOnlySelectedAssignment(t *testing.T) {
+	xdg := t.TempDir()
+	path := filepath.Join(xdg, "wtui", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initial := "# keep me\n[agent]\nplan_prompt = \"custom plan\"\ncommand = \"codex\"\n\n[flow_prompts]\nplan = \"custom flow\"\nimplementation = \"keep implementation\"\n"
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := config.ResetPromptTemplate("flow_prompts", "plan",
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return t.TempDir(), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("ResetPromptTemplate returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	for _, want := range []string{"# keep me", `plan_prompt = "custom plan"`, `command = "codex"`, `implementation = "keep implementation"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected reset config to contain %q, got:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, `plan = "custom flow"`) {
+		t.Fatalf("expected flow plan prompt removed, got:\n%s", text)
+	}
+}
+
+func TestResetPromptTemplate_MissingConfigDoesNotCreateFile(t *testing.T) {
+	xdg := t.TempDir()
+	home := t.TempDir()
+
+	err := config.ResetPromptTemplate("agent", "plan_prompt",
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return home, nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("ResetPromptTemplate returned error: %v", err)
+	}
+
+	path := filepath.Join(xdg, "wtui", "config.toml")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("reset missing config should not create %s, stat err=%v", path, err)
+	}
+}
+
 func TestSaveAgentCommand_UpdatesExistingFallbackConfig(t *testing.T) {
 	xdg := t.TempDir()
 	home := t.TempDir()

--- a/docs/config.md
+++ b/docs/config.md
@@ -210,7 +210,11 @@ value immediately, creating the config file if needed.
 | `command` | string | Supported values: `codex`, `codex-app`, or `claude`. |
 | `codex_reasoning_effort` | string | Optional Codex CLI reasoning effort for new launches. Supported values: `default`, `minimal`, `low`, `medium`, `high`, `xhigh`. Empty or `default` omits the Codex override and keeps provider defaults. |
 | `claude_reasoning_effort` | string | Optional Claude Code reasoning effort for new launches. Supported values: `default`, `low`, `medium`, `high`, `xhigh`, `max`. Empty or `default` omits the Claude override and keeps provider defaults. |
-| `plan_prompt` | string | Optional one-line template for the editable instructions opened by `i` in the plans pane. Supports `{title}`, `{plan_id}`, `{plan_path}`, `{repo_path}`, and `{worktree_path}`. Unknown placeholders remain literal. Blank or omitted uses the built-in prompt. |
+| `plan_prompt` | string | Optional template for the editable instructions opened by `i` in the plans pane. Supports `{title}`, `{plan_id}`, `{plan_path}`, `{repo_path}`, and `{worktree_path}`. Unknown placeholders remain literal. Blank or omitted uses the built-in prompt. |
+
+Press `F2` in normal TUI views to open the prompt-template editor. The editor
+can save a custom `[agent].plan_prompt`, reset it to the built-in default, or
+preview the built-in prompt.
 
 In the flows pane, `E` opens a provider-specific reasoning-effort picker for
 the selected CLI agent and persists the corresponding key. New Codex CLI
@@ -226,6 +230,9 @@ the built-in prompt for that phase. Unknown placeholders remain literal. wtui
 appends `After completing this phase goal, mark this Flow phase done with wtui-flow.`
 to both built-in prompts and configured templates unless the template already
 ends with that exact standalone instruction.
+
+The `F2` prompt-template editor also manages these Flow prompt keys. Saving a
+blank template resets that key by removing the config override.
 
 | Key | Type | Description |
 |-----|------|-------------|

--- a/docs/config.md
+++ b/docs/config.md
@@ -210,7 +210,7 @@ value immediately, creating the config file if needed.
 | `command` | string | Supported values: `codex`, `codex-app`, or `claude`. |
 | `codex_reasoning_effort` | string | Optional Codex CLI reasoning effort for new launches. Supported values: `default`, `minimal`, `low`, `medium`, `high`, `xhigh`. Empty or `default` omits the Codex override and keeps provider defaults. |
 | `claude_reasoning_effort` | string | Optional Claude Code reasoning effort for new launches. Supported values: `default`, `low`, `medium`, `high`, `xhigh`, `max`. Empty or `default` omits the Claude override and keeps provider defaults. |
-| `plan_prompt` | string | Optional template for the editable instructions opened by `i` in the plans pane. Supports `{title}`, `{plan_id}`, `{plan_path}`, `{repo_path}`, and `{worktree_path}`. Unknown placeholders remain literal. Blank or omitted uses the built-in prompt. |
+| `plan_prompt` | string | Optional template for the editable instructions opened by `i` in the plans pane. Supports `{title}`, `{plan_id}`, `{plan_path}`, `{repo_path}`, and `{worktree_path}`. When a saved-plan phase row is selected, it also supports `{phase_id}`, `{phase_title}`, and `{phase_status}`. Unknown placeholders remain literal. Blank or omitted uses the built-in prompt. |
 
 Press `F2` in normal TUI views to open the prompt-template editor. The editor
 can save a custom `[agent].plan_prompt`, reset it to the built-in default, or

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -21,9 +21,12 @@ type FlowStartRequest struct {
 	ReasoningEffort     string
 	SessionStateRoot    string
 	FlowPromptTemplates FlowPromptTemplates
-	PlanPhaseID         string
-	PlanPhaseTitle      string
-	PlanPhaseStatus     string
+	// FlowPromptTemplatesProvided forces StartPlan to use FlowPromptTemplates
+	// even when every template has been reset to the built-in default.
+	FlowPromptTemplatesProvided bool
+	PlanPhaseID                 string
+	PlanPhaseTitle              string
+	PlanPhaseStatus             string
 }
 
 // FlowStartResult is the prepared or launch-ready result of creating a new Flow.
@@ -169,7 +172,7 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 }
 
 func (s FlowStarter) promptTemplatesForRequest(req FlowStartRequest) FlowPromptTemplates {
-	if req.FlowPromptTemplates != (FlowPromptTemplates{}) {
+	if req.FlowPromptTemplatesProvided || req.FlowPromptTemplates != (FlowPromptTemplates{}) {
 		return req.FlowPromptTemplates
 	}
 	return s.flowPromptTemplates

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -13,16 +13,17 @@ const flowPlanPhaseID = "plan"
 // FlowStartRequest contains the user operation inputs needed to create a Flow
 // and optionally prepare the initial plan-phase agent launch.
 type FlowStartRequest struct {
-	RepoPath         string
-	Title            string
-	Instructions     string
-	BaseRef          string
-	AgentCommand     string
-	ReasoningEffort  string
-	SessionStateRoot string
-	PlanPhaseID      string
-	PlanPhaseTitle   string
-	PlanPhaseStatus  string
+	RepoPath            string
+	Title               string
+	Instructions        string
+	BaseRef             string
+	AgentCommand        string
+	ReasoningEffort     string
+	SessionStateRoot    string
+	FlowPromptTemplates FlowPromptTemplates
+	PlanPhaseID         string
+	PlanPhaseTitle      string
+	PlanPhaseStatus     string
 }
 
 // FlowStartResult is the prepared or launch-ready result of creating a new Flow.
@@ -162,9 +163,16 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 		PlanPhaseStatus:  phaseStatus,
 		FlowID:           flow.FlowID,
 		FlowPhaseID:      phaseID,
-		InitialPrompt:    flowPlanPrompt(flowStartPromptRecord(flow, req, worktree, commit), s.flowPromptTemplates),
+		InitialPrompt:    flowPlanPrompt(flowStartPromptRecord(flow, req, worktree, commit), s.promptTemplatesForRequest(req)),
 	}
 	return result, nil
+}
+
+func (s FlowStarter) promptTemplatesForRequest(req FlowStartRequest) FlowPromptTemplates {
+	if req.FlowPromptTemplates != (FlowPromptTemplates{}) {
+		return req.FlowPromptTemplates
+	}
+	return s.flowPromptTemplates
 }
 
 func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) {

--- a/model/flow_start_test.go
+++ b/model/flow_start_test.go
@@ -281,6 +281,52 @@ func TestFlowStarterStartPlanUsesConfiguredPromptTemplate(t *testing.T) {
 	}
 }
 
+func TestFlowStarterStartPlanUsesRequestTimePromptTemplate(t *testing.T) {
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-live"
+			return record, nil
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{WorktreePath: "/dev/alpha-worktrees/live", Branch: "flow/live"}, nil
+		},
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{
+				FlowID:       update.FlowID,
+				Instructions: "Build live",
+				WorktreePath: update.WorktreePath,
+				Branch:       update.Branch,
+				Commit:       update.Commit,
+			}, nil
+		},
+		AddPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		ResolveCommit: func(string) string { return "abc123" },
+		NewLaunchID:   func() string { return "launch-live" },
+		FlowPromptTemplates: model.FlowPromptTemplates{
+			Plan: "old template {flow_id}",
+		},
+	})
+
+	result, err := starter.StartPlan(model.FlowStartRequest{
+		RepoPath:     "/dev/alpha",
+		Title:        "Live",
+		Instructions: "Build live",
+		FlowPromptTemplates: model.FlowPromptTemplates{
+			Plan: "new template {flow_id}",
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartPlan returned error: %v", err)
+	}
+
+	want := appendFlowDoneInstructionForTest("new template flow-live")
+	if result.LaunchContext.InitialPrompt != want {
+		t.Fatalf("plan prompt = %q, want %q", result.LaunchContext.InitialPrompt, want)
+	}
+}
+
 func TestFlowStarterStartPlanRunsBootstrapBeforeLaunchID(t *testing.T) {
 	var gotCtx actions.BootstrapContext
 	var gotHook actions.BootstrapHook

--- a/model/flow_start_test.go
+++ b/model/flow_start_test.go
@@ -327,6 +327,57 @@ func TestFlowStarterStartPlanUsesRequestTimePromptTemplate(t *testing.T) {
 	}
 }
 
+func TestFlowStarterStartPlanUsesExplicitZeroRequestTimePromptTemplates(t *testing.T) {
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-reset"
+			return record, nil
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{WorktreePath: "/dev/alpha-worktrees/reset", Branch: "flow/reset"}, nil
+		},
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{
+				FlowID:       update.FlowID,
+				Title:        "Reset",
+				Instructions: "Build reset",
+				RepoPath:     "/dev/alpha",
+				WorktreePath: update.WorktreePath,
+				Branch:       update.Branch,
+				Commit:       update.Commit,
+			}, nil
+		},
+		AddPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		ResolveCommit: func(string) string { return "abc123" },
+		NewLaunchID:   func() string { return "launch-reset" },
+		FlowPromptTemplates: model.FlowPromptTemplates{
+			Plan: "old startup template {flow_id}",
+		},
+	})
+
+	result, err := starter.StartPlan(model.FlowStartRequest{
+		RepoPath:                    "/dev/alpha",
+		Title:                       "Reset",
+		Instructions:                "Build reset",
+		FlowPromptTemplates:         model.FlowPromptTemplates{},
+		FlowPromptTemplatesProvided: true,
+	})
+	if err != nil {
+		t.Fatalf("StartPlan returned error: %v", err)
+	}
+
+	if strings.Contains(result.LaunchContext.InitialPrompt, "old startup template") {
+		t.Fatalf("explicit zero request templates should not use startup template: %q", result.LaunchContext.InitialPrompt)
+	}
+	for _, want := range []string{"Use the wtui-flow skill", "Build reset", "After completing this phase goal"} {
+		if !strings.Contains(result.LaunchContext.InitialPrompt, want) {
+			t.Fatalf("built-in plan prompt missing %q: %q", want, result.LaunchContext.InitialPrompt)
+		}
+	}
+}
+
 func TestFlowStarterStartPlanRunsBootstrapBeforeLaunchID(t *testing.T) {
 	var gotCtx actions.BootstrapContext
 	var gotHook actions.BootstrapHook

--- a/model/modal/modal.go
+++ b/model/modal/modal.go
@@ -118,6 +118,7 @@ type Modal struct {
 	input        string
 	inputMode    InputMode
 	inputRaw     bool
+	inputHeight  int
 	inputCursor  int
 	inputColumn  int
 	inputErr     string
@@ -147,6 +148,7 @@ type View struct {
 	Force        bool
 	Input        string
 	InputMode    InputMode
+	InputHeight  int
 	InputCursor  int
 	InputErr     string
 	SelectItems  []SelectItem
@@ -203,6 +205,14 @@ func OpenMultiLineInput(prompt, placeholder, initial string, validate func(strin
 func OpenRawMultiLineInput(prompt, placeholder, initial string, validate func(string) error, submit func(string) tea.Cmd) Modal {
 	m := OpenMultiLineInput(prompt, placeholder, initial, validate, submit)
 	m.inputRaw = true
+	return m
+}
+
+func (m Modal) WithInputHeight(height int) Modal {
+	if height < 0 {
+		height = 0
+	}
+	m.inputHeight = height
 	return m
 }
 
@@ -301,6 +311,7 @@ func (m Modal) View() View {
 		Force:        m.force,
 		Input:        m.input,
 		InputMode:    m.inputMode,
+		InputHeight:  m.inputHeight,
 		InputCursor:  clampInputCursor(m.input, m.inputCursor),
 		InputErr:     m.inputErr,
 		SelectItems:  append([]SelectItem(nil), m.selectItems...),

--- a/model/modal/modal.go
+++ b/model/modal/modal.go
@@ -117,6 +117,7 @@ type Modal struct {
 	action       func() tea.Cmd
 	input        string
 	inputMode    InputMode
+	inputRaw     bool
 	inputCursor  int
 	inputColumn  int
 	inputErr     string
@@ -197,6 +198,12 @@ func OpenMultiLineInput(prompt, placeholder, initial string, validate func(strin
 		validate:    validate,
 		submit:      submit,
 	}
+}
+
+func OpenRawMultiLineInput(prompt, placeholder, initial string, validate func(string) error, submit func(string) tea.Cmd) Modal {
+	m := OpenMultiLineInput(prompt, placeholder, initial, validate, submit)
+	m.inputRaw = true
+	return m
 }
 
 func OpenSelect(prompt string, items []SelectItem, selectedIndex int, submit func(string) tea.Cmd) Modal {
@@ -401,7 +408,10 @@ func (m Modal) updateInput(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 		}
 		return m, Consumed, nil
 	case "enter":
-		input := strings.TrimSpace(m.input)
+		input := m.input
+		if !m.inputRaw {
+			input = strings.TrimSpace(input)
+		}
 		if m.validate != nil {
 			if err := m.validate(input); err != nil {
 				m.inputErr = err.Error()

--- a/model/modal/modal_test.go
+++ b/model/modal/modal_test.go
@@ -457,6 +457,27 @@ func TestMultiLineInputSubmitTrimsOuterWhitespaceOnly(t *testing.T) {
 	}
 }
 
+func TestRawMultiLineInputSubmitPreservesOuterWhitespace(t *testing.T) {
+	var submitted string
+	m := modal.OpenRawMultiLineInput("Template", "prompt template", "  first\n\nsecond  \n", nil, func(input string) tea.Cmd {
+		submitted = input
+		return nil
+	})
+
+	_, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if out != modal.Accepted {
+		t.Fatalf("outcome = %v, want Accepted", out)
+	}
+	if cmd == nil {
+		t.Fatal("expected deferred submit command")
+	}
+	cmd()
+	if submitted != "  first\n\nsecond  \n" {
+		t.Fatalf("submitted = %q, want raw input preserved", submitted)
+	}
+}
+
 func TestSelectSnapshotsPromptItemsAndInitialSelection(t *testing.T) {
 	items := []modal.SelectItem{
 		{Label: "Codex", Value: "codex"},

--- a/model/modal/modal_test.go
+++ b/model/modal/modal_test.go
@@ -478,6 +478,23 @@ func TestRawMultiLineInputSubmitPreservesOuterWhitespace(t *testing.T) {
 	}
 }
 
+func TestInputHeightIsCarriedInView(t *testing.T) {
+	view := modal.OpenRawMultiLineInput("Template", "prompt template", "", nil, nil).
+		WithInputHeight(16).
+		View()
+
+	if view.InputHeight != 16 {
+		t.Fatalf("input height = %d, want 16", view.InputHeight)
+	}
+
+	view = modal.OpenRawMultiLineInput("Template", "prompt template", "", nil, nil).
+		WithInputHeight(-1).
+		View()
+	if view.InputHeight != 0 {
+		t.Fatalf("negative input height = %d, want normalized 0", view.InputHeight)
+	}
+}
+
 func TestSelectSnapshotsPromptItemsAndInitialSelection(t *testing.T) {
 	items := []modal.SelectItem{
 		{Label: "Codex", Value: "codex"},

--- a/model/model.go
+++ b/model/model.go
@@ -703,6 +703,7 @@ func (m Model) View() string {
 		InputValue:                  modalView.Input,
 		InputError:                  modalView.InputErr,
 		InputMode:                   uiInputMode(modalView.InputMode),
+		InputHeight:                 modalView.InputHeight,
 		InputCursor:                 modalView.InputCursor,
 		WorktreeInputPrompt:         modalView.Prompt,
 		WorktreeInputPlaceholder:    modalView.Placeholder,

--- a/model/model.go
+++ b/model/model.go
@@ -109,6 +109,8 @@ type Model struct {
 	saveAgent                  func(string) error
 	saveAgentReasoningEffort   func(string, string) error
 	saveDefaultView            func(ui.Mode) error
+	savePromptTemplate         func(string, string, string) error
+	resetPromptTemplate        func(string, string) error
 	launchTerminal             func(string) (actions.TerminalLaunchSpec, error)
 	launchDetachedTerminal     func(string, string) (actions.TerminalLaunchSpec, error)
 	launchAgent                func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error)
@@ -192,6 +194,8 @@ type Options struct {
 	SaveAgentCommand         func(string) error
 	SaveAgentReasoningEffort func(string, string) error
 	SaveDefaultView          func(ui.Mode) error
+	SavePromptTemplate       func(section, key, value string) error
+	ResetPromptTemplate      func(section, key string) error
 	LaunchTerminal           func(path string) (actions.TerminalLaunchSpec, error)
 	LaunchDetachedTerminal   func(targetShellCommand, cwd string) (actions.TerminalLaunchSpec, error)
 	LaunchAgent              func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error)
@@ -220,6 +224,14 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	saveDefaultView := opts.SaveDefaultView
 	if saveDefaultView == nil {
 		saveDefaultView = func(ui.Mode) error { return nil }
+	}
+	savePromptTemplate := opts.SavePromptTemplate
+	if savePromptTemplate == nil {
+		savePromptTemplate = func(string, string, string) error { return nil }
+	}
+	resetPromptTemplate := opts.ResetPromptTemplate
+	if resetPromptTemplate == nil {
+		resetPromptTemplate = func(string, string) error { return nil }
 	}
 	fetchRepo := opts.FetchRepo
 	if fetchRepo == nil {
@@ -435,6 +447,8 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		saveAgent:                saveAgent,
 		saveAgentReasoningEffort: saveAgentReasoningEffort,
 		saveDefaultView:          saveDefaultView,
+		savePromptTemplate:       savePromptTemplate,
+		resetPromptTemplate:      resetPromptTemplate,
 		launchTerminal:           launchTerminal,
 		launchDetachedTerminal:   launchDetachedTerminal,
 		launchAgent:              launchAgent,
@@ -1210,6 +1224,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleDefaultViewSet(msg), nil
 	case DefaultViewSetFailedMsg:
 		return m.handleDefaultViewSetFailed(msg), nil
+	case promptTemplateEditRequestedMsg:
+		return m.handlePromptTemplateEditRequested(msg), nil
+	case PromptTemplateSavedMsg:
+		return m.handlePromptTemplateSaved(msg), nil
+	case PromptTemplateSaveFailedMsg:
+		return m.handlePromptTemplateSaveFailed(msg), nil
+	case PromptTemplateResetMsg:
+		return m.handlePromptTemplateReset(msg), nil
+	case PromptTemplateResetFailedMsg:
+		return m.handlePromptTemplateResetFailed(msg), nil
 	case PlanLaunchRequestedMsg:
 		if msg.Request != 0 && (!m.isCurrentRepo(msg.LaunchContext.RepoPath) || !m.isCurrentFlowCreateRequest(msg.Request)) {
 			return m, nil

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -1907,7 +1907,7 @@ func TestModel_DestructivePersistsAcrossRepoSwitch(t *testing.T) {
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
 	// Switch to left pane and navigate to a different repo
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if !m.Destructive() {
 		t.Error("expected destructive to persist after repo switch")
@@ -2756,7 +2756,7 @@ func TestModel_BranchCreatedPendingSelectionClearsOnRepoSwitch(t *testing.T) {
 	m = inBranchesMode(m)
 	m, _ = update(m, model.BranchCreatedMsg{RepoPath: "/dev/alpha", Name: "feature/one"})
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})   // left pane
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown}) // repo bravo
 	m, _ = update(m, model.BranchResultMsg{
 		RepoPath: "/dev/bravo",
@@ -3528,6 +3528,144 @@ func TestModel_ShiftVDoesNotReplaceExistingModal(t *testing.T) {
 	}
 }
 
+func TestModel_F2OpensPromptTemplatePicker(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		PlanPromptTemplate: "custom plan prompt",
+		FlowPromptTemplates: model.FlowPromptTemplates{
+			Plan: "custom flow plan",
+		},
+	})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF2})
+
+	if cmd != nil {
+		t.Fatalf("F2 returned cmd %T, want nil", cmd)
+	}
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("overlay = %v, want select", m.Overlay())
+	}
+	view := m.View()
+	for _, want := range []string{
+		"Prompt templates",
+		"Plan launch",
+		"Flow plan",
+		"Plan review",
+		"custom",
+		"default",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected prompt picker to contain %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestModel_PromptTemplateEditSavesRawValueAndReopensPicker(t *testing.T) {
+	var savedSection, savedKey, savedValue string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		PlanPromptTemplate: "  custom plan\n",
+		SavePromptTemplate: func(section, key, value string) error {
+			savedSection = section
+			savedKey = key
+			savedValue = value
+			return nil
+		},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected prompt template edit request")
+	}
+	m, _ = update(m, cmd())
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("overlay = %v, want input editor", m.Overlay())
+	}
+	if got := m.WorktreeInput(); got != "  custom plan\n" {
+		t.Fatalf("editor initial input = %q, want raw template", got)
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected save prompt template command")
+	}
+	m, _ = update(m, cmd())
+
+	if savedSection != "agent" || savedKey != "plan_prompt" || savedValue != "  custom plan\n" {
+		t.Fatalf("saved template = %q/%q %q, want agent/plan_prompt raw value", savedSection, savedKey, savedValue)
+	}
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("overlay = %v, want picker reopened", m.Overlay())
+	}
+	if !strings.Contains(m.View(), "Plan launch") || !strings.Contains(m.View(), "custom") {
+		t.Fatalf("expected refreshed picker with custom status:\n%s", m.View())
+	}
+}
+
+func TestModel_PromptTemplateResetClearsCustomValueAndReopensPicker(t *testing.T) {
+	var resetSection, resetKey string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		FlowPromptTemplates: model.FlowPromptTemplates{
+			Plan: "custom flow plan",
+		},
+		ResetPromptTemplate: func(section, key string) error {
+			resetSection = section
+			resetKey = key
+			return nil
+		},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("expected reset prompt template command")
+	}
+	m, _ = update(m, cmd())
+
+	if resetSection != "flow_prompts" || resetKey != "plan" {
+		t.Fatalf("reset template = %q/%q, want flow_prompts/plan", resetSection, resetKey)
+	}
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("overlay = %v, want picker reopened", m.Overlay())
+	}
+	view := m.View()
+	if strings.Contains(view, "Flow plan        custom") {
+		t.Fatalf("expected Flow plan reset to default:\n%s", view)
+	}
+	if !strings.Contains(view, "Flow plan") || !strings.Contains(view, "default") {
+		t.Fatalf("expected refreshed picker with default status:\n%s", view)
+	}
+}
+
+func TestModel_PromptTemplateViewDefaultRendersBuiltInWithPlaceholders(t *testing.T) {
+	m := model.New(testRepos())
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+
+	if m.Overlay() != ui.OverlayPlanText {
+		t.Fatalf("overlay = %v, want text preview", m.Overlay())
+	}
+	preview := m.OverlayText()
+	for _, want := range []string{"Implement the saved wtui plan", "{title}", "{plan_id}", "{plan_path}"} {
+		if !strings.Contains(preview, want) {
+			t.Fatalf("expected plan prompt preview to contain %q:\n%s", want, preview)
+		}
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEsc})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+
+	preview = m.OverlayText()
+	for _, want := range []string{"Use the wtui-flow skill", "{instructions}", "After completing this phase goal"} {
+		if !strings.Contains(preview, want) {
+			t.Fatalf("expected Flow plan preview to contain %q:\n%s", want, preview)
+		}
+	}
+}
+
 func TestModel_ViewChoicesCoverNumberedViews(t *testing.T) {
 	choices := model.ViewChoices()
 	if len(choices) != 9 {
@@ -4151,7 +4289,7 @@ func TestModel_ChangingRepoRefetchesSessionsMode(t *testing.T) {
 		t.Fatalf("initial Sessions() = %#v", got)
 	}
 
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	if cmd != nil {
 		t.Fatalf("expected nil cmd switching to repo pane, got %T", cmd)
 	}

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/brian-bell/wtui/gitquery"
 	"github.com/brian-bell/wtui/model"
 	"github.com/brian-bell/wtui/model/modal"
+	"github.com/brian-bell/wtui/planstore"
 	"github.com/brian-bell/wtui/scanner"
 	"github.com/brian-bell/wtui/sessions"
 	"github.com/brian-bell/wtui/ui"
@@ -3598,6 +3599,61 @@ func TestModel_PromptTemplateEditSavesRawValueAndReopensPicker(t *testing.T) {
 	}
 	if !strings.Contains(m.View(), "Plan launch") || !strings.Contains(m.View(), "custom") {
 		t.Fatalf("expected refreshed picker with custom status:\n%s", m.View())
+	}
+}
+
+func TestModel_PromptTemplateSaveFailurePreservesCurrentLaunchPrompt(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:       "codex",
+		PlanPromptTemplate: "old {title}",
+		PlanMarkdownPath:   func(string) (string, error) { return "/state/plans/plan-1/plan.md", nil },
+		SavePromptTemplate: func(string, string, string) error { return errors.New("read-only config") },
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected prompt template edit request")
+	}
+	m, _ = update(m, cmd())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlU})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("new {title}")})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected save prompt template command")
+	}
+	m, _ = update(m, cmd())
+
+	view := m.View()
+	if !strings.Contains(view, "read-only config") {
+		t.Fatalf("expected save failure status in view:\n%s", view)
+	}
+	if !strings.Contains(view, "Plan launch      custom") {
+		t.Fatalf("expected failed save to keep old custom picker status:\n%s", view)
+	}
+	if strings.Contains(view, "Plan launch      default") {
+		t.Fatalf("failed save should not mark existing custom template as default:\n%s", view)
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEsc})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
+	m, _ = update(m, model.PlanResultMsg{
+		RepoPath: "/dev/alpha",
+		Plans: []planstore.PlanRecord{{
+			PlanID:   "plan-1",
+			Title:    "Implement plans",
+			Status:   "approved",
+			RepoPath: "/dev/alpha",
+		}},
+		ListRequest: m.ListRequest(ui.ModePlans),
+	})
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd opening launch instructions, got %T", cmd)
+	}
+	if got, want := m.WorktreeInput(), "old Implement plans"; got != want {
+		t.Fatalf("launch prompt after failed save = %q, want %q", got, want)
 	}
 }
 

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3602,6 +3602,40 @@ func TestModel_PromptTemplateEditSavesRawValueAndReopensPicker(t *testing.T) {
 	}
 }
 
+func TestModel_PromptTemplateEditUsesTallEditor(t *testing.T) {
+	template := strings.Join([]string{
+		"line 01",
+		"line 02",
+		"line 03",
+		"line 04",
+		"line 05",
+		"line 06",
+		"line 07",
+		"line 08",
+		"line 09",
+		"line 10",
+		"line 11",
+		"line 12",
+	}, "\n")
+	m := model.NewWithOptions(testRepos(), model.Options{
+		PlanPromptTemplate: template,
+	})
+	m, _ = update(m, tea.WindowSizeMsg{Width: 100, Height: 24})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected prompt template edit request")
+	}
+	m, _ = update(m, cmd())
+
+	view := ansi.Strip(m.View())
+	for _, want := range []string{"line 01", "line 12█"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("prompt template editor should show %q with tall editor:\n%s", want, view)
+		}
+	}
+}
+
 func TestModel_PromptTemplateSaveFailurePreservesCurrentLaunchPrompt(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand:       "codex",

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -480,16 +480,17 @@ func (m Model) createFlowAndLaunchPlanForRepo(repoPath, title, instructions, bas
 	command, reasoningEffort := m.flowLaunchAgentSettings()
 	return func() tea.Msg {
 		result, err := m.startFlowPlan(FlowStartRequest{
-			RepoPath:         repoPath,
-			Title:            title,
-			Instructions:     instructions,
-			BaseRef:          baseRef,
-			AgentCommand:     command,
-			ReasoningEffort:  reasoningEffort,
-			SessionStateRoot: m.sessionStateRoot,
-			PlanPhaseID:      flowPlanPhaseID,
-			PlanPhaseTitle:   "Plan",
-			PlanPhaseStatus:  flowstore.PhaseRunning,
+			RepoPath:            repoPath,
+			Title:               title,
+			Instructions:        instructions,
+			BaseRef:             baseRef,
+			AgentCommand:        command,
+			ReasoningEffort:     reasoningEffort,
+			SessionStateRoot:    m.sessionStateRoot,
+			FlowPromptTemplates: m.flowPromptTemplates,
+			PlanPhaseID:         flowPlanPhaseID,
+			PlanPhaseTitle:      "Plan",
+			PlanPhaseStatus:     flowstore.PhaseRunning,
 		})
 		if err != nil {
 			return FlowCreateFailedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title, Err: err.Error()}

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -480,17 +480,18 @@ func (m Model) createFlowAndLaunchPlanForRepo(repoPath, title, instructions, bas
 	command, reasoningEffort := m.flowLaunchAgentSettings()
 	return func() tea.Msg {
 		result, err := m.startFlowPlan(FlowStartRequest{
-			RepoPath:            repoPath,
-			Title:               title,
-			Instructions:        instructions,
-			BaseRef:             baseRef,
-			AgentCommand:        command,
-			ReasoningEffort:     reasoningEffort,
-			SessionStateRoot:    m.sessionStateRoot,
-			FlowPromptTemplates: m.flowPromptTemplates,
-			PlanPhaseID:         flowPlanPhaseID,
-			PlanPhaseTitle:      "Plan",
-			PlanPhaseStatus:     flowstore.PhaseRunning,
+			RepoPath:                    repoPath,
+			Title:                       title,
+			Instructions:                instructions,
+			BaseRef:                     baseRef,
+			AgentCommand:                command,
+			ReasoningEffort:             reasoningEffort,
+			SessionStateRoot:            m.sessionStateRoot,
+			FlowPromptTemplates:         m.flowPromptTemplates,
+			FlowPromptTemplatesProvided: true,
+			PlanPhaseID:                 flowPlanPhaseID,
+			PlanPhaseTitle:              "Plan",
+			PlanPhaseStatus:             flowstore.PhaseRunning,
 		})
 		if err != nil {
 			return FlowCreateFailedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title, Err: err.Error()}

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -157,7 +157,7 @@ func TestModel_ActiveFlowsGlobalResultSurvivesRepoMoveAndUsesLeftPaneFilter(t *t
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 	result := activeFlowResultFromCommand(t, cmd)
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	if cmd != nil {
 		t.Fatalf("switching active flows to repo pane returned command %T, want nil", cmd)
 	}
@@ -175,7 +175,7 @@ func TestModel_ActiveFlowsGlobalResultSurvivesRepoMoveAndUsesLeftPaneFilter(t *t
 		t.Fatalf("active Flow filters = %#v, want one global fetch", filters)
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 	view = ansi.Strip(m.View())
 	if !strings.Contains(view, "Alpha Flow") || !strings.Contains(view, "Bravo Flow") {
 		t.Fatalf("returning focus to content pane should restore global active flows:\n%s", view)
@@ -194,7 +194,7 @@ func TestModel_ActiveFlowsLeftPaneFilterCleansRepoPath(t *testing.T) {
 	m := inRightPane(model.New(testRepos()))
 	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{alpha, bravo})
 	m, _ = update(m, tea.WindowSizeMsg{Width: 220, Height: 24})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
 	view := ansi.Strip(m.View())
@@ -217,7 +217,7 @@ func TestModel_ActiveFlowsGlobalFetchErrorSurvivesRepoMove(t *testing.T) {
 		t.Fatal("expected active Flow fetch command")
 	}
 	msg := cmd()
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, repoMoveCmd := update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if repoMoveCmd != nil {
 		t.Fatalf("repo movement in active flows returned command %T, want nil", repoMoveCmd)
@@ -252,7 +252,7 @@ func TestModel_ActiveFlowsLeftPaneEnterShowsGlobalActiveFlows(t *testing.T) {
 
 	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}})
 	m, _ = update(m, activeFlowResultFromCommand(t, cmd))
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if got := model.ActiveFlowsForTest(m); len(got) != 1 || got[0].FlowID != "bravo-flow" {
 		t.Fatalf("left-pane active flows = %#v, want repo-filtered bravo", got)
@@ -562,7 +562,7 @@ func TestModel_ActiveFlowsTabWithTerminalSwitchesBetweenListAndTerminal(t *testi
 	}
 }
 
-func TestModel_ActiveFlowsF2ClearsSelectedPhaseWhenLeavingRightPane(t *testing.T) {
+func TestModel_ActiveFlowsBackspaceClearsSelectedPhaseWhenLeavingRightPane(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
@@ -574,18 +574,18 @@ func TestModel_ActiveFlowsF2ClearsSelectedPhaseWhenLeavingRightPane(t *testing.T
 		t.Fatalf("selected active Flow phase = %q, want plan before leaving right pane", got)
 	}
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	if cmd != nil {
-		t.Fatalf("F2 from active Flow surface returned command %T, want nil", cmd)
+		t.Fatalf("Backspace from active Flow surface returned command %T, want nil", cmd)
 	}
 	if m.ActivePane() != 0 {
-		t.Fatalf("F2 from active Flow surface active pane = %d, want left pane", m.ActivePane())
+		t.Fatalf("Backspace from active Flow surface active pane = %d, want left pane", m.ActivePane())
 	}
 	if m.Mode() != ui.ModeActiveFlows {
-		t.Fatalf("F2 from active Flow surface mode = %d, want active flows", m.Mode())
+		t.Fatalf("Backspace from active Flow surface mode = %d, want active flows", m.Mode())
 	}
 	if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "" {
-		t.Fatalf("F2 from active Flow surface left selected phase = %q, want cleared", got)
+		t.Fatalf("Backspace from active Flow surface left selected phase = %q, want cleared", got)
 	}
 }
 
@@ -594,7 +594,7 @@ func TestModel_ActiveFlowsLeftPaneNumberedKeysAreNoOps(t *testing.T) {
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
 	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
@@ -3850,7 +3850,7 @@ func TestModel_SelectedFlowPhaseClearsWhenFlowSelectionChanges(t *testing.T) {
 
 func TestModel_SelectedFlowPhaseClearsWhenLeavingRightPane(t *testing.T) {
 	for _, key := range []tea.KeyMsg{
-		{Type: tea.KeyF2},
+		{Type: tea.KeyBackspace},
 	} {
 		m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithPhaseDetails()})
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
@@ -4000,7 +4000,7 @@ func TestModel_ChangingRepoRefetchesFlowsMode(t *testing.T) {
 		t.Fatalf("initial Flows() = %#v", got)
 	}
 
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	if cmd != nil {
 		t.Fatalf("expected nil cmd switching to repo pane, got %T", cmd)
 	}
@@ -6712,7 +6712,7 @@ func TestModel_BackKeysForwardWhenFlowTerminalInputOwnsKeys(t *testing.T) {
 	}
 }
 
-func TestModel_F2SwitchesPaneWithoutFocusingInactiveFlowTerminal(t *testing.T) {
+func TestModel_BackspaceSwitchesPaneWithoutFocusingInactiveFlowTerminal(t *testing.T) {
 	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -6735,18 +6735,18 @@ func TestModel_F2SwitchesPaneWithoutFocusingInactiveFlowTerminal(t *testing.T) {
 	}
 	m, _ = update(m, cmd())
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	if m.ActivePane() != 0 {
-		t.Fatalf("f2 with inactive Flow terminal activePane = %d, want left pane", m.ActivePane())
+		t.Fatalf("backspace with inactive Flow terminal activePane = %d, want left pane", m.ActivePane())
 	}
 	if len(fakeTerm.writes) != 0 {
-		t.Fatalf("inactive Flow terminal should not receive f2 writes: %#v", fakeTerm.writes)
+		t.Fatalf("inactive Flow terminal should not receive backspace writes: %#v", fakeTerm.writes)
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if len(fakeTerm.writes) != 0 {
-		t.Fatalf("returning from f2 should keep Flow list focus, not terminal focus: %#v", fakeTerm.writes)
+		t.Fatalf("returning from backspace should keep Flow list focus, not terminal focus: %#v", fakeTerm.writes)
 	}
 	if got := m.SelectedFlowPhaseID(); got != "plan" {
 		t.Fatalf("selected Flow phase = %q, want list focus to move to first phase", got)
@@ -8993,7 +8993,7 @@ func TestModel_NewFlowCodexAppStaleLaunchIgnoredAfterRepoChange(t *testing.T) {
 		t.Fatal("expected flow creation command")
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	staleMsg := createCmd()
 	if launchMsg, ok := staleMsg.(model.PlanLaunchRequestedMsg); !ok || launchMsg.Request == 0 {
@@ -9096,7 +9096,7 @@ func TestModel_NewFlowStaleLaunchIgnoredAfterRepoChange(t *testing.T) {
 		t.Fatal("expected flow creation command")
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	staleMsg := createCmd()
 	if launchMsg, ok := staleMsg.(model.FlowEmbeddedLaunchRequestedMsg); !ok || launchMsg.Request == 0 {
@@ -9161,7 +9161,7 @@ func TestModel_NewFlowStaleParkedCreateIgnoredAfterRepoChange(t *testing.T) {
 		t.Fatal("expected parked Flow creation command")
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	staleMsg := createCmd()
 	if created, ok := staleMsg.(model.FlowCreatedMsg); !ok || created.Request == 0 {
@@ -9300,7 +9300,7 @@ func TestModel_NewFlowStaleStartFailureIgnoredAfterRepoChange(t *testing.T) {
 		t.Fatal("flow create failure should be tagged with the active create request")
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	next, cmd := update(m, staleMsg)
 	if cmd != nil {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1891,7 +1891,7 @@ func (m Model) planLaunchContext() (actions.AgentLaunchContext, bool, Model) {
 		ctx.PlanPhaseID = phase.PhaseID
 		ctx.PlanPhaseTitle = phase.Title
 		ctx.PlanPhaseStatus = phase.Status
-		ctx.InitialPrompt = implementationPromptForPhase(plan, planPath, phase)
+		ctx.InitialPrompt = m.implementationPromptForPhase(plan, planPath, repoPath, launchPath, phase)
 	}
 	return ctx, true, m
 }
@@ -1904,8 +1904,19 @@ func validatePlanLaunchInput(input string) error {
 }
 
 func (m Model) implementationPrompt(plan planstore.PlanRecord, planPath, repoPath, worktreePath string) string {
+	return m.renderPlanPromptTemplate(plan, planPath, repoPath, worktreePath, planstore.PlanPhase{}, false)
+}
+
+func (m Model) implementationPromptForPhase(plan planstore.PlanRecord, planPath, repoPath, worktreePath string, phase planstore.PlanPhase) string {
+	return m.renderPlanPromptTemplate(plan, planPath, repoPath, worktreePath, phase, true)
+}
+
+func (m Model) renderPlanPromptTemplate(plan planstore.PlanRecord, planPath, repoPath, worktreePath string, phase planstore.PlanPhase, phaseSelected bool) string {
 	template := m.planPromptTemplate
 	if strings.TrimSpace(template) == "" {
+		if phaseSelected {
+			return defaultImplementationPromptForPhase(plan, planPath, phase)
+		}
 		return defaultImplementationPrompt(plan, planPath)
 	}
 	title := plan.Title
@@ -1919,6 +1930,26 @@ func (m Model) implementationPrompt(plan planstore.PlanRecord, planPath, repoPat
 		"{repo_path}", repoPath,
 		"{worktree_path}", worktreePath,
 	)
+	if phaseSelected {
+		phaseTitle := phase.Title
+		if phaseTitle == "" {
+			phaseTitle = "(untitled)"
+		}
+		phaseStatus := phase.Status
+		if phaseStatus == "" {
+			phaseStatus = "(unknown)"
+		}
+		replacer = strings.NewReplacer(
+			"{title}", title,
+			"{plan_id}", plan.PlanID,
+			"{plan_path}", planPath,
+			"{repo_path}", repoPath,
+			"{worktree_path}", worktreePath,
+			"{phase_id}", phase.PhaseID,
+			"{phase_title}", phaseTitle,
+			"{phase_status}", phaseStatus,
+		)
+	}
 	return replacer.Replace(template)
 }
 
@@ -1930,7 +1961,7 @@ func defaultImplementationPrompt(plan planstore.PlanRecord, planPath string) str
 	return fmt.Sprintf("Implement the saved wtui plan %q (ID: %s) at %s. Read the plan file, then begin implementation.", title, plan.PlanID, planPath)
 }
 
-func implementationPromptForPhase(plan planstore.PlanRecord, planPath string, phase planstore.PlanPhase) string {
+func defaultImplementationPromptForPhase(plan planstore.PlanRecord, planPath string, phase planstore.PlanPhase) string {
 	title := plan.Title
 	if title == "" {
 		title = "(untitled)"

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -23,6 +23,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
 	if m.modal.IsOpen() {
+		if next, cmd, handled := m.handlePromptTemplateModalKey(msg); handled {
+			return next, cmd
+		}
 		var cmd tea.Cmd
 		view := m.modal.View()
 		var outcome modal.Outcome
@@ -104,8 +107,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if key == "f2" {
-		m = m.togglePrimaryPaneFocus()
-		return m, nil
+		return m.handlePromptTemplates()
 	}
 
 	if key == "tab" && m.activePane == 0 {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -143,6 +143,34 @@ type VisibleRepoFetchStatusExpiredMsg struct {
 	Text    string
 }
 
+type promptTemplateEditRequestedMsg struct {
+	Value string
+}
+
+type PromptTemplateSavedMsg struct {
+	Section string
+	Key     string
+	Value   string
+}
+
+type PromptTemplateSaveFailedMsg struct {
+	Section string
+	Key     string
+	Value   string
+	Err     string
+}
+
+type PromptTemplateResetMsg struct {
+	Section string
+	Key     string
+}
+
+type PromptTemplateResetFailedMsg struct {
+	Section string
+	Key     string
+	Err     string
+}
+
 type RepoRefreshResultMsg struct {
 	Request uint64
 	Repos   []scanner.Repo

--- a/model/model_plan_overlay_test.go
+++ b/model/model_plan_overlay_test.go
@@ -449,7 +449,7 @@ func TestModel_CollapsingExpandedPlanResumesPlanMovement(t *testing.T) {
 	}
 }
 
-func TestModel_F2AwayFromPlansAndBackKeepsSelectedPhaseCleared(t *testing.T) {
+func TestModel_BackspaceAwayFromPlansAndTabBackKeepsSelectedPhaseCleared(t *testing.T) {
 	m := model.New(testRepos())
 	m = plansInRightPane(t, m, []planstore.PlanRecord{
 		{PlanID: "plan-1", RepoPath: "/dev/alpha", Title: "Plan 1", Status: "draft",
@@ -462,9 +462,9 @@ func TestModel_F2AwayFromPlansAndBackKeepsSelectedPhaseCleared(t *testing.T) {
 		t.Fatalf("selected phase = %q, want p1", got)
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	if got := m.ActivePane(); got != 0 {
-		t.Fatalf("F2 should move focus to repo pane, got active pane %d", got)
+		t.Fatalf("backspace should move focus to repo pane, got active pane %d", got)
 	}
 	if got := m.SelectedPlanPhaseID(); got != "" {
 		t.Fatalf("selected phase should clear when focus leaves plans pane, got %q", got)
@@ -473,9 +473,9 @@ func TestModel_F2AwayFromPlansAndBackKeepsSelectedPhaseCleared(t *testing.T) {
 		t.Fatalf("leaving plans should preserve phase expansion:\n%s", view)
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 	if got := m.ActivePane(); got != 1 {
-		t.Fatalf("F2 should return focus to plans pane, got active pane %d", got)
+		t.Fatalf("tab should return focus to plans pane, got active pane %d", got)
 	}
 	if got := m.SelectedPlanPhaseID(); got != "" {
 		t.Fatalf("selected phase should not restore when focus returns, got %q", got)

--- a/model/model_plan_test.go
+++ b/model/model_plan_test.go
@@ -72,7 +72,7 @@ func TestModel_ChangingRepoRefetchesPlansMode(t *testing.T) {
 		t.Fatalf("initial Plans() = %#v", got)
 	}
 
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	if cmd != nil {
 		t.Fatalf("expected nil cmd switching to repo pane, got %T", cmd)
 	}
@@ -640,7 +640,7 @@ func TestModel_IKeyMissingPlanLaunchPathShowsStatus(t *testing.T) {
 		AgentCommand:     "codex",
 		PlanMarkdownPath: func(string) (string, error) { return "/state/plans/plan-1/plan.md", nil },
 	})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
 	m, _ = update(m, model.PlanResultMsg{Plans: []planstore.PlanRecord{
 		{PlanID: "plan-1", Title: "Implement plans", Status: "approved"},

--- a/model/model_plan_test.go
+++ b/model/model_plan_test.go
@@ -243,6 +243,57 @@ func TestModel_PlanPromptTemplateReplacesSupportedPlaceholders(t *testing.T) {
 	}
 }
 
+func TestModel_PlanPromptTemplateAppliesToSelectedPlanPhase(t *testing.T) {
+	var got actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand:       "codex",
+		PlanPromptTemplate: "Do phase {phase_id}: {phase_title} ({phase_status}) for {title} from {plan_path} in {repo_path} at {worktree_path}; keep {unknown}",
+		PlanMarkdownPath:   func(string) (string, error) { return "/state/plans/plan-1/plan.md", nil },
+		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			got = ctx
+			return actions.TerminalLaunchSpec{Cmd: exec.Command("true"), Interactive: true}, nil
+		},
+	})
+	m = plansInRightPane(t, m, []planstore.PlanRecord{{
+		PlanID:       "plan-1",
+		Title:        "Implement plans",
+		Status:       "approved",
+		RepoPath:     "/dev/plan-repo",
+		WorktreePath: "/dev/plan-worktree",
+		Phases: []planstore.PlanPhase{
+			{PhaseID: "p1", Title: "Store tracer bullet", Status: "completed", Order: 1},
+			{PhaseID: "p2", Title: "CLI subcommands", Status: "pending", Order: 2},
+		},
+	}})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd opening launch instructions, got %T", cmd)
+	}
+	want := "Do phase p2: CLI subcommands (pending) for Implement plans from /state/plans/plan-1/plan.md in /dev/plan-repo at /dev/plan-worktree; keep {unknown}"
+	if m.WorktreeInput() != want {
+		t.Fatalf("phase launch instructions = %q, want %q", m.WorktreeInput(), want)
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected submit command")
+	}
+	_, launchCmd := update(m, cmd())
+	if launchCmd == nil {
+		t.Fatal("expected agent launch command")
+	}
+	if got.InitialPrompt != want {
+		t.Fatalf("submitted phase launch prompt = %q, want %q", got.InitialPrompt, want)
+	}
+	if got.PlanPhaseID != "p2" || got.PlanPhaseTitle != "CLI subcommands" || got.PlanPhaseStatus != "pending" {
+		t.Fatalf("unexpected phase launch context: %#v", got)
+	}
+}
+
 func TestModel_PlanPromptTemplateBlankFallsBackToDefault(t *testing.T) {
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand:       "codex",

--- a/model/model_refresh_test.go
+++ b/model/model_refresh_test.go
@@ -408,7 +408,7 @@ func TestModel_RepoSelectionResetInvalidatesStaleNonCurrentPaneResults(t *testin
 	}
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
 	m, _ = update(m, stalePlan)

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -509,22 +509,6 @@ func TestModel_EnterFromLeftPaneSwitchesToRightWithoutChangingSelectionOrMode(t 
 	}
 }
 
-func TestModel_F2FromLeftPaneSwitchesToRightWithoutChangingSelectionOrMode(t *testing.T) {
-	m := model.New(testRepos())
-	m = selectBravo(m)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
-
-	if m.ActivePane() != 1 {
-		t.Fatalf("expected right pane after f2, got %d", m.ActivePane())
-	}
-	if m.Selected() != 1 {
-		t.Fatalf("selected repo = %d, want unchanged 1", m.Selected())
-	}
-	if m.Mode() != ui.ModeWorktrees {
-		t.Fatalf("mode = %d, want unchanged worktrees", m.Mode())
-	}
-}
-
 func TestModel_TabDoesNotChangeMode(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
@@ -538,14 +522,14 @@ func TestModel_TabDoesNotChangeMode(t *testing.T) {
 	}
 }
 
-func TestModel_F2FromRightPaneSwitchesToLeftWithoutChangingMode(t *testing.T) {
+func TestModel_BackspaceFromRightPaneSwitchesToLeftWithoutChangingMode(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}}) // mode 3 (stashes)
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})                        // right → left
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})                 // right to left
 
 	if m.ActivePane() != 0 {
-		t.Fatalf("expected left pane after f2, got %d", m.ActivePane())
+		t.Fatalf("expected left pane after backspace, got %d", m.ActivePane())
 	}
 	if m.Mode() != ui.ModeStashes {
 		t.Fatalf("mode = %d, want unchanged stashes", m.Mode())
@@ -599,7 +583,7 @@ func TestModel_BackspaceFromRightPaneSwitchesToLeftAcrossModes(t *testing.T) {
 	}
 }
 
-func TestModel_F2FromPlansPaneClearsSelectedPhase(t *testing.T) {
+func TestModel_BackspaceFromPlansPaneClearsSelectedPhase(t *testing.T) {
 	m := plansInRightPane(t, model.New(testRepos()), []planstore.PlanRecord{{
 		PlanID:   "plan-1",
 		RepoPath: "/dev/alpha",
@@ -610,13 +594,13 @@ func TestModel_F2FromPlansPaneClearsSelectedPhase(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if got := m.SelectedPlanPhaseID(); got != "p1" {
-		t.Fatalf("selected plan phase = %q, want p1 before f2", got)
+		t.Fatalf("selected plan phase = %q, want p1 before backspace", got)
 	}
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 
 	if m.ActivePane() != 0 {
-		t.Fatalf("expected left pane after f2, got %d", m.ActivePane())
+		t.Fatalf("expected left pane after backspace, got %d", m.ActivePane())
 	}
 	if got := m.SelectedPlanPhaseID(); got != "" {
 		t.Fatalf("selected plan phase = %q, want cleared", got)
@@ -666,14 +650,14 @@ func TestModel_BackKeysFromPlansPaneClearSelectedPhase(t *testing.T) {
 	}
 }
 
-func TestModel_F2FromFlowsPaneClearsSelectedPhase(t *testing.T) {
+func TestModel_BackspaceFromFlowsPaneClearsSelectedPhase(t *testing.T) {
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithPhaseDetails()})
 	m = selectFlowPhaseByID(t, m, "implementation")
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 
 	if m.ActivePane() != 0 {
-		t.Fatalf("expected left pane after f2, got %d", m.ActivePane())
+		t.Fatalf("expected left pane after backspace, got %d", m.ActivePane())
 	}
 	if got := m.SelectedFlowPhaseID(); got != "" {
 		t.Fatalf("selected flow phase = %q, want cleared", got)
@@ -688,7 +672,7 @@ func TestModel_TabFromLeftPaneReturnsToActiveFlowsWithoutChangingMode(t *testing
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
 	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyTab})
@@ -784,7 +768,7 @@ func TestModel_LeftPaneDownFiresFetchInBranchMode(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}) // branches
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})                        // back to left pane
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})                 // back to left pane
 	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if cmd == nil {
 		t.Error("expected fetch cmd after repo navigation in branches mode, got nil")
@@ -860,7 +844,7 @@ func TestModel_LeftPaneDownResetsRightPaneCursors(t *testing.T) {
 	}})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown}) // move branch cursor
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown}) // branchSelected=2
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})   // back to left pane
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown}) // navigate to bravo
 	if m.BranchSelected() != 0 {
 		t.Errorf("expected branchSelected reset to 0, got %d", m.BranchSelected())
@@ -932,7 +916,7 @@ func TestModel_RightArrowFromLeftPaneInNonEdgeModeIsNoOp(t *testing.T) {
 		{Name: "main"}, {Name: "feature"},
 	}})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRight})
@@ -963,7 +947,7 @@ func TestModel_LeftArrowFromLeftPaneAtFlowsIsNoOp(t *testing.T) {
 	}, ListRequest: m.ListRequest(ui.ModeFlows)})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyLeft})
@@ -2177,7 +2161,7 @@ func TestModel_RepoSwitchClearsCommits(t *testing.T) {
 	if len(m.Commits()) != 3 {
 		t.Fatal("expected 3 commits")
 	}
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2}) // switch to left pane
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if len(m.Commits()) != 0 {
 		t.Errorf("expected commits cleared on repo switch, got %d", len(m.Commits()))
@@ -2345,7 +2329,7 @@ func TestModel_RepoSwitchClearsReflogs(t *testing.T) {
 		t.Fatalf("expected 3 reflogs loaded, got %d", len(m.Reflogs()))
 	}
 	// Switch to left pane and navigate down
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 	if len(m.Reflogs()) != 0 {
 		t.Errorf("expected reflogs cleared on repo switch, got %d", len(m.Reflogs()))

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -342,8 +342,8 @@ func TestModel_ViewStatusBarShowsKeyHints(t *testing.T) {
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
 
 	view := m.View()
-	if !strings.Contains(view, "f2/tab pane") {
-		t.Error("view should contain 'f2/tab pane' shortcut")
+	if !strings.Contains(view, "tab") || !strings.Contains(view, "pane") {
+		t.Error("view should contain tab pane shortcut")
 	}
 }
 

--- a/model/prompt_templates.go
+++ b/model/prompt_templates.go
@@ -1,0 +1,313 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/model/modal"
+	"github.com/brian-bell/wtui/planstore"
+)
+
+const promptTemplatePickerPrompt = "Prompt templates"
+
+type promptTemplateTarget struct {
+	Section string
+	Key     string
+	Title   string
+}
+
+var promptTemplateTargets = []promptTemplateTarget{
+	{Section: "agent", Key: "plan_prompt", Title: "Plan launch"},
+	{Section: "flow_prompts", Key: "plan", Title: "Flow plan"},
+	{Section: "flow_prompts", Key: "plan_review", Title: "Plan review"},
+	{Section: "flow_prompts", Key: "implementation", Title: "Implementation"},
+	{Section: "flow_prompts", Key: "review_loop", Title: "Review loop"},
+	{Section: "flow_prompts", Key: "pr_creation", Title: "PR creation"},
+	{Section: "flow_prompts", Key: "autoreview", Title: "Autoreview"},
+	{Section: "flow_prompts", Key: "merge", Title: "Merge"},
+	{Section: "flow_prompts", Key: "generic", Title: "Generic"},
+}
+
+func (m Model) handlePromptTemplates() (tea.Model, tea.Cmd) {
+	return m.openPromptTemplatePicker(0), nil
+}
+
+func (m Model) openPromptTemplatePicker(selected int) Model {
+	m.modal = modal.OpenSelectWithLayout(
+		promptTemplatePickerPrompt,
+		m.promptTemplateSelectItems(),
+		selected,
+		modal.Layout{Width: 42, Height: len(promptTemplateTargets) + 3, Placement: modal.PlacementCenter},
+		func(value string) tea.Cmd {
+			return func() tea.Msg { return promptTemplateEditRequestedMsg{Value: value} }
+		},
+	)
+	return m
+}
+
+func (m Model) handlePromptTemplateModalKey(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
+	view := m.modal.View()
+	if view.Kind != modal.Select || view.Prompt != promptTemplatePickerPrompt {
+		return m, nil, false
+	}
+	switch msg.String() {
+	case "r":
+		target, ok := selectedPromptTemplateTarget(view)
+		if !ok {
+			return m, nil, true
+		}
+		return m, m.resetPromptTemplateCommand(target), true
+	case "v":
+		target, ok := selectedPromptTemplateTarget(view)
+		if !ok {
+			return m, nil, true
+		}
+		m.modal = modal.OpenText(m.builtInPromptTemplatePreview(target))
+		return m, nil, true
+	default:
+		return m, nil, false
+	}
+}
+
+func selectedPromptTemplateTarget(view modal.View) (promptTemplateTarget, bool) {
+	if view.SelectIndex < 0 || view.SelectIndex >= len(view.SelectItems) {
+		return promptTemplateTarget{}, false
+	}
+	return promptTemplateTargetByValue(view.SelectItems[view.SelectIndex].Value)
+}
+
+func (m Model) handlePromptTemplateEditRequested(msg promptTemplateEditRequestedMsg) Model {
+	target, ok := promptTemplateTargetByValue(msg.Value)
+	if !ok {
+		return m.setStatus(statusOther, "Prompt template is unavailable")
+	}
+	m.modal = modal.OpenRawMultiLineInput(
+		"Edit "+target.Title,
+		"prompt template",
+		m.promptTemplateValue(target),
+		nil,
+		func(input string) tea.Cmd {
+			if strings.TrimSpace(input) == "" {
+				return m.resetPromptTemplateCommand(target)
+			}
+			return m.savePromptTemplateCommand(target, input)
+		},
+	)
+	return m
+}
+
+func (m Model) savePromptTemplateCommand(target promptTemplateTarget, value string) tea.Cmd {
+	return func() tea.Msg {
+		if err := m.savePromptTemplate(target.Section, target.Key, value); err != nil {
+			return PromptTemplateSaveFailedMsg{Section: target.Section, Key: target.Key, Value: value, Err: err.Error()}
+		}
+		return PromptTemplateSavedMsg{Section: target.Section, Key: target.Key, Value: value}
+	}
+}
+
+func (m Model) resetPromptTemplateCommand(target promptTemplateTarget) tea.Cmd {
+	return func() tea.Msg {
+		if err := m.resetPromptTemplate(target.Section, target.Key); err != nil {
+			return PromptTemplateResetFailedMsg{Section: target.Section, Key: target.Key, Err: err.Error()}
+		}
+		return PromptTemplateResetMsg{Section: target.Section, Key: target.Key}
+	}
+}
+
+func (m Model) handlePromptTemplateSaved(msg PromptTemplateSavedMsg) Model {
+	target, ok := promptTemplateTargetBySectionKey(msg.Section, msg.Key)
+	if !ok {
+		return m.setStatus(statusOther, "Prompt template is unavailable")
+	}
+	m = m.withPromptTemplateValue(target, msg.Value)
+	m = m.clearStatus(statusOther)
+	return m.openPromptTemplatePicker(promptTemplateTargetIndex(target))
+}
+
+func (m Model) handlePromptTemplateSaveFailed(msg PromptTemplateSaveFailedMsg) Model {
+	target, ok := promptTemplateTargetBySectionKey(msg.Section, msg.Key)
+	if ok {
+		m = m.withPromptTemplateValue(target, msg.Value)
+		m = m.openPromptTemplatePicker(promptTemplateTargetIndex(target))
+	}
+	errText := msg.Err
+	if errText == "" {
+		errText = "Unable to persist prompt template"
+	}
+	return m.setStatus(statusOther, errText)
+}
+
+func (m Model) handlePromptTemplateReset(msg PromptTemplateResetMsg) Model {
+	target, ok := promptTemplateTargetBySectionKey(msg.Section, msg.Key)
+	if !ok {
+		return m.setStatus(statusOther, "Prompt template is unavailable")
+	}
+	m = m.withPromptTemplateValue(target, "")
+	m = m.clearStatus(statusOther)
+	return m.openPromptTemplatePicker(promptTemplateTargetIndex(target))
+}
+
+func (m Model) handlePromptTemplateResetFailed(msg PromptTemplateResetFailedMsg) Model {
+	errText := msg.Err
+	if errText == "" {
+		errText = "Unable to reset prompt template"
+	}
+	return m.setStatus(statusOther, errText)
+}
+
+func (m Model) promptTemplateSelectItems() []modal.SelectItem {
+	items := make([]modal.SelectItem, 0, len(promptTemplateTargets))
+	for _, target := range promptTemplateTargets {
+		status := "default"
+		if strings.TrimSpace(m.promptTemplateValue(target)) != "" {
+			status = "custom"
+		}
+		items = append(items, modal.SelectItem{
+			Label: fmt.Sprintf("%-16s %s", target.Title, status),
+			Value: promptTemplateTargetValue(target),
+		})
+	}
+	return items
+}
+
+func promptTemplateTargetValue(target promptTemplateTarget) string {
+	return target.Section + "." + target.Key
+}
+
+func promptTemplateTargetByValue(value string) (promptTemplateTarget, bool) {
+	for _, target := range promptTemplateTargets {
+		if promptTemplateTargetValue(target) == value {
+			return target, true
+		}
+	}
+	return promptTemplateTarget{}, false
+}
+
+func promptTemplateTargetBySectionKey(section, key string) (promptTemplateTarget, bool) {
+	for _, target := range promptTemplateTargets {
+		if target.Section == section && target.Key == key {
+			return target, true
+		}
+	}
+	return promptTemplateTarget{}, false
+}
+
+func promptTemplateTargetIndex(target promptTemplateTarget) int {
+	for i, candidate := range promptTemplateTargets {
+		if candidate.Section == target.Section && candidate.Key == target.Key {
+			return i
+		}
+	}
+	return 0
+}
+
+func (m Model) promptTemplateValue(target promptTemplateTarget) string {
+	if target.Section == "agent" && target.Key == "plan_prompt" {
+		return m.planPromptTemplate
+	}
+	if target.Section != "flow_prompts" {
+		return ""
+	}
+	switch target.Key {
+	case "plan":
+		return m.flowPromptTemplates.Plan
+	case "plan_review":
+		return m.flowPromptTemplates.PlanReview
+	case "implementation":
+		return m.flowPromptTemplates.Implementation
+	case "review_loop":
+		return m.flowPromptTemplates.ReviewLoop
+	case "pr_creation":
+		return m.flowPromptTemplates.PRCreation
+	case "autoreview":
+		return m.flowPromptTemplates.Autoreview
+	case "merge":
+		return m.flowPromptTemplates.Merge
+	case "generic":
+		return m.flowPromptTemplates.Generic
+	default:
+		return ""
+	}
+}
+
+func (m Model) withPromptTemplateValue(target promptTemplateTarget, value string) Model {
+	if target.Section == "agent" && target.Key == "plan_prompt" {
+		m.planPromptTemplate = value
+		return m
+	}
+	if target.Section != "flow_prompts" {
+		return m
+	}
+	switch target.Key {
+	case "plan":
+		m.flowPromptTemplates.Plan = value
+	case "plan_review":
+		m.flowPromptTemplates.PlanReview = value
+	case "implementation":
+		m.flowPromptTemplates.Implementation = value
+	case "review_loop":
+		m.flowPromptTemplates.ReviewLoop = value
+	case "pr_creation":
+		m.flowPromptTemplates.PRCreation = value
+	case "autoreview":
+		m.flowPromptTemplates.Autoreview = value
+	case "merge":
+		m.flowPromptTemplates.Merge = value
+	case "generic":
+		m.flowPromptTemplates.Generic = value
+	}
+	return m
+}
+
+func (m Model) builtInPromptTemplatePreview(target promptTemplateTarget) string {
+	if target.Section == "agent" && target.Key == "plan_prompt" {
+		return defaultImplementationPrompt(planstore.PlanRecord{
+			PlanID: "{plan_id}",
+			Title:  "{title}",
+		}, "{plan_path}")
+	}
+
+	record := flowstore.FlowRecord{
+		FlowID:       "{flow_id}",
+		Title:        "{flow_title}",
+		Instructions: "{instructions}",
+		RepoPath:     "{repo_path}",
+		WorktreePath: "{worktree_path}",
+		Branch:       "{branch}",
+		Commit:       "{commit}",
+		BaseRef:      "{base_ref}",
+		PlanID:       "{plan_id}",
+		PlanPath:     "{plan_path}",
+		PR: flowstore.PullRequest{
+			Provider:   "{pr_provider}",
+			Number:     123,
+			URL:        "{pr_url}",
+			HeadBranch: "{pr_head}",
+			BaseBranch: "{pr_base}",
+			Status:     "{pr_status}",
+		},
+	}
+	if target.Key == "plan" {
+		return flowPlanPrompt(record, FlowPromptTemplates{})
+	}
+	phase := flowstore.FlowPhase{PhaseID: flowPhaseIDForPromptTemplateKey(target.Key), Title: "{phase_title}"}
+	return flowPhasePrompt(record, phase, "{plan_path}", "{plan_body}", FlowPromptTemplates{})
+}
+
+func flowPhaseIDForPromptTemplateKey(key string) string {
+	switch key {
+	case "plan_review":
+		return "plan-review"
+	case "review_loop":
+		return "review-loop"
+	case "pr_creation":
+		return "pr-creation"
+	case "generic":
+		return "{phase_id}"
+	default:
+		return key
+	}
+}

--- a/model/prompt_templates.go
+++ b/model/prompt_templates.go
@@ -9,9 +9,8 @@ import (
 	"github.com/brian-bell/wtui/flowstore"
 	"github.com/brian-bell/wtui/model/modal"
 	"github.com/brian-bell/wtui/planstore"
+	"github.com/brian-bell/wtui/ui"
 )
-
-const promptTemplatePickerPrompt = "Prompt templates"
 
 type promptTemplateTarget struct {
 	Section string
@@ -37,7 +36,7 @@ func (m Model) handlePromptTemplates() (tea.Model, tea.Cmd) {
 
 func (m Model) openPromptTemplatePicker(selected int) Model {
 	m.modal = modal.OpenSelectWithLayout(
-		promptTemplatePickerPrompt,
+		ui.PromptTemplateSelectPrompt,
 		m.promptTemplateSelectItems(),
 		selected,
 		modal.Layout{Width: 42, Height: len(promptTemplateTargets) + 3, Placement: modal.PlacementCenter},
@@ -50,7 +49,7 @@ func (m Model) openPromptTemplatePicker(selected int) Model {
 
 func (m Model) handlePromptTemplateModalKey(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
 	view := m.modal.View()
-	if view.Kind != modal.Select || view.Prompt != promptTemplatePickerPrompt {
+	if view.Kind != modal.Select || view.Prompt != ui.PromptTemplateSelectPrompt {
 		return m, nil, false
 	}
 	switch msg.String() {
@@ -130,7 +129,6 @@ func (m Model) handlePromptTemplateSaved(msg PromptTemplateSavedMsg) Model {
 func (m Model) handlePromptTemplateSaveFailed(msg PromptTemplateSaveFailedMsg) Model {
 	target, ok := promptTemplateTargetBySectionKey(msg.Section, msg.Key)
 	if ok {
-		m = m.withPromptTemplateValue(target, msg.Value)
 		m = m.openPromptTemplatePicker(promptTemplateTargetIndex(target))
 	}
 	errText := msg.Err

--- a/model/prompt_templates.go
+++ b/model/prompt_templates.go
@@ -12,6 +12,8 @@ import (
 	"github.com/brian-bell/wtui/ui"
 )
 
+const promptTemplateEditorVisibleLines = 16
+
 type promptTemplateTarget struct {
 	Section string
 	Key     string
@@ -94,7 +96,7 @@ func (m Model) handlePromptTemplateEditRequested(msg promptTemplateEditRequested
 			}
 			return m.savePromptTemplateCommand(target, input)
 		},
-	)
+	).WithInputHeight(promptTemplateEditorVisibleLines)
 	return m
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1093,6 +1093,7 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	global := []shortcutHint{
 		{Key: paneShortcutKeyForStatus(sp), Label: "pane"},
 		{Key: "q/esc", Label: "quit"},
+		{Key: "f2", Label: "edit prompts"},
 		{Key: "f5", Label: "refresh"},
 	}
 	if !flowSurfaceActive {
@@ -1534,19 +1535,20 @@ func renderGenericFooterShortcuts(sp statusBarParams, sections []shortcutSection
 	for _, drop := range [][]string{
 		{},
 		{"f5"},
-		{"f5", "A"},
-		{"f5", "A", "D"},
-		{"f5", "A", "D", "←/→"},
-		{"f5", "A", "D", "←/→", "↑/↓"},
-		{"f5", "A", "D", "←/→", "↑/↓", "q/esc"},
-		{"f5", "A", "D", "←/→", "↑/↓", "q/esc", paneKey},
+		{"f5", "f2"},
+		{"f5", "f2", "A"},
+		{"f5", "f2", "A", "D"},
+		{"f5", "f2", "A", "D", "←/→"},
+		{"f5", "f2", "A", "D", "←/→", "↑/↓"},
+		{"f5", "f2", "A", "D", "←/→", "↑/↓", "q/esc"},
+		{"f5", "f2", "A", "D", "←/→", "↑/↓", "q/esc", paneKey},
 	} {
 		candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, drop...)))
 		if lipgloss.Width(candidate) <= sp.Width {
 			return candidate
 		}
 	}
-	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "A", "D", "←/→", "↑/↓", "q/esc", paneKey)))
+	candidate := "  " + renderFooterHintList(footerSectionOrder(withoutShortcutKeys(sections, "f5", "f2", "A", "D", "←/→", "↑/↓", "q/esc", paneKey)))
 	return ansi.Truncate(candidate, sp.Width, "")
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -239,6 +239,7 @@ type RenderParams struct {
 	InputValue                  string
 	InputError                  string
 	InputMode                   InputMode
+	InputHeight                 int
 	InputCursor                 int
 	WorktreeInputPrompt         string
 	WorktreeInputPlaceholder    string
@@ -3653,6 +3654,7 @@ type inputRenderParams struct {
 	value       string
 	errText     string
 	mode        InputMode
+	height      int
 	cursor      int
 }
 
@@ -3670,6 +3672,7 @@ func inputRenderParamsFrom(p RenderParams) inputRenderParams {
 			value:       p.InputValue,
 			errText:     p.InputError,
 			mode:        p.InputMode,
+			height:      p.InputHeight,
 			cursor:      p.InputCursor,
 		}
 	}
@@ -3683,6 +3686,7 @@ func inputRenderParamsFrom(p RenderParams) inputRenderParams {
 		value:       p.WorktreeInput,
 		errText:     p.WorktreeInputErr,
 		mode:        p.InputMode,
+		height:      p.InputHeight,
 		cursor:      cursor,
 	}
 }
@@ -3716,7 +3720,7 @@ func renderInputDialog(params inputRenderParams, width, height int) []string {
 
 	bodyLines := inputDialogBodyLines(params, contentWidth)
 	cursorLine := lineIndexContainingCursor(bodyLines)
-	maxInputLines := maxInputDialogLines(height, params.errText, contentWidth)
+	maxInputLines := maxInputDialogLines(height, params.errText, contentWidth, params.height)
 	bodyLines = compactInputDialogLines(bodyLines, maxInputLines, cursorLine)
 
 	content := make([]string, 0, len(bodyLines)+3)
@@ -3905,8 +3909,11 @@ func lineIndexContainingCursor(lines []string) int {
 	return -1
 }
 
-func maxInputDialogLines(height int, errText string, contentWidth int) int {
+func maxInputDialogLines(height int, errText string, contentWidth int, configuredLines int) int {
 	maxLines := launchInstructionsMaxLines
+	if configuredLines > 0 {
+		maxLines = configuredLines
+	}
 	available := height - 2
 	if errText != "" {
 		available -= 1 + len(wrapPlainText(errText, contentWidth))

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -142,7 +142,7 @@ const ShortcutPaneWidth = 28
 const (
 	shortcutKeyColumnWidth = 6
 	shortcutOverflowMarker = "..."
-	paneShortcutKey        = "f2/tab"
+	paneShortcutKey        = "tab"
 	paneBackShortcutKey    = "bksp"
 )
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -60,6 +60,7 @@ const FlowBaseRefPrompt = "New flow base ref"
 const LaunchInstructionsPrompt = "Launch instructions"
 const WorktreeMovePrompt = "Move worktree to"
 const PRWorktreePrompt = "PR worktree"
+const PromptTemplateSelectPrompt = "Prompt templates"
 const WorktreeInputPlaceholder = "branch, tag, or new branch name"
 const FlowTitleInputPlaceholder = "flow title"
 const FlowInstructionsInputPlaceholder = "task instructions"
@@ -762,6 +763,7 @@ type statusBarParams struct {
 	InputMode                   InputMode
 	FormHasMultiline            bool
 	WorktreeInputPrompt         string
+	SelectPrompt                string
 	ActivePane                  int
 	Destructive                 bool
 	RepoSelected                bool
@@ -893,6 +895,9 @@ func renderStatusBarWithState(sp statusBarParams) string {
 		}
 		return renderStatusText(width, "  enter: submit  esc: cancel  bksp/del: edit  left/right: move")
 	case overlay == OverlaySelect:
+		if sp.SelectPrompt == PromptTemplateSelectPrompt {
+			return renderStatusText(width, "  up/down select  enter: edit  r: reset  v: preview  esc: cancel")
+		}
 		return renderStatusText(width, "  up/down select  enter: confirm  esc: cancel")
 	case overlay == OverlayForm:
 		if sp.FormHasMultiline {
@@ -3094,6 +3099,7 @@ func renderSelectOverlayStatusBar(p RenderParams) string {
 		Width:                  p.Width,
 		Mode:                   p.Mode,
 		Overlay:                p.Overlay,
+		SelectPrompt:           p.SelectPrompt,
 		ActivePane:             p.ActivePane,
 		Destructive:            p.Destructive,
 		TransientError:         p.TransientError,
@@ -3360,6 +3366,7 @@ func renderOverlay(p RenderParams) string {
 		InputMode:              inputParams.mode,
 		FormHasMultiline:       formHasMultilineField(p.Form),
 		WorktreeInputPrompt:    inputParams.prompt,
+		SelectPrompt:           p.SelectPrompt,
 		ActivePane:             p.ActivePane,
 		Destructive:            p.Destructive,
 		TransientError:         p.TransientError,

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1099,10 +1099,8 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	if !flowSurfaceActive {
 		global = slices.Insert(global, 2, shortcutHint{Key: "A", Label: "set agent"})
 	}
-	if !flowSurfaceActive {
-		if label := defaultViewShortcutLabel(sp.DefaultViewLabel); label != "" {
-			global = slices.Insert(global, len(global)-1, shortcutHint{Key: "V", Label: label})
-		}
+	if label := defaultViewShortcutLabel(sp.DefaultViewLabel); label != "" {
+		global = slices.Insert(global, len(global)-1, shortcutHint{Key: "V", Label: label})
 	}
 
 	var actions []shortcutHint
@@ -1326,9 +1324,6 @@ func flowShortcutSections(sp statusBarParams, actions, navigation, global []shor
 	if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); agentConfigured && effortLabel != "" {
 		flowAgentControls = append(flowAgentControls, shortcutHint{Key: "E", Label: effortLabel})
 	}
-	if label := defaultViewShortcutLabel(sp.DefaultViewLabel); label != "" {
-		flowAgentControls = append(flowAgentControls, shortcutHint{Key: "V", Label: label})
-	}
 	var sections []shortcutSection
 	if len(actions) > 0 {
 		sections = append(sections, shortcutSection{Title: "Actions", Hints: actions})
@@ -1367,7 +1362,7 @@ func defaultViewShortcutLabel(value string) string {
 	if value == "" {
 		return ""
 	}
-	return "default " + value
+	return "default view"
 }
 
 func muteShortcutSections(sections []shortcutSection) []shortcutSection {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -3196,6 +3196,29 @@ func TestRender_SelectDialogShowsPromptItemsAndSelection(t *testing.T) {
 	}
 }
 
+func TestRender_PromptTemplateSelectShowsPromptSpecificFooter(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:          90,
+		Height:         16,
+		Mode:           ModeWorktrees,
+		Overlay:        OverlaySelect,
+		SelectPrompt:   "Prompt templates",
+		SelectItems:    []SelectItem{{Label: "Plan launch     default", Value: "agent.plan_prompt"}},
+		SelectSelected: 0,
+	})
+
+	stripped := ansi.Strip(view)
+	for _, want := range []string{"enter: edit", "r: reset", "v: preview", "esc: cancel"} {
+		if !strings.Contains(stripped, want) {
+			t.Fatalf("prompt template select footer should contain %q:\n%s", want, stripped)
+		}
+	}
+	if strings.Contains(stripped, "enter: confirm") {
+		t.Fatalf("prompt template select footer should not use generic confirm copy:\n%s", stripped)
+	}
+}
+
 func TestRender_SelectOverlayUsesBoundedPanelAndKeepsBaseVisible(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
@@ -3229,6 +3252,14 @@ func TestRender_SelectOverlayUsesBoundedPanelAndKeepsBaseVisible(t *testing.T) {
 	}
 	if !strings.Contains(stripped, "up/down select") || strings.Contains(stripped, "bksp") {
 		t.Fatalf("select overlay status bar should use select hints only:\n%s", stripped)
+	}
+	if !strings.Contains(stripped, "enter: confirm") {
+		t.Fatalf("generic select overlay should keep confirm footer copy:\n%s", stripped)
+	}
+	for _, notWant := range []string{"enter: edit", "r: reset", "v: preview"} {
+		if strings.Contains(stripped, notWant) {
+			t.Fatalf("generic select overlay should not show prompt-template hint %q:\n%s", notWant, stripped)
+		}
 	}
 }
 

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -3073,6 +3073,57 @@ func TestRender_InputDialogOverflowKeepsCursorVisible(t *testing.T) {
 	}
 }
 
+func TestRender_InputDialogConfiguredHeightShowsMoreText(t *testing.T) {
+	value := strings.Join([]string{
+		"line 01",
+		"line 02",
+		"line 03",
+		"line 04",
+		"line 05",
+		"line 06",
+		"line 07",
+		"line 08",
+		"line 09",
+		"line 10",
+		"line 11",
+		"line 12",
+	}, "\n")
+
+	defaultView := Render(RenderParams{
+		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:       72,
+		Height:      22,
+		Mode:        ModePlans,
+		Overlay:     OverlayInput,
+		InputPrompt: "Edit Plan launch",
+		InputValue:  value,
+		InputCursor: len([]rune(value)),
+		InputMode:   InputMultiLine,
+	})
+	tallView := Render(RenderParams{
+		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:       72,
+		Height:      22,
+		Mode:        ModePlans,
+		Overlay:     OverlayInput,
+		InputPrompt: "Edit Plan launch",
+		InputValue:  value,
+		InputCursor: len([]rune(value)),
+		InputMode:   InputMultiLine,
+		InputHeight: 16,
+	})
+
+	if strings.Contains(ansi.Strip(defaultView), "line 01") {
+		t.Fatalf("default input height unexpectedly shows the first line:\n%s", ansi.Strip(defaultView))
+	}
+	strippedTall := ansi.Strip(tallView)
+	for _, want := range []string{"line 01", "line 12█"} {
+		if !strings.Contains(strippedTall, want) {
+			t.Fatalf("configured input height should show %q:\n%s", want, strippedTall)
+		}
+	}
+}
+
 func TestRender_InputDialogTinyHeightKeepsCursorVisible(t *testing.T) {
 	value := strings.Join([]string{
 		"line one",

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1622,6 +1622,15 @@ func TestRender_ShortcutPaneShowsGlobalRefreshShortcut(t *testing.T) {
 	}
 }
 
+func TestRender_ShortcutPaneShowsPromptTemplatesInGlobalSection(t *testing.T) {
+	pane := shortcutPaneText(renderShortcutPane(statusBarParams{Mode: ModeWorktrees}, 26, 20))
+	global := strings.Index(pane, "Global")
+	promptTemplates := strings.Index(pane, "f2     edit prompts")
+	if global < 0 || promptTemplates < 0 || promptTemplates < global {
+		t.Fatalf("shortcut pane should expose prompt templates in Global section, got:\n%s", pane)
+	}
+}
+
 func TestSidebarShortcutHintsGroupsOnlyAdjacentPairs(t *testing.T) {
 	grouped := sidebarShortcutHints([]shortcutHint{
 		{Key: "f", Label: "fetch"},

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1172,7 +1172,7 @@ func TestRender_ShortcutPaneShowsDefaultViewSetting(t *testing.T) {
 		Repos:            []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
 		Selected:         0,
 		Width:            140,
-		Height:           18,
+		Height:           28,
 		Mode:             ModeWorktrees,
 		ActivePane:       1,
 		DefaultViewLabel: "8 flows",
@@ -1180,7 +1180,7 @@ func TestRender_ShortcutPaneShowsDefaultViewSetting(t *testing.T) {
 		WorktreeSelected: 0,
 	})
 	pane := shortcutPaneText(view)
-	if !strings.Contains(pane, "V      default 8 flows") {
+	if !strings.Contains(pane, "V      default view") {
 		t.Fatalf("shortcut pane should advertise default view setting:\n%s", pane)
 	}
 }
@@ -1190,7 +1190,7 @@ func TestRender_FlowShortcutPaneShowsDefaultViewSetting(t *testing.T) {
 		Repos:            []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
 		Selected:         0,
 		Width:            160,
-		Height:           18,
+		Height:           28,
 		Mode:             ModeFlows,
 		ActivePane:       1,
 		DefaultViewLabel: "2 branches",
@@ -1198,8 +1198,10 @@ func TestRender_FlowShortcutPaneShowsDefaultViewSetting(t *testing.T) {
 		FlowSelected:     0,
 	})
 	pane := shortcutPaneText(view)
-	if !strings.Contains(pane, "V      default 2 branches") {
-		t.Fatalf("flow shortcut pane should advertise default view setting:\n%s", pane)
+	global := strings.Index(pane, "Global")
+	defaultView := strings.Index(pane, "V      default view")
+	if global < 0 || defaultView < 0 || defaultView < global {
+		t.Fatalf("flow shortcut pane should advertise default view setting in Global section:\n%s", pane)
 	}
 }
 

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -177,7 +177,7 @@ func TestStatusBar_ActionHintsHiddenWhenLeftPaneActive(t *testing.T) {
 		}
 	}
 	// Pane switching and q/esc should still appear.
-	for _, hint := range []string{"f2/tab: pane", "q/esc: quit"} {
+	for _, hint := range []string{"tab: pane", "q/esc: quit"} {
 		if !strings.Contains(bar, hint) {
 			t.Errorf("hint %q should appear even when left pane is active", hint)
 		}
@@ -1409,7 +1409,7 @@ func TestRender_WideLayoutReplacesFooterHints(t *testing.T) {
 
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	if strings.Contains(footer, "f2/tab: pane") || strings.Contains(footer, "q/esc: quit") {
+	if strings.Contains(footer, "tab: pane") || strings.Contains(footer, "q/esc: quit") {
 		t.Fatalf("wide render footer should not carry shortcut hints, got %q", footer)
 	}
 	if !strings.Contains(shortcutPaneText(view), "bksp   pane") {
@@ -1428,8 +1428,8 @@ func TestRender_NarrowLayoutKeepsFooterHints(t *testing.T) {
 
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	if !strings.Contains(footer, "f2/tab: pane") {
-		t.Fatalf("narrow render should expose f2 pane hint, got %q", footer)
+	if !strings.Contains(footer, "tab: pane") {
+		t.Fatalf("narrow render should expose tab pane hint, got %q", footer)
 	}
 	if strings.Contains(view, "Shortcuts") {
 		t.Fatal("narrow render should not reserve a shortcut pane")
@@ -1482,7 +1482,7 @@ func TestRender_ShortWideLayoutKeepsClippedShortcutPane(t *testing.T) {
 	}
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	for _, forbidden := range []string{"f2/tab: pane", "n: new worktree", "F: pull", "c: code"} {
+	for _, forbidden := range []string{"tab: pane", "n: new worktree", "F: pull", "c: code"} {
 		if strings.Contains(footer, forbidden) {
 			t.Fatalf("short wide footer should not carry shortcut hint %q, got %q", forbidden, footer)
 		}
@@ -1825,8 +1825,8 @@ func TestRender_ShortcutPaneShowsArrowViewHintOnlyForRightPane(t *testing.T) {
 		Mode:       ModeFlows,
 		ActivePane: 0,
 	}, 26, 18))
-	if !strings.Contains(leftPane, "f2") || !strings.Contains(leftPane, "pane") {
-		t.Fatalf("left-pane shortcut pane should include f2 pane hint, got:\n%s", leftPane)
+	if !strings.Contains(leftPane, "tab") || !strings.Contains(leftPane, "pane") {
+		t.Fatalf("left-pane shortcut pane should include tab pane hint, got:\n%s", leftPane)
 	}
 	if strings.Contains(leftPane, "←/→") || strings.Contains(leftPane, "pane/view") {
 		t.Fatalf("left-pane shortcut pane should not include arrow view hint, got:\n%s", leftPane)
@@ -1878,7 +1878,7 @@ func TestRender_BranchShortcutPaneKeepsLegend(t *testing.T) {
 	}
 	lines := strings.Split(view, "\n")
 	footer := lines[len(lines)-1]
-	if strings.Contains(footer, "f2/tab: pane") || strings.Contains(footer, "no upstream") {
+	if strings.Contains(footer, "tab: pane") || strings.Contains(footer, "no upstream") {
 		t.Fatalf("branch wide footer should not duplicate shortcut or legend hints, got %q", footer)
 	}
 }
@@ -4010,7 +4010,7 @@ func TestStatusBar_RightPaneShowsBackspacePaneHint(t *testing.T) {
 		}
 	}
 	if strings.Contains(bar, "f2: pane") {
-		t.Fatalf("right-pane status bar should not duplicate f2 pane hint, got %q", bar)
+		t.Fatalf("right-pane status bar should not duplicate tab pane hint, got %q", bar)
 	}
 	if strings.Contains(bar, "⌫") {
 		t.Fatalf("right-pane status bar should use bksp label, got %q", bar)


### PR DESCRIPTION
## Summary
- Add an F2 prompt-template editor for `[agent].plan_prompt` and `[flow_prompts]` templates, including edit, reset, and built-in preview flows.
- Persist prompt-template changes to the wtui config and use live template state for plan launches, selected plan phases, and Flow plan/phase launches.
- Harden config updates for reset-to-default Flow prompt behavior and existing multiline TOML prompt values.
- Document prompt-template settings and available placeholders.

## Implementation Notes
- The TUI picker distinguishes custom/default templates and exposes prompt-specific footer hints.
- Failed template saves now leave live launch prompts unchanged.
- Selected saved-plan phases support `{phase_id}`, `{phase_title}`, and `{phase_status}` in `[agent].plan_prompt`.
- Flow plan launches explicitly pass request-time templates so resetting the last override does not resurrect startup config.
- Config save/reset removes complete multiline TOML string assignments before replacing/removing prompt keys.

## Verification
- `gofmt -l .`
- `make test`
- `make build`
- `git diff --check HEAD`
- `autoreview --mode branch --base origin/main --parallel-tests "make test"` clean: no accepted/actionable findings reported
