### PR TITLE
Route Flow phase gates by semantic kind

### DIFF
--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -482,13 +482,21 @@ func runFlowPhaseAction(args []string, deps runDeps, spec flowPhaseActionSpec) e
 	if *phaseID == "" {
 		return fmt.Errorf("flow phase %s requires --phase-id", spec.command)
 	}
-	actionOutcome := strings.TrimSpace(*outcome)
-	if actionOutcome == "" {
-		actionOutcome = defaultFlowPhaseActionOutcome(normalizeFlowPhaseID(*phaseID), spec)
-	}
 	store, err := newFlowStore(*stateRoot, deps)
 	if err != nil {
 		return err
+	}
+	actionOutcome := strings.TrimSpace(*outcome)
+	if actionOutcome == "" {
+		record, err := store.Read(*flowID)
+		if err != nil {
+			return err
+		}
+		phase, ok := flowPhaseByID(record, *phaseID)
+		if !ok {
+			return fmt.Errorf("phase %q not found in flow %q", *phaseID, *flowID)
+		}
+		actionOutcome = defaultFlowPhaseActionOutcome(flowstore.SemanticKind(phase), spec)
 	}
 	record, err := store.SetPhase(flowstore.PhaseUpdate{
 		FlowID:  *flowID,
@@ -514,11 +522,11 @@ func runFlowPhaseAction(args []string, deps runDeps, spec flowPhaseActionSpec) e
 	})
 }
 
-func defaultFlowPhaseActionOutcome(phaseID string, spec flowPhaseActionSpec) string {
-	switch phaseID {
-	case "plan-review":
+func defaultFlowPhaseActionOutcome(kind string, spec flowPhaseActionSpec) string {
+	switch kind {
+	case flowstore.KindPlanReview:
 		return spec.defaultOutcome
-	case "autoreview":
+	case flowstore.KindAutoreview:
 		switch spec.status {
 		case flowstore.PhaseCompleted:
 			return "passed"

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -1126,6 +1126,64 @@ func TestRunFlowPhaseActionsDefaultPlanReviewOutcomes(t *testing.T) {
 	}
 }
 
+func TestRunFlowPhaseActionsDefaultOutcomesByKind(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		FlowID:       "custom-action-outcomes",
+		Title:        "Custom Action Outcomes",
+		Instructions: "default outcomes by kind",
+		RepoPath:     filepath.Join(root, "repo"),
+		Branch:       "flow/custom-action-outcomes",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "design-review", Title: "Design Review", Kind: flowstore.KindPlanReview, DependsOn: []string{}, Status: flowstore.PhaseReady, Order: 1, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "second-review", Title: "Second Review", Kind: flowstore.KindAutoreview, DependsOn: []string{}, Status: flowstore.PhaseReady, Order: 2, CreatedAt: now, UpdatedAt: now},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err = run([]string{
+		"wtui", "flow", "phase", "complete",
+		"--flow-id", record.FlowID,
+		"--phase-id", "design-review",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: &stdout}))
+	if err != nil {
+		t.Fatalf("run plan-review-kind action returned error: %v", err)
+	}
+	var result flowPhaseActionResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("output is not JSON action result: %v\n%s", err, stdout.String())
+	}
+	if result.UpdatedPhase.Outcome != flowstore.OutcomeApproved {
+		t.Fatalf("design-review outcome = %q, want approved", result.UpdatedPhase.Outcome)
+	}
+
+	stdout.Reset()
+	err = run([]string{
+		"wtui", "flow", "phase", "complete",
+		"--flow-id", record.FlowID,
+		"--phase-id", "second-review",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: &stdout}))
+	if err != nil {
+		t.Fatalf("run autoreview-kind action returned error: %v", err)
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("output is not JSON action result: %v\n%s", err, stdout.String())
+	}
+	if result.UpdatedPhase.Outcome != "passed" {
+		t.Fatalf("second-review outcome = %q, want passed", result.UpdatedPhase.Outcome)
+	}
+}
+
 func TestRunFlowPhaseActionsDefaultAutoreviewOutcomes(t *testing.T) {
 	root := t.TempDir()
 	for _, tc := range []struct {
@@ -1441,7 +1499,7 @@ func TestRunFlowPhaseResetRejectsIneligiblePhasesWithoutChangingRecord(t *testin
 				}
 				return record
 			},
-			want: "requires satisfied predecessors",
+			want: "requires running recoverable phase",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1465,7 +1523,11 @@ func TestRunFlowPhaseResetRejectsIneligiblePhasesWithoutChangingRecord(t *testin
 				t.Fatalf("Read() error = %v", err)
 			}
 			after := phaseByID(read, "implementation")
-			if before.Status != after.Status || strings.Join(before.LaunchIDs, ",") != strings.Join(after.LaunchIDs, ",") || len(before.Sessions) != len(after.Sessions) {
+			wantAfterStatus := before.Status
+			if tc.name == "unsatisfied predecessors" {
+				wantAfterStatus = flowstore.PhasePending
+			}
+			if after.Status != wantAfterStatus || strings.Join(before.LaunchIDs, ",") != strings.Join(after.LaunchIDs, ",") || len(before.Sessions) != len(after.Sessions) {
 				t.Fatalf("record changed after rejected reset: before=%#v after=%#v", before, after)
 			}
 		})

--- a/flowstore/graph.go
+++ b/flowstore/graph.go
@@ -63,14 +63,8 @@ func validatePhaseGraph(phases []FlowPhase) error {
 	if len(graph.topo) != len(phases) {
 		return fmt.Errorf("phase graph contains a cycle: %s", cycleDescription(phases, graph))
 	}
-	mergeCount := 0
-	for _, phase := range phases {
-		if SemanticKind(phase) == KindMerge {
-			mergeCount++
-		}
-	}
-	if mergeCount > 1 {
-		return fmt.Errorf("phase graph can include at most one merge phase")
+	if err := validateUniqueMergePhaseKind(phases); err != nil {
+		return err
 	}
 	topLevelCount := 0
 	rootCount := 0
@@ -85,6 +79,19 @@ func validatePhaseGraph(phases []FlowPhase) error {
 	}
 	if topLevelCount > 0 && rootCount == 0 {
 		return fmt.Errorf("phase graph must include at least one root phase")
+	}
+	return nil
+}
+
+func validateUniqueMergePhaseKind(phases []FlowPhase) error {
+	mergeCount := 0
+	for _, phase := range phases {
+		if SemanticKind(phase) == KindMerge {
+			mergeCount++
+		}
+	}
+	if mergeCount > 1 {
+		return fmt.Errorf("phase graph can include at most one merge phase")
 	}
 	return nil
 }

--- a/flowstore/graph.go
+++ b/flowstore/graph.go
@@ -63,6 +63,15 @@ func validatePhaseGraph(phases []FlowPhase) error {
 	if len(graph.topo) != len(phases) {
 		return fmt.Errorf("phase graph contains a cycle: %s", cycleDescription(phases, graph))
 	}
+	mergeCount := 0
+	for _, phase := range phases {
+		if SemanticKind(phase) == KindMerge {
+			mergeCount++
+		}
+	}
+	if mergeCount > 1 {
+		return fmt.Errorf("phase graph can include at most one merge phase")
+	}
 	topLevelCount := 0
 	rootCount := 0
 	for _, phase := range phases {
@@ -479,7 +488,7 @@ func allDependencyGatesSatisfied(record FlowRecord, graph phaseGraph, idx int) b
 func phaseDependsOnPlanReviewFailure(record FlowRecord, graph phaseGraph, idx int, failedPlanReview map[int]bool) bool {
 	for _, prereq := range graph.prereqsByIdx[idx] {
 		phase := record.Phases[prereq]
-		if failedPlanReview[prereq] || phase.PhaseID == "plan-review" && !phaseSatisfiesDownstreamGate(record, phase) {
+		if failedPlanReview[prereq] || SemanticKind(phase) == KindPlanReview && !phaseSatisfiesDownstreamGate(record, phase) {
 			return true
 		}
 	}
@@ -505,7 +514,7 @@ func PhaseLaunchEligible(record FlowRecord, orderedIndex int) bool {
 	if !allDependencyGatesSatisfied(FlowRecord{PR: record.PR, Phases: ordered}, graph, orderedIndex) {
 		return false
 	}
-	return artifacts.NormalizePhaseID(phase.PhaseID) != "merge"
+	return SemanticKind(phase) != KindMerge
 }
 
 func phaseLaunchEligibleAtIndex(record FlowRecord, phaseIndex int) bool {
@@ -523,7 +532,7 @@ func phaseLaunchEligibleAtIndex(record FlowRecord, phaseIndex int) bool {
 	if !allDependencyGatesSatisfied(record, graph, phaseIndex) {
 		return false
 	}
-	return artifacts.NormalizePhaseID(phase.PhaseID) != "merge"
+	return SemanticKind(phase) != KindMerge
 }
 
 // FirstLaunchablePhase returns the first ordered phase that can be launched.

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -61,6 +61,17 @@ const (
 	OutcomeBlocked              = "blocked"
 )
 
+const (
+	KindPlan                = "plan"
+	KindPlanReview          = "plan_review"
+	KindImplementation      = "implementation"
+	KindReviewLoop          = "review_loop"
+	KindPRCreation          = "pr_creation"
+	KindAutoreview          = "autoreview"
+	KindMerge               = "merge"
+	KindImplementationChild = "implementation_child"
+)
+
 // Store reads and writes flow records under an artifact root.
 type Store struct {
 	root        string
@@ -382,7 +393,7 @@ func (s *Store) Create(record FlowRecord) (FlowRecord, error) {
 			}
 		}
 	}
-	record = normalizeRecord(record)
+	record = normalizeRecord(record, false)
 	record.Status = DeriveStatus(record)
 	if err := s.write(record); err != nil {
 		return FlowRecord{}, err
@@ -448,9 +459,7 @@ func (s *Store) SetPhase(update PhaseUpdate) (FlowRecord, error) {
 	phase.UpdatedAt = now
 	record.Phases[phaseIndex] = phase
 	record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
-	if phase.PhaseID == "merge" && (phase.Status == PhaseRunning || phase.Status == PhaseSkipped) {
-		record.Merge = Merge{Status: MergePending}
-	}
+	record = resetMergePendingForActiveMergePhase(record, phase)
 	record.UpdatedAt = now
 	record = refreshPhaseReadiness(record, now)
 	record.Status = DeriveStatus(record)
@@ -512,9 +521,7 @@ func (s *Store) RestartPhase(update PhaseRestartUpdate) (FlowRecord, error) {
 		phase.UpdatedAt = now
 		record.Phases[phaseIndex] = phase
 		record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
-		if phase.PhaseID == "merge" {
-			record.Merge = Merge{Status: MergePending}
-		}
+		record = resetMergePendingForActiveMergePhase(record, phase)
 		record.UpdatedAt = now
 		record = refreshPhaseReadiness(record, now)
 		return record, nil
@@ -533,7 +540,7 @@ func (s *Store) AddChildPhase(update ChildPhaseUpdate) (FlowRecord, error) {
 		if parentIndex < 0 {
 			return FlowRecord{}, fmt.Errorf("parent phase %q not found in flow %q", update.ParentPhaseID, update.FlowID)
 		}
-		if record.Phases[parentIndex].PhaseID != "implementation" {
+		if SemanticKind(record.Phases[parentIndex]) != KindImplementation {
 			return FlowRecord{}, fmt.Errorf("child phases can only be added under implementation")
 		}
 		childIndex := phaseIndexByID(record.Phases, update.PhaseID)
@@ -549,13 +556,13 @@ func (s *Store) AddChildPhase(update ChildPhaseUpdate) (FlowRecord, error) {
 			child = record.Phases[childIndex]
 			if child.PhaseID == update.PhaseID &&
 				child.Title == strings.TrimSpace(update.Title) &&
-				child.Kind == "implementation_child" &&
+				child.Kind == KindImplementationChild &&
 				child.Order == update.Order {
 				return record, nil
 			}
 			child.PhaseID = update.PhaseID
 			child.Title = strings.TrimSpace(update.Title)
-			child.Kind = "implementation_child"
+			child.Kind = KindImplementationChild
 			child.Order = update.Order
 			child.UpdatedAt = now
 			record.Phases[childIndex] = child
@@ -568,7 +575,7 @@ func (s *Store) AddChildPhase(update ChildPhaseUpdate) (FlowRecord, error) {
 			PhaseID:       update.PhaseID,
 			ParentPhaseID: update.ParentPhaseID,
 			Title:         strings.TrimSpace(update.Title),
-			Kind:          "implementation_child",
+			Kind:          KindImplementationChild,
 			Status:        PhasePending,
 			Order:         update.Order,
 			CreatedAt:     now,
@@ -761,7 +768,7 @@ func (s *Store) MarkManualMerge(update ManualMergeUpdate) (FlowRecord, error) {
 	if !ok {
 		return FlowRecord{}, flowNotFoundError(update.FlowID)
 	}
-	phaseIndex := phaseIndexByID(record.Phases, "merge")
+	phaseIndex := mergePhaseIndex(record)
 	if phaseIndex < 0 {
 		return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", "merge", update.FlowID)
 	}
@@ -785,7 +792,6 @@ func (s *Store) MarkManualMerge(update ManualMergeUpdate) (FlowRecord, error) {
 	phase.Status = PhaseCompleted
 	phase.Outcome = MergeMerged
 	phase.Summary = summary
-	phase.PhaseID = "merge"
 	phase.UpdatedAt = now
 	record.Phases[phaseIndex] = phase
 	record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
@@ -942,9 +948,7 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 		phase.UpdatedAt = now
 		record.Phases[phaseIndex] = phase
 		record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
-		if phase.PhaseID == "merge" && phase.Status == PhaseRunning {
-			record.Merge = Merge{Status: MergePending}
-		}
+		record = resetMergePendingForActiveMergePhase(record, phase)
 		record.UpdatedAt = now
 		record = refreshPhaseReadiness(record, now)
 		record.Status = DeriveStatus(record)
@@ -957,11 +961,10 @@ func validateAutoPhaseLaunch(record FlowRecord, phaseIndex int) error {
 	if phaseIndex >= 0 && phaseIndex < len(record.Phases) {
 		phase = record.Phases[phaseIndex]
 	}
-	phaseID := artifacts.NormalizePhaseID(phase.PhaseID)
 	switch {
 	case !record.AutoMode:
 		return fmt.Errorf("auto launch for flow %q is disabled: %w", record.FlowID, errAutoLaunchOutdated)
-	case phaseID == "" || phaseID == "merge":
+	case artifacts.NormalizePhaseID(phase.PhaseID) == "" || SemanticKind(phase) == KindMerge:
 		return fmt.Errorf("auto launch target %q is not eligible: %w", phase.PhaseID, errAutoLaunchOutdated)
 	case phase.Status != PhaseReady:
 		return fmt.Errorf("auto launch target %q is %s, not ready: %w", phase.PhaseID, phase.Status, errAutoLaunchOutdated)
@@ -1206,7 +1209,7 @@ func (s *Store) updateFlow(flowID string, mutate func(FlowRecord, time.Time) (Fl
 	if err != nil {
 		return FlowRecord{}, err
 	}
-	record = normalizeRecord(record)
+	record = normalizeRecord(record, true)
 	record.Status = DeriveStatus(record)
 	if err := s.write(record); err != nil {
 		return FlowRecord{}, err
@@ -1359,9 +1362,6 @@ func validateChildPhaseUpdate(update ChildPhaseUpdate) error {
 	if err := validatePhaseID(update.ParentPhaseID); err != nil {
 		return fmt.Errorf("invalid parent phase id: %w", err)
 	}
-	if update.ParentPhaseID != "implementation" {
-		return fmt.Errorf("child phases can only be added under implementation")
-	}
 	if err := validatePhaseID(update.PhaseID); err != nil {
 		return err
 	}
@@ -1398,7 +1398,7 @@ func refreshPhaseReadiness(record FlowRecord, now time.Time) FlowRecord {
 		}
 		phase = record.Phases[i]
 		if !phaseSatisfiesDownstreamGate(record, phase) {
-			if phase.PhaseID == "plan-review" {
+			if SemanticKind(phase) == KindPlanReview {
 				failedPlanReview[i] = true
 			}
 			if phaseDependsOnPlanReviewFailure(record, graph, i, failedPlanReview) {
@@ -1471,7 +1471,8 @@ func shouldResetBlockedDownstreamPhase(phase FlowPhase, resetBlocked bool) bool 
 }
 
 func phaseSatisfiesDownstreamGate(record FlowRecord, phase FlowPhase) bool {
-	if phase.PhaseID == "plan-review" {
+	switch SemanticKind(phase) {
+	case KindPlanReview:
 		switch phase.Status {
 		case PhaseSkipped:
 			return strings.TrimSpace(phase.Notes) != ""
@@ -1480,14 +1481,56 @@ func phaseSatisfiesDownstreamGate(record FlowRecord, phase FlowPhase) bool {
 		default:
 			return false
 		}
-	}
-	if phase.PhaseID == "pr-creation" {
+	case KindPRCreation:
 		return phase.Status == PhaseCompleted && HasPRTarget(record.PR)
 	}
 	if phase.Status == PhaseSkipped {
 		return strings.TrimSpace(phase.Notes) != ""
 	}
 	return phase.Status == PhaseCompleted
+}
+
+// PhaseGateSatisfied reports whether phase satisfies the semantic gate that
+// unlocks downstream phases in the Flow graph.
+func PhaseGateSatisfied(record FlowRecord, phase FlowPhase) bool {
+	return phaseSatisfiesDownstreamGate(record, phase)
+}
+
+// SemanticKind returns the normalized semantic kind for a phase. Persisted kind
+// wins; otherwise default preset phase IDs are inferred for legacy records.
+func SemanticKind(phase FlowPhase) string {
+	if kind := strings.ToLower(strings.TrimSpace(phase.Kind)); kind != "" {
+		return kind
+	}
+	switch artifacts.NormalizePhaseID(phase.PhaseID) {
+	case "plan":
+		return KindPlan
+	case "plan-review":
+		return KindPlanReview
+	case "implementation":
+		return KindImplementation
+	case "review-loop":
+		return KindReviewLoop
+	case "pr-creation":
+		return KindPRCreation
+	case "autoreview":
+		return KindAutoreview
+	case "merge":
+		return KindMerge
+	default:
+		return ""
+	}
+}
+
+// FindPhaseByKind returns the first phase with the requested semantic kind.
+func FindPhaseByKind(record FlowRecord, kind string) (FlowPhase, bool) {
+	kind = strings.ToLower(strings.TrimSpace(kind))
+	for _, phase := range OrderedPhases(record.Phases) {
+		if SemanticKind(phase) == kind {
+			return phase, true
+		}
+	}
+	return FlowPhase{}, false
 }
 
 // PhasePredecessorsSatisfied reports whether all graph prerequisites for
@@ -1647,14 +1690,14 @@ func validateMergeUpdate(record FlowRecord, update MergeUpdate) (Merge, error) {
 		if update.MergedAt.IsZero() {
 			return Merge{}, fmt.Errorf("merge status merged requires merge timestamp")
 		}
-		phaseIndex := phaseIndexByID(record.Phases, "merge")
+		phaseIndex := mergePhaseIndex(record)
 		if phaseIndex < 0 || record.Phases[phaseIndex].Status != PhaseCompleted {
 			return Merge{}, fmt.Errorf("merge status merged requires completed merge phase")
 		}
 		mergedAt := update.MergedAt.UTC()
 		return Merge{Status: MergeMerged, Commit: commit, MergedAt: &mergedAt}, nil
 	case MergeBlocked:
-		phaseIndex := phaseIndexByID(record.Phases, "merge")
+		phaseIndex := mergePhaseIndex(record)
 		if phaseIndex < 0 || record.Phases[phaseIndex].Status != PhaseBlocked || strings.TrimSpace(record.Phases[phaseIndex].Notes) == "" {
 			return Merge{}, fmt.Errorf("merge status blocked requires blocked merge phase notes")
 		}
@@ -1690,7 +1733,7 @@ func validateManualMergeUpdate(record FlowRecord, phase FlowPhase, update Manual
 	case PhaseReady:
 		if err := validatePhaseUpdate(phase, PhaseUpdate{
 			FlowID:  update.FlowID,
-			PhaseID: "merge",
+			PhaseID: phase.PhaseID,
 			Status:  PhaseCompleted,
 			Outcome: MergeMerged,
 		}); err != nil {
@@ -1721,7 +1764,7 @@ func mergeEqual(left, right Merge) bool {
 }
 
 func validatePlanReviewUpdate(current FlowPhase, update PhaseUpdate) error {
-	if current.PhaseID != "plan-review" {
+	if SemanticKind(current) != KindPlanReview {
 		return nil
 	}
 	if current.Status == PhasePending && update.Status != PhaseSkipped {
@@ -1732,47 +1775,54 @@ func validatePlanReviewUpdate(current FlowPhase, update PhaseUpdate) error {
 	if outcome == "" {
 		switch update.Status {
 		case PhaseCompleted:
-			return fmt.Errorf("plan-review completed requires outcome approved or approved_with_concerns")
+			return fmt.Errorf("%s completed requires outcome approved or approved_with_concerns", reviewPhaseLabel(current))
 		case PhaseNeedsAttention:
-			return fmt.Errorf("plan-review needs_attention requires outcome changes_requested")
+			return fmt.Errorf("%s needs_attention requires outcome changes_requested", reviewPhaseLabel(current))
 		case PhaseBlocked:
-			return fmt.Errorf("plan-review blocked requires outcome blocked")
+			return fmt.Errorf("%s blocked requires outcome blocked", reviewPhaseLabel(current))
 		}
 		return nil
 	}
 	if update.Status == PhaseBlocked && outcome != OutcomeBlocked {
-		return fmt.Errorf("plan-review blocked requires outcome blocked")
+		return fmt.Errorf("%s blocked requires outcome blocked", reviewPhaseLabel(current))
 	}
 	switch outcome {
 	case OutcomeApproved:
 		if update.Status != PhaseCompleted {
-			return fmt.Errorf("plan-review outcome approved requires completed status")
+			return fmt.Errorf("%s outcome approved requires completed status", reviewPhaseLabel(current))
 		}
 	case OutcomeApprovedWithConcerns:
 		if update.Status != PhaseCompleted {
-			return fmt.Errorf("plan-review outcome approved_with_concerns requires completed status")
+			return fmt.Errorf("%s outcome approved_with_concerns requires completed status", reviewPhaseLabel(current))
 		}
 		if notes == "" {
-			return fmt.Errorf("plan-review approved_with_concerns requires notes")
+			return fmt.Errorf("%s approved_with_concerns requires notes", reviewPhaseLabel(current))
 		}
 	case OutcomeChangesRequested:
 		if update.Status != PhaseNeedsAttention {
-			return fmt.Errorf("plan-review outcome changes_requested requires needs_attention status")
+			return fmt.Errorf("%s outcome changes_requested requires needs_attention status", reviewPhaseLabel(current))
 		}
 		if notes == "" {
-			return fmt.Errorf("plan-review changes_requested requires notes")
+			return fmt.Errorf("%s changes_requested requires notes", reviewPhaseLabel(current))
 		}
 	case OutcomeBlocked:
 		if update.Status != PhaseBlocked {
-			return fmt.Errorf("plan-review blocked requires outcome blocked")
+			return fmt.Errorf("%s blocked requires outcome blocked", reviewPhaseLabel(current))
 		}
 		if notes == "" {
-			return fmt.Errorf("plan-review blocked requires notes")
+			return fmt.Errorf("%s blocked requires notes", reviewPhaseLabel(current))
 		}
 	default:
-		return fmt.Errorf("invalid plan-review outcome %q", outcome)
+		return fmt.Errorf("invalid %s outcome %q", reviewPhaseLabel(current), outcome)
 	}
 	return nil
+}
+
+func reviewPhaseLabel(phase FlowPhase) string {
+	if artifacts.NormalizePhaseID(phase.PhaseID) == "plan-review" {
+		return "plan-review"
+	}
+	return fmt.Sprintf("%s (%s)", phase.PhaseID, KindPlanReview)
 }
 
 // DeriveStatus computes the flow-level status from phase and merge state.
@@ -1827,13 +1877,13 @@ func defaultPhases(createdAt, updatedAt time.Time) []FlowPhase {
 		title string
 		kind  string
 	}{
-		{"plan", "Plan", "plan"},
-		{"plan-review", "Plan Review", "plan_review"},
-		{"implementation", "Implementation", "implementation"},
-		{"review-loop", "Review loop", "review_loop"},
-		{"pr-creation", "PR creation", "pr_creation"},
-		{"autoreview", "Autoreview", "autoreview"},
-		{"merge", "Merge", "merge"},
+		{"plan", "Plan", KindPlan},
+		{"plan-review", "Plan Review", KindPlanReview},
+		{"implementation", "Implementation", KindImplementation},
+		{"review-loop", "Review loop", KindReviewLoop},
+		{"pr-creation", "PR creation", KindPRCreation},
+		{"autoreview", "Autoreview", KindAutoreview},
+		{"merge", "Merge", KindMerge},
 	}
 	phases := make([]FlowPhase, 0, len(specs))
 	for i, spec := range specs {
@@ -1901,8 +1951,9 @@ func (s *Store) readRecord(flowID string) (FlowRecord, bool) {
 	if record.FlowID != flowID || record.SchemaVersion != schemaVersion {
 		return FlowRecord{}, false
 	}
+	selfHeal := rawDependsOnPresentForTopLevel(record.Phases, presence)
 	record.Phases = backfillLinearDependsOnFromRaw(record.Phases, presence)
-	record = normalizeRecord(record)
+	record = normalizeRecord(record, selfHeal)
 	record.Status = DeriveStatus(record)
 	return record, true
 }
@@ -1922,6 +1973,15 @@ func rawDependsOnPresence(data []byte) []rawDependsOnState {
 		}
 	}
 	return presence
+}
+
+func rawDependsOnPresentForTopLevel(phases []FlowPhase, presence []rawDependsOnState) bool {
+	for i, phase := range phases {
+		if phase.ParentPhaseID == "" && i < len(presence) && presence[i].Present {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Store) flowDir(flowID string) string {
@@ -1960,24 +2020,25 @@ func defaultTime(value, fallback time.Time) time.Time {
 	return value
 }
 
-func normalizeRecord(record FlowRecord) FlowRecord {
+func normalizeRecord(record FlowRecord, selfHeal bool) FlowRecord {
 	if record.Merge.Status == "" {
 		record.Merge.Status = MergePending
 	}
-	// Load-path normalization only: standard graphs (identified by a
-	// plan-review phase) self-heal here; phase-affecting mutations call
+	record.Phases = backfillPhaseKinds(record.Phases)
+	// Load-path normalization only: edge-aware records and plan-review-kind
+	// records self-heal here; phase-affecting mutations call
 	// refreshPhaseReadiness explicitly for every graph shape.
-	if hasPhase(record, "plan-review") {
-		record = normalizePlanReviewOutcomes(record)
+	if selfHeal || hasPlanReviewKind(record) {
+		record = normalizeReviewOutcomes(record)
 		record = refreshPhaseReadiness(record, record.UpdatedAt)
 	}
 	return record
 }
 
-func normalizePlanReviewOutcomes(record FlowRecord) FlowRecord {
+func normalizeReviewOutcomes(record FlowRecord) FlowRecord {
 	for i := range record.Phases {
 		phase := record.Phases[i]
-		if phase.PhaseID != "plan-review" {
+		if SemanticKind(phase) != KindPlanReview {
 			continue
 		}
 		phase.Outcome = strings.TrimSpace(phase.Outcome)
@@ -1989,8 +2050,18 @@ func normalizePlanReviewOutcomes(record FlowRecord) FlowRecord {
 	return record
 }
 
-func hasPhase(record FlowRecord, phaseID string) bool {
-	return phaseIndexByID(record.Phases, phaseID) >= 0
+func backfillPhaseKinds(phases []FlowPhase) []FlowPhase {
+	for i := range phases {
+		if strings.TrimSpace(phases[i].Kind) == "" {
+			phases[i].Kind = SemanticKind(phases[i])
+		}
+	}
+	return phases
+}
+
+func hasPlanReviewKind(record FlowRecord) bool {
+	_, ok := FindPhaseByKind(record, KindPlanReview)
+	return ok
 }
 
 // collapseDuplicatePhaseRows keeps the row at keepIndex and drops every other
@@ -2064,4 +2135,20 @@ func phaseIndexByID(phases []FlowPhase, phaseID string) int {
 		}
 	}
 	return -1
+}
+
+func mergePhaseIndex(record FlowRecord) int {
+	for i, phase := range record.Phases {
+		if SemanticKind(phase) == KindMerge {
+			return i
+		}
+	}
+	return -1
+}
+
+func resetMergePendingForActiveMergePhase(record FlowRecord, phase FlowPhase) FlowRecord {
+	if SemanticKind(phase) == KindMerge && (phase.Status == PhaseRunning || phase.Status == PhaseSkipped) {
+		record.Merge = Merge{Status: MergePending}
+	}
+	return record
 }

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -703,7 +703,7 @@ func (s *Store) SetPR(update PRUpdate) (FlowRecord, error) {
 	if err := validateFlowID(update.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
-	return s.updateFlowMetadataOnly(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
 		pr, err := validatePRUpdate(record, update)
 		if err != nil {
 			return FlowRecord{}, err

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -387,6 +387,9 @@ func (s *Store) Create(record FlowRecord) (FlowRecord, error) {
 		}
 		authoritativeEdges := graphHasAuthoritativeEdges(record.Phases)
 		record.Phases = backfillLinearDependsOnForCreate(record.Phases)
+		if err := validateUniqueMergePhaseKind(record.Phases); err != nil {
+			return FlowRecord{}, err
+		}
 		if authoritativeEdges {
 			if err := validatePhaseGraph(record.Phases); err != nil {
 				return FlowRecord{}, err

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -687,7 +687,7 @@ func (s *Store) SetPlanLink(update PlanLinkUpdate) (FlowRecord, error) {
 	if _, err := planStore.ReadPlan(planID); err != nil {
 		return FlowRecord{}, err
 	}
-	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+	return s.updateFlowMetadataOnly(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
 		if record.PlanID == planID && record.PlanPath == planPath {
 			return record, nil
 		}
@@ -703,7 +703,7 @@ func (s *Store) SetPR(update PRUpdate) (FlowRecord, error) {
 	if err := validateFlowID(update.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
-	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+	return s.updateFlowMetadataOnly(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
 		pr, err := validatePRUpdate(record, update)
 		if err != nil {
 			return FlowRecord{}, err
@@ -723,7 +723,7 @@ func (s *Store) SetIssue(update IssueUpdate) (FlowRecord, error) {
 	if err := validateFlowID(update.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
-	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+	return s.updateFlowMetadataOnly(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
 		issue, err := validateIssueUpdate(update)
 		if err != nil {
 			return FlowRecord{}, err
@@ -742,7 +742,7 @@ func (s *Store) SetMerge(update MergeUpdate) (FlowRecord, error) {
 	if err := validateFlowID(update.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
-	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+	return s.updateFlowMetadataOnly(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
 		merge, err := validateMergeUpdate(record, update)
 		if err != nil {
 			return FlowRecord{}, err
@@ -829,7 +829,7 @@ func (s *Store) SetAutoMode(update AutoModeUpdate) (FlowRecord, error) {
 	if err := validateFlowID(update.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
-	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+	return s.updateFlowMetadataOnly(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
 		if record.AutoMode == update.Enabled {
 			return record, nil
 		}
@@ -851,7 +851,7 @@ func (s *Store) SetStartMetadata(update StartMetadataUpdate) (FlowRecord, error)
 	if strings.TrimSpace(update.PlanPath) != "" && !filepath.IsAbs(update.PlanPath) {
 		return FlowRecord{}, fmt.Errorf("flow plan path must be absolute: %s", update.PlanPath)
 	}
-	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+	return s.updateFlowMetadataOnly(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
 		if value := strings.TrimSpace(update.WorktreePath); value != "" {
 			record.WorktreePath = filepath.Clean(value)
 		}
@@ -1092,7 +1092,7 @@ func (s *Store) MarkPhaseLaunchEnded(update PhaseLaunchEndUpdate) (FlowRecord, e
 	if launchID == "" {
 		return FlowRecord{}, fmt.Errorf("launch id is required")
 	}
-	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+	return s.updateFlowMetadataOnly(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
 		phaseIndex := phaseIndexPreferringExactID(record.Phases, requestedPhaseID)
 		if phaseIndex < 0 {
 			return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
@@ -1144,7 +1144,7 @@ func (s *Store) AttachSession(update SessionAttachUpdate) (FlowRecord, error) {
 	if strings.TrimSpace(update.Session.SessionID) == "" {
 		return FlowRecord{}, fmt.Errorf("session id is required")
 	}
-	return s.updateFlow(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
+	return s.updateFlowMetadataOnly(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {
 		// Attaching a session is metadata-only and never changes phase status,
 		// so prefer the row that matches the id exactly: when a legacy record
 		// still holds a stale duplicate ahead of the active row, collapsing
@@ -1199,12 +1199,20 @@ func (s *Store) Delete(flowID string) error {
 }
 
 func (s *Store) updateFlow(flowID string, mutate func(FlowRecord, time.Time) (FlowRecord, error)) (FlowRecord, error) {
+	return s.updateFlowWithReadiness(flowID, true, mutate)
+}
+
+func (s *Store) updateFlowMetadataOnly(flowID string, mutate func(FlowRecord, time.Time) (FlowRecord, error)) (FlowRecord, error) {
+	return s.updateFlowWithReadiness(flowID, false, mutate)
+}
+
+func (s *Store) updateFlowWithReadiness(flowID string, selfHealOnRead bool, mutate func(FlowRecord, time.Time) (FlowRecord, error)) (FlowRecord, error) {
 	release, err := s.acquireFlowLock(flowID)
 	if err != nil {
 		return FlowRecord{}, err
 	}
 	defer release()
-	record, ok := s.readRecord(flowID)
+	record, ok := s.readRecordWithReadiness(flowID, selfHealOnRead)
 	if !ok {
 		return FlowRecord{}, flowNotFoundError(flowID)
 	}
@@ -1212,7 +1220,7 @@ func (s *Store) updateFlow(flowID string, mutate func(FlowRecord, time.Time) (Fl
 	if err != nil {
 		return FlowRecord{}, err
 	}
-	record = normalizeRecord(record, true)
+	record = normalizeRecordBase(record)
 	record.Status = DeriveStatus(record)
 	if err := s.write(record); err != nil {
 		return FlowRecord{}, err
@@ -1939,6 +1947,10 @@ func (s *Store) write(record FlowRecord) error {
 }
 
 func (s *Store) readRecord(flowID string) (FlowRecord, bool) {
+	return s.readRecordWithReadiness(flowID, true)
+}
+
+func (s *Store) readRecordWithReadiness(flowID string, selfHealOnRead bool) (FlowRecord, bool) {
 	if err := validateFlowID(flowID); err != nil {
 		return FlowRecord{}, false
 	}
@@ -1956,7 +1968,11 @@ func (s *Store) readRecord(flowID string) (FlowRecord, bool) {
 	}
 	selfHeal := rawDependsOnPresentForTopLevel(record.Phases, presence)
 	record.Phases = backfillLinearDependsOnFromRaw(record.Phases, presence)
-	record = normalizeRecord(record, selfHeal)
+	if selfHealOnRead {
+		record = normalizeRecord(record, selfHeal)
+	} else {
+		record = normalizeRecordBase(record)
+	}
 	record.Status = DeriveStatus(record)
 	return record, true
 }
@@ -2024,10 +2040,7 @@ func defaultTime(value, fallback time.Time) time.Time {
 }
 
 func normalizeRecord(record FlowRecord, selfHeal bool) FlowRecord {
-	if record.Merge.Status == "" {
-		record.Merge.Status = MergePending
-	}
-	record.Phases = backfillPhaseKinds(record.Phases)
+	record = normalizeRecordBase(record)
 	// Load-path normalization only: edge-aware records and plan-review-kind
 	// records self-heal here; phase-affecting mutations call
 	// refreshPhaseReadiness explicitly for every graph shape.
@@ -2035,6 +2048,14 @@ func normalizeRecord(record FlowRecord, selfHeal bool) FlowRecord {
 		record = normalizeReviewOutcomes(record)
 		record = refreshPhaseReadiness(record, record.UpdatedAt)
 	}
+	return record
+}
+
+func normalizeRecordBase(record FlowRecord) FlowRecord {
+	if record.Merge.Status == "" {
+		record.Merge.Status = MergePending
+	}
+	record.Phases = backfillPhaseKinds(record.Phases)
 	return record
 }
 

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -1284,7 +1284,7 @@ func TestStoreResetAwaitingSessionPhaseRejectsIneligiblePhases(t *testing.T) {
 				return record
 			},
 			phaseID: "beta",
-			want:    "requires satisfied predecessors",
+			want:    "requires running recoverable phase",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1462,8 +1462,12 @@ func TestStoreResetRecoverableRunningPhaseRejectsLiveSessionMergedFromDuplicateR
 		t.Fatalf("phase rows changed after rejected reset: %#v", read.Phases)
 	}
 	for i := range read.Phases {
+		wantStatus := record.Phases[i].Status
+		if record.Phases[i].PhaseID == "omega" {
+			wantStatus = flowstore.PhaseReady
+		}
 		if read.Phases[i].PhaseID != record.Phases[i].PhaseID ||
-			read.Phases[i].Status != record.Phases[i].Status ||
+			read.Phases[i].Status != wantStatus ||
 			strings.Join(read.Phases[i].LaunchIDs, ",") != strings.Join(record.Phases[i].LaunchIDs, ",") ||
 			len(read.Phases[i].Sessions) != len(record.Phases[i].Sessions) {
 			t.Fatalf("phase %d changed after rejected reset: before=%#v after=%#v", i, record.Phases[i], read.Phases[i])
@@ -1515,8 +1519,12 @@ func TestStoreResetRecoverableRunningPhaseRejectsOtherLiveLaunchMergedFromDuplic
 		t.Fatalf("phase rows changed after rejected reset: %#v", read.Phases)
 	}
 	for i := range read.Phases {
+		wantStatus := record.Phases[i].Status
+		if record.Phases[i].PhaseID == "omega" {
+			wantStatus = flowstore.PhaseReady
+		}
 		if read.Phases[i].PhaseID != record.Phases[i].PhaseID ||
-			read.Phases[i].Status != record.Phases[i].Status ||
+			read.Phases[i].Status != wantStatus ||
 			strings.Join(read.Phases[i].LaunchIDs, ",") != strings.Join(record.Phases[i].LaunchIDs, ",") ||
 			len(read.Phases[i].Sessions) != len(record.Phases[i].Sessions) {
 			t.Fatalf("phase %d changed after rejected reset: before=%#v after=%#v", i, record.Phases[i], read.Phases[i])
@@ -3020,8 +3028,8 @@ func TestStoreSetPhaseConcurrentUpdatesDoNotOverwriteEachOther(t *testing.T) {
 		CreatedAt:    now,
 		UpdatedAt:    now,
 		Phases: []flowstore.FlowPhase{
-			{PhaseID: "plan", Title: "Plan", Kind: "plan", Status: flowstore.PhaseRunning, Order: 1, CreatedAt: now, UpdatedAt: now},
-			{PhaseID: "implementation", Title: "Implementation", Kind: "implementation", Status: flowstore.PhaseRunning, Order: 2, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "plan", Title: "Plan", Kind: flowstore.KindPlan, DependsOn: []string{}, Status: flowstore.PhaseRunning, Order: 1, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "implementation", Title: "Implementation", Kind: flowstore.KindImplementation, DependsOn: []string{}, Status: flowstore.PhaseRunning, Order: 2, CreatedAt: now, UpdatedAt: now},
 		},
 	})
 	if err != nil {
@@ -5646,6 +5654,209 @@ func TestCreateRejectsCyclicPhases(t *testing.T) {
 	}
 }
 
+func TestKindConstantsAndSemanticKind(t *testing.T) {
+	want := map[string]string{
+		"plan":                 flowstore.KindPlan,
+		"plan_review":          flowstore.KindPlanReview,
+		"implementation":       flowstore.KindImplementation,
+		"review_loop":          flowstore.KindReviewLoop,
+		"pr_creation":          flowstore.KindPRCreation,
+		"autoreview":           flowstore.KindAutoreview,
+		"merge":                flowstore.KindMerge,
+		"implementation_child": flowstore.KindImplementationChild,
+	}
+	for value, got := range want {
+		if got != value {
+			t.Fatalf("kind constant = %q, want %q", got, value)
+		}
+	}
+	if got := flowstore.SemanticKind(flowstore.FlowPhase{PhaseID: "plan-review"}); got != flowstore.KindPlanReview {
+		t.Fatalf("SemanticKind(plan-review) = %q, want plan_review", got)
+	}
+	if got := flowstore.SemanticKind(flowstore.FlowPhase{PhaseID: "plan-review", Kind: flowstore.KindImplementation}); got != flowstore.KindImplementation {
+		t.Fatalf("SemanticKind(explicit kind) = %q, want implementation", got)
+	}
+	if got := flowstore.SemanticKind(flowstore.FlowPhase{PhaseID: "custom"}); got != "" {
+		t.Fatalf("SemanticKind(custom) = %q, want empty", got)
+	}
+}
+
+func TestReadBackfillsKindFromWellKnownID(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := graphRecord(root, "20260607T120000Z-kind-backfill", []flowstore.FlowPhase{
+		graphPhase(now, "plan", flowstore.PhaseCompleted, nil),
+		graphPhase(now, "plan-review", flowstore.PhaseCompleted, nil),
+	})
+	record.Phases[1].Outcome = ""
+	writeFreshFlowRecordForTest(t, root, record)
+
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	review := phaseByID(t, read, "plan-review")
+	if review.Kind != flowstore.KindPlanReview {
+		t.Fatalf("plan-review Kind = %q, want %q", review.Kind, flowstore.KindPlanReview)
+	}
+	if review.Outcome != flowstore.OutcomeApproved {
+		t.Fatalf("plan-review Outcome = %q, want approved", review.Outcome)
+	}
+}
+
+func TestDownstreamGateByKind(t *testing.T) {
+	pr := flowstore.PullRequest{
+		Provider:   "github",
+		Number:     42,
+		URL:        "https://github.com/brian-bell/wtui/pull/42",
+		HeadBranch: "flow/kind",
+		BaseBranch: "main",
+	}
+	tests := []struct {
+		name  string
+		phase flowstore.FlowPhase
+		pr    flowstore.PullRequest
+		want  bool
+	}{
+		{name: "plan_review approved", phase: flowstore.FlowPhase{PhaseID: "design-review", Kind: flowstore.KindPlanReview, Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved}, want: true},
+		{name: "plan_review missing outcome", phase: flowstore.FlowPhase{PhaseID: "design-review", Kind: flowstore.KindPlanReview, Status: flowstore.PhaseCompleted}, want: false},
+		{name: "pr_creation with target", phase: flowstore.FlowPhase{PhaseID: "open-pr", Kind: flowstore.KindPRCreation, Status: flowstore.PhaseCompleted}, pr: pr, want: true},
+		{name: "pr_creation missing target", phase: flowstore.FlowPhase{PhaseID: "open-pr", Kind: flowstore.KindPRCreation, Status: flowstore.PhaseCompleted}, want: false},
+		{name: "default completed", phase: flowstore.FlowPhase{PhaseID: "verify", Kind: flowstore.KindImplementation, Status: flowstore.PhaseCompleted}, want: true},
+		{name: "id ignored when kind differs", phase: flowstore.FlowPhase{PhaseID: "plan-review", Kind: flowstore.KindImplementation, Status: flowstore.PhaseCompleted}, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			record := flowstore.FlowRecord{PR: tc.pr}
+			if got := flowstore.PhaseGateSatisfied(record, tc.phase); got != tc.want {
+				t.Fatalf("PhaseGateSatisfied() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReviewOutcomeValidationByKind(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		FlowID:       "custom-review-validation",
+		Title:        "Custom Review",
+		Instructions: "validate custom review outcomes",
+		RepoPath:     filepath.Join(root, "repo"),
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "design-review", Title: "Design Review", Kind: flowstore.KindPlanReview, DependsOn: []string{}, Status: flowstore.PhaseReady, Order: 1, CreatedAt: now, UpdatedAt: now},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	_, err = store.SetPhase(flowstore.PhaseUpdate{FlowID: record.FlowID, PhaseID: "design-review", Status: flowstore.PhaseCompleted})
+	if err == nil || !strings.Contains(err.Error(), "design-review (plan_review) completed requires outcome") {
+		t.Fatalf("SetPhase() error = %v, want custom review outcome validation", err)
+	}
+}
+
+func TestMergeKindPhaseByCustomID(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		FlowID:       "custom-merge-kind",
+		Title:        "Custom Merge",
+		Instructions: "merge by kind",
+		RepoPath:     filepath.Join(root, "repo"),
+		Branch:       "flow/custom-merge",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "ship", Title: "Ship", Kind: flowstore.KindMerge, DependsOn: []string{}, Status: flowstore.PhaseReady, Order: 1, CreatedAt: now, UpdatedAt: now},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	_, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{FlowID: record.FlowID, PhaseID: "ship", LaunchID: "launch-1", AutoLaunch: true})
+	if err == nil || !flowstore.IsAutoLaunchOutdated(err) {
+		t.Fatalf("auto AddPhaseLaunchID(custom merge) error = %v, want auto-launch outdated", err)
+	}
+	record, err = store.SetPhase(flowstore.PhaseUpdate{FlowID: record.FlowID, PhaseID: "ship", Status: flowstore.PhaseCompleted, Outcome: flowstore.MergeMerged})
+	if err != nil {
+		t.Fatalf("SetPhase(ship completed) error = %v", err)
+	}
+	record.PR = flowstore.PullRequest{Provider: "github", Number: 42, URL: "https://github.com/brian-bell/wtui/pull/42", HeadBranch: "flow/custom-merge", BaseBranch: "main"}
+	record, err = store.SetPR(flowstore.PRUpdate{FlowID: record.FlowID, Provider: record.PR.Provider, Number: record.PR.Number, URL: record.PR.URL, HeadBranch: record.PR.HeadBranch, BaseBranch: record.PR.BaseBranch})
+	if err != nil {
+		t.Fatalf("SetPR() error = %v", err)
+	}
+	_, err = store.SetMerge(flowstore.MergeUpdate{FlowID: record.FlowID, Status: flowstore.MergeMerged, Commit: "abc123", MergedAt: now})
+	if err != nil {
+		t.Fatalf("SetMerge(custom merge kind) error = %v", err)
+	}
+}
+
+func TestGraphRejectsTwoMergeKindPhases(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	_, err = store.Create(flowstore.FlowRecord{
+		Title:        "Two merges",
+		Instructions: "reject ambiguous merge phases",
+		RepoPath:     filepath.Join(root, "repo"),
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "ship", Title: "Ship", Kind: flowstore.KindMerge, DependsOn: []string{}, Status: flowstore.PhasePending, Order: 1, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "release", Title: "Release", Kind: flowstore.KindMerge, DependsOn: []string{}, Status: flowstore.PhasePending, Order: 2, CreatedAt: now, UpdatedAt: now},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "at most one merge phase") {
+		t.Fatalf("Create() error = %v, want single merge validation", err)
+	}
+}
+
+func TestAddChildPhaseUnderCustomImplementationID(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		FlowID:       "custom-implementation-parent",
+		Title:        "Custom Implementation",
+		Instructions: "children by kind",
+		RepoPath:     filepath.Join(root, "repo"),
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "build", Title: "Build", Kind: flowstore.KindImplementation, DependsOn: []string{}, Status: flowstore.PhaseCompleted, Order: 1, CreatedAt: now, UpdatedAt: now},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	updated, err := store.AddChildPhase(flowstore.ChildPhaseUpdate{FlowID: record.FlowID, ParentPhaseID: "build", PhaseID: "api", Title: "API", Order: 1})
+	if err != nil {
+		t.Fatalf("AddChildPhase(custom implementation) error = %v", err)
+	}
+	child := phaseByID(t, updated, "api")
+	if child.ParentPhaseID != "build" || child.Kind != flowstore.KindImplementationChild {
+		t.Fatalf("child = %#v, want implementation child under build", child)
+	}
+	_, err = store.AddChildPhase(flowstore.ChildPhaseUpdate{FlowID: record.FlowID, ParentPhaseID: "missing", PhaseID: "x", Title: "X", Order: 1})
+	if err == nil || !strings.Contains(err.Error(), `flow "custom-implementation-parent"`) {
+		t.Fatalf("AddChildPhase(missing parent) error = %v, want flow-loaded parent error", err)
+	}
+}
+
 func TestCreateRejectsChildDeclaredDependencies(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
@@ -5837,15 +6048,15 @@ func TestStoreAddPhaseLaunchIDRejectsReadyPhaseWithUnsatisfiedDependency(t *test
 		LaunchID:   "launch-stale-ready",
 		AutoLaunch: true,
 	})
-	if err == nil || !strings.Contains(err.Error(), "not eligible") {
-		t.Fatalf("AddPhaseLaunchID(stale ready) error = %v, want not eligible", err)
+	if err == nil || !strings.Contains(err.Error(), "not ready") {
+		t.Fatalf("AddPhaseLaunchID(stale ready) error = %v, want not ready", err)
 	}
 	read, err := store.Read(record.FlowID)
 	if err != nil {
 		t.Fatalf("Read() error = %v", err)
 	}
-	if got := phaseByID(t, read, "publish"); len(got.LaunchIDs) != 0 || got.Status != flowstore.PhaseReady {
-		t.Fatalf("publish after rejected launch = %#v, want unchanged ready without launch", got)
+	if got := phaseByID(t, read, "publish"); len(got.LaunchIDs) != 0 || got.Status != flowstore.PhasePending {
+		t.Fatalf("publish after rejected launch = %#v, want demoted pending without launch", got)
 	}
 }
 

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5824,6 +5824,27 @@ func TestGraphRejectsTwoMergeKindPhases(t *testing.T) {
 	}
 }
 
+func TestGraphRejectsTwoMergeKindPhasesWithoutExplicitEdges(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	_, err = store.Create(flowstore.FlowRecord{
+		Title:        "Two merges",
+		Instructions: "reject ambiguous merge phases",
+		RepoPath:     filepath.Join(root, "repo"),
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "ship", Title: "Ship", Kind: flowstore.KindMerge, Status: flowstore.PhasePending, Order: 1, CreatedAt: now, UpdatedAt: now},
+			{PhaseID: "release", Title: "Release", Kind: flowstore.KindMerge, Status: flowstore.PhasePending, Order: 2, CreatedAt: now, UpdatedAt: now},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "at most one merge phase") {
+		t.Fatalf("Create() error = %v, want single merge validation", err)
+	}
+}
+
 func TestAddChildPhaseUnderCustomImplementationID(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -3248,6 +3248,80 @@ func TestStoreSetIssuePersistsMetadata(t *testing.T) {
 	}
 }
 
+func TestStoreSetIssueDoesNotRefreshCustomFlowReadiness(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{
+		Root: root,
+		Now:  func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Issue metadata",
+		Instructions: "record the issue without touching phase state",
+		RepoPath:     filepath.Join(root, "repo"),
+		Phases: []flowstore.FlowPhase{
+			{
+				PhaseID:   "discover",
+				Title:     "Discover",
+				Kind:      flowstore.KindPlan,
+				Status:    flowstore.PhaseRunning,
+				Order:     1,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			{
+				PhaseID:   "build",
+				Title:     "Build",
+				Kind:      flowstore.KindImplementation,
+				DependsOn: []string{"discover"},
+				Status:    flowstore.PhaseRunning,
+				Order:     2,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	later := now.Add(time.Minute)
+	store, err = flowstore.NewStore(flowstore.StoreOptions{
+		Root: root,
+		Now:  func() time.Time { return later },
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	updated, err := store.SetIssue(flowstore.IssueUpdate{
+		FlowID:   record.FlowID,
+		Provider: "github",
+		Number:   123,
+		URL:      "https://github.com/brian-bell/wtui/issues/123",
+	})
+	if err != nil {
+		t.Fatalf("SetIssue() error = %v", err)
+	}
+
+	if got := phaseByID(t, updated, "build").Status; got != flowstore.PhaseRunning {
+		t.Fatalf("build status after SetIssue = %q, want running", got)
+	}
+	metaJSON, err := os.ReadFile(filepath.Join(root, "flows", record.FlowID, "meta.json"))
+	if err != nil {
+		t.Fatalf("read meta.json: %v", err)
+	}
+	var persisted flowstore.FlowRecord
+	if err := json.Unmarshal(metaJSON, &persisted); err != nil {
+		t.Fatalf("decode meta.json: %v", err)
+	}
+	if got := phaseByID(t, persisted, "build").Status; got != flowstore.PhaseRunning {
+		t.Fatalf("persisted build status after SetIssue = %q, want running", got)
+	}
+}
+
 func TestStoreSetIssueIdempotent(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -3193,6 +3193,77 @@ func TestStoreSetPRPersistsMetadataAndUngatesAutoreview(t *testing.T) {
 	}
 }
 
+func TestStoreSetPRNormalizesLegacyPlanReviewApprovalBeforeRefresh(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{
+		Root: root,
+		Now:  func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(flowstore.FlowRecord{
+		Title:        "Legacy PR metadata",
+		Instructions: "record the pull request for a legacy review outcome",
+		RepoPath:     filepath.Join(root, "repo"),
+		Branch:       "flow/legacy-pr-metadata",
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	for _, phaseID := range []string{"plan", "plan-review", "implementation", "review-loop", "pr-creation"} {
+		update := flowstore.PhaseUpdate{
+			FlowID:  record.FlowID,
+			PhaseID: phaseID,
+			Status:  flowstore.PhaseCompleted,
+		}
+		if phaseID == "plan-review" {
+			update.Outcome = flowstore.OutcomeApproved
+		}
+		record, err = store.SetPhase(update)
+		if err != nil {
+			t.Fatalf("SetPhase(%s completed) error = %v", phaseID, err)
+		}
+	}
+	for i := range record.Phases {
+		if record.Phases[i].PhaseID == "plan-review" {
+			record.Phases[i].Outcome = ""
+		}
+	}
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent() error = %v", err)
+	}
+	metaPath := filepath.Join(root, "flows", record.FlowID, "meta.json")
+	if err := os.WriteFile(metaPath, data, 0o600); err != nil {
+		t.Fatalf("WriteFile(meta.json) error = %v", err)
+	}
+
+	updated, err := store.SetPR(flowstore.PRUpdate{
+		FlowID:     record.FlowID,
+		Provider:   "github",
+		Number:     116,
+		URL:        "https://github.com/brian-bell/wtui/pull/116",
+		HeadBranch: "flow/legacy-pr-metadata",
+		BaseBranch: "main",
+		Status:     "open",
+	})
+	if err != nil {
+		t.Fatalf("SetPR() error = %v", err)
+	}
+
+	if got := phaseByID(t, updated, "plan-review").Outcome; got != flowstore.OutcomeApproved {
+		t.Fatalf("plan-review outcome after SetPR = %q, want legacy approved normalization", got)
+	}
+	if got := phaseByID(t, updated, "implementation").Status; got != flowstore.PhaseCompleted {
+		t.Fatalf("implementation status after SetPR = %q, want completed", got)
+	}
+	if got := phaseByID(t, updated, "autoreview").Status; got != flowstore.PhaseReady {
+		t.Fatalf("autoreview status after SetPR = %q, want ready", got)
+	}
+}
+
 func TestStoreSetIssuePersistsMetadata(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)

--- a/model/flow_advance_tick.go
+++ b/model/flow_advance_tick.go
@@ -236,7 +236,7 @@ func autoAdvanceStatusEvents(previous []flowstore.FlowRecord, launched []autoAdv
 			switch {
 			case phase.Status == flowstore.PhaseNeedsAttention && previousPhase.Status != flowstore.PhaseNeedsAttention:
 				events = append(events, "Flow "+flowTitleForStatus(record)+": needs attention")
-			case phaseID == "merge" && phase.Status == flowstore.PhaseReady && previousPhase.Status != flowstore.PhaseReady:
+			case flowstore.SemanticKind(phase) == flowstore.KindMerge && phase.Status == flowstore.PhaseReady && previousPhase.Status != flowstore.PhaseReady:
 				events = append(events, "Flow "+flowTitleForStatus(record)+": ready to merge")
 			}
 		}

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -79,7 +79,6 @@ func (m Model) flowPhaseLauncher() FlowPhaseLauncher {
 }
 
 func (l FlowPhaseLauncher) Preflight(req FlowPhaseLaunchRequest) (FlowPhaseLaunchPreparedRequest, error) {
-	phaseID := artifacts.NormalizePhaseID(req.Phase.PhaseID)
 	if agent.Normalize(l.AgentCommand) == "" {
 		return FlowPhaseLaunchPreparedRequest{}, FlowPhaseLaunchValidationError{
 			Message: "Press A to choose " + ui.AgentInputPlaceholder + " before launching an agent",
@@ -107,7 +106,7 @@ func (l FlowPhaseLauncher) Preflight(req FlowPhaseLaunchRequest) (FlowPhaseLaunc
 			return FlowPhaseLaunchPreparedRequest{}, FlowPhaseLaunchValidationError{Message: err.Error()}
 		}
 	}
-	if phaseID == "plan-review" && req.Record.PlanID == "" {
+	if flowstore.SemanticKind(req.Phase) == flowstore.KindPlanReview && req.Record.PlanID == "" {
 		return FlowPhaseLaunchPreparedRequest{}, FlowPhaseLaunchValidationError{Message: "Plan Review needs a linked plan before launch"}
 	}
 	generateLaunchID := l.NewLaunchID
@@ -125,7 +124,7 @@ func (l FlowPhaseLauncher) Preflight(req FlowPhaseLaunchRequest) (FlowPhaseLaunc
 
 func (l FlowPhaseLauncher) Prepare(req FlowPhaseLaunchPreparedRequest) (FlowPhaseLaunchResult, error) {
 	planBody := ""
-	if req.Record.PlanID != "" && flowPhasePromptNeedsPlanBody(req.Phase.PhaseID) {
+	if req.Record.PlanID != "" && flowPhasePromptNeedsPlanBody(req.Phase) {
 		body, err := l.readPlan(req.Record.PlanID)
 		if err != nil {
 			return FlowPhaseLaunchResult{}, fmt.Errorf("failed to read linked plan %s: %w", req.Record.PlanID, err)
@@ -337,7 +336,7 @@ func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstor
 			m = m.clearResolvedSuppressedAutoFlowLaunches(record)
 			continue
 		}
-		if artifacts.NormalizePhaseID(completedPhase.PhaseID) == "autoreview" {
+		if flowstore.SemanticKind(completedPhase) == flowstore.KindAutoreview {
 			continue
 		}
 		if m.isAutoFlowLaunchSuppressed(record.FlowID, completedPhase) {
@@ -579,14 +578,13 @@ func flowPhaseCanLaunchAtIndex(record flowstore.FlowRecord, phaseIndex int) bool
 		return false
 	}
 	phase := record.Phases[phaseIndex]
-	phaseID := artifacts.NormalizePhaseID(phase.PhaseID)
 	if phase.Status == flowstore.PhaseReady {
-		if phaseID == "merge" {
+		if flowstore.SemanticKind(phase) == flowstore.KindMerge {
 			return flowstore.PhasePredecessorsSatisfied(record, phase.PhaseID)
 		}
 		return flowstore.PhaseLaunchEligible(record, phaseIndex)
 	}
-	return phaseID == "autoreview" &&
+	return flowstore.SemanticKind(phase) == flowstore.KindAutoreview &&
 		(phase.Status == flowstore.PhaseNeedsAttention || phase.Status == flowstore.PhaseBlocked) &&
 		flowstore.HasPRTarget(record.PR) &&
 		flowstore.PhasePredecessorsSatisfied(record, phase.PhaseID)
@@ -612,8 +610,8 @@ func flowAutoreviewMissingPRTarget(record flowstore.FlowRecord) bool {
 	if flowstore.HasPRTarget(record.PR) {
 		return false
 	}
-	prCreation, hasPRCreation := flowPhaseByID(record, "pr-creation")
-	autoreview, hasAutoreview := flowPhaseByID(record, "autoreview")
+	prCreation, hasPRCreation := flowstore.FindPhaseByKind(record, flowstore.KindPRCreation)
+	autoreview, hasAutoreview := flowstore.FindPhaseByKind(record, flowstore.KindAutoreview)
 	if !hasPRCreation || !hasAutoreview || prCreation.Status != flowstore.PhaseCompleted {
 		return false
 	}

--- a/model/flow_phase_launch_internal_test.go
+++ b/model/flow_phase_launch_internal_test.go
@@ -64,6 +64,36 @@ func TestNextAutoLaunchPhaseSkipsDuplicateReadyRow(t *testing.T) {
 	}
 }
 
+func TestNextAutoLaunchPhaseSkipsMergeKindCustomID(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID:   "flow-1",
+		RepoPath: "/dev/alpha",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "ship", Kind: flowstore.KindMerge, Title: "Ship", DependsOn: []string{}, Status: flowstore.PhaseReady, Order: 1},
+			{PhaseID: "verify", Kind: flowstore.KindImplementation, Title: "Verify", DependsOn: []string{}, Status: flowstore.PhaseReady, Order: 2},
+		},
+	}
+
+	phase, ok := nextAutoLaunchPhase(record)
+	if !ok {
+		t.Fatal("nextAutoLaunchPhase() found no launchable phase")
+	}
+	if phase.PhaseID != "verify" {
+		t.Fatalf("nextAutoLaunchPhase() = %q, want verify", phase.PhaseID)
+	}
+}
+
+func TestFlowPhaseLaunchPreflightRequiresPlanForReviewKindCustomID(t *testing.T) {
+	launcher := FlowPhaseLauncher{AgentCommand: "codex"}
+	_, err := launcher.Preflight(FlowPhaseLaunchRequest{
+		Record: flowstore.FlowRecord{FlowID: "flow-1", RepoPath: "/dev/alpha"},
+		Phase:  flowstore.FlowPhase{PhaseID: "design-review", Kind: flowstore.KindPlanReview},
+	})
+	if err == nil || !strings.Contains(err.Error(), "Plan Review needs a linked plan") {
+		t.Fatalf("Preflight() error = %v, want linked-plan guard", err)
+	}
+}
+
 func TestSelectedFlowNextLaunchablePhaseSkipsDuplicateReadyRow(t *testing.T) {
 	record := flowstore.FlowRecord{
 		FlowID:   "flow-1",

--- a/model/flow_prompt_completion_test.go
+++ b/model/flow_prompt_completion_test.go
@@ -159,6 +159,43 @@ func TestFlowPhasePromptIncludesIssueMetadata(t *testing.T) {
 	}
 }
 
+func TestFlowPhasePromptUsesSemanticKindForCustomID(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		Instructions: "Build the requested change.",
+		PlanID:       "plan-1",
+		PlanPath:     "/state/plans/plan-1/plan.md",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-kind",
+		Branch:       "flow/kind",
+		Commit:       "abc123",
+		PR: flowstore.PullRequest{
+			Provider:   "github",
+			Number:     42,
+			URL:        "https://github.com/brian-bell/wtui/pull/42",
+			HeadBranch: "flow/kind",
+			BaseBranch: "main",
+		},
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "write-plan", Kind: flowstore.KindPlan, Title: "Write Plan", Status: flowstore.PhaseCompleted},
+			{PhaseID: "design-review", Kind: flowstore.KindPlanReview, Title: "Design Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
+		},
+	}
+
+	prPrompt := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "open-pr", Kind: flowstore.KindPRCreation, Title: "Open PR"}, record.PlanPath, "", model.FlowPromptTemplates{})
+	if !strings.Contains(prPrompt, "Use the ship skill") || strings.Contains(prPrompt, "Saved plan body") {
+		t.Fatalf("custom pr_creation prompt should use PR template without plan body:\n%s", prPrompt)
+	}
+	genericPrompt := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "qa-check", Title: "QA Check"}, record.PlanPath, "Plan body here.", model.FlowPromptTemplates{})
+	if !strings.Contains(genericPrompt, "Saved plan body:\nPlan body here.") {
+		t.Fatalf("unknown kind prompt should include plan body:\n%s", genericPrompt)
+	}
+	reviewPrompt := model.FlowPhasePromptForTest(record, flowstore.FlowPhase{PhaseID: "build", Kind: flowstore.KindImplementation, Title: "Build"}, "", "", model.FlowPromptTemplates{})
+	if !strings.Contains(reviewPrompt, "design-review") {
+		t.Fatalf("implementation prompt should pull plan-review context by kind:\n%s", reviewPrompt)
+	}
+}
+
 func TestFlowPromptPhaseDoneInstructionDuplicateGuard(t *testing.T) {
 	instruction := model.FlowPhaseDoneInstructionForTest()
 	record := flowstore.FlowRecord{

--- a/model/flow_prompts.go
+++ b/model/flow_prompts.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/brian-bell/wtui/flowstore"
-	"github.com/brian-bell/wtui/internal/artifacts"
 )
 
 const flowPhaseDoneInstruction = "After completing this phase goal, mark this Flow phase done with wtui-flow."
@@ -24,21 +23,21 @@ type FlowPromptTemplates struct {
 	Generic        string
 }
 
-func (templates FlowPromptTemplates) templateForPhase(phaseID string) string {
-	switch artifacts.NormalizePhaseID(phaseID) {
-	case "plan":
+func (templates FlowPromptTemplates) templateForPhase(phase flowstore.FlowPhase) string {
+	switch flowstore.SemanticKind(phase) {
+	case flowstore.KindPlan:
 		return templates.Plan
-	case "plan-review":
+	case flowstore.KindPlanReview:
 		return templates.PlanReview
-	case "implementation":
+	case flowstore.KindImplementation:
 		return templates.Implementation
-	case "review-loop":
+	case flowstore.KindReviewLoop:
 		return templates.ReviewLoop
-	case "pr-creation":
+	case flowstore.KindPRCreation:
 		return templates.PRCreation
-	case "autoreview":
+	case flowstore.KindAutoreview:
 		return templates.Autoreview
-	case "merge":
+	case flowstore.KindMerge:
 		return templates.Merge
 	default:
 		return templates.Generic
@@ -114,25 +113,25 @@ func lastNonEmptyPromptLine(text string) string {
 }
 
 func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string, templates FlowPromptTemplates) string {
-	if template := templates.templateForPhase(phase.PhaseID); strings.TrimSpace(template) != "" {
+	if template := templates.templateForPhase(phase); strings.TrimSpace(template) != "" {
 		prompt := renderFlowPromptTemplate(template, record, phase, planPath, planBody)
 		return ensureFlowPhaseDoneInstruction(prompt, template)
 	}
 	var prompt string
-	switch artifacts.NormalizePhaseID(phase.PhaseID) {
-	case "plan":
+	switch flowstore.SemanticKind(phase) {
+	case flowstore.KindPlan:
 		prompt = flowPlanPrompt(record, templates)
-	case "plan-review":
+	case flowstore.KindPlanReview:
 		prompt = flowPlanReviewPrompt(record, phase, planPath, planBody)
-	case "implementation":
+	case flowstore.KindImplementation:
 		prompt = flowImplementationPrompt(record, phase, planPath, planBody)
-	case "review-loop":
+	case flowstore.KindReviewLoop:
 		prompt = flowReviewLoopPrompt(record, phase, planPath, planBody)
-	case "pr-creation":
+	case flowstore.KindPRCreation:
 		prompt = flowPRCreationPrompt(record, phase, planPath, planBody)
-	case "autoreview":
+	case flowstore.KindAutoreview:
 		prompt = flowAutoreviewPrompt(record, phase, planPath, planBody)
-	case "merge":
+	case flowstore.KindMerge:
 		prompt = flowMergePrompt(record, phase, planPath, planBody)
 	default:
 		prompt = flowGenericPhasePrompt(record, phase, planPath, planBody)
@@ -140,9 +139,9 @@ func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, pla
 	return ensureFlowPhaseDoneInstruction(prompt, "")
 }
 
-func flowPhasePromptNeedsPlanBody(phaseID string) bool {
-	switch artifacts.NormalizePhaseID(phaseID) {
-	case "plan", "plan-review", "implementation", "review-loop", "pr-creation", "autoreview", "merge":
+func flowPhasePromptNeedsPlanBody(phase flowstore.FlowPhase) bool {
+	switch flowstore.SemanticKind(phase) {
+	case flowstore.KindPlan, flowstore.KindPlanReview, flowstore.KindImplementation, flowstore.KindReviewLoop, flowstore.KindPRCreation, flowstore.KindAutoreview, flowstore.KindMerge:
 		return false
 	default:
 		return true
@@ -166,7 +165,7 @@ func flowImplementationWithoutPlanPrompt(record flowstore.FlowRecord, phase flow
 	writeFlowChangeMetadata(&b, record)
 	writeFlowPromptHeader(&b, record, "")
 	writeFlowPromptPlanContext(&b, record, "")
-	writeFlowPromptPhaseSummary(&b, record, "Plan Review context", "plan-review")
+	writeFlowPromptPhaseSummaryByKind(&b, record, "Plan Review context", flowstore.KindPlanReview)
 	writeFlowRestartPromptIfNeeded(&b, record, phase)
 	b.WriteString("\nUse the commit skill before completing this phase.")
 	b.WriteString("\nAdvance this phase with `wtui flow phase set` only after the implementation is complete, blocked, or needs attention.")
@@ -291,16 +290,16 @@ func flowGenericPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPha
 	return b.String()
 }
 
-func writeFlowPromptPhaseSummary(b *strings.Builder, record flowstore.FlowRecord, title, phaseID string) {
+func writeFlowPromptPhaseSummaryByKind(b *strings.Builder, record flowstore.FlowRecord, title, kind string) {
 	b.WriteString("\n")
 	b.WriteString(title)
 	b.WriteString(":\n")
-	if phase, ok := flowPhaseByID(record, phaseID); ok {
+	if phase, ok := flowstore.FindPhaseByKind(record, kind); ok {
 		writeFlowPhaseContext(b, phase)
 		return
 	}
 	b.WriteString("- Phase: ")
-	b.WriteString(phaseID)
+	b.WriteString(kind)
 	b.WriteString("\n")
 }
 
@@ -322,7 +321,7 @@ func writeFlowPromptHeader(b *strings.Builder, record flowstore.FlowRecord, plan
 }
 
 func writeFlowPromptPlanContext(b *strings.Builder, record flowstore.FlowRecord, planBody string) {
-	if plan, ok := flowPhaseByID(record, "plan"); ok {
+	if plan, ok := flowstore.FindPhaseByKind(record, flowstore.KindPlan); ok {
 		b.WriteString("\nPrior Plan context:\n")
 		writeFlowPhaseContext(b, plan)
 	}

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -7772,6 +7772,57 @@ func TestModel_GFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNeedsAttention(t 
 	}
 }
 
+func TestModel_ActiveFlowCustomPlanReviewLaunchFailureMarksBlocked(t *testing.T) {
+	var phaseUpdate flowstore.PhaseUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		SetFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+			phaseUpdate = update
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return nil, errors.New("pty unavailable")
+		},
+	})
+	flow := flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/flow-failure",
+		PlanID:       "plan-1",
+		PlanPath:     "/tmp/plan.md",
+		Title:        "Custom review failure",
+		Status:       flowstore.StatusInProgress,
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "design-review", Title: "Design Review", Kind: flowstore.KindPlanReview, Status: flowstore.PhaseReady},
+		},
+	}
+	m = enterActiveFlowsWithRecords(t, m, []flowstore.FlowRecord{flow})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	for i := 0; i < 50 && model.SelectedActiveFlowPhaseIDForTest(m) != "design-review"; i++ {
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if got := model.SelectedActiveFlowPhaseIDForTest(m); got != "design-review" {
+		t.Fatalf("selected active Flow phase = %q, want design-review", got)
+	}
+
+	m, cmd := update(m, flowLaunchKey())
+	if cmd == nil {
+		t.Fatal("g should prepare an embedded launch")
+	}
+	m, _ = update(m, cmd())
+
+	if phaseUpdate.FlowID != "flow-1" ||
+		phaseUpdate.PhaseID != "design-review" ||
+		phaseUpdate.Status != flowstore.PhaseBlocked ||
+		phaseUpdate.Outcome != flowstore.OutcomeBlocked ||
+		!strings.Contains(phaseUpdate.Notes, "pty unavailable") {
+		t.Fatalf("phase update = %#v", phaseUpdate)
+	}
+}
+
 func TestModel_GFlowPhaseEmbeddedInteractivePrefillFailureCleansUpTerminal(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -887,7 +887,7 @@ func flowManualMergeEligible(record flowstore.FlowRecord) bool {
 	if record.Status == flowstore.StatusMerged || !flowstore.HasPRTarget(record.PR) {
 		return false
 	}
-	merge, ok := flowRecordPhaseByID(record, "merge")
+	merge, ok := flowstore.FindPhaseByKind(record, flowstore.KindMerge)
 	if !ok || !flowstore.PhasePredecessorsSatisfied(record, merge.PhaseID) {
 		return false
 	}
@@ -899,6 +899,15 @@ func flowManualMergeEligible(record flowstore.FlowRecord) bool {
 	default:
 		return false
 	}
+}
+
+func flowRecordByID(records []flowstore.FlowRecord, flowID string) (flowstore.FlowRecord, bool) {
+	for _, record := range records {
+		if record.FlowID == flowID {
+			return record, true
+		}
+	}
+	return flowstore.FlowRecord{}, false
 }
 
 func (m Model) markFlowManuallyMergedCmd(repoPath string, record flowstore.FlowRecord) tea.Cmd {
@@ -2303,7 +2312,15 @@ func (m Model) markFlowLaunchNeedsAttention(ctx actions.AgentLaunchContext, errT
 	}
 	status := flowstore.PhaseNeedsAttention
 	outcome := ""
-	if ctx.FlowPhaseID == "plan-review" {
+	if record, ok := flowRecordByID(m.flows.Items(), ctx.FlowID); ok {
+		if phase, ok := flowPhaseByID(record, ctx.FlowPhaseID); ok && flowstore.SemanticKind(phase) == flowstore.KindPlanReview {
+			status = flowstore.PhaseBlocked
+			outcome = flowstore.OutcomeBlocked
+		} else if ctx.FlowPhaseID == "plan-review" {
+			status = flowstore.PhaseBlocked
+			outcome = flowstore.OutcomeBlocked
+		}
+	} else if ctx.FlowPhaseID == "plan-review" {
 		status = flowstore.PhaseBlocked
 		outcome = flowstore.OutcomeBlocked
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -901,15 +901,6 @@ func flowManualMergeEligible(record flowstore.FlowRecord) bool {
 	}
 }
 
-func flowRecordByID(records []flowstore.FlowRecord, flowID string) (flowstore.FlowRecord, bool) {
-	for _, record := range records {
-		if record.FlowID == flowID {
-			return record, true
-		}
-	}
-	return flowstore.FlowRecord{}, false
-}
-
 func (m Model) markFlowManuallyMergedCmd(repoPath string, record flowstore.FlowRecord) tea.Cmd {
 	return func() tea.Msg {
 		merge, err := m.lookupPRMerge(record.PR.Number, record.PR.URL)
@@ -2312,14 +2303,9 @@ func (m Model) markFlowLaunchNeedsAttention(ctx actions.AgentLaunchContext, errT
 	}
 	status := flowstore.PhaseNeedsAttention
 	outcome := ""
-	if record, ok := flowRecordByID(m.flows.Items(), ctx.FlowID); ok {
-		if phase, ok := flowPhaseByID(record, ctx.FlowPhaseID); ok && flowstore.SemanticKind(phase) == flowstore.KindPlanReview {
-			status = flowstore.PhaseBlocked
-			outcome = flowstore.OutcomeBlocked
-		} else if ctx.FlowPhaseID == "plan-review" {
-			status = flowstore.PhaseBlocked
-			outcome = flowstore.OutcomeBlocked
-		}
+	if _, phase, ok := m.flowPhaseByID(ctx.FlowID, ctx.FlowPhaseID); ok && flowstore.SemanticKind(phase) == flowstore.KindPlanReview {
+		status = flowstore.PhaseBlocked
+		outcome = flowstore.OutcomeBlocked
 	} else if ctx.FlowPhaseID == "plan-review" {
 		status = flowstore.PhaseBlocked
 		outcome = flowstore.OutcomeBlocked

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -2954,7 +2954,7 @@ func flowPhaseState(record flowstore.FlowRecord, phase flowstore.FlowPhase) stri
 	if session, ok := flowstore.LatestPhaseSession(phase, false); ok && strings.TrimSpace(session.SessionID) == "" {
 		return "missing-session-id"
 	}
-	if phase.PhaseID == "autoreview" && flowMissingPRTarget(record) && phaseCanReportMissingPR(phase) {
+	if flowstore.SemanticKind(phase) == flowstore.KindAutoreview && flowMissingPRTarget(record) && phaseCanReportMissingPR(phase) {
 		return "missing-pr"
 	}
 	return flowBasePhaseState(phase)
@@ -3050,7 +3050,7 @@ func flowMissingPRTarget(record flowstore.FlowRecord) bool {
 		return false
 	}
 	for _, phase := range record.Phases {
-		if phase.PhaseID == "pr-creation" && phase.Status == flowstore.PhaseCompleted {
+		if flowstore.SemanticKind(phase) == flowstore.KindPRCreation && phase.Status == flowstore.PhaseCompleted {
 			return true
 		}
 	}

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -2353,6 +2353,32 @@ func TestRender_FlowsModeShowsAutoreviewMissingPRMetadata(t *testing.T) {
 	}
 }
 
+func TestRender_FlowsModeShowsAutoreviewKindMissingPRMetadata(t *testing.T) {
+	view := Render(RenderParams{
+		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},
+		Selected: 0,
+		Width:    240,
+		Height:   12,
+		Mode:     ModeFlows,
+		Flows: []flowstore.FlowRecord{{
+			FlowID: "missing-pr-flow",
+			Title:  "Needs PR metadata",
+			Status: flowstore.StatusInProgress,
+			Branch: "flow/missing-pr",
+			Phases: []flowstore.FlowPhase{
+				{PhaseID: "open-pr", Kind: flowstore.KindPRCreation, Title: "Open PR", Status: flowstore.PhaseCompleted},
+				{PhaseID: "second-review", Kind: flowstore.KindAutoreview, Title: "Second Review", Status: flowstore.PhasePending},
+			},
+		}},
+		ActivePane:   1,
+		FlowSelected: 0,
+	})
+
+	if !strings.Contains(view, "second-review:missing-pr") {
+		t.Fatalf("missing PR metadata view should key off autoreview kind:\n%s", view)
+	}
+}
+
 func TestRender_FlowsModeShowsRecoveryWarnings(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/dev/wtui", DisplayName: "wtui"}},


### PR DESCRIPTION
## Summary

Implements Flow graph M2 for issue #267 by moving Flow gate and semantic decisions away from literal preset phase IDs and onto phase kinds.

## Implementation

- Added phase kind constants/helpers and load-time normalization/backfill so persisted custom graphs can use semantic kind routing while preserving default preset behavior.
- Reworked flowstore gate validation, transition semantics, CLI outcome defaulting, model launch/readiness logic, and UI labels to route by phase kind.
- Covered custom phase graph behavior across flowstore, cmd/wtui, model, and UI tests, including duplicate merge-kind validation and review-loop follow-up fixes.

## Verification

- `gofmt -l .`
- `make test`
- `make build`

Closes #267.