### PR TITLE
Add manual Flow merge shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ filter matches, or a load failure with details in the status bar.
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
 | `m` | Move or rename a linked worktree (worktrees view), or toggle auto mode for the selected Flow (flows view) |
+| `M` | Mark the selected Flow's GitHub PR as already merged, after verifying the stored PR is merged in GitHub |
 | `A` | Choose and persist the coding agent from a picker (`codex`, `codex-app`, or `claude`) |
 | `V` | Choose and persist the startup default view (`1` through `9`) |
 | `a` | Launch the selected coding agent in the selected worktree, or launch the selected plan or plan phase |
@@ -360,7 +361,11 @@ fresh Flow phase launch attempt, while `codex-app` resumes navigate to the
 existing app thread without extra launch tracking. Press `m` on a Flow row or
 expanded phase row to toggle per-Flow auto mode, which is on by default for new
 Flows and persisted on that Flow record. Flows created before this field existed
-remain manual until auto mode is toggled on. When auto mode is on, a successful
+remain manual until auto mode is toggled on. Press `M` on an eligible Flow row
+when its recorded GitHub PR was merged manually in GitHub; wtui verifies the PR
+is merged with `gh`, records the merge commit and timestamp, marks the Merge
+phase completed, and hides the Flow from active lists without launching a Merge
+phase agent. When auto mode is on, a successful
 completed phase transition launches the next ready non-merge phase in that same
 Flow through the same launch path as pressing `g`. For CLI phases running in an
 embedded Flow terminal, wtui waits until the completed phase's terminal exits
@@ -506,6 +511,9 @@ also marks a matching saved-plan phase with the same normalized phase ID as
 marks the Flow phase `needs_attention` and reports the persistence error.
 Repeating `completed` for an already-completed Flow phase preserves that
 completed state even if the linked-plan sync later fails.
+The TUI-owned manual merge shortcut still treats linked-plan sync failure as
+recoverable: it clears terminal merge metadata, marks the Merge phase
+`needs_attention`, and keeps the Flow visible for repair.
 
 Child implementation phases gate downstream readiness in phase order: review
 loop and PR creation remain pending until required implementation children are

--- a/README.md
+++ b/README.md
@@ -512,8 +512,9 @@ marks the Flow phase `needs_attention` and reports the persistence error.
 Repeating `completed` for an already-completed Flow phase preserves that
 completed state even if the linked-plan sync later fails.
 The TUI-owned manual merge shortcut still treats linked-plan sync failure as
-recoverable: it clears terminal merge metadata, marks the Merge phase
-`needs_attention`, and keeps the Flow visible for repair.
+recoverable: it restores the previous PR status, clears terminal merge
+metadata, marks the Merge phase `needs_attention`, and keeps the Flow visible
+for repair.
 
 Child implementation phases gate downstream readiness in phase order: review
 loop and PR creation remain pending until required implementation children are

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -35,6 +35,25 @@ type envVar struct {
 type lookPathFunc func(string) (string, error)
 type getenvFunc func(string) string
 
+// CommandRunner executes a command and returns stdout, stderr, and the command error.
+type CommandRunner interface {
+	Run(name string, args ...string) ([]byte, []byte, error)
+}
+
+type execCommandRunner struct{}
+
+func (execCommandRunner) Run(name string, args ...string) ([]byte, []byte, error) {
+	cmd := exec.Command(name, args...)
+	stdout, err := cmd.Output()
+	if err == nil {
+		return stdout, nil, nil
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return stdout, exitErr.Stderr, err
+	}
+	return stdout, nil, err
+}
+
 // BootstrapHook configures a script to run after a worktree is created.
 type BootstrapHook struct {
 	Script         string
@@ -67,6 +86,12 @@ type BootstrapContext struct {
 	WorktreePath string
 	Ref          string
 	Kind         WorktreeCreateKind
+}
+
+// PullRequestMerge is the verified GitHub merge metadata for a PR.
+type PullRequestMerge struct {
+	Commit   string
+	MergedAt time.Time
 }
 
 // RemoveWorktree runs `git worktree remove` for the given worktree path,
@@ -475,6 +500,57 @@ func NormalizePullRequestWorktreeRef(input string) (string, error) {
 		return "", err
 	}
 	return strconv.Itoa(pr.Number), nil
+}
+
+// LookupGitHubPRMerge returns verified merge metadata for a GitHub PR.
+func LookupGitHubPRMerge(number int, prURL string) (PullRequestMerge, error) {
+	return LookupGitHubPRMergeWithRunner(number, prURL, execCommandRunner{})
+}
+
+// LookupGitHubPRMergeWithRunner returns verified merge metadata using runner.
+func LookupGitHubPRMergeWithRunner(number int, prURL string, runner CommandRunner) (PullRequestMerge, error) {
+	if number <= 0 {
+		return PullRequestMerge{}, fmt.Errorf("PR number must be positive")
+	}
+	pr, err := parsePullRequestInput(prURL)
+	if err != nil || pr.Owner == "" || pr.Repo == "" {
+		return PullRequestMerge{}, fmt.Errorf("manual merge lookup requires GitHub PR URL with owner and repo")
+	}
+	if pr.Number != number {
+		return PullRequestMerge{}, fmt.Errorf("PR URL number %d must match PR number %d", pr.Number, number)
+	}
+	stdout, stderr, err := runner.Run("gh", "pr", "view", strconv.Itoa(number), "--repo", pr.Owner+"/"+pr.Repo, "--json", "state,mergedAt,mergeCommit")
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return PullRequestMerge{}, fmt.Errorf("gh executable not found")
+		}
+		detail := strings.TrimSpace(string(stderr))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return PullRequestMerge{}, fmt.Errorf("gh pr view failed: %s", detail)
+	}
+	var parsed struct {
+		State       string `json:"state"`
+		MergedAt    string `json:"mergedAt"`
+		MergeCommit *struct {
+			OID string `json:"oid"`
+		} `json:"mergeCommit"`
+	}
+	if err := json.Unmarshal(stdout, &parsed); err != nil {
+		return PullRequestMerge{}, fmt.Errorf("parse gh PR JSON: %w", err)
+	}
+	if parsed.State != "MERGED" {
+		return PullRequestMerge{}, fmt.Errorf("GitHub PR #%d is %s, not MERGED", number, parsed.State)
+	}
+	if parsed.MergeCommit == nil || strings.TrimSpace(parsed.MergeCommit.OID) == "" {
+		return PullRequestMerge{}, fmt.Errorf("GitHub PR #%d is missing merge commit", number)
+	}
+	mergedAt, err := time.Parse(time.RFC3339, strings.TrimSpace(parsed.MergedAt))
+	if err != nil {
+		return PullRequestMerge{}, fmt.Errorf("invalid mergedAt for GitHub PR #%d: %w", number, err)
+	}
+	return PullRequestMerge{Commit: strings.TrimSpace(parsed.MergeCommit.OID), MergedAt: mergedAt}, nil
 }
 
 // DefaultWorktreePath returns the conventional sibling path used for new

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1933,14 +1933,16 @@ func parsePullRequestInput(input string) (pullRequestInput, error) {
 	}
 
 	rawURL := input
-	if strings.HasPrefix(rawURL, "github.com/") {
+	if strings.HasPrefix(strings.ToLower(rawURL), "github.com/") ||
+		strings.HasPrefix(strings.ToLower(rawURL), "www.github.com/") {
 		rawURL = "https://" + rawURL
 	}
 	u, err := url.Parse(rawURL)
 	if err != nil || u.Host == "" {
 		return pullRequestInput{}, fmt.Errorf("invalid PR number or URL: %q", input)
 	}
-	if strings.EqualFold(u.Host, "github.com") {
+	host := strings.ToLower(u.Hostname())
+	if host == "github.com" || host == "www.github.com" {
 		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 		if len(parts) >= 4 && parts[2] == "pull" {
 			if number, ok := parsePositiveInt(parts[3]); ok {
@@ -1949,7 +1951,7 @@ func parsePullRequestInput(input string) (pullRequestInput, error) {
 		}
 		return pullRequestInput{}, fmt.Errorf("invalid GitHub PR URL: %q", input)
 	}
-	return pullRequestInput{}, fmt.Errorf("unsupported PR URL host: %s", u.Host)
+	return pullRequestInput{}, fmt.Errorf("unsupported PR URL host: %s", u.Hostname())
 }
 
 func parsePositiveInt(s string) (int, bool) {

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -954,6 +954,22 @@ func TestLookupGitHubPRMergeWithRunnerReturnsMergedMetadata(t *testing.T) {
 	}
 }
 
+func TestLookupGitHubPRMergeWithRunnerAcceptsValidatedGitHubURLHosts(t *testing.T) {
+	runner := &fakeCommandRunner{
+		stdout: []byte(`{"state":"MERGED","mergedAt":"2026-06-08T15:04:05Z","mergeCommit":{"oid":"0123456789abcdef"}}`),
+	}
+
+	_, err := actions.LookupGitHubPRMergeWithRunner(123, "https://www.github.com:443/acme/project/pull/123", runner)
+	if err != nil {
+		t.Fatalf("LookupGitHubPRMergeWithRunner() error = %v", err)
+	}
+
+	wantArgs := []string{"pr", "view", "123", "--repo", "acme/project", "--json", "state,mergedAt,mergeCommit"}
+	if !reflect.DeepEqual(runner.args, wantArgs) {
+		t.Fatalf("runner args = %#v, want %#v", runner.args, wantArgs)
+	}
+}
+
 func TestLookupGitHubPRMergeWithRunnerValidatesGitHubResult(t *testing.T) {
 	for _, tc := range []struct {
 		name   string

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1,15 +1,34 @@
 package actions_test
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/brian-bell/wtui/actions"
 )
+
+var errFakeCommand = errors.New("fake command failed")
+
+type fakeCommandRunner struct {
+	name   string
+	args   []string
+	stdout []byte
+	stderr []byte
+	err    error
+}
+
+func (r *fakeCommandRunner) Run(name string, args ...string) ([]byte, []byte, error) {
+	r.name = name
+	r.args = append([]string(nil), args...)
+	return r.stdout, r.stderr, r.err
+}
 
 func mustRun(t *testing.T, dir string, args ...string) {
 	t.Helper()
@@ -907,6 +926,104 @@ func TestCreatePullRequestWorktree_FromGitHubURL(t *testing.T) {
 	}
 	if got := runOutput(t, worktreePath, "git", "rev-parse", "HEAD"); got != wantHead {
 		t.Fatalf("expected worktree HEAD %s, got %s", wantHead, got)
+	}
+}
+
+func TestLookupGitHubPRMergeWithRunnerReturnsMergedMetadata(t *testing.T) {
+	runner := &fakeCommandRunner{
+		stdout: []byte(`{"state":"MERGED","mergedAt":"2026-06-08T15:04:05Z","mergeCommit":{"oid":"0123456789abcdef"}}`),
+	}
+
+	result, err := actions.LookupGitHubPRMergeWithRunner(123, "https://github.com/acme/project/pull/123", runner)
+	if err != nil {
+		t.Fatalf("LookupGitHubPRMergeWithRunner() error = %v", err)
+	}
+
+	if result.Commit != "0123456789abcdef" {
+		t.Fatalf("Commit = %q, want merge commit oid", result.Commit)
+	}
+	if want := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC); !result.MergedAt.Equal(want) {
+		t.Fatalf("MergedAt = %s, want %s", result.MergedAt, want)
+	}
+	if runner.name != "gh" {
+		t.Fatalf("runner command = %q, want gh", runner.name)
+	}
+	wantArgs := []string{"pr", "view", "123", "--repo", "acme/project", "--json", "state,mergedAt,mergeCommit"}
+	if !reflect.DeepEqual(runner.args, wantArgs) {
+		t.Fatalf("runner args = %#v, want %#v", runner.args, wantArgs)
+	}
+}
+
+func TestLookupGitHubPRMergeWithRunnerValidatesGitHubResult(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		number int
+		url    string
+		stdout string
+		stderr string
+		err    error
+		want   string
+	}{
+		{
+			name:   "open PR",
+			number: 123,
+			url:    "https://github.com/acme/project/pull/123",
+			stdout: `{"state":"OPEN","mergedAt":null,"mergeCommit":null}`,
+			want:   "is OPEN, not MERGED",
+		},
+		{
+			name:   "missing merge commit",
+			number: 123,
+			url:    "https://github.com/acme/project/pull/123",
+			stdout: `{"state":"MERGED","mergedAt":"2026-06-08T15:04:05Z","mergeCommit":null}`,
+			want:   "missing merge commit",
+		},
+		{
+			name:   "bad timestamp",
+			number: 123,
+			url:    "https://github.com/acme/project/pull/123",
+			stdout: `{"state":"MERGED","mergedAt":"not-time","mergeCommit":{"oid":"abc123"}}`,
+			want:   "invalid mergedAt",
+		},
+		{
+			name:   "malformed JSON",
+			number: 123,
+			url:    "https://github.com/acme/project/pull/123",
+			stdout: `not json`,
+			want:   "parse gh PR JSON",
+		},
+		{
+			name:   "URL without repo",
+			number: 123,
+			url:    "123",
+			want:   "requires GitHub PR URL with owner and repo",
+		},
+		{
+			name:   "command failure",
+			number: 123,
+			url:    "https://github.com/acme/project/pull/123",
+			stderr: "authentication required",
+			err:    errFakeCommand,
+			want:   "authentication required",
+		},
+		{
+			name:   "command not found",
+			number: 123,
+			url:    "https://github.com/acme/project/pull/123",
+			err:    exec.ErrNotFound,
+			want:   "gh executable not found",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := actions.LookupGitHubPRMergeWithRunner(tc.number, tc.url, &fakeCommandRunner{
+				stdout: []byte(tc.stdout),
+				stderr: []byte(tc.stderr),
+				err:    tc.err,
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("LookupGitHubPRMergeWithRunner() error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -348,7 +348,10 @@ launchable phase for the selected Flow. Press `y` to copy the selected Flow
 worktree path from either a Flow row or one of its expanded phase rows. Press
 `m` to toggle per-Flow auto mode. New Flow records start with auto mode on, and
 the toggle is persisted on each Flow. Flows created before this field existed
-remain manual until auto mode is toggled on. When auto mode is on, completed
+remain manual until auto mode is toggled on. Press `M` on an eligible Flow row
+to mark a recorded GitHub PR as already merged; wtui verifies the PR with `gh`,
+records the existing merge commit and timestamp, completes the Merge phase, and
+does not launch a Merge phase agent. When auto mode is on, completed
 CLI phases running in an embedded Flow terminal advance only after the completed
 phase's terminal exits normally and auto-closes; terminal exit also triggers a
 Flow refresh so newly persisted completion state is discovered without waiting
@@ -438,6 +441,9 @@ also marks a matching saved-plan phase with the same normalized phase ID as
 marks the Flow phase `needs_attention` and reports the persistence error.
 Repeating `completed` for an already-completed Flow phase preserves that
 completed state even if the linked-plan sync later fails.
+The TUI-owned manual merge shortcut still treats linked-plan sync failure as
+recoverable: terminal merge metadata is cleared, the Merge phase is marked
+`needs_attention`, and the Flow stays visible.
 
 Flow IDs use the same safe single-path-segment shape as plans:
 `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`. Generated IDs use

--- a/docs/config.md
+++ b/docs/config.md
@@ -442,8 +442,9 @@ marks the Flow phase `needs_attention` and reports the persistence error.
 Repeating `completed` for an already-completed Flow phase preserves that
 completed state even if the linked-plan sync later fails.
 The TUI-owned manual merge shortcut still treats linked-plan sync failure as
-recoverable: terminal merge metadata is cleared, the Merge phase is marked
-`needs_attention`, and the Flow stays visible.
+recoverable: the previous PR status is restored, terminal merge metadata is
+cleared, the Merge phase is marked `needs_attention`, and the Flow stays
+visible.
 
 Flow IDs use the same safe single-path-segment shape as plans:
 `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`. Generated IDs use

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -129,6 +129,12 @@ phase blocked → `blocked`; any phase needs_attention → `needs_attention`; al
 phases completed/skipped → `completed`; any phase started → `in_progress`;
 otherwise `pending`.
 
+The TUI can also record a manual GitHub merge for a Flow whose PR metadata is
+present and whose Merge phase is eligible. That operation verifies the PR is
+already merged in GitHub, completes the Merge phase, records structured merge
+metadata, and lets the derived Flow status become `merged` without launching a
+Merge phase agent.
+
 ## Linked plan sync
 
 When a Flow has a linked saved plan, transitioning a Flow phase to `completed`
@@ -139,6 +145,10 @@ transition, wtui marks the Flow phase `needs_attention` with a sync-failure note
 and returns the persistence error so the agent can report it. Repeating
 `completed` for an already-completed Flow phase preserves that completed state
 even if the linked-plan sync later fails.
+Manual GitHub merge recording is stricter: if syncing the linked plan's Merge
+phase fails while terminal merge metadata is being recorded, wtui clears that
+terminal metadata, marks the Merge phase `needs_attention`, and keeps the Flow
+recoverable instead of deriving it as `merged`.
 
 ## Compatibility and migration
 

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -146,9 +146,10 @@ and returns the persistence error so the agent can report it. Repeating
 `completed` for an already-completed Flow phase preserves that completed state
 even if the linked-plan sync later fails.
 Manual GitHub merge recording is stricter: if syncing the linked plan's Merge
-phase fails while terminal merge metadata is being recorded, wtui clears that
-terminal metadata, marks the Merge phase `needs_attention`, and keeps the Flow
-recoverable instead of deriving it as `merged`.
+phase fails while terminal merge metadata is being recorded, wtui restores the
+previous PR status, clears that terminal metadata, marks the Merge phase
+`needs_attention`, and keeps the Flow recoverable instead of deriving it as
+`merged`.
 
 ## Compatibility and migration
 

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -146,6 +146,8 @@ type MergeUpdate struct {
 // ManualMergeUpdate records metadata for a PR that was manually merged in GitHub.
 type ManualMergeUpdate struct {
 	FlowID   string
+	PRNumber int
+	PRURL    string
 	Commit   string
 	MergedAt time.Time
 	Summary  string
@@ -1467,6 +1469,12 @@ func validateMergeUpdate(record FlowRecord, update MergeUpdate) (Merge, error) {
 func validateManualMergeUpdate(record FlowRecord, phase FlowPhase, update ManualMergeUpdate) (Merge, error) {
 	if !HasPRTarget(record.PR) {
 		return Merge{}, fmt.Errorf("manual merge requires existing PR metadata")
+	}
+	if update.PRNumber <= 0 || strings.TrimSpace(update.PRURL) == "" {
+		return Merge{}, fmt.Errorf("manual merge requires verified PR target")
+	}
+	if update.PRNumber != record.PR.Number || strings.TrimSpace(update.PRURL) != strings.TrimSpace(record.PR.URL) {
+		return Merge{}, fmt.Errorf("manual merge PR target changed after verification")
 	}
 	commit := strings.TrimSpace(update.Commit)
 	if commit == "" {

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -143,6 +143,14 @@ type MergeUpdate struct {
 	MergedAt time.Time
 }
 
+// ManualMergeUpdate records metadata for a PR that was manually merged in GitHub.
+type ManualMergeUpdate struct {
+	FlowID   string
+	Commit   string
+	MergedAt time.Time
+	Summary  string
+}
+
 // Merge stores agent-reported merge metadata.
 type Merge struct {
 	Status   string     `json:"status,omitempty"`
@@ -678,6 +686,73 @@ func (s *Store) SetMerge(update MergeUpdate) (FlowRecord, error) {
 		record.UpdatedAt = now
 		return record, nil
 	})
+}
+
+// MarkManualMerge completes the merge phase and records verified GitHub merge
+// metadata for a PR that was merged outside wtui.
+func (s *Store) MarkManualMerge(update ManualMergeUpdate) (FlowRecord, error) {
+	if err := validateFlowID(update.FlowID); err != nil {
+		return FlowRecord{}, err
+	}
+	release, err := s.acquireFlowLock(update.FlowID)
+	if err != nil {
+		return FlowRecord{}, err
+	}
+	defer release()
+	record, ok := s.readRecord(update.FlowID)
+	if !ok {
+		return FlowRecord{}, flowNotFoundError(update.FlowID)
+	}
+	phaseIndex := phaseIndexByID(record.Phases, "merge")
+	if phaseIndex < 0 {
+		return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", "merge", update.FlowID)
+	}
+	phase := record.Phases[phaseIndex]
+	merge, err := validateManualMergeUpdate(record, phase, update)
+	if err != nil {
+		return FlowRecord{}, err
+	}
+	if record.PR.Status == MergeMerged &&
+		phase.Status == PhaseCompleted &&
+		mergeEqual(record.Merge, merge) {
+		return record, nil
+	}
+
+	now := s.now()
+	summary := strings.TrimSpace(update.Summary)
+	if summary == "" {
+		summary = fmt.Sprintf("Marked GitHub PR #%d as manually merged at %s.", record.PR.Number, merge.Commit)
+	}
+	phase.Status = PhaseCompleted
+	phase.Outcome = MergeMerged
+	phase.Summary = summary
+	phase.PhaseID = "merge"
+	phase.UpdatedAt = now
+	record.Phases[phaseIndex] = phase
+	record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
+	record.PR.Status = MergeMerged
+	record.Merge = merge
+	record.UpdatedAt = now
+	record = refreshPhaseReadiness(record, now)
+	record.Status = DeriveStatus(record)
+	if err := s.write(record); err != nil {
+		return FlowRecord{}, err
+	}
+	if err := s.syncLinkedPlanPhase(record, phase); err != nil {
+		failedPhase := markPhaseSyncNeedsAttention(phase, err, now)
+		if failedIndex := phaseIndexByID(record.Phases, failedPhase.PhaseID); failedIndex >= 0 {
+			record.Phases[failedIndex] = failedPhase
+		}
+		record.Merge = Merge{Status: MergePending}
+		record.UpdatedAt = now
+		record = refreshPhaseReadiness(record, now)
+		record.Status = DeriveStatus(record)
+		if writeErr := s.write(record); writeErr != nil {
+			return FlowRecord{}, fmt.Errorf("%w; additionally failed to persist needs_attention state: %v", err, writeErr)
+		}
+		return FlowRecord{}, err
+	}
+	return record, nil
 }
 
 // SetAutoMode enables or disables TUI-owned automatic phase launching for one Flow.
@@ -1385,6 +1460,42 @@ func validateMergeUpdate(record FlowRecord, update MergeUpdate) (Merge, error) {
 	default:
 		return Merge{}, fmt.Errorf("invalid merge status %q", update.Status)
 	}
+}
+
+func validateManualMergeUpdate(record FlowRecord, phase FlowPhase, update ManualMergeUpdate) (Merge, error) {
+	if !HasPRTarget(record.PR) {
+		return Merge{}, fmt.Errorf("manual merge requires existing PR metadata")
+	}
+	commit := strings.TrimSpace(update.Commit)
+	if commit == "" {
+		return Merge{}, fmt.Errorf("manual merge requires merge commit")
+	}
+	if update.MergedAt.IsZero() {
+		return Merge{}, fmt.Errorf("manual merge requires merge timestamp")
+	}
+	if !PhasePredecessorsSatisfied(record, phase.PhaseID) {
+		return Merge{}, fmt.Errorf("manual merge requires satisfied predecessors for %s", phase.PhaseID)
+	}
+	mergedAt := update.MergedAt.UTC()
+	merge := Merge{Status: MergeMerged, Commit: commit, MergedAt: &mergedAt}
+	switch phase.Status {
+	case PhaseReady, PhaseRunning:
+		if err := validatePhaseUpdate(phase, PhaseUpdate{
+			FlowID:  update.FlowID,
+			PhaseID: "merge",
+			Status:  PhaseCompleted,
+			Outcome: MergeMerged,
+		}); err != nil {
+			return Merge{}, err
+		}
+	case PhaseCompleted:
+		if record.Merge.Status == MergeMerged && !mergeEqual(record.Merge, merge) {
+			return Merge{}, fmt.Errorf("manual merge metadata differs from existing merge metadata")
+		}
+	default:
+		return Merge{}, fmt.Errorf("manual merge requires merge phase ready, running, or completed; merge is %s", phase.Status)
+	}
+	return merge, nil
 }
 
 func mergeEqual(left, right Merge) bool {

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -723,6 +723,7 @@ func (s *Store) MarkManualMerge(update ManualMergeUpdate) (FlowRecord, error) {
 	if summary == "" {
 		summary = fmt.Sprintf("Marked GitHub PR #%d as manually merged at %s.", record.PR.Number, merge.Commit)
 	}
+	previousPRStatus := record.PR.Status
 	phase.Status = PhaseCompleted
 	phase.Outcome = MergeMerged
 	phase.Summary = summary
@@ -743,6 +744,7 @@ func (s *Store) MarkManualMerge(update ManualMergeUpdate) (FlowRecord, error) {
 		if failedIndex := phaseIndexByID(record.Phases, failedPhase.PhaseID); failedIndex >= 0 {
 			record.Phases[failedIndex] = failedPhase
 		}
+		record.PR.Status = previousPRStatus
 		record.Merge = Merge{Status: MergePending}
 		record.UpdatedAt = now
 		record = refreshPhaseReadiness(record, now)
@@ -750,7 +752,7 @@ func (s *Store) MarkManualMerge(update ManualMergeUpdate) (FlowRecord, error) {
 		if writeErr := s.write(record); writeErr != nil {
 			return FlowRecord{}, fmt.Errorf("%w; additionally failed to persist needs_attention state: %v", err, writeErr)
 		}
-		return FlowRecord{}, err
+		return record, err
 	}
 	return record, nil
 }
@@ -1479,7 +1481,7 @@ func validateManualMergeUpdate(record FlowRecord, phase FlowPhase, update Manual
 	mergedAt := update.MergedAt.UTC()
 	merge := Merge{Status: MergeMerged, Commit: commit, MergedAt: &mergedAt}
 	switch phase.Status {
-	case PhaseReady, PhaseRunning:
+	case PhaseReady:
 		if err := validatePhaseUpdate(phase, PhaseUpdate{
 			FlowID:  update.FlowID,
 			PhaseID: "merge",
@@ -1493,7 +1495,7 @@ func validateManualMergeUpdate(record FlowRecord, phase FlowPhase, update Manual
 			return Merge{}, fmt.Errorf("manual merge metadata differs from existing merge metadata")
 		}
 	default:
-		return Merge{}, fmt.Errorf("manual merge requires merge phase ready, running, or completed; merge is %s", phase.Status)
+		return Merge{}, fmt.Errorf("manual merge requires merge phase ready or completed; merge is %s", phase.Status)
 	}
 	return merge, nil
 }

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -2981,6 +2981,8 @@ func TestStoreMarkManualMergeCompletesMergeAndRecordsMetadata(t *testing.T) {
 
 	updated, err := store.MarkManualMerge(flowstore.ManualMergeUpdate{
 		FlowID:   record.FlowID,
+		PRNumber: 116,
+		PRURL:    "https://github.com/brian-bell/wtui/pull/116",
 		Commit:   "0123456789abcdef",
 		MergedAt: mergedAt,
 	})
@@ -3005,6 +3007,47 @@ func TestStoreMarkManualMergeCompletesMergeAndRecordsMetadata(t *testing.T) {
 		updated.Merge.MergedAt == nil ||
 		!updated.Merge.MergedAt.Equal(mergedAt) {
 		t.Fatalf("merge metadata = %#v", updated.Merge)
+	}
+}
+
+func TestStoreMarkManualMergeRejectsChangedPRTarget(t *testing.T) {
+	root := t.TempDir()
+	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := mustCreateManualMergeFlow(t, store, root, true, true)
+	record, err = store.SetPR(flowstore.PRUpdate{
+		FlowID:     record.FlowID,
+		Provider:   "github",
+		Number:     117,
+		URL:        "https://github.com/brian-bell/wtui/pull/117",
+		HeadBranch: "flow/manual-merge",
+		BaseBranch: "main",
+		Status:     "open",
+	})
+	if err != nil {
+		t.Fatalf("SetPR() error = %v", err)
+	}
+
+	_, err = store.MarkManualMerge(flowstore.ManualMergeUpdate{
+		FlowID:   record.FlowID,
+		PRNumber: 116,
+		PRURL:    "https://github.com/brian-bell/wtui/pull/116",
+		Commit:   "0123456789abcdef",
+		MergedAt: mergedAt,
+	})
+	if err == nil || !strings.Contains(err.Error(), "PR target changed") {
+		t.Fatalf("MarkManualMerge() error = %v, want PR target changed", err)
+	}
+
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.Status == flowstore.StatusMerged || read.PR.Status == flowstore.MergeMerged || read.Merge.Status == flowstore.MergeMerged {
+		t.Fatalf("rejected manual merge mutated record to merged: %#v", read)
 	}
 }
 
@@ -3067,6 +3110,8 @@ func TestStoreMarkManualMergeValidatesEligibility(t *testing.T) {
 
 			_, err = store.MarkManualMerge(flowstore.ManualMergeUpdate{
 				FlowID:   record.FlowID,
+				PRNumber: record.PR.Number,
+				PRURL:    record.PR.URL,
 				Commit:   tc.commit,
 				MergedAt: tc.mergedAt,
 			})
@@ -3104,6 +3149,8 @@ func TestStoreMarkManualMergeCollapsesDuplicateMergePhases(t *testing.T) {
 
 	updated, err := store.MarkManualMerge(flowstore.ManualMergeUpdate{
 		FlowID:   record.FlowID,
+		PRNumber: 116,
+		PRURL:    "https://github.com/brian-bell/wtui/pull/116",
 		Commit:   "0123456789abcdef",
 		MergedAt: mergedAt,
 	})
@@ -3144,6 +3191,8 @@ func TestStoreMarkManualMergeLinkedPlanSyncFailureKeepsFlowRecoverable(t *testin
 
 	updated, err := store.MarkManualMerge(flowstore.ManualMergeUpdate{
 		FlowID:   record.FlowID,
+		PRNumber: 116,
+		PRURL:    "https://github.com/brian-bell/wtui/pull/116",
 		Commit:   "0123456789abcdef",
 		MergedAt: mergedAt,
 	})

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -2940,6 +2940,174 @@ func TestStoreSetMergePersistsMergedMetadataAndCompletesFlow(t *testing.T) {
 	}
 }
 
+func TestStoreMarkManualMergeCompletesMergeAndRecordsMetadata(t *testing.T) {
+	root := t.TempDir()
+	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Manual merge",
+		Instructions: "record manually merged GitHub PR",
+		RepoPath:     filepath.Join(root, "repo"),
+		Branch:       "flow/manual-merge",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	record, err = store.SetPR(flowstore.PRUpdate{
+		FlowID:     record.FlowID,
+		Provider:   "github",
+		Number:     116,
+		URL:        "https://github.com/brian-bell/wtui/pull/116",
+		HeadBranch: "flow/manual-merge",
+		BaseBranch: "main",
+		Status:     "open",
+	})
+	if err != nil {
+		t.Fatalf("SetPR() error = %v", err)
+	}
+	record, err = store.SetPhase(flowstore.PhaseUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "autoreview",
+		Status:  flowstore.PhaseCompleted,
+		Outcome: "passed",
+	})
+	if err != nil {
+		t.Fatalf("SetPhase(autoreview completed) error = %v", err)
+	}
+
+	updated, err := store.MarkManualMerge(flowstore.ManualMergeUpdate{
+		FlowID:   record.FlowID,
+		Commit:   "0123456789abcdef",
+		MergedAt: mergedAt,
+	})
+	if err != nil {
+		t.Fatalf("MarkManualMerge() error = %v", err)
+	}
+
+	if updated.Status != flowstore.StatusMerged {
+		t.Fatalf("flow status = %q, want merged", updated.Status)
+	}
+	if updated.PR.Status != flowstore.MergeMerged {
+		t.Fatalf("PR status = %q, want merged", updated.PR.Status)
+	}
+	mergePhase := phaseByID(t, updated, "merge")
+	if mergePhase.Status != flowstore.PhaseCompleted ||
+		mergePhase.Outcome != flowstore.MergeMerged ||
+		!strings.Contains(mergePhase.Summary, "Marked GitHub PR #116 as manually merged at 0123456789abcdef") {
+		t.Fatalf("merge phase = %#v", mergePhase)
+	}
+	if updated.Merge.Status != flowstore.MergeMerged ||
+		updated.Merge.Commit != "0123456789abcdef" ||
+		updated.Merge.MergedAt == nil ||
+		!updated.Merge.MergedAt.Equal(mergedAt) {
+		t.Fatalf("merge metadata = %#v", updated.Merge)
+	}
+}
+
+func TestStoreMarkManualMergeValidatesEligibility(t *testing.T) {
+	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	for _, tc := range []struct {
+		name        string
+		withPR      bool
+		commit      string
+		mergedAt    time.Time
+		mergeStatus string
+		skipAutoRev bool
+		want        string
+	}{
+		{name: "missing PR", commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseReady, want: "requires existing PR metadata"},
+		{name: "missing commit", withPR: true, mergedAt: mergedAt, mergeStatus: flowstore.PhaseReady, want: "requires merge commit"},
+		{name: "missing timestamp", withPR: true, commit: "abc123", mergeStatus: flowstore.PhaseReady, want: "requires merge timestamp"},
+		{name: "predecessors incomplete", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhasePending, skipAutoRev: true, want: "requires satisfied predecessors"},
+		{name: "blocked merge", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseBlocked, want: "requires merge phase ready, running, or completed"},
+		{name: "needs attention merge", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseNeedsAttention, want: "requires merge phase ready, running, or completed"},
+		{name: "skipped merge", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseSkipped, want: "requires merge phase ready, running, or completed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			if err != nil {
+				t.Fatalf("NewStore() error = %v", err)
+			}
+			record := mustCreateManualMergeFlow(t, store, root, tc.withPR, !tc.skipAutoRev)
+			if tc.mergeStatus != "" {
+				for i := range record.Phases {
+					if record.Phases[i].PhaseID == "merge" {
+						record.Phases[i].Status = tc.mergeStatus
+						if tc.mergeStatus == flowstore.PhaseBlocked || tc.mergeStatus == flowstore.PhaseSkipped {
+							record.Phases[i].Notes = "not mergeable"
+						}
+					}
+				}
+				if err := writeFlowRecordForTest(root, record); err != nil {
+					t.Fatalf("write test flow: %v", err)
+				}
+			}
+
+			_, err = store.MarkManualMerge(flowstore.ManualMergeUpdate{
+				FlowID:   record.FlowID,
+				Commit:   tc.commit,
+				MergedAt: tc.mergedAt,
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("MarkManualMerge() error = %v, want %q", err, tc.want)
+			}
+			read, readErr := store.Read(record.FlowID)
+			if readErr != nil {
+				t.Fatalf("Read() error = %v", readErr)
+			}
+			if read.Merge.Status == flowstore.MergeMerged || read.Status == flowstore.StatusMerged {
+				t.Fatalf("rejected manual merge mutated record to merged: %#v", read)
+			}
+		})
+	}
+}
+
+func TestStoreMarkManualMergeLinkedPlanSyncFailureKeepsFlowRecoverable(t *testing.T) {
+	root := t.TempDir()
+	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := mustCreateManualMergeFlow(t, store, root, true, true)
+	record, err = store.SetStartMetadata(flowstore.StartMetadataUpdate{
+		FlowID:   record.FlowID,
+		PlanID:   "missing-plan",
+		PlanPath: filepath.Join(root, "plans", "missing-plan", "plan.md"),
+	})
+	if err != nil {
+		t.Fatalf("SetStartMetadata() error = %v", err)
+	}
+
+	_, err = store.MarkManualMerge(flowstore.ManualMergeUpdate{
+		FlowID:   record.FlowID,
+		Commit:   "0123456789abcdef",
+		MergedAt: mergedAt,
+	})
+	if err == nil || !strings.Contains(err.Error(), "sync linked plan phase") {
+		t.Fatalf("MarkManualMerge() error = %v, want sync failure", err)
+	}
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	mergePhase := phaseByID(t, read, "merge")
+	if mergePhase.Status != flowstore.PhaseNeedsAttention || !strings.Contains(mergePhase.Notes, "missing-plan") {
+		t.Fatalf("merge phase after sync failure = %#v", mergePhase)
+	}
+	if read.Merge.Status != flowstore.MergePending || read.Merge.Commit != "" || read.Merge.MergedAt != nil {
+		t.Fatalf("merge metadata after sync failure = %#v, want pending", read.Merge)
+	}
+	if read.Status == flowstore.StatusMerged {
+		t.Fatalf("flow status after sync failure = %q, want recoverable non-merged", read.Status)
+	}
+}
+
 func TestStoreSetMergeValidatesMergedMetadata(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
@@ -4361,6 +4529,68 @@ func mustCompleteFlowPhases(t *testing.T, store *flowstore.Store, record *flowst
 		}
 		*record = updated
 	}
+}
+
+func mustCreateManualMergeFlow(t *testing.T, store *flowstore.Store, root string, withPR, completeAutoreview bool) flowstore.FlowRecord {
+	t.Helper()
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Manual merge fixture",
+		Instructions: "mark manually merged",
+		RepoPath:     filepath.Join(root, "repo"),
+		Branch:       "flow/manual-merge",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review", "implementation", "review-loop", "pr-creation")
+	if withPR {
+		record, err = store.SetPR(flowstore.PRUpdate{
+			FlowID:     record.FlowID,
+			Provider:   "github",
+			Number:     116,
+			URL:        "https://github.com/brian-bell/wtui/pull/116",
+			HeadBranch: "flow/manual-merge",
+			BaseBranch: "main",
+			Status:     "open",
+		})
+		if err != nil {
+			t.Fatalf("SetPR() error = %v", err)
+		}
+	}
+	if completeAutoreview && withPR {
+		record, err = store.SetPhase(flowstore.PhaseUpdate{
+			FlowID:  record.FlowID,
+			PhaseID: "autoreview",
+			Status:  flowstore.PhaseCompleted,
+			Outcome: "passed",
+		})
+		if err != nil {
+			t.Fatalf("SetPhase(autoreview completed) error = %v", err)
+		}
+	} else if completeAutoreview {
+		for i := range record.Phases {
+			if record.Phases[i].PhaseID == "autoreview" {
+				record.Phases[i].Status = flowstore.PhaseCompleted
+				record.Phases[i].Outcome = "passed"
+			}
+			if record.Phases[i].PhaseID == "merge" {
+				record.Phases[i].Status = flowstore.PhaseReady
+			}
+		}
+		if err := writeFlowRecordForTest(root, record); err != nil {
+			t.Fatalf("write test flow: %v", err)
+		}
+	}
+	return record
+}
+
+func writeFlowRecordForTest(root string, record flowstore.FlowRecord) error {
+	metaPath := filepath.Join(root, "flows", record.FlowID, "meta.json")
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(metaPath, append(data, '\n'), 0o600)
 }
 
 func assertPhaseOrder(t *testing.T, record flowstore.FlowRecord, phaseIDs []string) {

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -3017,15 +3017,26 @@ func TestStoreMarkManualMergeValidatesEligibility(t *testing.T) {
 		mergedAt    time.Time
 		mergeStatus string
 		skipAutoRev bool
+		mutate      func(*flowstore.FlowRecord)
 		want        string
 	}{
 		{name: "missing PR", commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseReady, want: "requires existing PR metadata"},
 		{name: "missing commit", withPR: true, mergedAt: mergedAt, mergeStatus: flowstore.PhaseReady, want: "requires merge commit"},
 		{name: "missing timestamp", withPR: true, commit: "abc123", mergeStatus: flowstore.PhaseReady, want: "requires merge timestamp"},
 		{name: "predecessors incomplete", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhasePending, skipAutoRev: true, want: "requires satisfied predecessors"},
-		{name: "blocked merge", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseBlocked, want: "requires merge phase ready, running, or completed"},
-		{name: "needs attention merge", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseNeedsAttention, want: "requires merge phase ready, running, or completed"},
-		{name: "skipped merge", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseSkipped, want: "requires merge phase ready, running, or completed"},
+		{name: "running merge", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseRunning, want: "requires merge phase ready or completed"},
+		{name: "blocked merge", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseBlocked, want: "requires merge phase ready or completed"},
+		{name: "needs attention merge", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseNeedsAttention, want: "requires merge phase ready or completed"},
+		{name: "skipped merge", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseSkipped, want: "requires merge phase ready or completed"},
+		{name: "invalid PR provider", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseReady, mutate: func(record *flowstore.FlowRecord) {
+			record.PR.Provider = "gitlab"
+		}, want: "requires existing PR metadata"},
+		{name: "invalid PR number", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseReady, mutate: func(record *flowstore.FlowRecord) {
+			record.PR.Number = 0
+		}, want: "requires existing PR metadata"},
+		{name: "invalid PR URL", withPR: true, commit: "abc123", mergedAt: mergedAt, mergeStatus: flowstore.PhaseReady, mutate: func(record *flowstore.FlowRecord) {
+			record.PR.URL = "not-a-url"
+		}, want: "requires existing PR metadata"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			root := t.TempDir()
@@ -3043,6 +3054,12 @@ func TestStoreMarkManualMergeValidatesEligibility(t *testing.T) {
 						}
 					}
 				}
+				if err := writeFlowRecordForTest(root, record); err != nil {
+					t.Fatalf("write test flow: %v", err)
+				}
+			}
+			if tc.mutate != nil {
+				tc.mutate(&record)
 				if err := writeFlowRecordForTest(root, record); err != nil {
 					t.Fatalf("write test flow: %v", err)
 				}
@@ -3067,6 +3084,47 @@ func TestStoreMarkManualMergeValidatesEligibility(t *testing.T) {
 	}
 }
 
+func TestStoreMarkManualMergeCollapsesDuplicateMergePhases(t *testing.T) {
+	root := t.TempDir()
+	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := mustCreateManualMergeFlow(t, store, root, true, true)
+	record.Phases = append(record.Phases, flowstore.FlowPhase{
+		PhaseID: " Merge ",
+		Title:   "Legacy duplicate merge",
+		Status:  flowstore.PhaseBlocked,
+		Notes:   "legacy duplicate should collapse",
+	})
+	if err := writeFlowRecordForTest(root, record); err != nil {
+		t.Fatalf("write test flow: %v", err)
+	}
+
+	updated, err := store.MarkManualMerge(flowstore.ManualMergeUpdate{
+		FlowID:   record.FlowID,
+		Commit:   "0123456789abcdef",
+		MergedAt: mergedAt,
+	})
+	if err != nil {
+		t.Fatalf("MarkManualMerge() error = %v", err)
+	}
+
+	var mergeRows int
+	for _, phase := range updated.Phases {
+		if strings.EqualFold(strings.TrimSpace(phase.PhaseID), "merge") {
+			mergeRows++
+			if phase.PhaseID != "merge" || phase.Status != flowstore.PhaseCompleted {
+				t.Fatalf("collapsed merge phase = %#v", phase)
+			}
+		}
+	}
+	if mergeRows != 1 {
+		t.Fatalf("merge phase rows = %d, want 1 in %#v", mergeRows, updated.Phases)
+	}
+}
+
 func TestStoreMarkManualMergeLinkedPlanSyncFailureKeepsFlowRecoverable(t *testing.T) {
 	root := t.TempDir()
 	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
@@ -3084,13 +3142,16 @@ func TestStoreMarkManualMergeLinkedPlanSyncFailureKeepsFlowRecoverable(t *testin
 		t.Fatalf("SetStartMetadata() error = %v", err)
 	}
 
-	_, err = store.MarkManualMerge(flowstore.ManualMergeUpdate{
+	updated, err := store.MarkManualMerge(flowstore.ManualMergeUpdate{
 		FlowID:   record.FlowID,
 		Commit:   "0123456789abcdef",
 		MergedAt: mergedAt,
 	})
 	if err == nil || !strings.Contains(err.Error(), "sync linked plan phase") {
 		t.Fatalf("MarkManualMerge() error = %v, want sync failure", err)
+	}
+	if updated.FlowID != record.FlowID {
+		t.Fatalf("MarkManualMerge() returned flow ID %q, want recovered record", updated.FlowID)
 	}
 	read, err := store.Read(record.FlowID)
 	if err != nil {
@@ -3102,6 +3163,9 @@ func TestStoreMarkManualMergeLinkedPlanSyncFailureKeepsFlowRecoverable(t *testin
 	}
 	if read.Merge.Status != flowstore.MergePending || read.Merge.Commit != "" || read.Merge.MergedAt != nil {
 		t.Fatalf("merge metadata after sync failure = %#v, want pending", read.Merge)
+	}
+	if read.PR.Status != "open" {
+		t.Fatalf("PR status after sync failure = %q, want open", read.PR.Status)
 	}
 	if read.Status == flowstore.StatusMerged {
 		t.Fatalf("flow status after sync failure = %q, want recoverable non-merged", read.Status)

--- a/model/model.go
+++ b/model/model.go
@@ -98,6 +98,8 @@ type Model struct {
 	startFlowPlan              func(FlowStartRequest) (FlowStartResult, error)
 	setFlowPhase               func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
 	setFlowAutoMode            func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
+	lookupPRMerge              func(int, string) (actions.PullRequestMerge, error)
+	markFlowManualMerge        func(flowstore.ManualMergeUpdate) (flowstore.FlowRecord, error)
 	addFlowPhaseLaunchID       func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
 	resetFlowPhase             func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error)
 	deleteFlow                 func(string) error
@@ -183,6 +185,8 @@ type Options struct {
 	StartFlowPlan            func(FlowStartRequest) (FlowStartResult, error)
 	SetFlowPhase             func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
 	SetFlowAutoMode          func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
+	LookupPRMerge            func(int, string) (actions.PullRequestMerge, error)
+	MarkFlowManualMerge      func(flowstore.ManualMergeUpdate) (flowstore.FlowRecord, error)
 	AddFlowPhaseLaunchID     func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
 	ResetFlowPhase           func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error)
 	DeleteFlow               func(flowID string) error
@@ -277,6 +281,21 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 				return flowstore.FlowRecord{}, err
 			}
 			return store.SetAutoMode(update)
+		}
+	}
+	lookupPRMerge := opts.LookupPRMerge
+	if lookupPRMerge == nil {
+		lookupPRMerge = actions.LookupGitHubPRMerge
+	}
+	markFlowManualMerge := opts.MarkFlowManualMerge
+	if markFlowManualMerge == nil {
+		root := opts.SessionStateRoot
+		markFlowManualMerge = func(update flowstore.ManualMergeUpdate) (flowstore.FlowRecord, error) {
+			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			if err != nil {
+				return flowstore.FlowRecord{}, err
+			}
+			return store.MarkManualMerge(update)
 		}
 	}
 	addFlowPhaseLaunchID := opts.AddFlowPhaseLaunchID
@@ -436,6 +455,8 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		startFlowPlan:            startFlowPlan,
 		setFlowPhase:             setFlowPhase,
 		setFlowAutoMode:          setFlowAutoMode,
+		lookupPRMerge:            lookupPRMerge,
+		markFlowManualMerge:      markFlowManualMerge,
 		addFlowPhaseLaunchID:     addFlowPhaseLaunchID,
 		resetFlowPhase:           resetFlowPhase,
 		deleteFlow:               deleteFlow,
@@ -682,103 +703,104 @@ func (m Model) View() string {
 	}
 	modalView := m.modal.View()
 	return ui.Render(ui.RenderParams{
-		Repos:                       repos,
-		ActiveTerminalRepoPaths:     m.activeTerminalRepoPaths(),
-		Selected:                    selected,
-		Width:                       m.width,
-		Height:                      m.height,
-		Mode:                        m.mode,
-		ActiveFlows:                 m.activeFlowSurfaceVisible(),
-		Branches:                    rows,
-		Stashes:                     stashes,
-		BranchSelected:              branchSelected,
-		StashSelected:               stashSelected,
-		Overlay:                     m.overlayState(),
-		OverlayDiff:                 modalView.Diff,
-		OverlayScroll:               modalView.Scroll,
-		ConfirmPrompt:               modalView.Prompt,
-		ConfirmForce:                modalView.Force,
-		InputPrompt:                 modalView.Prompt,
-		InputPlaceholder:            modalView.Placeholder,
-		InputValue:                  modalView.Input,
-		InputError:                  modalView.InputErr,
-		InputMode:                   uiInputMode(modalView.InputMode),
-		InputHeight:                 modalView.InputHeight,
-		InputCursor:                 modalView.InputCursor,
-		WorktreeInputPrompt:         modalView.Prompt,
-		WorktreeInputPlaceholder:    modalView.Placeholder,
-		WorktreeInput:               modalView.Input,
-		WorktreeInputErr:            modalView.InputErr,
-		SelectPrompt:                modalView.Prompt,
-		SelectItems:                 uiSelectItems(modalView.SelectItems),
-		SelectSelected:              modalView.SelectIndex,
-		SelectWidth:                 modalView.SelectLayout.Width,
-		SelectHeight:                modalView.SelectLayout.Height,
-		SelectPlacement:             uiSelectPlacement(modalView.SelectLayout.Placement),
-		Form:                        uiFormView(modalView.Form),
-		BranchScroll:                branchScroll,
-		RepoScroll:                  repoScroll,
-		StashScroll:                 stashScroll,
-		ActivePane:                  m.activePane,
-		Destructive:                 m.destructive,
-		Worktrees:                   worktrees,
-		WorktreeSelected:            worktreeSelected,
-		WorktreeScroll:              worktreeScroll,
-		WorktreeSessions:            worktreeSessions,
-		WorktreeSessionSelected:     worktreeSessionSelected,
-		WorktreeSessionScroll:       worktreeSessionScroll,
-		InlineWorktreeSessions:      m.inlineWorktreeSessionPath != "",
-		Commits:                     commits,
-		CommitSelected:              commitSelected,
-		CommitScroll:                commitScroll,
-		Reflogs:                     reflogs,
-		ReflogSelected:              reflogSelected,
-		ReflogScroll:                reflogScroll,
-		Sessions:                    sessions,
-		SessionSelected:             sessionSelected,
-		SessionScroll:               sessionScroll,
-		EmbeddedTerminals:           m.embeddedTerminalTabs(),
-		EmbeddedTerminalLines:       m.embeddedTerminalLines(),
-		EmbeddedTerminalPrefix:      m.terminalPrefixActive,
-		Plans:                       plans,
-		PlanSelected:                planSelected,
-		PlanScroll:                  planScroll,
-		Flows:                       flows,
-		FlowSelected:                flowSelected,
-		FlowScroll:                  flowScroll,
-		FlowEmbeddedTerminals:       m.flowEmbeddedTerminalTabs(),
-		FlowEmbeddedTerminalLines:   m.flowEmbeddedTerminalLines(),
-		FlowEmbeddedTerminalPrefix:  m.terminalPrefixActive && m.flowFocus == flowFocusTerminal,
-		FlowTerminalActivity:        m.flowTerminalActivity(),
-		FlowTerminalFocused:         m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow),
-		ExpandedPlanID:              m.expandedPlanID,
-		ExpandedFlowID:              m.currentExpandedFlowID(),
-		SelectedPlanPhaseID:         m.selectedPlanPhaseID,
-		SelectedFlowPhaseID:         m.currentSelectedFlowPhaseID(),
-		FlowHeadless:                m.flowHeadless,
-		FlowAutoModeSelected:        flowAutoModeSelected,
-		FlowAgentLabel:              m.flowAgentShortcutLabel(),
-		FlowReasoningEffort:         m.flowReasoningEffortLabel(),
-		DefaultViewLabel:            ViewChoiceLabel(m.defaultView),
-		FlowNextLaunchReady:         m.selectedFlowHasLaunchablePhase(),
-		FlowPhaseResetReadySelected: m.selectedFlowPhaseResettable(),
-		FlowPhaseResumableSelected:  m.selectedFlowPhaseResumable(),
-		OverlayText:                 modalView.Text,
-		TransientError:              m.visibleStatusText(),
-		TransientErrorFadeStep:      m.visibleStatusFadeStep(),
-		SearchActive:                m.searchActive,
-		RepoSearch:                  m.repos.Query(),
-		ItemSearch:                  m.activeItemPaneQuery(),
-		RepoEmptyMessage:            repoEmptyMessage,
-		RightEmptyMessage:           rightEmptyMessage,
-		FetchAvailable:              m.canFetch(),
-		FetchVisibleAvailable:       m.canFetchVisibleRepos(),
-		RepoCreateAvailable:         m.canCreateRepo(),
-		PullAvailable:               m.canPull(),
-		WorktreeMoveAvailable:       m.canMoveWorktree(),
-		WorktreeSessionsOpen:        m.inlineWorktreeSessionPath != "",
-		AgentAvailable:              m.canLaunchAgent(),
-		NewAgentAvailable:           m.canCreateAndLaunchAgent(),
+		Repos:                        repos,
+		ActiveTerminalRepoPaths:      m.activeTerminalRepoPaths(),
+		Selected:                     selected,
+		Width:                        m.width,
+		Height:                       m.height,
+		Mode:                         m.mode,
+		ActiveFlows:                  m.activeFlowSurfaceVisible(),
+		Branches:                     rows,
+		Stashes:                      stashes,
+		BranchSelected:               branchSelected,
+		StashSelected:                stashSelected,
+		Overlay:                      m.overlayState(),
+		OverlayDiff:                  modalView.Diff,
+		OverlayScroll:                modalView.Scroll,
+		ConfirmPrompt:                modalView.Prompt,
+		ConfirmForce:                 modalView.Force,
+		InputPrompt:                  modalView.Prompt,
+		InputPlaceholder:             modalView.Placeholder,
+		InputValue:                   modalView.Input,
+		InputError:                   modalView.InputErr,
+		InputMode:                    uiInputMode(modalView.InputMode),
+		InputHeight:                  modalView.InputHeight,
+		InputCursor:                  modalView.InputCursor,
+		WorktreeInputPrompt:          modalView.Prompt,
+		WorktreeInputPlaceholder:     modalView.Placeholder,
+		WorktreeInput:                modalView.Input,
+		WorktreeInputErr:             modalView.InputErr,
+		SelectPrompt:                 modalView.Prompt,
+		SelectItems:                  uiSelectItems(modalView.SelectItems),
+		SelectSelected:               modalView.SelectIndex,
+		SelectWidth:                  modalView.SelectLayout.Width,
+		SelectHeight:                 modalView.SelectLayout.Height,
+		SelectPlacement:              uiSelectPlacement(modalView.SelectLayout.Placement),
+		Form:                         uiFormView(modalView.Form),
+		BranchScroll:                 branchScroll,
+		RepoScroll:                   repoScroll,
+		StashScroll:                  stashScroll,
+		ActivePane:                   m.activePane,
+		Destructive:                  m.destructive,
+		Worktrees:                    worktrees,
+		WorktreeSelected:             worktreeSelected,
+		WorktreeScroll:               worktreeScroll,
+		WorktreeSessions:             worktreeSessions,
+		WorktreeSessionSelected:      worktreeSessionSelected,
+		WorktreeSessionScroll:        worktreeSessionScroll,
+		InlineWorktreeSessions:       m.inlineWorktreeSessionPath != "",
+		Commits:                      commits,
+		CommitSelected:               commitSelected,
+		CommitScroll:                 commitScroll,
+		Reflogs:                      reflogs,
+		ReflogSelected:               reflogSelected,
+		ReflogScroll:                 reflogScroll,
+		Sessions:                     sessions,
+		SessionSelected:              sessionSelected,
+		SessionScroll:                sessionScroll,
+		EmbeddedTerminals:            m.embeddedTerminalTabs(),
+		EmbeddedTerminalLines:        m.embeddedTerminalLines(),
+		EmbeddedTerminalPrefix:       m.terminalPrefixActive,
+		Plans:                        plans,
+		PlanSelected:                 planSelected,
+		PlanScroll:                   planScroll,
+		Flows:                        flows,
+		FlowSelected:                 flowSelected,
+		FlowScroll:                   flowScroll,
+		FlowEmbeddedTerminals:        m.flowEmbeddedTerminalTabs(),
+		FlowEmbeddedTerminalLines:    m.flowEmbeddedTerminalLines(),
+		FlowEmbeddedTerminalPrefix:   m.terminalPrefixActive && m.flowFocus == flowFocusTerminal,
+		FlowTerminalActivity:         m.flowTerminalActivity(),
+		FlowTerminalFocused:          m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow),
+		ExpandedPlanID:               m.expandedPlanID,
+		ExpandedFlowID:               m.currentExpandedFlowID(),
+		SelectedPlanPhaseID:          m.selectedPlanPhaseID,
+		SelectedFlowPhaseID:          m.currentSelectedFlowPhaseID(),
+		FlowHeadless:                 m.flowHeadless,
+		FlowAutoModeSelected:         flowAutoModeSelected,
+		FlowAgentLabel:               m.flowAgentShortcutLabel(),
+		FlowReasoningEffort:          m.flowReasoningEffortLabel(),
+		DefaultViewLabel:             ViewChoiceLabel(m.defaultView),
+		FlowNextLaunchReady:          m.selectedFlowHasLaunchablePhase(),
+		FlowManualMergeReadySelected: m.selectedFlowManualMergeReady(),
+		FlowPhaseResetReadySelected:  m.selectedFlowPhaseResettable(),
+		FlowPhaseResumableSelected:   m.selectedFlowPhaseResumable(),
+		OverlayText:                  modalView.Text,
+		TransientError:               m.visibleStatusText(),
+		TransientErrorFadeStep:       m.visibleStatusFadeStep(),
+		SearchActive:                 m.searchActive,
+		RepoSearch:                   m.repos.Query(),
+		ItemSearch:                   m.activeItemPaneQuery(),
+		RepoEmptyMessage:             repoEmptyMessage,
+		RightEmptyMessage:            rightEmptyMessage,
+		FetchAvailable:               m.canFetch(),
+		FetchVisibleAvailable:        m.canFetchVisibleRepos(),
+		RepoCreateAvailable:          m.canCreateRepo(),
+		PullAvailable:                m.canPull(),
+		WorktreeMoveAvailable:        m.canMoveWorktree(),
+		WorktreeSessionsOpen:         m.inlineWorktreeSessionPath != "",
+		AgentAvailable:               m.canLaunchAgent(),
+		NewAgentAvailable:            m.canCreateAndLaunchAgent(),
 	})
 }
 
@@ -1162,6 +1184,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleFlowAutoModeSet(msg), nil
 	case FlowAutoModeSetFailedMsg:
 		return m.handleFlowAutoModeSetFailed(msg), nil
+	case FlowManualMergeSetMsg:
+		return m.handleFlowManualMergeSet(msg), nil
+	case FlowManualMergeSetFailedMsg:
+		return m.handleFlowManualMergeSetFailed(msg), nil
 	case flowPhaseResetConfirmedMsg:
 		return m.handleFlowPhaseResetConfirmed(msg)
 	case flowPhaseResetMsg:
@@ -1453,6 +1479,11 @@ func (m Model) selectedFlowPhaseResumable() bool {
 func (m Model) selectedFlowHasLaunchablePhase() bool {
 	_, _, ok := m.selectedFlowNextLaunchablePhase()
 	return ok
+}
+
+func (m Model) selectedFlowManualMergeReady() bool {
+	record, _, ok := m.selectedManualMergeFlow()
+	return ok && flowManualMergeEligible(record)
 }
 
 func (m Model) selectedFlowPhaseResettable() bool {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1503,6 +1503,8 @@ func TestModel_ShiftMMarksSelectedFlowAsManuallyMerged(t *testing.T) {
 	}
 	if len(markCalls) != 1 ||
 		markCalls[0].FlowID != "flow-1" ||
+		markCalls[0].PRNumber != 116 ||
+		markCalls[0].PRURL != "https://github.com/brian-bell/wtui/pull/116" ||
 		markCalls[0].Commit != "0123456789abcdef" ||
 		!markCalls[0].MergedAt.Equal(mergedAt) {
 		t.Fatalf("manual merge calls = %#v", markCalls)

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -75,6 +75,34 @@ func flowWithPhaseDetails() flowstore.FlowRecord {
 	}
 }
 
+func manualMergeEligibleFlow() flowstore.FlowRecord {
+	return flowstore.FlowRecord{
+		FlowID:   "flow-1",
+		RepoPath: "/dev/alpha",
+		Title:    "Manual merge Flow",
+		Status:   flowstore.StatusInProgress,
+		Branch:   "flow/manual-merge",
+		PR: flowstore.PullRequest{
+			Provider:   "github",
+			Number:     116,
+			URL:        "https://github.com/brian-bell/wtui/pull/116",
+			HeadBranch: "flow/manual-merge",
+			BaseBranch: "main",
+			Status:     "open",
+		},
+		Merge: flowstore.Merge{Status: flowstore.MergePending},
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
+			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted},
+			{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseCompleted},
+			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhaseCompleted},
+			{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseCompleted, Outcome: "passed"},
+			{PhaseID: "merge", Title: "Merge", Status: flowstore.PhaseReady},
+		},
+	}
+}
+
 func TestModel_Key9ShowsGlobalActiveFlowsWithoutPollutingFlowsCache(t *testing.T) {
 	alpha := flowWithPhaseDetails()
 	alpha.FlowID = "alpha-flow"
@@ -1420,6 +1448,119 @@ func TestModel_MKeyFlowAutoModeNoopsWithoutSelectedFlow(t *testing.T) {
 	}
 	if called {
 		t.Fatal("SetFlowAutoMode should not be called without a selected Flow")
+	}
+}
+
+func TestModel_ShiftMMarksSelectedFlowAsManuallyMerged(t *testing.T) {
+	flow := manualMergeEligibleFlow()
+	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	updated := flow
+	updated.Status = flowstore.StatusMerged
+	updated.PR.Status = flowstore.MergeMerged
+	updated.Merge = flowstore.Merge{Status: flowstore.MergeMerged, Commit: "0123456789abcdef", MergedAt: &mergedAt}
+	updated.Phases[len(updated.Phases)-1].Status = flowstore.PhaseCompleted
+	updated.Phases[len(updated.Phases)-1].Outcome = flowstore.MergeMerged
+
+	var lookupCalls int
+	var markCalls []flowstore.ManualMergeUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		LookupPRMerge: func(number int, url string) (actions.PullRequestMerge, error) {
+			lookupCalls++
+			if number != 116 || url != "https://github.com/brian-bell/wtui/pull/116" {
+				t.Fatalf("LookupPRMerge(%d, %q), want stored PR", number, url)
+			}
+			return actions.PullRequestMerge{Commit: "0123456789abcdef", MergedAt: mergedAt}, nil
+		},
+		MarkFlowManualMerge: func(update flowstore.ManualMergeUpdate) (flowstore.FlowRecord, error) {
+			markCalls = append(markCalls, update)
+			return updated, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	if cmd != nil {
+		t.Fatalf("opening manual merge confirmation returned command %T, want nil", cmd)
+	}
+	if m.Overlay() != ui.OverlayConfirm || !strings.Contains(m.ConfirmPrompt(), "Mark PR #116 as merged?") {
+		t.Fatalf("manual merge confirmation prompt = %q overlay=%d", m.ConfirmPrompt(), m.Overlay())
+	}
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("confirming manual merge should return command")
+	}
+	raw := cmd()
+	if _, ok := raw.(model.FlowEmbeddedLaunchRequestedMsg); ok {
+		t.Fatal("manual merge must not launch a Flow phase")
+	}
+	m, cmd = update(m, raw)
+	if cmd != nil {
+		t.Fatalf("manual merge result returned follow-up command %T, want nil", cmd)
+	}
+
+	if lookupCalls != 1 {
+		t.Fatalf("lookup calls = %d, want 1", lookupCalls)
+	}
+	if len(markCalls) != 1 ||
+		markCalls[0].FlowID != "flow-1" ||
+		markCalls[0].Commit != "0123456789abcdef" ||
+		!markCalls[0].MergedAt.Equal(mergedAt) {
+		t.Fatalf("manual merge calls = %#v", markCalls)
+	}
+	if got := m.Flows(); len(got) != 1 || got[0].Status != flowstore.StatusMerged {
+		t.Fatalf("Flows() = %#v, want merged replacement", got)
+	}
+}
+
+func TestModel_ShiftMManualMergeNoopsOnSelectedPhaseRow(t *testing.T) {
+	flow := manualMergeEligibleFlow()
+	called := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		LookupPRMerge: func(int, string) (actions.PullRequestMerge, error) {
+			called = true
+			return actions.PullRequestMerge{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+	m = selectFlowPhaseByID(t, m, "merge")
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	if cmd != nil {
+		t.Fatalf("M on selected phase returned command %T, want nil", cmd)
+	}
+	if m.Overlay() == ui.OverlayConfirm {
+		t.Fatalf("M on selected phase opened confirmation %q", m.ConfirmPrompt())
+	}
+	if called {
+		t.Fatal("LookupPRMerge should not run for selected phase row")
+	}
+}
+
+func TestModel_ShiftMManualMergeRemovesMergedRecordFromActiveFlows(t *testing.T) {
+	flow := manualMergeEligibleFlow()
+	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	merged := flow
+	merged.Status = flowstore.StatusMerged
+	merged.PR.Status = flowstore.MergeMerged
+	merged.Merge = flowstore.Merge{Status: flowstore.MergeMerged, Commit: "0123456789abcdef", MergedAt: &mergedAt}
+	m := enterActiveFlowsWithRecords(t, model.NewWithOptions(testRepos(), model.Options{
+		LookupPRMerge: func(int, string) (actions.PullRequestMerge, error) {
+			return actions.PullRequestMerge{Commit: "0123456789abcdef", MergedAt: mergedAt}, nil
+		},
+		MarkFlowManualMerge: func(flowstore.ManualMergeUpdate) (flowstore.FlowRecord, error) {
+			return merged, nil
+		},
+	}), []flowstore.FlowRecord{flow})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("confirming manual merge should return command")
+	}
+	m, _ = update(m, cmd())
+
+	if strings.Contains(m.View(), "Manual merge Flow") {
+		t.Fatalf("merged Flow should be filtered from active view:\n%s", m.View())
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1536,6 +1536,67 @@ func TestModel_ShiftMManualMergeNoopsOnSelectedPhaseRow(t *testing.T) {
 	}
 }
 
+func TestModel_ShiftMManualMergeNoopsWhenMergePhaseRunning(t *testing.T) {
+	flow := manualMergeEligibleFlow()
+	flow.Phases[len(flow.Phases)-1].Status = flowstore.PhaseRunning
+	called := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		LookupPRMerge: func(int, string) (actions.PullRequestMerge, error) {
+			called = true
+			return actions.PullRequestMerge{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	if cmd != nil {
+		t.Fatalf("M on running merge phase returned command %T, want nil", cmd)
+	}
+	if m.Overlay() == ui.OverlayConfirm {
+		t.Fatalf("M on running merge phase opened confirmation %q", m.ConfirmPrompt())
+	}
+	if called {
+		t.Fatal("LookupPRMerge should not run when merge phase is running")
+	}
+}
+
+func TestModel_ShiftMManualMergeFailureReplacesRecoveredFlowState(t *testing.T) {
+	flow := manualMergeEligibleFlow()
+	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	recovered := flow
+	recovered.Phases = append([]flowstore.FlowPhase(nil), flow.Phases...)
+	recovered.Phases[len(recovered.Phases)-1].Status = flowstore.PhaseNeedsAttention
+	recovered.Phases[len(recovered.Phases)-1].Notes = "sync linked plan phase: missing plan"
+	recovered.Merge = flowstore.Merge{Status: flowstore.MergePending}
+	m := flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{
+		LookupPRMerge: func(int, string) (actions.PullRequestMerge, error) {
+			return actions.PullRequestMerge{Commit: "0123456789abcdef", MergedAt: mergedAt}, nil
+		},
+		MarkFlowManualMerge: func(flowstore.ManualMergeUpdate) (flowstore.FlowRecord, error) {
+			return recovered, errors.New("sync linked plan phase: missing plan")
+		},
+	}), []flowstore.FlowRecord{flow})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("confirming manual merge should return command")
+	}
+	m, _ = update(m, cmd())
+
+	got := m.Flows()
+	if len(got) != 1 {
+		t.Fatalf("Flows() length = %d, want 1", len(got))
+	}
+	mergePhase := phaseByID(got[0], "merge")
+	if mergePhase.Status != flowstore.PhaseNeedsAttention || !strings.Contains(mergePhase.Notes, "missing plan") {
+		t.Fatalf("manual merge failure did not replace recovered flow state: %#v", got[0])
+	}
+	if strings.Contains(m.View(), "M      mark merged") {
+		t.Fatalf("recovered needs_attention Flow should not advertise manual merge:\n%s", m.View())
+	}
+}
+
 func TestModel_ShiftMManualMergeRemovesMergedRecordFromActiveFlows(t *testing.T) {
 	flow := manualMergeEligibleFlow()
 	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -485,6 +485,10 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.flowSurfaceVisible() {
 			return m.handleToggleFlowAutoMode()
 		}
+	case "M":
+		if m.flowSurfaceVisible() {
+			return m.handleMarkFlowManuallyMerged()
+		}
 	case "N":
 		if m.mode == ui.ModeWorktrees {
 			return m.handleNewWorktree(true)
@@ -565,6 +569,8 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleOpenFlowPlanText()
 	case "m":
 		return m.handleToggleFlowAutoMode()
+	case "M":
+		return m.handleMarkFlowManuallyMerged()
 	case "y":
 		return m.handleCopyFlowWorktreePath()
 	case "r":
@@ -844,6 +850,83 @@ func (m Model) setFlowAutoModeCmd(repoPath, flowID string, enabled bool) tea.Cmd
 			FlowID:   flowID,
 			Flow:     flow,
 			Enabled:  enabled,
+		}
+	}
+}
+
+func (m Model) handleMarkFlowManuallyMerged() (tea.Model, tea.Cmd) {
+	record, repoPath, ok := m.selectedManualMergeFlow()
+	if !ok {
+		return m, nil
+	}
+	m.modal = modal.OpenConfirm(fmt.Sprintf("Mark PR #%d as merged? (y/n)", record.PR.Number), func() tea.Cmd {
+		return m.markFlowManuallyMergedCmd(repoPath, record)
+	})
+	return m, nil
+}
+
+func (m Model) selectedManualMergeFlow() (flowstore.FlowRecord, string, bool) {
+	if !m.flowSurfaceVisible() || m.currentSelectedFlowPhaseID() != "" {
+		return flowstore.FlowRecord{}, "", false
+	}
+	record, ok := m.selectedFlow()
+	if !ok || record.FlowID == "" {
+		return flowstore.FlowRecord{}, "", false
+	}
+	repoPath := record.RepoPath
+	if repoPath == "" {
+		repoPath, _ = m.currentRepoPath()
+	}
+	if repoPath == "" || !flowManualMergeEligible(record) {
+		return flowstore.FlowRecord{}, "", false
+	}
+	return record, repoPath, true
+}
+
+func flowManualMergeEligible(record flowstore.FlowRecord) bool {
+	if record.Status == flowstore.StatusMerged || !flowstore.HasPRTarget(record.PR) {
+		return false
+	}
+	merge, ok := flowRecordPhaseByID(record, "merge")
+	if !ok || !flowstore.PhasePredecessorsSatisfied(record, merge.PhaseID) {
+		return false
+	}
+	switch merge.Status {
+	case flowstore.PhaseReady, flowstore.PhaseRunning:
+		return true
+	case flowstore.PhaseCompleted:
+		return record.Merge.Status == flowstore.MergePending || record.Merge.Status == flowstore.MergeMerged
+	default:
+		return false
+	}
+}
+
+func (m Model) markFlowManuallyMergedCmd(repoPath string, record flowstore.FlowRecord) tea.Cmd {
+	return func() tea.Msg {
+		merge, err := m.lookupPRMerge(record.PR.Number, record.PR.URL)
+		if err != nil {
+			return FlowManualMergeSetFailedMsg{
+				RepoPath: repoPath,
+				FlowID:   record.FlowID,
+				Err:      fmt.Sprintf("failed to verify PR merge: %v", err),
+			}
+		}
+		flow, err := m.markFlowManualMerge(flowstore.ManualMergeUpdate{
+			FlowID:   record.FlowID,
+			Commit:   merge.Commit,
+			MergedAt: merge.MergedAt,
+		})
+		if err != nil {
+			return FlowManualMergeSetFailedMsg{
+				RepoPath: repoPath,
+				FlowID:   record.FlowID,
+				Err:      fmt.Sprintf("failed to mark Flow as merged: %v", err),
+			}
+		}
+		return FlowManualMergeSetMsg{
+			RepoPath: repoPath,
+			FlowID:   record.FlowID,
+			Flow:     flow,
 		}
 	}
 }

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -892,7 +892,7 @@ func flowManualMergeEligible(record flowstore.FlowRecord) bool {
 		return false
 	}
 	switch merge.Status {
-	case flowstore.PhaseReady, flowstore.PhaseRunning:
+	case flowstore.PhaseReady:
 		return true
 	case flowstore.PhaseCompleted:
 		return record.Merge.Status == flowstore.MergePending || record.Merge.Status == flowstore.MergeMerged
@@ -920,6 +920,7 @@ func (m Model) markFlowManuallyMergedCmd(repoPath string, record flowstore.FlowR
 			return FlowManualMergeSetFailedMsg{
 				RepoPath: repoPath,
 				FlowID:   record.FlowID,
+				Flow:     flow,
 				Err:      fmt.Sprintf("failed to mark Flow as merged: %v", err),
 			}
 		}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -918,6 +918,8 @@ func (m Model) markFlowManuallyMergedCmd(repoPath string, record flowstore.FlowR
 		}
 		flow, err := m.markFlowManualMerge(flowstore.ManualMergeUpdate{
 			FlowID:   record.FlowID,
+			PRNumber: record.PR.Number,
+			PRURL:    record.PR.URL,
 			Commit:   merge.Commit,
 			MergedAt: merge.MergedAt,
 		})

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -317,6 +317,7 @@ type FlowManualMergeSetMsg struct {
 type FlowManualMergeSetFailedMsg struct {
 	RepoPath string
 	FlowID   string
+	Flow     flowstore.FlowRecord
 	Err      string
 }
 
@@ -1385,6 +1386,9 @@ func (m Model) handleFlowManualMergeSetFailed(msg FlowManualMergeSetFailedMsg) M
 	errText := strings.TrimSpace(msg.Err)
 	if errText == "" {
 		errText = "failed to mark Flow as merged"
+	}
+	if msg.Flow.FlowID != "" {
+		m = m.replaceFlowRecord(msg.Flow)
 	}
 	return m.setStatus(statusOther, errText)
 }

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -308,6 +308,18 @@ type FlowAutoModeSetFailedMsg struct {
 	Err      string
 }
 
+type FlowManualMergeSetMsg struct {
+	RepoPath string
+	FlowID   string
+	Flow     flowstore.FlowRecord
+}
+
+type FlowManualMergeSetFailedMsg struct {
+	RepoPath string
+	FlowID   string
+	Err      string
+}
+
 type PlanReadResultMsg struct {
 	RepoPath    string
 	PlanID      string
@@ -1355,6 +1367,24 @@ func (m Model) handleFlowAutoModeSetFailed(msg FlowAutoModeSetFailedMsg) Model {
 	errText := strings.TrimSpace(msg.Err)
 	if errText == "" {
 		errText = "failed to set Flow auto mode"
+	}
+	return m.setStatus(statusOther, errText)
+}
+
+func (m Model) handleFlowManualMergeSet(msg FlowManualMergeSetMsg) Model {
+	if msg.FlowID == "" || (!m.activeFlowSurfaceVisible() && !m.isCurrentRepo(msg.RepoPath)) {
+		return m
+	}
+	return m.replaceFlowRecord(msg.Flow)
+}
+
+func (m Model) handleFlowManualMergeSetFailed(msg FlowManualMergeSetFailedMsg) Model {
+	if !m.activeFlowSurfaceVisible() && !m.isCurrentRepo(msg.RepoPath) {
+		return m
+	}
+	errText := strings.TrimSpace(msg.Err)
+	if errText == "" {
+		errText = "failed to mark Flow as merged"
 	}
 	return m.setStatus(statusOther, errText)
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -218,103 +218,104 @@ const StashPrefixWidth = 15
 
 // RenderParams holds everything the renderer needs.
 type RenderParams struct {
-	Repos                       []scanner.Repo
-	ActiveTerminalRepoPaths     map[string]bool
-	Selected                    int
-	Width                       int
-	Height                      int
-	Mode                        Mode
-	ActiveFlows                 bool
-	Branches                    []gitquery.BranchRow
-	Stashes                     []gitquery.Stash
-	BranchSelected              int
-	StashSelected               int
-	Overlay                     OverlayState
-	OverlayDiff                 string
-	OverlayScroll               int
-	ConfirmPrompt               string
-	ConfirmForce                bool
-	InputPrompt                 string
-	InputPlaceholder            string
-	InputValue                  string
-	InputError                  string
-	InputMode                   InputMode
-	InputHeight                 int
-	InputCursor                 int
-	WorktreeInputPrompt         string
-	WorktreeInputPlaceholder    string
-	WorktreeInput               string
-	WorktreeInputErr            string
-	SelectPrompt                string
-	SelectItems                 []SelectItem
-	SelectSelected              int
-	SelectWidth                 int
-	SelectHeight                int
-	SelectPlacement             SelectPlacement
-	Form                        FormView
-	BranchScroll                int
-	RepoScroll                  int
-	StashScroll                 int
-	ActivePane                  int
-	Destructive                 bool
-	Worktrees                   []gitquery.Worktree
-	WorktreeSelected            int
-	WorktreeScroll              int
-	WorktreeSessions            []sessions.SessionRecord
-	WorktreeSessionSelected     int
-	WorktreeSessionScroll       int
-	InlineWorktreeSessions      bool
-	Commits                     []gitquery.Commit
-	CommitSelected              int
-	CommitScroll                int
-	Reflogs                     []gitquery.ReflogEntry
-	ReflogSelected              int
-	ReflogScroll                int
-	Sessions                    []sessions.SessionRecord
-	SessionSelected             int
-	SessionScroll               int
-	EmbeddedTerminals           []EmbeddedTerminalTab
-	EmbeddedTerminalLines       []string
-	EmbeddedTerminalPrefix      bool
-	Plans                       []planstore.PlanRecord
-	PlanSelected                int
-	PlanScroll                  int
-	Flows                       []flowstore.FlowRecord
-	FlowSelected                int
-	FlowScroll                  int
-	FlowEmbeddedTerminals       []EmbeddedTerminalTab
-	FlowEmbeddedTerminalLines   []string
-	FlowEmbeddedTerminalPrefix  bool
-	FlowTerminalActivity        []FlowTerminalActivity
-	FlowTerminalFocused         bool
-	ExpandedPlanID              string
-	ExpandedFlowID              string
-	SelectedPlanPhaseID         string
-	SelectedFlowPhaseID         string
-	FlowHeadless                bool
-	FlowAutoModeSelected        bool
-	FlowAgentLabel              string
-	FlowReasoningEffort         string
-	DefaultViewLabel            string
-	FlowNextLaunchReady         bool
-	FlowPhaseResetReadySelected bool
-	FlowPhaseResumableSelected  bool
-	OverlayText                 string
-	TransientError              string
-	TransientErrorFadeStep      int
-	SearchActive                bool
-	RepoSearch                  string
-	ItemSearch                  string
-	RepoEmptyMessage            string
-	RightEmptyMessage           string
-	FetchAvailable              bool
-	FetchVisibleAvailable       bool
-	RepoCreateAvailable         bool
-	PullAvailable               bool
-	WorktreeMoveAvailable       bool
-	WorktreeSessionsOpen        bool
-	AgentAvailable              bool
-	NewAgentAvailable           bool
+	Repos                        []scanner.Repo
+	ActiveTerminalRepoPaths      map[string]bool
+	Selected                     int
+	Width                        int
+	Height                       int
+	Mode                         Mode
+	ActiveFlows                  bool
+	Branches                     []gitquery.BranchRow
+	Stashes                      []gitquery.Stash
+	BranchSelected               int
+	StashSelected                int
+	Overlay                      OverlayState
+	OverlayDiff                  string
+	OverlayScroll                int
+	ConfirmPrompt                string
+	ConfirmForce                 bool
+	InputPrompt                  string
+	InputPlaceholder             string
+	InputValue                   string
+	InputError                   string
+	InputMode                    InputMode
+	InputHeight                  int
+	InputCursor                  int
+	WorktreeInputPrompt          string
+	WorktreeInputPlaceholder     string
+	WorktreeInput                string
+	WorktreeInputErr             string
+	SelectPrompt                 string
+	SelectItems                  []SelectItem
+	SelectSelected               int
+	SelectWidth                  int
+	SelectHeight                 int
+	SelectPlacement              SelectPlacement
+	Form                         FormView
+	BranchScroll                 int
+	RepoScroll                   int
+	StashScroll                  int
+	ActivePane                   int
+	Destructive                  bool
+	Worktrees                    []gitquery.Worktree
+	WorktreeSelected             int
+	WorktreeScroll               int
+	WorktreeSessions             []sessions.SessionRecord
+	WorktreeSessionSelected      int
+	WorktreeSessionScroll        int
+	InlineWorktreeSessions       bool
+	Commits                      []gitquery.Commit
+	CommitSelected               int
+	CommitScroll                 int
+	Reflogs                      []gitquery.ReflogEntry
+	ReflogSelected               int
+	ReflogScroll                 int
+	Sessions                     []sessions.SessionRecord
+	SessionSelected              int
+	SessionScroll                int
+	EmbeddedTerminals            []EmbeddedTerminalTab
+	EmbeddedTerminalLines        []string
+	EmbeddedTerminalPrefix       bool
+	Plans                        []planstore.PlanRecord
+	PlanSelected                 int
+	PlanScroll                   int
+	Flows                        []flowstore.FlowRecord
+	FlowSelected                 int
+	FlowScroll                   int
+	FlowEmbeddedTerminals        []EmbeddedTerminalTab
+	FlowEmbeddedTerminalLines    []string
+	FlowEmbeddedTerminalPrefix   bool
+	FlowTerminalActivity         []FlowTerminalActivity
+	FlowTerminalFocused          bool
+	ExpandedPlanID               string
+	ExpandedFlowID               string
+	SelectedPlanPhaseID          string
+	SelectedFlowPhaseID          string
+	FlowHeadless                 bool
+	FlowAutoModeSelected         bool
+	FlowAgentLabel               string
+	FlowReasoningEffort          string
+	DefaultViewLabel             string
+	FlowNextLaunchReady          bool
+	FlowManualMergeReadySelected bool
+	FlowPhaseResetReadySelected  bool
+	FlowPhaseResumableSelected   bool
+	OverlayText                  string
+	TransientError               string
+	TransientErrorFadeStep       int
+	SearchActive                 bool
+	RepoSearch                   string
+	ItemSearch                   string
+	RepoEmptyMessage             string
+	RightEmptyMessage            string
+	FetchAvailable               bool
+	FetchVisibleAvailable        bool
+	RepoCreateAvailable          bool
+	PullAvailable                bool
+	WorktreeMoveAvailable        bool
+	WorktreeSessionsOpen         bool
+	AgentAvailable               bool
+	NewAgentAvailable            bool
 }
 
 func FlowSplitPanelHeights(height int) (listHeight, terminalHeight int) {
@@ -481,60 +482,61 @@ func renderApplication(p RenderParams) string {
 	planPhaseSelected := selectedPlanPhaseID != ""
 	flowPhaseSelected := selectedFlowPhaseID != ""
 	status := statusBarParams{
-		Width:                       p.Width,
-		Mode:                        p.Mode,
-		ActiveFlows:                 activeFlows,
-		Overlay:                     p.Overlay,
-		InputMode:                   inputRenderParamsFrom(p).mode,
-		FormHasMultiline:            formHasMultilineField(p.Form),
-		WorktreeInputPrompt:         p.WorktreeInputPrompt,
-		ActivePane:                  p.ActivePane,
-		Destructive:                 p.Destructive,
-		RepoSelected:                repoPath != "",
-		WorktreeSelected:            worktreeSelected,
-		StaleSelected:               staleSelected,
-		DirtySelected:               dirtySelected,
-		LockedSelected:              lockedSelected,
-		WorktreeDeletableSelected:   worktreeDeletableSelected,
-		WorktreeOpenableSelected:    worktreeOpenableSelected,
-		WorktreeMoveSelected:        worktreeMoveSelected,
-		WorktreeSessionsOpen:        p.WorktreeSessionsOpen,
-		WorktreeSessionSelected:     worktreeSessionSelected,
-		BranchDirtySelected:         branchDirtySelected,
-		BranchDeletableSelected:     branchDeletableSelected,
-		BranchOpenableSelected:      branchOpenableSelected,
-		StashSelected:               stashSelected,
-		CommitSelected:              commitSelected,
-		ReflogSelected:              reflogSelected,
-		SessionSelected:             sessionSelected,
-		EmbeddedTerminalActive:      terminalShortcutsActive,
-		EmbeddedTerminalPrefix:      p.EmbeddedTerminalPrefix || p.FlowEmbeddedTerminalPrefix,
-		PlanSelected:                planSelected,
-		PlanPhaseSelected:           planPhaseSelected,
-		FlowSelected:                flowSelected,
-		FlowPhaseSelected:           flowPhaseSelected,
-		FlowDeletableSelected:       flowDeletableSelected,
-		FlowWorktreePathSelected:    flowWorktreePathSelected,
-		FlowPlanLinked:              flowPlanLinked,
-		FlowHeadless:                p.FlowHeadless,
-		FlowAutoModeSelected:        flowAutoModeSelected,
-		FlowAgentLabel:              p.FlowAgentLabel,
-		FlowReasoningEffort:         p.FlowReasoningEffort,
-		DefaultViewLabel:            p.DefaultViewLabel,
-		FlowNextLaunchReady:         p.FlowNextLaunchReady,
-		FlowPhaseResetReadySelected: p.FlowPhaseResetReadySelected,
-		FlowPhaseResumableSelected:  p.FlowPhaseResumableSelected,
-		TransientError:              p.TransientError,
-		TransientErrorFadeStep:      p.TransientErrorFadeStep,
-		SearchActive:                p.SearchActive,
-		RepoSearch:                  p.RepoSearch,
-		ItemSearch:                  p.ItemSearch,
-		FetchAvailable:              p.FetchAvailable,
-		FetchVisibleAvailable:       p.FetchVisibleAvailable,
-		RepoCreateAvailable:         p.RepoCreateAvailable,
-		PullAvailable:               p.PullAvailable,
-		AgentAvailable:              p.AgentAvailable,
-		NewAgent:                    p.NewAgentAvailable,
+		Width:                        p.Width,
+		Mode:                         p.Mode,
+		ActiveFlows:                  activeFlows,
+		Overlay:                      p.Overlay,
+		InputMode:                    inputRenderParamsFrom(p).mode,
+		FormHasMultiline:             formHasMultilineField(p.Form),
+		WorktreeInputPrompt:          p.WorktreeInputPrompt,
+		ActivePane:                   p.ActivePane,
+		Destructive:                  p.Destructive,
+		RepoSelected:                 repoPath != "",
+		WorktreeSelected:             worktreeSelected,
+		StaleSelected:                staleSelected,
+		DirtySelected:                dirtySelected,
+		LockedSelected:               lockedSelected,
+		WorktreeDeletableSelected:    worktreeDeletableSelected,
+		WorktreeOpenableSelected:     worktreeOpenableSelected,
+		WorktreeMoveSelected:         worktreeMoveSelected,
+		WorktreeSessionsOpen:         p.WorktreeSessionsOpen,
+		WorktreeSessionSelected:      worktreeSessionSelected,
+		BranchDirtySelected:          branchDirtySelected,
+		BranchDeletableSelected:      branchDeletableSelected,
+		BranchOpenableSelected:       branchOpenableSelected,
+		StashSelected:                stashSelected,
+		CommitSelected:               commitSelected,
+		ReflogSelected:               reflogSelected,
+		SessionSelected:              sessionSelected,
+		EmbeddedTerminalActive:       terminalShortcutsActive,
+		EmbeddedTerminalPrefix:       p.EmbeddedTerminalPrefix || p.FlowEmbeddedTerminalPrefix,
+		PlanSelected:                 planSelected,
+		PlanPhaseSelected:            planPhaseSelected,
+		FlowSelected:                 flowSelected,
+		FlowPhaseSelected:            flowPhaseSelected,
+		FlowDeletableSelected:        flowDeletableSelected,
+		FlowWorktreePathSelected:     flowWorktreePathSelected,
+		FlowPlanLinked:               flowPlanLinked,
+		FlowHeadless:                 p.FlowHeadless,
+		FlowAutoModeSelected:         flowAutoModeSelected,
+		FlowAgentLabel:               p.FlowAgentLabel,
+		FlowReasoningEffort:          p.FlowReasoningEffort,
+		DefaultViewLabel:             p.DefaultViewLabel,
+		FlowNextLaunchReady:          p.FlowNextLaunchReady,
+		FlowManualMergeReadySelected: p.FlowManualMergeReadySelected && flowSelected && !flowPhaseSelected,
+		FlowPhaseResetReadySelected:  p.FlowPhaseResetReadySelected,
+		FlowPhaseResumableSelected:   p.FlowPhaseResumableSelected,
+		TransientError:               p.TransientError,
+		TransientErrorFadeStep:       p.TransientErrorFadeStep,
+		SearchActive:                 p.SearchActive,
+		RepoSearch:                   p.RepoSearch,
+		ItemSearch:                   p.ItemSearch,
+		FetchAvailable:               p.FetchAvailable,
+		FetchVisibleAvailable:        p.FetchVisibleAvailable,
+		RepoCreateAvailable:          p.RepoCreateAvailable,
+		PullAvailable:                p.PullAvailable,
+		AgentAvailable:               p.AgentAvailable,
+		NewAgent:                     p.NewAgentAvailable,
 	}
 	innerHeight := p.Height - 3 // status bar + top/bottom borders
 	activeStatusQuery := hasActiveStatusQuery(status)
@@ -757,61 +759,62 @@ func RenderStatusBar(width int, mode Mode, overlay OverlayState, activePane int,
 // statusBarParams groups the many fields the status-bar renderer needs,
 // avoiding a long and error-prone positional parameter list.
 type statusBarParams struct {
-	Width                       int
-	Mode                        Mode
-	ActiveFlows                 bool
-	Overlay                     OverlayState
-	InputMode                   InputMode
-	FormHasMultiline            bool
-	WorktreeInputPrompt         string
-	SelectPrompt                string
-	ActivePane                  int
-	Destructive                 bool
-	RepoSelected                bool
-	WorktreeSelected            bool
-	StaleSelected               bool
-	DirtySelected               bool
-	LockedSelected              bool
-	WorktreeDeletableSelected   bool
-	WorktreeOpenableSelected    bool
-	WorktreeMoveSelected        bool
-	WorktreeSessionsOpen        bool
-	WorktreeSessionSelected     bool
-	BranchDirtySelected         bool
-	BranchDeletableSelected     bool
-	BranchOpenableSelected      bool
-	StashSelected               bool
-	CommitSelected              bool
-	ReflogSelected              bool
-	SessionSelected             bool
-	EmbeddedTerminalActive      bool
-	EmbeddedTerminalPrefix      bool
-	PlanSelected                bool
-	PlanPhaseSelected           bool
-	FlowSelected                bool
-	FlowPhaseSelected           bool
-	FlowDeletableSelected       bool
-	FlowWorktreePathSelected    bool
-	FlowPlanLinked              bool
-	FlowHeadless                bool
-	FlowAutoModeSelected        bool
-	FlowAgentLabel              string
-	FlowReasoningEffort         string
-	DefaultViewLabel            string
-	FlowNextLaunchReady         bool
-	FlowPhaseResetReadySelected bool
-	FlowPhaseResumableSelected  bool
-	TransientError              string
-	TransientErrorFadeStep      int
-	SearchActive                bool
-	RepoSearch                  string
-	ItemSearch                  string
-	FetchAvailable              bool
-	FetchVisibleAvailable       bool
-	RepoCreateAvailable         bool
-	PullAvailable               bool
-	AgentAvailable              bool
-	NewAgent                    bool
+	Width                        int
+	Mode                         Mode
+	ActiveFlows                  bool
+	Overlay                      OverlayState
+	InputMode                    InputMode
+	FormHasMultiline             bool
+	WorktreeInputPrompt          string
+	SelectPrompt                 string
+	ActivePane                   int
+	Destructive                  bool
+	RepoSelected                 bool
+	WorktreeSelected             bool
+	StaleSelected                bool
+	DirtySelected                bool
+	LockedSelected               bool
+	WorktreeDeletableSelected    bool
+	WorktreeOpenableSelected     bool
+	WorktreeMoveSelected         bool
+	WorktreeSessionsOpen         bool
+	WorktreeSessionSelected      bool
+	BranchDirtySelected          bool
+	BranchDeletableSelected      bool
+	BranchOpenableSelected       bool
+	StashSelected                bool
+	CommitSelected               bool
+	ReflogSelected               bool
+	SessionSelected              bool
+	EmbeddedTerminalActive       bool
+	EmbeddedTerminalPrefix       bool
+	PlanSelected                 bool
+	PlanPhaseSelected            bool
+	FlowSelected                 bool
+	FlowPhaseSelected            bool
+	FlowDeletableSelected        bool
+	FlowWorktreePathSelected     bool
+	FlowPlanLinked               bool
+	FlowHeadless                 bool
+	FlowAutoModeSelected         bool
+	FlowAgentLabel               string
+	FlowReasoningEffort          string
+	DefaultViewLabel             string
+	FlowNextLaunchReady          bool
+	FlowManualMergeReadySelected bool
+	FlowPhaseResetReadySelected  bool
+	FlowPhaseResumableSelected   bool
+	TransientError               string
+	TransientErrorFadeStep       int
+	SearchActive                 bool
+	RepoSearch                   string
+	ItemSearch                   string
+	FetchAvailable               bool
+	FetchVisibleAvailable        bool
+	RepoCreateAvailable          bool
+	PullAvailable                bool
+	AgentAvailable               bool
+	NewAgent                     bool
 }
 
 type shortcutHint struct {
@@ -1298,6 +1301,9 @@ func flowShortcutSections(sp statusBarParams, actions, navigation, global []shor
 			if sp.FlowNextLaunchReady {
 				actions = append(actions, shortcutHint{Key: "g", Label: "launch next"})
 			}
+			if !sp.FlowPhaseSelected && sp.FlowManualMergeReadySelected {
+				actions = append(actions, shortcutHint{Key: "M", Label: "mark merged"})
+			}
 			if sp.FlowPhaseSelected && sp.FlowPhaseResetReadySelected {
 				actions = append(actions, shortcutHint{Key: "x", Label: "reset ready"})
 			}
@@ -1561,14 +1567,14 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 	tinyBase := footerHintsForKeys(hints, "q/esc")
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
-	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "g", "d")
-	coreActionsWithoutSafety := footerHintsForKeys(hints, "h", "enter", "g", "d")
-	coreActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "d", "m")
-	coreActionsWithAutoWithoutSafety := footerHintsForKeys(hints, "h", "enter", "g", "d", "m")
-	selectedActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "x", "o", "y", "d", "r", "m")
-	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "E", "f", "F")
-	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "f", "F")
-	actionsWithoutAgentAndEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "f", "F")
+	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "g", "M", "d")
+	coreActionsWithoutSafety := footerHintsForKeys(hints, "h", "enter", "g", "M", "d")
+	coreActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "M", "d", "m")
+	coreActionsWithAutoWithoutSafety := footerHintsForKeys(hints, "h", "enter", "g", "M", "d", "m")
+	selectedActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "M", "x", "o", "y", "d", "r", "m")
+	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "M", "x", "o", "y", "d", "r", "m", "A", "E", "f", "F")
+	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "M", "x", "o", "y", "d", "r", "m", "A", "f", "F")
+	actionsWithoutAgentAndEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "M", "x", "o", "y", "d", "r", "m", "f", "F")
 
 	for _, parts := range [][]string{
 		appendParts(base, upDown, arrow, actions),

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -921,6 +921,34 @@ func TestStatusBar_FlowsModeShowsPhaseToggleHintForSelectedFlow(t *testing.T) {
 	}
 }
 
+func TestStatusBar_FlowsModeShowsManualMergeOnlyForEligibleFlowRow(t *testing.T) {
+	base := statusBarParams{
+		Width:                        160,
+		Mode:                         ModeFlows,
+		ActivePane:                   1,
+		RepoSelected:                 true,
+		FlowSelected:                 true,
+		FlowManualMergeReadySelected: true,
+	}
+	flowRow := renderStatusBarWithState(base)
+	if !strings.Contains(flowRow, "M: mark merged") {
+		t.Fatalf("eligible Flow row should expose manual merge shortcut, got %q", flowRow)
+	}
+
+	base.FlowPhaseSelected = true
+	phaseRow := renderStatusBarWithState(base)
+	if strings.Contains(phaseRow, "mark merged") {
+		t.Fatalf("selected Flow phase should hide manual merge shortcut, got %q", phaseRow)
+	}
+
+	base.FlowPhaseSelected = false
+	base.FlowManualMergeReadySelected = false
+	ineligible := renderStatusBarWithState(base)
+	if strings.Contains(ineligible, "mark merged") {
+		t.Fatalf("ineligible Flow row should hide manual merge shortcut, got %q", ineligible)
+	}
+}
+
 func TestStatusBar_FlowsModeFullFooterPreservesSectionOrder(t *testing.T) {
 	bar := renderStatusBarWithState(statusBarParams{
 		Width:                    240,


### PR DESCRIPTION
## Summary
- add a manual Flow PR merge action that records GitHub merge metadata without launching the merge phase
- recover missing PR status from GitHub when needed and surface stale/failure states in the Flow UI
- document the shortcut, config behavior, and phase semantics

## Verification
- gofmt -l .
- make test
- make build