### PR TITLE
Cycle pane focus with tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,9 @@ WORKTREE_ROOT=~/projects ./bin/wtui
 
 The UI has two panes: repos on the left, content on the right. Press `enter`
 or `tab` on a selected repo to focus the content pane; from the content pane,
-`bksp` returns focus to the repo pane. Press `f2` to open the prompt-template
-editor for plan and Flow launch prompts. When a Flow embedded terminal is open, `tab`
-switches focus between the Flow list and that terminal while the right pane
-remains active.
+`tab` or `bksp` returns focus to the repo pane. Press `f2` to open the
+prompt-template editor for plan and Flow launch prompts. When a Flow embedded
+terminal is open, `tab` cycles through the repo pane, Flow list, and terminal.
 The active pane is highlighted with a blue border.
 
 **Destructive mode:** The app starts in read-only mode — deletion keys are disabled. Press `D` (Shift+D) to toggle destructive mode on/off. When active, the right pane border turns red and delete/drop hints appear in red as a visual warning.
@@ -112,6 +111,7 @@ filter matches, or a load failure with details in the status bar.
 | `e` | Edit selected plan Markdown (plans view) |
 | `i` | Alias for plan implementation launch |
 | `D` | Toggle destructive mode |
+| `tab` | Cycle pane focus forward; with a Flow terminal open, cycles repo pane → Flow list → terminal |
 | `bksp` | Switch focus to left pane |
 | `f2` | Edit prompt templates |
 | `q`/`esc` | Close a prompt/dialog or quit |
@@ -122,7 +122,7 @@ flows, and active flows. Horizontal view switching wraps between worktrees and
 active flows. Press `V` to choose which numbered view wtui opens on future
 launches; leaving it unset keeps the built-in startup default of Flows. Press
 `enter` or `tab` from the repo pane to focus the content pane. In the content
-pane, `bksp` switches focus back to the left repo pane. Press `f2` from normal
+pane, `tab` or `bksp` switches focus back to the left repo pane. Press `f2` from normal
 TUI views to edit the `[agent].plan_prompt` and `[flow_prompts]` templates;
 Flow terminal input focus passes F2 through to the embedded agent.
 
@@ -228,9 +228,11 @@ transcript.
 Resuming a CLI `codex` or `claude` session from the full sessions view opens a
 runtime-only embedded terminal in the sessions pane. While embedded terminals
 exist, the saved-session table is hidden and the pane shows a compact numbered
-terminal header plus the active terminal screen. Keys go directly to the active
-PTY (including agent shortcuts like `ctrl+g`); press `ctrl+]` for wtui
-commands: `ctrl+] 1`-`9` switches terminals, `ctrl+] l` opens a saved-session
+terminal header plus the active terminal screen. While the session terminal
+right pane is focused, all keys except `tab` go directly to the active PTY
+(including agent shortcuts like `ctrl+g`); after tabbing to the left pane, repo
+pane keys operate normally. Press `ctrl+]` for wtui commands: `ctrl+] 1`-`9`
+switches terminals, `ctrl+] l` opens a saved-session
 picker, `ctrl+] d` detaches a tmux-backed terminal and opens a new external
 terminal attached to that tmux session, `ctrl+] x` dismisses an exited terminal or confirms termination of a
 running one, `ctrl+] q` or `ctrl+] esc` quits with cleanup, and
@@ -404,7 +406,7 @@ directly, while `claude --print` is run with `--output-format stream-json
 a closing summary) so a Claude phase shows live progress as it works instead of a
 blank terminal. While a Flow terminal is open,
 the Flow list uses a smaller top panel and the terminal uses a bottom panel;
-`tab` switches focus between them while the right pane remains active. Manually
+`tab` cycles focus through the repo pane, Flow list, and Flow terminal. Manually
 tabbing into Flow terminal focus starts in wtui command mode: `left`/`right`
 cycle Flow terminals, `1`-`9` switches by number, `x` closes, `d` detaches to
 tmux when available and opens the detached session in an external terminal,

--- a/docs/config.md
+++ b/docs/config.md
@@ -378,8 +378,9 @@ configured agent and that agent's configured effort.
 app-side/default reasoning. Press `r` to resume an attached
 provider session from the selected phase row; CLI resumes open in runtime-only
 embedded PTYs in the flows pane, while `codex-app` resumes navigate externally.
-While a Flow terminal is open, `tab` switches focus between the Flow list and
-terminal. Manually tabbing into Flow terminal focus starts in wtui command mode:
+While a Flow terminal is open, `tab` cycles focus through the repo pane, Flow
+list, and Flow terminal. Manually tabbing into Flow terminal focus starts in
+wtui command mode:
 `left`/`right` cycles Flow terminals, `1`-`9` switches by number, `d` detaches to
 tmux when available, `x` closes, `q`/`esc` quits, unknown ordinary keys do not
 pass through to the PTY, and `ctrl+]` sends a literal `ctrl+]`; `i` enters

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -654,7 +654,13 @@ func (m Model) handleEmbeddedTerminalKey(msg tea.KeyMsg) (Model, tea.Cmd, bool) 
 		return m.handleEmbeddedTerminalKeyForScope(msg, embeddedTerminalScopeFlow)
 	}
 	if m.mode == ui.ModeSessions && !m.activeFlowSurfaceVisible() && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeSession) {
-		return m.handleEmbeddedTerminalKeyForScope(msg, embeddedTerminalScopeSession)
+		if msg.String() == "tab" {
+			m.terminalPrefixActive = false
+			return m.cyclePaneFocusForward(), nil, true
+		}
+		if m.activePane == 1 {
+			return m.handleEmbeddedTerminalKeyForScope(msg, embeddedTerminalScopeSession)
+		}
 	}
 	return m, nil, false
 }

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -665,9 +665,7 @@ func (m Model) handleEmbeddedTerminalKeyForScope(msg tea.KeyMsg, scope embeddedT
 		if m.terminalPrefixActive {
 			switch key {
 			case "tab":
-				m.flowFocus = flowFocusList
-				m.terminalPrefixActive = false
-				return m, nil, true
+				return m.cyclePaneFocusForward(), nil, true
 			case "left":
 				return m.cycleEmbeddedTerminalForScope(scope, -1), nil, true
 			case "right":

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -4825,6 +4825,68 @@ func TestModel_BackKeysForwardWhenSessionTerminalOwnsKeys(t *testing.T) {
 	}
 }
 
+func TestModel_TabCyclesPaneFocusWhenSessionTerminalOwnsKeys(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
+	m := model.NewWithOptions(testRepos(), model.Options{
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return fakeTerm, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 180, Height: 14})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m, _ = update(m, model.SessionResultMsg{RepoPath: "/dev/alpha", Sessions: []sessions.SessionRecord{{
+		Provider:     sessions.ProviderCodex,
+		SessionID:    "codex-session-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/feat",
+		CWD:          "/dev/alpha-worktrees/feat",
+		Branch:       "feature/api",
+	}}, ListRequest: m.ListRequest(ui.ModeSessions)})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("embedded session resume should schedule terminal repaint ticks")
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if cmd != nil {
+		t.Fatalf("tab from session terminal returned cmd %T, want nil", cmd)
+	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("tab from session terminal active pane = %d, want left pane", m.ActivePane())
+	}
+	if len(fakeTerm.writes) != 0 {
+		t.Fatalf("tab from session terminal should not write to PTY: %#v", fakeTerm.writes)
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if m.Selected() != 1 {
+		t.Fatalf("j in left pane selected repo = %d, want 1", m.Selected())
+	}
+	if len(fakeTerm.writes) != 0 {
+		t.Fatalf("left pane key should not write to session terminal: %#v", fakeTerm.writes)
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if cmd != nil {
+		t.Fatalf("tab back to session terminal returned cmd %T, want nil", cmd)
+	}
+	if m.ActivePane() != 1 {
+		t.Fatalf("second tab active pane = %d, want right pane", m.ActivePane())
+	}
+	if len(fakeTerm.writes) != 0 {
+		t.Fatalf("tab back to session terminal should not write to PTY: %#v", fakeTerm.writes)
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyBackspace})
+	if cmd != nil {
+		t.Fatalf("backspace after returning to session terminal returned cmd %T, want nil", cmd)
+	}
+	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "\x7f" {
+		t.Fatalf("backspace after returning to session terminal writes = %#v, want delete byte", fakeTerm.writes)
+	}
+}
+
 func TestModel_EmbeddedTerminalViewRendersRealPTYOutput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("pty tests require a Unix-like platform")

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -481,7 +481,7 @@ func TestModel_ActiveFlowsNewFlowKeyIsIgnored(t *testing.T) {
 	assertListRequestsUnchanged(t, before, m)
 }
 
-func TestModel_ActiveFlowsTabWithoutTerminalKeepsFlowSurfaceFocused(t *testing.T) {
+func TestModel_ActiveFlowsTabWithoutTerminalCyclesBetweenLeftAndList(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
@@ -492,8 +492,8 @@ func TestModel_ActiveFlowsTabWithoutTerminalKeepsFlowSurfaceFocused(t *testing.T
 	if cmd != nil {
 		t.Fatalf("tab from active Flow surface returned command %T, want nil", cmd)
 	}
-	if m.ActivePane() != 1 {
-		t.Fatalf("tab from active Flow surface active pane = %d, want right pane", m.ActivePane())
+	if m.ActivePane() != 0 {
+		t.Fatalf("tab from active Flow surface active pane = %d, want left pane", m.ActivePane())
 	}
 	if m.Mode() != ui.ModeActiveFlows {
 		t.Fatalf("tab from active Flow surface mode = %d, want active flows", m.Mode())
@@ -502,9 +502,18 @@ func TestModel_ActiveFlowsTabWithoutTerminalKeepsFlowSurfaceFocused(t *testing.T
 		t.Fatalf("tab from active Flow surface should keep active Flow view visible:\n%s", view)
 	}
 	assertListRequestsUnchanged(t, before, m)
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if cmd != nil {
+		t.Fatalf("tab back to active Flow surface returned command %T, want nil", cmd)
+	}
+	if m.ActivePane() != 1 {
+		t.Fatalf("second tab active pane = %d, want active Flow list", m.ActivePane())
+	}
+	assertListRequestsUnchanged(t, before, m)
 }
 
-func TestModel_ActiveFlowsTabWithTerminalSwitchesBetweenListAndTerminal(t *testing.T) {
+func TestModel_ActiveFlowsTabWithTerminalCyclesListTerminalLeft(t *testing.T) {
 	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
 	flowOne := flowWithPhaseDetails()
 	flowTwo := flowWithPhaseDetails()
@@ -548,8 +557,21 @@ func TestModel_ActiveFlowsTabWithTerminalSwitchesBetweenListAndTerminal(t *testi
 	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "\x1d" {
 		t.Fatalf("ctrl+] in active Flow terminal command mode should send literal ctrl+], writes = %#v", fakeTerm.writes)
 	}
+	before := listRequests(m)
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if m.ActivePane() != 0 {
+		t.Fatalf("tab from active Flow terminal active pane = %d, want left pane", m.ActivePane())
+	}
+	assertListRequestsUnchanged(t, before, m)
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if m.ActivePane() != 1 {
+		t.Fatalf("tab from left pane active pane = %d, want active Flow list", m.ActivePane())
+	}
+	if view := ansi.Strip(m.View()); !strings.Contains(view, "agent output") {
+		t.Fatalf("returning to active Flow list should keep the selected Flow terminal associated:\n%s", view)
+	}
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if len(fakeTerm.writes) != 1 {
 		t.Fatalf("active Flow list focus should not forward j to terminal: %#v", fakeTerm.writes)
@@ -560,6 +582,29 @@ func TestModel_ActiveFlowsTabWithTerminalSwitchesBetweenListAndTerminal(t *testi
 	if got := model.ActiveFlowSelectedForTest(m); got != 1 {
 		t.Fatalf("active Flow selection = %d, want list focus to move to second flow", got)
 	}
+}
+
+func TestModel_FlowsTabWithoutTerminalCyclesBetweenLeftAndList(t *testing.T) {
+	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flowWithPhaseDetails()})
+	before := listRequests(m)
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if cmd != nil {
+		t.Fatalf("tab from Flow list returned command %T, want nil", cmd)
+	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("tab from Flow list active pane = %d, want left pane", m.ActivePane())
+	}
+	assertListRequestsUnchanged(t, before, m)
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if cmd != nil {
+		t.Fatalf("tab back to Flow list returned command %T, want nil", cmd)
+	}
+	if m.ActivePane() != 1 {
+		t.Fatalf("second tab active pane = %d, want Flow list", m.ActivePane())
+	}
+	assertListRequestsUnchanged(t, before, m)
 }
 
 func TestModel_ActiveFlowsBackspaceClearsSelectedPhaseWhenLeavingRightPane(t *testing.T) {
@@ -6539,7 +6584,7 @@ func TestModel_GFlowPhaseEmbeddedInteractivePrefillFailureCleansUpTerminal(t *te
 	}
 }
 
-func TestModel_FlowTerminalFocusUsesPersistentCommandModeAndTabReturnsToList(t *testing.T) {
+func TestModel_FlowTabCyclesListTerminalLeft(t *testing.T) {
 	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
@@ -6590,14 +6635,24 @@ func TestModel_FlowTerminalFocusUsesPersistentCommandModeAndTabReturnsToList(t *
 	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "\x1d" {
 		t.Fatalf("ctrl+] in Flow command mode should send a literal ctrl+], writes = %#v", fakeTerm.writes)
 	}
+	before := listRequests(m)
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if m.ActivePane() != 0 {
+		t.Fatalf("tab from Flow terminal active pane = %d, want left pane", m.ActivePane())
+	}
+	assertListRequestsUnchanged(t, before, m)
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if m.ActivePane() != 1 {
+		t.Fatalf("tab from left pane active pane = %d, want Flow list", m.ActivePane())
+	}
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if len(fakeTerm.writes) != 1 {
 		t.Fatalf("list focus should not forward j to terminal: %#v", fakeTerm.writes)
 	}
-	if m.FlowSelected() != 1 {
-		t.Fatalf("flow selection = %d, want list focus to move to second flow", m.FlowSelected())
+	if got := m.SelectedFlowPhaseID(); got != "implementation" {
+		t.Fatalf("selected Flow phase = %q, want list focus to move to first phase", got)
 	}
 }
 
@@ -6895,12 +6950,17 @@ func TestModel_FlowTerminalCommandModeCanEnterInputMode(t *testing.T) {
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlCloseBracket})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if len(fakeTerm.writes) != 2 {
 		t.Fatalf("command mode should let tab leave focus without writing: %#v", fakeTerm.writes)
 	}
-	if m.FlowSelected() != 1 {
-		t.Fatalf("flow selection = %d, want list focus to move to second flow", m.FlowSelected())
+	if m.ActivePane() != 0 {
+		t.Fatalf("tab from command-mode terminal active pane = %d, want left pane", m.ActivePane())
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if got := m.SelectedFlowPhaseID(); got != "implementation" {
+		t.Fatalf("selected Flow phase = %q, want list focus to move to first phase", got)
 	}
 }
 
@@ -7003,16 +7063,20 @@ func TestModel_FlowTerminalTabLeavesFocusEvenAfterCommandKey(t *testing.T) {
 	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "\x1d" {
 		t.Fatalf("ctrl+] should send literal byte before tab leaves focus, writes = %#v", fakeTerm.writes)
 	}
+	if m.ActivePane() != 0 {
+		t.Fatalf("tab from command-mode terminal active pane = %d, want left pane", m.ActivePane())
+	}
 	if got := m.TransientError(); strings.Contains(got, "Unknown terminal prefix command") {
 		t.Fatalf("tab should not be treated as an unknown terminal command, status = %q", got)
 	}
 
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	if len(fakeTerm.writes) != 1 {
 		t.Fatalf("list focus should not forward j to terminal: %#v", fakeTerm.writes)
 	}
-	if m.FlowSelected() != 1 {
-		t.Fatalf("flow selection = %d, want list focus to move to second flow", m.FlowSelected())
+	if got := m.SelectedFlowPhaseID(); got != "plan" {
+		t.Fatalf("selected Flow phase = %q, want list focus to move to first phase", got)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -110,8 +110,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handlePromptTemplates()
 	}
 
-	if key == "tab" && m.activePane == 0 {
-		m = m.togglePrimaryPaneFocus()
+	if key == "tab" {
+		m = m.cyclePaneFocusForward()
 		return m, nil
 	}
 
@@ -438,12 +438,6 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.flowSurfaceVisible() {
 			return m.handleResetSelectedFlowPhase()
 		}
-	case "tab":
-		if m.flowSurfaceVisible() && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
-			m.flowFocus = flowFocusTerminal
-			m.terminalPrefixActive = true
-			return m, nil
-		}
 	case "g":
 		if m.flowSurfaceVisible() {
 			return m.handleLaunchNextFlowPhase()
@@ -539,6 +533,45 @@ func (m Model) togglePrimaryPaneFocus() Model {
 	return m
 }
 
+func (m Model) cyclePaneFocusForward() Model {
+	if !m.flowSurfaceVisible() {
+		if m.activePane == 0 {
+			m.activePane = 1
+			return m
+		}
+		m.activePane = 0
+		if m.mode == ui.ModePlans {
+			m = m.clearSelectedPlanPhase()
+		}
+		return m
+	}
+
+	if m.activePane == 0 {
+		m.activePane = 1
+		m.flowFocus = flowFocusList
+		m.terminalPrefixActive = false
+		if m.activeFlowSurfaceVisible() {
+			m = m.syncActiveFlowsFromCache()
+		}
+		return m.syncActiveFlowTerminalToSelectedFlow()
+	}
+
+	if m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) && m.flowFocus != flowFocusTerminal {
+		m.flowFocus = flowFocusTerminal
+		m.terminalPrefixActive = true
+		return m
+	}
+
+	m.activePane = 0
+	m.flowFocus = flowFocusList
+	m.terminalPrefixActive = false
+	m = m.clearSelectedFlowPhase()
+	if m.activeFlowSurfaceVisible() {
+		return m.syncActiveFlowsFromCache()
+	}
+	return m
+}
+
 func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 	switch key {
 	case "up", "k":
@@ -551,12 +584,6 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleHorizontalNavigation(1)
 	case "h":
 		return m.handleToggleFlowHeadless()
-	case "tab":
-		if m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
-			m.flowFocus = flowFocusTerminal
-			m.terminalPrefixActive = true
-			return m, nil
-		}
 	case "g":
 		return m.handleLaunchNextFlowPhase()
 	case "enter":

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -451,15 +451,15 @@ func TestModel_QuitKeys(t *testing.T) {
 
 // --- Pane switching ---
 
-func TestModel_TabFromRightPaneDoesNotSwitchToLeft(t *testing.T) {
+func TestModel_TabFromRightPaneSwitchesToLeft(t *testing.T) {
 	m := model.New(testRepos())
 	m = inRightPane(m)
 	before := listRequests(m)
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyTab})
 
-	if m.ActivePane() != 1 {
-		t.Errorf("expected right pane after tab, got %d", m.ActivePane())
+	if m.ActivePane() != 0 {
+		t.Errorf("expected left pane after tab, got %d", m.ActivePane())
 	}
 	if cmd != nil {
 		t.Fatalf("tab from right pane produced cmd %T, want nil", cmd)
@@ -517,8 +517,8 @@ func TestModel_TabDoesNotChangeMode(t *testing.T) {
 	if m.Mode() != 3 {
 		t.Errorf("expected mode unchanged at 3, got %d", m.Mode())
 	}
-	if m.ActivePane() != 1 {
-		t.Errorf("expected active pane unchanged at right pane, got %d", m.ActivePane())
+	if m.ActivePane() != 0 {
+		t.Errorf("expected active pane cycled to left pane, got %d", m.ActivePane())
 	}
 }
 


### PR DESCRIPTION
## Summary
- make Tab cycle pane focus forward across the repo pane and right pane
- include Flow terminal focus in the Tab cycle when a Flow embedded terminal is open
- let session embedded terminals yield Tab back to wtui focus navigation while preserving normal PTY key forwarding
- update keybinding docs for the new pane cycling behavior

## Verification
- gofmt -l .
- make test
- make build