### PR TITLE
Add Flow agent model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ filter matches, or a load failure with details in the status bar.
 | `1`/`2`/`3`/`4`/`5`/`6`/`7`/`8`/`9` | Switch to worktrees / branches / stashes / history / reflog / sessions / plans / flows / active flows |
 | `←`/`→`/`l` | Switch views in the right pane, wrapping between worktrees and active flows; use arrows or `l` in flows view because `h` toggles Flow headless/interactive command mode |
 | `h` | Switch to the previous view outside flows view; toggle Flow headless/interactive command mode in flows view |
+| `M` | Choose and persist model for the selected CLI agent in flows view |
 | `E` | Choose and persist reasoning effort for the selected CLI agent in flows view |
 | `enter` | Page diff in `less` (dirty worktree, dirty branch, stash, commit, or reflog entry), resume an inline worktree session, page a session transcript, or expand/collapse plan or Flow phases |
 | `g` | Launch the next launchable phase for the selected Flow in flows view |
@@ -391,13 +392,15 @@ Creating a new Flow has its own default-on Headless checkbox for the initial
 Plan launch; uncheck it for an interactive initial Plan launch. That checkbox
 is ignored when Plan Now is off and does not change the selected-phase `h`
 setting. Manual phase launches, auto-launched phases, and new Flow Plan
-launches all use the configured agent and that agent's configured effort. Press
-`E` to choose the selected CLI agent's reasoning effort; the shortcut pane shows
-the current value. Codex CLI launches use `--config
-model_reasoning_effort=<effort>`, Claude launches use `--effort <effort>`, and
-session resumes do not receive effort flags. `codex-app` always uses the
-external deep-link route and keeps app-side/default reasoning. Embedded headless output
-is readable terminal text, not raw JSON events: `codex exec` streams its progress
+launches all use the configured agent and that agent's configured model and
+effort. Press `M` to choose the selected CLI agent's model; press `E` to choose
+its reasoning effort. The shortcut pane shows the current values. Codex CLI
+launches use `--model <model>` and `--config
+model_reasoning_effort=<effort>`; Claude launches use `--model <model>` and
+`--effort <effort>`. Session resumes do not receive model or effort flags.
+`codex-app` always uses the external deep-link route and keeps app-side/default
+model and reasoning. Embedded headless output is readable terminal text, not raw
+JSON events: `codex exec` streams its progress
 directly, while `claude --print` is run with `--output-format stream-json
 --include-partial-messages` and wtui translates those events into readable lines
 (thinking, tool calls and results, the final answer streamed token-by-token, and
@@ -579,6 +582,8 @@ max_depth = 2
 
 [agent]
 command = "codex"
+codex_model = "gpt-5.5"
+claude_model = "claude-sonnet-5"
 codex_reasoning_effort = "high"
 claude_reasoning_effort = "max"
 plan_prompt = "Implement the saved wtui plan {title} (ID: {plan_id}) at {plan_path}. Read the plan file, then begin implementation."
@@ -608,7 +613,10 @@ for compatibility. The same root is resolved to an absolute path when used as
 the parent directory for left-pane repo creation.
 `[agent].codex_reasoning_effort` and `[agent].claude_reasoning_effort`
 configure provider-specific effort for new CLI agent launches; empty or
-`default` keeps provider defaults. `[ui].default_view` accepts `1` through `9`
+`default` keeps provider defaults. `[agent].codex_model` supports `default` and
+`gpt-5.5`; `[agent].claude_model` supports `default`, `claude-opus-4-8`,
+`claude-sonnet-5`, and `claude-fable-5`. Empty or `default` omits the model
+override and keeps provider defaults. `[ui].default_view` accepts `1` through `9`
 and controls the startup view; omitting it keeps the built-in Flows default.
 `[agent].plan_prompt` customizes the
 editable instructions shown before launching an agent from the plans pane, while

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -645,6 +645,7 @@ type AgentLaunchContext struct {
 	FlowPhaseTerminal bool
 	Embedded          bool
 	Headless          bool
+	Model             string
 	ReasoningEffort   string
 	// InitialPrompt is canonical launch metadata. It is delivered either as a
 	// provider argv or by embedded PTY prefill, depending on launch mode.
@@ -898,7 +899,16 @@ func agentCommandSpec(ctx AgentLaunchContext) (*exec.Cmd, []envVar, error) {
 			return nil, nil, fmt.Errorf("reasoning effort cannot be set for session resume")
 		}
 	}
-	args := agentLaunchArgs(command, resumeSessionID, ctx.Headless, reasoningEffort, agentLaunchArgsOptions{
+	model := agent.NormalizeModel(ctx.Model)
+	if model != "" && model != agent.ModelDefault {
+		if err := agent.ValidateModel(command, model); err != nil {
+			return nil, nil, err
+		}
+		if resumeSessionID != "" {
+			return nil, nil, fmt.Errorf("model cannot be set for session resume")
+		}
+	}
+	args := agentLaunchArgs(command, resumeSessionID, ctx.Headless, model, reasoningEffort, agentLaunchArgsOptions{
 		embedded:   ctx.Embedded,
 		streamJSON: UsesStreamJSONOutput(ctx),
 	})
@@ -961,6 +971,10 @@ func resumeSessionIDForLaunch(raw string) (string, error) {
 }
 
 func codexAppLaunchURL(ctx AgentLaunchContext) (string, error) {
+	model := agent.NormalizeModel(ctx.Model)
+	if model != "" && model != agent.ModelDefault {
+		return "", fmt.Errorf("model cannot be set for codex-app launch")
+	}
 	resumeSessionID, err := resumeSessionIDForLaunch(ctx.ResumeSessionID)
 	if err != nil {
 		return "", err
@@ -1136,12 +1150,15 @@ type agentLaunchArgsOptions struct {
 	streamJSON bool
 }
 
-func agentLaunchArgs(command, resumeSessionID string, headless bool, reasoningEffort string, opts agentLaunchArgsOptions) []string {
+func agentLaunchArgs(command, resumeSessionID string, headless bool, model string, reasoningEffort string, opts agentLaunchArgsOptions) []string {
 	switch command {
 	case "codex":
 		hookCommand := wtuiSessionHookCommand("codex")
 		hookConfig := "hooks.Stop=[{hooks=[{type=\"command\", command=" + strconv.Quote(hookCommand) + ", timeout=30, statusMessage=\"Saving wtui session\"}]}]"
 		args := []string{"--config", hookConfig}
+		if model != "" && model != agent.ModelDefault {
+			args = append(args, "--model", model)
+		}
 		if reasoningEffort != "" && reasoningEffort != agent.ReasoningEffortDefault {
 			args = append(args, "--config", "model_reasoning_effort="+reasoningEffort)
 		}
@@ -1159,6 +1176,9 @@ func agentLaunchArgs(command, resumeSessionID string, headless bool, reasoningEf
 		hookCommand := wtuiSessionHookCommand("claude")
 		settings := claudeSessionHookSettings(hookCommand)
 		args := []string{"--settings", settings}
+		if model != "" && model != agent.ModelDefault {
+			args = append(args, "--model", model)
+		}
 		if reasoningEffort != "" && reasoningEffort != agent.ReasoningEffortDefault {
 			args = append(args, "--effort", reasoningEffort)
 		}

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -947,6 +947,9 @@ func agentCommandSpec(ctx AgentLaunchContext) (*exec.Cmd, []envVar, error) {
 }
 
 func codexAppLaunch(ctx AgentLaunchContext, goos string) (TerminalLaunchSpec, error) {
+	if err := validateCodexAppModel(ctx); err != nil {
+		return TerminalLaunchSpec{}, err
+	}
 	if goos != "darwin" {
 		return TerminalLaunchSpec{}, fmt.Errorf("codex-app launch is only supported on macOS")
 	}
@@ -957,6 +960,14 @@ func codexAppLaunch(ctx AgentLaunchContext, goos string) (TerminalLaunchSpec, er
 	cmd := exec.Command("open", launchURL)
 	cmd.Env = envWithoutPrefix("WTUI_")
 	return TerminalLaunchSpec{Cmd: cmd}, nil
+}
+
+func validateCodexAppModel(ctx AgentLaunchContext) error {
+	model := agent.NormalizeModel(ctx.Model)
+	if model != "" && model != agent.ModelDefault {
+		return fmt.Errorf("model cannot be set for codex-app launch")
+	}
+	return nil
 }
 
 // resumeSessionIDForLaunch trims a resume session ID and rejects resume
@@ -971,9 +982,8 @@ func resumeSessionIDForLaunch(raw string) (string, error) {
 }
 
 func codexAppLaunchURL(ctx AgentLaunchContext) (string, error) {
-	model := agent.NormalizeModel(ctx.Model)
-	if model != "" && model != agent.ModelDefault {
-		return "", fmt.Errorf("model cannot be set for codex-app launch")
+	if err := validateCodexAppModel(ctx); err != nil {
+		return "", err
 	}
 	resumeSessionID, err := resumeSessionIDForLaunch(ctx.ResumeSessionID)
 	if err != nil {

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1964,6 +1964,155 @@ func TestAgentCommandRejectsResumeWithReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestAgentCommandCodexAddsModelBeforeExec(t *testing.T) {
+	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
+		Command:       "codex",
+		WorktreePath:  "/repo/worktree",
+		Embedded:      true,
+		Headless:      true,
+		Model:         "gpt-5.5",
+		InitialPrompt: "Implement this phase.",
+	})
+	if err != nil {
+		t.Fatalf("AgentCommand returned error: %v", err)
+	}
+
+	args := cmd.Args
+	modelIndex := slices.Index(args, "--model")
+	execIndex := slices.Index(args, "exec")
+	if modelIndex == -1 || modelIndex+1 >= len(args) || args[modelIndex+1] != "gpt-5.5" {
+		t.Fatalf("expected codex --model gpt-5.5 pair, got %#v", args)
+	}
+	if execIndex == -1 || modelIndex > execIndex {
+		t.Fatalf("expected codex model before exec, got %#v", args)
+	}
+	if args[len(args)-1] != "Implement this phase." {
+		t.Fatalf("expected prompt to remain final arg, got %#v", args)
+	}
+}
+
+func TestAgentCommandCodexInteractiveAddsModelAsGlobalFlag(t *testing.T) {
+	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
+		Command:       "codex",
+		WorktreePath:  "/repo/worktree",
+		Model:         " GPT-5.5 ",
+		InitialPrompt: "Implement this phase.",
+	})
+	if err != nil {
+		t.Fatalf("AgentCommand returned error: %v", err)
+	}
+
+	args := cmd.Args
+	modelIndex := slices.Index(args, "--model")
+	if modelIndex == -1 || modelIndex+1 >= len(args) || args[modelIndex+1] != "gpt-5.5" {
+		t.Fatalf("expected codex --model gpt-5.5 pair, got %#v", args)
+	}
+	if args[len(args)-1] != "Implement this phase." {
+		t.Fatalf("expected prompt to remain final arg, got %#v", args)
+	}
+}
+
+func TestAgentCommandClaudeAddsModelArg(t *testing.T) {
+	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
+		Command:       "claude",
+		WorktreePath:  "/repo/worktree",
+		Embedded:      true,
+		Headless:      true,
+		Model:         "claude-sonnet-5",
+		InitialPrompt: "Implement this phase.",
+	})
+	if err != nil {
+		t.Fatalf("AgentCommand returned error: %v", err)
+	}
+
+	args := cmd.Args
+	modelFlagIndex := slices.Index(args, "--model")
+	printIndex := slices.Index(args, "--print")
+	streamIndex := slices.Index(args, "stream-json")
+	if modelFlagIndex == -1 || modelFlagIndex+1 >= len(args) || args[modelFlagIndex+1] != "claude-sonnet-5" {
+		t.Fatalf("expected claude --model claude-sonnet-5 pair, got %#v", args)
+	}
+	if printIndex == -1 || streamIndex == -1 {
+		t.Fatalf("expected headless stream-json args to remain, got %#v", args)
+	}
+	if args[len(args)-1] != "Implement this phase." {
+		t.Fatalf("expected prompt to remain final arg, got %#v", args)
+	}
+}
+
+func TestAgentCommandDefaultModelOmitsProviderArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		model   string
+	}{
+		{name: "codex empty", command: "codex", model: ""},
+		{name: "codex default", command: "codex", model: "default"},
+		{name: "claude default", command: "claude", model: " default "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
+				Command:       tt.command,
+				WorktreePath:  "/repo/worktree",
+				Model:         tt.model,
+				InitialPrompt: "Implement this phase.",
+			})
+			if err != nil {
+				t.Fatalf("AgentCommand returned error: %v", err)
+			}
+			if slices.Contains(cmd.Args, "--model") {
+				t.Fatalf("default model should not add --model, got %#v", cmd.Args)
+			}
+		})
+	}
+}
+
+func TestAgentCommandRejectsUnsupportedModel(t *testing.T) {
+	_, err := actions.AgentCommand(actions.AgentLaunchContext{
+		Command:      "codex",
+		WorktreePath: "/repo/worktree",
+		Model:        "claude-sonnet-5",
+	})
+	if err == nil {
+		t.Fatal("expected unsupported model error")
+	}
+	if !strings.Contains(err.Error(), "unsupported model") {
+		t.Fatalf("expected unsupported model error, got %q", err.Error())
+	}
+}
+
+func TestAgentCommandRejectsResumeWithModel(t *testing.T) {
+	_, err := actions.AgentCommand(actions.AgentLaunchContext{
+		Command:          "claude",
+		WorktreePath:     "/repo/worktree",
+		ResumeSessionID:  "session-1",
+		Model:            "claude-opus-4-8",
+		SessionStateRoot: "/state/wtui/sessions/v1",
+	})
+	if err == nil {
+		t.Fatal("expected resume model error")
+	}
+	if !strings.Contains(err.Error(), "model") || !strings.Contains(err.Error(), "resume") {
+		t.Fatalf("expected resume model error, got %q", err.Error())
+	}
+}
+
+func TestAgentLaunchRejectsCodexAppModelOverride(t *testing.T) {
+	_, err := actions.AgentLaunch(actions.AgentLaunchContext{
+		Command:      "codex-app",
+		WorktreePath: "/repo/worktree",
+		Model:        "gpt-5.5",
+	})
+	if err == nil {
+		t.Fatal("expected codex-app model error")
+	}
+	if !strings.Contains(err.Error(), "model") || !strings.Contains(err.Error(), "codex-app") {
+		t.Fatalf("expected codex-app model error, got %q", err.Error())
+	}
+}
+
 func TestAgentCommandBuildsEmbeddedInteractiveCodexCommand(t *testing.T) {
 	cmd, err := actions.AgentCommand(actions.AgentLaunchContext{
 		Command:           "codex",

--- a/actions/agent_launch_internal_test.go
+++ b/actions/agent_launch_internal_test.go
@@ -819,6 +819,16 @@ func TestCodexAppLaunchRejectsUnsupportedPlatform(t *testing.T) {
 	}
 }
 
+func TestCodexAppLaunchRejectsModelBeforeUnsupportedPlatform(t *testing.T) {
+	_, err := agentLaunch(AgentLaunchContext{Command: "codex-app", WorktreePath: "/repo/worktree", Model: "gpt-5.5"}, "linux", fakeGetenv(nil), fakeLookPath())
+	if err == nil {
+		t.Fatal("expected codex-app model error")
+	}
+	if !strings.Contains(err.Error(), "model") || !strings.Contains(err.Error(), "codex-app") {
+		t.Fatalf("expected codex-app model error, got %q", err.Error())
+	}
+}
+
 func TestEmbeddedTmuxAgentCommandBuildsPrivateScriptTransport(t *testing.T) {
 	putAgentOnPath(t, "codex")
 	t.Setenv("TMUX", "/tmp/parent-tmux.sock")

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -21,6 +21,14 @@ const (
 	ReasoningEffortMax     = "max"
 )
 
+const (
+	ModelDefault       = "default"
+	ModelGPT55         = "gpt-5.5"
+	ModelClaudeOpus48  = "claude-opus-4-8"
+	ModelClaudeSonnet5 = "claude-sonnet-5"
+	ModelClaudeFable5  = "claude-fable-5"
+)
+
 func Normalize(command string) string {
 	return strings.ToLower(strings.TrimSpace(command))
 }
@@ -48,6 +56,10 @@ func NormalizeReasoningEffort(effort string) string {
 	return strings.ToLower(strings.TrimSpace(effort))
 }
 
+func NormalizeModel(model string) string {
+	return strings.ToLower(strings.TrimSpace(model))
+}
+
 func ReasoningEffortChoices(command string) []string {
 	switch Normalize(command) {
 	case CommandCodex:
@@ -56,6 +68,19 @@ func ReasoningEffortChoices(command string) []string {
 		return []string{ReasoningEffortDefault, ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh, ReasoningEffortXHigh, ReasoningEffortMax}
 	case CommandCodexApp:
 		return []string{ReasoningEffortDefault}
+	default:
+		return nil
+	}
+}
+
+func ModelChoices(command string) []string {
+	switch Normalize(command) {
+	case CommandCodex:
+		return []string{ModelDefault, ModelGPT55}
+	case CommandClaude:
+		return []string{ModelDefault, ModelClaudeOpus48, ModelClaudeSonnet5, ModelClaudeFable5}
+	case CommandCodexApp:
+		return []string{ModelDefault}
 	default:
 		return nil
 	}
@@ -76,4 +101,21 @@ func ValidateReasoningEffort(command, effort string) error {
 		}
 	}
 	return fmt.Errorf("unsupported reasoning effort %q for %s", effort, command)
+}
+
+func ValidateModel(command, model string) error {
+	command = Normalize(command)
+	if err := Validate(command); err != nil {
+		return err
+	}
+	model = NormalizeModel(model)
+	if model == "" {
+		return nil
+	}
+	for _, choice := range ModelChoices(command) {
+		if model == choice {
+			return nil
+		}
+	}
+	return fmt.Errorf("unsupported model %q for %s", model, command)
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -75,3 +75,44 @@ func TestValidateReasoningEffortRejectsUnsupportedProviderValues(t *testing.T) {
 		t.Fatalf("expected default claude effort to be accepted, got %v", err)
 	}
 }
+
+func TestModelChoicesAreProviderSpecific(t *testing.T) {
+	tests := []struct {
+		command string
+		want    []string
+	}{
+		{agent.CommandCodex, []string{"default", "gpt-5.5"}},
+		{agent.CommandClaude, []string{"default", "claude-opus-4-8", "claude-sonnet-5", "claude-fable-5"}},
+		{agent.CommandCodexApp, []string{"default"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			got := agent.ModelChoices(tt.command)
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Fatalf("ModelChoices(%q) = %#v, want %#v", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateModelRejectsUnsupportedProviderValues(t *testing.T) {
+	if err := agent.ValidateModel(agent.CommandCodex, "claude-sonnet-5"); err == nil {
+		t.Fatal("expected codex claude-sonnet-5 model to be rejected")
+	}
+	if err := agent.ValidateModel(agent.CommandCodex, " GPT-5.5 "); err != nil {
+		t.Fatalf("expected codex gpt-5.5 model to be accepted, got %v", err)
+	}
+	if err := agent.ValidateModel(agent.CommandClaude, "claude-fable-5"); err != nil {
+		t.Fatalf("expected claude-fable-5 model to be accepted, got %v", err)
+	}
+	if err := agent.ValidateModel(agent.CommandCodex, ""); err != nil {
+		t.Fatalf("expected empty codex model to mean default, got %v", err)
+	}
+	if err := agent.ValidateModel(agent.CommandClaude, " DEFAULT "); err != nil {
+		t.Fatalf("expected default claude model to be accepted, got %v", err)
+	}
+	if err := agent.ValidateModel(agent.CommandCodexApp, "gpt-5.5"); err == nil {
+		t.Fatal("expected codex-app non-default model to be rejected")
+	}
+}

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -325,6 +325,8 @@ func modelOptionsFromConfig(cfg config.Config, scanRepos func() ([]scanner.Repo,
 	}
 	return model.Options{
 		AgentCommand:          cfg.Agent.Command,
+		CodexModel:            cfg.Agent.CodexModel,
+		ClaudeModel:           cfg.Agent.ClaudeModel,
 		CodexReasoningEffort:  cfg.Agent.CodexReasoningEffort,
 		ClaudeReasoningEffort: cfg.Agent.ClaudeReasoningEffort,
 		StartupMode:           startupMode,
@@ -368,6 +370,9 @@ func modelOptionsFromConfig(cfg config.Config, scanRepos func() ([]scanner.Repo,
 		},
 		SaveAgentReasoningEffort: func(command, effort string) error {
 			return config.SaveAgentReasoningEffort(command, effort)
+		},
+		SaveAgentModel: func(command, model string) error {
+			return config.SaveAgentModel(command, model)
 		},
 		SaveDefaultView: func(mode ui.Mode) error {
 			number, ok := model.ViewNumber(mode)

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -396,6 +396,8 @@ func TestModelOptionsFromConfigPassesReasoningEffort(t *testing.T) {
 	opts := modelOptionsFromConfig(config.Config{
 		Agent: config.AgentConfig{
 			Command:               "codex",
+			CodexModel:            "gpt-5.5",
+			ClaudeModel:           "claude-sonnet-5",
 			CodexReasoningEffort:  "high",
 			ClaudeReasoningEffort: "max",
 		},
@@ -404,8 +406,14 @@ func TestModelOptionsFromConfigPassesReasoningEffort(t *testing.T) {
 	if opts.CodexReasoningEffort != "high" || opts.ClaudeReasoningEffort != "max" {
 		t.Fatalf("reasoning efforts = codex %q claude %q, want high/max", opts.CodexReasoningEffort, opts.ClaudeReasoningEffort)
 	}
+	if opts.CodexModel != "gpt-5.5" || opts.ClaudeModel != "claude-sonnet-5" {
+		t.Fatalf("models = codex %q claude %q, want gpt-5.5/claude-sonnet-5", opts.CodexModel, opts.ClaudeModel)
+	}
 	if opts.SaveAgentReasoningEffort == nil {
 		t.Fatal("SaveAgentReasoningEffort should be wired")
+	}
+	if opts.SaveAgentModel == nil {
+		t.Fatal("SaveAgentModel should be wired")
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,8 @@ type UIConfig struct {
 type AgentConfig struct {
 	Command               string `toml:"command"`
 	PlanPrompt            string `toml:"plan_prompt"`
+	CodexModel            string `toml:"codex_model"`
+	ClaudeModel           string `toml:"claude_model"`
 	CodexReasoningEffort  string `toml:"codex_reasoning_effort"`
 	ClaudeReasoningEffort string `toml:"claude_reasoning_effort"`
 }
@@ -192,6 +194,18 @@ func parseConfigData(path string, data []byte, opts loadOptions) (Config, error)
 	if cfg.Agent.Command != "" {
 		cfg.Agent.Command = agent.Normalize(cfg.Agent.Command)
 		if err := agent.Validate(cfg.Agent.Command); err != nil {
+			return Config{}, fmt.Errorf("parse config %s: %w", path, err)
+		}
+	}
+	if cfg.Agent.CodexModel != "" {
+		cfg.Agent.CodexModel = agent.NormalizeModel(cfg.Agent.CodexModel)
+		if err := agent.ValidateModel(agent.CommandCodex, cfg.Agent.CodexModel); err != nil {
+			return Config{}, fmt.Errorf("parse config %s: %w", path, err)
+		}
+	}
+	if cfg.Agent.ClaudeModel != "" {
+		cfg.Agent.ClaudeModel = agent.NormalizeModel(cfg.Agent.ClaudeModel)
+		if err := agent.ValidateModel(agent.CommandClaude, cfg.Agent.ClaudeModel); err != nil {
 			return Config{}, fmt.Errorf("parse config %s: %w", path, err)
 		}
 	}
@@ -328,6 +342,33 @@ func SaveAgentReasoningEffort(command, effort string, options ...Option) error {
 	return saveAgentReasoningEffortTo(path, command, effort, options...)
 }
 
+// SaveAgentModel persists the selected provider-specific model to wtui's
+// default config file, creating the config directory when needed. An empty
+// model is saved as "default".
+func SaveAgentModel(command, model string, options ...Option) error {
+	command = agent.Normalize(command)
+	if command != agent.CommandCodex && command != agent.CommandClaude {
+		if err := agent.Validate(command); err != nil {
+			return err
+		}
+		return fmt.Errorf("model is configurable only for codex or claude")
+	}
+	model = agent.NormalizeModel(model)
+	if model == "" {
+		model = agent.ModelDefault
+	}
+	if err := agent.ValidateModel(command, model); err != nil {
+		return err
+	}
+
+	opts := defaultOptions(options...)
+	path, err := writableDefaultPath(opts)
+	if err != nil {
+		return err
+	}
+	return saveAgentModelTo(path, command, model, options...)
+}
+
 // SaveDefaultView persists the startup default view number to wtui's default
 // config file, creating the config directory when needed.
 func SaveDefaultView(view int, options ...Option) error {
@@ -426,6 +467,16 @@ func saveAgentReasoningEffortTo(path, command, effort string, options ...Option)
 	})
 }
 
+func saveAgentModelTo(path, command, model string, options ...Option) error {
+	key := "codex_model"
+	if command == agent.CommandClaude {
+		key = "claude_model"
+	}
+	return saveAgentConfigTo(path, options, func(data []byte) []byte {
+		return patchAgentModel(data, key, model)
+	})
+}
+
 func saveDefaultViewTo(path string, view int, options ...Option) error {
 	return saveAgentConfigTo(path, options, func(data []byte) []byte {
 		return patchSectionAssignment(data, "ui", "default_view", fmt.Sprintf("default_view = %d\n", view))
@@ -488,6 +539,10 @@ func patchAgentCommand(data []byte, command string) []byte {
 
 func patchAgentReasoningEffort(data []byte, key, effort string) []byte {
 	return patchSectionAssignment(data, "agent", key, agentReasoningEffortLine(key, effort))
+}
+
+func patchAgentModel(data []byte, key, model string) []byte {
+	return patchSectionAssignment(data, "agent", key, agentModelLine(key, model))
 }
 
 func patchSectionAssignment(data []byte, section, key, assignmentLine string) []byte {
@@ -668,6 +723,10 @@ func agentCommandLine(command string) string {
 
 func agentReasoningEffortLine(key, effort string) string {
 	return fmt.Sprintf("%s = %q\n", key, effort)
+}
+
+func agentModelLine(key, model string) string {
+	return fmt.Sprintf("%s = %q\n", key, model)
 }
 
 func escapeTOMLString(value string) string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -47,6 +47,8 @@ default_view = 8
 [agent]
 command = "codex"
 plan_prompt = "Implement {title} from {plan_path}"
+codex_model = " GPT-5.5 "
+claude_model = "claude-fable-5"
 codex_reasoning_effort = " HIGH "
 claude_reasoning_effort = "max"
 
@@ -108,6 +110,12 @@ timeout_seconds = 300
 	}
 	if cfg.Agent.PlanPrompt != "Implement {title} from {plan_path}" {
 		t.Fatalf("expected agent plan prompt to parse, got %q", cfg.Agent.PlanPrompt)
+	}
+	if cfg.Agent.CodexModel != "gpt-5.5" {
+		t.Fatalf("expected normalized codex model gpt-5.5, got %q", cfg.Agent.CodexModel)
+	}
+	if cfg.Agent.ClaudeModel != "claude-fable-5" {
+		t.Fatalf("expected claude model claude-fable-5, got %q", cfg.Agent.ClaudeModel)
 	}
 	if cfg.Agent.CodexReasoningEffort != "high" {
 		t.Fatalf("expected normalized codex reasoning effort high, got %q", cfg.Agent.CodexReasoningEffort)
@@ -438,6 +446,42 @@ func TestLoadFrom_RejectsInvalidReasoningEfforts(t *testing.T) {
 	}
 }
 
+func TestLoadFrom_RejectsInvalidModels(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "codex claude model",
+			body: "[agent]\ncodex_model = \"claude-sonnet-5\"\n",
+			want: "unsupported model",
+		},
+		{
+			name: "claude unknown",
+			body: "[agent]\nclaude_model = \"turbo\"\n",
+			want: "unsupported model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(tt.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := config.LoadFrom(path)
+			if err == nil {
+				t.Fatal("expected invalid model error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error to mention %q, got %q", tt.want, err.Error())
+			}
+		})
+	}
+}
+
 func TestSaveAgentCommand_WritesCodexApp(t *testing.T) {
 	xdg := t.TempDir()
 	err := config.SaveAgentCommand("codex-app",
@@ -655,6 +699,121 @@ func TestSaveAgentReasoningEffort_RejectsUnsupportedEffort(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported reasoning effort") {
 		t.Fatalf("expected unsupported effort error, got %q", err.Error())
+	}
+}
+
+func TestSaveAgentModel_CreatesMissingConfig(t *testing.T) {
+	xdg := t.TempDir()
+	err := config.SaveAgentModel("codex", "gpt-5.5",
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return t.TempDir(), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("SaveAgentModel returned error: %v", err)
+	}
+
+	path := filepath.Join(xdg, "wtui", "config.toml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `codex_model = "gpt-5.5"`) {
+		t.Fatalf("expected codex model in saved config, got:\n%s", raw)
+	}
+
+	cfg, err := config.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if cfg.Agent.CodexModel != "gpt-5.5" {
+		t.Fatalf("expected saved codex model gpt-5.5, got %q", cfg.Agent.CodexModel)
+	}
+}
+
+func TestSaveAgentModel_UpdatesExistingAgentSection(t *testing.T) {
+	xdg := t.TempDir()
+	path := filepath.Join(xdg, "wtui", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initial := "# keep me\n[agent]\n# keep agent note\ncommand = \"claude\"\nclaude_model = \"claude-opus-4-8\"\n\n[scan]\nroot = \"/src\"\n"
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := config.SaveAgentModel("claude", "claude-sonnet-5",
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return t.TempDir(), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("SaveAgentModel returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(raw)
+	for _, want := range []string{"# keep me", "# keep agent note", `command = "claude"`, `claude_model = "claude-sonnet-5"`, `root = "/src"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected saved config to contain %q, got:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "codex_model") {
+		t.Fatalf("claude save should not add codex model key, got:\n%s", text)
+	}
+}
+
+func TestSaveAgentModel_PersistsEmptyAsDefault(t *testing.T) {
+	xdg := t.TempDir()
+	err := config.SaveAgentModel("claude", "",
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return t.TempDir(), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("SaveAgentModel returned error: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(xdg, "wtui", "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `claude_model = "default"`) {
+		t.Fatalf("expected default claude model in saved config, got:\n%s", raw)
+	}
+}
+
+func TestSaveAgentModel_RejectsUnsupportedModel(t *testing.T) {
+	err := config.SaveAgentModel("codex", "claude-sonnet-5",
+		config.WithGetenv(func(string) string { return t.TempDir() }),
+		config.WithHomeDir(func() (string, error) { return t.TempDir(), nil }),
+	)
+	if err == nil {
+		t.Fatal("expected unsupported model error")
+	}
+	if !strings.Contains(err.Error(), "unsupported model") {
+		t.Fatalf("expected unsupported model error, got %q", err.Error())
 	}
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,6 +25,7 @@ exist:
 | Plan editor command | `[editor].command` | `EDITOR` | unset |
 | Terminal command | `TERMINAL` | `[terminal].command` | platform fallback |
 | Coding agent | none | `[agent].command` | unset |
+| Agent model | none | `[agent].codex_model` / `[agent].claude_model` | provider default |
 | Agent reasoning effort | none | `[agent].codex_reasoning_effort` / `[agent].claude_reasoning_effort` | provider default |
 | Startup default view | none | `[ui].default_view` | flows view (`8`) |
 | Plan launch prompt | none | `[agent].plan_prompt` | built-in plan implementation prompt |
@@ -66,6 +67,8 @@ default_view = 8
 
 [agent]
 command = "codex"
+codex_model = "gpt-5.5"
+claude_model = "claude-sonnet-5"
 codex_reasoning_effort = "high"
 claude_reasoning_effort = "max"
 plan_prompt = "Implement the saved wtui plan {title} (ID: {plan_id}) at {plan_path}. Read the plan file, then begin implementation."
@@ -208,6 +211,8 @@ value immediately, creating the config file if needed.
 | Key | Type | Description |
 |-----|------|-------------|
 | `command` | string | Supported values: `codex`, `codex-app`, or `claude`. |
+| `codex_model` | string | Optional Codex CLI model for new launches. Supported values: `default`, `gpt-5.5`. Empty or `default` omits the Codex override and keeps provider defaults. |
+| `claude_model` | string | Optional Claude Code model for new launches. Supported values: `default`, `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`. Empty or `default` omits the Claude override and keeps provider defaults. |
 | `codex_reasoning_effort` | string | Optional Codex CLI reasoning effort for new launches. Supported values: `default`, `minimal`, `low`, `medium`, `high`, `xhigh`. Empty or `default` omits the Codex override and keeps provider defaults. |
 | `claude_reasoning_effort` | string | Optional Claude Code reasoning effort for new launches. Supported values: `default`, `low`, `medium`, `high`, `xhigh`, `max`. Empty or `default` omits the Claude override and keeps provider defaults. |
 | `plan_prompt` | string | Optional template for the editable instructions opened by `i` in the plans pane. Supports `{title}`, `{plan_id}`, `{plan_path}`, `{repo_path}`, and `{worktree_path}`. When a saved-plan phase row is selected, it also supports `{phase_id}`, `{phase_title}`, and `{phase_status}`. Unknown placeholders remain literal. Blank or omitted uses the built-in prompt. |
@@ -216,12 +221,13 @@ Press `F2` in normal TUI views to open the prompt-template editor. The editor
 can save a custom `[agent].plan_prompt`, reset it to the built-in default, or
 preview the built-in prompt.
 
-In the flows pane, `E` opens a provider-specific reasoning-effort picker for
-the selected CLI agent and persists the corresponding key. New Codex CLI
-launches use `--config model_reasoning_effort=<effort>`; new Claude Code
-launches use `--effort <effort>`. Session resumes do not receive effort flags.
-`codex-app` launches keep app-side/default reasoning because the current deep
-link path cannot carry a verified effort setting.
+In the flows pane, `M` opens a provider-specific model picker for the selected
+CLI agent and persists the corresponding key. `E` opens the reasoning-effort
+picker. New Codex CLI launches use `--model <model>` and `--config
+model_reasoning_effort=<effort>`; new Claude Code launches use
+`--model <model>` and `--effort <effort>`. Session resumes do not receive model
+or effort flags. `codex-app` launches keep app-side/default model and reasoning
+because the current deep-link path cannot carry verified provider settings.
 
 ### `[flow_prompts]`
 
@@ -370,12 +376,12 @@ mode so you can review or edit it before pressing enter. Headless launches keep
 focus on the Flow list. Creating a new Flow has its own default-on Headless
 checkbox for the initial Plan launch; uncheck it for an interactive initial
 Plan launch. That checkbox does not change the selected-phase `h` setting.
-Press `E` to choose the configured CLI agent's reasoning effort for future
-launches; the shortcut pane shows the current value. Manual phase
-launches, auto-launched phases, and new Flow Plan launches all use the
-configured agent and that agent's configured effort.
+Press `M` to choose the configured CLI agent's model and `E` to choose its
+reasoning effort for future launches; the shortcut pane shows the current
+values. Manual phase launches, auto-launched phases, and new Flow Plan launches
+all use the configured agent and that agent's configured model and effort.
 `codex-app` remains URL/deep-link based, launches externally, and uses
-app-side/default reasoning. Press `r` to resume an attached
+app-side/default model and reasoning. Press `r` to resume an attached
 provider session from the selected phase row; CLI resumes open in runtime-only
 embedded PTYs in the flows pane, while `codex-app` resumes navigate externally.
 While a Flow terminal is open, `tab` switches focus between the Flow list and

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -57,12 +57,13 @@ type FlowPhaseLauncher struct {
 	NewLaunchID          func() string
 	SessionStateRoot     string
 	AgentCommand         string
+	Model                string
 	ReasoningEffort      string
 	PromptTemplates      FlowPromptTemplates
 }
 
 func (m Model) flowPhaseLauncher() FlowPhaseLauncher {
-	command, reasoningEffort := m.flowLaunchAgentSettings()
+	command, model, reasoningEffort := m.flowLaunchAgentSettings()
 	return FlowPhaseLauncher{
 		CurrentRepoPath:      m.currentRepoPath,
 		PlanMarkdownPath:     m.planMarkdownPath,
@@ -71,6 +72,7 @@ func (m Model) flowPhaseLauncher() FlowPhaseLauncher {
 		NewLaunchID:          newLaunchID,
 		SessionStateRoot:     m.sessionStateRoot,
 		AgentCommand:         command,
+		Model:                model,
 		ReasoningEffort:      reasoningEffort,
 		PromptTemplates:      m.flowPromptTemplates,
 	}
@@ -149,6 +151,7 @@ func (l FlowPhaseLauncher) Prepare(req FlowPhaseLaunchPreparedRequest) (FlowPhas
 	command := agent.Normalize(l.AgentCommand)
 	ctx := actions.AgentLaunchContext{
 		Command:          command,
+		Model:            l.model(command),
 		ReasoningEffort:  l.reasoningEffort(command),
 		LaunchID:         req.LaunchID,
 		RepoPath:         req.RepoPath,
@@ -191,6 +194,15 @@ func (l FlowPhaseLauncher) reasoningEffort(command string) string {
 	switch command {
 	case agent.CommandCodex, agent.CommandClaude:
 		return l.ReasoningEffort
+	default:
+		return ""
+	}
+}
+
+func (l FlowPhaseLauncher) model(command string) string {
+	switch command {
+	case agent.CommandCodex, agent.CommandClaude:
+		return l.Model
 	default:
 		return ""
 	}

--- a/model/flow_phase_launch_test.go
+++ b/model/flow_phase_launch_test.go
@@ -42,6 +42,7 @@ func TestFlowPhaseLauncherPrepareManualReadyPhaseLaunch(t *testing.T) {
 		NewLaunchID:      func() string { return "launch-1" },
 		SessionStateRoot: "/state/wtui/sessions/v1",
 		AgentCommand:     "codex",
+		Model:            "gpt-5.5",
 		ReasoningEffort:  "high",
 	}
 
@@ -76,6 +77,7 @@ func TestFlowPhaseLauncherPrepareManualReadyPhaseLaunch(t *testing.T) {
 	}
 	ctx := result.Context
 	if ctx.Command != "codex" ||
+		ctx.Model != "gpt-5.5" ||
 		ctx.ReasoningEffort != "high" ||
 		ctx.LaunchID != "launch-1" ||
 		ctx.RepoPath != record.RepoPath ||

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -18,6 +18,7 @@ type FlowStartRequest struct {
 	Instructions        string
 	BaseRef             string
 	AgentCommand        string
+	Model               string
 	ReasoningEffort     string
 	SessionStateRoot    string
 	FlowPromptTemplates FlowPromptTemplates
@@ -154,6 +155,7 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 	}
 	result.LaunchContext = actions.AgentLaunchContext{
 		Command:          req.AgentCommand,
+		Model:            req.Model,
 		ReasoningEffort:  req.ReasoningEffort,
 		LaunchID:         launchID,
 		RepoPath:         req.RepoPath,

--- a/model/flow_start_test.go
+++ b/model/flow_start_test.go
@@ -67,6 +67,7 @@ func TestFlowStarterStartPlanReturnsLaunchContext(t *testing.T) {
 		Instructions:     "Build the thing",
 		BaseRef:          "main",
 		AgentCommand:     "codex",
+		Model:            "gpt-5.5",
 		SessionStateRoot: "/state/wtui/sessions/v1",
 		PlanPhaseID:      "plan",
 		PlanPhaseTitle:   "Plan",
@@ -106,6 +107,7 @@ func TestFlowStarterStartPlanReturnsLaunchContext(t *testing.T) {
 
 	ctx := result.LaunchContext
 	if ctx.Command != "codex" ||
+		ctx.Model != "gpt-5.5" ||
 		ctx.LaunchID != "launch-1" ||
 		ctx.RepoPath != "/dev/alpha" ||
 		ctx.WorktreePath != "/dev/alpha-worktrees/flow-add-flow-mode" ||

--- a/model/model.go
+++ b/model/model.go
@@ -81,6 +81,8 @@ type Model struct {
 	pendingBranchSelection     string
 	pendingWorktreeSelection   string
 	agentCommand               string
+	codexModel                 string
+	claudeModel                string
 	codexReasoningEffort       string
 	claudeReasoningEffort      string
 	defaultView                ui.Mode
@@ -107,6 +109,7 @@ type Model struct {
 	pageText                   func(string) (actions.TerminalLaunchSpec, error)
 	editFile                   func(string) (actions.TerminalLaunchSpec, error)
 	saveAgent                  func(string) error
+	saveAgentModel             func(string, string) error
 	saveAgentReasoningEffort   func(string, string) error
 	saveDefaultView            func(ui.Mode) error
 	savePromptTemplate         func(string, string, string) error
@@ -166,6 +169,8 @@ type visibleRepoFetchState struct {
 // simple for tests.
 type Options struct {
 	AgentCommand             string
+	CodexModel               string
+	ClaudeModel              string
 	CodexReasoningEffort     string
 	ClaudeReasoningEffort    string
 	StartupMode              ui.Mode
@@ -192,6 +197,7 @@ type Options struct {
 	PageText                 func(body string) (actions.TerminalLaunchSpec, error)
 	EditFile                 func(path string) (actions.TerminalLaunchSpec, error)
 	SaveAgentCommand         func(string) error
+	SaveAgentModel           func(string, string) error
 	SaveAgentReasoningEffort func(string, string) error
 	SaveDefaultView          func(ui.Mode) error
 	SavePromptTemplate       func(section, key, value string) error
@@ -220,6 +226,10 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	saveAgentReasoningEffort := opts.SaveAgentReasoningEffort
 	if saveAgentReasoningEffort == nil {
 		saveAgentReasoningEffort = func(string, string) error { return nil }
+	}
+	saveAgentModel := opts.SaveAgentModel
+	if saveAgentModel == nil {
+		saveAgentModel = func(string, string) error { return nil }
 	}
 	saveDefaultView := opts.SaveDefaultView
 	if saveDefaultView == nil {
@@ -420,6 +430,8 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		mode:                     initialMode,
 		defaultView:              initialMode,
 		agentCommand:             agent.Normalize(opts.AgentCommand),
+		codexModel:               agent.NormalizeModel(opts.CodexModel),
+		claudeModel:              agent.NormalizeModel(opts.ClaudeModel),
 		codexReasoningEffort:     agent.NormalizeReasoningEffort(opts.CodexReasoningEffort),
 		claudeReasoningEffort:    agent.NormalizeReasoningEffort(opts.ClaudeReasoningEffort),
 		planPromptTemplate:       opts.PlanPromptTemplate,
@@ -445,6 +457,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		pageText:                 pageText,
 		editFile:                 editFile,
 		saveAgent:                saveAgent,
+		saveAgentModel:           saveAgentModel,
 		saveAgentReasoningEffort: saveAgentReasoningEffort,
 		saveDefaultView:          saveDefaultView,
 		savePromptTemplate:       savePromptTemplate,
@@ -583,6 +596,26 @@ func (m Model) ReasoningEffortFor(command string) string {
 	}
 }
 
+func (m Model) ModelFor(command string) string {
+	switch agent.Normalize(command) {
+	case agent.CommandCodex:
+		return m.codexModel
+	case agent.CommandClaude:
+		return m.claudeModel
+	default:
+		return ""
+	}
+}
+
+func (m Model) launchModelFor(command string) string {
+	switch agent.Normalize(command) {
+	case agent.CommandCodex, agent.CommandClaude:
+		return m.ModelFor(command)
+	default:
+		return ""
+	}
+}
+
 func (m Model) launchReasoningEffortFor(command string) string {
 	switch agent.Normalize(command) {
 	case agent.CommandCodex, agent.CommandClaude:
@@ -592,9 +625,21 @@ func (m Model) launchReasoningEffortFor(command string) string {
 	}
 }
 
-func (m Model) flowLaunchAgentSettings() (string, string) {
+func (m Model) flowLaunchAgentSettings() (string, string, string) {
 	command := agent.Normalize(m.agentCommand)
-	return command, m.launchReasoningEffortFor(command)
+	return command, m.launchModelFor(command), m.launchReasoningEffortFor(command)
+}
+
+func (m Model) flowModelLabel() string {
+	command := agent.Normalize(m.agentCommand)
+	switch command {
+	case agent.CommandCodex, agent.CommandClaude:
+		return fmt.Sprintf("model: %s", modelDisplay(m.ModelFor(command)))
+	case agent.CommandCodexApp:
+		return "app default"
+	default:
+		return ""
+	}
 }
 
 func (m Model) flowReasoningEffortLabel() string {
@@ -624,6 +669,25 @@ func reasoningEffortDisplay(effort string) string {
 		return agent.ReasoningEffortDefault
 	}
 	return effort
+}
+
+func modelDisplay(model string) string {
+	model = agent.NormalizeModel(model)
+	if model == "" {
+		return agent.ModelDefault
+	}
+	return model
+}
+
+func (m Model) withModel(command, model string) Model {
+	model = agent.NormalizeModel(model)
+	switch agent.Normalize(command) {
+	case agent.CommandCodex:
+		m.codexModel = model
+	case agent.CommandClaude:
+		m.claudeModel = model
+	}
+	return m
 }
 
 func (m Model) withReasoningEffort(command, effort string) Model {
@@ -758,6 +822,7 @@ func (m Model) View() string {
 		FlowHeadless:                m.flowHeadless,
 		FlowAutoModeSelected:        flowAutoModeSelected,
 		FlowAgentLabel:              m.flowAgentShortcutLabel(),
+		FlowModel:                   m.flowModelLabel(),
 		FlowReasoningEffort:         m.flowReasoningEffortLabel(),
 		DefaultViewLabel:            ViewChoiceLabel(m.defaultView),
 		FlowNextLaunchReady:         m.selectedFlowHasLaunchablePhase(),
@@ -1217,6 +1282,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleAgentSet(msg), nil
 	case AgentSetFailedMsg:
 		return m.handleAgentSetFailed(msg), nil
+	case AgentModelSetMsg:
+		return m.handleAgentModelSet(msg), nil
+	case AgentModelSetFailedMsg:
+		return m.handleAgentModelSetFailed(msg), nil
 	case AgentReasoningEffortSetMsg:
 		return m.handleAgentReasoningEffortSet(msg), nil
 	case AgentReasoningEffortSetFailedMsg:

--- a/model/model.go
+++ b/model/model.go
@@ -636,7 +636,7 @@ func (m Model) flowModelLabel() string {
 	case agent.CommandCodex, agent.CommandClaude:
 		return fmt.Sprintf("model: %s", modelDisplay(m.ModelFor(command)))
 	case agent.CommandCodexApp:
-		return "app default"
+		return "model: app"
 	default:
 		return ""
 	}
@@ -648,7 +648,7 @@ func (m Model) flowReasoningEffortLabel() string {
 	case agent.CommandCodex, agent.CommandClaude:
 		return fmt.Sprintf("effort: %s", reasoningEffortDisplay(m.ReasoningEffortFor(command)))
 	case agent.CommandCodexApp:
-		return "app default"
+		return "effort: app"
 	default:
 		return ""
 	}

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3833,6 +3833,50 @@ func TestModel_FlowEffortPickerUsesCodexChoicesAndPersists(t *testing.T) {
 	}
 }
 
+func TestModel_FlowModelPickerUsesCodexChoicesAndPersists(t *testing.T) {
+	var savedCommand, savedModel string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		SaveAgentModel: func(command, selectedModel string) error {
+			savedCommand = command
+			savedModel = selectedModel
+			return nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd opening model picker, got %T", cmd)
+	}
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("expected model select overlay, got %d", m.Overlay())
+	}
+	view := m.View()
+	for _, want := range []string{"Choose codex model", "default", "gpt-5.5"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("codex model picker missing %q:\n%s", want, view)
+		}
+	}
+	if strings.Contains(view, "claude-sonnet-5") {
+		t.Fatalf("codex model picker should not include claude models:\n%s", view)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected save model command")
+	}
+	m, _ = update(m, cmd())
+	if savedCommand != "codex" || savedModel != "gpt-5.5" {
+		t.Fatalf("saved command/model = %q/%q, want codex/gpt-5.5", savedCommand, savedModel)
+	}
+	if got := m.ModelFor("codex"); got != "gpt-5.5" {
+		t.Fatalf("session codex model = %q, want gpt-5.5", got)
+	}
+}
+
 func TestModel_FlowsModeLabelsAgentAndEffortSeparately(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -4007,15 +4051,34 @@ func TestModel_FlowEffortPickerReportsCodexAppDefault(t *testing.T) {
 	}
 }
 
+func TestModel_FlowModelPickerReportsCodexAppDefault(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: "codex-app"})
+	m = inRightPane(m)
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'8'}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd for codex-app model, got %T", cmd)
+	}
+	if m.Overlay() != ui.OverlayNone {
+		t.Fatalf("expected no overlay for codex-app model, got %d", m.Overlay())
+	}
+	if got := m.TransientError(); !strings.Contains(got, "Codex App uses app default model") {
+		t.Fatalf("status = %q, want app default model message", got)
+	}
+}
+
 func TestModel_AKeyLaunchesAgentFromWorktree(t *testing.T) {
-	var gotPath, gotCommand, gotEffort string
+	var gotPath, gotCommand, gotModel, gotEffort string
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand:          "codex",
+		CodexModel:            "gpt-5.5",
 		CodexReasoningEffort:  "high",
 		ClaudeReasoningEffort: "max",
 		LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
 			gotPath = ctx.WorktreePath
 			gotCommand = ctx.Command
+			gotModel = ctx.Model
 			gotEffort = ctx.ReasoningEffort
 			return actions.TerminalLaunchSpec{Cmd: exec.Command("true"), Interactive: true}, nil
 		},
@@ -4031,6 +4094,9 @@ func TestModel_AKeyLaunchesAgentFromWorktree(t *testing.T) {
 	}
 	if gotPath != "/dev/alpha" || gotCommand != "codex" {
 		t.Fatalf("expected launch /dev/alpha with codex, got path=%q command=%q", gotPath, gotCommand)
+	}
+	if gotModel != "gpt-5.5" {
+		t.Fatalf("expected codex launch model gpt-5.5, got %q", gotModel)
 	}
 	if gotEffort != "high" {
 		t.Fatalf("expected codex launch effort high, got %q", gotEffort)

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3877,11 +3877,33 @@ func TestModel_FlowModelPickerUsesCodexChoicesAndPersists(t *testing.T) {
 	}
 }
 
+func TestModel_FlowModelPickerOpensFromLeftPane(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		StartupMode:  ui.ModeFlows,
+	})
+	if m.ActivePane() != 0 {
+		t.Fatalf("test setup active pane = %d, want left pane", m.ActivePane())
+	}
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	if cmd != nil {
+		t.Fatalf("expected nil cmd opening model picker, got %T", cmd)
+	}
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("expected model select overlay from left pane, got %d", m.Overlay())
+	}
+	if view := m.View(); !strings.Contains(view, "Choose codex model") {
+		t.Fatalf("codex model picker did not open from left pane:\n%s", view)
+	}
+}
+
 func TestModel_FlowsModeLabelsAgentAndEffortSeparately(t *testing.T) {
 	tests := []struct {
 		name       string
 		options    model.Options
 		wantAgent  string
+		wantModel  string
 		wantEffort string
 		notWant    []string
 	}{
@@ -3896,8 +3918,9 @@ func TestModel_FlowsModeLabelsAgentAndEffortSeparately(t *testing.T) {
 			name:       "codex app",
 			options:    model.Options{AgentCommand: "codex-app"},
 			wantAgent:  "A      codex-app",
-			wantEffort: "E      app default",
-			notWant:    []string{"E      codex-app default"},
+			wantModel:  "M      model: app",
+			wantEffort: "E      effort: app",
+			notWant:    []string{"M      app default", "E      app default", "E      codex-app default"},
 		},
 		{
 			name:       "claude",
@@ -3925,8 +3948,15 @@ func TestModel_FlowsModeLabelsAgentAndEffortSeparately(t *testing.T) {
 				t.Fatalf("Flow shortcuts missing agent label %q:\n%s", tt.wantAgent, view)
 			}
 			if tt.wantEffort != "" {
+				modelIndex := -1
+				if tt.wantModel != "" {
+					modelIndex = strings.Index(view, tt.wantModel)
+					if modelIndex < 0 || agentIndex > modelIndex {
+						t.Fatalf("Flow shortcuts should group agent before model %q:\n%s", tt.wantModel, view)
+					}
+				}
 				effortIndex := strings.Index(view, tt.wantEffort)
-				if effortIndex < 0 || agentIndex > effortIndex {
+				if effortIndex < 0 || agentIndex > effortIndex || (modelIndex >= 0 && modelIndex > effortIndex) {
 					t.Fatalf("Flow shortcuts should group agent before effort %q:\n%s", tt.wantEffort, view)
 				}
 			}

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -477,7 +477,7 @@ func (m Model) createFlowAndLaunchPlan(title, instructions, baseRef string, head
 }
 
 func (m Model) createFlowAndLaunchPlanForRepo(repoPath, title, instructions, baseRef string, headless bool) tea.Cmd {
-	command, reasoningEffort := m.flowLaunchAgentSettings()
+	command, model, reasoningEffort := m.flowLaunchAgentSettings()
 	return func() tea.Msg {
 		result, err := m.startFlowPlan(FlowStartRequest{
 			RepoPath:                    repoPath,
@@ -485,6 +485,7 @@ func (m Model) createFlowAndLaunchPlanForRepo(repoPath, title, instructions, bas
 			Instructions:                instructions,
 			BaseRef:                     baseRef,
 			AgentCommand:                command,
+			Model:                       model,
 			ReasoningEffort:             reasoningEffort,
 			SessionStateRoot:            m.sessionStateRoot,
 			FlowPromptTemplates:         m.flowPromptTemplates,

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1066,6 +1066,7 @@ func TestModel_FlowAutoLaunchUsesConfiguredCLIAgentAndEffort(t *testing.T) {
 	var launchUpdate flowstore.PhaseLaunchUpdate
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand:          "claude",
+		ClaudeModel:           "claude-sonnet-5",
 		ClaudeReasoningEffort: "max",
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
 			launchUpdate = update
@@ -1098,6 +1099,7 @@ func TestModel_FlowAutoLaunchUsesConfiguredCLIAgentAndEffort(t *testing.T) {
 		t.Fatalf("auto launch update = %#v", launchUpdate)
 	}
 	if launch.LaunchContext.Command != "claude" ||
+		launch.LaunchContext.Model != "claude-sonnet-5" ||
 		launch.LaunchContext.ReasoningEffort != "max" ||
 		launch.LaunchContext.FlowID != "flow-1" ||
 		launch.LaunchContext.FlowPhaseID != "implementation" ||
@@ -3153,6 +3155,7 @@ func TestModel_GOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHeadless
 	launchAgentRan := false
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand:          "claude",
+		ClaudeModel:           "claude-sonnet-5",
 		ClaudeReasoningEffort: "max",
 		SessionStateRoot:      "/state/wtui/sessions/v1",
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
@@ -3199,8 +3202,8 @@ func TestModel_GOnSelectedFlowPhaseLaunchesFirstLaunchablePhaseByDefaultHeadless
 	if started.FlowPhaseID != "implementation" || launchUpdate.PhaseID != "implementation" {
 		t.Fatalf("g launched %#v with update %#v, want first launchable implementation", started, launchUpdate)
 	}
-	if started.Command != "claude" || started.ReasoningEffort != "max" {
-		t.Fatalf("Flow phase launch agent settings = command %q effort %q, want claude/max", started.Command, started.ReasoningEffort)
+	if started.Command != "claude" || started.Model != "claude-sonnet-5" || started.ReasoningEffort != "max" {
+		t.Fatalf("Flow phase launch agent settings = command %q model %q effort %q, want claude/claude-sonnet-5/max", started.Command, started.Model, started.ReasoningEffort)
 	}
 	if !started.Embedded || !started.Headless || !started.FlowLaunchTracked {
 		t.Fatalf("Flow launch should be embedded, headless, and tracked: %#v", started)
@@ -4604,6 +4607,7 @@ func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 	fakeTerm := &fakeEmbeddedTerminal{state: "running"}
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand:         "codex",
+		CodexModel:           "gpt-5.5",
 		CodexReasoningEffort: "high",
 		SessionStateRoot:     "/state/wtui",
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
@@ -4656,6 +4660,7 @@ func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 		started.Branch != "flow/resume-sessions" ||
 		started.Commit != "abc123" ||
 		started.SessionStateRoot != "/state/wtui" ||
+		started.Model != "" ||
 		started.ReasoningEffort != "" ||
 		!started.Embedded ||
 		started.Headless ||

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -424,6 +424,10 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.flowSurfaceVisible() {
 			return m.handleSetReasoningEffort()
 		}
+	case "M":
+		if m.flowSurfaceVisible() {
+			return m.handleSetModel()
+		}
 	case "i":
 		if m.mode == ui.ModePlans {
 			return m.handleImplementPlan()
@@ -571,6 +575,8 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleResumeFlowPhaseSession()
 	case "E":
 		return m.handleSetReasoningEffort()
+	case "M":
+		return m.handleSetModel()
 	case "x":
 		return m.handleResetSelectedFlowPhase()
 	case "d":
@@ -1005,6 +1011,61 @@ func (m Model) handleSetReasoningEffort() (tea.Model, tea.Cmd) {
 		func(value string) tea.Cmd { return m.setReasoningEffort(command, value) },
 	)
 	return m, nil
+}
+
+func (m Model) handleSetModel() (tea.Model, tea.Cmd) {
+	command := agent.Normalize(m.agentCommand)
+	if command == "" {
+		m = m.setStatus(statusOther, "Press A to choose "+ui.AgentInputPlaceholder+" before setting model")
+		return m, nil
+	}
+	if command == agent.CommandCodexApp {
+		m = m.setStatus(statusOther, "Codex App uses app default model")
+		return m, nil
+	}
+	if err := agent.Validate(command); err != nil {
+		m = m.setStatus(statusOther, err.Error())
+		return m, nil
+	}
+	items := modelSelectItems(command)
+	m.modal = modal.OpenSelectWithLayout(
+		fmt.Sprintf("Choose %s model", command),
+		items,
+		selectedModelIndex(command, m.ModelFor(command)),
+		modal.Layout{Width: 38, Height: len(items) + 3, Placement: modal.PlacementCenter},
+		func(value string) tea.Cmd { return m.setModel(command, value) },
+	)
+	return m, nil
+}
+
+func modelSelectItems(command string) []modal.SelectItem {
+	choices := agent.ModelChoices(command)
+	items := make([]modal.SelectItem, 0, len(choices))
+	for _, choice := range choices {
+		items = append(items, modal.SelectItem{Label: choice, Value: choice})
+	}
+	return items
+}
+
+func selectedModelIndex(command, model string) int {
+	model = modelDisplay(model)
+	for i, choice := range agent.ModelChoices(command) {
+		if choice == model {
+			return i
+		}
+	}
+	return 0
+}
+
+func (m Model) setModel(command, selectedModel string) tea.Cmd {
+	command = agent.Normalize(command)
+	selectedModel = agent.NormalizeModel(selectedModel)
+	return func() tea.Msg {
+		if err := m.saveAgentModel(command, selectedModel); err != nil {
+			return AgentModelSetFailedMsg{Command: command, Model: selectedModel, Err: err.Error()}
+		}
+		return AgentModelSetMsg{Command: command, Model: selectedModel}
+	}
 }
 
 func reasoningEffortSelectItems(command string) []modal.SelectItem {
@@ -1876,6 +1937,7 @@ func (m Model) planLaunchContext() (actions.AgentLaunchContext, bool, Model) {
 	}
 	ctx := actions.AgentLaunchContext{
 		Command:          m.agentCommand,
+		Model:            m.launchModelFor(m.agentCommand),
 		ReasoningEffort:  m.launchReasoningEffortFor(m.agentCommand),
 		LaunchID:         newLaunchID(),
 		RepoPath:         repoPath,
@@ -2186,6 +2248,7 @@ func (m Model) agentLaunchContext(path string) actions.AgentLaunchContext {
 	}
 	return actions.AgentLaunchContext{
 		Command:          m.agentCommand,
+		Model:            m.launchModelFor(m.agentCommand),
 		ReasoningEffort:  m.launchReasoningEffortFor(m.agentCommand),
 		LaunchID:         newLaunchID(),
 		RepoPath:         repoPath,

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -98,6 +98,14 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleSetAgent()
 	}
 
+	if key == "M" && m.flowSurfaceVisible() {
+		return m.handleSetModel()
+	}
+
+	if key == "E" && m.flowSurfaceVisible() {
+		return m.handleSetReasoningEffort()
+	}
+
 	if key == "V" {
 		return m.handleSetDefaultView()
 	}

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -350,6 +350,17 @@ type AgentSetFailedMsg struct {
 	Err     string
 }
 
+type AgentModelSetMsg struct {
+	Command string
+	Model   string
+}
+
+type AgentModelSetFailedMsg struct {
+	Command string
+	Model   string
+	Err     string
+}
+
 type AgentReasoningEffortSetMsg struct {
 	Command string
 	Effort  string
@@ -991,6 +1002,23 @@ func (m Model) handleAgentSetFailed(msg AgentSetFailedMsg) Model {
 func (m Model) handleAgentReasoningEffortSet(msg AgentReasoningEffortSetMsg) Model {
 	m = m.withReasoningEffort(msg.Command, msg.Effort)
 	m = m.clearStatus(statusOther)
+	return m
+}
+
+func (m Model) handleAgentModelSet(msg AgentModelSetMsg) Model {
+	m = m.withModel(msg.Command, msg.Model)
+	m = m.clearStatus(statusOther)
+	return m
+}
+
+func (m Model) handleAgentModelSetFailed(msg AgentModelSetFailedMsg) Model {
+	// Keep the selection usable for this session even when persistence fails.
+	m = m.withModel(msg.Command, msg.Model)
+	errText := msg.Err
+	if errText == "" {
+		errText = "Unable to persist model"
+	}
+	m = m.setStatus(statusOther, errText)
 	return m
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -294,6 +294,7 @@ type RenderParams struct {
 	FlowHeadless                bool
 	FlowAutoModeSelected        bool
 	FlowAgentLabel              string
+	FlowModel                   string
 	FlowReasoningEffort         string
 	DefaultViewLabel            string
 	FlowNextLaunchReady         bool
@@ -519,6 +520,7 @@ func renderApplication(p RenderParams) string {
 		FlowHeadless:                p.FlowHeadless,
 		FlowAutoModeSelected:        flowAutoModeSelected,
 		FlowAgentLabel:              p.FlowAgentLabel,
+		FlowModel:                   p.FlowModel,
 		FlowReasoningEffort:         p.FlowReasoningEffort,
 		DefaultViewLabel:            p.DefaultViewLabel,
 		FlowNextLaunchReady:         p.FlowNextLaunchReady,
@@ -796,6 +798,7 @@ type statusBarParams struct {
 	FlowHeadless                bool
 	FlowAutoModeSelected        bool
 	FlowAgentLabel              string
+	FlowModel                   string
 	FlowReasoningEffort         string
 	DefaultViewLabel            string
 	FlowNextLaunchReady         bool
@@ -1321,6 +1324,9 @@ func flowShortcutSections(sp statusBarParams, actions, navigation, global []shor
 	}
 	agentLabel, agentConfigured := flowAgentShortcut(sp.FlowAgentLabel)
 	flowAgentControls = append(flowAgentControls, shortcutHint{Key: "A", Label: agentLabel})
+	if modelLabel := flowModelShortcutLabel(sp.FlowModel); agentConfigured && modelLabel != "" {
+		flowAgentControls = append(flowAgentControls, shortcutHint{Key: "M", Label: modelLabel})
+	}
 	if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); agentConfigured && effortLabel != "" {
 		flowAgentControls = append(flowAgentControls, shortcutHint{Key: "E", Label: effortLabel})
 	}
@@ -1353,6 +1359,11 @@ func shortcutsMuted(sp statusBarParams) bool {
 }
 
 func flowReasoningEffortShortcutLabel(value string) string {
+	value = strings.TrimSpace(value)
+	return value
+}
+
+func flowModelShortcutLabel(value string) string {
 	value = strings.TrimSpace(value)
 	return value
 }
@@ -1566,16 +1577,19 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 	coreActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "d", "m")
 	coreActionsWithAutoWithoutSafety := footerHintsForKeys(hints, "h", "enter", "g", "d", "m")
 	selectedActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "x", "o", "y", "d", "r", "m")
-	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "E", "f", "F")
-	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "f", "F")
-	actionsWithoutAgentAndEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "f", "F")
+	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "M", "E", "f", "F")
+	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "M", "f", "F")
+	actionsWithoutModelAndEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "f", "F")
+	actionsWithoutAgentAndPreferences := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "f", "F")
 
 	for _, parts := range [][]string{
 		appendParts(base, upDown, arrow, actions),
 		appendParts(base, upDown, arrow, actionsWithoutEffort),
+		appendParts(base, upDown, arrow, actionsWithoutModelAndEffort),
 		appendParts(base, arrow, actionsWithoutEffort),
-		appendParts(base, upDown, arrow, actionsWithoutAgentAndEffort),
-		appendParts(base, arrow, actionsWithoutAgentAndEffort),
+		appendParts(base, arrow, actionsWithoutModelAndEffort),
+		appendParts(base, upDown, arrow, actionsWithoutAgentAndPreferences),
+		appendParts(base, arrow, actionsWithoutAgentAndPreferences),
 		appendParts(base, arrow, selectedActionsWithAuto),
 		appendParts(compactBase, selectedActionsWithAuto),
 		appendParts(base, arrow, coreActionsWithAuto),

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -872,7 +872,7 @@ func TestRender_FlowsModeReasoningEffortShortcutHandlesSpecialLabels(t *testing.
 		want      string
 		wantNoKey string
 	}{
-		{name: "codex app", agent: "codex-app", effort: "app default", want: "A      codex-app\nE      app default"},
+		{name: "codex app", agent: "codex-app", effort: "effort: app", want: "A      codex-app\nE      effort: app"},
 		{name: "unset", agent: "choose agent", effort: "", want: "A      choose agent", wantNoKey: "E"},
 		{name: "missing agent label", effort: "effort: high", want: "A      choose agent", wantNoKey: "E"},
 	}

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -712,12 +712,13 @@ func TestRender_FlowsModeShowsReasoningEffortShortcut(t *testing.T) {
 		Mode:                ModeFlows,
 		ActivePane:          1,
 		FlowAgentLabel:      "codex",
+		FlowModel:           "model: gpt-5.5",
 		FlowReasoningEffort: "effort: high",
 	})
 
 	pane := shortcutPaneText(view)
-	if !strings.Contains(pane, "A      codex\nE      effort: high") {
-		t.Fatalf("flows shortcut pane should group agent before reasoning effort:\n%s", pane)
+	if !strings.Contains(pane, "A      codex\nM      model: gpt-5.5\nE      effort: high") {
+		t.Fatalf("flows shortcut pane should group agent before model and reasoning effort:\n%s", pane)
 	}
 	if strings.Contains(pane, "A      set agent") {
 		t.Fatalf("flows shortcut pane should not show generic set-agent label:\n%s", pane)
@@ -1309,12 +1310,14 @@ func TestStatusBar_FlowsModeFooterGroupsAgentAndEffort(t *testing.T) {
 		ActivePane:          1,
 		RepoSelected:        true,
 		FlowAgentLabel:      "codex",
+		FlowModel:           "model: gpt-5.5",
 		FlowReasoningEffort: "effort: high",
 	})
 	agentIndex := strings.Index(bar, "A: codex")
+	modelIndex := strings.Index(bar, "M: model: gpt-5.5")
 	effortIndex := strings.Index(bar, "E: effort: high")
-	if agentIndex < 0 || effortIndex < 0 || agentIndex > effortIndex {
-		t.Fatalf("Flow footer should group agent before effort, got %q", bar)
+	if agentIndex < 0 || modelIndex < 0 || effortIndex < 0 || agentIndex > modelIndex || modelIndex > effortIndex {
+		t.Fatalf("Flow footer should group agent before model before effort, got %q", bar)
 	}
 	if strings.Contains(bar, "A: set agent") || strings.Contains(bar, "E: codex effort: high") {
 		t.Fatalf("Flow footer should not show generic or duplicated labels, got %q", bar)


### PR DESCRIPTION
## Summary
- add agent model selection support for Flow launches via the `M` shortcut
- persist provider-specific model defaults in config and pass selected models into CLI launch/resume commands
- document supported model values and update Flow UI/tests around model labels and launch behavior

## Verification
- `gofmt -l .`
- `make test`
- `make build`