### PR TITLE
Add Flow phase dependency graph readiness

### DIFF
--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -1433,8 +1433,8 @@ func TestRunFlowPhaseResetRejectsIneligiblePhasesWithoutChangingRecord(t *testin
 			prepare: func(t *testing.T, store *flowstore.Store, record flowstore.FlowRecord) flowstore.FlowRecord {
 				t.Helper()
 				record.Phases = []flowstore.FlowPhase{
-					{PhaseID: "alpha", Title: "Alpha", Status: flowstore.PhaseRunning, Order: 1},
-					{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning, Order: 2, LaunchIDs: []string{"launch-orphan"}},
+					{PhaseID: "alpha", Title: "Alpha", DependsOn: []string{}, Status: flowstore.PhaseRunning, Order: 1},
+					{PhaseID: "implementation", Title: "Implementation", DependsOn: []string{"alpha"}, Status: flowstore.PhaseRunning, Order: 2, LaunchIDs: []string{"launch-orphan"}},
 				}
 				if err := overwriteFlowRecord(t, root, record); err != nil {
 					t.Fatalf("overwriteFlowRecord() error = %v", err)

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -101,8 +101,14 @@ standard graph; hand-authored records without one keep their stored statuses
 until a phase-affecting mutation touches them. Agents never need to know which
 phase becomes ready next; they only report their own phase.
 
-Walking phases in order, a `pending` phase becomes `ready` once every
-predecessor satisfies its downstream gate:
+Newly written Flow records persist explicit top-level dependency edges in each
+phase's `depends_on` field. Legacy standard records that do not have the key are
+backfilled as the same linear graph on read; explicit empty `depends_on` means a
+root phase. Implementation child phases remain structurally ordered under their
+parent rather than declaring their own dependencies.
+
+Walking phases in topological dependency order, a `pending` phase becomes
+`ready` once every prerequisite satisfies its downstream gate:
 
 - **Default gate**: the phase is `completed`, or `skipped` with notes.
 - **Plan Review**: `completed` with outcome `approved` or

--- a/flowstore/graph.go
+++ b/flowstore/graph.go
@@ -403,9 +403,6 @@ func backfillLinearDependsOnFromRaw(phases []FlowPhase, presence []rawDependsOnS
 	if anyPresent {
 		return normalizeDependsOnValues(phases)
 	}
-	if !phaseIDsCompatibleWithDefaultSequence(phases) {
-		return phases
-	}
 	return backfillLinearDependsOn(phases)
 }
 

--- a/flowstore/graph.go
+++ b/flowstore/graph.go
@@ -200,7 +200,8 @@ func buildPhaseGraph(phases []FlowPhase) phaseGraph {
 		}
 		if phase.ParentPhaseID == "" {
 			for _, dep := range phase.DependsOn {
-				if _, ok := firstTopLevelByID[artifacts.NormalizePhaseID(dep)]; !ok {
+				depIdx, ok := firstTopLevelByID[artifacts.NormalizePhaseID(dep)]
+				if !ok || depIdx == i {
 					invalid[i] = true
 				}
 			}

--- a/flowstore/graph.go
+++ b/flowstore/graph.go
@@ -1,0 +1,507 @@
+package flowstore
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/brian-bell/wtui/internal/artifacts"
+)
+
+type phaseGraph struct {
+	prereqsByIdx  map[int][]int
+	dependents    map[int][]int
+	released      map[int]bool
+	topo          []int
+	orderedIndex  map[int]int
+	duplicateRows map[int]bool
+}
+
+func validatePhaseGraph(phases []FlowPhase) error {
+	graph := buildPhaseGraph(phases)
+	topLevelIDs := make(map[string]string)
+	childIDs := make(map[string]string)
+	for _, phase := range phases {
+		id := artifacts.NormalizePhaseID(phase.PhaseID)
+		if id == "" {
+			continue
+		}
+		if phase.ParentPhaseID == "" {
+			if existing := topLevelIDs[id]; existing != "" {
+				return fmt.Errorf("duplicate phase id %q", phase.PhaseID)
+			}
+			topLevelIDs[id] = phase.PhaseID
+			continue
+		}
+		childIDs[id] = phase.PhaseID
+	}
+	for idx, phase := range phases {
+		if phase.ParentPhaseID != "" {
+			if len(phase.DependsOn) > 0 {
+				return fmt.Errorf("child phase %q cannot declare dependencies", phase.PhaseID)
+			}
+			continue
+		}
+		for _, dep := range phase.DependsOn {
+			depID := artifacts.NormalizePhaseID(dep)
+			if depID == "" {
+				return fmt.Errorf("phase %q has empty dependency", phase.PhaseID)
+			}
+			if depID == artifacts.NormalizePhaseID(phase.PhaseID) {
+				return fmt.Errorf("phase %q depends on itself", phase.PhaseID)
+			}
+			if childID := childIDs[depID]; childID != "" {
+				return fmt.Errorf("phase %q depends on child phase %q", phase.PhaseID, childID)
+			}
+			if topLevelIDs[depID] == "" {
+				return fmt.Errorf("phase %q: unknown dependency %q", phase.PhaseID, dep)
+			}
+		}
+		if graph.duplicateRows[idx] {
+			return fmt.Errorf("duplicate phase id %q", phase.PhaseID)
+		}
+	}
+	if len(graph.topo) != len(phases) {
+		return fmt.Errorf("phase graph contains a cycle: %s", cycleDescription(phases, graph))
+	}
+	topLevelCount := 0
+	rootCount := 0
+	for _, phase := range phases {
+		if phase.ParentPhaseID != "" {
+			continue
+		}
+		topLevelCount++
+		if len(phase.DependsOn) == 0 {
+			rootCount++
+		}
+	}
+	if topLevelCount > 0 && rootCount == 0 {
+		return fmt.Errorf("phase graph must include at least one root phase")
+	}
+	return nil
+}
+
+func buildPhaseGraph(phases []FlowPhase) phaseGraph {
+	ordered := OrderedPhases(phases)
+	orderedIndex := make(map[int]int, len(phases))
+	used := make([]bool, len(phases))
+	for orderedPos, orderedPhase := range ordered {
+		for i, phase := range phases {
+			if used[i] || !samePhaseRow(phase, orderedPhase) {
+				continue
+			}
+			used[i] = true
+			orderedIndex[i] = orderedPos
+			break
+		}
+	}
+	firstTopLevelByID := make(map[string]int)
+	firstAnyByID := make(map[string]int)
+	duplicateRows := make(map[int]bool)
+	for i, phase := range phases {
+		id := artifacts.NormalizePhaseID(phase.PhaseID)
+		if id == "" {
+			continue
+		}
+		if _, ok := firstAnyByID[id]; ok {
+			duplicateRows[i] = true
+		} else {
+			firstAnyByID[id] = i
+		}
+		if phase.ParentPhaseID != "" {
+			continue
+		}
+		if _, ok := firstTopLevelByID[id]; ok {
+			duplicateRows[i] = true
+			continue
+		}
+		firstTopLevelByID[id] = i
+	}
+
+	childrenByParent := make(map[string][]int)
+	for i, phase := range phases {
+		if phase.ParentPhaseID == "" {
+			continue
+		}
+		parentID := artifacts.NormalizePhaseID(phase.ParentPhaseID)
+		childrenByParent[parentID] = append(childrenByParent[parentID], i)
+	}
+	for parentID := range childrenByParent {
+		sort.SliceStable(childrenByParent[parentID], func(i, j int) bool {
+			left := phases[childrenByParent[parentID][i]]
+			right := phases[childrenByParent[parentID][j]]
+			if left.Order == right.Order {
+				return left.PhaseID < right.PhaseID
+			}
+			return left.Order < right.Order
+		})
+	}
+
+	prereqSets := make(map[int]map[int]bool, len(phases))
+	for i := range phases {
+		prereqSets[i] = make(map[int]bool)
+	}
+	for i, phase := range phases {
+		if phase.ParentPhaseID != "" {
+			continue
+		}
+		for _, dep := range phase.DependsOn {
+			depIdx, ok := firstTopLevelByID[artifacts.NormalizePhaseID(dep)]
+			if !ok || depIdx == i {
+				continue
+			}
+			prereqSets[i][depIdx] = true
+			for _, childIdx := range childrenByParent[artifacts.NormalizePhaseID(phases[depIdx].PhaseID)] {
+				prereqSets[i][childIdx] = true
+			}
+		}
+	}
+	for parentID, childIndexes := range childrenByParent {
+		parentIdx, ok := firstTopLevelByID[parentID]
+		if !ok {
+			continue
+		}
+		for childPos, childIdx := range childIndexes {
+			prereqSets[childIdx][parentIdx] = true
+			if childPos > 0 {
+				prereqSets[childIdx][childIndexes[childPos-1]] = true
+			}
+		}
+	}
+
+	prereqsByIdx := make(map[int][]int, len(phases))
+	dependents := make(map[int][]int, len(phases))
+	invalid := make(map[int]bool)
+	for i, phase := range phases {
+		if duplicateRows[i] {
+			invalid[i] = true
+		}
+		if phase.ParentPhaseID == "" {
+			for _, dep := range phase.DependsOn {
+				if _, ok := firstTopLevelByID[artifacts.NormalizePhaseID(dep)]; !ok {
+					invalid[i] = true
+				}
+			}
+		}
+		for prereq := range prereqSets[i] {
+			prereqsByIdx[i] = append(prereqsByIdx[i], prereq)
+			dependents[prereq] = append(dependents[prereq], i)
+		}
+	}
+	sortByOrderedPosition := func(values []int) {
+		sort.SliceStable(values, func(i, j int) bool {
+			left := orderedIndex[values[i]]
+			right := orderedIndex[values[j]]
+			if left == right {
+				return values[i] < values[j]
+			}
+			return left < right
+		})
+	}
+	for i := range prereqsByIdx {
+		sortByOrderedPosition(prereqsByIdx[i])
+	}
+	for i := range dependents {
+		sortByOrderedPosition(dependents[i])
+	}
+
+	released := make(map[int]bool, len(phases))
+	topo := topologicalRelease(phases, prereqsByIdx, dependents, orderedIndex, invalid)
+	for _, idx := range topo {
+		released[idx] = true
+	}
+	return phaseGraph{
+		prereqsByIdx:  prereqsByIdx,
+		dependents:    dependents,
+		released:      released,
+		topo:          topo,
+		orderedIndex:  orderedIndex,
+		duplicateRows: duplicateRows,
+	}
+}
+
+func topologicalRelease(phases []FlowPhase, prereqsByIdx, dependents map[int][]int, orderedIndex map[int]int, invalid map[int]bool) []int {
+	invalidClosure := make(map[int]bool, len(invalid))
+	queue := make([]int, 0, len(invalid))
+	for idx := range invalid {
+		invalidClosure[idx] = true
+		queue = append(queue, idx)
+	}
+	for len(queue) > 0 {
+		idx := queue[0]
+		queue = queue[1:]
+		for _, dependent := range dependents[idx] {
+			if invalidClosure[dependent] {
+				continue
+			}
+			invalidClosure[dependent] = true
+			queue = append(queue, dependent)
+		}
+	}
+
+	indegree := make(map[int]int, len(phases))
+	for i := range phases {
+		if invalidClosure[i] {
+			continue
+		}
+		for _, prereq := range prereqsByIdx[i] {
+			if invalidClosure[prereq] {
+				continue
+			}
+			indegree[i]++
+		}
+	}
+	ready := make([]int, 0, len(phases))
+	for i := range phases {
+		if invalidClosure[i] || indegree[i] != 0 {
+			continue
+		}
+		ready = append(ready, i)
+	}
+	sort.SliceStable(ready, func(i, j int) bool {
+		return orderedIndex[ready[i]] < orderedIndex[ready[j]]
+	})
+	out := make([]int, 0, len(phases))
+	for len(ready) > 0 {
+		idx := ready[0]
+		ready = ready[1:]
+		out = append(out, idx)
+		for _, dependent := range dependents[idx] {
+			if invalidClosure[dependent] {
+				continue
+			}
+			indegree[dependent]--
+			if indegree[dependent] == 0 {
+				ready = append(ready, dependent)
+				sort.SliceStable(ready, func(i, j int) bool {
+					return orderedIndex[ready[i]] < orderedIndex[ready[j]]
+				})
+			}
+		}
+	}
+	return out
+}
+
+func samePhaseRow(left, right FlowPhase) bool {
+	return left.PhaseID == right.PhaseID &&
+		left.ParentPhaseID == right.ParentPhaseID &&
+		left.Title == right.Title &&
+		left.Order == right.Order &&
+		left.CreatedAt.Equal(right.CreatedAt) &&
+		left.UpdatedAt.Equal(right.UpdatedAt)
+}
+
+func cycleDescription(phases []FlowPhase, graph phaseGraph) string {
+	for i, phase := range phases {
+		if graph.released[i] || graph.duplicateRows[i] {
+			continue
+		}
+		for _, prereq := range graph.prereqsByIdx[i] {
+			if graph.released[prereq] || graph.duplicateRows[prereq] {
+				continue
+			}
+			return fmt.Sprintf("%s -> %s -> %s", phases[prereq].PhaseID, phase.PhaseID, phases[prereq].PhaseID)
+		}
+		return phase.PhaseID
+	}
+	return "unknown"
+}
+
+func phaseIDsCompatibleWithDefaultSequence(phases []FlowPhase) bool {
+	defaultIDs := []string{"plan", "plan-review", "implementation", "review-loop", "pr-creation", "autoreview", "merge"}
+	seen := make(map[string]bool)
+	pos := 0
+	for _, phase := range OrderedPhases(phases) {
+		if phase.ParentPhaseID != "" {
+			continue
+		}
+		id := artifacts.NormalizePhaseID(phase.PhaseID)
+		if seen[id] {
+			continue
+		}
+		for pos < len(defaultIDs) && defaultIDs[pos] != id {
+			pos++
+		}
+		if pos == len(defaultIDs) {
+			return false
+		}
+		seen[id] = true
+		pos++
+	}
+	return len(seen) > 0
+}
+
+func normalizeDependsOnValues(phases []FlowPhase) []FlowPhase {
+	for i := range phases {
+		if phases[i].ParentPhaseID != "" {
+			phases[i].DependsOn = []string{}
+			continue
+		}
+		values := make([]string, 0, len(phases[i].DependsOn))
+		seen := make(map[string]bool)
+		for _, dep := range phases[i].DependsOn {
+			normalized := artifacts.NormalizePhaseID(dep)
+			if normalized == "" || seen[normalized] {
+				continue
+			}
+			seen[normalized] = true
+			values = append(values, normalized)
+		}
+		sort.Strings(values)
+		phases[i].DependsOn = values
+	}
+	return phases
+}
+
+func backfillLinearDependsOnForCreate(phases []FlowPhase) []FlowPhase {
+	allNil := true
+	for _, phase := range phases {
+		if phase.ParentPhaseID == "" && phase.DependsOn != nil {
+			allNil = false
+			break
+		}
+	}
+	if !allNil {
+		return normalizeDependsOnValues(phases)
+	}
+	return backfillLinearDependsOn(phases)
+}
+
+type rawDependsOnState struct {
+	Present bool
+	NonNull bool
+}
+
+func backfillLinearDependsOnFromRaw(phases []FlowPhase, presence []rawDependsOnState) []FlowPhase {
+	anyPresent := false
+	anyNonNull := false
+	for i, phase := range phases {
+		if phase.ParentPhaseID == "" && i < len(presence) && presence[i].Present {
+			anyPresent = true
+			if presence[i].NonNull {
+				anyNonNull = true
+			}
+		}
+	}
+	if anyPresent && !anyNonNull && !hasNonEmptyTopLevelDependsOn(phases) {
+		return backfillLinearDependsOn(phases)
+	}
+	if anyPresent {
+		if !hasNonEmptyTopLevelDependsOn(phases) && phaseIDsCompatibleWithDefaultSequence(phases) {
+			return backfillLinearDependsOn(phases)
+		}
+		return normalizeDependsOnValues(phases)
+	}
+	if !phaseIDsCompatibleWithDefaultSequence(phases) {
+		return normalizeDependsOnValues(phases)
+	}
+	return backfillLinearDependsOn(phases)
+}
+
+func backfillLinearDependsOn(phases []FlowPhase) []FlowPhase {
+	ordered := OrderedPhases(phases)
+	previousByID := make(map[string]string)
+	seen := make(map[string]bool)
+	var previous string
+	for _, phase := range ordered {
+		if phase.ParentPhaseID != "" {
+			continue
+		}
+		id := artifacts.NormalizePhaseID(phase.PhaseID)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		previousByID[id] = previous
+		previous = id
+	}
+	for i := range phases {
+		if phases[i].ParentPhaseID != "" {
+			phases[i].DependsOn = []string{}
+			continue
+		}
+		id := artifacts.NormalizePhaseID(phases[i].PhaseID)
+		if seen[id] && previousByID[id] != "" && artifacts.NormalizePhaseID(phases[i].PhaseID) == id && !isDuplicateTopLevel(phases, i) {
+			phases[i].DependsOn = []string{previousByID[id]}
+		} else {
+			phases[i].DependsOn = []string{}
+		}
+	}
+	return phases
+}
+
+func isDuplicateTopLevel(phases []FlowPhase, idx int) bool {
+	id := artifacts.NormalizePhaseID(phases[idx].PhaseID)
+	for i := 0; i < idx; i++ {
+		if phases[i].ParentPhaseID == "" && artifacts.NormalizePhaseID(phases[i].PhaseID) == id {
+			return true
+		}
+	}
+	return false
+}
+
+func graphHasAuthoritativeEdges(phases []FlowPhase) bool {
+	for _, phase := range phases {
+		if phase.ParentPhaseID == "" && phase.DependsOn != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasNonEmptyTopLevelDependsOn(phases []FlowPhase) bool {
+	for _, phase := range phases {
+		if phase.ParentPhaseID == "" && len(phase.DependsOn) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func allDependencyGatesSatisfied(record FlowRecord, graph phaseGraph, idx int) bool {
+	for _, prereq := range graph.prereqsByIdx[idx] {
+		if !phaseSatisfiesDownstreamGate(record, record.Phases[prereq]) {
+			return false
+		}
+	}
+	return true
+}
+
+func phaseDependsOnPlanReviewFailure(record FlowRecord, graph phaseGraph, idx int, failedPlanReview map[int]bool) bool {
+	for _, prereq := range graph.prereqsByIdx[idx] {
+		phase := record.Phases[prereq]
+		if failedPlanReview[prereq] || phase.PhaseID == "plan-review" && !phaseSatisfiesDownstreamGate(record, phase) {
+			return true
+		}
+	}
+	return false
+}
+
+// PhaseLaunchEligible reports whether the phase at orderedIndex can be offered
+// for launch. It is index-aware so stale duplicate rows from hand-authored
+// records cannot be launched even when their stored status is ready.
+func PhaseLaunchEligible(record FlowRecord, orderedIndex int) bool {
+	ordered := OrderedPhases(record.Phases)
+	if orderedIndex < 0 || orderedIndex >= len(ordered) {
+		return false
+	}
+	graph := buildPhaseGraph(ordered)
+	if !graph.released[orderedIndex] || graph.duplicateRows[orderedIndex] {
+		return false
+	}
+	phase := ordered[orderedIndex]
+	if phase.Status != PhaseReady {
+		return false
+	}
+	return artifacts.NormalizePhaseID(phase.PhaseID) != "merge"
+}
+
+// FirstLaunchablePhase returns the first ordered phase that can be launched.
+func FirstLaunchablePhase(record FlowRecord) (FlowPhase, int, bool) {
+	ordered := OrderedPhases(record.Phases)
+	for i, phase := range ordered {
+		if PhaseLaunchEligible(FlowRecord{Phases: ordered}, i) {
+			return phase, i, true
+		}
+	}
+	return FlowPhase{}, -1, false
+}

--- a/flowstore/graph.go
+++ b/flowstore/graph.go
@@ -531,8 +531,10 @@ func phaseLaunchEligibleAtIndex(record FlowRecord, phaseIndex int) bool {
 // FirstLaunchablePhase returns the first ordered phase that can be launched.
 func FirstLaunchablePhase(record FlowRecord) (FlowPhase, int, bool) {
 	ordered := OrderedPhases(record.Phases)
+	orderedRecord := record
+	orderedRecord.Phases = ordered
 	for i, phase := range ordered {
-		if PhaseLaunchEligible(FlowRecord{Phases: ordered}, i) {
+		if PhaseLaunchEligible(orderedRecord, i) {
 			return phase, i, true
 		}
 	}

--- a/flowstore/graph.go
+++ b/flowstore/graph.go
@@ -17,6 +17,9 @@ type phaseGraph struct {
 }
 
 func validatePhaseGraph(phases []FlowPhase) error {
+	if err := validateDeclaredPhaseDependencies(phases); err != nil {
+		return err
+	}
 	graph := buildPhaseGraph(phases)
 	topLevelIDs := make(map[string]string)
 	childIDs := make(map[string]string)
@@ -36,9 +39,6 @@ func validatePhaseGraph(phases []FlowPhase) error {
 	}
 	for idx, phase := range phases {
 		if phase.ParentPhaseID != "" {
-			if len(phase.DependsOn) > 0 {
-				return fmt.Errorf("child phase %q cannot declare dependencies", phase.PhaseID)
-			}
 			continue
 		}
 		for _, dep := range phase.DependsOn {
@@ -76,6 +76,29 @@ func validatePhaseGraph(phases []FlowPhase) error {
 	}
 	if topLevelCount > 0 && rootCount == 0 {
 		return fmt.Errorf("phase graph must include at least one root phase")
+	}
+	return nil
+}
+
+func validateDeclaredPhaseDependencies(phases []FlowPhase) error {
+	for _, phase := range phases {
+		if phase.ParentPhaseID != "" && len(phase.DependsOn) > 0 {
+			return fmt.Errorf("child phase %q cannot declare dependencies", phase.PhaseID)
+		}
+		if phase.ParentPhaseID != "" {
+			continue
+		}
+		seen := make(map[string]bool)
+		for _, dep := range phase.DependsOn {
+			normalized := artifacts.NormalizePhaseID(dep)
+			if normalized == "" {
+				return fmt.Errorf("phase %q has empty dependency", phase.PhaseID)
+			}
+			if seen[normalized] {
+				return fmt.Errorf("phase %q has duplicate dependency %q", phase.PhaseID, dep)
+			}
+			seen[normalized] = true
+		}
 	}
 	return nil
 }
@@ -368,31 +391,20 @@ func backfillLinearDependsOnForCreate(phases []FlowPhase) []FlowPhase {
 
 type rawDependsOnState struct {
 	Present bool
-	NonNull bool
 }
 
 func backfillLinearDependsOnFromRaw(phases []FlowPhase, presence []rawDependsOnState) []FlowPhase {
 	anyPresent := false
-	anyNonNull := false
 	for i, phase := range phases {
 		if phase.ParentPhaseID == "" && i < len(presence) && presence[i].Present {
 			anyPresent = true
-			if presence[i].NonNull {
-				anyNonNull = true
-			}
 		}
-	}
-	if anyPresent && !anyNonNull && !hasNonEmptyTopLevelDependsOn(phases) {
-		return backfillLinearDependsOn(phases)
 	}
 	if anyPresent {
-		if !hasNonEmptyTopLevelDependsOn(phases) && phaseIDsCompatibleWithDefaultSequence(phases) {
-			return backfillLinearDependsOn(phases)
-		}
 		return normalizeDependsOnValues(phases)
 	}
 	if !phaseIDsCompatibleWithDefaultSequence(phases) {
-		return normalizeDependsOnValues(phases)
+		return phases
 	}
 	return backfillLinearDependsOn(phases)
 }
@@ -490,6 +502,27 @@ func PhaseLaunchEligible(record FlowRecord, orderedIndex int) bool {
 	}
 	phase := ordered[orderedIndex]
 	if phase.Status != PhaseReady {
+		return false
+	}
+	if !allDependencyGatesSatisfied(FlowRecord{PR: record.PR, Phases: ordered}, graph, orderedIndex) {
+		return false
+	}
+	return artifacts.NormalizePhaseID(phase.PhaseID) != "merge"
+}
+
+func phaseLaunchEligibleAtIndex(record FlowRecord, phaseIndex int) bool {
+	if phaseIndex < 0 || phaseIndex >= len(record.Phases) {
+		return false
+	}
+	graph := buildPhaseGraph(record.Phases)
+	if !graph.released[phaseIndex] || graph.duplicateRows[phaseIndex] {
+		return false
+	}
+	phase := record.Phases[phaseIndex]
+	if phase.Status != PhaseReady {
+		return false
+	}
+	if !allDependencyGatesSatisfied(record, graph, phaseIndex) {
 		return false
 	}
 	return artifacts.NormalizePhaseID(phase.PhaseID) != "merge"

--- a/flowstore/graph_test.go
+++ b/flowstore/graph_test.go
@@ -1,0 +1,80 @@
+package flowstore
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidatePhaseGraph(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	phase := func(id string, dependsOn ...string) FlowPhase {
+		return FlowPhase{
+			PhaseID:   id,
+			Title:     id,
+			DependsOn: dependsOn,
+			Status:    PhasePending,
+			Order:     1,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+	}
+	child := func(id, parent string) FlowPhase {
+		p := phase(id)
+		p.ParentPhaseID = parent
+		return p
+	}
+	tests := []struct {
+		name   string
+		phases []FlowPhase
+		want   string
+	}{
+		{
+			name:   "linear chain",
+			phases: []FlowPhase{phase("plan"), phase("review", "plan"), phase("ship", "review")},
+		},
+		{
+			name:   "diamond",
+			phases: []FlowPhase{phase("root"), phase("a", "root"), phase("b", "root"), phase("join", "a", "b")},
+		},
+		{
+			name:   "self dependency",
+			phases: []FlowPhase{phase("root", "root")},
+			want:   `phase "root" depends on itself`,
+		},
+		{
+			name:   "cycle",
+			phases: []FlowPhase{phase("a", "b"), phase("b", "a")},
+			want:   "phase graph contains a cycle",
+		},
+		{
+			name:   "dangling dependency",
+			phases: []FlowPhase{phase("publish", "reserch")},
+			want:   `phase "publish": unknown dependency "reserch"`,
+		},
+		{
+			name:   "dependency on child",
+			phases: []FlowPhase{phase("implementation"), child("api", "implementation"), phase("review", "api")},
+			want:   `phase "review" depends on child phase "api"`,
+		},
+		{
+			name:   "duplicate",
+			phases: []FlowPhase{phase("Plan"), phase("plan")},
+			want:   `duplicate phase id "plan"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePhaseGraph(tc.phases)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("validatePhaseGraph() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validatePhaseGraph() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -891,6 +891,19 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 			return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
 		}
 		phase := record.Phases[phaseIndex]
+		// Launching a phase is a mutation that derives its readiness. Custom graphs
+		// persist with pending roots (Create defers readiness derivation), so a
+		// now-eligible pending target would otherwise be rejected as an invalid
+		// pending -> running transition. Promote only the target row when the graph
+		// releases it; stale ready rows and other phases are left to the eligibility
+		// checks and the post-launch readiness refresh.
+		if phase.Status == PhasePending {
+			graph := buildPhaseGraph(record.Phases)
+			if graph.released[phaseIndex] && !graph.duplicateRows[phaseIndex] && allDependencyGatesSatisfied(record, graph, phaseIndex) {
+				phase.Status = PhaseReady
+				record.Phases[phaseIndex] = phase
+			}
+		}
 		if update.AutoLaunch {
 			if err := validateAutoPhaseLaunch(record, phaseIndex); err != nil {
 				return FlowRecord{}, err

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -92,6 +92,7 @@ type FlowPhase struct {
 	ParentPhaseID string    `json:"parent_phase_id,omitempty"`
 	Title         string    `json:"title"`
 	Kind          string    `json:"kind"`
+	DependsOn     []string  `json:"depends_on"`
 	Status        string    `json:"status"`
 	Order         int       `json:"order"`
 	Outcome       string    `json:"outcome,omitempty"`
@@ -368,6 +369,15 @@ func (s *Store) Create(record FlowRecord) (FlowRecord, error) {
 	record.AutoMode = true
 	if len(record.Phases) == 0 {
 		record.Phases = defaultPhases(record.CreatedAt, record.UpdatedAt)
+		record = refreshPhaseReadiness(record, now)
+	} else {
+		authoritativeEdges := graphHasAuthoritativeEdges(record.Phases)
+		record.Phases = backfillLinearDependsOnForCreate(record.Phases)
+		if authoritativeEdges {
+			if err := validatePhaseGraph(record.Phases); err != nil {
+				return FlowRecord{}, err
+			}
+		}
 	}
 	record = normalizeRecord(record)
 	record.Status = DeriveStatus(record)
@@ -1347,24 +1357,30 @@ func validateChildPhaseUpdate(update ChildPhaseUpdate) error {
 
 func refreshPhaseReadiness(record FlowRecord, now time.Time) FlowRecord {
 	record.Phases = OrderedPhases(record.Phases)
-	predecessorsSatisfied := true
-	resetBlockedDownstream := false
-	for i := range record.Phases {
+	record.Phases = normalizeDependsOnValues(record.Phases)
+	graph := buildPhaseGraph(record.Phases)
+	failedPlanReview := make(map[int]bool)
+	for _, i := range graph.topo {
 		phase := record.Phases[i]
-		if predecessorsSatisfied && phase.Status == PhasePending {
+		dependenciesSatisfied := allDependencyGatesSatisfied(record, graph, i)
+		resetBlockedDownstream := phaseDependsOnPlanReviewFailure(record, graph, i, failedPlanReview)
+		if dependenciesSatisfied && phase.Status == PhasePending {
 			phase.Status = PhaseReady
 			phase.UpdatedAt = now
 			record.Phases[i] = phase
-		} else if !predecessorsSatisfied && shouldResetBlockedDownstreamPhase(phase, resetBlockedDownstream) {
+		} else if !dependenciesSatisfied && shouldResetBlockedDownstreamPhase(phase, resetBlockedDownstream) {
 			phase.Status = PhasePending
 			phase.Outcome = ""
 			phase.UpdatedAt = now
 			record.Phases[i] = phase
 		}
+		phase = record.Phases[i]
 		if !phaseSatisfiesDownstreamGate(record, phase) {
-			predecessorsSatisfied = false
 			if phase.PhaseID == "plan-review" {
-				resetBlockedDownstream = true
+				failedPlanReview[i] = true
+			}
+			if phaseDependsOnPlanReviewFailure(record, graph, i, failedPlanReview) {
+				failedPlanReview[i] = true
 			}
 		}
 	}
@@ -1452,18 +1468,16 @@ func phaseSatisfiesDownstreamGate(record FlowRecord, phase FlowPhase) bool {
 	return phase.Status == PhaseCompleted
 }
 
-// PhasePredecessorsSatisfied reports whether all phases before phaseID satisfy
-// the Flow gate rules used to derive downstream readiness.
+// PhasePredecessorsSatisfied reports whether all graph prerequisites for
+// phaseID satisfy the Flow gate rules used to derive downstream readiness.
 func PhasePredecessorsSatisfied(record FlowRecord, phaseID string) bool {
-	for _, phase := range OrderedPhases(record.Phases) {
-		if phase.PhaseID == phaseID {
-			return true
-		}
-		if !phaseSatisfiesDownstreamGate(record, phase) {
-			return false
-		}
+	ordered := backfillLinearDependsOnForCreate(OrderedPhases(record.Phases))
+	graph := buildPhaseGraph(ordered)
+	idx := phaseIndexByID(ordered, phaseID)
+	if idx < 0 || !graph.released[idx] {
+		return false
 	}
-	return false
+	return allDependencyGatesSatisfied(FlowRecord{PR: record.PR, Phases: ordered}, graph, idx)
 }
 
 // HasPRTarget reports whether PR metadata contains enough target context for
@@ -1801,15 +1815,16 @@ func defaultPhases(createdAt, updatedAt time.Time) []FlowPhase {
 	}
 	phases := make([]FlowPhase, 0, len(specs))
 	for i, spec := range specs {
-		status := PhasePending
-		if i == 0 {
-			status = PhaseReady
+		dependsOn := []string{}
+		if i > 0 {
+			dependsOn = []string{specs[i-1].id}
 		}
 		phases = append(phases, FlowPhase{
 			PhaseID:   spec.id,
 			Title:     spec.title,
 			Kind:      spec.kind,
-			Status:    status,
+			DependsOn: dependsOn,
+			Status:    PhasePending,
 			Order:     i + 1,
 			CreatedAt: createdAt,
 			UpdatedAt: updatedAt,
@@ -1833,6 +1848,7 @@ func (s *Store) write(record FlowRecord) error {
 	if err := validateFlowID(record.FlowID); err != nil {
 		return err
 	}
+	record.Phases = normalizeDependsOnValues(record.Phases)
 	dir, err := artifacts.EnsureRecordDir(s.root, "flows", record.FlowID)
 	if err != nil {
 		return fmt.Errorf("secure flow directory: %w", err)
@@ -1855,6 +1871,7 @@ func (s *Store) readRecord(flowID string) (FlowRecord, bool) {
 	if err != nil {
 		return FlowRecord{}, false
 	}
+	presence := rawDependsOnPresence(data)
 	var record FlowRecord
 	if err := json.Unmarshal(data, &record); err != nil {
 		return FlowRecord{}, false
@@ -1862,9 +1879,28 @@ func (s *Store) readRecord(flowID string) (FlowRecord, bool) {
 	if record.FlowID != flowID || record.SchemaVersion != schemaVersion {
 		return FlowRecord{}, false
 	}
+	record.Phases = backfillLinearDependsOnFromRaw(record.Phases, presence)
 	record = normalizeRecord(record)
 	record.Status = DeriveStatus(record)
 	return record, true
+}
+
+func rawDependsOnPresence(data []byte) []rawDependsOnState {
+	var raw struct {
+		Phases []map[string]json.RawMessage `json:"phases"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	presence := make([]rawDependsOnState, len(raw.Phases))
+	for i, phase := range raw.Phases {
+		value, ok := phase["depends_on"]
+		presence[i] = rawDependsOnState{
+			Present: ok,
+			NonNull: ok && string(value) != "null",
+		}
+	}
+	return presence
 }
 
 func (s *Store) flowDir(flowID string) string {

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -371,6 +371,9 @@ func (s *Store) Create(record FlowRecord) (FlowRecord, error) {
 		record.Phases = defaultPhases(record.CreatedAt, record.UpdatedAt)
 		record = refreshPhaseReadiness(record, now)
 	} else {
+		if err := validateDeclaredPhaseDependencies(record.Phases); err != nil {
+			return FlowRecord{}, err
+		}
 		authoritativeEdges := graphHasAuthoritativeEdges(record.Phases)
 		record.Phases = backfillLinearDependsOnForCreate(record.Phases)
 		if authoritativeEdges {
@@ -889,7 +892,7 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 		}
 		phase := record.Phases[phaseIndex]
 		if update.AutoLaunch {
-			if err := validateAutoPhaseLaunch(record, phase); err != nil {
+			if err := validateAutoPhaseLaunch(record, phaseIndex); err != nil {
 				return FlowRecord{}, err
 			}
 		}
@@ -936,7 +939,11 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 	})
 }
 
-func validateAutoPhaseLaunch(record FlowRecord, phase FlowPhase) error {
+func validateAutoPhaseLaunch(record FlowRecord, phaseIndex int) error {
+	var phase FlowPhase
+	if phaseIndex >= 0 && phaseIndex < len(record.Phases) {
+		phase = record.Phases[phaseIndex]
+	}
 	phaseID := artifacts.NormalizePhaseID(phase.PhaseID)
 	switch {
 	case !record.AutoMode:
@@ -945,6 +952,8 @@ func validateAutoPhaseLaunch(record FlowRecord, phase FlowPhase) error {
 		return fmt.Errorf("auto launch target %q is not eligible: %w", phase.PhaseID, errAutoLaunchOutdated)
 	case phase.Status != PhaseReady:
 		return fmt.Errorf("auto launch target %q is %s, not ready: %w", phase.PhaseID, phase.Status, errAutoLaunchOutdated)
+	case !phaseLaunchEligibleAtIndex(record, phaseIndex):
+		return fmt.Errorf("auto launch target %q is not eligible: %w", phase.PhaseID, errAutoLaunchOutdated)
 	default:
 		return nil
 	}
@@ -1894,10 +1903,9 @@ func rawDependsOnPresence(data []byte) []rawDependsOnState {
 	}
 	presence := make([]rawDependsOnState, len(raw.Phases))
 	for i, phase := range raw.Phases {
-		value, ok := phase["depends_on"]
+		_, ok := phase["depends_on"]
 		presence[i] = rawDependsOnState{
 			Present: ok,
-			NonNull: ok && string(value) != "null",
 		}
 	}
 	return presence

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5245,6 +5245,345 @@ func TestStoreRejectsInvalidInputs(t *testing.T) {
 	}
 }
 
+func TestFlowPhaseDependsOnRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := graphRecord(root, "20260607T120000Z-depends-roundtrip", []flowstore.FlowPhase{
+		graphPhase(now, "root", flowstore.PhaseReady, nil),
+		graphPhase(now, "publish", flowstore.PhasePending, []string{"root"}),
+	})
+	writeFreshFlowRecordForTest(t, root, record)
+
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(t, read, "publish").DependsOn; len(got) != 1 || got[0] != "root" {
+		t.Fatalf("publish DependsOn = %#v, want [root]", got)
+	}
+
+	updated, err := store.SetPhase(flowstore.PhaseUpdate{FlowID: record.FlowID, PhaseID: "root", Status: flowstore.PhaseCompleted})
+	if err != nil {
+		t.Fatalf("SetPhase(root completed) error = %v", err)
+	}
+	if got := phaseByID(t, updated, "publish").DependsOn; len(got) != 1 || got[0] != "root" {
+		t.Fatalf("updated publish DependsOn = %#v, want [root]", got)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "flows", record.FlowID, "meta.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(meta.json) error = %v", err)
+	}
+	if !strings.Contains(string(data), `"depends_on": [
+        "root"
+      ]`) {
+		t.Fatalf("meta.json did not persist depends_on edge:\n%s", data)
+	}
+}
+
+func TestDependsOnNullCountsAsPresentEmpty(t *testing.T) {
+	root := t.TempDir()
+	flowID := "20260607T120000Z-null-depends"
+	flowDir := filepath.Join(root, "flows", flowID)
+	if err := os.MkdirAll(flowDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	meta := `{
+  "schema_version": 1,
+  "flow_id": "` + flowID + `",
+  "title": "Null depends",
+  "instructions": "explicit all roots",
+  "status": "pending",
+  "repo_path": "` + filepath.Join(root, "repo") + `",
+  "phases": [
+    {"phase_id": "alpha", "title": "Alpha", "kind": "", "depends_on": null, "status": "ready", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "beta", "title": "Beta", "kind": "", "depends_on": [], "status": "ready", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ],
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-01T00:00:00Z"
+}`
+	if err := os.WriteFile(filepath.Join(flowDir, "meta.json"), []byte(meta), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	read, err := store.Read(flowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(t, read, "alpha").DependsOn; len(got) != 0 || got == nil {
+		t.Fatalf("alpha DependsOn = %#v, want explicit empty slice", got)
+	}
+	updated, err := store.SetPhase(flowstore.PhaseUpdate{FlowID: flowID, PhaseID: "alpha", Status: flowstore.PhaseCompleted})
+	if err != nil {
+		t.Fatalf("SetPhase(alpha completed) error = %v", err)
+	}
+	if got := phaseByID(t, updated, "beta").Status; got != flowstore.PhaseReady {
+		t.Fatalf("beta status = %q, want ready as independent root", got)
+	}
+	data, err := os.ReadFile(filepath.Join(flowDir, "meta.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(meta.json) error = %v", err)
+	}
+	if strings.Contains(string(data), `"depends_on": null`) {
+		t.Fatalf("meta.json kept null depends_on:\n%s", data)
+	}
+}
+
+func TestReadBackfillsLinearDependsOn(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	flowID := "20260607T120000Z-legacy-default"
+	flowDir := filepath.Join(root, "flows", flowID)
+	if err := os.MkdirAll(flowDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	meta := `{
+  "schema_version": 1,
+  "flow_id": "` + flowID + `",
+  "title": "Legacy default",
+  "instructions": "backfill old records",
+  "status": "pending",
+  "repo_path": "` + filepath.Join(root, "repo") + `",
+  "phases": [
+    {"phase_id": "plan", "title": "Plan", "kind": "plan", "status": "ready", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "plan-review", "title": "Plan Review", "kind": "plan_review", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "implementation", "title": "Implementation", "kind": "implementation", "status": "pending", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ],
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-01T00:00:00Z"
+}`
+	if err := os.WriteFile(filepath.Join(flowDir, "meta.json"), []byte(meta), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	read, err := store.Read(flowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(t, read, "plan-review").DependsOn; len(got) != 1 || got[0] != "plan" {
+		t.Fatalf("plan-review DependsOn = %#v, want [plan]", got)
+	}
+	if got := phaseByID(t, read, "implementation").DependsOn; len(got) != 1 || got[0] != "plan-review" {
+		t.Fatalf("implementation DependsOn = %#v, want [plan-review]", got)
+	}
+}
+
+func TestReadinessFanOut(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := graphRecord(root, "20260607T120000Z-fanout", []flowstore.FlowPhase{
+		graphPhase(now, "root", flowstore.PhaseReady, []string{}),
+		graphPhase(now, "a", flowstore.PhasePending, []string{"root"}),
+		graphPhase(now, "b", flowstore.PhasePending, []string{"root"}),
+	})
+	writeFreshFlowRecordForTest(t, root, record)
+
+	updated, err := store.SetPhase(flowstore.PhaseUpdate{FlowID: record.FlowID, PhaseID: "root", Status: flowstore.PhaseCompleted})
+	if err != nil {
+		t.Fatalf("SetPhase(root completed) error = %v", err)
+	}
+	if got := phaseByID(t, updated, "a").Status; got != flowstore.PhaseReady {
+		t.Fatalf("a status = %q, want ready", got)
+	}
+	if got := phaseByID(t, updated, "b").Status; got != flowstore.PhaseReady {
+		t.Fatalf("b status = %q, want ready", got)
+	}
+}
+
+func TestReadinessFanIn(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := graphRecord(root, "20260607T120000Z-fanin", []flowstore.FlowPhase{
+		graphPhase(now, "a", flowstore.PhaseReady, []string{}),
+		graphPhase(now, "b", flowstore.PhaseReady, []string{}),
+		graphPhase(now, "join", flowstore.PhasePending, []string{"a", "b"}),
+	})
+	writeFreshFlowRecordForTest(t, root, record)
+
+	updated, err := store.SetPhase(flowstore.PhaseUpdate{FlowID: record.FlowID, PhaseID: "a", Status: flowstore.PhaseCompleted})
+	if err != nil {
+		t.Fatalf("SetPhase(a completed) error = %v", err)
+	}
+	if got := phaseByID(t, updated, "b").Status; got != flowstore.PhaseReady {
+		t.Fatalf("b status = %q, want ready independent root", got)
+	}
+	if got := phaseByID(t, updated, "join").Status; got != flowstore.PhasePending {
+		t.Fatalf("join status = %q, want pending until both branches complete", got)
+	}
+	updated, err = store.SetPhase(flowstore.PhaseUpdate{FlowID: record.FlowID, PhaseID: "b", Status: flowstore.PhaseCompleted})
+	if err != nil {
+		t.Fatalf("SetPhase(b completed) error = %v", err)
+	}
+	if got := phaseByID(t, updated, "join").Status; got != flowstore.PhaseReady {
+		t.Fatalf("join status = %q, want ready", got)
+	}
+}
+
+func TestReadinessIndependentBranchRegression(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := graphRecord(root, "20260607T120000Z-branch-regression", []flowstore.FlowPhase{
+		graphPhase(now, "root", flowstore.PhaseCompleted, []string{}),
+		graphPhase(now, "a", flowstore.PhaseCompleted, []string{"root"}),
+		graphPhase(now, "b", flowstore.PhaseRunning, []string{"root"}),
+		graphPhase(now, "join", flowstore.PhaseReady, []string{"a", "b"}),
+	})
+	writeFreshFlowRecordForTest(t, root, record)
+
+	updated, err := store.SetPhase(flowstore.PhaseUpdate{FlowID: record.FlowID, PhaseID: "a", Status: flowstore.PhaseRunning})
+	if err != nil {
+		t.Fatalf("SetPhase(a running) error = %v", err)
+	}
+	if got := phaseByID(t, updated, "b").Status; got != flowstore.PhaseRunning {
+		t.Fatalf("b status = %q, want running branch preserved", got)
+	}
+	if got := phaseByID(t, updated, "join").Status; got != flowstore.PhasePending {
+		t.Fatalf("join status = %q, want pending after dependency regression", got)
+	}
+}
+
+func TestCreateSeedsLinearDependsOn(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Default edges",
+		Instructions: "seed graph edges",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if got := phaseByID(t, record, "plan").DependsOn; len(got) != 0 || got == nil {
+		t.Fatalf("plan DependsOn = %#v, want explicit empty root", got)
+	}
+	if got := phaseByID(t, record, "plan-review").DependsOn; len(got) != 1 || got[0] != "plan" {
+		t.Fatalf("plan-review DependsOn = %#v, want [plan]", got)
+	}
+	if got := phaseByID(t, record, "plan").Status; got != flowstore.PhaseReady {
+		t.Fatalf("plan status = %q, want ready", got)
+	}
+}
+
+func TestCreateRejectsCyclicPhases(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	_, err = store.Create(flowstore.FlowRecord{
+		Title:        "Cycle",
+		Instructions: "reject cycles",
+		RepoPath:     filepath.Join(root, "repo"),
+		Phases: []flowstore.FlowPhase{
+			graphPhase(now, "a", flowstore.PhasePending, []string{"b"}),
+			graphPhase(now, "b", flowstore.PhasePending, []string{"a"}),
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "phase graph contains a cycle") {
+		t.Fatalf("Create() error = %v, want cycle", err)
+	}
+}
+
+func TestPhasePredecessorsSatisfiedDAG(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	record := flowstore.FlowRecord{Phases: []flowstore.FlowPhase{
+		graphPhase(now, "a", flowstore.PhaseCompleted, []string{}),
+		graphPhase(now, "b", flowstore.PhaseCompleted, []string{}),
+		graphPhase(now, "join", flowstore.PhasePending, []string{"a", "b"}),
+	}}
+	if !flowstore.PhasePredecessorsSatisfied(record, "join") {
+		t.Fatalf("PhasePredecessorsSatisfied(join) = false, want true")
+	}
+	record.Phases[1].Status = flowstore.PhaseRunning
+	if flowstore.PhasePredecessorsSatisfied(record, "join") {
+		t.Fatalf("PhasePredecessorsSatisfied(join) = true, want false with running dependency")
+	}
+	if flowstore.PhasePredecessorsSatisfied(record, "missing") {
+		t.Fatalf("PhasePredecessorsSatisfied(missing) = true, want false")
+	}
+}
+
+func TestDuplicateReadyRowNotLaunchEligible(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	record := flowstore.FlowRecord{AutoMode: true, Phases: []flowstore.FlowPhase{
+		graphPhase(now, "step-1", flowstore.PhaseCompleted, []string{}),
+		graphPhase(now, "step-1 ", flowstore.PhaseReady, []string{}),
+		graphPhase(now, "step-2", flowstore.PhaseReady, []string{"step-1"}),
+	}}
+	if flowstore.PhaseLaunchEligible(record, 1) {
+		t.Fatalf("duplicate ready row reported launch eligible")
+	}
+	if !flowstore.PhaseLaunchEligible(record, 2) {
+		t.Fatalf("non-duplicate ready row reported ineligible")
+	}
+}
+
+func graphRecord(root, flowID string, phases []flowstore.FlowPhase) flowstore.FlowRecord {
+	return flowstore.FlowRecord{
+		SchemaVersion: 1,
+		FlowID:        flowID,
+		Title:         "Graph fixture",
+		Instructions:  "exercise phase graph",
+		Status:        flowstore.StatusPending,
+		RepoPath:      filepath.Join(root, "repo"),
+		Merge:         flowstore.Merge{Status: flowstore.MergePending},
+		AutoMode:      true,
+		Phases:        phases,
+		CreatedAt:     time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC),
+		UpdatedAt:     time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func graphPhase(now time.Time, phaseID, status string, dependsOn []string) flowstore.FlowPhase {
+	return flowstore.FlowPhase{
+		PhaseID:   phaseID,
+		Title:     phaseID,
+		Kind:      "",
+		DependsOn: dependsOn,
+		Status:    status,
+		Order:     1,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+func writeFreshFlowRecordForTest(t *testing.T, root string, record flowstore.FlowRecord) {
+	t.Helper()
+	flowDir := filepath.Join(root, "flows", record.FlowID)
+	if err := os.MkdirAll(flowDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := writeFlowRecordForTest(root, record); err != nil {
+		t.Fatalf("write test flow: %v", err)
+	}
+}
+
 func phaseByID(t *testing.T, record flowstore.FlowRecord, phaseID string) flowstore.FlowPhase {
 	t.Helper()
 	for _, phase := range record.Phases {

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5428,6 +5428,53 @@ func TestReadBackfillsLinearDependsOn(t *testing.T) {
 	}
 }
 
+func TestReadBackfillsLinearDependsOnForLegacyCustomFlow(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	flowID := "20260607T120000Z-legacy-custom"
+	flowDir := filepath.Join(root, "flows", flowID)
+	if err := os.MkdirAll(flowDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	meta := `{
+  "schema_version": 1,
+  "flow_id": "` + flowID + `",
+  "title": "Legacy custom",
+  "instructions": "backfill custom records",
+  "status": "in_progress",
+  "repo_path": "` + filepath.Join(root, "repo") + `",
+  "phases": [
+    {"phase_id": "alpha", "title": "Alpha", "kind": "", "status": "running", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "beta", "title": "Beta", "kind": "", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ],
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-01T00:00:00Z"
+}`
+	if err := os.WriteFile(filepath.Join(flowDir, "meta.json"), []byte(meta), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	read, err := store.Read(flowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(t, read, "beta").DependsOn; len(got) != 1 || got[0] != "alpha" {
+		t.Fatalf("beta DependsOn = %#v, want [alpha]", got)
+	}
+
+	updated, err := store.SetPhase(flowstore.PhaseUpdate{FlowID: flowID, PhaseID: "alpha", Status: flowstore.PhaseNeedsAttention})
+	if err != nil {
+		t.Fatalf("SetPhase(alpha needs_attention) error = %v", err)
+	}
+	if got := phaseByID(t, updated, "beta").Status; got != flowstore.PhasePending {
+		t.Fatalf("beta status = %q, want pending while alpha is unsatisfied", got)
+	}
+}
+
 func TestReadinessFanOut(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5712,6 +5712,19 @@ func TestDuplicateReadyRowNotLaunchEligible(t *testing.T) {
 	}
 }
 
+func TestSelfDependencyNotLaunchEligible(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	record := flowstore.FlowRecord{AutoMode: true, Phases: []flowstore.FlowPhase{
+		graphPhase(now, "self", flowstore.PhaseReady, []string{"self"}),
+	}}
+	if flowstore.PhaseLaunchEligible(record, 0) {
+		t.Fatalf("self-dependent ready row reported launch eligible")
+	}
+	if phase, idx, ok := flowstore.FirstLaunchablePhase(record); ok {
+		t.Fatalf("FirstLaunchablePhase() = (%#v, %d, true), want none", phase, idx)
+	}
+}
+
 func TestFirstLaunchablePhasePreservesPRMetadataForAutoreviewGate(t *testing.T) {
 	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
 	record := flowstore.FlowRecord{

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -2147,6 +2147,45 @@ func TestStoreAddPhaseLaunchIDResumeRefreshesReadinessForCustomGraph(t *testing.
 	}
 }
 
+func TestStoreAddPhaseLaunchIDLaunchesReadyRootOfCustomGraph(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	// A custom depends_on DAG without plan-review is created with pending roots;
+	// launching the root must derive readiness first so the transition to running
+	// is not rejected, otherwise the flow can never launch any phase.
+	record, err := store.Create(flowstore.FlowRecord{
+		FlowID:       "custom-launch",
+		Title:        "Custom launch",
+		Instructions: "launch the root of a custom DAG without plan-review",
+		RepoPath:     filepath.Join(root, "repo"),
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "alpha", Title: "Alpha", Status: flowstore.PhasePending, Order: 1},
+			{PhaseID: "beta", Title: "Beta", Status: flowstore.PhasePending, Order: 2, DependsOn: []string{"alpha"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	launched, err := store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:   record.FlowID,
+		PhaseID:  "alpha",
+		LaunchID: "launch-alpha-1",
+	})
+	if err != nil {
+		t.Fatalf("AddPhaseLaunchID(alpha) error = %v", err)
+	}
+	if got := phaseByID(t, launched, "alpha").Status; got != flowstore.PhaseRunning {
+		t.Fatalf("alpha status after launch = %q, want running", got)
+	}
+	if got := phaseByID(t, launched, "beta").Status; got != flowstore.PhasePending {
+		t.Fatalf("beta status after launch = %q, want pending behind running alpha", got)
+	}
+}
+
 func TestStoreAddPhaseLaunchIDResumeStillRestartsNeedsAttentionPhase(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5665,6 +5665,28 @@ func TestDuplicateReadyRowNotLaunchEligible(t *testing.T) {
 	}
 }
 
+func TestFirstLaunchablePhasePreservesPRMetadataForAutoreviewGate(t *testing.T) {
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	record := flowstore.FlowRecord{
+		PR: flowstore.PullRequest{
+			Provider:   "github",
+			Number:     273,
+			URL:        "https://github.com/brian-bell/wtui/pull/273",
+			HeadBranch: "flow/phase-graph",
+			BaseBranch: "main",
+		},
+		Phases: []flowstore.FlowPhase{
+			graphPhase(now, "pr-creation", flowstore.PhaseCompleted, []string{}),
+			graphPhase(now, "autoreview", flowstore.PhaseReady, []string{"pr-creation"}),
+		},
+	}
+
+	phase, idx, ok := flowstore.FirstLaunchablePhase(record)
+	if !ok || phase.PhaseID != "autoreview" || idx != 1 {
+		t.Fatalf("FirstLaunchablePhase() = (%#v, %d, %v), want autoreview at index 1", phase, idx, ok)
+	}
+}
+
 func TestStoreAddPhaseLaunchIDRejectsDuplicateReadyRow(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5300,7 +5300,7 @@ func TestDependsOnNullCountsAsPresentEmpty(t *testing.T) {
   "repo_path": "` + filepath.Join(root, "repo") + `",
   "phases": [
     {"phase_id": "alpha", "title": "Alpha", "kind": "", "depends_on": null, "status": "ready", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
-    {"phase_id": "beta", "title": "Beta", "kind": "", "depends_on": [], "status": "ready", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+    {"phase_id": "beta", "title": "Beta", "kind": "", "depends_on": null, "status": "ready", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
   ],
   "created_at": "2026-01-01T00:00:00Z",
   "updated_at": "2026-01-01T00:00:00Z"
@@ -5319,6 +5319,9 @@ func TestDependsOnNullCountsAsPresentEmpty(t *testing.T) {
 	if got := phaseByID(t, read, "alpha").DependsOn; len(got) != 0 || got == nil {
 		t.Fatalf("alpha DependsOn = %#v, want explicit empty slice", got)
 	}
+	if got := phaseByID(t, read, "beta").DependsOn; len(got) != 0 || got == nil {
+		t.Fatalf("beta DependsOn = %#v, want explicit empty slice", got)
+	}
 	updated, err := store.SetPhase(flowstore.PhaseUpdate{FlowID: flowID, PhaseID: "alpha", Status: flowstore.PhaseCompleted})
 	if err != nil {
 		t.Fatalf("SetPhase(alpha completed) error = %v", err)
@@ -5326,12 +5329,59 @@ func TestDependsOnNullCountsAsPresentEmpty(t *testing.T) {
 	if got := phaseByID(t, updated, "beta").Status; got != flowstore.PhaseReady {
 		t.Fatalf("beta status = %q, want ready as independent root", got)
 	}
+	updated, err = store.SetPhase(flowstore.PhaseUpdate{FlowID: flowID, PhaseID: "alpha", Status: flowstore.PhaseRunning})
+	if err != nil {
+		t.Fatalf("SetPhase(alpha running) error = %v", err)
+	}
+	if got := phaseByID(t, updated, "beta").Status; got != flowstore.PhaseReady {
+		t.Fatalf("beta status = %q after alpha regression, want ready as independent root", got)
+	}
 	data, err := os.ReadFile(filepath.Join(flowDir, "meta.json"))
 	if err != nil {
 		t.Fatalf("ReadFile(meta.json) error = %v", err)
 	}
 	if strings.Contains(string(data), `"depends_on": null`) {
 		t.Fatalf("meta.json kept null depends_on:\n%s", data)
+	}
+}
+
+func TestExplicitEmptyDependsOnDefaultGraphMeansRoots(t *testing.T) {
+	root := t.TempDir()
+	flowID := "20260607T120000Z-explicit-default-roots"
+	flowDir := filepath.Join(root, "flows", flowID)
+	if err := os.MkdirAll(flowDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	meta := `{
+  "schema_version": 1,
+  "flow_id": "` + flowID + `",
+  "title": "Explicit default roots",
+  "instructions": "explicit empty depends_on",
+  "status": "pending",
+  "repo_path": "` + filepath.Join(root, "repo") + `",
+  "phases": [
+    {"phase_id": "plan", "title": "Plan", "kind": "plan", "depends_on": [], "status": "running", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "plan-review", "title": "Plan Review", "kind": "plan_review", "depends_on": [], "status": "ready", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ],
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-01T00:00:00Z"
+}`
+	if err := os.WriteFile(filepath.Join(flowDir, "meta.json"), []byte(meta), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	read, err := store.Read(flowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(t, read, "plan-review").DependsOn; len(got) != 0 || got == nil {
+		t.Fatalf("plan-review DependsOn = %#v, want explicit empty slice", got)
+	}
+	if got := phaseByID(t, read, "plan-review").Status; got != flowstore.PhaseReady {
+		t.Fatalf("plan-review status = %q, want ready as explicit root", got)
 	}
 }
 
@@ -5510,6 +5560,77 @@ func TestCreateRejectsCyclicPhases(t *testing.T) {
 	}
 }
 
+func TestCreateRejectsChildDeclaredDependencies(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	_, err = store.Create(flowstore.FlowRecord{
+		Title:        "Child dependency",
+		Instructions: "reject child edges",
+		RepoPath:     filepath.Join(root, "repo"),
+		Phases: []flowstore.FlowPhase{
+			graphPhase(now, "implementation", flowstore.PhasePending, nil),
+			{
+				PhaseID:       "api",
+				ParentPhaseID: "implementation",
+				Title:         "api",
+				DependsOn:     []string{"implementation"},
+				Status:        flowstore.PhasePending,
+				Order:         1,
+				CreatedAt:     now,
+				UpdatedAt:     now,
+			},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), `child phase "api" cannot declare dependencies`) {
+		t.Fatalf("Create() error = %v, want child dependency rejection", err)
+	}
+}
+
+func TestCreateRejectsInvalidDeclaredDependenciesBeforeNormalization(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		dependsOn []string
+		want      string
+	}{
+		{
+			name:      "empty dependency",
+			dependsOn: []string{""},
+			want:      `phase "publish" has empty dependency`,
+		},
+		{
+			name:      "duplicate dependency",
+			dependsOn: []string{"root", " Root "},
+			want:      `phase "publish" has duplicate dependency " Root "`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: t.TempDir()})
+			if err != nil {
+				t.Fatalf("NewStore() error = %v", err)
+			}
+			_, err = store.Create(flowstore.FlowRecord{
+				Title:        tc.name,
+				Instructions: "reject invalid dependency declarations",
+				RepoPath:     filepath.Join(root, "repo"),
+				Phases: []flowstore.FlowPhase{
+					graphPhase(now, "root", flowstore.PhasePending, []string{}),
+					graphPhase(now, "publish", flowstore.PhasePending, tc.dependsOn),
+				},
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Create() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestPhasePredecessorsSatisfiedDAG(t *testing.T) {
 	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
 	record := flowstore.FlowRecord{Phases: []flowstore.FlowPhase{
@@ -5541,6 +5662,69 @@ func TestDuplicateReadyRowNotLaunchEligible(t *testing.T) {
 	}
 	if !flowstore.PhaseLaunchEligible(record, 2) {
 		t.Fatalf("non-duplicate ready row reported ineligible")
+	}
+}
+
+func TestStoreAddPhaseLaunchIDRejectsDuplicateReadyRow(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := graphRecord(root, "20260607T120000Z-duplicate-launch", []flowstore.FlowPhase{
+		graphPhase(now, "Step-1", flowstore.PhaseCompleted, []string{}),
+		graphPhase(now, "step-1", flowstore.PhaseReady, []string{}),
+		graphPhase(now, "step-2", flowstore.PhaseReady, []string{"step-1"}),
+	})
+	writeFreshFlowRecordForTest(t, root, record)
+
+	_, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:     record.FlowID,
+		PhaseID:    "step-1",
+		LaunchID:   "launch-duplicate",
+		AutoLaunch: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not eligible") {
+		t.Fatalf("AddPhaseLaunchID(duplicate) error = %v, want not eligible", err)
+	}
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(t, read, "step-1"); len(got.LaunchIDs) != 0 || got.Status != flowstore.PhaseReady {
+		t.Fatalf("duplicate row after rejected launch = %#v, want unchanged ready without launch", got)
+	}
+}
+
+func TestStoreAddPhaseLaunchIDRejectsReadyPhaseWithUnsatisfiedDependency(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := graphRecord(root, "20260607T120000Z-stale-ready-launch", []flowstore.FlowPhase{
+		graphPhase(now, "root", flowstore.PhaseRunning, []string{}),
+		graphPhase(now, "publish", flowstore.PhaseReady, []string{"root"}),
+	})
+	writeFreshFlowRecordForTest(t, root, record)
+
+	_, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:     record.FlowID,
+		PhaseID:    "publish",
+		LaunchID:   "launch-stale-ready",
+		AutoLaunch: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not eligible") {
+		t.Fatalf("AddPhaseLaunchID(stale ready) error = %v, want not eligible", err)
+	}
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(t, read, "publish"); len(got.LaunchIDs) != 0 || got.Status != flowstore.PhaseReady {
+		t.Fatalf("publish after rejected launch = %#v, want unchanged ready without launch", got)
 	}
 }
 

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -230,16 +230,8 @@ func newlyCompletedFlowPhase(previous, current flowstore.FlowRecord) (flowstore.
 }
 
 func nextAutoLaunchPhase(record flowstore.FlowRecord) (flowstore.FlowPhase, bool) {
-	for _, phase := range flowstore.OrderedPhases(record.Phases) {
-		switch artifacts.NormalizePhaseID(phase.PhaseID) {
-		case "", "merge":
-			continue
-		}
-		if phase.Status == flowstore.PhaseReady {
-			return phase, true
-		}
-	}
-	return flowstore.FlowPhase{}, false
+	phase, _, ok := flowstore.FirstLaunchablePhase(record)
+	return phase, ok
 }
 
 func (m Model) selectedFlowNextLaunchablePhase() (flowstore.FlowRecord, flowstore.FlowPhase, bool) {

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -239,8 +239,11 @@ func (m Model) selectedFlowNextLaunchablePhase() (flowstore.FlowRecord, flowstor
 	if !ok || record.FlowID == "" {
 		return flowstore.FlowRecord{}, flowstore.FlowPhase{}, false
 	}
-	for _, phase := range flowstore.OrderedPhases(record.Phases) {
-		if flowPhaseCanLaunch(record, phase) {
+	ordered := flowstore.OrderedPhases(record.Phases)
+	orderedRecord := record
+	orderedRecord.Phases = ordered
+	for i, phase := range ordered {
+		if flowPhaseCanLaunchAtIndex(orderedRecord, i) {
 			return record, phase, true
 		}
 	}
@@ -559,10 +562,31 @@ func (m Model) prepareDeferredAutoFlowPhaseLaunchesFrom(records []flowstore.Flow
 }
 
 func flowPhaseCanLaunch(record flowstore.FlowRecord, phase flowstore.FlowPhase) bool {
-	if phase.Status == flowstore.PhaseReady {
-		return true
+	ordered := flowstore.OrderedPhases(record.Phases)
+	orderedRecord := record
+	orderedRecord.Phases = ordered
+	phaseID := artifacts.NormalizePhaseID(phase.PhaseID)
+	for i, candidate := range ordered {
+		if artifacts.NormalizePhaseID(candidate.PhaseID) == phaseID && candidate.Status == phase.Status {
+			return flowPhaseCanLaunchAtIndex(orderedRecord, i)
+		}
 	}
-	return artifacts.NormalizePhaseID(phase.PhaseID) == "autoreview" &&
+	return false
+}
+
+func flowPhaseCanLaunchAtIndex(record flowstore.FlowRecord, phaseIndex int) bool {
+	if phaseIndex < 0 || phaseIndex >= len(record.Phases) {
+		return false
+	}
+	phase := record.Phases[phaseIndex]
+	phaseID := artifacts.NormalizePhaseID(phase.PhaseID)
+	if phase.Status == flowstore.PhaseReady {
+		if phaseID == "merge" {
+			return flowstore.PhasePredecessorsSatisfied(record, phase.PhaseID)
+		}
+		return flowstore.PhaseLaunchEligible(record, phaseIndex)
+	}
+	return phaseID == "autoreview" &&
 		(phase.Status == flowstore.PhaseNeedsAttention || phase.Status == flowstore.PhaseBlocked) &&
 		flowstore.HasPRTarget(record.PR) &&
 		flowstore.PhasePredecessorsSatisfied(record, phase.PhaseID)

--- a/model/flow_phase_launch_internal_test.go
+++ b/model/flow_phase_launch_internal_test.go
@@ -44,6 +44,46 @@ func TestFlowPhaseLaunchCoordinatorSelectsFirstLaunchablePhase(t *testing.T) {
 	}
 }
 
+func TestNextAutoLaunchPhaseSkipsDuplicateReadyRow(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID:   "flow-1",
+		RepoPath: "/dev/alpha",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "Step-1", Title: "Step 1", DependsOn: []string{}, Status: flowstore.PhaseCompleted, Order: 1},
+			{PhaseID: "step-1", Title: "Step 1 stale duplicate", DependsOn: []string{}, Status: flowstore.PhaseReady, Order: 2},
+			{PhaseID: "step-2", Title: "Step 2", DependsOn: []string{"step-1"}, Status: flowstore.PhaseReady, Order: 3},
+		},
+	}
+
+	phase, ok := nextAutoLaunchPhase(record)
+	if !ok {
+		t.Fatal("nextAutoLaunchPhase() found no launchable phase")
+	}
+	if phase.PhaseID != "step-2" {
+		t.Fatalf("nextAutoLaunchPhase() = %q, want step-2", phase.PhaseID)
+	}
+}
+
+func TestNextAutoLaunchPhaseSkipsReadyPhaseWithUnsatisfiedDependency(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID:   "flow-1",
+		RepoPath: "/dev/alpha",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "root", Title: "Root", DependsOn: []string{}, Status: flowstore.PhaseRunning, Order: 1},
+			{PhaseID: "stale", Title: "Stale", DependsOn: []string{"root"}, Status: flowstore.PhaseReady, Order: 2},
+			{PhaseID: "independent", Title: "Independent", DependsOn: []string{}, Status: flowstore.PhaseReady, Order: 3},
+		},
+	}
+
+	phase, ok := nextAutoLaunchPhase(record)
+	if !ok {
+		t.Fatal("nextAutoLaunchPhase() found no launchable phase")
+	}
+	if phase.PhaseID != "independent" {
+		t.Fatalf("nextAutoLaunchPhase() = %q, want independent", phase.PhaseID)
+	}
+}
+
 func TestFlowPhaseLaunchTargetManualPreflightFailureSetsStatus(t *testing.T) {
 	m := New([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}})
 	record := flowstore.FlowRecord{

--- a/model/flow_phase_launch_internal_test.go
+++ b/model/flow_phase_launch_internal_test.go
@@ -64,6 +64,28 @@ func TestNextAutoLaunchPhaseSkipsDuplicateReadyRow(t *testing.T) {
 	}
 }
 
+func TestSelectedFlowNextLaunchablePhaseSkipsDuplicateReadyRow(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID:   "flow-1",
+		RepoPath: "/dev/alpha",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "Step-1", Title: "Step 1", DependsOn: []string{}, Status: flowstore.PhaseCompleted, Order: 1},
+			{PhaseID: "step-1", Title: "Step 1 stale duplicate", DependsOn: []string{}, Status: flowstore.PhaseReady, Order: 2},
+			{PhaseID: "step-2", Title: "Step 2", DependsOn: []string{"step-1"}, Status: flowstore.PhaseReady, Order: 3},
+		},
+	}
+	m := New([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}})
+	m.flows = m.flows.SetItems([]flowstore.FlowRecord{record})
+
+	_, phase, ok := m.selectedFlowNextLaunchablePhase()
+	if !ok {
+		t.Fatal("selectedFlowNextLaunchablePhase() found no launchable phase")
+	}
+	if phase.PhaseID != "step-2" {
+		t.Fatalf("selectedFlowNextLaunchablePhase() = %q, want step-2", phase.PhaseID)
+	}
+}
+
 func TestNextAutoLaunchPhaseSkipsReadyPhaseWithUnsatisfiedDependency(t *testing.T) {
 	record := flowstore.FlowRecord{
 		FlowID:   "flow-1",


### PR DESCRIPTION
## Summary
- add a reusable Flow phase dependency graph that evaluates parent/depends-on readiness in topological order
- persist dependency metadata in Flow records and expose eligible phase selection through the store
- harden model launch eligibility so blocked dependency paths do not become launchable

## Verification
- `gofmt -l .`
- `make test`
- `make build`