### PR TITLE
Add Flow PR browser shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ filter matches, or a load failure with details in the status bar.
 | `V` | Choose and persist the startup default view (`1` through `9`) |
 | `a` | Launch the selected coding agent in the selected worktree, or launch the selected plan or plan phase |
 | `d` | Delete worktree/branch, drop stash, or delete Flow data — requires destructive mode |
-| `p` | Prune stale worktree — requires destructive mode (worktrees view) |
+| `p` | Prune stale worktree — requires destructive mode (worktrees view), or open the linked PR (flows and active flows views, when PR metadata exists) |
 | `u` | Unlock a locked worktree (worktrees view) |
 | `f` | Fetch with `--prune` (worktrees and branches views) |
 | `F` | Pull with `--ff-only` (worktrees, and branches with a checked-out worktree) |
@@ -349,6 +349,7 @@ worktrees, branches, checked-out code, linked plans, sessions, transcripts, or
 active embedded terminals. Expanded phase rows cannot be deleted with this
 action. On a Flow row or an expanded phase row, `enter` expands or collapses
 the phase list. Press
+`p` on a Flow row with linked PR metadata to open the PR in the browser. Press
 `g` to launch the first launchable phase in the selected Flow's
 canonical phase order. This action
 uses the selected Flow, so a highlighted pending phase row can still launch an
@@ -377,7 +378,8 @@ Browse active Flow records across all repos. This view hides merged Flow records
 moving focus to the left repo pane temporarily filters the visible active rows to
 the selected repo, and returning focus to the middle pane restores the global
 list. Normal Flow actions, phase launches, attached-session resumes, auto-mode
-toggles, and embedded Flow terminals work from the visible active Flow rows.
+toggles, linked-PR opening with `p`, and embedded Flow terminals work from the
+visible active Flow rows.
 
 Flow headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in a runtime-only embedded

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -520,6 +520,21 @@ func CopyToClipboard(text string) error {
 	return cmd.Run()
 }
 
+// OpenURL opens an absolute http(s) URL in the system browser.
+func OpenURL(rawURL string) error {
+	rawURL = strings.TrimSpace(rawURL)
+	if err := validateBrowserURL(rawURL); err != nil {
+		return err
+	}
+	spec, err := selectBrowserCommand(runtime.GOOS, exec.LookPath)
+	if err != nil {
+		return err
+	}
+	args := append([]string(nil), spec.args...)
+	args = append(args, rawURL)
+	return exec.Command(spec.name, args...).Run()
+}
+
 // PageText builds an interactive pager command for read-only text views.
 func PageText(body string) (TerminalLaunchSpec, error) {
 	return pageText(body, exec.LookPath)
@@ -1747,6 +1762,38 @@ func selectClipboardCommand(goos string, lookPath lookPathFunc) (commandSpec, er
 	}
 
 	return commandSpec{}, fmt.Errorf("clipboard copy is not supported on %s", goos)
+}
+
+func validateBrowserURL(rawURL string) error {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return fmt.Errorf("browser URL cannot be empty")
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parse browser URL: %w", err)
+	}
+	if !parsed.IsAbs() || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return fmt.Errorf("browser URL must be an absolute http(s) URL")
+	}
+	return nil
+}
+
+func selectBrowserCommand(goos string, lookPath lookPathFunc) (commandSpec, error) {
+	switch goos {
+	case "darwin":
+		if !commandExists("open", lookPath) {
+			return commandSpec{}, errors.New("browser command open not found")
+		}
+		return commandSpec{name: "open"}, nil
+	case "linux":
+		if !commandExists("xdg-open", lookPath) {
+			return commandSpec{}, errors.New("browser command xdg-open not found")
+		}
+		return commandSpec{name: "xdg-open"}, nil
+	default:
+		return commandSpec{}, fmt.Errorf("browser opening is not supported on %s", goos)
+	}
 }
 
 // WorktreeSessionName returns a tmux/Zellij-safe session name derived from

--- a/actions/actions_select_test.go
+++ b/actions/actions_select_test.go
@@ -105,6 +105,59 @@ func TestSelectClipboardCommand_LinuxReportsMissingTools(t *testing.T) {
 	}
 }
 
+func TestSelectBrowserCommand_DarwinUsesOpen(t *testing.T) {
+	spec, err := selectBrowserCommand("darwin", fakeLookPath("open"))
+	if err != nil {
+		t.Fatalf("selectBrowserCommand returned error: %v", err)
+	}
+	assertSpec(t, spec, "open", nil)
+}
+
+func TestSelectBrowserCommand_LinuxUsesXDGOpen(t *testing.T) {
+	spec, err := selectBrowserCommand("linux", fakeLookPath("xdg-open"))
+	if err != nil {
+		t.Fatalf("selectBrowserCommand returned error: %v", err)
+	}
+	assertSpec(t, spec, "xdg-open", nil)
+}
+
+func TestSelectBrowserCommandReportsUnsupportedOrMissingTools(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		want string
+	}{
+		{name: "linux missing xdg-open", goos: "linux", want: "xdg-open"},
+		{name: "windows unsupported", goos: "windows", want: "not supported"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := selectBrowserCommand(tt.goos, fakeLookPath())
+			if err == nil {
+				t.Fatal("expected browser command error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error to mention %q, got %q", tt.want, err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateBrowserURLRequiresAbsoluteHTTPURL(t *testing.T) {
+	tests := []string{"", "   ", "github.com/brian-bell/wtui/pull/123", "ftp://github.com/brian-bell/wtui/pull/123"}
+	for _, input := range tests {
+		t.Run(strconv.Quote(input), func(t *testing.T) {
+			if err := validateBrowserURL(input); err == nil {
+				t.Fatal("expected invalid browser URL error")
+			}
+		})
+	}
+
+	if err := validateBrowserURL("https://github.com/brian-bell/wtui/pull/123"); err != nil {
+		t.Fatalf("validateBrowserURL returned error: %v", err)
+	}
+}
+
 func TestTerminalLaunch_UsesMultiplexerBeforeTerminal(t *testing.T) {
 	env := fakeGetenv(map[string]string{
 		"TMUX":     "/tmp/tmux.sock",

--- a/model/model.go
+++ b/model/model.go
@@ -675,7 +675,7 @@ func (m Model) View() string {
 	if flowSelected >= 0 && flowSelected < len(flows) {
 		flowAutoModeSelected = flows[flowSelected].AutoMode
 	}
-	_, flowPRTargetSelected := m.selectedFlowPRURL()
+	_, flowPRTargetSelected := m.selectedFlowPR()
 	repoEmptyMessage := m.repoEmptyMessage(len(repos))
 	rightEmptyMessage := m.rightEmptyMessage(len(repos), len(worktrees), len(rows), len(stashes), len(commits), len(reflogs), len(sessions), len(plans), len(flows))
 	if len(repos) == 0 {
@@ -1197,6 +1197,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case OpenURLResultMsg:
 		if msg.Err != "" {
 			m = m.setStatus(statusOther, msg.Err)
+		} else if msg.Label != "" {
+			m = m.setStatus(statusOther, msg.Label)
 		}
 		return m, nil
 	case TerminalResultMsg:
@@ -1394,18 +1396,18 @@ func (m Model) selectedFlowID() string {
 	return record.FlowID
 }
 
-func (m Model) selectedFlowPRURL() (string, bool) {
+func (m Model) selectedFlowPR() (flowstore.PullRequest, bool) {
 	if !m.flowSurfaceVisible() {
-		return "", false
+		return flowstore.PullRequest{}, false
 	}
 	if _, ok := m.selectedFlowPhase(); ok {
-		return "", false
+		return flowstore.PullRequest{}, false
 	}
 	record, ok := m.selectedFlow()
 	if !ok || !flowstore.HasPRTarget(record.PR) {
-		return "", false
+		return flowstore.PullRequest{}, false
 	}
-	return record.PR.URL, true
+	return record.PR, true
 }
 
 func (m Model) selectedPlanID() string {

--- a/model/model.go
+++ b/model/model.go
@@ -104,6 +104,7 @@ type Model struct {
 	readPlan                   func(string) (string, error)
 	planMarkdownPath           func(string) (string, error)
 	copyToClipboard            func(string) error
+	openURL                    func(string) error
 	pageText                   func(string) (actions.TerminalLaunchSpec, error)
 	editFile                   func(string) (actions.TerminalLaunchSpec, error)
 	saveAgent                  func(string) error
@@ -189,6 +190,7 @@ type Options struct {
 	ReadPlan                 func(string) (string, error)
 	PlanMarkdownPath         func(planID string) (string, error)
 	CopyToClipboard          func(text string) error
+	OpenURL                  func(url string) error
 	PageText                 func(body string) (actions.TerminalLaunchSpec, error)
 	EditFile                 func(path string) (actions.TerminalLaunchSpec, error)
 	SaveAgentCommand         func(string) error
@@ -327,6 +329,10 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if copyToClipboard == nil {
 		copyToClipboard = actions.CopyToClipboard
 	}
+	openURL := opts.OpenURL
+	if openURL == nil {
+		openURL = actions.OpenURL
+	}
 	pageText := opts.PageText
 	if pageText == nil {
 		pageText = actions.PageText
@@ -442,6 +448,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		readPlan:                 readPlan,
 		planMarkdownPath:         planMarkdownPath,
 		copyToClipboard:          copyToClipboard,
+		openURL:                  openURL,
 		pageText:                 pageText,
 		editFile:                 editFile,
 		saveAgent:                saveAgent,
@@ -668,6 +675,7 @@ func (m Model) View() string {
 	if flowSelected >= 0 && flowSelected < len(flows) {
 		flowAutoModeSelected = flows[flowSelected].AutoMode
 	}
+	_, flowPRTargetSelected := m.selectedFlowPRURL()
 	repoEmptyMessage := m.repoEmptyMessage(len(repos))
 	rightEmptyMessage := m.rightEmptyMessage(len(repos), len(worktrees), len(rows), len(stashes), len(commits), len(reflogs), len(sessions), len(plans), len(flows))
 	if len(repos) == 0 {
@@ -757,6 +765,7 @@ func (m Model) View() string {
 		SelectedFlowPhaseID:         m.currentSelectedFlowPhaseID(),
 		FlowHeadless:                m.flowHeadless,
 		FlowAutoModeSelected:        flowAutoModeSelected,
+		FlowPRTargetSelected:        flowPRTargetSelected,
 		FlowAgentLabel:              m.flowAgentShortcutLabel(),
 		FlowReasoningEffort:         m.flowReasoningEffortLabel(),
 		DefaultViewLabel:            ViewChoiceLabel(m.defaultView),
@@ -1185,6 +1194,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m = m.setStatus(statusOther, msg.Err)
 		}
 		return m, nil
+	case OpenURLResultMsg:
+		if msg.Err != "" {
+			m = m.setStatus(statusOther, msg.Err)
+		}
+		return m, nil
 	case TerminalResultMsg:
 		if msg.Err != "" {
 			m = m.setStatus(statusOther, msg.Err)
@@ -1378,6 +1392,20 @@ func (m Model) selectedFlowID() string {
 		return ""
 	}
 	return record.FlowID
+}
+
+func (m Model) selectedFlowPRURL() (string, bool) {
+	if !m.flowSurfaceVisible() {
+		return "", false
+	}
+	if _, ok := m.selectedFlowPhase(); ok {
+		return "", false
+	}
+	record, ok := m.selectedFlow()
+	if !ok || !flowstore.HasPRTarget(record.PR) {
+		return "", false
+	}
+	return record.PR.URL, true
 }
 
 func (m Model) selectedPlanID() string {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -3809,11 +3809,19 @@ func TestModel_PKeyOpensSelectedFlowPullRequest(t *testing.T) {
 	if m.Mode() != ui.ModeFlows || m.FlowSelected() != 0 || m.SelectedFlowPhaseID() != "" || m.Overlay() != ui.OverlayNone {
 		t.Fatalf("p changed Flow selection state: mode=%v selected=%d phase=%q overlay=%v", m.Mode(), m.FlowSelected(), m.SelectedFlowPhaseID(), m.Overlay())
 	}
-	if msg := cmd(); msg != (model.OpenURLResultMsg{}) {
-		t.Fatalf("open PR command returned %#v, want empty OpenURLResultMsg", msg)
+	msg, ok := cmd().(model.OpenURLResultMsg)
+	if !ok {
+		t.Fatalf("open PR command returned %T, want OpenURLResultMsg", msg)
+	}
+	if msg.Err != "" || msg.Label != "Opened PR #123 in browser" {
+		t.Fatalf("open PR command returned %#v, want success label", msg)
 	}
 	if got := opened; !slices.Equal(got, []string{prURL}) {
 		t.Fatalf("opened URLs = %#v, want %q", got, prURL)
+	}
+	m, _ = update(m, msg)
+	if got := m.TransientError(); got != "Opened PR #123 in browser" {
+		t.Fatalf("status = %q, want PR open success", got)
 	}
 }
 
@@ -3832,11 +3840,61 @@ func TestModel_PKeyOpensSelectedActiveFlowPullRequest(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("p on selected Active Flow with PR target should return open command")
 	}
-	if msg := cmd(); msg != (model.OpenURLResultMsg{}) {
-		t.Fatalf("open active Flow PR command returned %#v, want empty OpenURLResultMsg", msg)
+	msg, ok := cmd().(model.OpenURLResultMsg)
+	if !ok {
+		t.Fatalf("open active Flow PR command returned %T, want OpenURLResultMsg", msg)
+	}
+	if msg.Err != "" || msg.Label != "Opened PR #123 in browser" {
+		t.Fatalf("open active Flow PR command returned %#v, want success label", msg)
 	}
 	if got := opened; !slices.Equal(got, []string{prURL}) {
 		t.Fatalf("opened URLs = %#v, want %q", got, prURL)
+	}
+}
+
+func TestModel_PKeyOpenFlowPullRequestFailureSetsStatus(t *testing.T) {
+	const prURL = "https://github.com/brian-bell/wtui/pull/123"
+	m := model.NewWithOptions(testRepos(), model.Options{
+		OpenURL: func(string) error {
+			return errors.New("browser unavailable")
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPullRequestTarget("flow-1", prURL)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if cmd == nil {
+		t.Fatal("p on selected Flow with PR target should return open command")
+	}
+	msg, ok := cmd().(model.OpenURLResultMsg)
+	if !ok {
+		t.Fatalf("open PR command returned %T, want OpenURLResultMsg", msg)
+	}
+	if msg.Err != "browser unavailable" {
+		t.Fatalf("open PR command error = %q, want browser unavailable", msg.Err)
+	}
+	m, _ = update(m, msg)
+	if got := m.TransientError(); got != "browser unavailable" {
+		t.Fatalf("status = %q, want browser failure", got)
+	}
+}
+
+func TestModel_UppercasePDoesNotOpenSelectedFlowPullRequest(t *testing.T) {
+	const prURL = "https://github.com/brian-bell/wtui/pull/123"
+	var opened []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		OpenURL: func(url string) error {
+			opened = append(opened, url)
+			return nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPullRequestTarget("flow-1", prURL)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'P'}})
+	if cmd != nil {
+		t.Fatalf("uppercase P on selected Flow with PR target returned command %T, want nil", cmd)
+	}
+	if len(opened) != 0 {
+		t.Fatalf("opened URLs = %#v, want none", opened)
 	}
 }
 
@@ -3845,6 +3903,7 @@ func TestModel_PKeyFlowPullRequestGuards(t *testing.T) {
 	valid := flowWithPullRequestTarget("flow-1", prURL)
 	incomplete := valid
 	incomplete.PR.BaseBranch = ""
+	var terminalInputTerm *fakeEmbeddedTerminal
 
 	tests := []struct {
 		name  string
@@ -3926,6 +3985,41 @@ func TestModel_PKeyFlowPullRequestGuards(t *testing.T) {
 				m, _ = update(m, cmd())
 				m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 				return m
+			},
+		},
+		{
+			name: "Flow terminal input forwards p",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				fakeTerm := &fakeEmbeddedTerminal{state: "running"}
+				terminalInputTerm = fakeTerm
+				m := model.NewWithOptions(testRepos(), model.Options{
+					AgentCommand: "codex",
+					OpenURL:      openURL,
+					AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+						return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+					},
+					StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+						return fakeTerm, nil
+					},
+				})
+				m = flowsInRightPane(t, m, []flowstore.FlowRecord{valid})
+				m = selectFlowPhaseByID(t, m, "implementation")
+				m, cmd := update(m, flowLaunchKey())
+				if cmd == nil {
+					t.Fatal("g should prepare an embedded Flow launch")
+				}
+				m, _ = update(m, cmd())
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+				return m
+			},
+			check: func(t *testing.T, m model.Model) {
+				if terminalInputTerm == nil {
+					t.Fatal("terminal input test did not capture fake terminal")
+				}
+				if !slices.Equal(terminalInputTerm.writes, []string{"p"}) {
+					t.Fatalf("terminal input writes = %#v, want p", terminalInputTerm.writes)
+				}
 			},
 		},
 		{

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -3791,6 +3791,223 @@ func TestModel_YKeyDoesNothingWhenSelectedFlowWorktreePathIsBlank(t *testing.T) 
 	}
 }
 
+func TestModel_PKeyOpensSelectedFlowPullRequest(t *testing.T) {
+	const prURL = "https://github.com/brian-bell/wtui/pull/123"
+	var opened []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		OpenURL: func(url string) error {
+			opened = append(opened, url)
+			return nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPullRequestTarget("flow-1", prURL)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if cmd == nil {
+		t.Fatal("p on selected Flow with PR target should return open command")
+	}
+	if m.Mode() != ui.ModeFlows || m.FlowSelected() != 0 || m.SelectedFlowPhaseID() != "" || m.Overlay() != ui.OverlayNone {
+		t.Fatalf("p changed Flow selection state: mode=%v selected=%d phase=%q overlay=%v", m.Mode(), m.FlowSelected(), m.SelectedFlowPhaseID(), m.Overlay())
+	}
+	if msg := cmd(); msg != (model.OpenURLResultMsg{}) {
+		t.Fatalf("open PR command returned %#v, want empty OpenURLResultMsg", msg)
+	}
+	if got := opened; !slices.Equal(got, []string{prURL}) {
+		t.Fatalf("opened URLs = %#v, want %q", got, prURL)
+	}
+}
+
+func TestModel_PKeyOpensSelectedActiveFlowPullRequest(t *testing.T) {
+	const prURL = "https://github.com/brian-bell/wtui/pull/123"
+	var opened []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		OpenURL: func(url string) error {
+			opened = append(opened, url)
+			return nil
+		},
+	})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flowWithPullRequestTarget("flow-1", prURL)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	if cmd == nil {
+		t.Fatal("p on selected Active Flow with PR target should return open command")
+	}
+	if msg := cmd(); msg != (model.OpenURLResultMsg{}) {
+		t.Fatalf("open active Flow PR command returned %#v, want empty OpenURLResultMsg", msg)
+	}
+	if got := opened; !slices.Equal(got, []string{prURL}) {
+		t.Fatalf("opened URLs = %#v, want %q", got, prURL)
+	}
+}
+
+func TestModel_PKeyFlowPullRequestGuards(t *testing.T) {
+	const prURL = "https://github.com/brian-bell/wtui/pull/123"
+	valid := flowWithPullRequestTarget("flow-1", prURL)
+	incomplete := valid
+	incomplete.PR.BaseBranch = ""
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, openURL func(string) error) model.Model
+		check func(t *testing.T, m model.Model)
+	}{
+		{
+			name: "no selected Flow",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				return flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{OpenURL: openURL}), nil)
+			},
+		},
+		{
+			name: "incomplete PR metadata",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				return flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{OpenURL: openURL}), []flowstore.FlowRecord{incomplete})
+			},
+		},
+		{
+			name: "selected phase row",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				m := flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{OpenURL: openURL}), []flowstore.FlowRecord{valid})
+				return selectFlowPhaseByID(t, m, "implementation")
+			},
+			check: func(t *testing.T, m model.Model) {
+				if got := m.SelectedFlowPhaseID(); got != "implementation" {
+					t.Fatalf("selected phase = %q, want implementation", got)
+				}
+			},
+		},
+		{
+			name: "active search",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				m := flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{OpenURL: openURL}), []flowstore.FlowRecord{valid})
+				return model.SetSearchActiveForTest(m, true)
+			},
+			check: func(t *testing.T, m model.Model) {
+				if !m.SearchActive() {
+					t.Fatal("search should remain active")
+				}
+			},
+		},
+		{
+			name: "open modal",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				m := flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{OpenURL: openURL}), []flowstore.FlowRecord{valid})
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+				if m.Overlay() == ui.OverlayNone {
+					t.Fatal("expected new Flow modal to open")
+				}
+				return m
+			},
+			check: func(t *testing.T, m model.Model) {
+				if m.Overlay() == ui.OverlayNone {
+					t.Fatal("modal should remain open")
+				}
+			},
+		},
+		{
+			name: "Flow terminal focus forwards p",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				fakeTerm := &fakeEmbeddedTerminal{state: "running"}
+				m := model.NewWithOptions(testRepos(), model.Options{
+					AgentCommand: "codex",
+					OpenURL:      openURL,
+					AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+						return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+					},
+					StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+						return fakeTerm, nil
+					},
+				})
+				m = flowsInRightPane(t, m, []flowstore.FlowRecord{valid})
+				m = selectFlowPhaseByID(t, m, "implementation")
+				m, cmd := update(m, flowLaunchKey())
+				if cmd == nil {
+					t.Fatal("g should prepare an embedded Flow launch")
+				}
+				m, _ = update(m, cmd())
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+				return m
+			},
+		},
+		{
+			name: "Flow terminal command prefix",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				fakeTerm := &fakeEmbeddedTerminal{state: "running"}
+				m := model.NewWithOptions(testRepos(), model.Options{
+					AgentCommand: "codex",
+					OpenURL:      openURL,
+					AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+						return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+					},
+					StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+						return fakeTerm, nil
+					},
+				})
+				m = flowsInRightPane(t, m, []flowstore.FlowRecord{valid})
+				m = selectFlowPhaseByID(t, m, "implementation")
+				m, cmd := update(m, flowLaunchKey())
+				if cmd == nil {
+					t.Fatal("g should prepare an embedded Flow launch")
+				}
+				m, _ = update(m, cmd())
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlCloseBracket})
+				return m
+			},
+		},
+		{
+			name: "active Flow incomplete PR",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				return enterActiveFlowsWithRecords(t, model.NewWithOptions(testRepos(), model.Options{OpenURL: openURL}), []flowstore.FlowRecord{incomplete})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opened []string
+			m := tt.setup(t, func(url string) error {
+				opened = append(opened, url)
+				return nil
+			})
+			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+			if cmd != nil {
+				t.Fatalf("p returned command %T, want nil", cmd)
+			}
+			if len(opened) != 0 {
+				t.Fatalf("opened URLs = %#v, want none", opened)
+			}
+			if m.Overlay() == ui.OverlayConfirm {
+				t.Fatal("p in Flow surfaces should not open destructive confirmation")
+			}
+			if tt.check != nil {
+				tt.check(t, m)
+			}
+		})
+	}
+}
+
+func flowWithPullRequestTarget(flowID, prURL string) flowstore.FlowRecord {
+	return flowstore.FlowRecord{
+		FlowID:       flowID,
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/" + flowID,
+		Title:        "Flow with PR",
+		Status:       flowstore.StatusInProgress,
+		Branch:       "flow/add-pr-shortcut",
+		PR: flowstore.PullRequest{
+			Provider:   "github",
+			Number:     123,
+			URL:        prURL,
+			HeadBranch: "flow/add-pr-shortcut",
+			BaseBranch: "main",
+			Status:     "open",
+		},
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady},
+		},
+	}
+}
+
 func TestModel_ExpandedFlowArrowKeysSelectPhaseRows(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -464,6 +464,11 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModeWorktrees {
 			return m.handleNewPullRequestWorktree()
 		}
+	case "p":
+		if m.flowSurfaceVisible() {
+			return m.handleOpenSelectedFlowPR()
+		}
+		return m.handlePrune()
 	case "o":
 		if m.mode == ui.ModeSessions {
 			return m.handleEnter()
@@ -499,8 +504,6 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleOpenAgent()
 	case "d":
 		return m.handleDelete()
-	case "p":
-		return m.handlePrune()
 	case "u":
 		return m.handleUnlock()
 	case "f":
@@ -565,6 +568,8 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleOpenFlowPlanText()
 	case "m":
 		return m.handleToggleFlowAutoMode()
+	case "p":
+		return m.handleOpenSelectedFlowPR()
 	case "y":
 		return m.handleCopyFlowWorktreePath()
 	case "r":

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -328,7 +328,8 @@ type ClipboardResultMsg struct {
 }
 
 type OpenURLResultMsg struct {
-	Err string
+	Label string
+	Err   string
 }
 
 type TerminalResultMsg struct {
@@ -1763,15 +1764,15 @@ func (m Model) handleCopyFlowWorktreePath() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleOpenSelectedFlowPR() (tea.Model, tea.Cmd) {
-	prURL, ok := m.selectedFlowPRURL()
+	pr, ok := m.selectedFlowPR()
 	if !ok {
 		return m, nil
 	}
 	return m, func() tea.Msg {
-		if err := m.openURL(prURL); err != nil {
+		if err := m.openURL(pr.URL); err != nil {
 			return OpenURLResultMsg{Err: err.Error()}
 		}
-		return OpenURLResultMsg{}
+		return OpenURLResultMsg{Label: fmt.Sprintf("Opened PR #%d in browser", pr.Number)}
 	}
 }
 

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -327,6 +327,10 @@ type ClipboardResultMsg struct {
 	Err string
 }
 
+type OpenURLResultMsg struct {
+	Err string
+}
+
 type TerminalResultMsg struct {
 	Err string
 }
@@ -1755,6 +1759,19 @@ func (m Model) handleCopyFlowWorktreePath() (tea.Model, tea.Cmd) {
 			return ClipboardResultMsg{Err: err.Error()}
 		}
 		return ClipboardResultMsg{}
+	}
+}
+
+func (m Model) handleOpenSelectedFlowPR() (tea.Model, tea.Cmd) {
+	prURL, ok := m.selectedFlowPRURL()
+	if !ok {
+		return m, nil
+	}
+	return m, func() tea.Msg {
+		if err := m.openURL(prURL); err != nil {
+			return OpenURLResultMsg{Err: err.Error()}
+		}
+		return OpenURLResultMsg{}
 	}
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -293,6 +293,7 @@ type RenderParams struct {
 	SelectedFlowPhaseID         string
 	FlowHeadless                bool
 	FlowAutoModeSelected        bool
+	FlowPRTargetSelected        bool
 	FlowAgentLabel              string
 	FlowReasoningEffort         string
 	DefaultViewLabel            string
@@ -462,10 +463,12 @@ func renderApplication(p RenderParams) string {
 	flowPlanLinked := false
 	flowWorktreePathSelected := false
 	flowAutoModeSelected := false
+	flowPRTargetSelected := false
 	if flowSelected {
 		flowPlanLinked = strings.TrimSpace(p.Flows[p.FlowSelected].PlanID) != ""
 		flowWorktreePathSelected = strings.TrimSpace(p.Flows[p.FlowSelected].WorktreePath) != ""
 		flowAutoModeSelected = p.FlowAutoModeSelected
+		flowPRTargetSelected = p.FlowPRTargetSelected
 	}
 	worktreeSessionSelected := p.Mode == ModeWorktrees && p.InlineWorktreeSessions && p.WorktreeSessionSelected >= 0 && p.WorktreeSessionSelected < len(p.WorktreeSessions)
 	selectedPlanPhaseID := scopedSelectedPlanPhaseID(p, planSelected)
@@ -477,9 +480,13 @@ func renderApplication(p RenderParams) string {
 		flowDeletableSelected = false
 		flowWorktreePathSelected = false
 		flowAutoModeSelected = false
+		flowPRTargetSelected = false
 	}
 	planPhaseSelected := selectedPlanPhaseID != ""
 	flowPhaseSelected := selectedFlowPhaseID != ""
+	if flowPhaseSelected {
+		flowPRTargetSelected = false
+	}
 	status := statusBarParams{
 		Width:                       p.Width,
 		Mode:                        p.Mode,
@@ -516,6 +523,7 @@ func renderApplication(p RenderParams) string {
 		FlowDeletableSelected:       flowDeletableSelected,
 		FlowWorktreePathSelected:    flowWorktreePathSelected,
 		FlowPlanLinked:              flowPlanLinked,
+		FlowPRTargetSelected:        flowPRTargetSelected,
 		FlowHeadless:                p.FlowHeadless,
 		FlowAutoModeSelected:        flowAutoModeSelected,
 		FlowAgentLabel:              p.FlowAgentLabel,
@@ -793,6 +801,7 @@ type statusBarParams struct {
 	FlowDeletableSelected       bool
 	FlowWorktreePathSelected    bool
 	FlowPlanLinked              bool
+	FlowPRTargetSelected        bool
 	FlowHeadless                bool
 	FlowAutoModeSelected        bool
 	FlowAgentLabel              string
@@ -1303,6 +1312,9 @@ func flowShortcutSections(sp statusBarParams, actions, navigation, global []shor
 			}
 			if !sp.FlowPhaseSelected && sp.FlowPlanLinked {
 				actions = append(actions, shortcutHint{Key: "o", Label: "open"})
+			}
+			if sp.FlowPRTargetSelected {
+				actions = append(actions, shortcutHint{Key: "p", Label: "open PR"})
 			}
 			if sp.FlowWorktreePathSelected {
 				actions = append(actions, shortcutHint{Key: "y", Label: "copy path"})

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -843,6 +843,93 @@ func TestRender_ActiveFlowsShortcutSectionsHideNewFlow(t *testing.T) {
 	}
 }
 
+func TestRender_FlowShortcutPaneShowsOpenPRWhenTargetSelected(t *testing.T) {
+	base := RenderParams{
+		Repos:        []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:     0,
+		Width:        180,
+		Height:       28,
+		Mode:         ModeFlows,
+		ActivePane:   1,
+		FlowSelected: 0,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "Flow with PR",
+			Status: flowstore.StatusInProgress,
+			PR: flowstore.PullRequest{
+				Provider:   "github",
+				Number:     123,
+				URL:        "https://github.com/brian-bell/wtui/pull/123",
+				HeadBranch: "flow/add-pr-shortcut",
+				BaseBranch: "main",
+			},
+			Phases: []flowstore.FlowPhase{{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady}},
+		}},
+		FlowPRTargetSelected: true,
+	}
+
+	for _, tt := range []struct {
+		name string
+		mut  func(*RenderParams)
+	}{
+		{name: "flows"},
+		{name: "active flows", mut: func(p *RenderParams) { p.ActiveFlows = true }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			params := base
+			if tt.mut != nil {
+				tt.mut(&params)
+			}
+			pane := shortcutPaneText(Render(params))
+			if !strings.Contains(pane, "p      open PR") {
+				t.Fatalf("Flow shortcut pane missing open PR hint:\n%s", pane)
+			}
+		})
+	}
+}
+
+func TestRender_FlowShortcutPaneHidesOpenPRWithoutTopLevelPRTarget(t *testing.T) {
+	base := RenderParams{
+		Repos:        []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:     0,
+		Width:        180,
+		Height:       28,
+		Mode:         ModeFlows,
+		ActivePane:   1,
+		FlowSelected: 0,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "Flow without PR",
+			Status: flowstore.StatusInProgress,
+			Phases: []flowstore.FlowPhase{{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady}},
+		}},
+	}
+
+	for _, tt := range []struct {
+		name string
+		mut  func(*RenderParams)
+	}{
+		{name: "missing PR metadata"},
+		{name: "selected phase row", mut: func(p *RenderParams) {
+			p.FlowPRTargetSelected = true
+			p.ExpandedFlowID = "flow-1"
+			p.SelectedFlowPhaseID = "implementation"
+		}},
+		{name: "active flows missing PR metadata", mut: func(p *RenderParams) { p.ActiveFlows = true }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			params := base
+			if tt.mut != nil {
+				tt.mut(&params)
+			}
+			pane := shortcutPaneText(Render(params))
+			if strings.Contains(pane, "p      open PR") {
+				t.Fatalf("Flow shortcut pane should hide open PR hint:\n%s", pane)
+			}
+		})
+	}
+}
+
 func shortcutSectionTitles(pane string) []string {
 	known := map[string]bool{
 		"Actions":  true,


### PR DESCRIPTION
## Summary

Adds a Flow shortcut for opening linked GitHub PRs directly from wtui:

- Enables `p` on Flow and Active Flow rows when structured PR metadata includes a URL.
- Routes PR opening through the existing browser opener path and reports success/failure in Flow status messages.
- Shows the `open PR` shortcut only for top-level Flow rows with PR metadata, not expanded phase rows or terminal-focused states.
- Documents the shortcut in the README.

## Verification

- `gofmt -l .`
- `make test`
- `make build`
