### PR TITLE
Add Flow ID copy shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ filter matches, or a load failure with details in the status bar.
 | `f` | Fetch with `--prune` (worktrees and branches views) |
 | `F` | Pull with `--ff-only` (worktrees, and branches with a checked-out worktree) |
 | `t` | Open or attach to a tmux/Zellij session for the worktree |
-| `c` | Open VSCode at worktree path |
+| `c` | Open VSCode at worktree path outside Flow surfaces, or copy the selected Flow ID in flows and active flows views |
 | `x` | Show/hide sessions for the selected worktree (worktrees view), expand/collapse plan phase rows, or reset a selected `await-session` Flow phase after confirmation |
 | `y` | Copy hash to clipboard (history/reflog view), selected agent session ID (sessions view), plan Markdown path (plans view), or selected Flow worktree path (flows view) |
 | `r` | Resume selected agent session (sessions view; CLI agents embed in-pane) or selected attached Flow phase session (flows view) |
@@ -353,8 +353,9 @@ the phase list. Press
 canonical phase order. This action
 uses the selected Flow, so a highlighted pending phase row can still launch an
 earlier ready sibling, and nothing is persisted when no phase is launchable.
-Press `y` to copy the selected Flow worktree path from either a Flow row or one
-of its expanded phase rows. Press `r` on an expanded phase row with an
+Press `c` to copy the selected Flow ID, and press `y` to copy the selected Flow
+worktree path, from either a Flow row or one of its expanded phase rows. Press
+`r` on an expanded phase row with an
 attached provider session to resume that session; CLI resumes are recorded as a
 fresh Flow phase launch attempt, while `codex-app` resumes navigate to the
 existing app thread without extra launch tracking. Press `m` on a Flow row or
@@ -377,7 +378,8 @@ Browse active Flow records across all repos. This view hides merged Flow records
 moving focus to the left repo pane temporarily filters the visible active rows to
 the selected repo, and returning focus to the middle pane restores the global
 list. Normal Flow actions, phase launches, attached-session resumes, auto-mode
-toggles, and embedded Flow terminals work from the visible active Flow rows.
+toggles, `c` Flow ID copy, `y` worktree path copy, and embedded Flow terminals
+work from the visible active Flow rows and their expanded phase rows.
 
 Flow headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in a runtime-only embedded

--- a/docs/config.md
+++ b/docs/config.md
@@ -344,11 +344,12 @@ is set. The pane shows linked plan
 IDs when present; press `n` to create a new Flow. On a Flow row or expanded
 phase row, `enter` expands or collapses read-only phase detail rows; `o` opens
 the linked plan body from the selected Flow. Press `g` to launch the first
-launchable phase for the selected Flow. Press `y` to copy the selected Flow
-worktree path from either a Flow row or one of its expanded phase rows. Press
-`m` to toggle per-Flow auto mode. New Flow records start with auto mode on, and
-the toggle is persisted on each Flow. Flows created before this field existed
-remain manual until auto mode is toggled on. When auto mode is on, completed
+launchable phase for the selected Flow. Press `c` to copy the selected Flow ID,
+and press `y` to copy the selected Flow worktree path, from either a Flow row or
+one of its expanded phase rows. Press `m` to toggle per-Flow auto mode. New Flow
+records start with auto mode on, and the toggle is persisted on each Flow. Flows
+created before this field existed remain manual until auto mode is toggled on.
+When auto mode is on, completed
 CLI phases running in an embedded Flow terminal advance only after the completed
 phase's terminal exits normally and auto-closes; terminal exit also triggers a
 Flow refresh so newly persisted completion state is discovered without waiting
@@ -358,8 +359,8 @@ The active flows pane (mode `9`) shows active Flows across all repos and hides
 merged Flow records. Moving focus to the left repo pane temporarily filters the
 visible active rows to the selected repo, and returning focus to the middle pane
 restores the global list. It supports the same Flow actions, phase launches,
-attached-session resumes, auto-mode toggles, and embedded Flow terminal
-management as the flows pane.
+attached-session resumes, auto-mode toggles, `c` Flow ID copy, `y` worktree path
+copy, and embedded Flow terminal management as the flows pane.
 Headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in an embedded terminal
 inside the flows pane. Press `h` to choose the CLI command mode: headless runs

--- a/model/model.go
+++ b/model/model.go
@@ -104,6 +104,7 @@ type Model struct {
 	readPlan                   func(string) (string, error)
 	planMarkdownPath           func(string) (string, error)
 	copyToClipboard            func(string) error
+	openCode                   func(string) error
 	pageText                   func(string) (actions.TerminalLaunchSpec, error)
 	editFile                   func(string) (actions.TerminalLaunchSpec, error)
 	saveAgent                  func(string) error
@@ -189,6 +190,7 @@ type Options struct {
 	ReadPlan                 func(string) (string, error)
 	PlanMarkdownPath         func(planID string) (string, error)
 	CopyToClipboard          func(text string) error
+	OpenCode                 func(path string) error
 	PageText                 func(body string) (actions.TerminalLaunchSpec, error)
 	EditFile                 func(path string) (actions.TerminalLaunchSpec, error)
 	SaveAgentCommand         func(string) error
@@ -327,6 +329,10 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if copyToClipboard == nil {
 		copyToClipboard = actions.CopyToClipboard
 	}
+	openCode := opts.OpenCode
+	if openCode == nil {
+		openCode = actions.OpenVSCode
+	}
 	pageText := opts.PageText
 	if pageText == nil {
 		pageText = actions.PageText
@@ -442,6 +448,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		readPlan:                 readPlan,
 		planMarkdownPath:         planMarkdownPath,
 		copyToClipboard:          copyToClipboard,
+		openCode:                 openCode,
 		pageText:                 pageText,
 		editFile:                 editFile,
 		saveAgent:                saveAgent,

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -3907,13 +3907,33 @@ func TestModel_CKeyDoesNothingWhenSelectedFlowIDIsBlank(t *testing.T) {
 	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}); cmd != nil {
 		t.Fatalf("blank Flow ID returned copy command %T, want nil", cmd)
 	}
+
+	m = enterActiveFlowsWithRecords(t, m, nil)
+	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}); cmd != nil {
+		t.Fatalf("empty active Flow pane returned copy command %T, want nil", cmd)
+	}
+
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{{
+		FlowID: "  ",
+		Title:  "Blank active Flow ID",
+		Status: flowstore.StatusInProgress,
+	}})
+	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}); cmd != nil {
+		t.Fatalf("blank active Flow ID returned copy command %T, want nil", cmd)
+	}
 	if copied {
 		t.Fatal("blank Flow ID should not copy to clipboard")
 	}
 }
 
 func TestModel_CKeyStillOpensCodeOutsideFlowSurfaces(t *testing.T) {
-	m := model.New(testRepos())
+	var opened []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		OpenCode: func(path string) error {
+			opened = append(opened, path)
+			return nil
+		},
+	})
 	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 18})
 	m = inRightPane(m)
 	m, _ = update(m, model.WorktreeResultMsg{
@@ -3926,6 +3946,11 @@ func TestModel_CKeyStillOpensCodeOutsideFlowSurfaces(t *testing.T) {
 
 	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}); cmd == nil {
 		t.Fatal("expected non-flow c key to keep open-code command path")
+	} else {
+		_ = cmd()
+	}
+	if got := opened; !slices.Equal(got, []string{"/dev/alpha"}) {
+		t.Fatalf("opened code paths = %#v, want /dev/alpha", got)
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -3791,6 +3791,144 @@ func TestModel_YKeyDoesNothingWhenSelectedFlowWorktreePathIsBlank(t *testing.T) 
 	}
 }
 
+func TestModel_CKeyCopiesSelectedFlowID(t *testing.T) {
+	var copied []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		CopyToClipboard: func(text string) error {
+			copied = append(copied, text)
+			return nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID: "flow-1",
+		Title:  "Copy flow ID",
+		Status: flowstore.StatusInProgress,
+	}})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	if cmd == nil {
+		t.Fatal("expected flow ID copy command")
+	}
+	_ = cmd()
+	if got := copied[len(copied)-1]; got != "flow-1" {
+		t.Fatalf("copied Flow ID = %q, want flow-1", got)
+	}
+}
+
+func TestModel_CKeyCopiesParentFlowIDFromSelectedPhaseRow(t *testing.T) {
+	var copied []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		CopyToClipboard: func(text string) error {
+			copied = append(copied, text)
+			return nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	if cmd == nil {
+		t.Fatal("expected selected phase to copy parent Flow ID")
+	}
+	_ = cmd()
+	if got := copied[len(copied)-1]; got != "flow-1" {
+		t.Fatalf("copied selected phase parent Flow ID = %q, want flow-1", got)
+	}
+}
+
+func TestModel_CKeyCopiesSelectedActiveFlowID(t *testing.T) {
+	var copied []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		CopyToClipboard: func(text string) error {
+			copied = append(copied, text)
+			return nil
+		},
+	})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{{
+		FlowID: "active-flow",
+		Title:  "Copy active Flow ID",
+		Status: flowstore.StatusInProgress,
+	}})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	if cmd == nil {
+		t.Fatal("expected active Flow ID copy command")
+	}
+	_ = cmd()
+	if got := copied[len(copied)-1]; got != "active-flow" {
+		t.Fatalf("copied active Flow ID = %q, want active-flow", got)
+	}
+}
+
+func TestModel_CKeyCopiesParentActiveFlowIDFromSelectedPhaseRow(t *testing.T) {
+	var copied []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		CopyToClipboard: func(text string) error {
+			copied = append(copied, text)
+			return nil
+		},
+	})
+	flow := flowWithPhaseDetails()
+	flow.FlowID = "active-flow"
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	if cmd == nil {
+		t.Fatal("expected selected active Flow phase to copy parent Flow ID")
+	}
+	_ = cmd()
+	if got := copied[len(copied)-1]; got != "active-flow" {
+		t.Fatalf("copied selected active Flow phase parent Flow ID = %q, want active-flow", got)
+	}
+}
+
+func TestModel_CKeyDoesNothingWhenSelectedFlowIDIsBlank(t *testing.T) {
+	copied := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		CopyToClipboard: func(string) error {
+			copied = true
+			return nil
+		},
+	})
+
+	m = flowsInRightPane(t, m, nil)
+	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}); cmd != nil {
+		t.Fatalf("empty Flow pane returned copy command %T, want nil", cmd)
+	}
+
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID: "  ",
+		Title:  "Blank flow ID",
+		Status: flowstore.StatusInProgress,
+	}})
+	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}); cmd != nil {
+		t.Fatalf("blank Flow ID returned copy command %T, want nil", cmd)
+	}
+	if copied {
+		t.Fatal("blank Flow ID should not copy to clipboard")
+	}
+}
+
+func TestModel_CKeyStillOpensCodeOutsideFlowSurfaces(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 18})
+	m = inRightPane(m)
+	m, _ = update(m, model.WorktreeResultMsg{
+		RepoPath: "/dev/alpha",
+		Worktrees: []gitquery.Worktree{{
+			Path:       "/dev/alpha",
+			BranchName: "main",
+		}},
+	})
+
+	if _, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}}); cmd == nil {
+		t.Fatal("expected non-flow c key to keep open-code command path")
+	}
+}
+
 func TestModel_ExpandedFlowArrowKeysSelectPhaseRows(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := flowsInRightPane(t, model.New(testRepos()), []flowstore.FlowRecord{flow})

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -510,6 +510,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 	case "t":
 		return m.handleOpenTerminal()
 	case "c":
+		if m.flowSurfaceVisible() {
+			return m.handleCopyFlowID()
+		}
 		return m.handleOpenCode()
 	case "q", "ctrl+c", "esc":
 		return m.handleEmbeddedTerminalQuitPrefix()
@@ -567,6 +570,8 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleToggleFlowAutoMode()
 	case "y":
 		return m.handleCopyFlowWorktreePath()
+	case "c":
+		return m.handleCopyFlowID()
 	case "r":
 		return m.handleResumeFlowPhaseSession()
 	case "E":

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -2228,7 +2228,7 @@ func (m Model) handleOpenTerminal() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleOpenCode() (tea.Model, tea.Cmd) {
-	return m.openAtPath(actions.OpenVSCode)
+	return m.openAtPath(m.openCode)
 }
 
 func (m Model) pageBody(body string) (Model, tea.Cmd) {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1758,6 +1758,22 @@ func (m Model) handleCopyFlowWorktreePath() (tea.Model, tea.Cmd) {
 	}
 }
 
+func (m Model) handleCopyFlowID() (tea.Model, tea.Cmd) {
+	if !m.flowSurfaceVisible() {
+		return m, nil
+	}
+	flowID := m.selectedFlowID()
+	if strings.TrimSpace(flowID) == "" {
+		return m, nil
+	}
+	return m, func() tea.Msg {
+		if err := m.copyToClipboard(flowID); err != nil {
+			return ClipboardResultMsg{Err: err.Error()}
+		}
+		return ClipboardResultMsg{}
+	}
+}
+
 func (m Model) handleShowSessionSummary() (tea.Model, tea.Cmd) {
 	if m.mode != ui.ModeSessions {
 		return m, nil

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1304,6 +1304,7 @@ func flowShortcutSections(sp statusBarParams, actions, navigation, global []shor
 			if !sp.FlowPhaseSelected && sp.FlowPlanLinked {
 				actions = append(actions, shortcutHint{Key: "o", Label: "open"})
 			}
+			actions = append(actions, shortcutHint{Key: "c", Label: "copy id"})
 			if sp.FlowWorktreePathSelected {
 				actions = append(actions, shortcutHint{Key: "y", Label: "copy path"})
 			}
@@ -1388,6 +1389,9 @@ func shortcutSectionsForPane(sp statusBarParams, height int) []shortcutSection {
 	}
 	if (sp.Mode == ModeFlows || sp.Mode == ModeActiveFlows || sp.ActiveFlows) && !sp.FlowSelected && height <= 9 {
 		sections = withoutShortcutKeys(sections, "D", "n", "f5")
+	}
+	if (sp.Mode == ModeFlows || sp.Mode == ModeActiveFlows || sp.ActiveFlows) && sp.FlowSelected && height <= 12 {
+		sections = withoutShortcutKey(sections, "n")
 	}
 	if height < 20 {
 		return withoutShortcutKey(sections, "f5")

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -696,10 +696,13 @@ func TestStatusBar_ActiveFlowsHidesNewFlowHint(t *testing.T) {
 	if strings.Contains(bar, "n: new flow") {
 		t.Fatalf("active Flow status bar should not expose new flow, got %q", bar)
 	}
-	for _, want := range []string{"enter: phases", "g: launch next", "h: headless on", "o: open", "y: copy path"} {
+	for _, want := range []string{"enter: phases", "g: launch next", "h: headless on", "o: open", "c: copy id", "y: copy path"} {
 		if !strings.Contains(bar, want) {
 			t.Fatalf("active Flow status bar missing %q, got %q", want, bar)
 		}
+	}
+	if strings.Contains(bar, "c: code") {
+		t.Fatalf("active Flow status bar should not expose c: code, got %q", bar)
 	}
 }
 
@@ -900,7 +903,7 @@ func TestRender_FlowsModeReasoningEffortShortcutHandlesSpecialLabels(t *testing.
 
 func TestStatusBar_FlowsModeShowsPhaseToggleHintForSelectedFlow(t *testing.T) {
 	bar := renderStatusBarWithState(statusBarParams{
-		Width:                    120,
+		Width:                    240,
 		Mode:                     ModeFlows,
 		ActivePane:               1,
 		RepoSelected:             true,
@@ -909,15 +912,55 @@ func TestStatusBar_FlowsModeShowsPhaseToggleHintForSelectedFlow(t *testing.T) {
 		FlowPlanLinked:           true,
 		FlowHeadless:             true,
 	})
-	for _, want := range []string{"enter: phases", "h: headless on", "o: open", "y: copy path"} {
+	for _, want := range []string{"enter: phases", "h: headless on", "o: open", "c: copy id", "y: copy path"} {
 		if !strings.Contains(bar, want) {
 			t.Fatalf("expected selected flow hint %q, got %q", want, bar)
 		}
 	}
-	for _, notWant := range []string{"x: phases", "a: launch phase", "i: embed phase"} {
+	for _, notWant := range []string{"x: phases", "a: launch phase", "i: embed phase", "c: code"} {
 		if strings.Contains(bar, notWant) {
 			t.Fatalf("selected flow hint should not include %q, got %q", notWant, bar)
 		}
+	}
+}
+
+func TestStatusBar_FlowsModeShowsFlowIDCopyHintWithoutWorktreePath(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:        240,
+		Mode:         ModeFlows,
+		ActivePane:   1,
+		RepoSelected: true,
+		FlowSelected: true,
+		FlowHeadless: true,
+	})
+	if !strings.Contains(bar, "c: copy id") {
+		t.Fatalf("selected flow without worktree path should expose copy id, got %q", bar)
+	}
+	for _, notWant := range []string{"c: code", "y: copy path"} {
+		if strings.Contains(bar, notWant) {
+			t.Fatalf("selected flow without worktree path should not include %q, got %q", notWant, bar)
+		}
+	}
+}
+
+func TestStatusBar_ActiveFlowsModeShowsFlowIDCopyHint(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:                    240,
+		Mode:                     ModeActiveFlows,
+		ActiveFlows:              true,
+		ActivePane:               1,
+		RepoSelected:             true,
+		FlowSelected:             true,
+		FlowWorktreePathSelected: true,
+		FlowHeadless:             true,
+	})
+	for _, want := range []string{"c: copy id", "y: copy path"} {
+		if !strings.Contains(bar, want) {
+			t.Fatalf("active flows selected flow hint missing %q, got %q", want, bar)
+		}
+	}
+	if strings.Contains(bar, "c: code") {
+		t.Fatalf("active flows selected flow should not include c: code, got %q", bar)
 	}
 }
 
@@ -1189,12 +1232,12 @@ func TestRender_FlowsModeShowsLaunchAndHeadlessShortcutForLaunchableSelectedPhas
 	})
 
 	pane := shortcutPaneText(view)
-	for _, want := range []string{"enter  phases", "g      launch next", "h      headless off", "y      copy path"} {
+	for _, want := range []string{"enter  phases", "g      launch next", "h      headless off", "c      copy id", "y      copy path"} {
 		if !strings.Contains(pane, want) {
 			t.Fatalf("launchable selected Flow phase shortcut pane missing %q:\n%s", want, pane)
 		}
 	}
-	for _, notWant := range []string{"enter  launch phase", "x      phases", "a      launch phase", "i      embed phase", "y      copy id"} {
+	for _, notWant := range []string{"enter  launch phase", "x      phases", "a      launch phase", "i      embed phase", "c      code"} {
 		if strings.Contains(pane, notWant) {
 			t.Fatalf("launchable selected Flow phase shortcut pane should not include %q:\n%s", notWant, pane)
 		}

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -771,6 +771,7 @@ func TestRender_FlowsModeShortcutSectionsUseFlowGroups(t *testing.T) {
 		"enter  phases",
 		"g      launch next",
 		"o      open",
+		"c      copy id",
 		"y      copy path",
 		"d      delete",
 		"h      headless on",
@@ -834,6 +835,7 @@ func TestRender_ActiveFlowsShortcutSectionsHideNewFlow(t *testing.T) {
 		"enter  phases",
 		"g      launch next",
 		"o      open",
+		"c      copy id",
 		"y      copy path",
 		"h      headless on",
 		"m      auto: on",
@@ -940,6 +942,35 @@ func TestStatusBar_FlowsModeShowsFlowIDCopyHintWithoutWorktreePath(t *testing.T)
 		if strings.Contains(bar, notWant) {
 			t.Fatalf("selected flow without worktree path should not include %q, got %q", notWant, bar)
 		}
+	}
+}
+
+func TestRender_FlowsModeCompactSelectedFlowPrioritizesFlowActions(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:      []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:   0,
+		Width:      180,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: 1,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "Compact selected flow",
+			Status: flowstore.StatusInProgress,
+		}},
+		FlowSelected:         0,
+		FlowHeadless:         true,
+		FlowAutoModeSelected: true,
+	})
+
+	pane := shortcutPaneText(view)
+	for _, want := range []string{"enter  phases", "c      copy id", "h      headless on"} {
+		if !strings.Contains(pane, want) {
+			t.Fatalf("compact selected Flow pane missing %q:\n%s", want, pane)
+		}
+	}
+	if strings.Contains(pane, "n      new flow") {
+		t.Fatalf("compact selected Flow pane should prioritize selected-flow actions over new-flow shortcut:\n%s", pane)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `c` handling to copy the selected Flow ID from the Flows and Active Flows panes
- show copy confirmation and keep the shortcut scoped away from non-Flow contexts
- update shortcut hints, README/config docs, and model/ui coverage

## Verification
- `gofmt -l .`
- `go test -count=1 ./model ./ui`
- `make build`
- `git diff --check origin/main..HEAD`

## Note
- `make test` timed out after 10m in `embeddedterm.TestTmuxBackedTerminalRealTmuxDetachLeavesSessionAlive`; the changed `model` and `ui` packages passed during that run and in the focused rerun above.