### PR TITLE
Auto-expire status messages

### DIFF
--- a/model/flow_advance_tick.go
+++ b/model/flow_advance_tick.go
@@ -31,20 +31,9 @@ type AutoAdvanceResultMsg struct {
 	Request uint64
 }
 
-type AutoAdvanceStatusExpiredMsg struct {
-	Seq  uint64
-	Text string
-}
-
 func autoAdvanceTickCmd() tea.Cmd {
 	return tea.Tick(autoAdvanceTickInterval, func(time.Time) tea.Msg {
 		return autoAdvanceTickMsg{}
-	})
-}
-
-func expireAutoAdvanceStatus(seq uint64, text string) tea.Cmd {
-	return tea.Tick(3*time.Second, func(time.Time) tea.Msg {
-		return AutoAdvanceStatusExpiredMsg{Seq: seq, Text: text}
 	})
 }
 
@@ -155,30 +144,6 @@ func (m Model) restoreAutoAdvanceRetrySnapshot(record flowstore.FlowRecord) Mode
 		}
 	}
 	m.autoAdvanceSnapshot = append(m.autoAdvanceSnapshot, prior)
-	return m
-}
-
-func (m Model) setAutoAdvanceStatus(text string) (Model, tea.Cmd) {
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return m, nil
-	}
-	if m.status.Text != "" && m.status.Source != statusFlowAutoAdvance {
-		return m, nil
-	}
-	m.autoAdvanceStatusSeq++
-	seq := m.autoAdvanceStatusSeq
-	m.status = statusError{Text: text, Source: statusFlowAutoAdvance}
-	return m, expireAutoAdvanceStatus(seq, text)
-}
-
-func (m Model) handleAutoAdvanceStatusExpired(msg AutoAdvanceStatusExpiredMsg) Model {
-	if msg.Seq == 0 || msg.Seq != m.autoAdvanceStatusSeq {
-		return m
-	}
-	if m.status.Source == statusFlowAutoAdvance && m.status.Text == msg.Text {
-		m.status = statusError{}
-	}
 	return m
 }
 

--- a/model/flow_advance_tick_test.go
+++ b/model/flow_advance_tick_test.go
@@ -885,12 +885,12 @@ func TestModel_AutoAdvanceStatusEventsExpireAndDoNotStompOtherStatus(t *testing.
 	if m.status.Source != statusFlowAutoAdvance || m.status.Text != "Flow Bravo Flow: needs attention" {
 		t.Fatalf("status = %#v, want needs attention auto-advance status", m.status)
 	}
-	seq := m.autoAdvanceStatusSeq
-	m = m.handleAutoAdvanceStatusExpired(AutoAdvanceStatusExpiredMsg{Seq: seq + 1, Text: m.status.Text})
+	seq := m.status.Seq
+	m = m.handleStatusExpired(StatusExpiredMsg{Seq: seq + 1})
 	if m.status.Text == "" {
 		t.Fatal("stale auto-advance status expiry should not clear status")
 	}
-	m = m.handleAutoAdvanceStatusExpired(AutoAdvanceStatusExpiredMsg{Seq: seq, Text: "Flow Bravo Flow: needs attention"})
+	m = m.handleStatusExpired(StatusExpiredMsg{Seq: seq})
 	if m.status.Text != "" {
 		t.Fatalf("status after matching expiry = %#v, want cleared", m.status)
 	}

--- a/model/model.go
+++ b/model/model.go
@@ -929,7 +929,11 @@ func (m Model) rightEmptyMessage(filteredRepos, filteredWorktrees, filteredBranc
 		return "No " + modeResultName(m.mode) + " results for " + m.activeItemPaneQuery()
 	}
 	if m.status.Source == statusFetch && m.status.FetchKind == FetchList && m.status.Mode == m.activeContentFetchMode() {
-		return "Could not load " + modeDataName(m.activeContentFetchMode()) + "; see status bar"
+		message := "Could not load " + modeDataName(m.activeContentFetchMode())
+		if m.status.Text != "" {
+			message += "; see status bar"
+		}
+		return message
 	}
 	if m.activeFlowSurfaceVisible() {
 		return "No active flows"

--- a/model/model.go
+++ b/model/model.go
@@ -76,8 +76,10 @@ type Model struct {
 	activeFlowsReturnMode      ui.Mode
 	destructive                bool
 	status                     statusError
+	statusSeq                  uint64
+	statusTimer                statusTimerFactory
+	pendingStatusCmds          []tea.Cmd
 	visibleRepoFetchSeq        uint64
-	visibleRepoFetchStatusSeq  uint64
 	visibleRepoFetch           visibleRepoFetchState
 	searchActive               bool
 	pendingBranchSelection     string
@@ -139,7 +141,6 @@ type Model struct {
 	autoAdvanceInFlight        uint64
 	autoAdvanceSnapshot        []flowstore.FlowRecord
 	autoAdvanceLaunchedPhases  []autoAdvanceLaunchedPhase
-	autoAdvanceStatusSeq       uint64
 	terminalPrefixActive       bool
 	terminalConfirmID          embeddedTerminalID
 	terminalConfirmScope       embeddedTerminalScope
@@ -157,11 +158,13 @@ const (
 	statusGitMutation
 	statusOther
 	statusFlowAutoAdvance
+	statusVisibleRepoFetchSummary
 )
 
 type statusError struct {
 	Text      string
 	Source    statusSource
+	Seq       uint64
 	FetchKind FetchKind
 	Mode      ui.Mode
 	FadeStep  int
@@ -1157,7 +1160,15 @@ func (m Model) activeViewMatches(kind FetchKind, mode ui.Mode, request uint64) b
 
 // --- Update ---
 
-func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (next tea.Model, cmd tea.Cmd) {
+	defer func() {
+		modelNext, ok := next.(Model)
+		if !ok {
+			return
+		}
+		modelNext, cmd = modelNext.drainStatusCmds(cmd)
+		next = modelNext
+	}()
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		return m.handleKey(msg)
@@ -1197,8 +1208,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.startAutoAdvanceFetch()
 	case AutoAdvanceResultMsg:
 		return m.handleAutoAdvanceResult(msg)
-	case AutoAdvanceStatusExpiredMsg:
-		return m.handleAutoAdvanceStatusExpired(msg), nil
+	case StatusExpiredMsg:
+		return m.handleStatusExpired(msg), nil
+	case StatusFadeMsg:
+		return m.handleStatusFade(msg), nil
 	case BranchResultMsg:
 		return m.handleBranchResult(msg), nil
 	case StashResultMsg:
@@ -1233,10 +1246,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleGitFetchFailed(msg), nil
 	case VisibleRepoFetchResultMsg:
 		return m.handleVisibleRepoFetchResult(msg)
-	case VisibleRepoFetchStatusFadeMsg:
-		return m.handleVisibleRepoFetchStatusFade(msg), nil
-	case VisibleRepoFetchStatusExpiredMsg:
-		return m.handleVisibleRepoFetchStatusExpired(msg), nil
 	case RepoRefreshResultMsg:
 		return m.handleRepoRefreshResult(msg)
 	case RepoRefreshFailedMsg:

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -883,6 +883,7 @@ func TestModel_VisibleRepoFetchProgressSuccessAndRefresh(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected one selected-repo refresh when batch completes")
 	}
+	requireBatchCommandCount(t, cmd, 4)
 }
 
 func TestModel_VisibleRepoFetchFinalStatusExpires(t *testing.T) {
@@ -1288,6 +1289,33 @@ func runLeadingBatchCmd(t *testing.T, cmd tea.Cmd) []tea.Msg {
 		return nil
 	}
 	return runBatchCmd(t, batch[0])
+}
+
+func requireBatchCommandCount(t *testing.T, cmd tea.Cmd, wantAtLeast int) {
+	t.Helper()
+	requireBatchMsg(t, cmd, wantAtLeast)
+}
+
+func runLeadingBatchCmdWithCount(t *testing.T, cmd tea.Cmd, wantAtLeast int) []tea.Msg {
+	t.Helper()
+	batch := requireBatchMsg(t, cmd, wantAtLeast)
+	return runBatchCmd(t, batch[0])
+}
+
+func requireBatchMsg(t *testing.T, cmd tea.Cmd, wantAtLeast int) tea.BatchMsg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected command")
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want batch", msg)
+	}
+	if len(batch) < wantAtLeast {
+		t.Fatalf("batch has %d command(s), want at least %d", len(batch), wantAtLeast)
+	}
+	return batch
 }
 
 // --- Branch diff (enter key) ---

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -815,8 +815,8 @@ func TestModel_LeftPaneFKeyWithNoVisibleReposShowsStatus(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
-	if cmd != nil {
-		t.Fatal("expected no command when no repos are visible")
+	if cmd == nil {
+		t.Fatal("expected status expiry command when no repos are visible")
 	}
 	if !strings.Contains(m.View(), "No visible repos to fetch") {
 		t.Fatalf("expected no-visible-repos status, got:\n%s", m.View())
@@ -898,7 +898,7 @@ func TestModel_VisibleRepoFetchFinalStatusExpires(t *testing.T) {
 		t.Fatalf("expected final success status before expiry, got:\n%s", m.View())
 	}
 
-	m, _ = update(m, model.VisibleRepoFetchStatusExpiredMsg{Request: 1, Text: "Fetched 3 visible repos"})
+	m, _ = update(m, model.StatusExpiredMsg{Seq: 1})
 	if strings.Contains(m.View(), "Fetched 3 visible repos") {
 		t.Fatalf("expected final success status to expire, got:\n%s", m.View())
 	}
@@ -917,7 +917,7 @@ func TestModel_VisibleRepoFetchFinalStatusFadesBeforeExpiry(t *testing.T) {
 		t.Fatalf("expected fresh status to start unfaded, got step %d", m.TransientErrorFadeStep())
 	}
 
-	m, _ = update(m, model.VisibleRepoFetchStatusFadeMsg{Request: 1, Text: "Fetched 3 visible repos", Step: 1})
+	m, _ = update(m, model.StatusFadeMsg{Seq: 1, Step: 1})
 	if m.TransientErrorFadeStep() != 1 {
 		t.Fatalf("expected fade step 1, got %d", m.TransientErrorFadeStep())
 	}
@@ -925,7 +925,7 @@ func TestModel_VisibleRepoFetchFinalStatusFadesBeforeExpiry(t *testing.T) {
 		t.Fatalf("fade should keep status visible, got:\n%s", m.View())
 	}
 
-	m, _ = update(m, model.VisibleRepoFetchStatusFadeMsg{Request: 1, Text: "Fetched 3 visible repos", Step: 2})
+	m, _ = update(m, model.StatusFadeMsg{Seq: 1, Step: 2})
 	if m.TransientErrorFadeStep() != 2 {
 		t.Fatalf("expected fade step 2, got %d", m.TransientErrorFadeStep())
 	}
@@ -940,7 +940,7 @@ func TestModel_VisibleRepoFetchFinalStatusStillClearsOnKeypress(t *testing.T) {
 	for _, msg := range runBatchCmd(t, cmd) {
 		m, _ = update(m, msg)
 	}
-	m, _ = update(m, model.VisibleRepoFetchStatusFadeMsg{Request: 1, Text: "Fetched 3 visible repos", Step: 1})
+	m, _ = update(m, model.StatusFadeMsg{Seq: 1, Step: 1})
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 	if strings.Contains(m.View(), "Fetched 3 visible repos") {
@@ -959,7 +959,7 @@ func TestModel_VisibleRepoFetchStatusExpiryDoesNotClearNewerStatus(t *testing.T)
 	}
 	m, _ = update(m, model.GitFetchFailedMsg{RepoPath: "/dev/alpha", Err: "fetch failed: newer"})
 
-	m, _ = update(m, model.VisibleRepoFetchStatusExpiredMsg{Request: 1, Text: "Fetched 3 visible repos"})
+	m, _ = update(m, model.StatusExpiredMsg{Seq: 1})
 	view := m.View()
 	if !strings.Contains(view, "fetch failed: newer") {
 		t.Fatalf("expiry should not clear a newer git status, got:\n%s", view)
@@ -1272,6 +1272,22 @@ func runBatchCmd(t *testing.T, cmd tea.Cmd) []tea.Msg {
 		msgs = append(msgs, subcmd())
 	}
 	return msgs
+}
+
+func runLeadingBatchCmd(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected command")
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		return []tea.Msg{msg}
+	}
+	if len(batch) == 0 {
+		return nil
+	}
+	return runBatchCmd(t, batch[0])
 }
 
 // --- Branch diff (enter key) ---
@@ -2534,8 +2550,8 @@ func TestModel_NKeyInBranchesModeWithNoRepoIsNoOp(t *testing.T) {
 	if m.Overlay() != ui.OverlayNone {
 		t.Errorf("expected OverlayNone, got %d", m.Overlay())
 	}
-	if cmd != nil {
-		t.Errorf("expected nil cmd, got %T", cmd)
+	if cmd == nil {
+		t.Error("expected status expiry command")
 	}
 }
 
@@ -4077,8 +4093,8 @@ func TestModel_FlowEffortPickerRequiresSelectedAgent(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'E'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd without selected agent, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command without selected agent")
 	}
 	if m.Overlay() != ui.OverlayNone {
 		t.Fatalf("expected no overlay without agent, got %d", m.Overlay())
@@ -4094,8 +4110,8 @@ func TestModel_FlowEffortPickerReportsCodexAppDefault(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'E'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd for codex-app effort, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for codex-app effort")
 	}
 	if m.Overlay() != ui.OverlayNone {
 		t.Fatalf("expected no overlay for codex-app effort, got %d", m.Overlay())
@@ -4111,8 +4127,8 @@ func TestModel_FlowModelPickerReportsCodexAppDefault(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd for codex-app model, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for codex-app model")
 	}
 	if m.Overlay() != ui.OverlayNone {
 		t.Fatalf("expected no overlay for codex-app model, got %d", m.Overlay())
@@ -4290,8 +4306,8 @@ func TestModel_AKeyWithNoSelectedAgentShowsStatus(t *testing.T) {
 		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
 	}})
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd without selected agent, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command without selected agent")
 	}
 	if !strings.Contains(m.View(), "Press A to choose") {
 		t.Fatal("expected unset-agent status")
@@ -4310,8 +4326,8 @@ func TestModel_AgentLaunchBuildErrorShowsStatus(t *testing.T) {
 		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
 	}})
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd when launch cannot be built, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command when launch cannot be built")
 	}
 	if !strings.Contains(m.View(), "agent unavailable") {
 		t.Fatal("expected launch build error in status bar")
@@ -4642,8 +4658,8 @@ func TestModel_SKeySessionSummaryPagerFailureShowsStatus(t *testing.T) {
 	}, ListRequest: m.ListRequest(ui.ModeSessions)})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
-	if cmd != nil {
-		t.Fatalf("pager construction failure should not return launch command, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for pager construction failure")
 	}
 	if got := m.TransientError(); !strings.Contains(got, "less not found") {
 		t.Fatalf("status = %q, want pager failure", got)
@@ -5732,8 +5748,8 @@ func TestModel_RKeySessionResumeWithFlowMetadataRunFailureDoesNotUpdateFlow(t *t
 	}, ListRequest: m.ListRequest(ui.ModeSessions)})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
-	if cmd != nil {
-		t.Fatalf("embedded start failure should not return command, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for embedded start failure")
 	}
 	if !strings.Contains(m.View(), "embedded start failed") {
 		t.Fatalf("expected embedded start failure in status:\n%s", m.View())
@@ -5867,8 +5883,8 @@ func TestModel_RKeyResumeMissingPathShowsStatus(t *testing.T) {
 	}, ListRequest: m.ListRequest(ui.ModeSessions)})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
-	if cmd != nil {
-		t.Fatalf("expected no command for missing resume path, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for missing resume path")
 	}
 	if called {
 		t.Fatal("expected missing path not to call launcher")
@@ -5893,8 +5909,8 @@ func TestModel_RKeyResumeBlankSessionIDShowsStatus(t *testing.T) {
 	}, ListRequest: m.ListRequest(ui.ModeSessions)})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
-	if cmd != nil {
-		t.Fatalf("expected no command for blank session id, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for blank session id")
 	}
 	if called {
 		t.Fatal("expected blank session id not to call launcher")
@@ -5929,8 +5945,8 @@ func TestModel_InlineSessionResumeBlankSessionIDShowsStatus(t *testing.T) {
 	m, _ = update(m, cmd())
 
 	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
-	if cmd != nil {
-		t.Fatalf("expected no command for blank inline session id, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for blank inline session id")
 	}
 	if called {
 		t.Fatal("expected blank inline session id not to call launcher")
@@ -6255,8 +6271,8 @@ func TestModel_ShiftNWithNoSelectedAgentShowsStatus(t *testing.T) {
 	m := model.New(testRepos())
 	m = inWorktreesMode(m)
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd without selected agent, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command without selected agent")
 	}
 	if !strings.Contains(m.View(), "Press A to choose") {
 		t.Fatal("expected unset-agent status")

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -3,7 +3,6 @@ package model
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -19,8 +18,6 @@ import (
 // --- Fetch commands ---
 
 const visibleRepoFetchFailureNameLimit = 3
-const visibleRepoFetchStatusTTL = 3 * time.Second
-const visibleRepoFetchFadeStepDuration = 1 * time.Second
 
 func (m Model) startFetchForMode() (Model, tea.Cmd) {
 	if m.activeFlowSurfaceVisible() {
@@ -304,18 +301,6 @@ func (m Model) replaceReposPreservingVisibleSelection(repos []scanner.Repo, prev
 	}
 	currentPath, _ := m.currentRepoPath()
 	return m.reflowRepos(), previousPath != currentPath, true
-}
-
-func expireVisibleRepoFetchStatus(request uint64, text string) tea.Cmd {
-	return tea.Tick(visibleRepoFetchStatusTTL, func(time.Time) tea.Msg {
-		return VisibleRepoFetchStatusExpiredMsg{Request: request, Text: text}
-	})
-}
-
-func fadeVisibleRepoFetchStatus(request uint64, text string, step int) tea.Cmd {
-	return tea.Tick(time.Duration(step)*visibleRepoFetchFadeStepDuration, func(time.Time) tea.Msg {
-		return VisibleRepoFetchStatusFadeMsg{Request: request, Text: text, Step: step}
-	})
 }
 
 func (m Model) canPull() bool {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1217,7 +1217,7 @@ func TestModel_FlowAutoLaunchWithCodexAppUsesExternalRouteWithoutEffort(t *testi
 	if cmd == nil {
 		t.Fatal("expected external codex-app agent result command")
 	}
-	_ = cmd()
+	_ = runLeadingBatchCmd(t, cmd)
 	if startEmbeddedRan {
 		t.Fatal("codex-app auto launch should not start an embedded terminal")
 	}
@@ -1341,7 +1341,7 @@ func runPreparedFlowEmbeddedLaunch(t *testing.T, m model.Model, cmd tea.Cmd) mod
 	if cmd == nil {
 		t.Fatal("expected embedded Flow launch command")
 	}
-	_ = cmd()
+	_ = runLeadingBatchCmd(t, cmd)
 	return m
 }
 
@@ -1435,7 +1435,9 @@ func TestModel_AKeyFlowAutoModeFailureReportsStatus(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("a on selected Flow row should return persistence command")
 	}
-	m, _ = update(m, cmd())
+	for _, refreshMsg := range runLeadingBatchCmd(t, cmd) {
+		m, _ = update(m, refreshMsg)
+	}
 	if got := m.TransientError(); !strings.Contains(got, "failed to set Flow auto mode") || !strings.Contains(got, "state root locked") {
 		t.Fatalf("status = %q, want persistence failure", got)
 	}
@@ -1740,7 +1742,9 @@ func TestModel_MKeyManualMergeFailureReplacesRecoveredFlowState(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("confirming manual merge should return command")
 	}
-	m, _ = update(m, cmd())
+	for _, refreshMsg := range runLeadingBatchCmd(t, cmd) {
+		m, _ = update(m, refreshMsg)
+	}
 
 	got := m.Flows()
 	if len(got) != 1 {
@@ -1795,8 +1799,8 @@ func TestModel_ShiftMManualMergeNoopsOnActiveFlowRow(t *testing.T) {
 	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'M'}})
-	if cmd != nil {
-		t.Fatalf("M on selected active Flow row returned command %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command on selected active Flow row")
 	}
 	if m.Overlay() == ui.OverlayConfirm {
 		t.Fatalf("M on selected active Flow row opened confirmation %q", m.ConfirmPrompt())
@@ -2111,8 +2115,8 @@ func TestModel_XKeyOnResettableFlowPhaseReportsResetFailure(t *testing.T) {
 		t.Fatal("confirmed reset should return persistence command")
 	}
 	m, fetchCmd := update(m, resetCmd())
-	if fetchCmd != nil {
-		t.Fatalf("reset failure returned refresh command %T, want nil", fetchCmd)
+	if fetchCmd == nil {
+		t.Fatal("expected status expiry command for reset failure")
 	}
 	if got := m.TransientError(); !strings.Contains(got, "state root locked") {
 		t.Fatalf("status after reset failure = %q, want persistence error", got)
@@ -4057,8 +4061,8 @@ func TestModel_GWithNoLaunchableFlowPhaseDoesNotMutateOrLaunch(t *testing.T) {
 	m = selectFlowPhaseByID(t, m, "implementation")
 
 	m, cmd := update(m, flowLaunchKey())
-	if cmd != nil {
-		t.Fatalf("g without a launchable phase returned command %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command without a launchable phase")
 	}
 	if addLaunchRan || launchAgentRan || startEmbeddedRan {
 		t.Fatalf("g without launchable phase launched: add=%v launch=%v embedded=%v", addLaunchRan, launchAgentRan, startEmbeddedRan)
@@ -4927,9 +4931,7 @@ func TestModel_PKeyFlowPullRequestGuards(t *testing.T) {
 				return nil
 			})
 			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
-			if cmd != nil {
-				t.Fatalf("p returned command %T, want nil", cmd)
-			}
+			_ = cmd
 			if len(opened) != 0 {
 				t.Fatalf("opened URLs = %#v, want none", opened)
 			}
@@ -5533,7 +5535,9 @@ func TestModel_FlowDeleteFailureHandling(t *testing.T) {
 		if !strings.Contains(m.TransientError(), "Flow already deleted") {
 			t.Fatalf("status after not-found delete = %q, want stale-list warning", m.TransientError())
 		}
-		m, _ = update(m, cmd())
+		for _, refreshMsg := range runLeadingBatchCmd(t, cmd) {
+			m, _ = update(m, refreshMsg)
+		}
 		if got := m.Flows(); len(got) != 0 {
 			t.Fatalf("flows after not-found refresh = %#v, want empty", got)
 		}
@@ -5560,8 +5564,8 @@ func TestModel_FlowDeleteFailureHandling(t *testing.T) {
 			Err:      "disk full",
 		})
 
-		if cmd != nil {
-			t.Fatalf("non-not-found FlowDeleteFailedMsg returned command %T, want nil", cmd)
+		if cmd == nil {
+			t.Fatal("expected status expiry command for non-not-found FlowDeleteFailedMsg")
 		}
 		if got := m.Flows(); len(got) != 1 || got[0].FlowID != "flow-1" {
 			t.Fatalf("flows after failed delete = %#v, want unchanged", got)
@@ -5787,8 +5791,8 @@ func TestModel_OKeyOnFlowWithoutPlanShowsStatus(t *testing.T) {
 	}})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
-	if cmd != nil {
-		t.Fatalf("unlinked flow o returned command %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for unlinked flow")
 	}
 	if m.Overlay() != ui.OverlayNone {
 		t.Fatalf("expected no overlay, got %d", m.Overlay())
@@ -5967,8 +5971,8 @@ func TestModel_FlowPhaseWithUnsupportedProviderDoesNotAdvertiseResume(t *testing
 		t.Fatalf("unsupported provider should not advertise Flow phase resume:\n%s", m.View())
 	}
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
-	if cmd != nil {
-		t.Fatalf("unsupported provider should not launch, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for unsupported provider")
 	}
 	if launchRan {
 		t.Fatal("LaunchAgent ran for unsupported Flow phase provider")
@@ -6007,8 +6011,8 @@ func TestModel_RKeyOnFlowPhaseAwaitingLatestSessionDoesNotResumeOlderSession(t *
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
-	if cmd != nil {
-		t.Fatalf("awaiting latest session should not launch, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for awaiting latest session")
 	}
 	if launchRan {
 		t.Fatal("LaunchAgent ran for stale Flow phase session")
@@ -6054,8 +6058,8 @@ func TestModel_RKeyOnFlowPhaseAwaitingLatestSessionDoesNotResumeOlderLiveSession
 		t.Fatalf("awaiting latest session with older live session should not advertise resume:\n%s", m.View())
 	}
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
-	if cmd != nil {
-		t.Fatalf("awaiting latest session should not launch, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for awaiting latest session")
 	}
 	if launchRan {
 		t.Fatal("launch ran for stale Flow phase session")
@@ -6081,8 +6085,8 @@ func TestModel_RKeyOnRunningEndedSessionFlowPhaseDoesNotResume(t *testing.T) {
 	m = selectFlowPhaseByID(t, m, "implementation")
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
-	if cmd != nil {
-		t.Fatalf("running ended-session phase should not launch, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for running ended-session phase")
 	}
 	if launchRan {
 		t.Fatal("launcher ran for running ended-session Flow phase")
@@ -6116,8 +6120,8 @@ func TestModel_RKeyOnRunningEndedLatestSessionDoesNotResumeWhenOlderSessionIsLiv
 		t.Fatalf("running ended latest session should not advertise resume:\n%s", m.View())
 	}
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
-	if cmd != nil {
-		t.Fatalf("running ended latest session should not launch, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for running ended latest session")
 	}
 	if launchRan {
 		t.Fatal("launcher ran for running ended latest session")
@@ -9059,8 +9063,8 @@ func TestModel_GWithoutReadyFlowPhaseShowsNoLaunchableStatus(t *testing.T) {
 	}
 
 	m, cmd := update(m, flowLaunchKey())
-	if cmd != nil {
-		t.Fatalf("not-ready flow launch returned command %T, want nil", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for not-ready flow launch")
 	}
 	if status := m.TransientError(); status != "No launchable Flow phase" {
 		t.Fatalf("status = %q, want no-launchable message", status)
@@ -9549,8 +9553,8 @@ func TestModel_GDoesNotRelaunchFlowPhaseAutoreviewWithoutPRTarget(t *testing.T) 
 
 	m = selectFlowPhaseByID(t, m, "autoreview")
 	m, cmd := update(m, flowLaunchKey())
-	if cmd != nil {
-		t.Fatal("g should not launch blocked autoreview without PR metadata")
+	if cmd == nil {
+		t.Fatal("expected status expiry command for blocked autoreview without PR metadata")
 	}
 	if launchAttempted {
 		t.Fatal("LaunchAgent() ran without PR metadata")
@@ -9598,8 +9602,8 @@ func TestModel_GDoesNotRelaunchFlowPhaseAutoreviewWhenPredecessorsAreUnsatisfied
 
 	m = selectFlowPhaseByID(t, m, "autoreview")
 	m, cmd := update(m, flowLaunchKey())
-	if cmd != nil {
-		t.Fatal("g should not launch blocked autoreview while predecessors are unsatisfied")
+	if cmd == nil {
+		t.Fatal("expected status expiry command for blocked autoreview with unsatisfied predecessors")
 	}
 	if got := m.TransientError(); got != "No launchable Flow phase" {
 		t.Fatalf("status = %q, want no-launchable message", got)
@@ -9995,7 +9999,7 @@ func TestModel_NewFlowPlanNowOffCreatesFlowWithoutLaunch(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected flow refresh command after parked Flow creation")
 	}
-	_ = cmd()
+	_ = runLeadingBatchCmd(t, cmd)
 
 	if createRequest.RepoPath != "/dev/alpha" ||
 		createRequest.Title != "Parked Flow" ||
@@ -10973,7 +10977,9 @@ func TestModel_FlowAgentResultFailureMarksPhaseAndRefreshesFlows(t *testing.T) {
 		!strings.Contains(phaseUpdate.Notes, "agent exited") {
 		t.Fatalf("phase update = %#v", phaseUpdate)
 	}
-	m, _ = update(m, cmd())
+	for _, refreshMsg := range runLeadingBatchCmd(t, cmd) {
+		m, _ = update(m, refreshMsg)
+	}
 	if !listed {
 		t.Fatal("expected ListFlows to run")
 	}

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -1436,7 +1436,11 @@ func TestModel_AKeyFlowAutoModeFailureReportsStatus(t *testing.T) {
 		t.Fatal("a on selected Flow row should return persistence command")
 	}
 	for _, refreshMsg := range runLeadingBatchCmd(t, cmd) {
-		m, _ = update(m, refreshMsg)
+		var statusCmd tea.Cmd
+		m, statusCmd = update(m, refreshMsg)
+		if statusCmd == nil {
+			t.Fatal("expected status expiry command")
+		}
 	}
 	if got := m.TransientError(); !strings.Contains(got, "failed to set Flow auto mode") || !strings.Contains(got, "state root locked") {
 		t.Fatalf("status = %q, want persistence failure", got)
@@ -5535,7 +5539,7 @@ func TestModel_FlowDeleteFailureHandling(t *testing.T) {
 		if !strings.Contains(m.TransientError(), "Flow already deleted") {
 			t.Fatalf("status after not-found delete = %q, want stale-list warning", m.TransientError())
 		}
-		for _, refreshMsg := range runLeadingBatchCmd(t, cmd) {
+		for _, refreshMsg := range runLeadingBatchCmdWithCount(t, cmd, 2) {
 			m, _ = update(m, refreshMsg)
 		}
 		if got := m.Flows(); len(got) != 0 {
@@ -10977,7 +10981,7 @@ func TestModel_FlowAgentResultFailureMarksPhaseAndRefreshesFlows(t *testing.T) {
 		!strings.Contains(phaseUpdate.Notes, "agent exited") {
 		t.Fatalf("phase update = %#v", phaseUpdate)
 	}
-	for _, refreshMsg := range runLeadingBatchCmd(t, cmd) {
+	for _, refreshMsg := range runLeadingBatchCmdWithCount(t, cmd, 2) {
 		m, _ = update(m, refreshMsg)
 	}
 	if !listed {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -708,14 +708,12 @@ func (m Model) handleVisibleRepoFetchResult(msg VisibleRepoFetchResultMsg) (tea.
 	finalStatus := m.visibleRepoFetchFinalStatusText()
 	m.visibleRepoFetch = visibleRepoFetchState{}
 	m = m.setVisibleRepoFetchSummaryStatus(finalStatus)
-	statusCmds := append([]tea.Cmd(nil), m.pendingStatusCmds...)
-	m.pendingStatusCmds = nil
 	if currentOK && shouldRefresh {
 		var fetchCmd tea.Cmd
 		m, fetchCmd = m.startFetchForMode()
-		statusCmds = append([]tea.Cmd{fetchCmd}, statusCmds...)
+		return m, fetchCmd
 	}
-	return m, tea.Batch(statusCmds...)
+	return m, nil
 }
 
 func (m Model) handleRepoRefreshResult(msg RepoRefreshResultMsg) (tea.Model, tea.Cmd) {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -132,17 +132,6 @@ type VisibleRepoFetchResultMsg struct {
 	Err         string
 }
 
-type VisibleRepoFetchStatusFadeMsg struct {
-	Request uint64
-	Text    string
-	Step    int
-}
-
-type VisibleRepoFetchStatusExpiredMsg struct {
-	Request uint64
-	Text    string
-}
-
 type promptTemplateEditRequestedMsg struct {
 	Value string
 }
@@ -551,30 +540,6 @@ func (m Model) isCurrentRepo(repoPath string) bool {
 	return ok && current == repoPath
 }
 
-func (m Model) setStatus(source statusSource, text string) Model {
-	m.status = statusError{Text: text, Source: source}
-	return m
-}
-
-func (m Model) setFetchStatus(msg FetchErrorMsg) Model {
-	m.status = statusError{Text: msg.Err, Source: statusFetch, FetchKind: msg.Kind, Mode: msg.Mode}
-	return m
-}
-
-func (m Model) clearStatus(source statusSource) Model {
-	if m.status.Source == source {
-		m.status = statusError{}
-	}
-	return m
-}
-
-func (m Model) clearFetchListStatus(mode ui.Mode) Model {
-	if m.status.Source == statusFetch && m.status.FetchKind == FetchList && m.status.Mode == mode {
-		m.status = statusError{}
-	}
-	return m
-}
-
 func (m Model) isCurrentListRequest(mode ui.Mode, request uint64) bool {
 	if request == 0 {
 		return false
@@ -597,11 +562,6 @@ func (m Model) acceptActiveFlowResult(request uint64) (Model, bool) {
 		return m, false
 	}
 	return m.clearFetchListStatus(ui.ModeActiveFlows), true
-}
-
-func (m Model) clearAnyStatus() Model {
-	m.status = statusError{}
-	return m
 }
 
 func (m Model) visibleStatusText() string {
@@ -747,40 +707,15 @@ func (m Model) handleVisibleRepoFetchResult(msg VisibleRepoFetchResultMsg) (tea.
 	_, shouldRefresh := m.visibleRepoFetch.CapturedPaths[currentPath]
 	finalStatus := m.visibleRepoFetchFinalStatusText()
 	m.visibleRepoFetch = visibleRepoFetchState{}
-	m.visibleRepoFetchStatusSeq++
-	statusRequest := m.visibleRepoFetchStatusSeq
-	m = m.setStatus(statusGitMutation, finalStatus)
-	statusCmds := []tea.Cmd{
-		fadeVisibleRepoFetchStatus(statusRequest, finalStatus, 1),
-		fadeVisibleRepoFetchStatus(statusRequest, finalStatus, 2),
-		expireVisibleRepoFetchStatus(statusRequest, finalStatus),
-	}
+	m = m.setVisibleRepoFetchSummaryStatus(finalStatus)
+	statusCmds := append([]tea.Cmd(nil), m.pendingStatusCmds...)
+	m.pendingStatusCmds = nil
 	if currentOK && shouldRefresh {
 		var fetchCmd tea.Cmd
 		m, fetchCmd = m.startFetchForMode()
 		statusCmds = append([]tea.Cmd{fetchCmd}, statusCmds...)
 	}
 	return m, tea.Batch(statusCmds...)
-}
-
-func (m Model) handleVisibleRepoFetchStatusFade(msg VisibleRepoFetchStatusFadeMsg) Model {
-	if msg.Request == 0 || msg.Request != m.visibleRepoFetchStatusSeq {
-		return m
-	}
-	if m.status.Source == statusGitMutation && m.status.Text == msg.Text {
-		m.status.FadeStep = msg.Step
-	}
-	return m
-}
-
-func (m Model) handleVisibleRepoFetchStatusExpired(msg VisibleRepoFetchStatusExpiredMsg) Model {
-	if msg.Request == 0 || msg.Request != m.visibleRepoFetchStatusSeq {
-		return m
-	}
-	if m.status.Source == statusGitMutation && m.status.Text == msg.Text {
-		m.status = statusError{}
-	}
-	return m
 }
 
 func (m Model) handleRepoRefreshResult(msg RepoRefreshResultMsg) (tea.Model, tea.Cmd) {

--- a/model/model_plan_test.go
+++ b/model/model_plan_test.go
@@ -604,8 +604,8 @@ func TestModel_IKeyWithNoSelectedAgentShowsStatus(t *testing.T) {
 	}, ListRequest: m.ListRequest(ui.ModePlans)})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd without selected agent, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command without selected agent")
 	}
 	if !strings.Contains(m.View(), "Press A to choose") {
 		t.Fatal("expected unset-agent status")
@@ -678,8 +678,8 @@ func TestModel_IKeyPlanPathResolverErrorShowsStatus(t *testing.T) {
 	}, ListRequest: m.ListRequest(ui.ModePlans)})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd on resolver error, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command on resolver error")
 	}
 	if !strings.Contains(m.View(), "bad plan path") {
 		t.Fatal("expected resolver error in status")
@@ -698,8 +698,8 @@ func TestModel_IKeyMissingPlanLaunchPathShowsStatus(t *testing.T) {
 	}, ListRequest: m.ListRequest(ui.ModePlans)})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'i'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd for missing launch path, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command for missing launch path")
 	}
 	if !strings.Contains(m.View(), "Cannot determine launch path for this plan") {
 		t.Fatal("expected missing launch path status")
@@ -729,8 +729,8 @@ func TestModel_IKeyLaunchErrorShowsStatus(t *testing.T) {
 		t.Fatal("expected submit command")
 	}
 	m, launchCmd := update(m, cmd())
-	if launchCmd != nil {
-		t.Fatalf("expected nil cmd on launch error, got %T", launchCmd)
+	if launchCmd == nil {
+		t.Fatal("expected status expiry command on launch error")
 	}
 	if !strings.Contains(m.View(), "agent unavailable") {
 		t.Fatal("expected launch error in status")
@@ -834,8 +834,8 @@ func TestModel_EKeyPlanEditorErrorShowsStatus(t *testing.T) {
 	})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd on editor error, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command on editor error")
 	}
 	if !strings.Contains(m.View(), "editor unavailable") {
 		t.Fatal("expected editor error in status")
@@ -913,8 +913,8 @@ func TestModel_YKeyPlanPathResolverErrorShowsStatus(t *testing.T) {
 	}, ListRequest: m.ListRequest(ui.ModePlans)})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
-	if cmd != nil {
-		t.Fatalf("expected nil cmd on resolver error, got %T", cmd)
+	if cmd == nil {
+		t.Fatal("expected status expiry command on resolver error")
 	}
 	if !strings.Contains(m.View(), "cannot resolve plan path") {
 		t.Fatal("expected resolver error in status")

--- a/model/model_refresh_test.go
+++ b/model/model_refresh_test.go
@@ -78,8 +78,8 @@ func TestModel_F5WithNoScannerReportsUnavailable(t *testing.T) {
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF5})
 
-	if cmd != nil {
-		t.Fatal("expected no command without refresh scanner")
+	if cmd == nil {
+		t.Fatal("expected status expiry command without refresh scanner")
 	}
 	if got := m.TransientError(); got != "refresh unavailable" {
 		t.Fatalf("TransientError() = %q, want refresh unavailable", got)
@@ -176,7 +176,7 @@ func TestModel_RepoRefreshPreservesSelectionAndKeepsCurrentListWhileFetchPending
 	})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF5})
-	scanMsg := repoRefreshResultFromBatch(t, runBatchCmd(t, cmd))
+	scanMsg := repoRefreshResultFromBatch(t, runLeadingBatchCmd(t, cmd))
 	m, followup := update(m, scanMsg)
 	if followup != nil {
 		t.Fatal("unchanged selected repo should not start a second post-scan fetch")
@@ -314,11 +314,11 @@ func TestModel_RepoRefreshKeepsFilterAndHandlesZeroVisibleRepos(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyF5})
-	scanMsg := repoRefreshResultFromBatch(t, runBatchCmd(t, cmd))
+	scanMsg := repoRefreshResultFromBatch(t, runLeadingBatchCmd(t, cmd))
 	m, followup := update(m, scanMsg)
 
-	if followup != nil {
-		t.Fatal("zero visible repos should not fetch right pane")
+	if followup == nil {
+		t.Fatal("zero visible repos should return status expiry command")
 	}
 	if got := m.RepoSearch(); got != "zzz" {
 		t.Fatalf("RepoSearch() = %q, want preserved query zzz", got)

--- a/model/model_repo_create_test.go
+++ b/model/model_repo_create_test.go
@@ -38,8 +38,8 @@ func TestModel_LeftPaneNReportsUnavailableWithoutRepoCreateRoot(t *testing.T) {
 	m := model.New(testRepos())
 
 	m, cmd := update(m, repoCreateKey("n"))
-	if cmd != nil {
-		t.Fatal("unavailable repo creation should not return command")
+	if cmd == nil {
+		t.Fatal("unavailable repo creation should return status expiry command")
 	}
 	if m.Overlay() != ui.OverlayNone {
 		t.Fatalf("Overlay() = %d, want none", m.Overlay())
@@ -149,7 +149,7 @@ func TestModel_RepoCreatedRefreshesAndSelectsNewRepo(t *testing.T) {
 	if refreshCmd == nil {
 		t.Fatal("repo creation success should start repo refresh")
 	}
-	refreshMsg := repoRefreshResultFromBatch(t, runBatchCmd(t, refreshCmd))
+	refreshMsg := repoRefreshResultFromBatch(t, runLeadingBatchCmd(t, refreshCmd))
 	m, _ = update(m, refreshMsg)
 
 	if got := m.Selected(); got != 1 {
@@ -185,7 +185,7 @@ func TestModel_RepoCreatedRefreshKeepsSelectedNewRepoVisible(t *testing.T) {
 		t.Fatal("repo creation should refresh repos")
 	}
 
-	refreshMsg := repoRefreshResultFromBatch(t, runBatchCmd(t, refreshCmd))
+	refreshMsg := repoRefreshResultFromBatch(t, runLeadingBatchCmd(t, refreshCmd))
 	m, _ = update(m, refreshMsg)
 
 	if got := m.Selected(); got != 24 {
@@ -223,7 +223,7 @@ func TestModel_RepoCreatedRefreshSelectsRelativeScanRepoFromAbsoluteDestination(
 		t.Fatal("repo creation should refresh repos")
 	}
 
-	refreshMsg := repoRefreshResultFromBatch(t, runBatchCmd(t, refreshCmd))
+	refreshMsg := repoRefreshResultFromBatch(t, runLeadingBatchCmd(t, refreshCmd))
 	m, _ = update(m, refreshMsg)
 
 	if got := m.Selected(); got != 1 {
@@ -331,7 +331,7 @@ func TestModel_RepoCreatePartialFailureRefreshesLocalRepo(t *testing.T) {
 		t.Fatalf("Overlay() = %d, want retry form", m.Overlay())
 	}
 
-	refreshMsg := repoRefreshResultFromBatch(t, runBatchCmd(t, refreshCmd))
+	refreshMsg := repoRefreshResultFromBatch(t, runLeadingBatchCmd(t, refreshCmd))
 	m, _ = update(m, refreshMsg)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEscape})
 

--- a/model/model_repo_create_test.go
+++ b/model/model_repo_create_test.go
@@ -149,7 +149,7 @@ func TestModel_RepoCreatedRefreshesAndSelectsNewRepo(t *testing.T) {
 	if refreshCmd == nil {
 		t.Fatal("repo creation success should start repo refresh")
 	}
-	refreshMsg := repoRefreshResultFromBatch(t, runLeadingBatchCmd(t, refreshCmd))
+	refreshMsg := repoRefreshResultFromBatch(t, runLeadingBatchCmdWithCount(t, refreshCmd, 2))
 	m, _ = update(m, refreshMsg)
 
 	if got := m.Selected(); got != 1 {

--- a/model/model_view_test.go
+++ b/model/model_view_test.go
@@ -876,6 +876,35 @@ func TestModel_ListFetchErrorOnEmptyPaneDoesNotLookLikeNoData(t *testing.T) {
 	}
 }
 
+func TestModel_ListFetchErrorOnEmptyPaneStillLooksFailedAfterStatusExpires(t *testing.T) {
+	m := model.New(testRepos())
+	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})
+	m = inRightPane(m)
+
+	m, _ = update(m, model.FetchErrorMsg{
+		RepoPath: "/dev/alpha",
+		Pane:     "worktrees",
+		Err:      "failed to load worktrees: boom",
+		Kind:     model.FetchList,
+		Mode:     ui.ModeWorktrees,
+	})
+	m, _ = update(m, model.StatusExpiredMsg{Seq: 1})
+
+	view := m.View()
+	if strings.Contains(view, "failed to load worktrees: boom") {
+		t.Fatalf("status bar text should expire, got:\n%s", view)
+	}
+	if !strings.Contains(view, "Could not load worktrees") {
+		t.Fatalf("empty failed pane should still show load failure after status expiry, got:\n%s", view)
+	}
+	if strings.Contains(view, "see status bar") {
+		t.Fatalf("expired status should not direct the user to an empty status bar, got:\n%s", view)
+	}
+	if strings.Contains(view, "No worktrees to show") {
+		t.Fatal("expired status should not make failed load look like successful empty data")
+	}
+}
+
 func TestModel_FilteredEmptyItemsTakePrecedenceOverListFetchErrorPlaceholder(t *testing.T) {
 	m := model.New(testRepos())
 	m, _ = update(m, tea.WindowSizeMsg{Width: 120, Height: 24})

--- a/model/status.go
+++ b/model/status.go
@@ -114,7 +114,7 @@ func (m Model) drainStatusCmds(cmd tea.Cmd) (Model, tea.Cmd) {
 }
 
 func (m Model) clearStatus(source statusSource) Model {
-	if m.status.Source == source {
+	if m.status.Text != "" && m.status.Source == source {
 		m.status = statusError{}
 		m = m.nextStatusSeq()
 	}

--- a/model/status.go
+++ b/model/status.go
@@ -84,7 +84,7 @@ func (m Model) setAutoAdvanceStatus(text string) (Model, tea.Cmd) {
 	if text == "" {
 		return m, nil
 	}
-	if m.status.Text != "" && m.status.Source != statusFlowAutoAdvance {
+	if m.status.isSet() && m.status.Source != statusFlowAutoAdvance {
 		return m, nil
 	}
 	m = m.setStatusNow(statusFlowAutoAdvance, text)

--- a/model/status.go
+++ b/model/status.go
@@ -1,0 +1,155 @@
+package model
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/brian-bell/wtui/ui"
+)
+
+const statusLifetime = 3 * time.Second
+
+type StatusExpiredMsg struct {
+	Seq uint64
+}
+
+type StatusFadeMsg struct {
+	Seq  uint64
+	Step int
+}
+
+type statusTimerFactory interface {
+	Expire(seq uint64, delay time.Duration) tea.Cmd
+	Fade(seq uint64, step int, delay time.Duration) tea.Cmd
+}
+
+type productionStatusTimer struct{}
+
+func (productionStatusTimer) Expire(seq uint64, delay time.Duration) tea.Cmd {
+	return tea.Tick(delay, func(time.Time) tea.Msg {
+		return StatusExpiredMsg{Seq: seq}
+	})
+}
+
+func (productionStatusTimer) Fade(seq uint64, step int, delay time.Duration) tea.Cmd {
+	return tea.Tick(delay, func(time.Time) tea.Msg {
+		return StatusFadeMsg{Seq: seq, Step: step}
+	})
+}
+
+func (m Model) currentStatusTimer() statusTimerFactory {
+	if m.statusTimer != nil {
+		return m.statusTimer
+	}
+	return productionStatusTimer{}
+}
+
+func (m Model) nextStatusSeq() Model {
+	m.statusSeq++
+	return m
+}
+
+func (m Model) setStatusNow(source statusSource, text string) Model {
+	m = m.nextStatusSeq()
+	m.status = statusError{Text: text, Source: source, Seq: m.statusSeq}
+	return m
+}
+
+func (m Model) setStatus(source statusSource, text string) Model {
+	m = m.setStatusNow(source, text)
+	return m.queueStatusExpiry(m.status.Seq)
+}
+
+func (m Model) setFetchStatus(msg FetchErrorMsg) Model {
+	m = m.nextStatusSeq()
+	m.status = statusError{Text: msg.Err, Source: statusFetch, Seq: m.statusSeq, FetchKind: msg.Kind, Mode: msg.Mode}
+	return m.queueStatusExpiry(m.status.Seq)
+}
+
+func (m Model) setVisibleRepoFetchSummaryStatus(text string) Model {
+	m = m.setStatusNow(statusVisibleRepoFetchSummary, text)
+	seq := m.status.Seq
+	timer := m.currentStatusTimer()
+	return m.queueStatusCmds(
+		timer.Fade(seq, 1, time.Second),
+		timer.Fade(seq, 2, 2*time.Second),
+		timer.Expire(seq, statusLifetime),
+	)
+}
+
+func (m Model) setAutoAdvanceStatus(text string) (Model, tea.Cmd) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return m, nil
+	}
+	if m.status.Text != "" && m.status.Source != statusFlowAutoAdvance {
+		return m, nil
+	}
+	m = m.setStatusNow(statusFlowAutoAdvance, text)
+	return m, m.currentStatusTimer().Expire(m.status.Seq, statusLifetime)
+}
+
+func (m Model) queueStatusExpiry(seq uint64) Model {
+	return m.queueStatusCmds(m.currentStatusTimer().Expire(seq, statusLifetime))
+}
+
+func (m Model) queueStatusCmds(cmds ...tea.Cmd) Model {
+	for _, cmd := range cmds {
+		if cmd != nil {
+			m.pendingStatusCmds = append(m.pendingStatusCmds, cmd)
+		}
+	}
+	return m
+}
+
+func (m Model) drainStatusCmds(cmd tea.Cmd) (Model, tea.Cmd) {
+	if len(m.pendingStatusCmds) == 0 {
+		return m, cmd
+	}
+	cmds := append([]tea.Cmd{cmd}, m.pendingStatusCmds...)
+	m.pendingStatusCmds = nil
+	return m, batchNonNil(cmds...)
+}
+
+func (m Model) clearStatus(source statusSource) Model {
+	if m.status.Source == source {
+		m.status = statusError{}
+		m = m.nextStatusSeq()
+	}
+	return m
+}
+
+func (m Model) clearFetchListStatus(mode ui.Mode) Model {
+	if m.status.Source == statusFetch && m.status.FetchKind == FetchList && m.status.Mode == mode {
+		m.status = statusError{}
+		m = m.nextStatusSeq()
+	}
+	return m
+}
+
+func (m Model) clearAnyStatus() Model {
+	if m.status.Text != "" {
+		m.status = statusError{}
+		m = m.nextStatusSeq()
+	}
+	return m
+}
+
+func (m Model) handleStatusExpired(msg StatusExpiredMsg) Model {
+	if msg.Seq == 0 || msg.Seq != m.status.Seq {
+		return m
+	}
+	m.status = statusError{}
+	m = m.nextStatusSeq()
+	return m
+}
+
+func (m Model) handleStatusFade(msg StatusFadeMsg) Model {
+	if msg.Seq == 0 || msg.Seq != m.status.Seq {
+		return m
+	}
+	m.status.FadeStep = msg.Step
+	return m
+}

--- a/model/status.go
+++ b/model/status.go
@@ -114,7 +114,7 @@ func (m Model) drainStatusCmds(cmd tea.Cmd) (Model, tea.Cmd) {
 }
 
 func (m Model) clearStatus(source statusSource) Model {
-	if m.status.Text != "" && m.status.Source == source {
+	if m.status.isSet() && m.status.Source == source {
 		m.status = statusError{}
 		m = m.nextStatusSeq()
 	}
@@ -130,7 +130,7 @@ func (m Model) clearFetchListStatus(mode ui.Mode) Model {
 }
 
 func (m Model) clearAnyStatus() Model {
-	if m.status.Text != "" {
+	if m.status.isSet() {
 		m.status = statusError{}
 		m = m.nextStatusSeq()
 	}
@@ -139,6 +139,13 @@ func (m Model) clearAnyStatus() Model {
 
 func (m Model) handleStatusExpired(msg StatusExpiredMsg) Model {
 	if msg.Seq == 0 || msg.Seq != m.status.Seq {
+		return m
+	}
+	if m.status.Source == statusFetch && m.status.FetchKind == FetchList {
+		m.status.Text = ""
+		m.status.FadeStep = 0
+		m = m.nextStatusSeq()
+		m.status.Seq = m.statusSeq
 		return m
 	}
 	m.status = statusError{}
@@ -152,4 +159,8 @@ func (m Model) handleStatusFade(msg StatusFadeMsg) Model {
 	}
 	m.status.FadeStep = msg.Step
 	return m
+}
+
+func (s statusError) isSet() bool {
+	return s.Source != statusNone || s.Text != ""
 }

--- a/model/status_test.go
+++ b/model/status_test.go
@@ -164,6 +164,17 @@ func TestSourceSpecificClearDoesNotClearNewerDifferentSource(t *testing.T) {
 	}
 }
 
+func TestSourceSpecificClearEmptyStatusDoesNotAdvanceSequence(t *testing.T) {
+	m := New(nil)
+	seq := m.statusSeq
+
+	m = m.clearStatus(statusGitMutation)
+
+	if m.statusSeq != seq {
+		t.Fatalf("status sequence = %d, want unchanged %d", m.statusSeq, seq)
+	}
+}
+
 func TestFetchStatusPreservesMetadataAndExpires(t *testing.T) {
 	m := New(nil)
 	m = m.setFetchStatus(FetchErrorMsg{Err: "fetch failed", Kind: FetchList, Mode: 2})

--- a/model/status_test.go
+++ b/model/status_test.go
@@ -208,6 +208,25 @@ func TestExpiredListFetchStatusClearsOnUserAction(t *testing.T) {
 	}
 }
 
+func TestAutoAdvanceStatusDoesNotReplaceExpiredListFetchStatus(t *testing.T) {
+	m := New(nil)
+	m = m.setFetchStatus(FetchErrorMsg{Err: "fetch failed", Kind: FetchList, Mode: 2})
+	m = m.handleStatusExpired(StatusExpiredMsg{Seq: m.status.Seq})
+	seq := m.statusSeq
+
+	next, cmd := m.setAutoAdvanceStatus("Flow Alpha: implementation queued")
+
+	if cmd != nil {
+		t.Fatal("auto-advance should not schedule status over hidden fetch failure")
+	}
+	if next.status.Source != statusFetch || next.status.FetchKind != FetchList || next.status.Mode != 2 {
+		t.Fatalf("status = %#v, want expired fetch failure preserved", next.status)
+	}
+	if next.statusSeq != seq {
+		t.Fatalf("status sequence = %d, want unchanged %d", next.statusSeq, seq)
+	}
+}
+
 func TestStatusCommandDrainsFromUpdate(t *testing.T) {
 	m := New(nil)
 	next, cmd := m.Update(OpenURLResultMsg{Label: "Opened PR #1"})

--- a/model/status_test.go
+++ b/model/status_test.go
@@ -1,0 +1,191 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type recordedStatusTimerEvent struct {
+	kind  string
+	seq   uint64
+	step  int
+	delay time.Duration
+}
+
+type recordingStatusTimer struct {
+	events *[]recordedStatusTimerEvent
+}
+
+func (r recordingStatusTimer) Expire(seq uint64, delay time.Duration) tea.Cmd {
+	*r.events = append(*r.events, recordedStatusTimerEvent{kind: "expire", seq: seq, delay: delay})
+	return func() tea.Msg {
+		return StatusExpiredMsg{Seq: seq}
+	}
+}
+
+func (r recordingStatusTimer) Fade(seq uint64, step int, delay time.Duration) tea.Cmd {
+	*r.events = append(*r.events, recordedStatusTimerEvent{kind: "fade", seq: seq, step: step, delay: delay})
+	return func() tea.Msg {
+		return StatusFadeMsg{Seq: seq, Step: step}
+	}
+}
+
+func TestStatusTransientExpiryUsesSequence(t *testing.T) {
+	var events []recordedStatusTimerEvent
+	m := New(nil)
+	m.statusTimer = recordingStatusTimer{events: &events}
+
+	m = m.setStatus(statusOther, "failed")
+	if m.status.Seq == 0 {
+		t.Fatal("status sequence should be non-zero")
+	}
+	if len(m.pendingStatusCmds) != 1 {
+		t.Fatalf("pending status commands = %d, want 1", len(m.pendingStatusCmds))
+	}
+	if len(events) != 1 || events[0].kind != "expire" || events[0].delay != statusLifetime {
+		t.Fatalf("timer events = %#v, want one 3s expiry", events)
+	}
+
+	m = m.handleStatusExpired(StatusExpiredMsg{Seq: m.status.Seq + 1})
+	if m.status.Text != "failed" {
+		t.Fatalf("stale expiry cleared status: %#v", m.status)
+	}
+	m = m.handleStatusExpired(StatusExpiredMsg{Seq: m.status.Seq})
+	if m.status.Text != "" {
+		t.Fatalf("matching expiry left status: %#v", m.status)
+	}
+}
+
+func TestStatusRepeatedTextUsesSequenceForStaleness(t *testing.T) {
+	m := New(nil)
+	m = m.setStatus(statusOther, "same")
+	firstSeq := m.status.Seq
+	m = m.setStatus(statusOther, "same")
+	secondSeq := m.status.Seq
+
+	if firstSeq == secondSeq {
+		t.Fatal("repeated text should still create a new sequence")
+	}
+	m = m.handleStatusExpired(StatusExpiredMsg{Seq: firstSeq})
+	if m.status.Text != "same" || m.status.Seq != secondSeq {
+		t.Fatalf("first expiry cleared newer identical status: %#v", m.status)
+	}
+	m = m.handleStatusExpired(StatusExpiredMsg{Seq: secondSeq})
+	if m.status.Text != "" {
+		t.Fatalf("second expiry did not clear status: %#v", m.status)
+	}
+}
+
+func TestVisibleRepoSummaryStatusSchedulesFadeAndExpiry(t *testing.T) {
+	var events []recordedStatusTimerEvent
+	m := New(nil)
+	m.statusTimer = recordingStatusTimer{events: &events}
+
+	m = m.setVisibleRepoFetchSummaryStatus("Fetched 3 visible repos")
+	if m.status.Source != statusVisibleRepoFetchSummary {
+		t.Fatalf("status source = %v, want visible repo summary", m.status.Source)
+	}
+	if len(events) != 3 {
+		t.Fatalf("timer events = %#v, want 3", events)
+	}
+	want := []recordedStatusTimerEvent{
+		{kind: "fade", seq: m.status.Seq, step: 1, delay: time.Second},
+		{kind: "fade", seq: m.status.Seq, step: 2, delay: 2 * time.Second},
+		{kind: "expire", seq: m.status.Seq, delay: statusLifetime},
+	}
+	for i := range want {
+		if events[i] != want[i] {
+			t.Fatalf("event %d = %#v, want %#v", i, events[i], want[i])
+		}
+	}
+
+	m = m.handleStatusFade(StatusFadeMsg{Seq: m.status.Seq, Step: 1})
+	if m.status.FadeStep != 1 {
+		t.Fatalf("fade step = %d, want 1", m.status.FadeStep)
+	}
+}
+
+func TestAutoAdvanceStatusDoesNotStompForegroundOrAdvanceSequence(t *testing.T) {
+	m := New(nil)
+	m = m.setStatus(statusOther, "keep")
+	seq := m.statusSeq
+
+	next, cmd := m.setAutoAdvanceStatus("Flow Alpha: ready to merge")
+	if cmd != nil {
+		t.Fatal("ignored auto-advance status should not schedule expiry")
+	}
+	if next.status.Text != "keep" || next.statusSeq != seq {
+		t.Fatalf("status = %#v seq=%d, want foreground preserved at seq %d", next.status, next.statusSeq, seq)
+	}
+}
+
+func TestOrdinaryStatusExpiresWhileVisibleFetchProgressOwnsDisplay(t *testing.T) {
+	m := New(nil)
+	m.visibleRepoFetch = visibleRepoFetchState{Request: 3, Total: 2, Completed: 0}
+	m = m.setStatus(statusOther, "hidden")
+	seq := m.status.Seq
+
+	if got := m.visibleStatusText(); got != "Fetching 0/2 visible repos..." {
+		t.Fatalf("visible status = %q, want fetch progress", got)
+	}
+	m = m.handleStatusExpired(StatusExpiredMsg{Seq: seq})
+	if m.status.Text != "" {
+		t.Fatalf("hidden status after expiry = %#v, want cleared", m.status)
+	}
+	if got := m.visibleStatusText(); got != "Fetching 0/2 visible repos..." {
+		t.Fatalf("visible status after hidden expiry = %q, want fetch progress", got)
+	}
+}
+
+func TestForegroundStatusReplacesAutoAdvanceStatus(t *testing.T) {
+	m := New(nil)
+	var cmd tea.Cmd
+	m, cmd = m.setAutoAdvanceStatus("Flow Alpha: ready to merge")
+	if cmd == nil || m.status.Source != statusFlowAutoAdvance {
+		t.Fatalf("auto status = %#v cmd=%v, want auto status and expiry", m.status, cmd)
+	}
+
+	m = m.setStatus(statusOther, "foreground")
+	if m.status.Source != statusOther || m.status.Text != "foreground" {
+		t.Fatalf("status = %#v, want foreground replacement", m.status)
+	}
+}
+
+func TestSourceSpecificClearDoesNotClearNewerDifferentSource(t *testing.T) {
+	m := New(nil)
+	m = m.setStatus(statusGitMutation, "git failed")
+	m = m.setStatus(statusOther, "foreground")
+	m = m.clearStatus(statusGitMutation)
+
+	if m.status.Source != statusOther || m.status.Text != "foreground" {
+		t.Fatalf("status = %#v, want newer foreground preserved", m.status)
+	}
+}
+
+func TestFetchStatusPreservesMetadataAndExpires(t *testing.T) {
+	m := New(nil)
+	m = m.setFetchStatus(FetchErrorMsg{Err: "fetch failed", Kind: FetchList, Mode: 2})
+	seq := m.status.Seq
+
+	if m.status.Source != statusFetch || m.status.FetchKind != FetchList || m.status.Mode != 2 {
+		t.Fatalf("fetch status = %#v, want metadata preserved", m.status)
+	}
+	m = m.handleStatusExpired(StatusExpiredMsg{Seq: seq})
+	if m.status.Text != "" {
+		t.Fatalf("fetch status after expiry = %#v, want cleared", m.status)
+	}
+}
+
+func TestStatusCommandDrainsFromUpdate(t *testing.T) {
+	m := New(nil)
+	next, cmd := m.Update(OpenURLResultMsg{Label: "Opened PR #1"})
+	if cmd == nil {
+		t.Fatal("status-setting update should return expiry command")
+	}
+	modelNext := next.(Model)
+	if modelNext.status.Text != "Opened PR #1" {
+		t.Fatalf("status = %#v, want Opened PR #1", modelNext.status)
+	}
+}

--- a/model/status_test.go
+++ b/model/status_test.go
@@ -175,7 +175,7 @@ func TestSourceSpecificClearEmptyStatusDoesNotAdvanceSequence(t *testing.T) {
 	}
 }
 
-func TestFetchStatusPreservesMetadataAndExpires(t *testing.T) {
+func TestListFetchStatusExpiryPreservesFailureMetadata(t *testing.T) {
 	m := New(nil)
 	m = m.setFetchStatus(FetchErrorMsg{Err: "fetch failed", Kind: FetchList, Mode: 2})
 	seq := m.status.Seq
@@ -185,7 +185,26 @@ func TestFetchStatusPreservesMetadataAndExpires(t *testing.T) {
 	}
 	m = m.handleStatusExpired(StatusExpiredMsg{Seq: seq})
 	if m.status.Text != "" {
-		t.Fatalf("fetch status after expiry = %#v, want cleared", m.status)
+		t.Fatalf("fetch status text after expiry = %#v, want hidden", m.status)
+	}
+	if m.status.Source != statusFetch || m.status.FetchKind != FetchList || m.status.Mode != 2 {
+		t.Fatalf("fetch status after expiry = %#v, want failure metadata preserved", m.status)
+	}
+}
+
+func TestExpiredListFetchStatusClearsOnUserAction(t *testing.T) {
+	m := New(nil)
+	m = m.setFetchStatus(FetchErrorMsg{Err: "fetch failed", Kind: FetchList, Mode: 2})
+	m = m.handleStatusExpired(StatusExpiredMsg{Seq: m.status.Seq})
+	seq := m.statusSeq
+
+	m = m.clearAnyStatus()
+
+	if m.status != (statusError{}) {
+		t.Fatalf("status after clear = %#v, want cleared", m.status)
+	}
+	if m.statusSeq != seq+1 {
+		t.Fatalf("status sequence = %d, want %d", m.statusSeq, seq+1)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated model status message timer so transient messages clear automatically after their configured duration
- centralize status message state and timer command plumbing in `model/status.go`
- update model tests around action, flow, refresh, plan, and repo-create status handling

## Verification
- `gofmt -l .`
- `make test`
- `make build`