### PR TITLE
Rearrange Flow shortcut keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,10 @@ filter matches, or a load failure with details in the status bar.
 | `n` | Create a new worktree in worktrees view, a new branch in branches view, or a new Flow in flows view |
 | `P` | Create a review worktree from a GitHub PR number or URL |
 | `N` | Create a new worktree and launch the selected coding agent |
-| `m` | Move or rename a linked worktree (worktrees view), or toggle auto mode for the selected Flow (flows view) |
-| `M` | Mark the selected Flow's GitHub PR as already merged, after verifying the stored PR is merged in GitHub |
+| `m` | Move or rename a linked worktree (worktrees view), or mark the selected Flow's GitHub PR as already merged after verifying it in GitHub (flows and active flows views) |
 | `A` | Choose and persist the coding agent from a picker (`codex`, `codex-app`, or `claude`) |
 | `V` | Choose and persist the startup default view (`1` through `9`) |
-| `a` | Launch the selected coding agent in the selected worktree, or launch the selected plan or plan phase |
+| `a` | Launch the selected coding agent in the selected worktree, launch the selected plan or plan phase, or toggle auto mode for the selected Flow (flows and active flows views) |
 | `d` | Delete worktree/branch, drop stash, or delete Flow data — requires destructive mode |
 | `p` | Prune stale worktree — requires destructive mode (worktrees view), or open the linked PR (flows and active flows views, when PR metadata exists) |
 | `u` | Unlock a locked worktree (worktrees view) |
@@ -363,10 +362,10 @@ worktree path, from either a Flow row or one of its expanded phase rows. Press
 `r` on an expanded phase row with an
 attached provider session to resume that session; CLI resumes are recorded as a
 fresh Flow phase launch attempt, while `codex-app` resumes navigate to the
-existing app thread without extra launch tracking. Press `m` on a Flow row or
+existing app thread without extra launch tracking. Press `a` on a Flow row or
 expanded phase row to toggle per-Flow auto mode, which is on by default for new
 Flows and persisted on that Flow record. Flows created before this field existed
-remain manual until auto mode is toggled on. Press `M` on an eligible Flow row
+remain manual until auto mode is toggled on. Press `m` on an eligible Flow row
 when its recorded GitHub PR was merged manually in GitHub; wtui verifies the PR
 is merged with `gh`, records the merge commit and timestamp, marks the Merge
 phase completed, and hides the Flow from active lists without launching a Merge

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ filter matches, or a load failure with details in the status bar.
 | `1`/`2`/`3`/`4`/`5`/`6`/`7`/`8`/`9` | Switch to worktrees / branches / stashes / history / reflog / sessions / plans / flows / active flows |
 | `←`/`→`/`l` | Switch views in the right pane, wrapping between worktrees and active flows; use arrows or `l` in flows view because `h` toggles Flow headless/interactive command mode |
 | `h` | Switch to the previous view outside flows view; toggle Flow headless/interactive command mode in flows view |
-| `M` | Choose and persist model for the selected CLI agent in flows view |
+| `M` | Choose and persist model for the selected CLI agent in flows view, except on selected top-level Flow rows |
 | `E` | Choose and persist reasoning effort for the selected CLI agent in flows view |
 | `enter` | Page diff in `less` (dirty worktree, dirty branch, stash, commit, or reflog entry), resume an inline worktree session, page a session transcript, or expand/collapse plan or Flow phases |
 | `g` | Launch the next launchable phase for the selected Flow in flows view |
@@ -403,8 +403,9 @@ Plan launch; uncheck it for an interactive initial Plan launch. That checkbox
 is ignored when Plan Now is off and does not change the selected-phase `h`
 setting. Manual phase launches, auto-launched phases, and new Flow Plan
 launches all use the configured agent and that agent's configured model and
-effort. Press `M` to choose the selected CLI agent's model; press `E` to choose
-its reasoning effort. The shortcut pane shows the current values. Codex CLI
+effort. Press `M` outside selected top-level Flow rows to choose the selected
+CLI agent's model; press `E` to choose its reasoning effort. The shortcut pane
+shows the current values. Codex CLI
 launches use `--model <model>` and `--config
 model_reasoning_effort=<effort>`; Claude launches use `--model <model>` and
 `--effort <effort>`. Session resumes do not receive model or effort flags.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ filter matches, or a load failure with details in the status bar.
 | `1`/`2`/`3`/`4`/`5`/`6`/`7`/`8`/`9` | Switch to worktrees / branches / stashes / history / reflog / sessions / plans / flows / active flows |
 | `←`/`→`/`l` | Switch views in the right pane, wrapping between worktrees and active flows; use arrows or `l` in flows view because `h` toggles Flow headless/interactive command mode |
 | `h` | Switch to the previous view outside flows view; toggle Flow headless/interactive command mode in flows view |
-| `M` | Choose and persist model for the selected CLI agent in flows view, except on selected top-level Flow rows |
+| `M` | Choose and persist model for the selected CLI agent in flows view |
 | `E` | Choose and persist reasoning effort for the selected CLI agent in flows view |
 | `enter` | Page diff in `less` (dirty worktree, dirty branch, stash, commit, or reflog entry), resume an inline worktree session, page a session transcript, or expand/collapse plan or Flow phases |
 | `g` | Launch the next launchable phase for the selected Flow in flows view |
@@ -403,9 +403,8 @@ Plan launch; uncheck it for an interactive initial Plan launch. That checkbox
 is ignored when Plan Now is off and does not change the selected-phase `h`
 setting. Manual phase launches, auto-launched phases, and new Flow Plan
 launches all use the configured agent and that agent's configured model and
-effort. Press `M` outside selected top-level Flow rows to choose the selected
-CLI agent's model; press `E` to choose its reasoning effort. The shortcut pane
-shows the current values. Codex CLI
+effort. Press `M` to choose the selected CLI agent's model; press `E` to choose
+its reasoning effort. The shortcut pane shows the current values. Codex CLI
 launches use `--model <model>` and `--config
 model_reasoning_effort=<effort>`; Claude launches use `--model <model>` and
 `--effort <effort>`. Session resumes do not receive model or effort flags.

--- a/docs/config.md
+++ b/docs/config.md
@@ -352,10 +352,10 @@ phase row, `enter` expands or collapses read-only phase detail rows; `o` opens
 the linked plan body from the selected Flow. Press `g` to launch the first
 launchable phase for the selected Flow. Press `c` to copy the selected Flow ID,
 and press `y` to copy the selected Flow worktree path, from either a Flow row or
-one of its expanded phase rows. Press `m` to toggle per-Flow auto mode. New Flow
+one of its expanded phase rows. Press `a` to toggle per-Flow auto mode. New Flow
 records start with auto mode on, and the toggle is persisted on each Flow. Flows
 created before this field existed remain manual until auto mode is toggled on.
-Press `M` on an eligible Flow row to mark a recorded GitHub PR as already
+Press `m` on an eligible Flow row to mark a recorded GitHub PR as already
 merged; wtui verifies the PR with `gh`, records the existing merge commit and
 timestamp, completes the Merge phase, and does not launch a Merge phase agent.
 When auto mode is on, completed

--- a/docs/config.md
+++ b/docs/config.md
@@ -221,9 +221,10 @@ Press `F2` in normal TUI views to open the prompt-template editor. The editor
 can save a custom `[agent].plan_prompt`, reset it to the built-in default, or
 preview the built-in prompt.
 
-In the flows pane, `M` opens a provider-specific model picker for the selected
-CLI agent and persists the corresponding key. `E` opens the reasoning-effort
-picker. New Codex CLI launches use `--model <model>` and `--config
+In the flows pane, `M` opens a provider-specific model picker outside selected
+top-level Flow rows and persists the corresponding key for the selected CLI
+agent. `E` opens the reasoning-effort picker. New Codex CLI launches use
+`--model <model>` and `--config
 model_reasoning_effort=<effort>`; new Claude Code launches use
 `--model <model>` and `--effort <effort>`. Session resumes do not receive model
 or effort flags. `codex-app` launches keep app-side/default model and reasoning
@@ -380,10 +381,11 @@ mode so you can review or edit it before pressing enter. Headless launches keep
 focus on the Flow list. Creating a new Flow has its own default-on Headless
 checkbox for the initial Plan launch; uncheck it for an interactive initial
 Plan launch. That checkbox does not change the selected-phase `h` setting.
-Press `M` to choose the configured CLI agent's model and `E` to choose its
-reasoning effort for future launches; the shortcut pane shows the current
-values. Manual phase launches, auto-launched phases, and new Flow Plan launches
-all use the configured agent and that agent's configured model and effort.
+Press `M` outside selected top-level Flow rows to choose the configured CLI
+agent's model and `E` to choose its reasoning effort for future launches; the
+shortcut pane shows the current values. Manual phase launches, auto-launched
+phases, and new Flow Plan launches all use the configured agent and that
+agent's configured model and effort.
 `codex-app` remains URL/deep-link based, launches externally, and uses
 app-side/default model and reasoning. Press `r` to resume an attached
 provider session from the selected phase row; CLI resumes open in runtime-only

--- a/docs/config.md
+++ b/docs/config.md
@@ -221,9 +221,9 @@ Press `F2` in normal TUI views to open the prompt-template editor. The editor
 can save a custom `[agent].plan_prompt`, reset it to the built-in default, or
 preview the built-in prompt.
 
-In the flows pane, `M` opens a provider-specific model picker outside selected
-top-level Flow rows and persists the corresponding key for the selected CLI
-agent. `E` opens the reasoning-effort picker. New Codex CLI launches use
+In the flows pane, `M` opens a provider-specific model picker and persists the
+corresponding key for the selected CLI agent. `E` opens the reasoning-effort
+picker. New Codex CLI launches use
 `--model <model>` and `--config
 model_reasoning_effort=<effort>`; new Claude Code launches use
 `--model <model>` and `--effort <effort>`. Session resumes do not receive model
@@ -381,8 +381,8 @@ mode so you can review or edit it before pressing enter. Headless launches keep
 focus on the Flow list. Creating a new Flow has its own default-on Headless
 checkbox for the initial Plan launch; uncheck it for an interactive initial
 Plan launch. That checkbox does not change the selected-phase `h` setting.
-Press `M` outside selected top-level Flow rows to choose the configured CLI
-agent's model and `E` to choose its reasoning effort for future launches; the
+Press `M` to choose the configured CLI agent's model and `E` to choose its
+reasoning effort for future launches; the
 shortcut pane shows the current values. Manual phase launches, auto-launched
 phases, and new Flow Plan launches all use the configured agent and that
 agent's configured model and effort.

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1391,7 +1391,7 @@ func flowLaunchKey() tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
 }
 
-func TestModel_MKeyTogglesFlowAutoModeFromFlowRow(t *testing.T) {
+func TestModel_AKeyTogglesFlowAutoModeFromFlowRow(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	updated := flow
 	updated.AutoMode = true
@@ -1404,9 +1404,9 @@ func TestModel_MKeyTogglesFlowAutoModeFromFlowRow(t *testing.T) {
 	})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	if cmd == nil {
-		t.Fatal("m on selected Flow row should persist auto-mode toggle")
+		t.Fatal("a on selected Flow row should persist auto-mode toggle")
 	}
 	m, follow := update(m, cmd())
 	if follow != nil {
@@ -1423,7 +1423,7 @@ func TestModel_MKeyTogglesFlowAutoModeFromFlowRow(t *testing.T) {
 	}
 }
 
-func TestModel_MKeyTogglesFlowAutoModeFromPhaseRowAndPreservesSelection(t *testing.T) {
+func TestModel_AKeyTogglesFlowAutoModeFromPhaseRowAndPreservesSelection(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	flow.AutoMode = true
 	updated := flow
@@ -1438,9 +1438,9 @@ func TestModel_MKeyTogglesFlowAutoModeFromPhaseRowAndPreservesSelection(t *testi
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m = selectFlowPhaseByID(t, m, "implementation")
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	if cmd == nil {
-		t.Fatal("m on selected Flow phase should persist auto-mode toggle")
+		t.Fatal("a on selected Flow phase should persist auto-mode toggle")
 	}
 	m, follow := update(m, cmd())
 	if follow != nil {
@@ -1457,7 +1457,7 @@ func TestModel_MKeyTogglesFlowAutoModeFromPhaseRowAndPreservesSelection(t *testi
 	}
 }
 
-func TestModel_MKeyFlowAutoModeFailureReportsStatus(t *testing.T) {
+func TestModel_AKeyFlowAutoModeFailureReportsStatus(t *testing.T) {
 	flow := flowWithPhaseDetails()
 	m := model.NewWithOptions(testRepos(), model.Options{
 		SetFlowAutoMode: func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error) {
@@ -1466,9 +1466,9 @@ func TestModel_MKeyFlowAutoModeFailureReportsStatus(t *testing.T) {
 	})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	if cmd == nil {
-		t.Fatal("m on selected Flow row should return persistence command")
+		t.Fatal("a on selected Flow row should return persistence command")
 	}
 	m, _ = update(m, cmd())
 	if got := m.TransientError(); !strings.Contains(got, "failed to set Flow auto mode") || !strings.Contains(got, "state root locked") {
@@ -1479,7 +1479,7 @@ func TestModel_MKeyFlowAutoModeFailureReportsStatus(t *testing.T) {
 	}
 }
 
-func TestModel_MKeyFlowAutoModeNoopsWithoutSelectedFlow(t *testing.T) {
+func TestModel_AKeyFlowAutoModeNoopsWithoutSelectedFlow(t *testing.T) {
 	called := false
 	m := model.NewWithOptions(testRepos(), model.Options{
 		SetFlowAutoMode: func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error) {
@@ -1489,16 +1489,85 @@ func TestModel_MKeyFlowAutoModeNoopsWithoutSelectedFlow(t *testing.T) {
 	})
 	m = flowsInRightPane(t, m, nil)
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
 	if cmd != nil {
-		t.Fatalf("m without selected Flow returned command %T, want nil", cmd)
+		t.Fatalf("a without selected Flow returned command %T, want nil", cmd)
 	}
 	if called {
 		t.Fatal("SetFlowAutoMode should not be called without a selected Flow")
 	}
 }
 
-func TestModel_ShiftMMarksSelectedFlowAsManuallyMerged(t *testing.T) {
+func TestModel_AKeyTogglesFlowAutoModeFromActiveFlowRow(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	updated := flow
+	updated.AutoMode = true
+	var calls []flowstore.AutoModeUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SetFlowAutoMode: func(update flowstore.AutoModeUpdate) (flowstore.FlowRecord, error) {
+			calls = append(calls, update)
+			return updated, nil
+		},
+	})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd == nil {
+		t.Fatal("a on selected active Flow row should persist auto-mode toggle")
+	}
+	m, follow := update(m, cmd())
+	if follow != nil {
+		t.Fatalf("auto-mode result returned follow-up command %T, want nil", follow)
+	}
+	if len(calls) != 1 || calls[0].FlowID != "flow-1" || !calls[0].Enabled {
+		t.Fatalf("auto-mode calls = %#v, want enable flow-1", calls)
+	}
+	if got := model.ActiveFlowsForTest(m); len(got) != 1 || !got[0].AutoMode {
+		t.Fatalf("active Flows = %#v, want auto mode enabled", got)
+	}
+}
+
+func TestModel_AKeyTogglesFlowAutoModeFromActiveFlowPhaseRowAndPreservesSelection(t *testing.T) {
+	flow := flowWithPhaseDetails()
+	flow.AutoMode = true
+	updated := flow
+	updated.AutoMode = false
+	var calls []flowstore.AutoModeUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SetFlowAutoMode: func(update flowstore.AutoModeUpdate) (flowstore.FlowRecord, error) {
+			calls = append(calls, update)
+			return updated, nil
+		},
+	})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	for i := 0; i < 50 && model.SelectedActiveFlowPhaseIDForTest(m) != "implementation"; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "implementation" {
+		t.Fatalf("selected active Flow phase = %q, want implementation", got)
+	}
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd == nil {
+		t.Fatal("a on selected active Flow phase should persist auto-mode toggle")
+	}
+	m, follow := update(m, cmd())
+	if follow != nil {
+		t.Fatalf("auto-mode result returned follow-up command %T, want nil", follow)
+	}
+	if len(calls) != 1 || calls[0].FlowID != "flow-1" || calls[0].Enabled {
+		t.Fatalf("auto-mode calls = %#v, want disable flow-1", calls)
+	}
+	if got := model.ActiveFlowsForTest(m); len(got) != 1 || got[0].AutoMode {
+		t.Fatalf("active Flows = %#v, want auto mode disabled", got)
+	}
+	if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "implementation" {
+		t.Fatalf("selected active Flow phase = %q, want preserved implementation", got)
+	}
+}
+
+func TestModel_MKeyMarksSelectedFlowAsManuallyMerged(t *testing.T) {
 	flow := manualMergeEligibleFlow()
 	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
 	updated := flow
@@ -1525,7 +1594,7 @@ func TestModel_ShiftMMarksSelectedFlowAsManuallyMerged(t *testing.T) {
 	})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
 	if cmd != nil {
 		t.Fatalf("opening manual merge confirmation returned command %T, want nil", cmd)
 	}
@@ -1561,7 +1630,30 @@ func TestModel_ShiftMMarksSelectedFlowAsManuallyMerged(t *testing.T) {
 	}
 }
 
-func TestModel_ShiftMManualMergeNoopsOnSelectedPhaseRow(t *testing.T) {
+func TestModel_ShiftMManualMergeNoopsOnSelectedFlowRow(t *testing.T) {
+	flow := manualMergeEligibleFlow()
+	called := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		LookupPRMerge: func(int, string) (actions.PullRequestMerge, error) {
+			called = true
+			return actions.PullRequestMerge{}, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	if cmd != nil {
+		t.Fatalf("M on selected Flow row returned command %T, want nil", cmd)
+	}
+	if m.Overlay() == ui.OverlayConfirm {
+		t.Fatalf("M on selected Flow row opened confirmation %q", m.ConfirmPrompt())
+	}
+	if called {
+		t.Fatal("LookupPRMerge should not run for uppercase M on selected Flow row")
+	}
+}
+
+func TestModel_MKeyManualMergeNoopsOnSelectedPhaseRow(t *testing.T) {
 	flow := manualMergeEligibleFlow()
 	called := false
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -1573,19 +1665,49 @@ func TestModel_ShiftMManualMergeNoopsOnSelectedPhaseRow(t *testing.T) {
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 	m = selectFlowPhaseByID(t, m, "merge")
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
 	if cmd != nil {
-		t.Fatalf("M on selected phase returned command %T, want nil", cmd)
+		t.Fatalf("m on selected phase returned command %T, want nil", cmd)
 	}
 	if m.Overlay() == ui.OverlayConfirm {
-		t.Fatalf("M on selected phase opened confirmation %q", m.ConfirmPrompt())
+		t.Fatalf("m on selected phase opened confirmation %q", m.ConfirmPrompt())
 	}
 	if called {
 		t.Fatal("LookupPRMerge should not run for selected phase row")
 	}
 }
 
-func TestModel_ShiftMManualMergeNoopsWhenMergePhaseRunning(t *testing.T) {
+func TestModel_MKeyManualMergeNoopsOnActiveFlowPhaseRow(t *testing.T) {
+	flow := manualMergeEligibleFlow()
+	called := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		LookupPRMerge: func(int, string) (actions.PullRequestMerge, error) {
+			called = true
+			return actions.PullRequestMerge{}, nil
+		},
+	})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	for i := 0; i < 50 && model.SelectedActiveFlowPhaseIDForTest(m) != "merge"; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "merge" {
+		t.Fatalf("selected active Flow phase = %q, want merge", got)
+	}
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	if cmd != nil {
+		t.Fatalf("m on selected active Flow phase returned command %T, want nil", cmd)
+	}
+	if m.Overlay() == ui.OverlayConfirm {
+		t.Fatalf("m on selected active Flow phase opened confirmation %q", m.ConfirmPrompt())
+	}
+	if called {
+		t.Fatal("LookupPRMerge should not run for selected active Flow phase row")
+	}
+}
+
+func TestModel_MKeyManualMergeNoopsWhenMergePhaseRunning(t *testing.T) {
 	flow := manualMergeEligibleFlow()
 	flow.Phases[len(flow.Phases)-1].Status = flowstore.PhaseRunning
 	called := false
@@ -1597,19 +1719,19 @@ func TestModel_ShiftMManualMergeNoopsWhenMergePhaseRunning(t *testing.T) {
 	})
 	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
 
-	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
 	if cmd != nil {
-		t.Fatalf("M on running merge phase returned command %T, want nil", cmd)
+		t.Fatalf("m on running merge phase returned command %T, want nil", cmd)
 	}
 	if m.Overlay() == ui.OverlayConfirm {
-		t.Fatalf("M on running merge phase opened confirmation %q", m.ConfirmPrompt())
+		t.Fatalf("m on running merge phase opened confirmation %q", m.ConfirmPrompt())
 	}
 	if called {
 		t.Fatal("LookupPRMerge should not run when merge phase is running")
 	}
 }
 
-func TestModel_ShiftMManualMergeFailureReplacesRecoveredFlowState(t *testing.T) {
+func TestModel_MKeyManualMergeFailureReplacesRecoveredFlowState(t *testing.T) {
 	flow := manualMergeEligibleFlow()
 	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
 	recovered := flow
@@ -1626,7 +1748,7 @@ func TestModel_ShiftMManualMergeFailureReplacesRecoveredFlowState(t *testing.T) 
 		},
 	}), []flowstore.FlowRecord{flow})
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if cmd == nil {
 		t.Fatal("confirming manual merge should return command")
@@ -1641,12 +1763,12 @@ func TestModel_ShiftMManualMergeFailureReplacesRecoveredFlowState(t *testing.T) 
 	if mergePhase.Status != flowstore.PhaseNeedsAttention || !strings.Contains(mergePhase.Notes, "missing plan") {
 		t.Fatalf("manual merge failure did not replace recovered flow state: %#v", got[0])
 	}
-	if strings.Contains(m.View(), "M      mark merged") {
+	if strings.Contains(m.View(), "m      mark merged") {
 		t.Fatalf("recovered needs_attention Flow should not advertise manual merge:\n%s", m.View())
 	}
 }
 
-func TestModel_ShiftMManualMergeRemovesMergedRecordFromActiveFlows(t *testing.T) {
+func TestModel_MKeyManualMergeRemovesMergedRecordFromActiveFlows(t *testing.T) {
 	flow := manualMergeEligibleFlow()
 	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
 	merged := flow
@@ -1662,7 +1784,7 @@ func TestModel_ShiftMManualMergeRemovesMergedRecordFromActiveFlows(t *testing.T)
 		},
 	}), []flowstore.FlowRecord{flow})
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if cmd == nil {
 		t.Fatal("confirming manual merge should return command")
@@ -1671,6 +1793,29 @@ func TestModel_ShiftMManualMergeRemovesMergedRecordFromActiveFlows(t *testing.T)
 
 	if strings.Contains(m.View(), "Manual merge Flow") {
 		t.Fatalf("merged Flow should be filtered from active view:\n%s", m.View())
+	}
+}
+
+func TestModel_ShiftMManualMergeNoopsOnActiveFlowRow(t *testing.T) {
+	flow := manualMergeEligibleFlow()
+	called := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		LookupPRMerge: func(int, string) (actions.PullRequestMerge, error) {
+			called = true
+			return actions.PullRequestMerge{}, nil
+		},
+	})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	if cmd != nil {
+		t.Fatalf("M on selected active Flow row returned command %T, want nil", cmd)
+	}
+	if m.Overlay() == ui.OverlayConfirm {
+		t.Fatalf("M on selected active Flow row opened confirmation %q", m.ConfirmPrompt())
+	}
+	if called {
+		t.Fatal("LookupPRMerge should not run for uppercase M on selected active Flow row")
 	}
 }
 
@@ -3911,7 +4056,7 @@ func TestModel_HKeyInFlowsTogglesHeadlessWithoutNavigatingModes(t *testing.T) {
 }
 
 func TestModel_LegacyFlowShortcutsDoNotToggleOrLaunch(t *testing.T) {
-	for _, key := range []rune{'x', 'a', 'i'} {
+	for _, key := range []rune{'x', 'i'} {
 		t.Run(string(key), func(t *testing.T) {
 			addLaunchRan := false
 			launchAgentRan := false
@@ -7525,10 +7670,20 @@ func TestModel_F2ForwardsWhenFlowTerminalInputOwnsKeys(t *testing.T) {
 
 func TestModel_FlowSettingsKeysDoNotOpenPickersWhileFlowTerminalFocused(t *testing.T) {
 	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
+	autoModeCalled := false
+	manualMergeLookupCalled := false
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
 			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		SetFlowAutoMode: func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error) {
+			autoModeCalled = true
+			return flowstore.FlowRecord{}, nil
+		},
+		LookupPRMerge: func(int, string) (actions.PullRequestMerge, error) {
+			manualMergeLookupCalled = true
+			return actions.PullRequestMerge{}, nil
 		},
 		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
 			return fakeTerm, nil
@@ -7563,6 +7718,22 @@ func TestModel_FlowSettingsKeysDoNotOpenPickersWhileFlowTerminalFocused(t *testi
 		t.Fatalf("status = %q, want unknown terminal command", got)
 	}
 
+	for _, key := range []rune{'a', 'm', 'M'} {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{key}})
+		if m.Overlay() != ui.OverlayNone {
+			t.Fatalf("terminal command-mode %c opened overlay %d", key, m.Overlay())
+		}
+		if len(fakeTerm.writes) != 0 {
+			t.Fatalf("terminal command-mode %c should not write to PTY: %#v", key, fakeTerm.writes)
+		}
+	}
+	if autoModeCalled {
+		t.Fatal("terminal command mode should not toggle Flow auto mode")
+	}
+	if manualMergeLookupCalled {
+		t.Fatal("terminal command mode should not start manual merge lookup")
+	}
+
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'E'}})
 	if m.Overlay() != ui.OverlayNone {
@@ -7578,6 +7749,22 @@ func TestModel_FlowSettingsKeysDoNotOpenPickersWhileFlowTerminalFocused(t *testi
 	}
 	if len(fakeTerm.writes) != 2 || fakeTerm.writes[1] != "V" {
 		t.Fatalf("terminal input-mode V writes = %#v, want E then V", fakeTerm.writes)
+	}
+
+	for _, key := range []rune{'a', 'm', 'M'} {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{key}})
+		if m.Overlay() != ui.OverlayNone {
+			t.Fatalf("terminal input-mode %c opened overlay %d", key, m.Overlay())
+		}
+	}
+	if !slices.Equal(fakeTerm.writes, []string{"E", "V", "a", "m", "M"}) {
+		t.Fatalf("terminal input-mode writes = %#v, want E, V, a, m, M", fakeTerm.writes)
+	}
+	if autoModeCalled {
+		t.Fatal("terminal input mode should not toggle Flow auto mode")
+	}
+	if manualMergeLookupCalled {
+		t.Fatal("terminal input mode should not start manual merge lookup")
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1630,10 +1630,11 @@ func TestModel_MKeyMarksSelectedFlowAsManuallyMerged(t *testing.T) {
 	}
 }
 
-func TestModel_ShiftMManualMergeNoopsOnSelectedFlowRow(t *testing.T) {
+func TestModel_ShiftMOpensModelPickerOnSelectedFlowRow(t *testing.T) {
 	flow := manualMergeEligibleFlow()
 	called := false
 	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
 		LookupPRMerge: func(int, string) (actions.PullRequestMerge, error) {
 			called = true
 			return actions.PullRequestMerge{}, nil
@@ -1645,8 +1646,11 @@ func TestModel_ShiftMManualMergeNoopsOnSelectedFlowRow(t *testing.T) {
 	if cmd != nil {
 		t.Fatalf("M on selected Flow row returned command %T, want nil", cmd)
 	}
-	if m.Overlay() == ui.OverlayConfirm {
-		t.Fatalf("M on selected Flow row opened confirmation %q", m.ConfirmPrompt())
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("M on selected Flow row overlay = %d, want model select", m.Overlay())
+	}
+	if view := m.View(); !strings.Contains(view, "Choose codex model") {
+		t.Fatalf("M on selected Flow row did not open model picker:\n%s", view)
 	}
 	if called {
 		t.Fatal("LookupPRMerge should not run for uppercase M on selected Flow row")

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1653,6 +1653,24 @@ func TestModel_ShiftMManualMergeNoopsOnSelectedFlowRow(t *testing.T) {
 	}
 }
 
+func TestModel_ShiftMOpensModelPickerOnSelectedFlowPhaseRow(t *testing.T) {
+	flow := manualMergeEligibleFlow()
+	m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: "codex"})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flow})
+	m = selectFlowPhaseByID(t, m, "merge")
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	if cmd != nil {
+		t.Fatalf("M on selected Flow phase returned command %T, want nil", cmd)
+	}
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("M on selected Flow phase overlay = %d, want model select", m.Overlay())
+	}
+	if view := m.View(); !strings.Contains(view, "Choose codex model") {
+		t.Fatalf("M on selected Flow phase did not open model picker:\n%s", view)
+	}
+}
+
 func TestModel_MKeyManualMergeNoopsOnSelectedPhaseRow(t *testing.T) {
 	flow := manualMergeEligibleFlow()
 	called := false
@@ -1816,6 +1834,30 @@ func TestModel_ShiftMManualMergeNoopsOnActiveFlowRow(t *testing.T) {
 	}
 	if called {
 		t.Fatal("LookupPRMerge should not run for uppercase M on selected active Flow row")
+	}
+}
+
+func TestModel_ShiftMOpensModelPickerOnSelectedActiveFlowPhaseRow(t *testing.T) {
+	flow := manualMergeEligibleFlow()
+	m := model.NewWithOptions(testRepos(), model.Options{AgentCommand: "codex"})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	for i := 0; i < 50 && model.SelectedActiveFlowPhaseIDForTest(m) != "merge"; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "merge" {
+		t.Fatalf("selected active Flow phase = %q, want merge", got)
+	}
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
+	if cmd != nil {
+		t.Fatalf("M on selected active Flow phase returned command %T, want nil", cmd)
+	}
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("M on selected active Flow phase overlay = %d, want model select", m.Overlay())
+	}
+	if view := m.View(); !strings.Contains(view, "Choose codex model") {
+		t.Fatalf("M on selected active Flow phase did not open model picker:\n%s", view)
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -99,7 +99,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if key == "M" && m.flowSurfaceVisible() {
-		return m.handleFlowModelOrManualMerge()
+		return m.handleFlowModelPicker()
 	}
 
 	if key == "E" && m.flowSurfaceVisible() {
@@ -434,7 +434,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		}
 	case "M":
 		if m.flowSurfaceVisible() {
-			return m.handleFlowModelOrManualMerge()
+			return m.handleFlowModelPicker()
 		}
 	case "i":
 		if m.mode == ui.ModePlans {
@@ -494,7 +494,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			return m.handleMoveWorktree()
 		}
 		if m.flowSurfaceVisible() {
-			return m.handleToggleFlowAutoMode()
+			return m.handleMarkFlowManuallyMerged()
 		}
 	case "N":
 		if m.mode == ui.ModeWorktrees {
@@ -505,7 +505,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 			return m.handleImplementPlan()
 		}
 		if m.flowSurfaceVisible() {
-			return m, nil
+			return m.handleToggleFlowAutoMode()
 		}
 		return m.handleOpenAgent()
 	case "d":
@@ -609,6 +609,8 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 	case "o":
 		return m.handleOpenFlowPlanText()
 	case "m":
+		return m.handleMarkFlowManuallyMerged()
+	case "a":
 		return m.handleToggleFlowAutoMode()
 	case "p":
 		return m.handleOpenSelectedFlowPR()
@@ -621,7 +623,7 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 	case "E":
 		return m.handleSetReasoningEffort()
 	case "M":
-		return m.handleFlowModelOrManualMerge()
+		return m.handleFlowModelPicker()
 	case "x":
 		return m.handleResetSelectedFlowPhase()
 	case "d":
@@ -1163,10 +1165,7 @@ func (m Model) handleSetModel() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) handleFlowModelOrManualMerge() (tea.Model, tea.Cmd) {
-	if _, _, ok := m.selectedManualMergeFlow(); ok {
-		return m.handleMarkFlowManuallyMerged()
-	}
+func (m Model) handleFlowModelPicker() (tea.Model, tea.Cmd) {
 	if _, ok := m.selectedFlow(); ok {
 		return m, nil
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1166,10 +1166,14 @@ func (m Model) handleSetModel() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleFlowModelPicker() (tea.Model, tea.Cmd) {
-	if _, ok := m.selectedFlow(); ok {
+	if m.flowModelPickerSuppressedForSelectedFlowRow() {
 		return m, nil
 	}
 	return m.handleSetModel()
+}
+
+func (m Model) flowModelPickerSuppressedForSelectedFlowRow() bool {
+	return m.flowSurfaceVisible() && m.activePane == 1 && m.currentSelectedFlowPhaseID() == "" && m.selectedFlowID() != ""
 }
 
 func modelSelectItems(command string) []modal.SelectItem {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -99,7 +99,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if key == "M" && m.flowSurfaceVisible() {
-		return m.handleFlowModelPicker()
+		return m.handleSetModel()
 	}
 
 	if key == "E" && m.flowSurfaceVisible() {
@@ -434,7 +434,7 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		}
 	case "M":
 		if m.flowSurfaceVisible() {
-			return m.handleFlowModelPicker()
+			return m.handleSetModel()
 		}
 	case "i":
 		if m.mode == ui.ModePlans {
@@ -623,7 +623,7 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 	case "E":
 		return m.handleSetReasoningEffort()
 	case "M":
-		return m.handleFlowModelPicker()
+		return m.handleSetModel()
 	case "x":
 		return m.handleResetSelectedFlowPhase()
 	case "d":
@@ -1163,17 +1163,6 @@ func (m Model) handleSetModel() (tea.Model, tea.Cmd) {
 		func(value string) tea.Cmd { return m.setModel(command, value) },
 	)
 	return m, nil
-}
-
-func (m Model) handleFlowModelPicker() (tea.Model, tea.Cmd) {
-	if m.flowModelPickerSuppressedForSelectedFlowRow() {
-		return m, nil
-	}
-	return m.handleSetModel()
-}
-
-func (m Model) flowModelPickerSuppressedForSelectedFlowRow() bool {
-	return m.flowSurfaceVisible() && m.activePane == 1 && m.currentSelectedFlowPhaseID() == "" && m.selectedFlowID() != ""
 }
 
 func modelSelectItems(command string) []modal.SelectItem {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1289,9 +1289,9 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 
 func flowAutoModeShortcutHint(enabled bool) shortcutHint {
 	if enabled {
-		return shortcutHint{Key: "m", Label: "auto: on", SuccessSuffix: "on"}
+		return shortcutHint{Key: "a", Label: "auto: on", SuccessSuffix: "on"}
 	}
-	return shortcutHint{Key: "m", Label: "auto: off"}
+	return shortcutHint{Key: "a", Label: "auto: off"}
 }
 
 func flowShortcutSections(sp statusBarParams, actions, navigation, global []shortcutHint) []shortcutSection {
@@ -1314,7 +1314,7 @@ func flowShortcutSections(sp statusBarParams, actions, navigation, global []shor
 				actions = append(actions, shortcutHint{Key: "g", Label: "launch next"})
 			}
 			if !sp.FlowPhaseSelected && sp.FlowManualMergeReadySelected {
-				actions = append(actions, shortcutHint{Key: "M", Label: "mark merged"})
+				actions = append(actions, shortcutHint{Key: "m", Label: "mark merged"})
 			}
 			if sp.FlowPhaseSelected && sp.FlowPhaseResetReadySelected {
 				actions = append(actions, shortcutHint{Key: "x", Label: "reset ready"})
@@ -1594,15 +1594,15 @@ func renderFlowFooterShortcuts(sp statusBarParams, sections []shortcutSection) s
 	tinyBase := footerHintsForKeys(hints, "q/esc")
 	upDown := footerHintsForKeys(hints, "↑/↓")
 	arrow := footerHintsForKeys(hints, "←/→")
-	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "g", "M", "d")
-	coreActionsWithoutSafety := footerHintsForKeys(hints, "h", "enter", "g", "M", "d")
-	coreActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "M", "d", "m")
-	coreActionsWithAutoWithoutSafety := footerHintsForKeys(hints, "h", "enter", "g", "M", "d", "m")
-	selectedActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "M", "x", "o", "y", "d", "r", "m")
-	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "M", "x", "o", "y", "d", "r", "m", "A", "E", "f", "F")
-	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "M", "x", "o", "y", "d", "r", "m", "A", "f", "F")
-	actionsWithoutModelAndEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "A", "f", "F")
-	actionsWithoutAgentAndPreferences := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "x", "o", "y", "d", "r", "m", "f", "F")
+	coreActions := footerHintsForKeys(hints, "D", "h", "enter", "g", "m", "d")
+	coreActionsWithoutSafety := footerHintsForKeys(hints, "h", "enter", "g", "m", "d")
+	coreActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "m", "d", "a")
+	coreActionsWithAutoWithoutSafety := footerHintsForKeys(hints, "h", "enter", "g", "m", "d", "a")
+	selectedActionsWithAuto := footerHintsForKeys(hints, "D", "h", "enter", "g", "m", "x", "o", "y", "d", "r", "a")
+	actions := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "m", "x", "o", "y", "d", "r", "a", "A", "M", "E", "f", "F")
+	actionsWithoutEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "m", "x", "o", "y", "d", "r", "a", "A", "M", "f", "F")
+	actionsWithoutModelAndEffort := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "m", "x", "o", "y", "d", "r", "a", "A", "f", "F")
+	actionsWithoutAgentAndPreferences := footerHintsForKeys(hints, "D", "n", "h", "enter", "g", "m", "x", "o", "y", "d", "r", "a", "f", "F")
 
 	for _, parts := range [][]string{
 		appendParts(base, upDown, arrow, actions),

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1343,8 +1343,7 @@ func flowShortcutSections(sp statusBarParams, actions, navigation, global []shor
 	}
 	agentLabel, agentConfigured := flowAgentShortcut(sp.FlowAgentLabel)
 	flowAgentControls = append(flowAgentControls, shortcutHint{Key: "A", Label: agentLabel})
-	selectedTopLevelFlowRow := sp.ActivePane == 1 && sp.FlowSelected && !sp.FlowPhaseSelected
-	if modelLabel := flowModelShortcutLabel(sp.FlowModel); agentConfigured && modelLabel != "" && !selectedTopLevelFlowRow {
+	if modelLabel := flowModelShortcutLabel(sp.FlowModel); agentConfigured && modelLabel != "" {
 		flowAgentControls = append(flowAgentControls, shortcutHint{Key: "M", Label: modelLabel})
 	}
 	if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); agentConfigured && effortLabel != "" {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1343,7 +1343,8 @@ func flowShortcutSections(sp statusBarParams, actions, navigation, global []shor
 	}
 	agentLabel, agentConfigured := flowAgentShortcut(sp.FlowAgentLabel)
 	flowAgentControls = append(flowAgentControls, shortcutHint{Key: "A", Label: agentLabel})
-	if modelLabel := flowModelShortcutLabel(sp.FlowModel); agentConfigured && modelLabel != "" {
+	selectedTopLevelFlowRow := sp.ActivePane == 1 && sp.FlowSelected && !sp.FlowPhaseSelected
+	if modelLabel := flowModelShortcutLabel(sp.FlowModel); agentConfigured && modelLabel != "" && !selectedTopLevelFlowRow {
 		flowAgentControls = append(flowAgentControls, shortcutHint{Key: "M", Label: modelLabel})
 	}
 	if effortLabel := flowReasoningEffortShortcutLabel(sp.FlowReasoningEffort); agentConfigured && effortLabel != "" {

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -776,7 +776,7 @@ func TestRender_FlowsModeShortcutSectionsUseFlowGroups(t *testing.T) {
 		"y      copy path",
 		"d      delete",
 		"h      headless on",
-		"m      auto: on",
+		"a      auto: on",
 		"A      codex",
 		"E      effort: high",
 		"bksp   pane",
@@ -839,7 +839,7 @@ func TestRender_ActiveFlowsShortcutSectionsHideNewFlow(t *testing.T) {
 		"c      copy id",
 		"y      copy path",
 		"h      headless on",
-		"m      auto: on",
+		"a      auto: on",
 		"A      codex",
 		"E      effort: high",
 	} {
@@ -1043,7 +1043,7 @@ func TestStatusBar_FlowsModeShowsManualMergeOnlyForEligibleFlowRow(t *testing.T)
 		FlowManualMergeReadySelected: true,
 	}
 	flowRow := renderStatusBarWithState(base)
-	if !strings.Contains(flowRow, "M: mark merged") {
+	if !strings.Contains(flowRow, "m: mark merged") {
 		t.Fatalf("eligible Flow row should expose manual merge shortcut, got %q", flowRow)
 	}
 
@@ -1151,7 +1151,7 @@ func TestStatusBar_FlowsModeShowsAutoModeToggleForSelectedFlow(t *testing.T) {
 		FlowSelected:         true,
 		FlowAutoModeSelected: false,
 	})
-	if !strings.Contains(flowRow, "m: auto: off") {
+	if !strings.Contains(flowRow, "a: auto: off") {
 		t.Fatalf("selected Flow row should expose auto-mode off toggle, got %q", flowRow)
 	}
 
@@ -1164,7 +1164,7 @@ func TestStatusBar_FlowsModeShowsAutoModeToggleForSelectedFlow(t *testing.T) {
 		FlowPhaseSelected:    true,
 		FlowAutoModeSelected: true,
 	})
-	if !strings.Contains(phaseRow, "m: auto: on") {
+	if !strings.Contains(phaseRow, "a: auto: on") {
 		t.Fatalf("selected Flow phase should expose auto-mode on toggle, got %q", phaseRow)
 	}
 }
@@ -1178,7 +1178,7 @@ func TestStatusBar_FlowsModeCompactFooterKeepsAutoModeToggle(t *testing.T) {
 		FlowSelected:         true,
 		FlowAutoModeSelected: false,
 	})
-	if !strings.Contains(flowRow, "m: auto: off") {
+	if !strings.Contains(flowRow, "a: auto: off") {
 		t.Fatalf("compact selected Flow row should keep auto-mode off toggle, got %q", flowRow)
 	}
 
@@ -1191,7 +1191,7 @@ func TestStatusBar_FlowsModeCompactFooterKeepsAutoModeToggle(t *testing.T) {
 		FlowPhaseSelected:    true,
 		FlowAutoModeSelected: true,
 	})
-	if !strings.Contains(phaseRow, "m: auto: on") {
+	if !strings.Contains(phaseRow, "a: auto: on") {
 		t.Fatalf("compact selected Flow phase should keep auto-mode on toggle, got %q", phaseRow)
 	}
 }

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -731,7 +731,7 @@ func TestRender_FlowsModeShowsReasoningEffortShortcut(t *testing.T) {
 	}
 }
 
-func TestRender_FlowsModeHidesModelShortcutOnSelectedFlowRow(t *testing.T) {
+func TestRender_FlowsModeShowsModelShortcutOnSelectedFlowRow(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:          []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
 		Selected:       0,
@@ -746,8 +746,8 @@ func TestRender_FlowsModeHidesModelShortcutOnSelectedFlowRow(t *testing.T) {
 	})
 
 	pane := shortcutPaneText(view)
-	if strings.Contains(pane, "M      model: gpt-5.5") {
-		t.Fatalf("selected Flow row should hide model shortcut:\n%s", pane)
+	if !strings.Contains(pane, "M      model: gpt-5.5") {
+		t.Fatalf("selected Flow row should expose model shortcut:\n%s", pane)
 	}
 	if !strings.Contains(pane, "A      codex") {
 		t.Fatalf("selected Flow row should keep agent shortcut:\n%s", pane)
@@ -1558,7 +1558,7 @@ func TestStatusBar_FlowsModeFooterGroupsAgentAndEffort(t *testing.T) {
 	}
 }
 
-func TestStatusBar_FlowsModeFooterHidesModelOnSelectedFlowRow(t *testing.T) {
+func TestStatusBar_FlowsModeFooterShowsModelOnSelectedFlowRow(t *testing.T) {
 	bar := renderStatusBarWithState(statusBarParams{
 		Width:          180,
 		Mode:           ModeFlows,
@@ -1568,8 +1568,8 @@ func TestStatusBar_FlowsModeFooterHidesModelOnSelectedFlowRow(t *testing.T) {
 		FlowAgentLabel: "codex",
 		FlowModel:      "model: gpt-5.5",
 	})
-	if strings.Contains(bar, "M: model: gpt-5.5") {
-		t.Fatalf("selected Flow row should hide model shortcut, got %q", bar)
+	if !strings.Contains(bar, "M: model: gpt-5.5") {
+		t.Fatalf("selected Flow row should expose model shortcut, got %q", bar)
 	}
 	if !strings.Contains(bar, "A: codex") {
 		t.Fatalf("selected Flow row should keep agent shortcut, got %q", bar)

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -731,6 +731,51 @@ func TestRender_FlowsModeShowsReasoningEffortShortcut(t *testing.T) {
 	}
 }
 
+func TestRender_FlowsModeHidesModelShortcutOnSelectedFlowRow(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:          []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:       0,
+		Width:          180,
+		Height:         28,
+		Mode:           ModeFlows,
+		ActivePane:     1,
+		Flows:          []flowstore.FlowRecord{{FlowID: "flow-1", Title: "Flow one", Status: flowstore.StatusInProgress}},
+		FlowSelected:   0,
+		FlowAgentLabel: "codex",
+		FlowModel:      "model: gpt-5.5",
+	})
+
+	pane := shortcutPaneText(view)
+	if strings.Contains(pane, "M      model: gpt-5.5") {
+		t.Fatalf("selected Flow row should hide model shortcut:\n%s", pane)
+	}
+	if !strings.Contains(pane, "A      codex") {
+		t.Fatalf("selected Flow row should keep agent shortcut:\n%s", pane)
+	}
+}
+
+func TestRender_FlowsModeShowsModelShortcutOnSelectedFlowPhaseRow(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:               []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:            0,
+		Width:               180,
+		Height:              28,
+		Mode:                ModeFlows,
+		ActivePane:          1,
+		Flows:               []flowstore.FlowRecord{{FlowID: "flow-1", Title: "Flow one", Status: flowstore.StatusInProgress, Phases: []flowstore.FlowPhase{{PhaseID: "merge", Title: "Merge", Status: flowstore.PhaseReady}}}},
+		FlowSelected:        0,
+		ExpandedFlowID:      "flow-1",
+		SelectedFlowPhaseID: "merge",
+		FlowAgentLabel:      "codex",
+		FlowModel:           "model: gpt-5.5",
+	})
+
+	pane := shortcutPaneText(view)
+	if !strings.Contains(pane, "M      model: gpt-5.5") {
+		t.Fatalf("selected Flow phase should expose model shortcut:\n%s", pane)
+	}
+}
+
 func TestRender_FlowsModeShortcutSectionsUseFlowGroups(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
@@ -1510,6 +1555,40 @@ func TestStatusBar_FlowsModeFooterGroupsAgentAndEffort(t *testing.T) {
 	}
 	if strings.Contains(bar, "A: set agent") || strings.Contains(bar, "E: codex effort: high") {
 		t.Fatalf("Flow footer should not show generic or duplicated labels, got %q", bar)
+	}
+}
+
+func TestStatusBar_FlowsModeFooterHidesModelOnSelectedFlowRow(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:          180,
+		Mode:           ModeFlows,
+		ActivePane:     1,
+		RepoSelected:   true,
+		FlowSelected:   true,
+		FlowAgentLabel: "codex",
+		FlowModel:      "model: gpt-5.5",
+	})
+	if strings.Contains(bar, "M: model: gpt-5.5") {
+		t.Fatalf("selected Flow row should hide model shortcut, got %q", bar)
+	}
+	if !strings.Contains(bar, "A: codex") {
+		t.Fatalf("selected Flow row should keep agent shortcut, got %q", bar)
+	}
+}
+
+func TestStatusBar_FlowsModeFooterShowsModelOnSelectedFlowPhaseRow(t *testing.T) {
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:             180,
+		Mode:              ModeFlows,
+		ActivePane:        1,
+		RepoSelected:      true,
+		FlowSelected:      true,
+		FlowPhaseSelected: true,
+		FlowAgentLabel:    "codex",
+		FlowModel:         "model: gpt-5.5",
+	})
+	if !strings.Contains(bar, "M: model: gpt-5.5") {
+		t.Fatalf("selected Flow phase should expose model shortcut, got %q", bar)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Move Flow auto-mode toggling from `m` to `a` in Flow and Active Flow views.
- Move manual GitHub merge marking from `M` to `m`, and suppress the model picker on selected top-level Flow rows so `M` remains available for phase rows.
- Update shortcut rendering, README/config docs, and Flow model/UI coverage for the new key layout.

## Verification
- `gofmt -l .`
- `make test`
- `make build`