### PR TITLE
Compact Flow model shortcut labels

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -678,7 +678,9 @@ func (m Model) flowLaunchAgentSettings() (string, string, string) {
 func (m Model) flowModelLabel() string {
 	command := agent.Normalize(m.agentCommand)
 	switch command {
-	case agent.CommandCodex, agent.CommandClaude:
+	case agent.CommandCodex:
+		return modelDisplay(m.ModelFor(command))
+	case agent.CommandClaude:
 		return strings.TrimPrefix(modelDisplay(m.ModelFor(command)), "claude-")
 	case agent.CommandCodexApp:
 		return "app"

--- a/model/model.go
+++ b/model/model.go
@@ -679,9 +679,9 @@ func (m Model) flowModelLabel() string {
 	command := agent.Normalize(m.agentCommand)
 	switch command {
 	case agent.CommandCodex, agent.CommandClaude:
-		return fmt.Sprintf("model: %s", modelDisplay(m.ModelFor(command)))
+		return strings.TrimPrefix(modelDisplay(m.ModelFor(command)), "claude-")
 	case agent.CommandCodexApp:
-		return "model: app"
+		return "app"
 	default:
 		return ""
 	}

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3908,30 +3908,40 @@ func TestModel_FlowsModeLabelsAgentAndEffortSeparately(t *testing.T) {
 	}{
 		{
 			name:       "codex",
-			options:    model.Options{AgentCommand: "codex", CodexReasoningEffort: "high"},
+			options:    model.Options{AgentCommand: "codex", CodexModel: "gpt-5.5", CodexReasoningEffort: "high"},
 			wantAgent:  "A      codex",
+			wantModel:  "M      gpt-5.5",
 			wantEffort: "E      effort: high",
-			notWant:    []string{"A      set agent", "E      codex effort: high"},
+			notWant:    []string{"A      set agent", "M      model: gpt-5.5", "E      codex effort: high"},
 		},
 		{
 			name:       "codex app",
 			options:    model.Options{AgentCommand: "codex-app"},
 			wantAgent:  "A      codex-app",
-			wantModel:  "M      model: app",
+			wantModel:  "M      app",
 			wantEffort: "E      effort: app",
-			notWant:    []string{"M      app default", "E      app default", "E      codex-app default"},
+			notWant:    []string{"M      model: app", "M      app default", "E      app default", "E      codex-app default"},
 		},
 		{
 			name:       "claude",
-			options:    model.Options{AgentCommand: "claude", ClaudeReasoningEffort: "max"},
+			options:    model.Options{AgentCommand: "claude", ClaudeModel: "claude-fable-5", ClaudeReasoningEffort: "max"},
 			wantAgent:  "A      claude",
+			wantModel:  "M      fable-5",
 			wantEffort: "E      effort: max",
-			notWant:    []string{"E      claude effort: max"},
+			notWant:    []string{"M      claude-fable-5", "M      model: fable-5", "E      claude effort: max"},
+		},
+		{
+			name:       "codex default model",
+			options:    model.Options{AgentCommand: "codex"},
+			wantAgent:  "A      codex",
+			wantModel:  "M      default",
+			wantEffort: "E      effort: default",
+			notWant:    []string{"M      model: default"},
 		},
 		{
 			name:      "unset",
 			wantAgent: "A      choose agent",
-			notWant:   []string{"E      choose agent", "E      effort:", "E      app default"},
+			notWant:   []string{"M      ", "E      choose agent", "E      effort:", "E      app default"},
 		},
 	}
 	for _, tt := range tests {
@@ -3946,14 +3956,14 @@ func TestModel_FlowsModeLabelsAgentAndEffortSeparately(t *testing.T) {
 			if agentIndex < 0 {
 				t.Fatalf("Flow shortcuts missing agent label %q:\n%s", tt.wantAgent, view)
 			}
-			if tt.wantEffort != "" {
-				modelIndex := -1
-				if tt.wantModel != "" {
-					modelIndex = strings.Index(view, tt.wantModel)
-					if modelIndex < 0 || agentIndex > modelIndex {
-						t.Fatalf("Flow shortcuts should group agent before model %q:\n%s", tt.wantModel, view)
-					}
+			modelIndex := -1
+			if tt.wantModel != "" {
+				modelIndex = strings.Index(view, tt.wantModel)
+				if modelIndex < 0 || agentIndex > modelIndex {
+					t.Fatalf("Flow shortcuts should group agent before model %q:\n%s", tt.wantModel, view)
 				}
+			}
+			if tt.wantEffort != "" {
 				effortIndex := strings.Index(view, tt.wantEffort)
 				if effortIndex < 0 || agentIndex > effortIndex || (modelIndex >= 0 && modelIndex > effortIndex) {
 					t.Fatalf("Flow shortcuts should group agent before effort %q:\n%s", tt.wantEffort, view)

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -3915,6 +3915,14 @@ func TestModel_FlowsModeLabelsAgentAndEffortSeparately(t *testing.T) {
 			notWant:    []string{"A      set agent", "M      model: gpt-5.5", "E      codex effort: high"},
 		},
 		{
+			name:       "codex model with claude prefix",
+			options:    model.Options{AgentCommand: "codex", CodexModel: "claude-compatible", CodexReasoningEffort: "high"},
+			wantAgent:  "A      codex",
+			wantModel:  "M      claude-compatible",
+			wantEffort: "E      effort: high",
+			notWant:    []string{"M      compatible", "M      model: claude-compatible"},
+		},
+		{
 			name:       "codex app",
 			options:    model.Options{AgentCommand: "codex-app"},
 			wantAgent:  "A      codex-app",

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -750,12 +750,12 @@ func TestRender_FlowsModeShowsReasoningEffortShortcut(t *testing.T) {
 		Mode:                ModeFlows,
 		ActivePane:          1,
 		FlowAgentLabel:      "codex",
-		FlowModel:           "model: gpt-5.5",
+		FlowModel:           "gpt-5.5",
 		FlowReasoningEffort: "effort: high",
 	})
 
 	pane := shortcutPaneText(view)
-	if !strings.Contains(pane, "A      codex\nM      model: gpt-5.5\nE      effort: high") {
+	if !strings.Contains(pane, "A      codex\nM      gpt-5.5\nE      effort: high") {
 		t.Fatalf("flows shortcut pane should group agent before model and reasoning effort:\n%s", pane)
 	}
 	if strings.Contains(pane, "A      set agent") {
@@ -777,11 +777,11 @@ func TestRender_FlowsModeShowsModelShortcutOnSelectedFlowRow(t *testing.T) {
 		Flows:          []flowstore.FlowRecord{{FlowID: "flow-1", Title: "Flow one", Status: flowstore.StatusInProgress}},
 		FlowSelected:   0,
 		FlowAgentLabel: "codex",
-		FlowModel:      "model: gpt-5.5",
+		FlowModel:      "gpt-5.5",
 	})
 
 	pane := shortcutPaneText(view)
-	if !strings.Contains(pane, "M      model: gpt-5.5") {
+	if !strings.Contains(pane, "M      gpt-5.5") {
 		t.Fatalf("selected Flow row should expose model shortcut:\n%s", pane)
 	}
 	if !strings.Contains(pane, "A      codex") {
@@ -802,11 +802,11 @@ func TestRender_FlowsModeShowsModelShortcutOnSelectedFlowPhaseRow(t *testing.T) 
 		ExpandedFlowID:      "flow-1",
 		SelectedFlowPhaseID: "merge",
 		FlowAgentLabel:      "codex",
-		FlowModel:           "model: gpt-5.5",
+		FlowModel:           "gpt-5.5",
 	})
 
 	pane := shortcutPaneText(view)
-	if !strings.Contains(pane, "M      model: gpt-5.5") {
+	if !strings.Contains(pane, "M      gpt-5.5") {
 		t.Fatalf("selected Flow phase should expose model shortcut:\n%s", pane)
 	}
 }
@@ -1622,11 +1622,11 @@ func TestStatusBar_FlowsModeFooterGroupsAgentAndEffort(t *testing.T) {
 		ActivePane:          1,
 		RepoSelected:        true,
 		FlowAgentLabel:      "codex",
-		FlowModel:           "model: gpt-5.5",
+		FlowModel:           "gpt-5.5",
 		FlowReasoningEffort: "effort: high",
 	})
 	agentIndex := strings.Index(bar, "A: codex")
-	modelIndex := strings.Index(bar, "M: model: gpt-5.5")
+	modelIndex := strings.Index(bar, "M: gpt-5.5")
 	effortIndex := strings.Index(bar, "E: effort: high")
 	if agentIndex < 0 || modelIndex < 0 || effortIndex < 0 || agentIndex > modelIndex || modelIndex > effortIndex {
 		t.Fatalf("Flow footer should group agent before model before effort, got %q", bar)
@@ -1644,9 +1644,9 @@ func TestStatusBar_FlowsModeFooterShowsModelOnSelectedFlowRow(t *testing.T) {
 		RepoSelected:   true,
 		FlowSelected:   true,
 		FlowAgentLabel: "codex",
-		FlowModel:      "model: gpt-5.5",
+		FlowModel:      "gpt-5.5",
 	})
-	if !strings.Contains(bar, "M: model: gpt-5.5") {
+	if !strings.Contains(bar, "M: gpt-5.5") {
 		t.Fatalf("selected Flow row should expose model shortcut, got %q", bar)
 	}
 	if !strings.Contains(bar, "A: codex") {
@@ -1663,9 +1663,9 @@ func TestStatusBar_FlowsModeFooterShowsModelOnSelectedFlowPhaseRow(t *testing.T)
 		FlowSelected:      true,
 		FlowPhaseSelected: true,
 		FlowAgentLabel:    "codex",
-		FlowModel:         "model: gpt-5.5",
+		FlowModel:         "gpt-5.5",
 	})
-	if !strings.Contains(bar, "M: model: gpt-5.5") {
+	if !strings.Contains(bar, "M: gpt-5.5") {
 		t.Fatalf("selected Flow phase should expose model shortcut, got %q", bar)
 	}
 }


### PR DESCRIPTION
## Summary
- Compact the Flow shortcut/footer model label by removing the `model:` prefix.
- Trim the `claude-` prefix for Claude model labels while leaving Codex model labels unchanged.
- Update model and UI tests around shortcut grouping and compact display text.

## Verification
- gofmt -l .
- go test ./model ./ui
- make test
- make build