### PR TITLE
Add optional GitHub issue metadata for Flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ CI requires clean `gofmt -l .`, `make test`, and `make build`.
 
 `wtui` is a Go Bubble Tea TUI for managing git worktrees across repositories. User-facing behavior, key bindings, and CLI examples are documented in `README.md`; config reference is `docs/config.md`; Flow phase semantics are `docs/flow-phases.md`.
 
-- `cmd/wtui/` — entrypoint. Handles `--version`, `session-hook --provider claude|codex`, and the `plan save|list|read|phase set` and `flow create|list|read|phase complete|phase block|phase needs-attention|phase restart|phase set|phase add-child|plan set|pr set|merge set` subcommands (`plan.go`, `flow.go`). Subcommands resolve the artifact root without scanning repos or starting the TUI.
+- `cmd/wtui/` — entrypoint. Handles `--version`, `session-hook --provider claude|codex`, and the `plan save|list|read|phase set` and `flow create|list|read|phase complete|phase block|phase needs-attention|phase restart|phase set|phase add-child|plan set|issue set|pr set|merge set` subcommands (`plan.go`, `flow.go`). Subcommands resolve the artifact root without scanning repos or starting the TUI.
 - `config/` — optional TOML from `$XDG_CONFIG_HOME/wtui/config.toml` or `~/.config/wtui/config.toml`. Missing config is non-fatal; an existing but unreadable or malformed config is startup-fatal.
 - `scanner/` — discovers repos under `WORKTREE_ROOT`, `[scan].root`, or `~/dev` (default depth 2, reducible via `[scan].max_depth`), excluding `*-worktrees`.
 - `gitquery/` — read-only git queries. `parse.go` is pure parsing; `runner.go` defines the `Runner` seam wrapped by a `Querier` (`NewQuerier` injects a fake `Runner` for tests).

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ filter matches, or a load failure with details in the status bar.
 | `s` | Page selected agent session summary (sessions view) |
 | `o` | Page selected session transcript (sessions view), selected plan Markdown (plans view), or linked plan body (flows view) |
 | `e` | Edit selected plan Markdown (plans view) |
-| `i` | Alias for plan implementation launch |
+| `i` | Alias for plan implementation launch, or open the linked GitHub issue (flows and active flows views, when issue metadata exists) |
 | `D` | Toggle destructive mode |
 | `tab` | Cycle pane focus forward; with a Flow terminal open, cycles repo pane → Flow list → terminal |
 | `bksp` | Switch focus to left pane |
@@ -333,10 +333,12 @@ skill dirs for use across repos. v1 has no TUI plan deletion.
 ### Flows view (mode 8)
 
 Browse persisted Flow records for the selected repo. Rows show status, branch
-or worktree basename, phase progress plus the current phase state, linked plan
-ID when present, PR number or label, updated date, and title. Use `/` to filter
-by title, instructions, status, branch, worktree basename, plan metadata, PR
-metadata, phase titles/statuses/summaries, and linked session metadata. Press
+or worktree basename, phase progress plus the current phase state, optional
+Issue reference, linked plan ID when present, PR number or label, updated date,
+and title. The column order is Status, Branch, Phase, Issue, Plan, PR, Updated,
+Title. Use `/` to filter by title, instructions, status, branch, worktree
+basename, plan metadata, issue metadata, PR metadata,
+phase titles/statuses/summaries, and linked session metadata. Press
 `n` to create a new Flow with one form for title, multiline instructions, and
 optional base ref plus Headless and Plan Now checkboxes; use `alt+enter` for
 instruction newlines. Plan Now is checked by default and immediately launches
@@ -352,6 +354,8 @@ worktrees, branches, checked-out code, linked plans, sessions, transcripts, or
 active embedded terminals. Expanded phase rows cannot be deleted with this
 action. On a Flow row or an expanded phase row, `enter` expands or collapses
 the phase list. Press
+`i` on a Flow row with linked GitHub issue metadata to open the issue in the
+browser. Press
 `p` on a Flow row with linked PR metadata to open the PR in the browser. Press
 `g` to launch the first launchable phase in the selected Flow's
 canonical phase order. This action
@@ -386,9 +390,9 @@ Browse active Flow records across all repos. This view hides merged Flow records
 moving focus to the left repo pane temporarily filters the visible active rows to
 the selected repo, and returning focus to the middle pane restores the global
 list. Normal Flow actions, phase launches, attached-session resumes, auto-mode
-toggles, linked-PR opening with `p`, `c` Flow ID copy, `y` worktree path copy,
-and embedded Flow terminals work from the visible active Flow rows and their
-expanded phase rows.
+toggles, linked-issue opening with `i`, linked-PR opening with `p`, `c` Flow ID
+copy, `y` worktree path copy, and embedded Flow terminals work from the visible
+active Flow rows and their expanded phase rows.
 
 Flow headless mode is on by default:
 selected CLI `codex` and `claude` phase launches run in a runtime-only embedded
@@ -465,6 +469,12 @@ wtui flow read --flow-id "$FLOW_ID"
 
 # Link a saved plan artifact back to a flow.
 wtui flow plan set --flow-id "$FLOW_ID" --plan-id "$PLAN_ID"
+
+# Record optional GitHub issue metadata when the task references an issue.
+wtui flow issue set --flow-id "$FLOW_ID" \
+  --provider github \
+  --number 123 \
+  --url "https://github.com/owner/repo/issues/123"
 
 # Record common phase outcomes without hand-assembling --status. These commands
 # print JSON with the updated phase and the next actionable phase state. For
@@ -606,7 +616,7 @@ plan_prompt = "Implement the saved wtui plan {title} (ID: {plan_id}) at {plan_pa
 default_view = 8
 
 [flow_prompts]
-implementation = "Implement {plan_path} from {worktree_path}, then use the commit skill before completing."
+implementation = "Implement {plan_path} from {worktree_path} for issue {issue_number}, then use the commit skill before completing."
 pr_creation = "Use the ship skill for {branch}, then record PR metadata for flow {flow_id}."
 
 [sessions]

--- a/agent-skills/skill_docs_test.go
+++ b/agent-skills/skill_docs_test.go
@@ -26,6 +26,7 @@ func TestWtuiFlowSkillDocumentsAgentContract(t *testing.T) {
 		"wtui flow phase restart",
 		"wtui flow phase set",
 		"wtui flow plan set",
+		"wtui flow issue set",
 		"wtui flow pr set",
 		"wtui plan save",
 		"wtui plan phase set",
@@ -82,6 +83,9 @@ func TestWtuiFlowSkillMatchesImplementedFlowCLIContract(t *testing.T) {
 	}
 	if !strings.Contains(skill, "wtui flow plan set") || !strings.Contains(flowCLI, "runFlowPlanSet") {
 		t.Fatal("skill and CLI should both expose flow plan set")
+	}
+	if !strings.Contains(skill, "wtui flow issue set") || !strings.Contains(flowCLI, "runFlowIssueSet") {
+		t.Fatal("skill and CLI should both expose flow issue set")
 	}
 	if !strings.Contains(skill, "wtui flow pr set") || !strings.Contains(flowCLI, "runFlowPRSet") {
 		t.Fatal("skill and CLI should both expose flow pr set")
@@ -649,6 +653,7 @@ func commandFunctionName(commandParts []string) (string, bool) {
 		"flow phase restart":         "runFlowPhaseRestart",
 		"flow phase add-child":       "runFlowPhaseAddChild",
 		"flow plan set":              "runFlowPlanSet",
+		"flow issue set":             "runFlowIssueSet",
 		"flow pr set":                "runFlowPRSet",
 		"flow merge set":             "runFlowMergeSet",
 		"plan save":                  "runPlanSave",

--- a/agent-skills/wtui-flow/SKILL.md
+++ b/agent-skills/wtui-flow/SKILL.md
@@ -115,7 +115,7 @@ wtui flow issue set \
   --url "https://github.com/owner/repo/issues/123" \
   "${FLOW_STATE_ARGS[@]}"
 ```
-5. Complete or block the Flow phase with `wtui flow phase complete` or
+6. Complete or block the Flow phase with `wtui flow phase complete` or
    `wtui flow phase block`.
 
 ```bash

--- a/agent-skills/wtui-flow/SKILL.md
+++ b/agent-skills/wtui-flow/SKILL.md
@@ -86,7 +86,7 @@ or a merge was recorded unless the corresponding command succeeded.
 The current Flow CLI exposes `create`, `list`, `read`, `phase complete`,
 `phase block`, `phase needs-attention`, `phase restart`, `phase set`,
 `phase add-child`,
-`plan set`, `pr set`, and `merge set`. Record merge metadata with
+`plan set`, `issue set`, `pr set`, and `merge set`. Record merge metadata with
 `wtui flow merge set`; do not claim a merge was recorded unless that structured
 command succeeds.
 
@@ -97,7 +97,24 @@ Goal: produce a saved wtui plan artifact.
 1. Read the flow.
 2. Save or update the plan through `wtui plan save`.
 3. Link the saved plan artifact back to the Flow with `wtui flow plan set`.
-4. Record plan progress with `wtui plan phase set` when the plan has phases.
+4. If the task references a GitHub issue, link it with `wtui flow issue set`.
+5. Record plan progress with `wtui plan phase set` when the plan has phases.
+
+When instructions give a full GitHub issue URL, use that URL directly. When
+instructions give only `#N`, derive
+`https://github.com/<owner>/<repo>/issues/<N>` only from an unambiguous GitHub
+`origin` remote in the worktree repository. If no GitHub origin can be
+established, do not persist a guessed issue URL; mention the ambiguity in the
+Plan phase summary or notes instead.
+
+```bash
+wtui flow issue set \
+  --flow-id "$WTUI_FLOW_ID" \
+  --provider github \
+  --number 123 \
+  --url "https://github.com/owner/repo/issues/123" \
+  "${FLOW_STATE_ARGS[@]}"
+```
 5. Complete or block the Flow phase with `wtui flow phase complete` or
    `wtui flow phase block`.
 

--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -22,7 +22,7 @@ func runFlow(args []string, deps runDeps) error {
 		return nil
 	}
 	if len(args) < 3 {
-		return fmt.Errorf("usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]")
+		return fmt.Errorf("usage: wtui flow <create|list|read|phase|plan|issue|pr|merge> [flags]")
 	}
 	switch args[2] {
 	case "create":
@@ -35,12 +35,14 @@ func runFlow(args []string, deps runDeps) error {
 		return runFlowPhase(args[3:], deps)
 	case "plan":
 		return runFlowPlan(args[3:], deps)
+	case "issue":
+		return runFlowIssue(args[3:], deps)
 	case "pr":
 		return runFlowPR(args[3:], deps)
 	case "merge":
 		return runFlowMerge(args[3:], deps)
 	default:
-		return unknownCommandError(args[2], []string{"create", "list", "read", "phase", "plan", "pr", "merge"}, flowHelpText)
+		return unknownCommandError(args[2], []string{"create", "list", "read", "phase", "plan", "issue", "pr", "merge"}, flowHelpText)
 	}
 }
 
@@ -48,7 +50,7 @@ func printFlowHelp(w io.Writer) {
 	io.WriteString(w, flowHelpText)
 }
 
-const flowHelpText = `Usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]
+const flowHelpText = `Usage: wtui flow <create|list|read|phase|plan|issue|pr|merge> [flags]
 
 Create and update task-centric Flow records under the wtui agent-artifact root.
 
@@ -64,6 +66,7 @@ Commands:
   phase set        Advance a Flow phase with explicit status.
   phase add-child  Add or update an implementation child phase.
   plan set         Link a saved plan artifact to a Flow.
+  issue set        Record GitHub issue metadata.
   pr set           Record pull request metadata.
   merge set        Record merge metadata.
 
@@ -76,6 +79,7 @@ Examples:
   wtui flow phase restart --flow-id "$FLOW_ID" --phase-id autoreview
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan --status completed --summary "Plan saved"
   wtui flow phase set --flow-id "$FLOW_ID" --phase-id plan-review --status completed --outcome approved
+  wtui flow issue set --flow-id "$FLOW_ID" --provider github --number 123 --url "$ISSUE_URL"
   wtui flow pr set --flow-id "$FLOW_ID" --provider github --number 155 --url "$PR_URL" --head "$BRANCH" --base main
   wtui flow merge set --flow-id "$FLOW_ID" --status merged --commit "$SHA" --merged-at "2026-06-09T12:00:00Z"
 
@@ -857,6 +861,100 @@ Common flags:
 
 Example:
   wtui flow plan set --flow-id "$FLOW_ID" --plan-id "$PLAN_ID"
+`)
+}
+
+func runFlowIssue(args []string, deps runDeps) error {
+	if len(args) == 1 && isHelpArg(args[0]) {
+		printFlowIssueHelp(deps.stdout)
+		return nil
+	}
+	if len(args) < 1 {
+		return fmt.Errorf("usage: wtui flow issue set [flags]")
+	}
+	if args[0] != "set" {
+		return unknownCommandError(args[0], []string{"set"}, flowIssueHelpText)
+	}
+	return runFlowIssueSet(args[1:], deps)
+}
+
+func printFlowIssueHelp(w io.Writer) {
+	io.WriteString(w, flowIssueHelpText)
+}
+
+const flowIssueHelpText = `Usage: wtui flow issue set [flags]
+
+Record GitHub issue metadata for a Flow.
+
+Required flags:
+  --flow-id FLOW_ID
+  --number N
+  --url URL
+
+Common flags:
+  --provider PROVIDER
+  --state-root PATH
+
+Example:
+  wtui flow issue set --flow-id "$FLOW_ID" --provider github --number 123 --url "$ISSUE_URL"
+`
+
+func runFlowIssueSet(args []string, deps runDeps) error {
+	flags := flag.NewFlagSet("flow issue set", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.Usage = func() { printFlowIssueSetHelp(deps.stdout) }
+	flowID := flags.String("flow-id", "", "flow id")
+	provider := flags.String("provider", "github", "issue provider")
+	number := flags.Int("number", 0, "issue number")
+	issueURL := flags.String("url", "", "issue URL")
+	stateRoot := flags.String("state-root", "", "artifact state root")
+	if help, err := parseCommandFlags(flags, args); help || err != nil {
+		if help {
+			return nil
+		}
+		return err
+	}
+	if *flowID == "" {
+		return fmt.Errorf("flow issue set requires --flow-id")
+	}
+	if *number <= 0 {
+		return fmt.Errorf("flow issue set requires positive --number")
+	}
+	if *issueURL == "" {
+		return fmt.Errorf("flow issue set requires --url")
+	}
+	store, err := newFlowStore(*stateRoot, deps)
+	if err != nil {
+		return err
+	}
+	record, err := store.SetIssue(flowstore.IssueUpdate{
+		FlowID:   *flowID,
+		Provider: *provider,
+		Number:   *number,
+		URL:      *issueURL,
+	})
+	if err != nil {
+		return err
+	}
+	return writeFlowJSON(deps.stdout, record)
+}
+
+func printFlowIssueSetHelp(w io.Writer) {
+	io.WriteString(w, `Usage: wtui flow issue set [flags]
+
+Record GitHub issue metadata for a Flow.
+
+Required flags:
+  --flow-id FLOW_ID
+  --number N
+  --url URL
+
+Common flags:
+  --provider PROVIDER
+  --state-root PATH
+
+Example:
+  wtui flow issue set --flow-id "$FLOW_ID" --provider github --number 123 --url "$ISSUE_URL"
 `)
 }
 

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -27,13 +27,14 @@ func TestRunFlowHelpPrintsUsageAndExamples(t *testing.T) {
 		t.Fatalf("run returned error: %v", err)
 	}
 	requireContainsAll(t, stdout.String(), []string{
-		"Usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]",
+		"Usage: wtui flow <create|list|read|phase|plan|issue|pr|merge> [flags]",
 		"wtui flow read --flow-id",
 		"wtui flow phase complete --flow-id",
 		"wtui flow phase block --flow-id",
 		"wtui flow phase needs-attention --flow-id",
 		"wtui flow phase restart --flow-id",
 		"wtui flow phase set --flow-id",
+		"wtui flow issue set --flow-id",
 		"wtui flow pr set --flow-id",
 		"wtui flow merge set --flow-id",
 	})
@@ -169,6 +170,39 @@ func TestRunFlowPRSetHelpPrintsUsageWithoutLoadingConfig(t *testing.T) {
 	})
 }
 
+func TestRunFlowIssueHelpPrintsUsageWithoutLoadingConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "issue", args: []string{"wtui", "flow", "issue", "--help"}},
+		{name: "issue set", args: []string{"wtui", "flow", "issue", "set", "--help"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			err := run(tc.args, noScanDeps(t, runDeps{
+				loadConfig: func() (config.Config, error) {
+					t.Fatal("loadConfig should not run for flow issue help")
+					return config.Config{}, nil
+				},
+				stdout: &stdout,
+			}))
+			if err != nil {
+				t.Fatalf("run returned error: %v", err)
+			}
+			if strings.Contains(stdout.String(), "flag: help requested") {
+				t.Fatalf("help output should not contain flag error:\n%s", stdout.String())
+			}
+			requireContainsAll(t, stdout.String(), []string{
+				"Usage: wtui flow issue set [flags]",
+				"--number N",
+				"--url URL",
+				"wtui flow issue set --flow-id",
+			})
+		})
+	}
+}
+
 func TestRunFlowLeafHelpPrintsUsageWithoutLoadingConfig(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -263,7 +297,8 @@ func TestRunFlowUnknownSubcommandSuggestsNearbyCommand(t *testing.T) {
 	}
 	requireContainsAll(t, err.Error(), []string{
 		`unknown command "phaze"; did you mean "phase"?`,
-		"Usage: wtui flow <create|list|read|phase|plan|pr|merge> [flags]",
+		"Usage: wtui flow <create|list|read|phase|plan|issue|pr|merge> [flags]",
+		"issue set",
 	})
 }
 
@@ -290,6 +325,7 @@ func TestRunFlowNestedSetSubcommandsSuggestSet(t *testing.T) {
 		args []string
 	}{
 		{name: "plan", args: []string{"wtui", "flow", "plan", "sete"}},
+		{name: "issue", args: []string{"wtui", "flow", "issue", "sete"}},
 		{name: "pr", args: []string{"wtui", "flow", "pr", "sete"}},
 		{name: "merge", args: []string{"wtui", "flow", "merge", "sete"}},
 	} {
@@ -605,6 +641,99 @@ func TestRunFlowPRSetValidatesRequiredInputs(t *testing.T) {
 			name: "branch mismatch",
 			args: []string{"wtui", "flow", "pr", "set", "--flow-id", created.FlowID, "--provider", "github", "--number", "115", "--url", "https://github.com/brian-bell/wtui/pull/115", "--head", "feature/other", "--base", "main", "--state-root", root},
 			want: "must match flow branch",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := run(tc.args, noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("run error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunFlowIssueSetPrintsJSONRecord(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	created := mustRunFlow(t, []string{
+		"wtui", "flow", "create",
+		"--title", "Issue metadata",
+		"--instructions", "link an issue",
+		"--repo-path", repoPath,
+		"--branch", "flow/issue-metadata",
+		"--json",
+		"--state-root", root,
+	})
+
+	var stdout bytes.Buffer
+	err := run([]string{
+		"wtui", "flow", "issue", "set",
+		"--flow-id", created.FlowID,
+		"--provider", "github",
+		"--number", "123",
+		"--url", "https://github.com/brian-bell/wtui/issues/123",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: &stdout}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	var updated flowstore.FlowRecord
+	if err := json.Unmarshal(stdout.Bytes(), &updated); err != nil {
+		t.Fatalf("output is not JSON record: %v\n%s", err, stdout.String())
+	}
+	if updated.Issue.Provider != "github" ||
+		updated.Issue.Number != 123 ||
+		updated.Issue.URL != "https://github.com/brian-bell/wtui/issues/123" {
+		t.Fatalf("Issue metadata = %#v", updated.Issue)
+	}
+
+	stdout.Reset()
+	err = run([]string{"wtui", "flow", "read", "--flow-id", created.FlowID, "--state-root", root},
+		noScanDeps(t, runDeps{stdout: &stdout}))
+	if err != nil {
+		t.Fatalf("flow read returned error: %v", err)
+	}
+	var read flowstore.FlowRecord
+	if err := json.Unmarshal(stdout.Bytes(), &read); err != nil {
+		t.Fatalf("read output is not JSON record: %v\n%s", err, stdout.String())
+	}
+	if read.Issue != updated.Issue {
+		t.Fatalf("read issue = %#v, want %#v", read.Issue, updated.Issue)
+	}
+}
+
+func TestRunFlowIssueSetValidatesRequiredInputs(t *testing.T) {
+	root := t.TempDir()
+	created := mustRunFlow(t, []string{
+		"wtui", "flow", "create",
+		"--title", "Issue validation",
+		"--instructions", "validate input",
+		"--repo-path", filepath.Join(root, "repo"),
+		"--branch", "flow/issue-validation",
+		"--json",
+		"--state-root", root,
+	})
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing flow id",
+			args: []string{"wtui", "flow", "issue", "set", "--provider", "github", "--number", "123", "--url", "https://github.com/brian-bell/wtui/issues/123", "--state-root", root},
+			want: "requires --flow-id",
+		},
+		{
+			name: "missing number",
+			args: []string{"wtui", "flow", "issue", "set", "--flow-id", created.FlowID, "--provider", "github", "--url", "https://github.com/brian-bell/wtui/issues/123", "--state-root", root},
+			want: "requires positive --number",
+		},
+		{
+			name: "missing url",
+			args: []string{"wtui", "flow", "issue", "set", "--flow-id", created.FlowID, "--provider", "github", "--number", "123", "--state-root", root},
+			want: "requires --url",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -75,7 +75,7 @@ plan_prompt = "Implement the saved wtui plan {title} (ID: {plan_id}) at {plan_pa
 
 [flow_prompts]
 plan = "Produce a plan only for: {instructions}"
-implementation = "Implement {plan_path} in {worktree_path}, then use the commit skill before completing."
+implementation = "Implement {plan_path} in {worktree_path} for issue {issue_number}, then use the commit skill before completing."
 review_loop = "Use review-loop for {branch}; use commit if revisions are made."
 pr_creation = "Use ship for {branch}; record PR metadata for flow {flow_id}."
 autoreview = "Autoreview {pr_url}; use ship when fixes require commits or pushes."
@@ -255,8 +255,9 @@ blank template resets that key by removing the config override.
 Supported Flow placeholders are `{flow_id}`, `{flow_title}`,
 `{instructions}`, `{phase_id}`, `{phase_title}`, `{plan_id}`, `{plan_path}`,
 `{plan_body}`, `{repo_path}`, `{worktree_path}`, `{branch}`, `{commit}`,
-`{base_ref}`, `{pr_provider}`, `{pr_number}`, `{pr_url}`, `{pr_head}`,
-`{pr_base}`, and `{pr_status}`. Standard Plan Review, Implementation, Review
+`{base_ref}`, `{issue_provider}`, `{issue_number}`, `{issue_url}`,
+`{pr_provider}`, `{pr_number}`, `{pr_url}`, `{pr_head}`, `{pr_base}`, and
+`{pr_status}`. Standard Plan Review, Implementation, Review
 Loop, PR Creation, Autoreview, and Merge launches do not pre-read the linked
 plan body, so `{plan_body}` is empty for those built-in phase types unless a
 future phase path explicitly supplies it.
@@ -441,6 +442,7 @@ wtui flow phase set --flow-id ID --phase-id ID --status STATUS \
 wtui flow phase add-child --flow-id ID --parent-phase-id implementation \
     --phase-id ID --title TITLE --order N [--state-root PATH]
 wtui flow plan set --flow-id ID --plan-id ID [--plan-path ABSOLUTE_PATH] [--state-root PATH]
+wtui flow issue set --flow-id ID --provider github --number N --url URL [--state-root PATH]
 wtui flow pr set --flow-id ID --provider github --number N --url URL \
     --head HEAD_BRANCH --base BASE_BRANCH [--status STATUS] [--state-root PATH]
 ```
@@ -534,6 +536,11 @@ GitHub PRs and validates the provider, absolute http(s) URL, positive PR
 number, required head/base branches, and that the head branch matches the Flow
 branch. Autoreview stays pending when PR Creation is complete but this PR target
 metadata is missing.
+
+The Plan phase can record an optional GitHub issue reference with
+`wtui flow issue set`. The command stores provider, positive issue number, and
+an absolute GitHub issue URL so wtui can show the Issue column and open it with
+the `i` shortcut.
 
 The flow state root is resolved as: `--state-root` >
 `WTUI_FLOW_STATE_ROOT` > `WTUI_PLAN_STATE_ROOT` > `WTUI_SESSION_STATE_ROOT` >

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -86,7 +86,7 @@ Additional rules:
 
 ## Derived readiness
 
-The phase-affecting mutations (`SetPhase`, `AddChildPhase`, `SetIssue`, `SetPR`,
+The phase-affecting mutations (`SetPhase`, `AddChildPhase`, `SetPR`,
 `AddPhaseLaunchID`, and `ResetAwaitingSessionPhase`) re-derive readiness with
 `refreshPhaseReadiness`, regardless of graph shape. Loads and the remaining
 mutations normalize only records containing a `plan-review` phase — the
@@ -160,7 +160,7 @@ previous PR status, clears that terminal metadata, marks the Merge phase
   strings were added, removed, or renamed. Existing Flow JSON needs no
   migration.
 - Derived state is self-healing: phase-affecting mutations (`SetPhase`,
-  `AddChildPhase`, `SetIssue`, `SetPR`, `AddPhaseLaunchID`,
+  `AddChildPhase`, `SetPR`, `AddPhaseLaunchID`,
   `ResetAwaitingSessionPhase`) re-derive readiness for any graph, and records
   containing a `plan-review` phase (the standard graph) are additionally
   normalized on load, so records written before a gate rule existed converge to

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -86,7 +86,7 @@ Additional rules:
 
 ## Derived readiness
 
-The phase-affecting mutations (`SetPhase`, `AddChildPhase`, `SetPR`,
+The phase-affecting mutations (`SetPhase`, `AddChildPhase`, `SetIssue`, `SetPR`,
 `AddPhaseLaunchID`, and `ResetAwaitingSessionPhase`) re-derive readiness with
 `refreshPhaseReadiness`, regardless of graph shape. Loads and the remaining
 mutations normalize only records containing a `plan-review` phase — the
@@ -110,6 +110,9 @@ predecessor satisfies its downstream gate:
   `wtui flow pr set` (provider, positive number, valid URL, head/base
   branches). Completion alone does not unlock Autoreview; a skipped PR
   Creation never unlocks it.
+- **Plan**: may record optional GitHub issue metadata with
+  `wtui flow issue set` when the task references an issue. Issue metadata is
+  informational and does not gate downstream phases.
 - **Implementation children**: every child phase under Implementation must be
   `completed` or `skipped` with notes before phases after Implementation can
   become ready.
@@ -157,7 +160,7 @@ previous PR status, clears that terminal metadata, marks the Merge phase
   strings were added, removed, or renamed. Existing Flow JSON needs no
   migration.
 - Derived state is self-healing: phase-affecting mutations (`SetPhase`,
-  `AddChildPhase`, `SetPR`, `AddPhaseLaunchID`,
+  `AddChildPhase`, `SetIssue`, `SetPR`, `AddPhaseLaunchID`,
   `ResetAwaitingSessionPhase`) re-derive readiness for any graph, and records
   containing a `plan-review` phase (the standard graph) are additionally
   normalized on load, so records written before a gate rule existed converge to

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -124,6 +124,13 @@ type PullRequest struct {
 	Status     string `json:"status,omitempty"`
 }
 
+// Issue stores agent-reported issue metadata.
+type Issue struct {
+	Provider string `json:"provider,omitempty"`
+	Number   int    `json:"number,omitempty"`
+	URL      string `json:"url,omitempty"`
+}
+
 // PRUpdate records metadata for the pull request created by a Flow.
 type PRUpdate struct {
 	FlowID     string
@@ -133,6 +140,14 @@ type PRUpdate struct {
 	HeadBranch string
 	BaseBranch string
 	Status     string
+}
+
+// IssueUpdate records metadata for the issue referenced by a Flow.
+type IssueUpdate struct {
+	FlowID   string
+	Provider string
+	Number   int
+	URL      string
 }
 
 // MergeUpdate records metadata for the merge that completed or blocked a Flow.
@@ -181,6 +196,7 @@ type FlowRecord struct {
 	Commit        string      `json:"commit,omitempty"`
 	PlanID        string      `json:"plan_id,omitempty"`
 	PlanPath      string      `json:"plan_path,omitempty"`
+	Issue         Issue       `json:"issue,omitempty"`
 	PR            PullRequest `json:"pr,omitempty"`
 	Merge         Merge       `json:"merge,omitempty"`
 	AutoMode      bool        `json:"auto_mode,omitempty"`
@@ -667,6 +683,25 @@ func (s *Store) SetPR(update PRUpdate) (FlowRecord, error) {
 		record.PR = pr
 		record.UpdatedAt = now
 		record = refreshPhaseReadiness(record, now)
+		return record, nil
+	})
+}
+
+// SetIssue validates and persists the issue metadata reported by an agent.
+func (s *Store) SetIssue(update IssueUpdate) (FlowRecord, error) {
+	if err := validateFlowID(update.FlowID); err != nil {
+		return FlowRecord{}, err
+	}
+	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+		issue, err := validateIssueUpdate(update)
+		if err != nil {
+			return FlowRecord{}, err
+		}
+		if record.Issue == issue {
+			return record, nil
+		}
+		record.Issue = issue
+		record.UpdatedAt = now
 		return record, nil
 	})
 }
@@ -1375,6 +1410,19 @@ func HasPRTarget(pr PullRequest) bool {
 		validateGitHubPRURL(parsed, pr.Number) == nil
 }
 
+// HasIssueTarget reports whether issue metadata contains enough target context
+// to open the issue in a browser.
+func HasIssueTarget(issue Issue) bool {
+	if strings.ToLower(strings.TrimSpace(issue.Provider)) != "github" || issue.Number <= 0 {
+		return false
+	}
+	parsed, err := url.Parse(strings.TrimSpace(issue.URL))
+	return err == nil &&
+		parsed.Host != "" &&
+		(parsed.Scheme == "https" || parsed.Scheme == "http") &&
+		validateGitHubIssueURL(parsed, issue.Number) == nil
+}
+
 func validatePRUpdate(record FlowRecord, update PRUpdate) (PullRequest, error) {
 	provider := strings.ToLower(strings.TrimSpace(update.Provider))
 	if provider != "github" {
@@ -1416,6 +1464,29 @@ func validatePRUpdate(record FlowRecord, update PRUpdate) (PullRequest, error) {
 	}, nil
 }
 
+func validateIssueUpdate(update IssueUpdate) (Issue, error) {
+	provider := strings.ToLower(strings.TrimSpace(update.Provider))
+	if provider != "github" {
+		return Issue{}, fmt.Errorf("unsupported issue provider %q", update.Provider)
+	}
+	if update.Number <= 0 {
+		return Issue{}, fmt.Errorf("issue number must be positive")
+	}
+	issueURL := strings.TrimSpace(update.URL)
+	parsed, err := url.Parse(issueURL)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "https" && parsed.Scheme != "http") {
+		return Issue{}, fmt.Errorf("issue URL must be an absolute http(s) URL")
+	}
+	if err := validateGitHubIssueURL(parsed, update.Number); err != nil {
+		return Issue{}, err
+	}
+	return Issue{
+		Provider: provider,
+		Number:   update.Number,
+		URL:      issueURL,
+	}, nil
+}
+
 func validateGitHubPRURL(parsed *url.URL, number int) error {
 	host := strings.ToLower(parsed.Hostname())
 	if host != "github.com" && host != "www.github.com" {
@@ -1431,6 +1502,25 @@ func validateGitHubPRURL(parsed *url.URL, number int) error {
 	}
 	if urlNumber != number {
 		return fmt.Errorf("GitHub PR URL number %d must match PR number %d", urlNumber, number)
+	}
+	return nil
+}
+
+func validateGitHubIssueURL(parsed *url.URL, number int) error {
+	host := strings.ToLower(parsed.Hostname())
+	if host != "github.com" && host != "www.github.com" {
+		return fmt.Errorf("GitHub issue URL must use github.com")
+	}
+	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if len(parts) != 4 || parts[0] == "" || parts[1] == "" || parts[2] != "issues" {
+		return fmt.Errorf("GitHub issue URL must have /owner/repo/issues/number path")
+	}
+	urlNumber, err := strconv.Atoi(parts[3])
+	if err != nil || urlNumber <= 0 {
+		return fmt.Errorf("GitHub issue URL must have numeric issue number")
+	}
+	if urlNumber != number {
+		return fmt.Errorf("GitHub issue URL number %d must match issue number %d", urlNumber, number)
 	}
 	return nil
 }

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -2731,6 +2731,253 @@ func TestStoreSetPRPersistsMetadataAndUngatesAutoreview(t *testing.T) {
 	}
 }
 
+func TestStoreSetIssuePersistsMetadata(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{
+		Root: root,
+		Now:  func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Issue metadata",
+		Instructions: "record the issue",
+		RepoPath:     filepath.Join(root, "repo"),
+		Branch:       "flow/issue-metadata",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	later := now.Add(time.Minute)
+	store, err = flowstore.NewStore(flowstore.StoreOptions{
+		Root: root,
+		Now:  func() time.Time { return later },
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	updated, err := store.SetIssue(flowstore.IssueUpdate{
+		FlowID:   record.FlowID,
+		Provider: "github",
+		Number:   123,
+		URL:      "https://github.com/brian-bell/wtui/issues/123",
+	})
+	if err != nil {
+		t.Fatalf("SetIssue() error = %v", err)
+	}
+
+	if updated.Issue.Provider != "github" ||
+		updated.Issue.Number != 123 ||
+		updated.Issue.URL != "https://github.com/brian-bell/wtui/issues/123" {
+		t.Fatalf("Issue metadata = %#v", updated.Issue)
+	}
+	if updated.UpdatedAt != later {
+		t.Fatalf("UpdatedAt = %s, want %s", updated.UpdatedAt, later)
+	}
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.Issue != updated.Issue {
+		t.Fatalf("Read().Issue = %#v, want %#v", read.Issue, updated.Issue)
+	}
+}
+
+func TestStoreSetIssueIdempotent(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{
+		Root: root,
+		Now:  func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Issue metadata",
+		Instructions: "record the issue",
+		RepoPath:     filepath.Join(root, "repo"),
+		Branch:       "flow/issue-metadata",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	update := flowstore.IssueUpdate{
+		FlowID:   record.FlowID,
+		Provider: "github",
+		Number:   123,
+		URL:      "https://github.com/brian-bell/wtui/issues/123",
+	}
+	record, err = store.SetIssue(update)
+	if err != nil {
+		t.Fatalf("SetIssue() error = %v", err)
+	}
+
+	later := now.Add(time.Minute)
+	store, err = flowstore.NewStore(flowstore.StoreOptions{
+		Root: root,
+		Now:  func() time.Time { return later },
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	same, err := store.SetIssue(update)
+	if err != nil {
+		t.Fatalf("SetIssue() second call error = %v", err)
+	}
+	if same.UpdatedAt != record.UpdatedAt {
+		t.Fatalf("UpdatedAt changed on idempotent SetIssue: %s, want %s", same.UpdatedAt, record.UpdatedAt)
+	}
+}
+
+func TestStoreReadLegacyFlowWithoutIssue(t *testing.T) {
+	root := t.TempDir()
+	flowID := "20260607T120000Z-legacy-issue-flow"
+	meta := filepath.Join(root, "flows", flowID, "meta.json")
+	if err := os.MkdirAll(filepath.Dir(meta), 0o700); err != nil {
+		t.Fatalf("create legacy flow dir: %v", err)
+	}
+	legacy := map[string]any{
+		"schema_version": 1,
+		"flow_id":        flowID,
+		"title":          "Legacy issue flow",
+		"instructions":   "older record",
+		"status":         flowstore.StatusPending,
+		"repo_path":      filepath.Join(root, "repo"),
+		"merge":          map[string]any{"status": flowstore.MergePending},
+		"phases": []map[string]any{
+			{
+				"phase_id":   "plan",
+				"title":      "Plan",
+				"kind":       "plan",
+				"status":     flowstore.PhaseReady,
+				"order":      1,
+				"created_at": time.Now().UTC(),
+				"updated_at": time.Now().UTC(),
+			},
+		},
+		"created_at": time.Now().UTC(),
+		"updated_at": time.Now().UTC(),
+	}
+	data, err := json.MarshalIndent(legacy, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal legacy record: %v", err)
+	}
+	if err := os.WriteFile(meta, data, 0o600); err != nil {
+		t.Fatalf("write legacy meta.json: %v", err)
+	}
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	read, err := store.Read(flowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.Issue != (flowstore.Issue{}) {
+		t.Fatalf("Issue = %#v, want zero value", read.Issue)
+	}
+	if flowstore.HasIssueTarget(read.Issue) {
+		t.Fatalf("HasIssueTarget(%#v) = true, want false", read.Issue)
+	}
+}
+
+func TestHasIssueTargetRequiresValidGitHubIssue(t *testing.T) {
+	valid := flowstore.Issue{
+		Provider: "github",
+		Number:   123,
+		URL:      "https://github.com/brian-bell/wtui/issues/123",
+	}
+	if !flowstore.HasIssueTarget(valid) {
+		t.Fatalf("HasIssueTarget(valid) = false, want true")
+	}
+	for _, tc := range []struct {
+		name  string
+		issue flowstore.Issue
+	}{
+		{name: "provider", issue: flowstore.Issue{Provider: "gitlab", Number: 123, URL: valid.URL}},
+		{name: "number", issue: flowstore.Issue{Provider: "github", Number: 0, URL: valid.URL}},
+		{name: "url", issue: flowstore.Issue{Provider: "github", Number: 123, URL: "https://github.com/brian-bell/wtui/pull/123"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if flowstore.HasIssueTarget(tc.issue) {
+				t.Fatalf("HasIssueTarget(%#v) = true, want false", tc.issue)
+			}
+		})
+	}
+}
+
+func TestStoreSetIssueValidatesMetadata(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		update flowstore.IssueUpdate
+		want   string
+	}{
+		{
+			name:   "provider",
+			update: flowstore.IssueUpdate{Provider: "gitlab", Number: 1, URL: "https://github.com/brian-bell/wtui/issues/1"},
+			want:   "unsupported issue provider",
+		},
+		{
+			name:   "number",
+			update: flowstore.IssueUpdate{Provider: "github", Number: 0, URL: "https://github.com/brian-bell/wtui/issues/1"},
+			want:   "issue number must be positive",
+		},
+		{
+			name:   "url",
+			update: flowstore.IssueUpdate{Provider: "github", Number: 1, URL: "not-a-url"},
+			want:   "issue URL must be an absolute http(s) URL",
+		},
+		{
+			name:   "url host",
+			update: flowstore.IssueUpdate{Provider: "github", Number: 1, URL: "https://example.com/brian-bell/wtui/issues/1"},
+			want:   "GitHub issue URL must use github.com",
+		},
+		{
+			name:   "url number",
+			update: flowstore.IssueUpdate{Provider: "github", Number: 2, URL: "https://github.com/brian-bell/wtui/issues/1"},
+			want:   "GitHub issue URL number",
+		},
+		{
+			name:   "url pull path",
+			update: flowstore.IssueUpdate{Provider: "github", Number: 1, URL: "https://github.com/brian-bell/wtui/pull/1"},
+			want:   "GitHub issue URL must have /owner/repo/issues/number path",
+		},
+		{
+			name:   "url extra path",
+			update: flowstore.IssueUpdate{Provider: "github", Number: 1, URL: "https://github.com/brian-bell/wtui/issues/1/comments"},
+			want:   "GitHub issue URL must have /owner/repo/issues/number path",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			if err != nil {
+				t.Fatalf("NewStore() error = %v", err)
+			}
+			record, err := store.Create(flowstore.FlowRecord{
+				Title:        "Issue validation",
+				Instructions: "validate issue metadata",
+				RepoPath:     filepath.Join(root, "repo"),
+				Branch:       "flow/issue",
+			})
+			if err != nil {
+				t.Fatalf("Create() error = %v", err)
+			}
+
+			tc.update.FlowID = record.FlowID
+			_, err = store.SetIssue(tc.update)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("SetIssue() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestStoreSetPhaseSkippedPRCreationDoesNotUngateAutoreview(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})

--- a/model/flow_prompt_completion_test.go
+++ b/model/flow_prompt_completion_test.go
@@ -20,7 +20,7 @@ func TestFlowPlanPromptAppendsPhaseDoneInstruction(t *testing.T) {
 		"",
 		"Produce a plan only; do not start coding in this phase.",
 		"Create and persist the plan with wtui plan save, link it back with wtui flow plan set, then report Flow persistence failures explicitly before ending.",
-		"If the task references a GitHub issue, link it with wtui flow issue set using the issue number and URL.",
+		"If the task references a GitHub issue, link it with wtui flow issue set using the issue number and URL; when only #N is given, derive the URL from an unambiguous GitHub origin remote or note the ambiguity instead of guessing.",
 		"",
 		model.FlowPhaseDoneInstructionForTest(),
 	}, "\n")

--- a/model/flow_prompt_completion_test.go
+++ b/model/flow_prompt_completion_test.go
@@ -20,6 +20,7 @@ func TestFlowPlanPromptAppendsPhaseDoneInstruction(t *testing.T) {
 		"",
 		"Produce a plan only; do not start coding in this phase.",
 		"Create and persist the plan with wtui plan save, link it back with wtui flow plan set, then report Flow persistence failures explicitly before ending.",
+		"If the task references a GitHub issue, link it with wtui flow issue set using the issue number and URL.",
 		"",
 		model.FlowPhaseDoneInstructionForTest(),
 	}, "\n")
@@ -91,8 +92,13 @@ func TestFlowPromptTemplatesAppendPhaseDoneInstruction(t *testing.T) {
 			BaseBranch: "main",
 			Status:     "open",
 		},
+		Issue: flowstore.Issue{
+			Provider: "github",
+			Number:   123,
+			URL:      "https://github.com/brian-bell/wtui/issues/123",
+		},
 	}
-	template := "Custom {phase_id} for {flow_id}: {plan_path} at {worktree_path}; keep {unknown}"
+	template := "Custom {phase_id} for {flow_id}: {plan_path} at {worktree_path}; issue {issue_provider}#{issue_number} {issue_url}; keep {unknown}"
 	tests := []struct {
 		name      string
 		phase     flowstore.FlowPhase
@@ -120,11 +126,36 @@ func TestFlowPromptTemplatesAppendPhaseDoneInstruction(t *testing.T) {
 			want = strings.ReplaceAll(want, "{flow_id}", record.FlowID)
 			want = strings.ReplaceAll(want, "{plan_path}", record.PlanPath)
 			want = strings.ReplaceAll(want, "{worktree_path}", record.WorktreePath)
+			want = strings.ReplaceAll(want, "{issue_provider}", record.Issue.Provider)
+			want = strings.ReplaceAll(want, "{issue_number}", "123")
+			want = strings.ReplaceAll(want, "{issue_url}", record.Issue.URL)
 			want += "\n\n" + model.FlowPhaseDoneInstructionForTest()
 			if got != want {
 				t.Fatalf("templated prompt = %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestFlowPhasePromptIncludesIssueMetadata(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		Instructions: "Build the requested change.",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-issue",
+		Branch:       "flow/issue",
+		Commit:       "abc123",
+		Issue: flowstore.Issue{
+			Provider: "github",
+			Number:   123,
+			URL:      "https://github.com/brian-bell/wtui/issues/123",
+		},
+	}
+
+	got := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "implementation", Title: "Implementation"}, "", "", model.FlowPromptTemplates{})
+
+	if !strings.Contains(got, "Issue: github #123 https://github.com/brian-bell/wtui/issues/123") {
+		t.Fatalf("prompt should include linked issue metadata:\n%s", got)
 	}
 }
 

--- a/model/flow_prompts.go
+++ b/model/flow_prompts.go
@@ -64,6 +64,9 @@ func renderFlowPromptTemplate(template string, record flowstore.FlowRecord, phas
 		"{branch}", record.Branch,
 		"{commit}", record.Commit,
 		"{base_ref}", record.BaseRef,
+		"{issue_provider}", record.Issue.Provider,
+		"{issue_number}", issueNumberPlaceholder(record.Issue.Number),
+		"{issue_url}", record.Issue.URL,
 		"{pr_provider}", record.PR.Provider,
 		"{pr_number}", prNumberPlaceholder(record.PR.Number),
 		"{pr_url}", record.PR.URL,
@@ -72,6 +75,13 @@ func renderFlowPromptTemplate(template string, record flowstore.FlowRecord, phas
 		"{pr_status}", record.PR.Status,
 	)
 	return replacer.Replace(template)
+}
+
+func issueNumberPlaceholder(number int) string {
+	if number == 0 {
+		return ""
+	}
+	return strconv.Itoa(number)
 }
 
 func prNumberPlaceholder(number int) string {
@@ -252,6 +262,14 @@ func writeFlowChangeMetadata(b *strings.Builder, record flowstore.FlowRecord) {
 	b.WriteString(record.Branch)
 	b.WriteString("\nStart commit: ")
 	b.WriteString(record.Commit)
+	if flowstore.HasIssueTarget(record.Issue) {
+		b.WriteString("\nIssue: ")
+		b.WriteString(record.Issue.Provider)
+		b.WriteString(" #")
+		b.WriteString(strconv.Itoa(record.Issue.Number))
+		b.WriteString(" ")
+		b.WriteString(record.Issue.URL)
+	}
 }
 
 func flowGenericPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string) string {

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -286,6 +286,6 @@ func flowPlanPrompt(flow flowstore.FlowRecord, templates FlowPromptTemplates) st
 	b.WriteString(flow.Instructions)
 	b.WriteString("\n\nProduce a plan only; do not start coding in this phase.")
 	b.WriteString("\nCreate and persist the plan with wtui plan save, link it back with wtui flow plan set, then report Flow persistence failures explicitly before ending.")
-	b.WriteString("\nIf the task references a GitHub issue, link it with wtui flow issue set using the issue number and URL.")
+	b.WriteString("\nIf the task references a GitHub issue, link it with wtui flow issue set using the issue number and URL; when only #N is given, derive the URL from an unambiguous GitHub origin remote or note the ambiguity instead of guessing.")
 	return ensureFlowPhaseDoneInstruction(b.String(), "")
 }

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -286,5 +286,6 @@ func flowPlanPrompt(flow flowstore.FlowRecord, templates FlowPromptTemplates) st
 	b.WriteString(flow.Instructions)
 	b.WriteString("\n\nProduce a plan only; do not start coding in this phase.")
 	b.WriteString("\nCreate and persist the plan with wtui plan save, link it back with wtui flow plan set, then report Flow persistence failures explicitly before ending.")
+	b.WriteString("\nIf the task references a GitHub issue, link it with wtui flow issue set using the issue number and URL.")
 	return ensureFlowPhaseDoneInstruction(b.String(), "")
 }

--- a/model/model.go
+++ b/model/model.go
@@ -767,6 +767,7 @@ func (m Model) View() string {
 	if flowSelected >= 0 && flowSelected < len(flows) {
 		flowAutoModeSelected = flows[flowSelected].AutoMode
 	}
+	_, flowIssueTargetSelected := m.selectedFlowIssue()
 	_, flowPRTargetSelected := m.selectedFlowPR()
 	repoEmptyMessage := m.repoEmptyMessage(len(repos))
 	rightEmptyMessage := m.rightEmptyMessage(len(repos), len(worktrees), len(rows), len(stashes), len(commits), len(reflogs), len(sessions), len(plans), len(flows))
@@ -857,6 +858,7 @@ func (m Model) View() string {
 		SelectedFlowPhaseID:          m.currentSelectedFlowPhaseID(),
 		FlowHeadless:                 m.flowHeadless,
 		FlowAutoModeSelected:         flowAutoModeSelected,
+		FlowIssueTargetSelected:      flowIssueTargetSelected,
 		FlowPRTargetSelected:         flowPRTargetSelected,
 		FlowAgentLabel:               m.flowAgentShortcutLabel(),
 		FlowModel:                    m.flowModelLabel(),
@@ -1510,6 +1512,20 @@ func (m Model) selectedFlowPR() (flowstore.PullRequest, bool) {
 		return flowstore.PullRequest{}, false
 	}
 	return record.PR, true
+}
+
+func (m Model) selectedFlowIssue() (flowstore.Issue, bool) {
+	if !m.flowSurfaceVisible() {
+		return flowstore.Issue{}, false
+	}
+	if _, ok := m.selectedFlowPhase(); ok {
+		return flowstore.Issue{}, false
+	}
+	record, ok := m.selectedFlow()
+	if !ok || !flowstore.HasIssueTarget(record.Issue) {
+		return flowstore.Issue{}, false
+	}
+	return record.Issue, true
 }
 
 func (m Model) selectedPlanID() string {

--- a/model/model_filter.go
+++ b/model/model_filter.go
@@ -305,6 +305,8 @@ func flowSearchText(record flowstore.FlowRecord) string {
 		filepath.Base(record.WorktreePath),
 		record.PlanID,
 		record.PlanPath,
+		record.Issue.Provider,
+		record.Issue.URL,
 		record.PR.URL,
 		record.PR.HeadBranch,
 		record.PR.BaseBranch,
@@ -316,6 +318,9 @@ func flowSearchText(record flowstore.FlowRecord) string {
 	}
 	if record.PR.Number > 0 {
 		parts = append(parts, fmt.Sprintf("#%d", record.PR.Number))
+	}
+	if record.Issue.Number > 0 {
+		parts = append(parts, fmt.Sprintf("#%d", record.Issue.Number))
 	}
 	for _, phase := range record.Phases {
 		parts = append(parts, phase.Title, phase.Status, phase.Summary)

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -4520,10 +4520,12 @@ func TestModel_IKeyFlowIssueGuards(t *testing.T) {
 	valid := flowWithIssueTarget("flow-1", issueURL)
 	incomplete := valid
 	incomplete.Issue.URL = ""
+	var terminalInputTerm *fakeEmbeddedTerminal
 
 	for _, tc := range []struct {
 		name  string
 		setup func(t *testing.T, openURL func(string) error) model.Model
+		check func(t *testing.T, m model.Model)
 	}{
 		{
 			name: "no selected Flow",
@@ -4544,6 +4546,41 @@ func TestModel_IKeyFlowIssueGuards(t *testing.T) {
 				return selectFlowPhaseByID(t, m, "implementation")
 			},
 		},
+		{
+			name: "Flow terminal input forwards i",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				fakeTerm := &fakeEmbeddedTerminal{state: "running"}
+				terminalInputTerm = fakeTerm
+				m := model.NewWithOptions(testRepos(), model.Options{
+					AgentCommand: "codex",
+					OpenURL:      openURL,
+					AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+						return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+					},
+					StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+						return fakeTerm, nil
+					},
+				})
+				m = flowsInRightPane(t, m, []flowstore.FlowRecord{valid})
+				m = selectFlowPhaseByID(t, m, "implementation")
+				m, cmd := update(m, flowLaunchKey())
+				if cmd == nil {
+					t.Fatal("g should prepare an embedded Flow launch")
+				}
+				m, _ = update(m, cmd())
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+				return m
+			},
+			check: func(t *testing.T, m model.Model) {
+				if terminalInputTerm == nil {
+					t.Fatal("terminal input test did not capture fake terminal")
+				}
+				if !slices.Equal(terminalInputTerm.writes, []string{"i"}) {
+					t.Fatalf("terminal input writes = %#v, want i", terminalInputTerm.writes)
+				}
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var opened []string
@@ -4557,6 +4594,9 @@ func TestModel_IKeyFlowIssueGuards(t *testing.T) {
 			}
 			if len(opened) != 0 {
 				t.Fatalf("opened URLs = %#v, want none", opened)
+			}
+			if tc.check != nil {
+				tc.check(t, m)
 			}
 		})
 	}

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -4458,6 +4458,139 @@ func TestModel_PKeyOpensSelectedActiveFlowPullRequest(t *testing.T) {
 	}
 }
 
+func TestModel_IKeyOpensSelectedFlowIssue(t *testing.T) {
+	const issueURL = "https://github.com/brian-bell/wtui/issues/123"
+	var opened []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		OpenURL: func(url string) error {
+			opened = append(opened, url)
+			return nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithIssueTarget("flow-1", issueURL)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd == nil {
+		t.Fatal("i on selected Flow with issue target should return open command")
+	}
+	if m.Mode() != ui.ModeFlows || m.FlowSelected() != 0 || m.SelectedFlowPhaseID() != "" || m.Overlay() != ui.OverlayNone {
+		t.Fatalf("i changed Flow selection state: mode=%v selected=%d phase=%q overlay=%v", m.Mode(), m.FlowSelected(), m.SelectedFlowPhaseID(), m.Overlay())
+	}
+	msg, ok := cmd().(model.OpenURLResultMsg)
+	if !ok {
+		t.Fatalf("open issue command returned %T, want OpenURLResultMsg", msg)
+	}
+	if msg.Err != "" || msg.Label != "Opened issue #123 in browser" {
+		t.Fatalf("open issue command returned %#v, want success label", msg)
+	}
+	if got := opened; !slices.Equal(got, []string{issueURL}) {
+		t.Fatalf("opened URLs = %#v, want %q", got, issueURL)
+	}
+}
+
+func TestModel_IKeyOpensSelectedActiveFlowIssue(t *testing.T) {
+	const issueURL = "https://github.com/brian-bell/wtui/issues/123"
+	var opened []string
+	m := model.NewWithOptions(testRepos(), model.Options{
+		OpenURL: func(url string) error {
+			opened = append(opened, url)
+			return nil
+		},
+	})
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flowWithIssueTarget("flow-1", issueURL)})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+	if cmd == nil {
+		t.Fatal("i on selected Active Flow with issue target should return open command")
+	}
+	msg, ok := cmd().(model.OpenURLResultMsg)
+	if !ok {
+		t.Fatalf("open active Flow issue command returned %T, want OpenURLResultMsg", msg)
+	}
+	if msg.Err != "" || msg.Label != "Opened issue #123 in browser" {
+		t.Fatalf("open active Flow issue command returned %#v, want success label", msg)
+	}
+	if got := opened; !slices.Equal(got, []string{issueURL}) {
+		t.Fatalf("opened URLs = %#v, want %q", got, issueURL)
+	}
+}
+
+func TestModel_IKeyFlowIssueGuards(t *testing.T) {
+	const issueURL = "https://github.com/brian-bell/wtui/issues/123"
+	valid := flowWithIssueTarget("flow-1", issueURL)
+	incomplete := valid
+	incomplete.Issue.URL = ""
+
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T, openURL func(string) error) model.Model
+	}{
+		{
+			name: "no selected Flow",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				return flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{OpenURL: openURL}), nil)
+			},
+		},
+		{
+			name: "incomplete issue metadata",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				return flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{OpenURL: openURL}), []flowstore.FlowRecord{incomplete})
+			},
+		},
+		{
+			name: "selected phase row",
+			setup: func(t *testing.T, openURL func(string) error) model.Model {
+				m := flowsInRightPane(t, model.NewWithOptions(testRepos(), model.Options{OpenURL: openURL}), []flowstore.FlowRecord{valid})
+				return selectFlowPhaseByID(t, m, "implementation")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var opened []string
+			m := tc.setup(t, func(url string) error {
+				opened = append(opened, url)
+				return nil
+			})
+			_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
+			if cmd != nil {
+				t.Fatalf("i returned command %T, want nil", cmd)
+			}
+			if len(opened) != 0 {
+				t.Fatalf("opened URLs = %#v, want none", opened)
+			}
+		})
+	}
+}
+
+func TestModel_FlowFilterMatchesIssueMetadata(t *testing.T) {
+	m := model.New(testRepos())
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{
+		flowWithIssueTarget("flow-1", "https://github.com/brian-bell/wtui/issues/123"),
+		{
+			FlowID: "flow-2",
+			Title:  "Unrelated flow",
+			Status: flowstore.StatusInProgress,
+			Branch: "flow/unrelated",
+		},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	for _, r := range "#123" {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	view := m.View()
+	if got := m.Flows(); len(got) != 1 || got[0].FlowID != "flow-1" {
+		t.Fatalf("filtered flows = %#v, want only flow-1", got)
+	}
+	if !strings.Contains(view, "#123") {
+		t.Fatalf("issue filter should keep matching Flow:\n%s", view)
+	}
+	if strings.Contains(view, "Unrelated flow") {
+		t.Fatalf("issue filter should hide non-matching Flow:\n%s", view)
+	}
+}
+
 func TestModel_PKeyOpenFlowPullRequestFailureSetsStatus(t *testing.T) {
 	const prURL = "https://github.com/brian-bell/wtui/pull/123"
 	m := model.NewWithOptions(testRepos(), model.Options{
@@ -4701,6 +4834,25 @@ func flowWithPullRequestTarget(flowID, prURL string) flowstore.FlowRecord {
 			HeadBranch: "flow/add-pr-shortcut",
 			BaseBranch: "main",
 			Status:     "open",
+		},
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady},
+		},
+	}
+}
+
+func flowWithIssueTarget(flowID, issueURL string) flowstore.FlowRecord {
+	return flowstore.FlowRecord{
+		FlowID:       flowID,
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/" + flowID,
+		Title:        "Flow with issue",
+		Status:       flowstore.StatusInProgress,
+		Branch:       "flow/add-issue-shortcut",
+		Issue: flowstore.Issue{
+			Provider: "github",
+			Number:   123,
+			URL:      issueURL,
 		},
 		Phases: []flowstore.FlowPhase{
 			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady},

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -440,6 +440,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		if m.mode == ui.ModePlans {
 			return m.handleImplementPlan()
 		}
+		if m.flowSurfaceVisible() {
+			return m.handleOpenSelectedFlowIssue()
+		}
 	case "x":
 		if m.mode == ui.ModeWorktrees {
 			return m.handleToggleWorktreeSessions()
@@ -612,6 +615,8 @@ func (m Model) handleActiveFlowSurfaceKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleMarkFlowManuallyMerged()
 	case "a":
 		return m.handleToggleFlowAutoMode()
+	case "i":
+		return m.handleOpenSelectedFlowIssue()
 	case "p":
 		return m.handleOpenSelectedFlowPR()
 	case "y":

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1854,6 +1854,19 @@ func (m Model) handleOpenSelectedFlowPR() (tea.Model, tea.Cmd) {
 	}
 }
 
+func (m Model) handleOpenSelectedFlowIssue() (tea.Model, tea.Cmd) {
+	issue, ok := m.selectedFlowIssue()
+	if !ok {
+		return m, nil
+	}
+	return m, func() tea.Msg {
+		if err := m.openURL(issue.URL); err != nil {
+			return OpenURLResultMsg{Err: err.Error()}
+		}
+		return OpenURLResultMsg{Label: fmt.Sprintf("Opened issue #%d in browser", issue.Number)}
+	}
+}
+
 func (m Model) handleShowSessionSummary() (tea.Model, tea.Cmd) {
 	if m.mode != ui.ModeSessions {
 		return m, nil

--- a/model/prompt_templates.go
+++ b/model/prompt_templates.go
@@ -281,6 +281,11 @@ func (m Model) builtInPromptTemplatePreview(target promptTemplateTarget) string 
 		BaseRef:      "{base_ref}",
 		PlanID:       "{plan_id}",
 		PlanPath:     "{plan_path}",
+		Issue: flowstore.Issue{
+			Provider: "{issue_provider}",
+			Number:   123,
+			URL:      "{issue_url}",
+		},
 		PR: flowstore.PullRequest{
 			Provider:   "{pr_provider}",
 			Number:     123,

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -293,6 +293,7 @@ type RenderParams struct {
 	SelectedFlowPhaseID          string
 	FlowHeadless                 bool
 	FlowAutoModeSelected         bool
+	FlowIssueTargetSelected      bool
 	FlowPRTargetSelected         bool
 	FlowAgentLabel               string
 	FlowModel                    string
@@ -465,11 +466,13 @@ func renderApplication(p RenderParams) string {
 	flowPlanLinked := false
 	flowWorktreePathSelected := false
 	flowAutoModeSelected := false
+	flowIssueTargetSelected := false
 	flowPRTargetSelected := false
 	if flowSelected {
 		flowPlanLinked = strings.TrimSpace(p.Flows[p.FlowSelected].PlanID) != ""
 		flowWorktreePathSelected = strings.TrimSpace(p.Flows[p.FlowSelected].WorktreePath) != ""
 		flowAutoModeSelected = p.FlowAutoModeSelected
+		flowIssueTargetSelected = p.FlowIssueTargetSelected
 		flowPRTargetSelected = p.FlowPRTargetSelected
 	}
 	worktreeSessionSelected := p.Mode == ModeWorktrees && p.InlineWorktreeSessions && p.WorktreeSessionSelected >= 0 && p.WorktreeSessionSelected < len(p.WorktreeSessions)
@@ -482,11 +485,13 @@ func renderApplication(p RenderParams) string {
 		flowDeletableSelected = false
 		flowWorktreePathSelected = false
 		flowAutoModeSelected = false
+		flowIssueTargetSelected = false
 		flowPRTargetSelected = false
 	}
 	planPhaseSelected := selectedPlanPhaseID != ""
 	flowPhaseSelected := selectedFlowPhaseID != ""
 	if flowPhaseSelected {
+		flowIssueTargetSelected = false
 		flowPRTargetSelected = false
 	}
 	status := statusBarParams{
@@ -525,6 +530,7 @@ func renderApplication(p RenderParams) string {
 		FlowDeletableSelected:        flowDeletableSelected,
 		FlowWorktreePathSelected:     flowWorktreePathSelected,
 		FlowPlanLinked:               flowPlanLinked,
+		FlowIssueTargetSelected:      flowIssueTargetSelected,
 		FlowPRTargetSelected:         flowPRTargetSelected,
 		FlowHeadless:                 p.FlowHeadless,
 		FlowAutoModeSelected:         flowAutoModeSelected,
@@ -805,6 +811,7 @@ type statusBarParams struct {
 	FlowDeletableSelected        bool
 	FlowWorktreePathSelected     bool
 	FlowPlanLinked               bool
+	FlowIssueTargetSelected      bool
 	FlowPRTargetSelected         bool
 	FlowHeadless                 bool
 	FlowAutoModeSelected         bool
@@ -1323,6 +1330,9 @@ func flowShortcutSections(sp statusBarParams, actions, navigation, global []shor
 				actions = append(actions, shortcutHint{Key: "o", Label: "open"})
 			}
 			actions = append(actions, shortcutHint{Key: "c", Label: "copy id"})
+			if sp.FlowIssueTargetSelected {
+				actions = append(actions, shortcutHint{Key: "i", Label: "open issue"})
+			}
 			if sp.FlowPRTargetSelected {
 				actions = append(actions, shortcutHint{Key: "p", Label: "open PR"})
 			}
@@ -2525,6 +2535,7 @@ const (
 	flowRepoWidth    = 16
 	flowBranchWidth  = 20
 	flowPhaseWidth   = 34
+	flowIssueWidth   = 8
 	flowPlanWidth    = 12
 	flowPRWidth      = 8
 	flowUpdatedWidth = 10
@@ -2549,7 +2560,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 	if height <= 0 {
 		return nil
 	}
-	header := truncateToWidth(statusStyle.Render(formatFlowColumns(showRepo, "   ", "Status", "Repo", "Branch", "Phase", "Plan", "PR", "Updated", "Title")), width)
+	header := truncateToWidth(statusStyle.Render(formatFlowColumns(showRepo, "   ", "Status", "Repo", "Branch", "Phase", "Issue", "Plan", "PR", "Updated", "Title")), width)
 	rowHeight := height - TableHeaderRows
 	if rowHeight <= 0 {
 		return []string{header}
@@ -2559,6 +2570,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 	var rows []string
 	for i, record := range records {
 		phase := flowPhaseProgress(record)
+		issue := flowIssueLabel(record)
 		plan := flowPlanLabel(record)
 		pr := flowPRLabel(record)
 		updated := flowUpdatedLabel(record)
@@ -2579,6 +2591,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 		repoCell := statusStyle.Render(fitSessionColumn(repo, flowRepoWidth))
 		branchCell := branchStyle.Render(fitSessionColumn(branch, flowBranchWidth))
 		phaseCell := diffHdrStyle.Render(fitSessionColumn(phase, flowPhaseWidth))
+		issueCell := statusStyle.Render(fitSessionColumn(issue, flowIssueWidth))
 		planCell := statusStyle.Render(fitSessionColumn(plan, flowPlanWidth))
 		prCell := statusStyle.Render(fitSessionColumn(pr, flowPRWidth))
 		updatedCell := stashDateStyle.Render(fitSessionColumn(updated, flowUpdatedWidth))
@@ -2588,6 +2601,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 			repoCell,
 			branchCell,
 			phaseCell,
+			issueCell,
 			planCell,
 			prCell,
 			updatedCell,
@@ -2599,6 +2613,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 				repo,
 				branch,
 				phase,
+				issue,
 				plan,
 				pr,
 				updated,
@@ -2616,7 +2631,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 func renderFlowPhaseRows(record flowstore.FlowRecord, width int, selectedPhaseID string, active flowTerminalActivitySet, showRepo bool) []string {
 	if len(record.Phases) == 0 {
 		if showRepo {
-			return []string{truncateToWidth(formatFlowColumns(showRepo, flowPhaseRowPrefix(false, false), "", "", "", "No phases", "", "", "", ""), width)}
+			return []string{truncateToWidth(formatFlowColumns(showRepo, flowPhaseRowPrefix(false, false), "", "", "", "No phases", "", "", "", "", ""), width)}
 		}
 		return []string{truncateToWidth("      No phases", width)}
 	}
@@ -2640,6 +2655,7 @@ func renderFlowPhaseRows(record flowstore.FlowRecord, width int, selectedPhaseID
 			"",
 			"",
 			"",
+			"",
 			stashMsgStyle.Render(title),
 		)
 		if phase.PhaseID == selectedPhaseID {
@@ -2648,6 +2664,7 @@ func renderFlowPhaseRows(record flowstore.FlowRecord, width int, selectedPhaseID
 				"",
 				"",
 				phase.PhaseID+":"+state,
+				"",
 				"",
 				"",
 				"",
@@ -2727,25 +2744,27 @@ func selectedFlowRowPrefix(active bool) string {
 	return selectedStyle.Render(">  ")
 }
 
-func formatFlowColumns(showRepo bool, prefix, status, repo, branch, phase, plan, pr, updated, title string) string {
+func formatFlowColumns(showRepo bool, prefix, status, repo, branch, phase, issue, plan, pr, updated, title string) string {
 	if showRepo {
-		return fmt.Sprintf("%s%s  %s  %s  %s  %s  %s  %s  %s",
+		return fmt.Sprintf("%s%s  %s  %s  %s  %s  %s  %s  %s  %s",
 			prefix,
 			fitSessionColumn(status, flowStatusWidth),
 			fitSessionColumn(repo, flowRepoWidth),
 			fitSessionColumn(branch, flowBranchWidth),
 			fitSessionColumn(phase, flowPhaseWidth),
+			fitSessionColumn(issue, flowIssueWidth),
 			fitSessionColumn(plan, flowPlanWidth),
 			fitSessionColumn(pr, flowPRWidth),
 			fitSessionColumn(updated, flowUpdatedWidth),
 			title,
 		)
 	}
-	return fmt.Sprintf("%s%s  %s  %s  %s  %s  %s  %s",
+	return fmt.Sprintf("%s%s  %s  %s  %s  %s  %s  %s  %s",
 		prefix,
 		fitSessionColumn(status, flowStatusWidth),
 		fitSessionColumn(branch, flowBranchWidth),
 		fitSessionColumn(phase, flowPhaseWidth),
+		fitSessionColumn(issue, flowIssueWidth),
 		fitSessionColumn(plan, flowPlanWidth),
 		fitSessionColumn(pr, flowPRWidth),
 		fitSessionColumn(updated, flowUpdatedWidth),
@@ -2753,7 +2772,7 @@ func formatFlowColumns(showRepo bool, prefix, status, repo, branch, phase, plan,
 	)
 }
 
-func renderSelectedFlowColumns(showRepo bool, prefix, status, repo, branch, phase, plan, pr, updated, title string, width int) string {
+func renderSelectedFlowColumns(showRepo bool, prefix, status, repo, branch, phase, issue, plan, pr, updated, title string, width int) string {
 	line := prefix
 	line += selectedStyle.Render(fitSessionColumn(status, flowStatusWidth))
 	line += selectedStyle.Render("  ")
@@ -2764,6 +2783,8 @@ func renderSelectedFlowColumns(showRepo bool, prefix, status, repo, branch, phas
 	line += selectedStyle.Render(fitSessionColumn(branch, flowBranchWidth))
 	line += selectedStyle.Render("  ")
 	line += selectedStyle.Render(fitSessionColumn(phase, flowPhaseWidth))
+	line += selectedStyle.Render("  ")
+	line += selectedStyle.Render(fitSessionColumn(issue, flowIssueWidth))
 	line += selectedStyle.Render("  ")
 	line += selectedStyle.Render(fitSessionColumn(plan, flowPlanWidth))
 	line += selectedStyle.Render("  ")
@@ -2908,6 +2929,16 @@ func flowPhaseSessionSummary(phase flowstore.FlowPhase) string {
 func flowPlanLabel(record flowstore.FlowRecord) string {
 	if record.PlanID != "" {
 		return record.PlanID
+	}
+	return "-"
+}
+
+func flowIssueLabel(record flowstore.FlowRecord) string {
+	if record.Issue.Number > 0 {
+		return fmt.Sprintf("#%d", record.Issue.Number)
+	}
+	if record.Issue.URL != "" {
+		return filepath.Base(record.Issue.URL)
 	}
 	return "-"
 }

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -28,6 +28,7 @@ func TestRender_FlowsModeShowsHeaderAndRows(t *testing.T) {
 			Branch:       "flow/add-flow-mode",
 			WorktreePath: "/dev/wtui-worktrees/flow-add-flow-mode",
 			PlanID:       "plan-1",
+			Issue:        flowstore.Issue{Number: 456, URL: "https://github.com/brian-bell/wtui/issues/456"},
 			PR:           flowstore.PullRequest{Number: 123, URL: "https://github.com/brian-bell/wtui/pull/123"},
 			UpdatedAt:    time.Date(2026, 6, 7, 14, 0, 0, 0, time.UTC),
 			Phases: []flowstore.FlowPhase{
@@ -39,17 +40,51 @@ func TestRender_FlowsModeShowsHeaderAndRows(t *testing.T) {
 		FlowSelected: 0,
 	})
 
-	for _, want := range []string{"[8] flows", "Status", "Branch", "Phase", "Plan", "PR", "Updated", "Title", "in_progress", "flow/add-flow-mode", "1/2", "plan-1", "#123", "2026-06-07", "Add Flow mode"} {
+	for _, want := range []string{"[8] flows", "Status", "Branch", "Phase", "Issue", "Plan", "PR", "Updated", "Title", "in_progress", "flow/add-flow-mode", "1/2", "#456", "plan-1", "#123", "2026-06-07", "Add Flow mode"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("flows view missing %q:\n%s", want, view)
 		}
 	}
+	header := ansi.Strip(lineContaining(view, "Status"))
+	if strings.Index(header, "Phase") > strings.Index(header, "Issue") || strings.Index(header, "Issue") > strings.Index(header, "Plan") {
+		t.Fatalf("flows header should order Phase, Issue, Plan:\n%s", header)
+	}
 	if strings.Contains(view, "Review loop") {
 		t.Fatalf("flow phase detail rows should be collapsed by default:\n%s", view)
 	}
-	header := lineContaining(view, "Status")
 	if strings.Contains(header, "Repo") {
 		t.Fatalf("normal flows header should not include active-flows Repo column:\n%s", header)
+	}
+}
+
+func TestRender_FlowsModeShowsMissingIssueCell(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    230,
+		Height:   10,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID:    "flow-1",
+			Title:     "Flow without issue",
+			Status:    flowstore.StatusInProgress,
+			Branch:    "flow/no-issue",
+			PlanID:    "plan-1",
+			UpdatedAt: time.Date(2026, 6, 7, 14, 0, 0, 0, time.UTC),
+			Phases:    []flowstore.FlowPhase{{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted}},
+		}},
+		ActivePane:   1,
+		FlowSelected: 0,
+	})
+
+	row := ansi.Strip(lineContaining(view, "Flow without issue"))
+	for _, want := range []string{"flow/no-issue", "1/1", "-", "plan-1"} {
+		if !strings.Contains(row, want) {
+			t.Fatalf("flows row missing %q:\n%s", want, row)
+		}
+	}
+	if !strings.Contains(row, "1/1 plan:completed                  -         plan-1") {
+		t.Fatalf("flows row should order Phase, Issue, Plan:\n%s", row)
 	}
 }
 
@@ -934,6 +969,49 @@ func TestRender_FlowShortcutPaneShowsOpenPRWhenTargetSelected(t *testing.T) {
 			pane := shortcutPaneText(Render(params))
 			if !strings.Contains(pane, "p      open PR") {
 				t.Fatalf("Flow shortcut pane missing open PR hint:\n%s", pane)
+			}
+		})
+	}
+}
+
+func TestRender_FlowShortcutPaneShowsOpenIssueWhenTargetSelected(t *testing.T) {
+	base := RenderParams{
+		Repos:        []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected:     0,
+		Width:        180,
+		Height:       28,
+		Mode:         ModeFlows,
+		ActivePane:   1,
+		FlowSelected: 0,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "flow-1",
+			Title:  "Flow with issue",
+			Status: flowstore.StatusInProgress,
+			Issue: flowstore.Issue{
+				Provider: "github",
+				Number:   123,
+				URL:      "https://github.com/brian-bell/wtui/issues/123",
+			},
+			Phases: []flowstore.FlowPhase{{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady}},
+		}},
+		FlowIssueTargetSelected: true,
+	}
+
+	for _, tt := range []struct {
+		name string
+		mut  func(*RenderParams)
+	}{
+		{name: "flows"},
+		{name: "active flows", mut: func(p *RenderParams) { p.ActiveFlows = true }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			params := base
+			if tt.mut != nil {
+				tt.mut(&params)
+			}
+			pane := shortcutPaneText(Render(params))
+			if !strings.Contains(pane, "i      open issue") {
+				t.Fatalf("Flow shortcut pane missing open issue hint:\n%s", pane)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- add optional GitHub issue metadata to Flow records and expose `wtui flow issue set`
- show linked issue numbers in the Flow list between Phase and Plan
- add the `i` shortcut to open linked issues, plus launch prompt/template/env plumbing for issue metadata

## Implementation
- mirrors existing PR metadata validation and persistence with `flowstore.Issue`, `IssueUpdate`, `SetIssue`, and `HasIssueTarget`
- adds CLI help/tests for `wtui flow issue set` and keeps agent skill docs in sync
- updates Flow rendering, filtering, key handling, and prompt rendering coverage

## Verification
- `gofmt -l .`
- `git diff --check dcf21fc455004088240fb0a3ab73fb8441d80a68..HEAD`
- `make test`
- `make build`