### PR TITLE
Flow graph M4: configurable phase graph surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,10 +347,12 @@ basename, plan metadata, issue metadata, PR metadata,
 phase titles/statuses/summaries, and linked session metadata. Press
 `n` to create a new Flow with one form for title, multiline instructions, and
 optional base ref plus Headless and Plan Now checkboxes; use `alt+enter` for
-instruction newlines. Plan Now is checked by default and immediately launches
-the initial Plan phase after creating the Flow. Uncheck it to create a parked
-Flow with its instructions, worktree, branch, and start commit saved; the ready
-Plan phase can be launched later from the Flow row. On a Flow row, `enter`
+instruction newlines. New Flows use the built-in default phase graph unless
+`[flow].preset` selects a configured custom graph. Plan Now is checked by
+default and immediately launches the first ready root phase after creating the
+Flow. Uncheck it to create a parked Flow with its instructions, worktree,
+branch, and start commit saved; the ready root phase can be launched later from
+the Flow row. On a Flow row, `enter`
 expands or collapses phase detail rows; `o` pages the linked plan body in
 `less -R`, and wtui shows a status message when the selected Flow has no linked
 plan. With
@@ -380,13 +382,14 @@ when its recorded GitHub PR was merged manually in GitHub; wtui verifies the PR
 is merged with `gh`, records the merge commit and timestamp, marks the Merge
 phase completed, and hides the Flow from active lists without launching a Merge
 phase agent. When auto mode is on, wtui runs an always-on, all-repos advance
-poll that detects live completed-phase transitions and launches the next ready
-non-merge phase in that Flow even when another view is active. Auto-launched CLI
-phases are always headless and do not change the current view or focus. If the
-completed phase still has an embedded Flow terminal, wtui waits until that
-terminal exits normally and auto-closes before launching the next phase. A 3 s
-status message announces auto-launches, `needs_attention`, and merge-ready
-transitions unless another status message is active. Skipped, blocked,
+poll that detects live completed-phase transitions and drains the Flow by
+launching the first ready non-merge phase in display order. Auto-launched CLI
+phases are always headless and do not change the current view or focus. wtui
+launches at most one phase per Flow at a time: if any phase is running or any
+Flow-scoped embedded terminal is still open or auto-closing, the drain waits.
+A 3 s status message announces auto-launches, `needs_attention`, and
+merge-ready transitions unless another status message is active. Skipped,
+blocked,
 needs-attention, failed-launch, or missing-PR-metadata states do not
 auto-launch. Automation stops before Merge: if Autoreview completes and Merge
 becomes ready, wtui keeps auto mode on and requires the existing manual Merge
@@ -481,6 +484,11 @@ wtui flow create --title "Ship saved plans" \
   --instructions "Plan, implement, review, open a PR, and merge." \
   --repo-path "$REPO" --json
 
+# Use a configured custom graph preset instead of the built-in default.
+wtui flow create --preset research --title "Evaluate parser" \
+  --instructions "Research, draft, and publish." \
+  --repo-path "$REPO" --json
+
 # List or read flows.
 wtui flow list --repo-path "$REPO" --json
 wtui flow read --flow-id "$FLOW_ID"
@@ -553,7 +561,10 @@ recoverable: it restores the previous PR status, clears terminal merge
 metadata, marks the Merge phase `needs_attention`, and keeps the Flow visible
 for repair.
 
-Child implementation phases gate downstream readiness in phase order: review
+Custom phase graph presets are configured in `[flow]`; see `docs/config.md`.
+Phase gates are keyed by semantic kind (`plan_review`, `pr_creation`, `merge`,
+and so on), while CLI commands still address phases by phase ID. Child
+implementation phases gate downstream readiness in phase order: review
 loop and PR creation remain pending until required implementation children are
 completed or explicitly skipped with notes. Flow phase launch prompts stay
 minimal: Plan Review and Implementation point to the saved plan artifact, while

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -729,6 +729,7 @@ type AgentLaunchContext struct {
 	PlanPhaseStatus   string
 	FlowID            string
 	FlowPhaseID       string
+	FlowPhaseKind     string
 	FlowLaunchTracked bool
 	FlowAutoLaunch    bool
 	// FlowPhaseTerminal records that the persisted phase kept a terminal

--- a/agent-skills/skill_docs_test.go
+++ b/agent-skills/skill_docs_test.go
@@ -17,6 +17,7 @@ func TestWtuiFlowSkillDocumentsAgentContract(t *testing.T) {
 		"name: wtui-flow",
 		"WTUI_FLOW_ID",
 		"WTUI_FLOW_PHASE_ID",
+		"WTUI_CURRENT_PHASE_ID",
 	})
 	requireContainsAll(t, "flow commands", skill, []string{
 		"wtui flow read --flow-id",
@@ -204,6 +205,9 @@ func TestWtuiFlowCreateSkillDocumentsAgentContract(t *testing.T) {
 
 	if hasRunnableCommandExample(skill, "wtui flow session attach") {
 		t.Fatal("skill includes a runnable example for unimplemented command \"wtui flow session attach\"")
+	}
+	if strings.Contains(skill, "FLOW_PRESET") && regexp.MustCompile(`(?s)wtui flow phase (?:block|complete|needs-attention).*?--phase-id plan`).MatchString(skill) {
+		t.Fatal("wtui-flow-create should use the created Flow's plan-kind phase ID instead of hardcoded --phase-id plan")
 	}
 }
 

--- a/agent-skills/skill_docs_test.go
+++ b/agent-skills/skill_docs_test.go
@@ -258,6 +258,9 @@ func TestWtuiFlowCreateSkillGuardsPersistenceFailures(t *testing.T) {
 			"exit 1",
 		})
 	}
+	if strings.Contains(importBlock, "ready or candidates") {
+		t.Fatal("plan import should leave FLOW_PLAN_PHASE_ID empty when no plan-kind phase is ready")
+	}
 
 	readbackIndex := strings.Index(skill, `if ! wtui plan read --plan-id "$PLAN_ID"`)
 	completeIndex := strings.Index(skill, "if ! wtui flow phase complete")

--- a/agent-skills/wtui-flow-create/SKILL.md
+++ b/agent-skills/wtui-flow-create/SKILL.md
@@ -186,7 +186,9 @@ fi
 
 Prefer `--instructions-file` when the instructions are more than a short
 sentence; use `--instructions` for compact task text. `wtui flow create --json`
-prints machine-readable output containing `flow_id`.
+prints machine-readable output containing `flow_id`. Set `FLOW_PRESET` only
+when the user or surrounding workflow explicitly asks for a configured custom
+phase graph; omitted uses `[flow].preset` or the built-in `default` preset.
 
 ```bash
 if [ -z "${FLOW_TITLE:-}" ] || [ -z "${WTUI_REPO_PATH:-}" ]; then
@@ -204,6 +206,10 @@ if [ -z "${FLOW_INSTRUCTIONS_FILE:-}" ] && [ -z "${FLOW_INSTRUCTIONS:-}" ]; then
   echo "Flow creation requires FLOW_INSTRUCTIONS or FLOW_INSTRUCTIONS_FILE; ask the user for the task instructions." >&2
   exit 1
 fi
+FLOW_PRESET_ARGS=()
+if [ -n "${FLOW_PRESET:-}" ]; then
+  FLOW_PRESET_ARGS=(--preset "$FLOW_PRESET")
+fi
 
 if [ -n "${FLOW_INSTRUCTIONS_FILE:-}" ]; then
   if ! FLOW_JSON=$(wtui flow create \
@@ -214,6 +220,7 @@ if [ -n "${FLOW_INSTRUCTIONS_FILE:-}" ]; then
     --branch "${WTUI_BRANCH:-}" \
     --base-ref "${WTUI_BASE_REF:-}" \
     --commit "${WTUI_COMMIT:-}" \
+    "${FLOW_PRESET_ARGS[@]}" \
     --json \
     "${FLOW_STATE_ARGS[@]}"); then
     echo "wtui flow create failed; report the command error to the user." >&2
@@ -228,6 +235,7 @@ else
     --branch "${WTUI_BRANCH:-}" \
     --base-ref "${WTUI_BASE_REF:-}" \
     --commit "${WTUI_COMMIT:-}" \
+    "${FLOW_PRESET_ARGS[@]}" \
     --json \
     "${FLOW_STATE_ARGS[@]}"); then
     echo "wtui flow create failed; report the command error to the user." >&2

--- a/agent-skills/wtui-flow-create/SKILL.md
+++ b/agent-skills/wtui-flow-create/SKILL.md
@@ -300,7 +300,7 @@ def semantic_kind(phase):
     return "plan" if (phase.get("phase_id") or "").strip().lower() == "plan" else ""
 candidates = [phase for phase in phases if semantic_kind(phase) == "plan"]
 ready = [phase for phase in candidates if phase.get("status") == "ready"]
-picked = (ready or candidates or [{}])[0]
+picked = (ready or [{}])[0]
 print(picked.get("phase_id", ""))'); then
   echo "wtui flow create returned JSON that could not be parsed for a plan-kind phase; report the command error to the user." >&2
   exit 1
@@ -360,9 +360,10 @@ else
 fi
 ```
 
-Only complete the new Flow's plan-kind phase after all four steps succeed: plan
-save, flow-plan link, plan readback, and phase completion. If the selected
-preset has no plan-kind phase, link the plan but do not complete a Flow phase.
+Only complete the new Flow's ready plan-kind phase after all four steps succeed:
+plan save, flow-plan link, plan readback, and phase completion. If the selected
+preset has no ready plan-kind phase, link the plan but do not complete a Flow
+phase.
 If there is no concrete plan body, report the new Flow ID and leave Plan ready
 for a normal Flow Plan launch.
 

--- a/agent-skills/wtui-flow-create/SKILL.md
+++ b/agent-skills/wtui-flow-create/SKILL.md
@@ -290,11 +290,31 @@ if [ -z "${PLAN_MARKDOWN:-}" ]; then
   exit 0
 fi
 
+if ! FLOW_PLAN_PHASE_ID=$(printf '%s' "$FLOW_JSON" | python3 -c 'import json, sys
+record = json.load(sys.stdin)
+phases = record.get("phases", [])
+def semantic_kind(phase):
+    kind = (phase.get("kind") or "").strip().lower()
+    if kind:
+        return kind
+    return "plan" if (phase.get("phase_id") or "").strip().lower() == "plan" else ""
+candidates = [phase for phase in phases if semantic_kind(phase) == "plan"]
+ready = [phase for phase in candidates if phase.get("status") == "ready"]
+picked = (ready or candidates or [{}])[0]
+print(picked.get("phase_id", ""))'); then
+  echo "wtui flow create returned JSON that could not be parsed for a plan-kind phase; report the command error to the user." >&2
+  exit 1
+fi
+
 record_plan_import_failure() {
   notes="${1:-}"
+  if [ -z "${FLOW_PLAN_PHASE_ID:-}" ]; then
+    echo "Plan import failed, and Flow $FLOW_ID has no plan-kind phase to mark blocked; report both facts to the user." >&2
+    return 0
+  fi
   if ! wtui flow phase block \
     --flow-id "$FLOW_ID" \
-    --phase-id plan \
+    --phase-id "$FLOW_PLAN_PHASE_ID" \
     --notes "$notes" \
     "${FLOW_STATE_ARGS[@]}"; then
     echo "wtui flow phase block failed after plan import failure; report both command errors to the user." >&2
@@ -326,20 +346,25 @@ if ! wtui plan read --plan-id "$PLAN_ID" "${PLAN_STATE_ARGS[@]}" >/dev/null; the
   exit 1
 fi
 
-if ! wtui flow phase complete \
-  --flow-id "$FLOW_ID" \
-  --phase-id plan \
-  --summary "Imported plan $PLAN_ID." \
-  "${FLOW_STATE_ARGS[@]}"; then
-  record_plan_import_failure "wtui flow phase complete failed after importing plan $PLAN_ID; report the command error to the user."
-  exit 1
+if [ -n "${FLOW_PLAN_PHASE_ID:-}" ]; then
+  if ! wtui flow phase complete \
+    --flow-id "$FLOW_ID" \
+    --phase-id "$FLOW_PLAN_PHASE_ID" \
+    --summary "Imported plan $PLAN_ID." \
+    "${FLOW_STATE_ARGS[@]}"; then
+    record_plan_import_failure "wtui flow phase complete failed after importing plan $PLAN_ID; report the command error to the user."
+    exit 1
+  fi
+else
+  echo "Imported and linked plan $PLAN_ID; Flow $FLOW_ID has no plan-kind phase to complete, so leave it ready for its configured first phase." >&2
 fi
 ```
 
-Only complete the new Flow's `plan` phase after all four steps succeed: plan
-save, flow-plan link, plan readback, and phase completion. If there is no
-concrete plan body, report the new Flow ID and leave Plan ready for a normal
-Flow Plan launch.
+Only complete the new Flow's plan-kind phase after all four steps succeed: plan
+save, flow-plan link, plan readback, and phase completion. If the selected
+preset has no plan-kind phase, link the plan but do not complete a Flow phase.
+If there is no concrete plan body, report the new Flow ID and leave Plan ready
+for a normal Flow Plan launch.
 
 ## Persistence Failures
 
@@ -355,13 +380,13 @@ also succeeded. The import snippet above uses this recovery command:
 ```bash
 wtui flow phase block \
   --flow-id "$FLOW_ID" \
-  --phase-id plan \
+  --phase-id "$FLOW_PLAN_PHASE_ID" \
   --notes "Plan import failed; report the wtui command error to the user." \
   "${FLOW_STATE_ARGS[@]}"
 ```
 
-Use `wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id plan
---notes "..." "${FLOW_STATE_ARGS[@]}"` instead when the Flow can continue but
-the imported plan should be reviewed before implementation. If this recovery
-update fails too, report both the original command error and the recovery
-command error.
+Use `wtui flow phase needs-attention --flow-id "$FLOW_ID" --phase-id
+"$FLOW_PLAN_PHASE_ID" --notes "..." "${FLOW_STATE_ARGS[@]}"` instead when the
+Flow can continue but the imported plan should be reviewed before
+implementation. If this recovery update fails too, report both the original
+command error and the recovery command error.

--- a/agent-skills/wtui-flow/SKILL.md
+++ b/agent-skills/wtui-flow/SKILL.md
@@ -25,8 +25,14 @@ if [ -n "$WTUI_ARTIFACT_ROOT" ]; then
   PLAN_STATE_ARGS=(--state-root "$WTUI_ARTIFACT_ROOT")
 fi
 
-if ! wtui flow read --flow-id "$WTUI_FLOW_ID" "${FLOW_STATE_ARGS[@]}" >/dev/null; then
+if ! FLOW_JSON=$(wtui flow read --flow-id "$WTUI_FLOW_ID" "${FLOW_STATE_ARGS[@]}"); then
   echo "wtui flow read failed; report the command error to the user." >&2
+  exit 1
+fi
+
+WTUI_CURRENT_PHASE_ID="${WTUI_FLOW_PHASE_ID:-${WTUI_PLAN_PHASE_ID:-}}"
+if [ -z "$WTUI_CURRENT_PHASE_ID" ]; then
+  echo "WTUI_FLOW_PHASE_ID is required; report the missing launch metadata to the user." >&2
   exit 1
 fi
 ```
@@ -35,6 +41,12 @@ Also use the launch metadata when present: `WTUI_FLOW_PHASE_ID`,
 `WTUI_PLAN_ID`, `WTUI_PLAN_PATH`, `WTUI_REPO_PATH`, `WTUI_WORKTREE_PATH`,
 `WTUI_BRANCH`, `WTUI_COMMIT`, `WTUI_SESSION_STATE_ROOT`, and
 `WTUI_PLAN_STATE_ROOT`.
+
+When mutating your own Flow phase, use `WTUI_CURRENT_PHASE_ID` rather than a
+hardcoded default preset phase ID. The default preset phase IDs are `plan`,
+`plan-review`, `implementation`, `review-loop`, `pr-creation`, `autoreview`,
+and `merge`, but custom presets may use different IDs for the same semantic
+phase kinds.
 
 Agent-facing phase statuses are `running`, `needs_attention`, `completed`,
 `blocked`, and `skipped`. Report only the status of your own phase honestly;
@@ -131,7 +143,7 @@ if ! PLAN_ID=$(printf '%s' "$PLAN_MARKDOWN" | wtui plan save \
     "${PLAN_STATE_ARGS[@]}"); then
   wtui flow phase set \
     --flow-id "$WTUI_FLOW_ID" \
-    --phase-id plan \
+    --phase-id "$WTUI_CURRENT_PHASE_ID" \
     --status blocked \
     --outcome "plan_save_failed" \
     --notes "wtui plan save failed; report the command error to the user." \
@@ -145,7 +157,7 @@ if ! wtui flow plan set \
     "${FLOW_STATE_ARGS[@]}"; then
   wtui flow phase set \
     --flow-id "$WTUI_FLOW_ID" \
-    --phase-id plan \
+    --phase-id "$WTUI_CURRENT_PHASE_ID" \
     --status blocked \
     --outcome "plan_link_failed" \
     --notes "wtui flow plan set failed for saved plan $PLAN_ID; report the command error to the user." \
@@ -153,27 +165,50 @@ if ! wtui flow plan set \
   exit 1
 fi
 
-if ! wtui plan phase set \
-    --plan-id "$PLAN_ID" \
-    --phase-id implementation \
-    --title "Implementation" \
-    --status pending \
-    --order 1 \
-    "${PLAN_STATE_ARGS[@]}"; then
+if ! WTUI_PLAN_PHASE_EXPORTS=$(printf '%s' "$FLOW_JSON" | python3 -c 'import json, shlex, sys
+record = json.load(sys.stdin)
+def semantic_kind(phase):
+    kind = (phase.get("kind") or "").strip().lower()
+    if kind:
+        return kind
+    return "implementation" if (phase.get("phase_id") or "").strip().lower() == "implementation" else ""
+phase = next((phase for phase in record.get("phases", []) if semantic_kind(phase) == "implementation"), {})
+print("WTUI_PLAN_NEXT_PHASE_ID=" + shlex.quote((phase.get("phase_id") or "").strip()))
+print("WTUI_PLAN_NEXT_PHASE_TITLE=" + shlex.quote((phase.get("title") or phase.get("phase_id") or "").strip()))'); then
   wtui flow phase set \
     --flow-id "$WTUI_FLOW_ID" \
-    --phase-id plan \
+    --phase-id "$WTUI_CURRENT_PHASE_ID" \
     --status blocked \
-    --outcome "plan_phase_save_failed" \
-    --notes "wtui plan phase set failed for saved plan $PLAN_ID; report the command error to the user." \
+    --outcome "plan_phase_discovery_failed" \
+    --notes "wtui flow read JSON could not be parsed for the next saved-plan phase; report the command error to the user." \
     "${FLOW_STATE_ARGS[@]}"
   exit 1
+fi
+eval "$WTUI_PLAN_PHASE_EXPORTS"
+
+if [ -n "${WTUI_PLAN_NEXT_PHASE_ID:-}" ]; then
+  if ! wtui plan phase set \
+      --plan-id "$PLAN_ID" \
+      --phase-id "$WTUI_PLAN_NEXT_PHASE_ID" \
+      --title "${WTUI_PLAN_NEXT_PHASE_TITLE:-$WTUI_PLAN_NEXT_PHASE_ID}" \
+      --status pending \
+      --order 1 \
+      "${PLAN_STATE_ARGS[@]}"; then
+    wtui flow phase set \
+      --flow-id "$WTUI_FLOW_ID" \
+      --phase-id "$WTUI_CURRENT_PHASE_ID" \
+      --status blocked \
+      --outcome "plan_phase_save_failed" \
+      --notes "wtui plan phase set failed for saved plan $PLAN_ID; report the command error to the user." \
+      "${FLOW_STATE_ARGS[@]}"
+    exit 1
+  fi
 fi
 
 if ! wtui plan read --plan-id "$PLAN_ID" "${PLAN_STATE_ARGS[@]}" >/dev/null; then
   wtui flow phase set \
     --flow-id "$WTUI_FLOW_ID" \
-    --phase-id plan \
+    --phase-id "$WTUI_CURRENT_PHASE_ID" \
     --status blocked \
     --outcome "plan_read_failed" \
     --notes "Saved plan $PLAN_ID could not be read back; report the command error to the user." \
@@ -183,7 +218,7 @@ fi
 
 wtui flow phase complete \
   --flow-id "$WTUI_FLOW_ID" \
-  --phase-id plan \
+  --phase-id "$WTUI_CURRENT_PHASE_ID" \
   --outcome "plan_saved" \
   --summary "Saved and linked plan $PLAN_ID." \
   "${FLOW_STATE_ARGS[@]}"
@@ -214,7 +249,7 @@ if [ -z "$WTUI_PLAN_ID" ]; then
   if ! WTUI_PLAN_ID=$(printf '%s' "$FLOW_JSON" | python3 -c 'import json, sys; print(json.load(sys.stdin).get("plan_id", ""))'); then
     wtui flow phase set \
       --flow-id "$WTUI_FLOW_ID" \
-      --phase-id plan-review \
+      --phase-id "$WTUI_CURRENT_PHASE_ID" \
       --status blocked \
       --outcome "blocked" \
       --notes "wtui flow read returned JSON that could not be parsed for plan_id; report the command error to the user." \
@@ -226,7 +261,7 @@ fi
 if [ -z "$WTUI_PLAN_ID" ]; then
   wtui flow phase set \
     --flow-id "$WTUI_FLOW_ID" \
-    --phase-id plan-review \
+    --phase-id "$WTUI_CURRENT_PHASE_ID" \
     --status blocked \
     --outcome "blocked" \
     --notes "Plan Review needs the plan ID from the completed Plan phase." \
@@ -237,7 +272,7 @@ fi
 if ! wtui plan read --plan-id "$WTUI_PLAN_ID" "${PLAN_STATE_ARGS[@]}" >/dev/null; then
   wtui flow phase set \
     --flow-id "$WTUI_FLOW_ID" \
-    --phase-id plan-review \
+    --phase-id "$WTUI_CURRENT_PHASE_ID" \
     --status blocked \
     --outcome "blocked" \
     --notes "wtui plan read failed for $WTUI_PLAN_ID; report the command error to the user." \
@@ -247,7 +282,7 @@ fi
 
 wtui flow phase complete \
   --flow-id "$WTUI_FLOW_ID" \
-  --phase-id plan-review \
+  --phase-id "$WTUI_CURRENT_PHASE_ID" \
   --summary "Plan is ready for implementation." \
   "${FLOW_STATE_ARGS[@]}"
 ```
@@ -289,7 +324,7 @@ its work is done.
 ```bash
 wtui flow phase set \
   --flow-id "$WTUI_FLOW_ID" \
-  --phase-id implementation \
+  --phase-id "$WTUI_CURRENT_PHASE_ID" \
   --status completed \
   --outcome "implemented" \
   --summary "Implemented the accepted plan and verified the target tests." \
@@ -313,7 +348,7 @@ fixed, `needs_attention` when non-blocking concerns remain for the user, and
 ```bash
 wtui flow phase set \
   --flow-id "$WTUI_FLOW_ID" \
-  --phase-id review-loop \
+  --phase-id "$WTUI_CURRENT_PHASE_ID" \
   --status completed \
   --outcome "completed" \
   --summary "Review loop passed after revisions." \
@@ -343,7 +378,7 @@ wtui flow pr set \
 
 wtui flow phase set \
   --flow-id "$WTUI_FLOW_ID" \
-  --phase-id pr-creation \
+  --phase-id "$WTUI_CURRENT_PHASE_ID" \
   --status completed \
   --outcome "pr_open" \
   --summary "Opened GitHub PR #123." \
@@ -372,14 +407,14 @@ complete it after the rerun succeeds:
 ```bash
 wtui flow phase restart \
   --flow-id "$WTUI_FLOW_ID" \
-  --phase-id autoreview \
+  --phase-id "$WTUI_CURRENT_PHASE_ID" \
   "${FLOW_STATE_ARGS[@]}"
 ```
 
 ```bash
 wtui flow phase complete \
   --flow-id "$WTUI_FLOW_ID" \
-  --phase-id autoreview \
+  --phase-id "$WTUI_CURRENT_PHASE_ID" \
   --summary "Autoreview passed; no blocking findings remain." \
   "${FLOW_STATE_ARGS[@]}"
 ```
@@ -397,7 +432,7 @@ commands must succeed before reporting the Flow as merged.
 ```bash
 wtui flow phase set \
   --flow-id "$WTUI_FLOW_ID" \
-  --phase-id merge \
+  --phase-id "$WTUI_CURRENT_PHASE_ID" \
   --status completed \
   --outcome "merged" \
   --summary "Merged PR github#123 at commit $MERGE_COMMIT." \
@@ -417,7 +452,7 @@ record the structured blocked merge status:
 ```bash
 wtui flow phase set \
   --flow-id "$WTUI_FLOW_ID" \
-  --phase-id merge \
+  --phase-id "$WTUI_CURRENT_PHASE_ID" \
   --status blocked \
   --outcome "blocked" \
   --notes "Explain why merge is blocked." \

--- a/agent-skills/wtui-flow/SKILL.md
+++ b/agent-skills/wtui-flow/SKILL.md
@@ -47,7 +47,8 @@ or needs-attention phase as `running` requires a rerun note; prefer
 omitted. Invalid transitions fail with the allowed next statuses; fix the
 reported state rather than retrying blindly.
 
-For the `plan-review` phase, wtui accepts only these review outcomes:
+For plan-review-kind phases (the default preset phase ID is `plan-review`),
+wtui accepts only these review outcomes:
 `approved`, `approved_with_concerns`, `changes_requested`, and `blocked`.
 `approved_with_concerns`, `changes_requested`, and `blocked` require
 `--notes`.
@@ -67,7 +68,7 @@ wtui flow phase complete \
 
 Use `wtui flow phase block --notes "..."` for blockers and
 `wtui flow phase needs-attention --notes "..."` for non-blocking concerns.
-For Plan Review, those wrappers fill default outcomes when omitted:
+For plan-review-kind phases, those wrappers fill default outcomes when omitted:
 `complete` => `approved`, `needs-attention` => `changes_requested`, and
 `block` => `blocked`. The `complete` wrapper can still take an explicit
 Plan Review outcome such as `approved_with_concerns`. For Autoreview, the
@@ -263,17 +264,18 @@ or an external dependency prevents review; the Plan Review outcome defaults to
 
 Goal: implement the reviewed plan in the Flow worktree.
 
-TUI-launched Implementation phases provide `WTUI_FLOW_ID`,
-`WTUI_FLOW_PHASE_ID=implementation`, `WTUI_PLAN_ID`, `WTUI_PLAN_PATH`,
-`WTUI_WORKTREE_PATH`, and the shared state roots. Use `wtui plan read` when
-`WTUI_PLAN_ID` is available, then implement and verify the requested behavior in
-the Flow worktree. If the work splits into follow-up child phases, create stable
-ordered children before advancing downstream phases:
+TUI-launched implementation-kind phases provide `WTUI_FLOW_ID`,
+`WTUI_FLOW_PHASE_ID` (default preset: `implementation`), `WTUI_PLAN_ID`,
+`WTUI_PLAN_PATH`, `WTUI_WORKTREE_PATH`, and the shared state roots. Use
+`wtui plan read` when `WTUI_PLAN_ID` is available, then implement and verify the
+requested behavior in the Flow worktree. If the work splits into follow-up
+child phases under an implementation-kind parent, create stable ordered children
+before advancing downstream phases:
 
 ```bash
 wtui flow phase add-child \
   --flow-id "$WTUI_FLOW_ID" \
-  --parent-phase-id implementation \
+  --parent-phase-id "$WTUI_FLOW_PHASE_ID" \
   --phase-id implementation-api \
   --title "API integration" \
   --order 10 \

--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -91,9 +91,6 @@ Most commands accept:
 `
 
 func newFlowStore(stateRoot string, deps runDeps) (*flowstore.Store, error) {
-	if stateRoot != "" {
-		return flowstore.NewStore(flowstore.StoreOptions{Root: stateRoot})
-	}
 	cfg, err := deps.loadConfig()
 	if err != nil {
 		return nil, fmt.Errorf("error loading config: %w", err)

--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -91,6 +91,19 @@ Most commands accept:
 `
 
 func newFlowStore(stateRoot string, deps runDeps) (*flowstore.Store, error) {
+	root := stateRoot
+	if root == "" {
+		if envRoot := deps.getenv("WTUI_FLOW_STATE_ROOT"); envRoot != "" {
+			root = envRoot
+		} else if envRoot := deps.getenv("WTUI_PLAN_STATE_ROOT"); envRoot != "" {
+			root = envRoot
+		} else if envRoot := deps.getenv("WTUI_SESSION_STATE_ROOT"); envRoot != "" {
+			root = envRoot
+		}
+	}
+	if root != "" {
+		return flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	}
 	cfg, err := deps.loadConfig()
 	if err != nil {
 		return nil, fmt.Errorf("error loading config: %w", err)

--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -91,18 +91,8 @@ Most commands accept:
 `
 
 func newFlowStore(stateRoot string, deps runDeps) (*flowstore.Store, error) {
-	root := stateRoot
-	if root == "" {
-		if envRoot := deps.getenv("WTUI_FLOW_STATE_ROOT"); envRoot != "" {
-			root = envRoot
-		} else if envRoot := deps.getenv("WTUI_PLAN_STATE_ROOT"); envRoot != "" {
-			root = envRoot
-		} else if envRoot := deps.getenv("WTUI_SESSION_STATE_ROOT"); envRoot != "" {
-			root = envRoot
-		}
-	}
-	if root != "" {
-		return flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if stateRoot != "" {
+		return flowstore.NewStore(flowstore.StoreOptions{Root: stateRoot})
 	}
 	cfg, err := deps.loadConfig()
 	if err != nil {

--- a/cmd/wtui/flow.go
+++ b/cmd/wtui/flow.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/brian-bell/wtui/config"
 	"github.com/brian-bell/wtui/flowstore"
 )
 
@@ -89,35 +90,31 @@ Most commands accept:
   --state-root PATH  Override the artifact state root after the leaf command.
 `
 
-// resolveFlowRoot applies the documented precedence:
-// --state-root > WTUI_FLOW_STATE_ROOT > WTUI_PLAN_STATE_ROOT >
-// WTUI_SESSION_STATE_ROOT > [sessions].root from config > flowstore.DefaultRoot().
-func resolveFlowRoot(stateRoot string, deps runDeps) (string, error) {
-	if stateRoot != "" {
-		return stateRoot, nil
-	}
-	if root := deps.getenv("WTUI_FLOW_STATE_ROOT"); root != "" {
-		return root, nil
-	}
-	if root := deps.getenv("WTUI_PLAN_STATE_ROOT"); root != "" {
-		return root, nil
-	}
-	if root := deps.getenv("WTUI_SESSION_STATE_ROOT"); root != "" {
-		return root, nil
-	}
+func newFlowStore(stateRoot string, deps runDeps) (*flowstore.Store, error) {
 	cfg, err := deps.loadConfig()
 	if err != nil {
-		return "", fmt.Errorf("error loading config: %w", err)
+		return nil, fmt.Errorf("error loading config: %w", err)
 	}
-	return cfg.Sessions.Root, nil
+	return newFlowStoreWithConfig(stateRoot, cfg, deps)
 }
 
-func newFlowStore(stateRoot string, deps runDeps) (*flowstore.Store, error) {
-	root, err := resolveFlowRoot(stateRoot, deps)
-	if err != nil {
-		return nil, err
+func newFlowStoreWithConfig(stateRoot string, cfg config.Config, deps runDeps) (*flowstore.Store, error) {
+	root := stateRoot
+	if root == "" {
+		if envRoot := deps.getenv("WTUI_FLOW_STATE_ROOT"); envRoot != "" {
+			root = envRoot
+		} else if envRoot := deps.getenv("WTUI_PLAN_STATE_ROOT"); envRoot != "" {
+			root = envRoot
+		} else if envRoot := deps.getenv("WTUI_SESSION_STATE_ROOT"); envRoot != "" {
+			root = envRoot
+		} else {
+			root = cfg.Sessions.Root
+		}
 	}
-	return flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if root == "" {
+		root = cfg.Sessions.Root
+	}
+	return flowstore.NewStore(flowstore.StoreOptions{Root: root, Presets: cfg.Flow.Presets})
 }
 
 func runFlowCreate(args []string, deps runDeps) error {
@@ -132,6 +129,7 @@ func runFlowCreate(args []string, deps runDeps) error {
 	branch := flags.String("branch", "", "branch name")
 	baseRef := flags.String("base-ref", "", "base ref")
 	commit := flags.String("commit", "", "start commit")
+	presetName := flags.String("preset", "", "flow phase graph preset")
 	stateRoot := flags.String("state-root", "", "artifact state root")
 	asJSON := flags.Bool("json", false, "emit JSON output")
 	if help, err := parseCommandFlags(flags, args); help || err != nil {
@@ -156,11 +154,19 @@ func runFlowCreate(args []string, deps runDeps) error {
 	if err != nil {
 		return err
 	}
-	store, err := newFlowStore(*stateRoot, deps)
+	cfg, err := deps.loadConfig()
+	if err != nil {
+		return fmt.Errorf("error loading config: %w", err)
+	}
+	preset, err := resolveConfiguredFlowPreset(cfg, *presetName)
 	if err != nil {
 		return err
 	}
-	record, err := store.Create(flowstore.FlowRecord{
+	store, err := newFlowStoreWithConfig(*stateRoot, cfg, deps)
+	if err != nil {
+		return err
+	}
+	record, err := store.CreateWithOptions(flowstore.FlowRecord{
 		Title:        *title,
 		Instructions: body,
 		RepoPath:     *repoPath,
@@ -168,11 +174,45 @@ func runFlowCreate(args []string, deps runDeps) error {
 		Branch:       *branch,
 		BaseRef:      *baseRef,
 		Commit:       *commit,
-	})
+	}, flowstore.CreateOptions{Preset: preset})
 	if err != nil {
 		return err
 	}
 	return writeFlowJSON(deps.stdout, record)
+}
+
+func resolveConfiguredFlowPreset(cfg config.Config, requested string) (*flowstore.Preset, error) {
+	name := normalizeFlowPresetName(requested)
+	if name == "" {
+		name = normalizeFlowPresetName(cfg.Flow.Preset)
+	}
+	if name == "" || name == "default" {
+		return nil, nil
+	}
+	for _, preset := range cfg.Flow.Presets {
+		presetName := normalizeFlowPresetName(preset.Name)
+		if presetName == name {
+			preset.Name = presetName
+			return &preset, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown flow preset %q (available presets: %s)", name, strings.Join(availableFlowPresetNames(cfg), ", "))
+}
+
+func availableFlowPresetNames(cfg config.Config) []string {
+	names := []string{"default"}
+	for _, preset := range cfg.Flow.Presets {
+		name := normalizeFlowPresetName(preset.Name)
+		if name != "" && !slices.Contains(names, name) {
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names)
+	return names
+}
+
+func normalizeFlowPresetName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
 }
 
 func printFlowCreateHelp(w io.Writer) {
@@ -191,6 +231,7 @@ Common flags:
   --branch BRANCH
   --base-ref REF
   --commit SHA
+  --preset NAME
   --state-root PATH
 
 Example:

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -423,7 +423,7 @@ func TestRunFlowCreatePrintsJSONRecord(t *testing.T) {
 	}
 }
 
-func TestRunFlowReadWithExplicitStateRootSkipsConfig(t *testing.T) {
+func TestRunFlowReadWithExplicitStateRootUsesRequestedRoot(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")
 	created := mustRunFlow(t, []string{"wtui", "flow", "create", "--title", "Readable", "--instructions", "read it", "--repo-path", repoPath, "--json", "--state-root", root})
@@ -431,10 +431,6 @@ func TestRunFlowReadWithExplicitStateRootSkipsConfig(t *testing.T) {
 	var stdout bytes.Buffer
 	err := run([]string{"wtui", "flow", "read", "--flow-id", created.FlowID, "--state-root", root},
 		noScanDeps(t, runDeps{
-			loadConfig: func() (config.Config, error) {
-				t.Fatal("loadConfig should not run with explicit state root")
-				return config.Config{}, nil
-			},
 			stdout: &stdout,
 		}))
 	if err != nil {
@@ -1924,6 +1920,57 @@ func TestRunFlowReadEnvRootLoadsConfigPresetsForRecovery(t *testing.T) {
 					return root
 				}
 				return ""
+			},
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	var record flowstore.FlowRecord
+	if err := json.Unmarshal(stdout.Bytes(), &record); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got := phaseByID(record, "draft").DependsOn; !slices.Equal(got, []string{"research"}) {
+		t.Fatalf("draft DependsOn = %#v, want [research]", got)
+	}
+}
+
+func TestRunFlowReadExplicitStateRootLoadsConfigPresetsForRecovery(t *testing.T) {
+	root := t.TempDir()
+	flowID := "20260607T120000Z-explicit-preset-recovery"
+	flowDir := filepath.Join(root, "flows", flowID)
+	if err := os.MkdirAll(flowDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	meta := `{
+  "schema_version": 1,
+  "flow_id": "` + flowID + `",
+  "title": "Explicit preset recovery",
+  "instructions": "restore named preset edges",
+  "status": "in_progress",
+  "repo_path": "` + filepath.Join(root, "repo") + `",
+  "preset_name": "research",
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "status": "completed", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "publish", "title": "Publish", "kind": "merge", "status": "pending", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ],
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-01T00:00:00Z"
+}`
+	if err := os.WriteFile(filepath.Join(flowDir, "meta.json"), []byte(meta), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "flow", "read", "--flow-id", flowID, "--state-root", root},
+		noScanDeps(t, runDeps{
+			loadConfig: func() (config.Config, error) {
+				return config.Config{
+					Flow: config.FlowConfig{
+						Presets: []flowstore.Preset{researchPresetForCLITest()},
+					},
+				}, nil
 			},
 			stdout: &stdout,
 		}))

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -423,6 +423,28 @@ func TestRunFlowCreatePrintsJSONRecord(t *testing.T) {
 	}
 }
 
+func TestRunFlowReadWithExplicitStateRootSkipsConfig(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	created := mustRunFlow(t, []string{"wtui", "flow", "create", "--title", "Readable", "--instructions", "read it", "--repo-path", repoPath, "--json", "--state-root", root})
+
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "flow", "read", "--flow-id", created.FlowID, "--state-root", root},
+		noScanDeps(t, runDeps{
+			loadConfig: func() (config.Config, error) {
+				t.Fatal("loadConfig should not run with explicit state root")
+				return config.Config{}, nil
+			},
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), created.FlowID) {
+		t.Fatalf("flow read output missing flow ID %q: %s", created.FlowID, stdout.String())
+	}
+}
+
 func TestRunFlowListJSONFiltersByRepo(t *testing.T) {
 	root := t.TempDir()
 	alpha := filepath.Join(root, "alpha")

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -1860,12 +1860,173 @@ func TestRunFlowCreateFallsBackToPlanThenSessionRoot(t *testing.T) {
 	}
 }
 
+func TestRunFlowCreateWithPresetFlagSeedsCustomGraph(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	var stdout bytes.Buffer
+	err := run([]string{
+		"wtui", "flow", "create",
+		"--title", "Research",
+		"--instructions", "phase it",
+		"--repo-path", repoPath,
+		"--preset", "research",
+		"--json",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			return config.Config{
+				Flow: config.FlowConfig{
+					Presets: []flowstore.Preset{researchPresetForCLITest()},
+				},
+			}, nil
+		},
+		stdout: &stdout,
+	}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	var record flowstore.FlowRecord
+	if err := json.Unmarshal(stdout.Bytes(), &record); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, stdout.String())
+	}
+	if record.PresetName != "research" {
+		t.Fatalf("preset name = %q, want research", record.PresetName)
+	}
+	if got := phaseIDs(record.Phases); !slices.Equal(got, []string{"research", "draft", "publish"}) {
+		t.Fatalf("phase IDs = %#v", got)
+	}
+	if record.Phases[0].Status != flowstore.PhaseReady {
+		t.Fatalf("root phase status = %q, want ready", record.Phases[0].Status)
+	}
+}
+
+func TestRunFlowCreateUsesConfiguredDefaultPreset(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	var stdout bytes.Buffer
+	err := run([]string{
+		"wtui", "flow", "create",
+		"--title", "Research",
+		"--instructions", "phase it",
+		"--repo-path", repoPath,
+		"--json",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			return config.Config{
+				Flow: config.FlowConfig{
+					Preset:  "research",
+					Presets: []flowstore.Preset{researchPresetForCLITest()},
+				},
+			}, nil
+		},
+		stdout: &stdout,
+	}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	var record flowstore.FlowRecord
+	if err := json.Unmarshal(stdout.Bytes(), &record); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, stdout.String())
+	}
+	if record.PresetName != "research" {
+		t.Fatalf("preset name = %q, want research", record.PresetName)
+	}
+	if got := phaseIDs(record.Phases); !slices.Equal(got, []string{"research", "draft", "publish"}) {
+		t.Fatalf("phase IDs = %#v", got)
+	}
+}
+
+func TestRunFlowCreateRejectsUnknownPreset(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	err := run([]string{
+		"wtui", "flow", "create",
+		"--title", "Research",
+		"--instructions", "phase it",
+		"--repo-path", repoPath,
+		"--preset", "missing",
+		"--json",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			return config.Config{
+				Flow: config.FlowConfig{
+					Presets: []flowstore.Preset{researchPresetForCLITest()},
+				},
+			}, nil
+		},
+		stdout: &bytes.Buffer{},
+	}))
+	if err == nil {
+		t.Fatal("expected unknown preset error")
+	}
+	for _, want := range []string{`unknown flow preset "missing"`, "available presets: default, research"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, err.Error())
+		}
+	}
+}
+
+func TestRunFlowCreateWithoutPresetUsesDefault(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	var stdout bytes.Buffer
+	err := run([]string{
+		"wtui", "flow", "create",
+		"--title", "Default",
+		"--instructions", "phase it",
+		"--repo-path", repoPath,
+		"--json",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{
+		loadConfig: func() (config.Config, error) {
+			return config.Config{}, nil
+		},
+		stdout: &stdout,
+	}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	var record flowstore.FlowRecord
+	if err := json.Unmarshal(stdout.Bytes(), &record); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, stdout.String())
+	}
+	if record.PresetName != "" {
+		t.Fatalf("preset name = %q, want empty for default preset", record.PresetName)
+	}
+	if got := phaseIDs(record.Phases); !slices.Equal(got, []string{"plan", "plan-review", "implementation", "review-loop", "pr-creation", "autoreview", "merge"}) {
+		t.Fatalf("phase IDs = %#v", got)
+	}
+}
+
 func TestRunFlowCreateRequiresJSON(t *testing.T) {
 	err := run([]string{"wtui", "flow", "create", "--title", "P", "--instructions", "i", "--repo-path", "/repo", "--state-root", t.TempDir()},
 		noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
 	if err == nil {
 		t.Fatal("expected error requiring --json")
 	}
+}
+
+func researchPresetForCLITest() flowstore.Preset {
+	return flowstore.Preset{
+		Name: "research",
+		Phases: []flowstore.PhaseSpec{
+			{ID: "research", Title: "Research", Kind: flowstore.KindPlan, DependsOn: []string{}},
+			{ID: "draft", Title: "Draft", Kind: flowstore.KindImplementation, DependsOn: []string{"research"}},
+			{ID: "publish", Title: "Publish", Kind: flowstore.KindMerge, DependsOn: []string{"draft"}},
+		},
+	}
+}
+
+func phaseIDs(phases []flowstore.FlowPhase) []string {
+	ids := make([]string, 0, len(phases))
+	for _, phase := range phases {
+		ids = append(ids, phase.PhaseID)
+	}
+	return ids
 }
 
 func TestRunFlowCreateValidatesRepoPathBeforeLoadingConfig(t *testing.T) {

--- a/cmd/wtui/flow_test.go
+++ b/cmd/wtui/flow_test.go
@@ -1882,6 +1882,63 @@ func TestRunFlowCreateFallsBackToPlanThenSessionRoot(t *testing.T) {
 	}
 }
 
+func TestRunFlowReadEnvRootLoadsConfigPresetsForRecovery(t *testing.T) {
+	root := t.TempDir()
+	flowID := "20260607T120000Z-env-preset-recovery"
+	flowDir := filepath.Join(root, "flows", flowID)
+	if err := os.MkdirAll(flowDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	meta := `{
+  "schema_version": 1,
+  "flow_id": "` + flowID + `",
+  "title": "Env preset recovery",
+  "instructions": "restore named preset edges",
+  "status": "in_progress",
+  "repo_path": "` + filepath.Join(root, "repo") + `",
+  "preset_name": "research",
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "status": "completed", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "publish", "title": "Publish", "kind": "merge", "status": "pending", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ],
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-01T00:00:00Z"
+}`
+	if err := os.WriteFile(filepath.Join(flowDir, "meta.json"), []byte(meta), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err := run([]string{"wtui", "flow", "read", "--flow-id", flowID},
+		noScanDeps(t, runDeps{
+			loadConfig: func() (config.Config, error) {
+				return config.Config{
+					Flow: config.FlowConfig{
+						Presets: []flowstore.Preset{researchPresetForCLITest()},
+					},
+				}, nil
+			},
+			getenv: func(key string) string {
+				if key == "WTUI_FLOW_STATE_ROOT" {
+					return root
+				}
+				return ""
+			},
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	var record flowstore.FlowRecord
+	if err := json.Unmarshal(stdout.Bytes(), &record); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got := phaseByID(record, "draft").DependsOn; !slices.Equal(got, []string{"research"}) {
+		t.Fatalf("draft DependsOn = %#v, want [research]", got)
+	}
+}
+
 func TestRunFlowCreateWithPresetFlagSeedsCustomGraph(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(t.TempDir(), "repo")

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -304,7 +304,7 @@ func startProgram(repos []scanner.Repo, opts startProgramOptions) error {
 	if err != nil {
 		return err
 	}
-	flowStore, err := flowstore.NewStore(flowstore.StoreOptions{Root: sessionStore.Root()})
+	flowStore, err := flowstore.NewStore(flowstore.StoreOptions{Root: sessionStore.Root(), Presets: cfg.Flow.Presets})
 	if err != nil {
 		return err
 	}
@@ -323,6 +323,7 @@ func modelOptionsFromConfig(cfg config.Config, scanRepos func() ([]scanner.Repo,
 			startupMode = mode
 		}
 	}
+	flowPreset, _ := resolveConfiguredFlowPreset(cfg, "")
 	return model.Options{
 		AgentCommand:          cfg.Agent.Command,
 		CodexModel:            cfg.Agent.CodexModel,
@@ -331,6 +332,8 @@ func modelOptionsFromConfig(cfg config.Config, scanRepos func() ([]scanner.Repo,
 		ClaudeReasoningEffort: cfg.Agent.ClaudeReasoningEffort,
 		StartupMode:           startupMode,
 		PlanPromptTemplate:    cfg.Agent.PlanPrompt,
+		FlowPresets:           cfg.Flow.Presets,
+		FlowPreset:            flowPreset,
 		FlowPromptTemplates: model.FlowPromptTemplates{
 			Plan:           cfg.FlowPrompts.Plan,
 			PlanReview:     cfg.FlowPrompts.PlanReview,

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -272,6 +272,7 @@ func runSessionHook(args []string, deps runDeps) error {
 	_, err = sessions.IngestHook(provider, deps.stdin, sessions.IngestOptions{
 		StateRoot:          root,
 		CopyRawTranscripts: cfg.Sessions.CopyRawTranscripts,
+		FlowPresets:        cfg.Flow.Presets,
 		Env: map[string]string{
 			"WTUI_LAUNCH_ID":          deps.getenv("WTUI_LAUNCH_ID"),
 			"WTUI_REPO_PATH":          deps.getenv("WTUI_REPO_PATH"),

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -949,6 +949,77 @@ func TestRunSessionHookEnvStateRootOverridesConfig(t *testing.T) {
 	}
 }
 
+func TestRunSessionHookPassesFlowPresetsForRecovery(t *testing.T) {
+	root := t.TempDir()
+	flowID := "20260607T120000Z-hook-preset-recovery"
+	flowDir := filepath.Join(root, "flows", flowID)
+	if err := os.MkdirAll(flowDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	meta := `{
+  "schema_version": 1,
+  "flow_id": "` + flowID + `",
+  "title": "Hook preset recovery",
+  "instructions": "attach session without losing preset edges",
+  "status": "in_progress",
+  "repo_path": "` + filepath.Join(root, "repo") + `",
+  "preset_name": "research",
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "status": "running", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "publish", "title": "Publish", "kind": "merge", "status": "pending", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ],
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-01T00:00:00Z"
+}`
+	if err := os.WriteFile(filepath.Join(flowDir, "meta.json"), []byte(meta), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	err := run([]string{"wtui", "session-hook", "--provider", "codex", "--state-root", root}, runDeps{
+		loadConfig: func() (config.Config, error) {
+			return config.Config{
+				Flow: config.FlowConfig{
+					Presets: []flowstore.Preset{researchPresetForCLITest()},
+				},
+			}, nil
+		},
+		getenv: func(key string) string {
+			switch key {
+			case "WTUI_FLOW_STATE_ROOT", "WTUI_SESSION_STATE_ROOT":
+				return root
+			case "WTUI_FLOW_ID":
+				return flowID
+			case "WTUI_FLOW_PHASE_ID":
+				return "research"
+			case "WTUI_LAUNCH_ID":
+				return "launch-hook-preset"
+			default:
+				return ""
+			}
+		},
+		stdin: strings.NewReader(`{"session_id":"codex-hook-preset","cwd":"/repo/worktree"}`),
+	})
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	read, err := store.Read(flowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(read, "draft").DependsOn; !reflect.DeepEqual(got, []string{"research"}) {
+		t.Fatalf("draft DependsOn = %#v, want [research]", got)
+	}
+	if sessions := phaseByID(read, "research").Sessions; len(sessions) != 1 {
+		t.Fatalf("research sessions = %#v, want one attached session", sessions)
+	}
+}
+
 func singleSessionFile(t *testing.T, root, provider, name string) string {
 	t.Helper()
 	matches, err := filepath.Glob(filepath.Join(root, "sessions", provider, "*", name))

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -444,6 +444,29 @@ func TestModelOptionsFromConfigMapsDefaultView(t *testing.T) {
 	}
 }
 
+func TestModelOptionsFromConfigPassesFlowPreset(t *testing.T) {
+	sessionStore, planStore, flowStore := testArtifactStores(t)
+	preset := flowstore.Preset{
+		Name: "research",
+		Phases: []flowstore.PhaseSpec{
+			{ID: "research", Title: "Research", Kind: flowstore.KindPlan, DependsOn: []string{}},
+		},
+	}
+	opts := modelOptionsFromConfig(config.Config{
+		Flow: config.FlowConfig{
+			Preset:  "research",
+			Presets: []flowstore.Preset{preset},
+		},
+	}, nil, sessionStore, planStore, flowStore)
+
+	if len(opts.FlowPresets) != 1 || opts.FlowPresets[0].Name != "research" {
+		t.Fatalf("FlowPresets = %#v, want research preset", opts.FlowPresets)
+	}
+	if opts.FlowPreset == nil || opts.FlowPreset.Name != "research" {
+		t.Fatalf("FlowPreset = %#v, want research", opts.FlowPreset)
+	}
+}
+
 func TestModelOptionsFromConfigPassesTerminalCommandToLaunchers(t *testing.T) {
 	t.Setenv("TMUX", "")
 	t.Setenv("ZELLIJ", "")

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/brian-bell/wtui/agent"
+	"github.com/brian-bell/wtui/flowstore"
 	"github.com/pelletier/go-toml/v2"
 )
 
@@ -24,6 +25,7 @@ type Config struct {
 	UI          UIConfig         `toml:"ui"`
 	Agent       AgentConfig      `toml:"agent"`
 	FlowPrompts FlowPromptConfig `toml:"flow_prompts"`
+	Flow        FlowConfig       `toml:"flow"`
 	Sessions    SessionsConfig   `toml:"sessions"`
 	Bootstrap   BootstrapConfig  `toml:"bootstrap"`
 }
@@ -79,6 +81,12 @@ type FlowPromptConfig struct {
 	Autoreview     string `toml:"autoreview"`
 	Merge          string `toml:"merge"`
 	Generic        string `toml:"generic"`
+}
+
+// FlowConfig stores Flow creation defaults and custom phase graph presets.
+type FlowConfig struct {
+	Preset  string             `toml:"preset"`
+	Presets []flowstore.Preset `toml:"presets"`
 }
 
 // SessionsConfig controls agent-session capture storage.
@@ -232,6 +240,10 @@ func parseConfigData(path string, data []byte, opts loadOptions) (Config, error)
 		cfg.Sessions.Root = root
 	}
 
+	if err := normalizeFlowConfig(path, &cfg.Flow); err != nil {
+		return Config{}, err
+	}
+
 	if err := normalizeBootstrapConfig(path, &cfg.Bootstrap, opts); err != nil {
 		return Config{}, err
 	}
@@ -248,6 +260,38 @@ func validateDefaultView(view int) error {
 		return fmt.Errorf("ui.default_view must be between 1 and 9")
 	}
 	return nil
+}
+
+func normalizeFlowConfig(path string, cfg *FlowConfig) error {
+	cfg.Preset = normalizeFlowPresetName(cfg.Preset)
+	seen := map[string]struct{}{}
+	for i := range cfg.Presets {
+		preset := &cfg.Presets[i]
+		preset.Name = normalizeFlowPresetName(preset.Name)
+		if preset.Name == "default" {
+			return fmt.Errorf("parse config %s: preset name \"default\" is reserved", path)
+		}
+		if _, ok := seen[preset.Name]; ok {
+			return fmt.Errorf("parse config %s: duplicate preset name %q", path, preset.Name)
+		}
+		seen[preset.Name] = struct{}{}
+		for j := range preset.Phases {
+			preset.Phases[j].Kind = strings.ToLower(strings.TrimSpace(preset.Phases[j].Kind))
+		}
+		if err := flowstore.ValidatePreset(*preset); err != nil {
+			return fmt.Errorf("parse config %s: flow.presets[%q]: %w", path, preset.Name, err)
+		}
+	}
+	if cfg.Preset != "" && cfg.Preset != "default" {
+		if _, ok := seen[cfg.Preset]; !ok {
+			return fmt.Errorf("parse config %s: flow.preset %q is not a defined preset", path, cfg.Preset)
+		}
+	}
+	return nil
+}
+
+func normalizeFlowPresetName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
 }
 
 func normalizeBootstrapConfig(path string, cfg *BootstrapConfig, opts loadOptions) error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/brian-bell/wtui/config"
+	"github.com/brian-bell/wtui/flowstore"
 )
 
 func TestLoadFrom_AllowsMissingConfig(t *testing.T) {
@@ -56,6 +57,23 @@ claude_reasoning_effort = "max"
 plan = "Plan only: {instructions}"
 implementation = "Implement {plan_path} in {worktree_path}"
 autoreview = "Review {pr_url} and ship fixes"
+
+[flow]
+preset = "research"
+
+[[flow.presets]]
+name = "research"
+
+[[flow.presets.phases]]
+id = "research"
+title = "Research"
+kind = "plan"
+
+[[flow.presets.phases]]
+id = "build"
+title = "Build"
+kind = " implementation "
+depends_on = ["research"]
 
 [sessions]
 root = "~/state/wtui/sessions"
@@ -128,6 +146,25 @@ timeout_seconds = 300
 		cfg.FlowPrompts.Autoreview != "Review {pr_url} and ship fixes" {
 		t.Fatalf("expected flow prompt templates to parse, got %#v", cfg.FlowPrompts)
 	}
+	if cfg.Flow.Preset != "research" {
+		t.Fatalf("expected flow preset research, got %q", cfg.Flow.Preset)
+	}
+	if len(cfg.Flow.Presets) != 1 {
+		t.Fatalf("expected one flow preset, got %#v", cfg.Flow.Presets)
+	}
+	preset := cfg.Flow.Presets[0]
+	if preset.Name != "research" {
+		t.Fatalf("expected normalized preset name research, got %q", preset.Name)
+	}
+	if len(preset.Phases) != 2 {
+		t.Fatalf("expected two preset phases, got %#v", preset.Phases)
+	}
+	if preset.Phases[1].Kind != flowstore.KindImplementation {
+		t.Fatalf("expected normalized phase kind %q, got %q", flowstore.KindImplementation, preset.Phases[1].Kind)
+	}
+	if got := preset.Phases[1].DependsOn; len(got) != 1 || got[0] != "research" {
+		t.Fatalf("expected build to depend on research, got %#v", got)
+	}
 	if cfg.Sessions.Root != filepath.Join(home, "state", "wtui", "sessions") {
 		t.Fatalf("expected expanded sessions root, got %q", cfg.Sessions.Root)
 	}
@@ -189,6 +226,106 @@ func TestLoadFrom_DefaultsSessionsCopyRawTranscriptsOff(t *testing.T) {
 	}
 	if cfg.Sessions.CopyRawTranscripts {
 		t.Fatal("expected sessions copy_raw_transcripts to default false")
+	}
+}
+
+func TestLoadFrom_ParsesFlowDefaultPreset(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[flow]\npreset = \"default\"\nunknown = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom returned error: %v", err)
+	}
+	if cfg.Flow.Preset != "default" {
+		t.Fatalf("expected default flow preset, got %q", cfg.Flow.Preset)
+	}
+}
+
+func TestLoadFrom_RejectsInvalidFlowConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "wrong preset type",
+			body: "[flow]\npreset = 3\n",
+			want: "toml",
+		},
+		{
+			name: "undefined default preset",
+			body: "[flow]\npreset = \"missing\"\n",
+			want: `flow.preset "missing" is not a defined preset`,
+		},
+		{
+			name: "invalid graph",
+			body: `
+[[flow.presets]]
+name = "research"
+
+[[flow.presets.phases]]
+id = "a"
+title = "A"
+depends_on = ["b"]
+
+[[flow.presets.phases]]
+id = "b"
+title = "B"
+depends_on = ["a"]
+`,
+			want: `flow.presets["research"]:`,
+		},
+		{
+			name: "duplicate preset name",
+			body: `
+[[flow.presets]]
+name = " Research "
+
+[[flow.presets.phases]]
+id = "a"
+title = "A"
+
+[[flow.presets]]
+name = "research"
+
+[[flow.presets.phases]]
+id = "b"
+title = "B"
+`,
+			want: `duplicate preset name "research"`,
+		},
+		{
+			name: "reserved default preset",
+			body: `
+[[flow.presets]]
+name = " default "
+
+[[flow.presets.phases]]
+id = "a"
+title = "A"
+`,
+			want: `preset name "default" is reserved`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(tt.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := config.LoadFrom(path)
+			if err == nil {
+				t.Fatal("expected invalid flow config error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error to contain %q, got %q", tt.want, err.Error())
+			}
+		})
 	}
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -32,6 +32,7 @@ exist:
 | Startup default view | none | `[ui].default_view` | flows view (config number `8`) |
 | Plan launch prompt | none | `[agent].plan_prompt` | built-in plan implementation prompt |
 | Flow phase launch prompts | none | `[flow_prompts]` | built-in Flow phase prompts |
+| Flow phase graph preset | `wtui flow create --preset` | `[flow].preset` | `default` |
 | TUI artifact root | `WTUI_FLOW_STATE_ROOT` > `WTUI_PLAN_STATE_ROOT` > `WTUI_SESSION_STATE_ROOT` | `[sessions].root` | `$XDG_STATE_HOME/wtui/sessions/v1` or `~/.local/state/wtui/sessions/v1` |
 | Session hook root | `--state-root` > `WTUI_SESSION_STATE_ROOT` | `[sessions].root` | same as sessions root |
 | Plan state root | `--state-root` > `WTUI_PLAN_STATE_ROOT` > `WTUI_SESSION_STATE_ROOT` | `[sessions].root` | same as sessions root (`<root>/plans/...`) |
@@ -81,6 +82,29 @@ implementation = "Implement {plan_path} in {worktree_path} for issue {issue_numb
 review_loop = "Use review-loop for {branch}; use commit if revisions are made."
 pr_creation = "Use ship for {branch}; record PR metadata for flow {flow_id}."
 autoreview = "Autoreview {pr_url}; use ship when fixes require commits or pushes."
+
+[flow]
+preset = "research"
+
+[[flow.presets]]
+name = "research"
+
+[[flow.presets.phases]]
+id = "research"
+title = "Research"
+kind = "plan"
+
+[[flow.presets.phases]]
+id = "draft"
+title = "Draft"
+kind = "implementation"
+depends_on = ["research"]
+
+[[flow.presets.phases]]
+id = "publish"
+title = "Publish"
+kind = "merge"
+depends_on = ["draft"]
 
 [sessions]
 root = "~/.local/state/wtui/sessions/v1"
@@ -263,6 +287,32 @@ Supported Flow placeholders are `{flow_id}`, `{flow_title}`,
 Loop, PR Creation, Autoreview, and Merge launches do not pre-read the linked
 plan body, so `{plan_body}` is empty for those built-in phase types unless a
 future phase path explicitly supplies it.
+
+### `[flow]`
+
+Configures the default phase graph for newly created Flows.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `preset` | string | Optional preset name used by TUI Flow creation and `wtui flow create` when `--preset` is omitted. Empty or `default` uses the built-in graph. |
+| `presets` | array of tables | Custom phase graph presets. User presets cannot be named `default`, and duplicate normalized names are startup-fatal. |
+
+Each `[[flow.presets]]` table requires `name` and one or more
+`[[flow.presets.phases]]` entries:
+
+| Phase key | Type | Description |
+|-----------|------|-------------|
+| `id` | string | Stable phase ID used by CLI commands and launch metadata. IDs are normalized like other Flow phase IDs. |
+| `title` | string | Display title for the phase row and launch prompt. |
+| `kind` | string | Optional semantic kind. Supported custom-preset kinds are `plan`, `plan_review`, `implementation`, `review_loop`, `pr_creation`, `autoreview`, and `merge`. Unknown kinds are rejected in config. |
+| `depends_on` | array of strings | Optional top-level prerequisite phase IDs. Omitted or empty means the phase is a root. |
+
+Custom presets must form an acyclic top-level graph, may include multiple root
+phases, and may include at most one `merge`-kind phase. Child implementation
+phases are still created dynamically with `wtui flow phase add-child`; they are
+not declared in config. Records created from a named preset persist
+`preset_name` so wtui can restore missing `depends_on` edges if an older binary
+partially rewrites the record.
 
 ### `[sessions]`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -475,7 +475,7 @@ Other phase and progression mutation remains CLI/agent-driven in v1.
 wtui flow create --title "Ship saved plans" \
     --instructions "Plan, implement, review, open a PR, and merge." \
     --repo-path "$REPO" [--worktree-path PATH] [--branch BRANCH] \
-    [--base-ref REF] [--commit HASH] [--state-root PATH] --json
+    [--base-ref REF] [--commit HASH] [--preset NAME] [--state-root PATH] --json
 
 # You may also read instructions from a file.
 wtui flow create --title "Ship saved plans" \

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -95,11 +95,8 @@ Additional rules:
 
 The phase-affecting mutations (`SetPhase`, `AddChildPhase`, `SetPR`,
 `AddPhaseLaunchID`, and `ResetRecoverableRunningPhase`) re-derive readiness with
-`refreshPhaseReadiness`, regardless of graph shape. Loads and the remaining
-mutations normalize only records containing a `plan-review` phase — the
-standard graph; hand-authored records without one keep their stored statuses
-until a phase-affecting mutation touches them. Agents never need to know which
-phase becomes ready next; they only report their own phase.
+`refreshPhaseReadiness`, regardless of graph shape. Agents never need to know
+which phase becomes ready next; they only report their own phase.
 
 Newly written Flow records persist explicit top-level dependency edges in each
 phase's `depends_on` field. Legacy standard records that do not have the key are
@@ -108,25 +105,27 @@ root phase. Implementation child phases remain structurally ordered under their
 parent rather than declaring their own dependencies.
 
 Walking phases in topological dependency order, a `pending` phase becomes
-`ready` once every prerequisite satisfies its downstream gate:
+`ready` once every prerequisite satisfies its downstream gate. Gates are keyed by
+semantic phase `kind`, not by literal phase ID:
 
 - **Default gate**: the phase is `completed`, or `skipped` with notes.
-- **Plan Review**: `completed` with outcome `approved` or
+- **Plan Review (`plan_review`)**: `completed` with outcome `approved` or
   `approved_with_concerns`, or `skipped` with notes. Any other outcome keeps
   Implementation `pending`. The high-level Plan Review wrappers fill the
   unambiguous outcomes when omitted: `complete` uses `approved`,
   `needs-attention` uses `changes_requested`, and `block` uses `blocked`.
-- **Autoreview**: the high-level wrappers fill the unambiguous outcomes when
+- **Autoreview (`autoreview`)**: the high-level wrappers fill the unambiguous outcomes when
   omitted: `complete` uses `passed`, `needs-attention` uses
   `needs_attention`, and `block` uses `blocked`.
-- **PR Creation**: `completed` *and* structured PR metadata recorded via
+- **PR Creation (`pr_creation`)**: `completed` *and* structured PR metadata recorded via
   `wtui flow pr set` (provider, positive number, valid URL, head/base
   branches). Completion alone does not unlock Autoreview; a skipped PR
   Creation never unlocks it.
-- **Plan**: may record optional GitHub issue metadata with
+- **Plan (`plan`)**: may record optional GitHub issue metadata with
   `wtui flow issue set` when the task references an issue. Issue metadata is
   informational and does not gate downstream phases.
-- **Implementation children**: every child phase under Implementation must be
+- **Implementation children**: every child phase under an implementation-kind
+  parent must be
   `completed` or `skipped` with notes before phases after Implementation can
   become ready.
 
@@ -136,6 +135,61 @@ stale readiness never survives a regression upstream. Downstream `blocked`
 phases are an exception: they are reset only when Plan Review's gate is
 unsatisfied — whether Plan Review itself regressed or an earlier gate broke —
 and keep their blocked state under any other gate regression.
+
+In branched graphs, reset propagation follows dependency edges. A regression in
+one branch resets only transitive successors of that branch; independent sibling
+branches keep their stored state.
+
+## Custom phase graphs
+
+The built-in `default` preset is the familiar linear graph: Plan → Plan Review
+→ Implementation → Review loop → PR Creation → Autoreview → Merge. Config can
+declare additional named presets under `[flow]`, and `wtui flow create
+--preset NAME` or `[flow].preset` can select them for new Flows. CLI and TUI
+"next phase" surfaces remain display-order based: with fan-out, "next" means
+the first ready launchable branch in `OrderedPhases` order, not a scheduling
+guarantee.
+
+Custom preset validation is strict at config/create time:
+
+- Phase IDs must be unique after normalization.
+- Top-level `depends_on` edges must reference top-level phases in the preset.
+- The graph must be acyclic and include at least one root.
+- At most one phase may have kind `merge`.
+- Unknown kinds are rejected in presets. Existing hand-authored records with an
+  unknown kind still load and use the default gate.
+
+Readiness is best-effort for existing on-disk records. If Kahn's algorithm
+cannot release a node because of a cycle, dangling dependency, duplicate
+normalized ID beyond the first occurrence, or a transitive dependency on one of
+those nodes, wtui leaves that node's stored status untouched. This avoids
+destroying recorded work on a malformed hand-authored record. Index-aware launch
+eligibility prevents stale duplicate rows from being selected for manual or
+AutoMode launches.
+
+Records created from named custom presets persist `preset_name`. If a record is
+later read with missing `depends_on` keys, wtui uses the named preset as a
+recovery hint when the preset is available and its phase IDs still match. The
+non-persisted `GraphRecovery.Status` values are:
+
+- `preset_edges_restored`: missing edges were restored from the named preset.
+- `missing_edges_unresolved`: wtui refused to invent a graph. Re-select or
+  recreate the preset, or repair the record manually.
+
+Default-preset records still use legacy linear backfill when `depends_on` is
+absent. Edge-less custom records without a recoverable preset remain readable
+but degraded; their stored statuses are preserved except where a later
+phase-affecting mutation can safely re-derive readiness from explicit edges.
+
+AutoMode is drain-based for DAGs. A successful phase completion arms an
+in-memory drain for that Flow; each poll launches the first ready non-merge
+launchable phase only when no phase in that Flow is `running` and no
+flow-scoped embedded terminal is still open or auto-closing. This serializes
+branches so parallel agents do not collide in one worktree. Skipped phases do
+not arm the drain, even when skip-with-notes readies successors. Resetting a
+phase back to `ready` also does not arm the drain. Completing an
+`autoreview`-kind phase may launch a custom non-merge successor; in the default
+preset it still stops because the only successor is merge-kind.
 
 ## Derived Flow status
 
@@ -174,11 +228,11 @@ previous PR status, clears that terminal metadata, marks the Merge phase
   migration.
 - Derived state is self-healing: phase-affecting mutations (`SetPhase`,
   `AddChildPhase`, `SetPR`, `AddPhaseLaunchID`,
-  `ResetRecoverableRunningPhase`) re-derive readiness for any graph, and records
-  containing a `plan-review` phase (the standard graph) are additionally
-  normalized on load, so records written before a gate rule existed converge to
-  correct `pending`/`ready` values. Records without a `plan-review` phase keep
-  their stored statuses until a phase-affecting mutation touches them.
+  `ResetRecoverableRunningPhase`) re-derive readiness for any graph. Records
+  with explicit persisted edges opt into load-time readiness normalization, and
+  records containing a plan-review-kind phase are also normalized on load.
+  Edge-less, kind-less custom records keep stored statuses instead of receiving
+  guessed edges.
 - Completed plan-review phases persisted before outcomes existed are
   normalized to `approved` on read.
 

--- a/flowstore/preset.go
+++ b/flowstore/preset.go
@@ -10,16 +10,16 @@ import (
 
 // PhaseSpec is a data-only phase declaration used by Flow phase graph presets.
 type PhaseSpec struct {
-	ID        string
-	Title     string
-	Kind      string
-	DependsOn []string
+	ID        string   `toml:"id"`
+	Title     string   `toml:"title"`
+	Kind      string   `toml:"kind"`
+	DependsOn []string `toml:"depends_on"`
 }
 
 // Preset declares a reusable graph of top-level Flow phases.
 type Preset struct {
-	Name   string
-	Phases []PhaseSpec
+	Name   string      `toml:"name"`
+	Phases []PhaseSpec `toml:"phases"`
 }
 
 // CreateOptions configures Flow creation without changing the persisted schema.
@@ -44,8 +44,33 @@ func DefaultPreset() Preset {
 	}
 }
 
+// ValidatePreset checks whether preset can seed a Flow phase graph.
+func ValidatePreset(preset Preset) error {
+	return validatePreset(preset)
+}
+
+func presetRegistry(presets []Preset) (map[string]Preset, error) {
+	if len(presets) == 0 {
+		return nil, nil
+	}
+	registry := make(map[string]Preset, len(presets))
+	for _, preset := range presets {
+		preset.Name = normalizePresetName(preset.Name)
+		if err := validatePreset(preset); err != nil {
+			return nil, err
+		}
+		registry[preset.Name] = preset
+	}
+	return registry, nil
+}
+
+func normalizePresetName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
 func validatePreset(preset Preset) error {
-	if strings.TrimSpace(preset.Name) == "" {
+	preset.Name = normalizePresetName(preset.Name)
+	if preset.Name == "" {
 		return fmt.Errorf("preset name is required")
 	}
 	if len(preset.Phases) == 0 {

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -1996,7 +1996,7 @@ func (s *Store) restoreMissingDependsOn(record FlowRecord, presence []rawDepends
 		record.GraphRecovery.Status = GraphRecoveryPresetEdgesRestored
 		return record
 	}
-	if phaseIDsCompatibleWithDefaultSequence(record.Phases) {
+	if recordAllowsDefaultEdgeRecovery(record) && phaseIDsCompatibleWithDefaultSequence(record.Phases) {
 		record.Phases = backfillLinearDependsOn(record.Phases)
 		return record
 	}
@@ -2012,6 +2012,11 @@ func (s *Store) presetForRecovery(record FlowRecord) (Preset, bool) {
 	}
 	preset, ok := s.presets[name]
 	return preset, ok
+}
+
+func recordAllowsDefaultEdgeRecovery(record FlowRecord) bool {
+	name := normalizePresetName(record.PresetName)
+	return name == "" || name == "default"
 }
 
 func presetMatchesRecord(preset Preset, record FlowRecord) bool {

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -1974,13 +1974,20 @@ func (s *Store) readRecordWithReadiness(flowID string, selfHealOnRead bool) (Flo
 	}
 	selfHeal := rawDependsOnPresentForTopLevel(record.Phases, presence)
 	record = s.restoreMissingDependsOn(record, presence)
+	unresolvedGraph := false
 	if record.GraphRecovery.Status == GraphRecoveryPresetEdgesRestored {
 		selfHeal = true
 	} else if record.GraphRecovery.Status == GraphRecoveryMissingEdgesUnresolved {
 		selfHeal = false
+		unresolvedGraph = true
 	}
 	if selfHealOnRead {
-		record = normalizeRecord(record, selfHeal)
+		if unresolvedGraph {
+			record = normalizeRecordBase(record)
+			record = normalizeReviewOutcomes(record)
+		} else {
+			record = normalizeRecord(record, selfHeal)
+		}
 	} else {
 		record = normalizeRecordBase(record)
 	}

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -1987,7 +1987,7 @@ func (s *Store) readRecordWithReadiness(flowID string, selfHealOnRead bool) (Flo
 }
 
 func (s *Store) restoreMissingDependsOn(record FlowRecord, presence []rawDependsOnState) FlowRecord {
-	if rawDependsOnPresentForTopLevel(record.Phases, presence) {
+	if rawDependsOnPresentForEveryTopLevel(record.Phases, presence) {
 		record.Phases = normalizeDependsOnValues(record.Phases)
 		return record
 	}
@@ -2079,6 +2079,20 @@ func rawDependsOnPresentForTopLevel(phases []FlowPhase, presence []rawDependsOnS
 		}
 	}
 	return false
+}
+
+func rawDependsOnPresentForEveryTopLevel(phases []FlowPhase, presence []rawDependsOnState) bool {
+	seenTopLevel := false
+	for i, phase := range phases {
+		if phase.ParentPhaseID != "" {
+			continue
+		}
+		seenTopLevel = true
+		if i >= len(presence) || !presence[i].Present {
+			return false
+		}
+	}
+	return seenTopLevel
 }
 
 func (s *Store) flowDir(flowID string) string {

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -1976,6 +1976,8 @@ func (s *Store) readRecordWithReadiness(flowID string, selfHealOnRead bool) (Flo
 	record = s.restoreMissingDependsOn(record, presence)
 	if record.GraphRecovery.Status == GraphRecoveryPresetEdgesRestored {
 		selfHeal = true
+	} else if record.GraphRecovery.Status == GraphRecoveryMissingEdgesUnresolved {
+		selfHeal = false
 	}
 	if selfHealOnRead {
 		record = normalizeRecord(record, selfHeal)

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -72,11 +72,17 @@ const (
 	KindImplementationChild = "implementation_child"
 )
 
+const (
+	GraphRecoveryPresetEdgesRestored    = "preset_edges_restored"
+	GraphRecoveryMissingEdgesUnresolved = "missing_edges_unresolved"
+)
+
 // Store reads and writes flow records under an artifact root.
 type Store struct {
 	root        string
 	now         func() time.Time
 	lockTimeout time.Duration
+	presets     map[string]Preset
 }
 
 // StoreOptions configures a Store.
@@ -84,6 +90,7 @@ type StoreOptions struct {
 	Root        string
 	Now         func() time.Time
 	LockTimeout time.Duration
+	Presets     []Preset
 }
 
 // IsNotFound reports whether err means the requested Flow record does not exist.
@@ -196,25 +203,33 @@ type AutoModeUpdate struct {
 
 // FlowRecord is the persisted task workflow record.
 type FlowRecord struct {
-	SchemaVersion int         `json:"schema_version"`
-	FlowID        string      `json:"flow_id"`
-	Title         string      `json:"title"`
-	Instructions  string      `json:"instructions"`
-	Status        string      `json:"status"`
-	RepoPath      string      `json:"repo_path"`
-	WorktreePath  string      `json:"worktree_path,omitempty"`
-	Branch        string      `json:"branch,omitempty"`
-	BaseRef       string      `json:"base_ref,omitempty"`
-	Commit        string      `json:"commit,omitempty"`
-	PlanID        string      `json:"plan_id,omitempty"`
-	PlanPath      string      `json:"plan_path,omitempty"`
-	Issue         Issue       `json:"issue,omitempty"`
-	PR            PullRequest `json:"pr,omitempty"`
-	Merge         Merge       `json:"merge,omitempty"`
-	AutoMode      bool        `json:"auto_mode,omitempty"`
-	Phases        []FlowPhase `json:"phases"`
-	CreatedAt     time.Time   `json:"created_at"`
-	UpdatedAt     time.Time   `json:"updated_at"`
+	SchemaVersion int                `json:"schema_version"`
+	FlowID        string             `json:"flow_id"`
+	Title         string             `json:"title"`
+	Instructions  string             `json:"instructions"`
+	Status        string             `json:"status"`
+	RepoPath      string             `json:"repo_path"`
+	WorktreePath  string             `json:"worktree_path,omitempty"`
+	Branch        string             `json:"branch,omitempty"`
+	BaseRef       string             `json:"base_ref,omitempty"`
+	Commit        string             `json:"commit,omitempty"`
+	PresetName    string             `json:"preset_name,omitempty"`
+	PlanID        string             `json:"plan_id,omitempty"`
+	PlanPath      string             `json:"plan_path,omitempty"`
+	Issue         Issue              `json:"issue,omitempty"`
+	PR            PullRequest        `json:"pr,omitempty"`
+	Merge         Merge              `json:"merge,omitempty"`
+	AutoMode      bool               `json:"auto_mode,omitempty"`
+	Phases        []FlowPhase        `json:"phases"`
+	CreatedAt     time.Time          `json:"created_at"`
+	UpdatedAt     time.Time          `json:"updated_at"`
+	GraphRecovery GraphRecoveryState `json:"-"`
+}
+
+// GraphRecoveryState reports non-persisted recovery performed while reading a
+// Flow record whose persisted graph metadata was missing or degraded.
+type GraphRecoveryState struct {
+	Status string
 }
 
 // FlowFilter narrows records returned by List.
@@ -325,7 +340,11 @@ func NewStore(opts StoreOptions) (*Store, error) {
 	if lockTimeout <= 0 {
 		lockTimeout = defaultLockTimeout
 	}
-	return &Store{root: root, now: now, lockTimeout: lockTimeout}, nil
+	presets, err := presetRegistry(opts.Presets)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{root: root, now: now, lockTimeout: lockTimeout, presets: presets}, nil
 }
 
 // DefaultRoot returns the default artifact root, matching sessions and plans.
@@ -391,6 +410,7 @@ func (s *Store) CreateWithOptions(record FlowRecord, opts CreateOptions) (FlowRe
 		preset := DefaultPreset()
 		if opts.Preset != nil {
 			preset = *opts.Preset
+			record.PresetName = strings.ToLower(strings.TrimSpace(preset.Name))
 		}
 		if err := validatePreset(preset); err != nil {
 			return FlowRecord{}, err
@@ -1953,7 +1973,10 @@ func (s *Store) readRecordWithReadiness(flowID string, selfHealOnRead bool) (Flo
 		return FlowRecord{}, false
 	}
 	selfHeal := rawDependsOnPresentForTopLevel(record.Phases, presence)
-	record.Phases = backfillLinearDependsOnFromRaw(record.Phases, presence)
+	record = s.restoreMissingDependsOn(record, presence)
+	if record.GraphRecovery.Status == GraphRecoveryPresetEdgesRestored {
+		selfHeal = true
+	}
 	if selfHealOnRead {
 		record = normalizeRecord(record, selfHeal)
 	} else {
@@ -1961,6 +1984,70 @@ func (s *Store) readRecordWithReadiness(flowID string, selfHealOnRead bool) (Flo
 	}
 	record.Status = DeriveStatus(record)
 	return record, true
+}
+
+func (s *Store) restoreMissingDependsOn(record FlowRecord, presence []rawDependsOnState) FlowRecord {
+	if rawDependsOnPresentForTopLevel(record.Phases, presence) {
+		record.Phases = normalizeDependsOnValues(record.Phases)
+		return record
+	}
+	if preset, ok := s.presetForRecovery(record); ok && presetMatchesRecord(preset, record) {
+		record.Phases = applyPresetDependsOn(record.Phases, preset)
+		record.GraphRecovery.Status = GraphRecoveryPresetEdgesRestored
+		return record
+	}
+	if phaseIDsCompatibleWithDefaultSequence(record.Phases) {
+		record.Phases = backfillLinearDependsOn(record.Phases)
+		return record
+	}
+	record.Phases = normalizeDependsOnValues(record.Phases)
+	record.GraphRecovery.Status = GraphRecoveryMissingEdgesUnresolved
+	return record
+}
+
+func (s *Store) presetForRecovery(record FlowRecord) (Preset, bool) {
+	name := normalizePresetName(record.PresetName)
+	if name == "" || name == "default" || s.presets == nil {
+		return Preset{}, false
+	}
+	preset, ok := s.presets[name]
+	return preset, ok
+}
+
+func presetMatchesRecord(preset Preset, record FlowRecord) bool {
+	var ids []string
+	for _, phase := range OrderedPhases(record.Phases) {
+		if phase.ParentPhaseID != "" {
+			continue
+		}
+		ids = append(ids, artifacts.NormalizePhaseID(phase.PhaseID))
+	}
+	if len(ids) != len(preset.Phases) {
+		return false
+	}
+	for i, spec := range preset.Phases {
+		if ids[i] != artifacts.NormalizePhaseID(spec.ID) {
+			return false
+		}
+	}
+	return true
+}
+
+func applyPresetDependsOn(phases []FlowPhase, preset Preset) []FlowPhase {
+	dependsOnByID := make(map[string][]string, len(preset.Phases))
+	for _, spec := range preset.Phases {
+		id := artifacts.NormalizePhaseID(spec.ID)
+		dependsOnByID[id] = append([]string{}, spec.DependsOn...)
+	}
+	for i := range phases {
+		if phases[i].ParentPhaseID != "" {
+			phases[i].DependsOn = []string{}
+			continue
+		}
+		id := artifacts.NormalizePhaseID(phases[i].PhaseID)
+		phases[i].DependsOn = append([]string{}, dependsOnByID[id]...)
+	}
+	return normalizeDependsOnValues(phases)
 }
 
 func rawDependsOnPresence(data []byte) []rawDependsOnState {

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -224,6 +224,8 @@ type FlowRecord struct {
 	CreatedAt     time.Time          `json:"created_at"`
 	UpdatedAt     time.Time          `json:"updated_at"`
 	GraphRecovery GraphRecoveryState `json:"-"`
+
+	preserveMissingDependsOn map[string]bool
 }
 
 // GraphRecoveryState reports non-persisted recovery performed while reading a
@@ -1942,7 +1944,7 @@ func (s *Store) write(record FlowRecord) error {
 	if err != nil {
 		return fmt.Errorf("secure flow directory: %w", err)
 	}
-	data, err := json.MarshalIndent(record, "", "  ")
+	data, err := marshalFlowRecord(record)
 	if err != nil {
 		return fmt.Errorf("encode flow metadata: %w", err)
 	}
@@ -1950,6 +1952,101 @@ func (s *Store) write(record FlowRecord) error {
 		return fmt.Errorf("write flow metadata: %w", err)
 	}
 	return nil
+}
+
+func marshalFlowRecord(record FlowRecord) ([]byte, error) {
+	if len(record.preserveMissingDependsOn) == 0 {
+		return json.MarshalIndent(record, "", "  ")
+	}
+	phases := make([]flowPhaseForWrite, 0, len(record.Phases))
+	for _, phase := range record.Phases {
+		phases = append(phases, flowPhaseForWriteFrom(phase, record.preserveMissingDependsOn[artifacts.NormalizePhaseID(phase.PhaseID)]))
+	}
+	return json.MarshalIndent(flowRecordForWrite{
+		SchemaVersion: record.SchemaVersion,
+		FlowID:        record.FlowID,
+		Title:         record.Title,
+		Instructions:  record.Instructions,
+		Status:        record.Status,
+		RepoPath:      record.RepoPath,
+		WorktreePath:  record.WorktreePath,
+		Branch:        record.Branch,
+		BaseRef:       record.BaseRef,
+		Commit:        record.Commit,
+		PresetName:    record.PresetName,
+		PlanID:        record.PlanID,
+		PlanPath:      record.PlanPath,
+		Issue:         record.Issue,
+		PR:            record.PR,
+		Merge:         record.Merge,
+		AutoMode:      record.AutoMode,
+		Phases:        phases,
+		CreatedAt:     record.CreatedAt,
+		UpdatedAt:     record.UpdatedAt,
+	}, "", "  ")
+}
+
+type flowRecordForWrite struct {
+	SchemaVersion int                 `json:"schema_version"`
+	FlowID        string              `json:"flow_id"`
+	Title         string              `json:"title"`
+	Instructions  string              `json:"instructions"`
+	Status        string              `json:"status"`
+	RepoPath      string              `json:"repo_path"`
+	WorktreePath  string              `json:"worktree_path,omitempty"`
+	Branch        string              `json:"branch,omitempty"`
+	BaseRef       string              `json:"base_ref,omitempty"`
+	Commit        string              `json:"commit,omitempty"`
+	PresetName    string              `json:"preset_name,omitempty"`
+	PlanID        string              `json:"plan_id,omitempty"`
+	PlanPath      string              `json:"plan_path,omitempty"`
+	Issue         Issue               `json:"issue,omitempty"`
+	PR            PullRequest         `json:"pr,omitempty"`
+	Merge         Merge               `json:"merge,omitempty"`
+	AutoMode      bool                `json:"auto_mode,omitempty"`
+	Phases        []flowPhaseForWrite `json:"phases"`
+	CreatedAt     time.Time           `json:"created_at"`
+	UpdatedAt     time.Time           `json:"updated_at"`
+}
+
+type flowPhaseForWrite struct {
+	PhaseID       string    `json:"phase_id"`
+	ParentPhaseID string    `json:"parent_phase_id,omitempty"`
+	Title         string    `json:"title"`
+	Kind          string    `json:"kind"`
+	DependsOn     *[]string `json:"depends_on,omitempty"`
+	Status        string    `json:"status"`
+	Order         int       `json:"order"`
+	Outcome       string    `json:"outcome,omitempty"`
+	Notes         string    `json:"notes,omitempty"`
+	Summary       string    `json:"summary,omitempty"`
+	LaunchIDs     []string  `json:"launch_ids,omitempty"`
+	Sessions      []Session `json:"sessions,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+func flowPhaseForWriteFrom(phase FlowPhase, omitDependsOn bool) flowPhaseForWrite {
+	var dependsOn *[]string
+	if !omitDependsOn {
+		dependsOn = &phase.DependsOn
+	}
+	return flowPhaseForWrite{
+		PhaseID:       phase.PhaseID,
+		ParentPhaseID: phase.ParentPhaseID,
+		Title:         phase.Title,
+		Kind:          phase.Kind,
+		DependsOn:     dependsOn,
+		Status:        phase.Status,
+		Order:         phase.Order,
+		Outcome:       phase.Outcome,
+		Notes:         phase.Notes,
+		Summary:       phase.Summary,
+		LaunchIDs:     phase.LaunchIDs,
+		Sessions:      phase.Sessions,
+		CreatedAt:     phase.CreatedAt,
+		UpdatedAt:     phase.UpdatedAt,
+	}
 }
 
 func (s *Store) readRecord(flowID string) (FlowRecord, bool) {
@@ -1990,6 +2087,9 @@ func (s *Store) readRecordWithReadiness(flowID string, selfHealOnRead bool) (Flo
 		}
 	} else {
 		record = normalizeRecordBase(record)
+		if unresolvedGraph {
+			record.preserveMissingDependsOn = missingTopLevelDependsOnByID(record.Phases, presence)
+		}
 	}
 	record.Status = DeriveStatus(record)
 	return record, true
@@ -2102,6 +2202,26 @@ func rawDependsOnPresentForEveryTopLevel(phases []FlowPhase, presence []rawDepen
 		}
 	}
 	return seenTopLevel
+}
+
+func missingTopLevelDependsOnByID(phases []FlowPhase, presence []rawDependsOnState) map[string]bool {
+	missing := make(map[string]bool)
+	for i, phase := range phases {
+		if phase.ParentPhaseID != "" {
+			continue
+		}
+		if i < len(presence) && presence[i].Present {
+			continue
+		}
+		id := artifacts.NormalizePhaseID(phase.PhaseID)
+		if id != "" {
+			missing[id] = true
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return missing
 }
 
 func (s *Store) flowDir(flowID string) string {

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -469,6 +469,9 @@ func (s *Store) SetPhase(update PhaseUpdate) (FlowRecord, error) {
 	if !ok {
 		return FlowRecord{}, flowNotFoundError(update.FlowID)
 	}
+	if err := validatePhaseGraphResolved(record); err != nil {
+		return FlowRecord{}, err
+	}
 	// When a legacy record still holds duplicate rows for this logical phase,
 	// the first row wins: it is validated, updated, and kept, while the others
 	// are merged into it by collapseDuplicatePhaseRows below.
@@ -809,6 +812,9 @@ func (s *Store) MarkManualMerge(update ManualMergeUpdate) (FlowRecord, error) {
 	if !ok {
 		return FlowRecord{}, flowNotFoundError(update.FlowID)
 	}
+	if err := validatePhaseGraphResolved(record); err != nil {
+		return FlowRecord{}, err
+	}
 	phaseIndex := mergePhaseIndex(record)
 	if phaseIndex < 0 {
 		return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", "merge", update.FlowID)
@@ -970,6 +976,9 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 			record.Status = DeriveStatus(record)
 			return record, nil
 		}
+		if err := validateFlowLaunchOccupancy(record, phaseIndex, update.AutoLaunch); err != nil {
+			return FlowRecord{}, err
+		}
 		launchPhaseUpdate := PhaseUpdate{FlowID: update.FlowID, PhaseID: update.PhaseID, Status: PhaseRunning}
 		if phase.Status == PhaseNeedsAttention || phase.Status == PhaseBlocked {
 			launchPhaseUpdate.Notes = fmt.Sprintf("Relaunched after %s.", phase.Status)
@@ -995,6 +1004,45 @@ func (s *Store) AddPhaseLaunchID(update PhaseLaunchUpdate) (FlowRecord, error) {
 		record.Status = DeriveStatus(record)
 		return record, nil
 	})
+}
+
+func validateFlowLaunchOccupancy(record FlowRecord, targetIndex int, autoLaunch bool) error {
+	graph := buildPhaseGraph(record.Phases)
+	for i, phase := range record.Phases {
+		if i == targetIndex || phase.Status != PhaseRunning {
+			continue
+		}
+		if phaseDependsOnTarget(graph, i, targetIndex) {
+			continue
+		}
+		message := fmt.Sprintf("flow %q already has running phase %q", record.FlowID, phase.PhaseID)
+		if autoLaunch {
+			return fmt.Errorf("%s: %w", message, errAutoLaunchOutdated)
+		}
+		return fmt.Errorf("%s", message)
+	}
+	return nil
+}
+
+func phaseDependsOnTarget(graph phaseGraph, phaseIndex, targetIndex int) bool {
+	seen := make(map[int]bool)
+	var visit func(int) bool
+	visit = func(idx int) bool {
+		if idx == targetIndex {
+			return true
+		}
+		if seen[idx] {
+			return false
+		}
+		seen[idx] = true
+		for _, prereq := range graph.prereqsByIdx[idx] {
+			if visit(prereq) {
+				return true
+			}
+		}
+		return false
+	}
+	return visit(phaseIndex)
 }
 
 func validateAutoPhaseLaunch(record FlowRecord, phaseIndex int) error {
@@ -1254,6 +1302,11 @@ func (s *Store) updateFlowWithReadiness(flowID string, selfHealOnRead bool, muta
 	if !ok {
 		return FlowRecord{}, flowNotFoundError(flowID)
 	}
+	if selfHealOnRead {
+		if err := validatePhaseGraphResolved(record); err != nil {
+			return FlowRecord{}, err
+		}
+	}
 	record, err = mutate(record, s.now())
 	if err != nil {
 		return FlowRecord{}, err
@@ -1264,6 +1317,17 @@ func (s *Store) updateFlowWithReadiness(flowID string, selfHealOnRead bool, muta
 		return FlowRecord{}, err
 	}
 	return record, nil
+}
+
+func validatePhaseGraphResolved(record FlowRecord) error {
+	if record.GraphRecovery.Status != GraphRecoveryMissingEdgesUnresolved {
+		return nil
+	}
+	preset := normalizePresetName(record.PresetName)
+	if preset == "" || preset == "default" {
+		return nil
+	}
+	return fmt.Errorf("flow %q has unresolved missing dependencies; restore preset %q or explicit depends_on before mutating phases", record.FlowID, preset)
 }
 
 func appendUnique(values []string, value string) []string {

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -3864,6 +3864,53 @@ func TestStoreMarkManualMergeCompletesMergeAndRecordsMetadata(t *testing.T) {
 	}
 }
 
+func TestStoreMarkManualMergeRejectsUnresolvedMissingDependsOn(t *testing.T) {
+	root := t.TempDir()
+	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	flowID := "20260607T120000Z-unresolved-manual-merge"
+	writeRawFlowMeta(t, root, flowID, `
+  "branch": "flow/manual-merge",
+  "preset_name": "research",
+  "pr": {"provider": "github", "number": 116, "url": "https://github.com/brian-bell/wtui/pull/116", "head_branch": "flow/manual-merge", "base_branch": "main", "status": "open"},
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "status": "completed", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "completed", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "publish", "title": "Publish", "kind": "merge", "status": "ready", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ]`)
+
+	_, err = store.MarkManualMerge(flowstore.ManualMergeUpdate{
+		FlowID:   flowID,
+		PRNumber: 116,
+		PRURL:    "https://github.com/brian-bell/wtui/pull/116",
+		Commit:   "0123456789abcdef",
+		MergedAt: mergedAt,
+	})
+	if err == nil || !strings.Contains(err.Error(), "unresolved missing dependencies") {
+		t.Fatalf("MarkManualMerge() error = %v, want unresolved graph error", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "flows", flowID, "meta.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(meta.json) error = %v", err)
+	}
+	var raw struct {
+		Phases []map[string]json.RawMessage `json:"phases"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal(meta.json) error = %v\n%s", err, data)
+	}
+	for _, phase := range raw.Phases {
+		if strings.Contains(string(phase["phase_id"]), "draft") {
+			if _, ok := phase["depends_on"]; ok {
+				t.Fatalf("draft depends_on was persisted after rejected manual merge:\n%s", data)
+			}
+		}
+	}
+}
+
 func TestStoreMarkManualMergeRejectsChangedPRTarget(t *testing.T) {
 	root := t.TempDir()
 	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
@@ -5899,6 +5946,44 @@ func TestMetadataOnlyUpdatePreservesUnresolvedMissingDependsOn(t *testing.T) {
 	}
 }
 
+func TestSetPhaseRejectsUnresolvedMissingDependsOn(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	flowID := "20260607T120000Z-unresolved-phase-mutation"
+	writeRawFlowMeta(t, root, flowID, `
+  "preset_name": "research",
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "status": "ready", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "publish", "title": "Publish", "kind": "merge", "status": "pending", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ]`)
+
+	_, err = store.SetPhase(flowstore.PhaseUpdate{FlowID: flowID, PhaseID: "research", Status: flowstore.PhaseCompleted})
+	if err == nil || !strings.Contains(err.Error(), "unresolved missing dependencies") {
+		t.Fatalf("SetPhase() error = %v, want unresolved graph error", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "flows", flowID, "meta.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(meta.json) error = %v", err)
+	}
+	var raw struct {
+		Phases []map[string]json.RawMessage `json:"phases"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal(meta.json) error = %v\n%s", err, data)
+	}
+	for _, phase := range raw.Phases {
+		if strings.Contains(string(phase["phase_id"]), "draft") {
+			if _, ok := phase["depends_on"]; ok {
+				t.Fatalf("draft depends_on was persisted after rejected mutation:\n%s", data)
+			}
+		}
+	}
+}
+
 func TestSetPhaseRestoresNamedPresetEdgesBeforeWrite(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{
@@ -6491,6 +6576,97 @@ func TestStoreAddPhaseLaunchIDRejectsReadyPhaseWithUnsatisfiedDependency(t *test
 	}
 	if got := phaseByID(t, read, "publish"); len(got.LaunchIDs) != 0 || got.Status != flowstore.PhasePending {
 		t.Fatalf("publish after rejected launch = %#v, want demoted pending without launch", got)
+	}
+}
+
+func TestStoreAddPhaseLaunchIDRejectsAutoLaunchWhenAnotherPhaseRunning(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := graphRecord(root, "20260607T120000Z-auto-occupied-launch", []flowstore.FlowPhase{
+		graphPhase(now, "branch-a", flowstore.PhaseRunning, []string{}),
+		graphPhase(now, "branch-b", flowstore.PhaseReady, []string{}),
+	})
+	writeFreshFlowRecordForTest(t, root, record)
+
+	_, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:     record.FlowID,
+		PhaseID:    "branch-b",
+		LaunchID:   "launch-branch-b",
+		AutoLaunch: true,
+	})
+	if err == nil || !flowstore.IsAutoLaunchOutdated(err) || !strings.Contains(err.Error(), "already has running phase") {
+		t.Fatalf("AddPhaseLaunchID(auto occupied) error = %v, want auto-launch outdated occupancy error", err)
+	}
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(t, read, "branch-b"); len(got.LaunchIDs) != 0 || got.Status != flowstore.PhaseReady {
+		t.Fatalf("branch-b after rejected auto launch = %#v, want unchanged ready without launch", got)
+	}
+}
+
+func TestStoreAddPhaseLaunchIDRejectsManualLaunchWhenAnotherPhaseRunning(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := graphRecord(root, "20260607T120000Z-manual-occupied-launch", []flowstore.FlowPhase{
+		graphPhase(now, "branch-a", flowstore.PhaseRunning, []string{}),
+		graphPhase(now, "branch-b", flowstore.PhaseReady, []string{}),
+	})
+	writeFreshFlowRecordForTest(t, root, record)
+
+	_, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:   record.FlowID,
+		PhaseID:  "branch-b",
+		LaunchID: "launch-branch-b",
+	})
+	if err == nil || flowstore.IsAutoLaunchOutdated(err) || !strings.Contains(err.Error(), "already has running phase") {
+		t.Fatalf("AddPhaseLaunchID(manual occupied) error = %v, want manual occupancy error", err)
+	}
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(t, read, "branch-b"); len(got.LaunchIDs) != 0 || got.Status != flowstore.PhaseReady {
+		t.Fatalf("branch-b after rejected manual launch = %#v, want unchanged ready without launch", got)
+	}
+}
+
+func TestStoreAddPhaseLaunchIDRejectsRelaunchWhenAnotherPhaseRunning(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := graphRecord(root, "20260607T120000Z-manual-occupied-relaunch", []flowstore.FlowPhase{
+		graphPhase(now, "branch-a", flowstore.PhaseRunning, []string{}),
+		graphPhase(now, "branch-b", flowstore.PhaseNeedsAttention, []string{}),
+	})
+	writeFreshFlowRecordForTest(t, root, record)
+
+	_, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:   record.FlowID,
+		PhaseID:  "branch-b",
+		LaunchID: "launch-branch-b",
+	})
+	if err == nil || !strings.Contains(err.Error(), "already has running phase") {
+		t.Fatalf("AddPhaseLaunchID(manual occupied relaunch) error = %v, want occupancy error", err)
+	}
+	read, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got := phaseByID(t, read, "branch-b"); len(got.LaunchIDs) != 0 || got.Status != flowstore.PhaseNeedsAttention {
+		t.Fatalf("branch-b after rejected relaunch = %#v, want unchanged needs_attention without launch", got)
 	}
 }
 

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5620,7 +5620,7 @@ func TestReadBackfillsLinearDependsOn(t *testing.T) {
 	}
 }
 
-func TestReadBackfillsLinearDependsOnForLegacyCustomFlow(t *testing.T) {
+func TestReadMissingDependsOnForLegacyCustomFlowStaysUnresolved(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Now: func() time.Time { return now }})
@@ -5654,16 +5654,119 @@ func TestReadBackfillsLinearDependsOnForLegacyCustomFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Read() error = %v", err)
 	}
-	if got := phaseByID(t, read, "beta").DependsOn; len(got) != 1 || got[0] != "alpha" {
-		t.Fatalf("beta DependsOn = %#v, want [alpha]", got)
+	if read.GraphRecovery.Status != flowstore.GraphRecoveryMissingEdgesUnresolved {
+		t.Fatalf("GraphRecovery.Status = %q, want %q", read.GraphRecovery.Status, flowstore.GraphRecoveryMissingEdgesUnresolved)
+	}
+	if got := phaseByID(t, read, "beta").DependsOn; len(got) != 0 || got == nil {
+		t.Fatalf("beta DependsOn = %#v, want explicit empty unresolved graph", got)
 	}
 
 	updated, err := store.SetPhase(flowstore.PhaseUpdate{FlowID: flowID, PhaseID: "alpha", Status: flowstore.PhaseNeedsAttention})
 	if err != nil {
 		t.Fatalf("SetPhase(alpha needs_attention) error = %v", err)
 	}
-	if got := phaseByID(t, updated, "beta").Status; got != flowstore.PhasePending {
-		t.Fatalf("beta status = %q, want pending while alpha is unsatisfied", got)
+	if got := phaseByID(t, updated, "beta").Status; got != flowstore.PhaseReady {
+		t.Fatalf("beta status = %q, want ready as unresolved independent root", got)
+	}
+}
+
+func TestReadRestoresMissingDependsOnFromNamedPreset(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{
+		Root:    root,
+		Now:     func() time.Time { return now },
+		Presets: []flowstore.Preset{researchPresetForStoreTest()},
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	writeRawFlowMeta(t, root, "20260607T120000Z-preset-recovery", `
+  "preset_name": "research",
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "status": "completed", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "publish", "title": "Publish", "kind": "merge", "status": "pending", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ]`)
+
+	read, err := store.Read("20260607T120000Z-preset-recovery")
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.GraphRecovery.Status != flowstore.GraphRecoveryPresetEdgesRestored {
+		t.Fatalf("GraphRecovery.Status = %q, want %q", read.GraphRecovery.Status, flowstore.GraphRecoveryPresetEdgesRestored)
+	}
+	if got := phaseByID(t, read, "draft").DependsOn; len(got) != 1 || got[0] != "research" {
+		t.Fatalf("draft DependsOn = %#v, want [research]", got)
+	}
+
+	records, err := store.List(flowstore.FlowFilter{})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(records) != 1 || records[0].GraphRecovery.Status != flowstore.GraphRecoveryPresetEdgesRestored {
+		t.Fatalf("List() recovery = %#v", records)
+	}
+}
+
+func TestReadMissingNamedPresetEdgesUnresolvedWhenPresetUnavailable(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	writeRawFlowMeta(t, root, "20260607T120000Z-missing-preset", `
+  "preset_name": "research",
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "status": "completed", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "completed", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ]`)
+
+	read, err := store.Read("20260607T120000Z-missing-preset")
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.GraphRecovery.Status != flowstore.GraphRecoveryMissingEdgesUnresolved {
+		t.Fatalf("GraphRecovery.Status = %q, want %q", read.GraphRecovery.Status, flowstore.GraphRecoveryMissingEdgesUnresolved)
+	}
+	if got := phaseByID(t, read, "draft").DependsOn; len(got) != 0 || got == nil {
+		t.Fatalf("draft DependsOn = %#v, want explicit empty unresolved graph", got)
+	}
+}
+
+func TestSetPhaseRestoresNamedPresetEdgesBeforeWrite(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{
+		Root:    root,
+		Presets: []flowstore.Preset{researchPresetForStoreTest()},
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	flowID := "20260607T120000Z-preset-mutation-recovery"
+	writeRawFlowMeta(t, root, flowID, `
+  "preset_name": "research",
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "status": "ready", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "publish", "title": "Publish", "kind": "merge", "status": "pending", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ]`)
+
+	updated, err := store.SetPhase(flowstore.PhaseUpdate{FlowID: flowID, PhaseID: "research", Status: flowstore.PhaseCompleted})
+	if err != nil {
+		t.Fatalf("SetPhase() error = %v", err)
+	}
+	if got := phaseByID(t, updated, "draft").DependsOn; len(got) != 1 || got[0] != "research" {
+		t.Fatalf("updated draft DependsOn = %#v, want [research]", got)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "flows", flowID, "meta.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(meta.json) error = %v", err)
+	}
+	if !strings.Contains(string(data), `"depends_on": [
+        "research"
+      ]`) {
+		t.Fatalf("meta.json did not persist restored depends_on:\n%s", data)
 	}
 }
 
@@ -6252,6 +6355,39 @@ func graphPhase(now time.Time, phaseID, status string, dependsOn []string) flows
 		Order:     1,
 		CreatedAt: now,
 		UpdatedAt: now,
+	}
+}
+
+func researchPresetForStoreTest() flowstore.Preset {
+	return flowstore.Preset{
+		Name: "research",
+		Phases: []flowstore.PhaseSpec{
+			{ID: "research", Title: "Research", Kind: flowstore.KindPlan, DependsOn: []string{}},
+			{ID: "draft", Title: "Draft", Kind: flowstore.KindImplementation, DependsOn: []string{"research"}},
+			{ID: "publish", Title: "Publish", Kind: flowstore.KindMerge, DependsOn: []string{"draft"}},
+		},
+	}
+}
+
+func writeRawFlowMeta(t *testing.T, root, flowID, fields string) {
+	t.Helper()
+	flowDir := filepath.Join(root, "flows", flowID)
+	if err := os.MkdirAll(flowDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	meta := `{
+  "schema_version": 1,
+  "flow_id": "` + flowID + `",
+  "title": "Raw flow",
+  "instructions": "raw migration fixture",
+  "status": "in_progress",
+  "repo_path": "` + filepath.Join(root, "repo") + `",
+` + fields + `,
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-01T00:00:00Z"
+}`
+	if err := os.WriteFile(filepath.Join(flowDir, "meta.json"), []byte(meta), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
 	}
 }
 

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5709,6 +5709,35 @@ func TestReadRestoresMissingDependsOnFromNamedPreset(t *testing.T) {
 	}
 }
 
+func TestReadRestoresPartiallyMissingDependsOnFromNamedPreset(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{
+		Root:    root,
+		Presets: []flowstore.Preset{researchPresetForStoreTest()},
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	writeRawFlowMeta(t, root, "20260607T120000Z-partial-preset-recovery", `
+  "preset_name": "research",
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "depends_on": [], "status": "completed", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "publish", "title": "Publish", "kind": "merge", "depends_on": ["draft"], "status": "pending", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ]`)
+
+	read, err := store.Read("20260607T120000Z-partial-preset-recovery")
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.GraphRecovery.Status != flowstore.GraphRecoveryPresetEdgesRestored {
+		t.Fatalf("GraphRecovery.Status = %q, want %q", read.GraphRecovery.Status, flowstore.GraphRecoveryPresetEdgesRestored)
+	}
+	if got := phaseByID(t, read, "draft").DependsOn; len(got) != 1 || got[0] != "research" {
+		t.Fatalf("draft DependsOn = %#v, want [research]", got)
+	}
+}
+
 func TestReadMissingNamedPresetEdgesUnresolvedWhenPresetUnavailable(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5846,6 +5846,59 @@ func TestReadUnresolvedGraphWithPlanReviewDoesNotSelfHealReadiness(t *testing.T)
 	}
 }
 
+func TestMetadataOnlyUpdatePreservesUnresolvedMissingDependsOn(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	flowID := "20260607T120000Z-unresolved-metadata"
+	writeRawFlowMeta(t, root, flowID, `
+  "preset_name": "research",
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "status": "completed", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "publish", "title": "Publish", "kind": "merge", "status": "pending", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ]`)
+
+	if _, err := store.SetIssue(flowstore.IssueUpdate{
+		FlowID:   flowID,
+		Provider: "github",
+		Number:   276,
+		URL:      "https://github.com/brian-bell/wtui/issues/276",
+	}); err != nil {
+		t.Fatalf("SetIssue() error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "flows", flowID, "meta.json"))
+	if err != nil {
+		t.Fatalf("ReadFile(meta.json) error = %v", err)
+	}
+	var raw struct {
+		Phases []map[string]json.RawMessage `json:"phases"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal(meta.json) error = %v\n%s", err, data)
+	}
+	for _, phase := range raw.Phases {
+		if strings.Contains(string(phase["phase_id"]), "draft") {
+			if _, ok := phase["depends_on"]; ok {
+				t.Fatalf("draft depends_on was persisted for unresolved graph:\n%s", data)
+			}
+		}
+	}
+
+	reread, err := store.Read(flowID)
+	if err != nil {
+		t.Fatalf("Read() after SetIssue error = %v", err)
+	}
+	if reread.GraphRecovery.Status != flowstore.GraphRecoveryMissingEdgesUnresolved {
+		t.Fatalf("GraphRecovery.Status = %q, want %q", reread.GraphRecovery.Status, flowstore.GraphRecoveryMissingEdgesUnresolved)
+	}
+	if got := phaseByID(t, reread, "draft").Status; got != flowstore.PhasePending {
+		t.Fatalf("draft status after metadata write = %q, want pending", got)
+	}
+}
+
 func TestSetPhaseRestoresNamedPresetEdgesBeforeWrite(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5792,6 +5792,31 @@ func TestReadMissingNamedPresetDoesNotBackfillDefaultEdges(t *testing.T) {
 	}
 }
 
+func TestReadPartiallyMissingUnavailableNamedPresetDoesNotSelfHealReadiness(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	writeRawFlowMeta(t, root, "20260607T120000Z-partial-missing-preset", `
+  "preset_name": "research",
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "depends_on": [], "status": "completed", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ]`)
+
+	read, err := store.Read("20260607T120000Z-partial-missing-preset")
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.GraphRecovery.Status != flowstore.GraphRecoveryMissingEdgesUnresolved {
+		t.Fatalf("GraphRecovery.Status = %q, want %q", read.GraphRecovery.Status, flowstore.GraphRecoveryMissingEdgesUnresolved)
+	}
+	if got := phaseByID(t, read, "draft").Status; got != flowstore.PhasePending {
+		t.Fatalf("draft status = %q, want pending while graph recovery is unresolved", got)
+	}
+}
+
 func TestSetPhaseRestoresNamedPresetEdgesBeforeWrite(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5817,6 +5817,35 @@ func TestReadPartiallyMissingUnavailableNamedPresetDoesNotSelfHealReadiness(t *t
 	}
 }
 
+func TestReadUnresolvedGraphWithPlanReviewDoesNotSelfHealReadiness(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	writeRawFlowMeta(t, root, "20260607T120000Z-unresolved-plan-review", `
+  "preset_name": "research",
+  "phases": [
+    {"phase_id": "research", "title": "Research", "kind": "plan", "depends_on": [], "status": "completed", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "review", "title": "Review", "kind": "plan_review", "depends_on": ["research"], "status": "completed", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "draft", "title": "Draft", "kind": "implementation", "status": "pending", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ]`)
+
+	read, err := store.Read("20260607T120000Z-unresolved-plan-review")
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.GraphRecovery.Status != flowstore.GraphRecoveryMissingEdgesUnresolved {
+		t.Fatalf("GraphRecovery.Status = %q, want %q", read.GraphRecovery.Status, flowstore.GraphRecoveryMissingEdgesUnresolved)
+	}
+	if got := phaseByID(t, read, "draft").Status; got != flowstore.PhasePending {
+		t.Fatalf("draft status = %q, want pending while graph recovery is unresolved", got)
+	}
+	if got := phaseByID(t, read, "review").Outcome; got != flowstore.OutcomeApproved {
+		t.Fatalf("review outcome = %q, want approved normalization without readiness refresh", got)
+	}
+}
+
 func TestSetPhaseRestoresNamedPresetEdgesBeforeWrite(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -5734,6 +5734,35 @@ func TestReadMissingNamedPresetEdgesUnresolvedWhenPresetUnavailable(t *testing.T
 	}
 }
 
+func TestReadMissingNamedPresetDoesNotBackfillDefaultEdges(t *testing.T) {
+	root := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	writeRawFlowMeta(t, root, "20260607T120000Z-missing-default-shaped-preset", `
+  "preset_name": "custom",
+  "phases": [
+    {"phase_id": "plan", "title": "Plan", "kind": "plan", "status": "completed", "order": 1, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "implementation", "title": "Implementation", "kind": "implementation", "status": "pending", "order": 2, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"},
+    {"phase_id": "review-loop", "title": "Review loop", "kind": "review_loop", "status": "pending", "order": 3, "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"}
+  ]`)
+
+	read, err := store.Read("20260607T120000Z-missing-default-shaped-preset")
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if read.GraphRecovery.Status != flowstore.GraphRecoveryMissingEdgesUnresolved {
+		t.Fatalf("GraphRecovery.Status = %q, want %q", read.GraphRecovery.Status, flowstore.GraphRecoveryMissingEdgesUnresolved)
+	}
+	if got := phaseByID(t, read, "implementation").DependsOn; len(got) != 0 || got == nil {
+		t.Fatalf("implementation DependsOn = %#v, want explicit empty unresolved graph", got)
+	}
+	if got := phaseByID(t, read, "review-loop").DependsOn; len(got) != 0 || got == nil {
+		t.Fatalf("review-loop DependsOn = %#v, want explicit empty unresolved graph", got)
+	}
+}
+
 func TestSetPhaseRestoresNamedPresetEdgesBeforeWrite(t *testing.T) {
 	root := t.TempDir()
 	store, err := flowstore.NewStore(flowstore.StoreOptions{

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -874,21 +874,16 @@ func (m Model) dismissExitedFlowEmbeddedTerminals() Model {
 	return m
 }
 
-func (m Model) exitedFlowEmbeddedTerminalAutoCloseKeys() []deferredAutoFlowLaunchKey {
-	keys := make([]deferredAutoFlowLaunchKey, 0)
+func (m Model) hasExitedFlowEmbeddedTerminalAutoClose() bool {
 	for _, slot := range m.embeddedTerminals {
 		if slot.Scope != embeddedTerminalScopeFlow || slot.Terminal == nil {
 			continue
 		}
-		if !flowEmbeddedTerminalAutoCloses(slot.Terminal.State()) {
-			continue
-		}
-		key, ok := newDeferredAutoFlowLaunchKey(slot.FlowID, slot.FlowPhaseID)
-		if ok {
-			keys = append(keys, key)
+		if flowEmbeddedTerminalAutoCloses(slot.Terminal.State()) {
+			return true
 		}
 	}
-	return keys
+	return false
 }
 
 func flowEmbeddedTerminalAutoCloses(state string) bool {
@@ -920,7 +915,6 @@ func (m Model) dismissEmbeddedTerminal(id embeddedTerminalID) Model {
 		if slot.ID != id {
 			next = append(next, slot)
 		} else {
-			m = m.clearDeferredAutoFlowLaunchForTerminal(slot)
 			removedScope = slot.Scope
 			removed = true
 		}

--- a/model/export_test.go
+++ b/model/export_test.go
@@ -49,6 +49,17 @@ func HasRunningFlowEmbeddedTerminalForPhaseForTest(m Model, flowID, phaseID stri
 	return m.hasRunningFlowEmbeddedTerminalForPhase(flowID, phaseID)
 }
 
+func ClearFlowEmbeddedTerminalsForTest(m Model) Model {
+	var kept []embeddedTerminalSlot
+	for _, slot := range m.embeddedTerminals {
+		if slot.Scope != embeddedTerminalScopeFlow {
+			kept = append(kept, slot)
+		}
+	}
+	m.embeddedTerminals = kept
+	return m
+}
+
 func AutoAdvanceResultForTest(m Model, flows []flowstore.FlowRecord) (Model, tea.Cmd) {
 	m.autoAdvanceInFlight = 1
 	return m.handleAutoAdvanceResult(AutoAdvanceResultMsg{Flows: flows, Request: 1})
@@ -62,8 +73,6 @@ func AutoAdvanceLaunchCommandForTest(m Model, flows []flowstore.FlowRecord) (Mod
 	var cmds []tea.Cmd
 	var cmd tea.Cmd
 	m, cmd, _ = m.prepareAutoFlowPhaseLaunch(previous, current)
-	cmds = append(cmds, cmd)
-	m, cmd = m.prepareDeferredAutoFlowPhaseLaunchesFrom(m.autoAdvanceSnapshot)
 	cmds = append(cmds, cmd)
 	return m, batchNonNil(cmds...)
 }

--- a/model/export_test.go
+++ b/model/export_test.go
@@ -87,7 +87,7 @@ func FlowPhaseDoneInstructionForTest() string {
 }
 
 func FlowPlanPromptForTest(record flowstore.FlowRecord, templates FlowPromptTemplates) string {
-	return flowPlanPrompt(record, templates)
+	return flowPlanPrompt(record, flowstore.FlowPhase{PhaseID: flowPlanPhaseID, Title: "Plan", Kind: flowstore.KindPlan}, templates)
 }
 
 func FlowPhasePromptForTest(record flowstore.FlowRecord, phase flowstore.FlowPhase, planPath, planBody string, templates FlowPromptTemplates) string {

--- a/model/flow_advance_tick.go
+++ b/model/flow_advance_tick.go
@@ -78,14 +78,9 @@ func (m Model) handleAutoAdvanceResult(msg AutoAdvanceResultMsg) (Model, tea.Cmd
 
 	var cmds []tea.Cmd
 	var autoCmd tea.Cmd
-	var retryEdges []deferredAutoFlowLaunchKey
-	m, autoCmd, retryEdges = m.prepareAutoFlowPhaseLaunch(previous, current)
+	m, autoCmd, _ = m.prepareAutoFlowPhaseLaunch(previous, current)
 	cmds = append(cmds, autoCmd)
-	m.autoAdvanceSnapshot = autoAdvanceSnapshotAfterResult(previous, current, retryEdges)
-
-	var deferredCmd tea.Cmd
-	m, deferredCmd = m.prepareDeferredAutoFlowPhaseLaunchesFrom(m.autoAdvanceSnapshot)
-	cmds = append(cmds, deferredCmd)
+	m.autoAdvanceSnapshot = current
 
 	statuses := autoAdvanceStatusEvents(previous, m.autoAdvanceLaunchedPhases, current)
 	if len(statuses) > 0 {
@@ -99,52 +94,6 @@ func (m Model) handleAutoAdvanceResult(msg AutoAdvanceResultMsg) (Model, tea.Cmd
 	m, tickCmd = m.finishAutoAdvanceFetch(msg.Request)
 	cmds = append(cmds, tickCmd)
 	return m, batchNonNil(cmds...)
-}
-
-func autoAdvanceSnapshotAfterResult(previous, current []flowstore.FlowRecord, retryEdges []deferredAutoFlowLaunchKey) []flowstore.FlowRecord {
-	if len(retryEdges) == 0 {
-		return current
-	}
-	retryFlowIDs := make(map[string]struct{}, len(retryEdges))
-	for _, edge := range retryEdges {
-		if edge.FlowID != "" {
-			retryFlowIDs[edge.FlowID] = struct{}{}
-		}
-	}
-	if len(retryFlowIDs) == 0 {
-		return current
-	}
-	previousByFlowID := make(map[string]flowstore.FlowRecord, len(previous))
-	for _, record := range previous {
-		if record.FlowID != "" {
-			previousByFlowID[record.FlowID] = record
-		}
-	}
-	snapshot := cloneFlowRecords(current)
-	for i, record := range snapshot {
-		if _, retry := retryFlowIDs[record.FlowID]; !retry {
-			continue
-		}
-		if prior, ok := previousByFlowID[record.FlowID]; ok {
-			snapshot[i] = prior
-		}
-	}
-	return snapshot
-}
-
-func (m Model) restoreAutoAdvanceRetrySnapshot(record flowstore.FlowRecord) Model {
-	if record.FlowID == "" {
-		return m
-	}
-	prior := cloneFlowRecord(record)
-	for i, current := range m.autoAdvanceSnapshot {
-		if current.FlowID == record.FlowID {
-			m.autoAdvanceSnapshot[i] = prior
-			return m
-		}
-	}
-	m.autoAdvanceSnapshot = append(m.autoAdvanceSnapshot, prior)
-	return m
 }
 
 func (m Model) seedAutoAdvanceSnapshot(flows []flowstore.FlowRecord) Model {

--- a/model/flow_advance_tick_test.go
+++ b/model/flow_advance_tick_test.go
@@ -50,6 +50,30 @@ func autoAdvanceTestFlow(flowID, repoPath string, autoMode bool, statuses map[st
 	}
 }
 
+func autoAdvanceCustomFlow(statuses map[string]string) flowstore.FlowRecord {
+	phases := []flowstore.FlowPhase{
+		{PhaseID: "root", Title: "Root", Kind: flowstore.KindPlan, Status: statuses["root"], Order: 1, DependsOn: []string{}},
+		{PhaseID: "branch-a", Title: "Branch A", Kind: flowstore.KindImplementation, Status: statuses["branch-a"], Order: 2, DependsOn: []string{"root"}},
+		{PhaseID: "branch-b", Title: "Branch B", Kind: flowstore.KindReviewLoop, Status: statuses["branch-b"], Order: 3, DependsOn: []string{"root"}},
+		{PhaseID: "summary", Title: "Summary", Kind: "", Status: statuses["summary"], Order: 4, DependsOn: []string{"branch-a", "branch-b"}},
+	}
+	for i := range phases {
+		if phases[i].Status == "" {
+			phases[i].Status = flowstore.PhasePending
+		}
+	}
+	return flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		Title:        "Custom Flow",
+		RepoPath:     "/dev/bravo",
+		WorktreePath: "/dev/bravo-worktrees/custom",
+		Branch:       "flow/custom",
+		Status:       flowstore.StatusInProgress,
+		AutoMode:     true,
+		Phases:       phases,
+	}
+}
+
 func runAutoAdvanceResultForTest(t *testing.T, m Model, flows []flowstore.FlowRecord) (Model, tea.Cmd) {
 	t.Helper()
 	m.autoAdvanceInFlight = 1
@@ -78,6 +102,139 @@ func firstFlowEmbeddedLaunchFromAutoAdvance(t *testing.T, cmd tea.Cmd) FlowEmbed
 	}
 	t.Fatalf("auto-advance batch returned no FlowEmbeddedLaunchRequestedMsg")
 	return FlowEmbeddedLaunchRequestedMsg{}
+}
+
+func TestAutoModeFanOutDrainsSequentially(t *testing.T) {
+	previous := autoAdvanceCustomFlow(map[string]string{
+		"root": flowstore.PhaseRunning,
+	})
+	rootCompleted := autoAdvanceCustomFlow(map[string]string{
+		"root":     flowstore.PhaseCompleted,
+		"branch-a": flowstore.PhaseReady,
+		"branch-b": flowstore.PhaseReady,
+	})
+	var updates []flowstore.PhaseLaunchUpdate
+	m := NewWithOptions(flowRefreshTestRepos(), Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			return rootCompleted, nil
+		},
+	})
+	m.autoAdvanceSnapshot = []flowstore.FlowRecord{previous}
+
+	m, cmd := runAutoAdvanceResultForTest(t, m, []flowstore.FlowRecord{rootCompleted})
+	launch := firstFlowEmbeddedLaunchFromAutoAdvance(t, cmd)
+	if launch.LaunchContext.FlowPhaseID != "branch-a" {
+		t.Fatalf("first drain launch = %q, want branch-a", launch.LaunchContext.FlowPhaseID)
+	}
+	if len(updates) != 1 || updates[0].PhaseID != "branch-a" {
+		t.Fatalf("updates = %#v, want branch-a launch", updates)
+	}
+
+	branchARunning := autoAdvanceCustomFlow(map[string]string{
+		"root":     flowstore.PhaseCompleted,
+		"branch-a": flowstore.PhaseRunning,
+		"branch-b": flowstore.PhaseReady,
+	})
+	m, _ = runAutoAdvanceResultForTest(t, m, []flowstore.FlowRecord{branchARunning})
+	if len(updates) != 1 {
+		t.Fatalf("updates while branch-a running = %#v, want no additional launch", updates)
+	}
+
+	branchACompleted := autoAdvanceCustomFlow(map[string]string{
+		"root":     flowstore.PhaseCompleted,
+		"branch-a": flowstore.PhaseCompleted,
+		"branch-b": flowstore.PhaseReady,
+	})
+	m, cmd = runAutoAdvanceResultForTest(t, m, []flowstore.FlowRecord{branchACompleted})
+	launch = firstFlowEmbeddedLaunchFromAutoAdvance(t, cmd)
+	if launch.LaunchContext.FlowPhaseID != "branch-b" {
+		t.Fatalf("second drain launch = %q, want branch-b", launch.LaunchContext.FlowPhaseID)
+	}
+}
+
+func TestAutoModeSkipDoesNotArmDrain(t *testing.T) {
+	previous := autoAdvanceCustomFlow(map[string]string{
+		"root": flowstore.PhaseRunning,
+	})
+	skipped := autoAdvanceCustomFlow(map[string]string{
+		"root":     flowstore.PhaseSkipped,
+		"branch-a": flowstore.PhaseReady,
+	})
+	skipped.Phases[0].Notes = "Skipped by user"
+	var updates []flowstore.PhaseLaunchUpdate
+	m := NewWithOptions(flowRefreshTestRepos(), Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			return skipped, nil
+		},
+	})
+	m.autoAdvanceSnapshot = []flowstore.FlowRecord{previous}
+
+	m, _ = runAutoAdvanceResultForTest(t, m, []flowstore.FlowRecord{skipped})
+	if len(updates) != 0 {
+		t.Fatalf("updates after skip = %#v, want none", updates)
+	}
+	if len(m.autoAdvanceDrainFlows) != 0 {
+		t.Fatalf("autoAdvanceDrainFlows = %#v, want skip not to arm drain", m.autoAdvanceDrainFlows)
+	}
+}
+
+func TestAutoModeAutoreviewSuccessorLaunches(t *testing.T) {
+	previous := autoAdvanceTestFlow("flow-1", "/dev/bravo", true, map[string]string{
+		"pr-creation": flowstore.PhaseCompleted,
+		"autoreview":  flowstore.PhaseRunning,
+	})
+	current := previous
+	current.Phases = append([]flowstore.FlowPhase(nil), previous.Phases...)
+	current.Phases[5].Status = flowstore.PhaseCompleted
+	current.Phases[6] = flowstore.FlowPhase{PhaseID: "summary", Title: "Summary", Kind: "", Status: flowstore.PhaseReady, Order: 7, DependsOn: []string{"autoreview"}}
+	var updates []flowstore.PhaseLaunchUpdate
+	m := NewWithOptions(flowRefreshTestRepos(), Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			return current, nil
+		},
+	})
+	m.autoAdvanceSnapshot = []flowstore.FlowRecord{previous}
+
+	_, cmd := runAutoAdvanceResultForTest(t, m, []flowstore.FlowRecord{current})
+	launch := firstFlowEmbeddedLaunchFromAutoAdvance(t, cmd)
+	if launch.LaunchContext.FlowPhaseID != "summary" {
+		t.Fatalf("autoreview successor launch = %q, want summary", launch.LaunchContext.FlowPhaseID)
+	}
+	if len(updates) != 1 || updates[0].PhaseID != "summary" {
+		t.Fatalf("updates = %#v, want summary", updates)
+	}
+}
+
+func TestAutoModeDisableDisarmsDrain(t *testing.T) {
+	current := autoAdvanceCustomFlow(map[string]string{
+		"root":     flowstore.PhaseCompleted,
+		"branch-a": flowstore.PhaseReady,
+	})
+	current.AutoMode = false
+	var updates []flowstore.PhaseLaunchUpdate
+	m := NewWithOptions(flowRefreshTestRepos(), Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			return current, nil
+		},
+	})
+	m.autoAdvanceSnapshot = []flowstore.FlowRecord{current}
+	m.autoAdvanceDrainFlows = map[string]struct{}{"flow-1": {}}
+
+	m, _ = runAutoAdvanceResultForTest(t, m, []flowstore.FlowRecord{current})
+	if len(updates) != 0 {
+		t.Fatalf("updates after disabling AutoMode = %#v, want none", updates)
+	}
+	if len(m.autoAdvanceDrainFlows) != 0 {
+		t.Fatalf("autoAdvanceDrainFlows = %#v, want disabled flow disarmed", m.autoAdvanceDrainFlows)
+	}
 }
 
 func collectMsgsFromCmd(t *testing.T, cmd tea.Cmd) []tea.Msg {
@@ -380,8 +537,11 @@ func TestModel_AutoAdvancePreflightFailurePreservesCompletionEdge(t *testing.T) 
 	if len(updates) != 0 {
 		t.Fatalf("launch updates after preflight failure = %#v, want none", updates)
 	}
-	if len(m.autoAdvanceSnapshot) != 1 || m.autoAdvanceSnapshot[0].Phases[1].Status != flowstore.PhaseRunning {
-		t.Fatalf("autoAdvanceSnapshot = %#v, want previous running edge preserved", m.autoAdvanceSnapshot)
+	if len(m.autoAdvanceSnapshot) != 1 || m.autoAdvanceSnapshot[0].Phases[2].Status != flowstore.PhaseReady {
+		t.Fatalf("autoAdvanceSnapshot = %#v, want current ready snapshot", m.autoAdvanceSnapshot)
+	}
+	if _, ok := m.autoAdvanceDrainFlows["flow-1"]; !ok {
+		t.Fatalf("autoAdvanceDrainFlows = %#v, want flow-1 armed", m.autoAdvanceDrainFlows)
 	}
 
 	m.agentCommand = "codex"
@@ -397,29 +557,24 @@ func TestModel_AutoAdvancePreflightFailurePreservesCompletionEdge(t *testing.T) 
 }
 
 func TestModel_AutoAdvanceActionFailureSetsStatusOffRepo(t *testing.T) {
-	previous := autoAdvanceTestFlow("flow-1", "/dev/bravo", true, map[string]string{
-		"plan":           flowstore.PhaseCompleted,
-		"plan-review":    flowstore.PhaseRunning,
-		"implementation": flowstore.PhasePending,
-	})
 	m := NewWithOptions(flowRefreshTestRepos(), Options{})
 	m.mode = ui.ModeWorktrees
 
 	m, cmd := updateFlowRefreshTest(m, ActionFailedMsg{
-		RepoPath:               "/dev/bravo",
-		Err:                    "failed to mark flow phase running: store unavailable",
-		AutoAdvanceRetryRecord: previous,
+		RepoPath:                "/dev/bravo",
+		Err:                     "failed to mark flow phase running: store unavailable",
+		AutoAdvanceRetryFlowID:  "flow-1",
+		AutoAdvanceRetryPhaseID: "implementation",
 	})
 	if cmd == nil {
 		t.Fatal("off-repo auto-advance failure should schedule status expiry")
 	}
 	if m.status.Source != statusFlowAutoAdvance ||
-		m.status.Text != "Flow Bravo Flow: failed to mark flow phase running: store unavailable" {
+		m.status.Text != "Flow flow-1: failed to mark flow phase running: store unavailable" {
 		t.Fatalf("status = %#v, want off-repo auto-advance failure", m.status)
 	}
-	if len(m.autoAdvanceSnapshot) != 1 || m.autoAdvanceSnapshot[0].FlowID != "flow-1" ||
-		m.autoAdvanceSnapshot[0].Phases[1].Status != flowstore.PhaseRunning {
-		t.Fatalf("autoAdvanceSnapshot = %#v, want previous running edge restored", m.autoAdvanceSnapshot)
+	if _, ok := m.autoAdvanceDrainFlows["flow-1"]; !ok {
+		t.Fatalf("autoAdvanceDrainFlows = %#v, want flow-1 rearmed", m.autoAdvanceDrainFlows)
 	}
 }
 
@@ -470,8 +625,8 @@ func TestModel_AutoAdvanceAsyncLaunchFailurePreservesCompletionEdge(t *testing.T
 	if !failed {
 		t.Fatal("queued auto-advance command should report ActionFailedMsg")
 	}
-	if len(m.autoAdvanceSnapshot) != 1 || m.autoAdvanceSnapshot[0].Phases[1].Status != flowstore.PhaseRunning {
-		t.Fatalf("autoAdvanceSnapshot = %#v, want previous running edge restored", m.autoAdvanceSnapshot)
+	if _, ok := m.autoAdvanceDrainFlows["flow-1"]; !ok {
+		t.Fatalf("autoAdvanceDrainFlows = %#v, want flow-1 rearmed", m.autoAdvanceDrainFlows)
 	}
 
 	failLaunchUpdate = false
@@ -492,7 +647,6 @@ func TestModel_AutoAdvanceDeferredPreflightFailurePreservesRetry(t *testing.T) {
 		"plan-review":    flowstore.PhaseCompleted,
 		"implementation": flowstore.PhaseReady,
 	})
-	key := deferredAutoFlowLaunchKey{FlowID: "flow-1", PhaseID: "plan-review"}
 	var updates []flowstore.PhaseLaunchUpdate
 	m := NewWithOptions(flowRefreshTestRepos(), Options{
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
@@ -501,12 +655,12 @@ func TestModel_AutoAdvanceDeferredPreflightFailurePreservesRetry(t *testing.T) {
 		},
 	})
 	m.autoAdvanceSnapshot = []flowstore.FlowRecord{current}
-	m.deferredAutoFlowLaunches = map[deferredAutoFlowLaunchKey]struct{}{key: {}}
+	m.autoAdvanceDrainFlows = map[string]struct{}{"flow-1": {}}
 	m.autoAdvanceInFlight = 1
 
 	m, _ = updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{current}, Request: 1})
-	if _, ok := m.deferredAutoFlowLaunches[key]; !ok {
-		t.Fatalf("deferredAutoFlowLaunches = %#v, want retry preserved after preflight failure", m.deferredAutoFlowLaunches)
+	if _, ok := m.autoAdvanceDrainFlows["flow-1"]; !ok {
+		t.Fatalf("autoAdvanceDrainFlows = %#v, want retry preserved after preflight failure", m.autoAdvanceDrainFlows)
 	}
 	if m.status.Source != statusFlowAutoAdvance || !strings.Contains(m.status.Text, "choose codex") {
 		t.Fatalf("status = %#v, want auto-advance preflight guidance", m.status)
@@ -521,9 +675,6 @@ func TestModel_AutoAdvanceDeferredPreflightFailurePreservesRetry(t *testing.T) {
 	}
 	if len(updates) != 1 || updates[0].PhaseID != "implementation" || !updates[0].AutoLaunch {
 		t.Fatalf("launch updates after deferred preflight fix = %#v, want implementation auto launch", updates)
-	}
-	if len(m.deferredAutoFlowLaunches) != 0 {
-		t.Fatalf("deferredAutoFlowLaunches after launch = %#v, want empty", m.deferredAutoFlowLaunches)
 	}
 }
 
@@ -827,8 +978,8 @@ func TestModel_AutoAdvanceDeferredLaunchResolvesFromPrivateSnapshotOffView(t *te
 	if len(updates) != 0 {
 		t.Fatalf("launch updates while source terminal runs = %#v, want none", updates)
 	}
-	if _, ok := m.deferredAutoFlowLaunches[deferredAutoFlowLaunchKey{FlowID: "flow-1", PhaseID: "plan-review"}]; !ok {
-		t.Fatalf("deferredAutoFlowLaunches = %#v, want plan-review deferred", m.deferredAutoFlowLaunches)
+	if _, ok := m.autoAdvanceDrainFlows["flow-1"]; !ok {
+		t.Fatalf("autoAdvanceDrainFlows = %#v, want flow-1 armed while source terminal runs", m.autoAdvanceDrainFlows)
 	}
 
 	m.embeddedTerminals = nil

--- a/model/flow_advance_tick_test.go
+++ b/model/flow_advance_tick_test.go
@@ -229,6 +229,40 @@ func TestAutoModeSkipDisarmsExistingDrain(t *testing.T) {
 	}
 }
 
+func TestAutoModeResetToReadyDisarmsExistingDrain(t *testing.T) {
+	branchARunning := autoAdvanceCustomFlow(map[string]string{
+		"root":     flowstore.PhaseCompleted,
+		"branch-a": flowstore.PhaseRunning,
+		"branch-b": flowstore.PhaseReady,
+	})
+	branchAReset := autoAdvanceCustomFlow(map[string]string{
+		"root":     flowstore.PhaseCompleted,
+		"branch-a": flowstore.PhaseReady,
+		"branch-b": flowstore.PhaseReady,
+	})
+	var updates []flowstore.PhaseLaunchUpdate
+	m := NewWithOptions(flowRefreshTestRepos(), Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			return branchAReset, nil
+		},
+	})
+	m.autoAdvanceSnapshot = []flowstore.FlowRecord{branchARunning}
+	m.autoAdvanceDrainFlows = map[string]struct{}{"flow-1": {}}
+
+	m, cmd, _ := m.prepareAutoFlowPhaseLaunch([]flowstore.FlowRecord{branchARunning}, []flowstore.FlowRecord{branchAReset})
+	if cmd != nil {
+		t.Fatal("reset-to-ready queued successor launch, want drain disarmed")
+	}
+	if len(updates) != 0 {
+		t.Fatalf("updates after reset-to-ready = %#v, want none", updates)
+	}
+	if len(m.autoAdvanceDrainFlows) != 0 {
+		t.Fatalf("autoAdvanceDrainFlows = %#v, want reset-to-ready to disarm drain", m.autoAdvanceDrainFlows)
+	}
+}
+
 func TestAutoModeAutoreviewSuccessorLaunches(t *testing.T) {
 	previous := autoAdvanceTestFlow("flow-1", "/dev/bravo", true, map[string]string{
 		"pr-creation": flowstore.PhaseCompleted,

--- a/model/flow_advance_tick_test.go
+++ b/model/flow_advance_tick_test.go
@@ -284,6 +284,34 @@ func TestAutoModeDisableDisarmsDrain(t *testing.T) {
 	}
 }
 
+func TestAutoModeDrainDisarmsWhenSchedulingLaunch(t *testing.T) {
+	current := autoAdvanceTestFlow("flow-1", "/dev/bravo", true, map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	m := NewWithOptions(flowRefreshTestRepos(), Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			t.Fatalf("AddFlowPhaseLaunchID() should not run until the queued command executes: %#v", update)
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+	m.autoAdvanceDrainFlows = map[string]struct{}{"flow-1": {}}
+
+	m, cmd := m.prepareAutoAdvanceDrainLaunches([]flowstore.FlowRecord{current})
+	if cmd == nil {
+		t.Fatal("prepareAutoAdvanceDrainLaunches() returned nil, want queued launch command")
+	}
+	if len(m.autoAdvanceDrainFlows) != 0 {
+		t.Fatalf("autoAdvanceDrainFlows = %#v, want scheduling launch to disarm drain", m.autoAdvanceDrainFlows)
+	}
+	_, duplicate := m.prepareAutoAdvanceDrainLaunches([]flowstore.FlowRecord{current})
+	if duplicate != nil {
+		t.Fatal("second drain pass queued duplicate launch before first command executed")
+	}
+}
+
 func collectMsgsFromCmd(t *testing.T, cmd tea.Cmd) []tea.Msg {
 	t.Helper()
 	if cmd == nil {

--- a/model/flow_advance_tick_test.go
+++ b/model/flow_advance_tick_test.go
@@ -182,6 +182,53 @@ func TestAutoModeSkipDoesNotArmDrain(t *testing.T) {
 	}
 }
 
+func TestAutoModeSkipDisarmsExistingDrain(t *testing.T) {
+	rootCompleted := autoAdvanceCustomFlow(map[string]string{
+		"root":     flowstore.PhaseCompleted,
+		"branch-a": flowstore.PhaseReady,
+		"branch-b": flowstore.PhaseReady,
+	})
+	branchARunning := autoAdvanceCustomFlow(map[string]string{
+		"root":     flowstore.PhaseCompleted,
+		"branch-a": flowstore.PhaseRunning,
+		"branch-b": flowstore.PhaseReady,
+	})
+	branchASkipped := autoAdvanceCustomFlow(map[string]string{
+		"root":     flowstore.PhaseCompleted,
+		"branch-a": flowstore.PhaseSkipped,
+		"branch-b": flowstore.PhaseReady,
+	})
+	branchASkipped.Phases[1].Notes = "Skipped by user"
+	var updates []flowstore.PhaseLaunchUpdate
+	m := NewWithOptions(flowRefreshTestRepos(), Options{
+		AgentCommand: "codex",
+		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			updates = append(updates, update)
+			return branchARunning, nil
+		},
+	})
+	m.autoAdvanceSnapshot = []flowstore.FlowRecord{autoAdvanceCustomFlow(map[string]string{
+		"root": flowstore.PhaseRunning,
+	})}
+
+	m, cmd := runAutoAdvanceResultForTest(t, m, []flowstore.FlowRecord{rootCompleted})
+	launch := firstFlowEmbeddedLaunchFromAutoAdvance(t, cmd)
+	if launch.LaunchContext.FlowPhaseID != "branch-a" {
+		t.Fatalf("first drain launch = %q, want branch-a", launch.LaunchContext.FlowPhaseID)
+	}
+	if len(updates) != 1 || updates[0].PhaseID != "branch-a" {
+		t.Fatalf("updates after first launch = %#v, want branch-a", updates)
+	}
+
+	m, _ = runAutoAdvanceResultForTest(t, m, []flowstore.FlowRecord{branchASkipped})
+	if len(updates) != 1 {
+		t.Fatalf("updates after skipped branch = %#v, want no successor launch", updates)
+	}
+	if len(m.autoAdvanceDrainFlows) != 0 {
+		t.Fatalf("autoAdvanceDrainFlows = %#v, want skipped branch to disarm drain", m.autoAdvanceDrainFlows)
+	}
+}
+
 func TestAutoModeAutoreviewSuccessorLaunches(t *testing.T) {
 	previous := autoAdvanceTestFlow("flow-1", "/dev/bravo", true, map[string]string{
 		"pr-creation": flowstore.PhaseCompleted,

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -331,6 +331,10 @@ func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstor
 		if !ok {
 			continue
 		}
+		if len(newlyStoppedAutoAdvanceFlowPhases(previous, record)) > 0 {
+			m = m.disarmAutoAdvanceDrain(record.FlowID)
+			continue
+		}
 		if len(newlyCompletedFlowPhases(previous, record)) > 0 {
 			m = m.armAutoAdvanceDrain(record.FlowID)
 		}
@@ -358,6 +362,36 @@ func newlyCompletedFlowPhases(previous, current flowstore.FlowRecord) []flowstor
 		}
 	}
 	return completed
+}
+
+func newlyStoppedAutoAdvanceFlowPhases(previous, current flowstore.FlowRecord) []flowstore.FlowPhase {
+	previousByPhaseID := make(map[string]flowstore.FlowPhase, len(previous.Phases))
+	for _, phase := range previous.Phases {
+		if phaseID := artifacts.NormalizePhaseID(phase.PhaseID); phaseID != "" {
+			previousByPhaseID[phaseID] = phase
+		}
+	}
+	var stopped []flowstore.FlowPhase
+	for _, phase := range flowstore.OrderedPhases(current.Phases) {
+		phaseID := artifacts.NormalizePhaseID(phase.PhaseID)
+		if phaseID == "" || !autoAdvanceStopStatus(phase.Status) {
+			continue
+		}
+		previousPhase, ok := previousByPhaseID[phaseID]
+		if ok && previousPhase.Status != phase.Status {
+			stopped = append(stopped, phase)
+		}
+	}
+	return stopped
+}
+
+func autoAdvanceStopStatus(status string) bool {
+	switch status {
+	case flowstore.PhaseSkipped, flowstore.PhaseBlocked, flowstore.PhaseNeedsAttention:
+		return true
+	default:
+		return false
+	}
 }
 
 func (m Model) armAutoAdvanceDrain(flowID string) Model {

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -452,6 +452,7 @@ func (m Model) prepareAutoAdvanceDrainLaunches(records []flowstore.FlowRecord) (
 			cmds = append(cmds, statusCmd)
 			continue
 		}
+		m = m.disarmAutoAdvanceDrain(record.FlowID)
 		target.AutoAdvanceRetryFlowID = record.FlowID
 		target.AutoAdvanceRetryPhaseID = phase.PhaseID
 		m.autoAdvanceLaunchedPhases = append(m.autoAdvanceLaunchedPhases, autoAdvanceLaunchedPhase{

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -251,7 +251,6 @@ func (m Model) selectedFlowNextLaunchablePhase() (flowstore.FlowRecord, flowstor
 
 type flowPhaseLaunchTarget struct {
 	FlowPhaseLaunchPreparedRequest
-	AutoAdvanceRetryRecord  flowstore.FlowRecord
 	AutoAdvanceRetryFlowID  string
 	AutoAdvanceRetryPhaseID string
 }
@@ -295,7 +294,6 @@ func (m Model) prepareFlowPhaseLaunch(target flowPhaseLaunchTarget) tea.Cmd {
 			return ActionFailedMsg{
 				RepoPath:                target.RepoPath,
 				Err:                     err.Error(),
-				AutoAdvanceRetryRecord:  target.AutoAdvanceRetryRecord,
 				AutoAdvanceRetryFlowID:  target.AutoAdvanceRetryFlowID,
 				AutoAdvanceRetryPhaseID: target.AutoAdvanceRetryPhaseID,
 			}
@@ -314,50 +312,101 @@ func (m Model) flowPhaseLaunchMessage(result FlowPhaseLaunchResult) tea.Msg {
 	return PlanLaunchRequestedMsg{LaunchContext: result.Context}
 }
 
-func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstore.FlowRecord) (Model, tea.Cmd, []deferredAutoFlowLaunchKey) {
+func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstore.FlowRecord) (Model, tea.Cmd, []string) {
 	previousByFlowID := make(map[string]flowstore.FlowRecord, len(previousFlows))
 	for _, record := range previousFlows {
 		if record.FlowID != "" {
 			previousByFlowID[record.FlowID] = record
 		}
 	}
-	var cmds []tea.Cmd
-	var retryEdges []deferredAutoFlowLaunchKey
 	for _, record := range currentFlows {
-		if !record.AutoMode || record.FlowID == "" {
+		if record.FlowID == "" {
+			continue
+		}
+		if !record.AutoMode {
+			m = m.disarmAutoAdvanceDrain(record.FlowID)
 			continue
 		}
 		previous, ok := previousByFlowID[record.FlowID]
 		if !ok {
 			continue
 		}
-		completedPhase, ok := newlyCompletedFlowPhase(previous, record)
-		if !ok {
-			m = m.clearResolvedSuppressedAutoFlowLaunches(record)
+		if len(newlyCompletedFlowPhases(previous, record)) > 0 {
+			m = m.armAutoAdvanceDrain(record.FlowID)
+		}
+	}
+	m, cmd := m.prepareAutoAdvanceDrainLaunches(currentFlows)
+	return m, cmd, nil
+}
+
+func newlyCompletedFlowPhases(previous, current flowstore.FlowRecord) []flowstore.FlowPhase {
+	previousByPhaseID := make(map[string]flowstore.FlowPhase, len(previous.Phases))
+	for _, phase := range previous.Phases {
+		if phaseID := artifacts.NormalizePhaseID(phase.PhaseID); phaseID != "" {
+			previousByPhaseID[phaseID] = phase
+		}
+	}
+	var completed []flowstore.FlowPhase
+	for _, phase := range flowstore.OrderedPhases(current.Phases) {
+		phaseID := artifacts.NormalizePhaseID(phase.PhaseID)
+		if phaseID == "" || phase.Status != flowstore.PhaseCompleted {
 			continue
 		}
-		if flowstore.SemanticKind(completedPhase) == flowstore.KindAutoreview {
+		previousPhase, ok := previousByPhaseID[phaseID]
+		if ok && previousPhase.Status != flowstore.PhaseCompleted {
+			completed = append(completed, phase)
+		}
+	}
+	return completed
+}
+
+func (m Model) armAutoAdvanceDrain(flowID string) Model {
+	if strings.TrimSpace(flowID) == "" {
+		return m
+	}
+	if m.autoAdvanceDrainFlows == nil {
+		m.autoAdvanceDrainFlows = make(map[string]struct{})
+	}
+	m.autoAdvanceDrainFlows[flowID] = struct{}{}
+	return m
+}
+
+func (m Model) disarmAutoAdvanceDrain(flowID string) Model {
+	if len(m.autoAdvanceDrainFlows) == 0 {
+		return m
+	}
+	delete(m.autoAdvanceDrainFlows, flowID)
+	if len(m.autoAdvanceDrainFlows) == 0 {
+		m.autoAdvanceDrainFlows = nil
+	}
+	return m
+}
+
+func (m Model) prepareAutoAdvanceDrainLaunches(records []flowstore.FlowRecord) (Model, tea.Cmd) {
+	if len(m.autoAdvanceDrainFlows) == 0 {
+		return m, nil
+	}
+	recordsByID := make(map[string]flowstore.FlowRecord, len(records))
+	for _, record := range records {
+		if record.FlowID != "" {
+			recordsByID[record.FlowID] = record
+		}
+	}
+	var cmds []tea.Cmd
+	for flowID := range m.autoAdvanceDrainFlows {
+		record, ok := recordsByID[flowID]
+		if !ok || !record.AutoMode {
+			m = m.disarmAutoAdvanceDrain(flowID)
 			continue
 		}
-		if m.isAutoFlowLaunchSuppressed(record.FlowID, completedPhase) {
-			m = m.clearSuppressedAutoFlowLaunch(record.FlowID, completedPhase)
-			continue
-		}
-		sourceLaunchID := flowstore.LatestPhaseLaunchID(completedPhase)
-		if m.hasRunningFlowEmbeddedTerminalForPhaseLaunch(record.FlowID, completedPhase.PhaseID, sourceLaunchID) ||
-			m.hasAutoClosingFlowEmbeddedTerminalForPhaseLaunch(record.FlowID, completedPhase.PhaseID, sourceLaunchID) {
-			m = m.deferAutoFlowPhaseLaunch(record.FlowID, completedPhase.PhaseID)
-			continue
-		}
-		if m.hasFlowEmbeddedTerminalForPhaseLaunch(record.FlowID, completedPhase.PhaseID, sourceLaunchID) {
-			m = m.suppressAutoFlowPhaseLaunch(record.FlowID, completedPhase.PhaseID, sourceLaunchID)
+		if m.flowAutoAdvanceOccupied(record) {
 			continue
 		}
 		phase, ok := nextAutoLaunchPhase(record)
 		if !ok {
+			m = m.disarmAutoAdvanceDrain(flowID)
 			continue
 		}
-		var cmd tea.Cmd
 		target, targetOK, next, statusCmd := m.flowPhaseLaunchTarget(FlowPhaseLaunchRequest{
 			Record:     record,
 			Phase:      phase,
@@ -367,197 +416,40 @@ func (m Model) prepareAutoFlowPhaseLaunch(previousFlows, currentFlows []flowstor
 		m = next
 		if !targetOK {
 			cmds = append(cmds, statusCmd)
-			if key, ok := newDeferredAutoFlowLaunchKey(record.FlowID, completedPhase.PhaseID); ok {
-				retryEdges = append(retryEdges, key)
-			}
 			continue
 		}
-		target.AutoAdvanceRetryRecord = previous
+		target.AutoAdvanceRetryFlowID = record.FlowID
+		target.AutoAdvanceRetryPhaseID = phase.PhaseID
 		m.autoAdvanceLaunchedPhases = append(m.autoAdvanceLaunchedPhases, autoAdvanceLaunchedPhase{
 			FlowTitle: record.Title,
 			PhaseID:   phase.PhaseID,
 		})
-		cmd = m.prepareFlowPhaseLaunch(target)
-		if cmd != nil {
+		if cmd := m.prepareFlowPhaseLaunch(target); cmd != nil {
 			cmds = append(cmds, cmd)
-		} else if key, ok := newDeferredAutoFlowLaunchKey(record.FlowID, completedPhase.PhaseID); ok {
-			retryEdges = append(retryEdges, key)
 		}
-	}
-	return m, batchNonNil(cmds...), retryEdges
-}
-
-type deferredAutoFlowLaunchKey struct {
-	FlowID  string
-	PhaseID string
-}
-
-type suppressedAutoFlowLaunchKey struct {
-	FlowID   string
-	PhaseID  string
-	LaunchID string
-}
-
-func (m Model) deferAutoFlowPhaseLaunch(flowID, phaseID string) Model {
-	key, ok := newDeferredAutoFlowLaunchKey(flowID, phaseID)
-	if !ok {
-		return m
-	}
-	if m.deferredAutoFlowLaunches == nil {
-		m.deferredAutoFlowLaunches = make(map[deferredAutoFlowLaunchKey]struct{})
-	}
-	m.deferredAutoFlowLaunches[key] = struct{}{}
-	return m
-}
-
-func (m Model) suppressAutoFlowPhaseLaunch(flowID, phaseID, launchID string) Model {
-	key, ok := newSuppressedAutoFlowLaunchKey(flowID, phaseID, launchID)
-	if !ok {
-		return m
-	}
-	if m.suppressedAutoFlowLaunches == nil {
-		m.suppressedAutoFlowLaunches = make(map[suppressedAutoFlowLaunchKey]struct{})
-	}
-	m.suppressedAutoFlowLaunches[key] = struct{}{}
-	deferredKey, ok := newDeferredAutoFlowLaunchKey(flowID, phaseID)
-	if ok {
-		m = m.clearDeferredAutoFlowLaunch(deferredKey)
-	}
-	return m
-}
-
-func newSuppressedAutoFlowLaunchKey(flowID, phaseID, launchID string) (suppressedAutoFlowLaunchKey, bool) {
-	phaseID = artifacts.NormalizePhaseID(phaseID)
-	launchID = strings.TrimSpace(launchID)
-	if flowID == "" || phaseID == "" {
-		return suppressedAutoFlowLaunchKey{}, false
-	}
-	return suppressedAutoFlowLaunchKey{FlowID: flowID, PhaseID: phaseID, LaunchID: launchID}, true
-}
-
-func suppressedAutoFlowLaunchKeyForPhase(flowID string, phase flowstore.FlowPhase) (suppressedAutoFlowLaunchKey, bool) {
-	return newSuppressedAutoFlowLaunchKey(flowID, phase.PhaseID, flowstore.LatestPhaseLaunchID(phase))
-}
-
-func (m Model) isAutoFlowLaunchSuppressed(flowID string, phase flowstore.FlowPhase) bool {
-	key, ok := suppressedAutoFlowLaunchKeyForPhase(flowID, phase)
-	if !ok {
-		return false
-	}
-	_, suppressed := m.suppressedAutoFlowLaunches[key]
-	return suppressed
-}
-
-func (m Model) clearSuppressedAutoFlowLaunch(flowID string, phase flowstore.FlowPhase) Model {
-	key, ok := suppressedAutoFlowLaunchKeyForPhase(flowID, phase)
-	if !ok || len(m.suppressedAutoFlowLaunches) == 0 {
-		return m
-	}
-	delete(m.suppressedAutoFlowLaunches, key)
-	if len(m.suppressedAutoFlowLaunches) == 0 {
-		m.suppressedAutoFlowLaunches = nil
-	}
-	return m
-}
-
-func (m Model) clearResolvedSuppressedAutoFlowLaunches(record flowstore.FlowRecord) Model {
-	if len(m.suppressedAutoFlowLaunches) == 0 || record.FlowID == "" {
-		return m
-	}
-	for _, phase := range record.Phases {
-		if phase.Status == flowstore.PhaseRunning || phase.Status == flowstore.PhaseCompleted {
-			continue
-		}
-		m = m.clearSuppressedAutoFlowLaunch(record.FlowID, phase)
-	}
-	return m
-}
-
-func (m Model) clearDeferredAutoFlowLaunch(key deferredAutoFlowLaunchKey) Model {
-	if len(m.deferredAutoFlowLaunches) == 0 {
-		return m
-	}
-	delete(m.deferredAutoFlowLaunches, key)
-	if len(m.deferredAutoFlowLaunches) == 0 {
-		m.deferredAutoFlowLaunches = nil
-	}
-	return m
-}
-
-func newDeferredAutoFlowLaunchKey(flowID, phaseID string) (deferredAutoFlowLaunchKey, bool) {
-	phaseID = artifacts.NormalizePhaseID(phaseID)
-	if flowID == "" || phaseID == "" {
-		return deferredAutoFlowLaunchKey{}, false
-	}
-	return deferredAutoFlowLaunchKey{FlowID: flowID, PhaseID: phaseID}, true
-}
-
-func (m Model) prepareAutoFlowPhaseLaunchForRecord(record flowstore.FlowRecord, phase flowstore.FlowPhase, retryPhaseID string) (Model, tea.Cmd, bool) {
-	target, ok, next, statusCmd := m.flowPhaseLaunchTarget(FlowPhaseLaunchRequest{
-		Record:     record,
-		Phase:      phase,
-		AutoLaunch: true,
-		Headless:   true,
-	})
-	m = next
-	if !ok {
-		return m, statusCmd, false
-	}
-	m.autoAdvanceLaunchedPhases = append(m.autoAdvanceLaunchedPhases, autoAdvanceLaunchedPhase{
-		FlowTitle: record.Title,
-		PhaseID:   phase.PhaseID,
-	})
-	target.AutoAdvanceRetryFlowID = record.FlowID
-	target.AutoAdvanceRetryPhaseID = retryPhaseID
-	return m, next.prepareFlowPhaseLaunch(target), true
-}
-
-func (m Model) prepareDeferredAutoFlowPhaseLaunchesFrom(records []flowstore.FlowRecord) (Model, tea.Cmd) {
-	recordsByID := make(map[string]flowstore.FlowRecord, len(records))
-	for _, record := range records {
-		if record.FlowID != "" {
-			recordsByID[record.FlowID] = record
-		}
-	}
-	var cmds []tea.Cmd
-	for key := range m.deferredAutoFlowLaunches {
-		delete(m.deferredAutoFlowLaunches, key)
-		record, ok := recordsByID[key.FlowID]
-		if !ok {
-			continue
-		}
-		if !record.AutoMode {
-			continue
-		}
-		sourcePhase, sourcePhaseOK := flowRecordPhaseByID(record, key.PhaseID)
-		sourceLaunchID := flowstore.LatestPhaseLaunchID(sourcePhase)
-		if sourcePhaseOK && m.hasRunningFlowEmbeddedTerminalForPhaseLaunch(key.FlowID, key.PhaseID, sourceLaunchID) {
-			m.deferredAutoFlowLaunches[key] = struct{}{}
-			continue
-		}
-		if sourcePhaseOK && m.hasAutoClosingFlowEmbeddedTerminalForPhaseLaunch(key.FlowID, key.PhaseID, sourceLaunchID) {
-			m.deferredAutoFlowLaunches[key] = struct{}{}
-			continue
-		}
-		if sourcePhaseOK && m.hasFlowEmbeddedTerminalForPhaseLaunch(key.FlowID, key.PhaseID, sourceLaunchID) {
-			continue
-		}
-		if phase, ok := nextAutoLaunchPhase(record); ok {
-			var cmd tea.Cmd
-			var prepared bool
-			m, cmd, prepared = m.prepareAutoFlowPhaseLaunchForRecord(record, phase, key.PhaseID)
-			if cmd != nil {
-				cmds = append(cmds, cmd)
-			}
-			if !prepared {
-				m.deferredAutoFlowLaunches[key] = struct{}{}
-			}
-		}
-	}
-	if len(m.deferredAutoFlowLaunches) == 0 {
-		m.deferredAutoFlowLaunches = nil
 	}
 	return m, batchNonNil(cmds...)
+}
+
+func (m Model) flowAutoAdvanceOccupied(record flowstore.FlowRecord) bool {
+	for _, phase := range record.Phases {
+		if phase.Status == flowstore.PhaseRunning {
+			return true
+		}
+	}
+	return m.hasFlowEmbeddedTerminalForFlow(record.FlowID)
+}
+
+func (m Model) hasFlowEmbeddedTerminalForFlow(flowID string) bool {
+	if strings.TrimSpace(flowID) == "" {
+		return false
+	}
+	for _, slot := range m.embeddedTerminals {
+		if slot.Scope == embeddedTerminalScopeFlow && slot.FlowID == flowID && slot.Terminal != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func flowPhaseCanLaunch(record flowstore.FlowRecord, phase flowstore.FlowPhase) bool {

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -375,23 +375,23 @@ func newlyStoppedAutoAdvanceFlowPhases(previous, current flowstore.FlowRecord) [
 	var stopped []flowstore.FlowPhase
 	for _, phase := range flowstore.OrderedPhases(current.Phases) {
 		phaseID := artifacts.NormalizePhaseID(phase.PhaseID)
-		if phaseID == "" || !autoAdvanceStopStatus(phase.Status) {
+		if phaseID == "" {
 			continue
 		}
 		previousPhase, ok := previousByPhaseID[phaseID]
-		if ok && previousPhase.Status != phase.Status {
+		if ok && autoAdvanceStopped(previousPhase.Status, phase.Status) {
 			stopped = append(stopped, phase)
 		}
 	}
 	return stopped
 }
 
-func autoAdvanceStopStatus(status string) bool {
-	switch status {
+func autoAdvanceStopped(previousStatus, currentStatus string) bool {
+	switch currentStatus {
 	case flowstore.PhaseSkipped, flowstore.PhaseBlocked, flowstore.PhaseNeedsAttention:
-		return true
+		return previousStatus != currentStatus
 	default:
-		return false
+		return previousStatus == flowstore.PhaseRunning && currentStatus == flowstore.PhaseReady
 	}
 }
 

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -162,6 +162,7 @@ func (l FlowPhaseLauncher) Prepare(req FlowPhaseLaunchPreparedRequest) (FlowPhas
 		PlanPath:         req.PlanPath,
 		FlowID:           req.Record.FlowID,
 		FlowPhaseID:      launchPhase.PhaseID,
+		FlowPhaseKind:    flowstore.SemanticKind(launchPhase),
 		FlowAutoLaunch:   req.AutoLaunch,
 		InitialPrompt:    flowPhasePrompt(req.Record, launchPhase, req.PlanPath, planBody, l.PromptTemplates),
 	}

--- a/model/flow_phase_launch_internal_test.go
+++ b/model/flow_phase_launch_internal_test.go
@@ -237,7 +237,7 @@ func TestFlowPhaseLaunchCoordinatorPreparesDirectAutoLaunchTarget(t *testing.T) 
 	}
 }
 
-func TestFlowPhaseLaunchCoordinatorClearsSuppressedAutoLaunchWithoutRelaunch(t *testing.T) {
+func TestFlowPhaseLaunchCoordinatorDrainIgnoresObsoleteSuppression(t *testing.T) {
 	previous := flowstore.FlowRecord{
 		FlowID:       "flow-1",
 		RepoPath:     "/dev/alpha",
@@ -253,21 +253,20 @@ func TestFlowPhaseLaunchCoordinatorClearsSuppressedAutoLaunchWithoutRelaunch(t *
 		{PhaseID: "plan-review", Status: flowstore.PhaseCompleted, LaunchIDs: []string{"source-launch"}, Order: 1},
 		{PhaseID: "implementation", Status: flowstore.PhaseReady, Order: 2},
 	}
+	var updates []flowstore.PhaseLaunchUpdate
 	m := NewWithOptions(nil, Options{
 		AgentCommand: "codex",
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
-			t.Fatalf("AddFlowPhaseLaunchID() should not run for a suppressed source phase: %#v", update)
-			return flowstore.FlowRecord{}, nil
+			updates = append(updates, update)
+			return current, nil
 		},
 	})
-	m = m.suppressAutoFlowPhaseLaunch("flow-1", "plan-review", "source-launch")
-
 	m, cmd, _ := m.prepareAutoFlowPhaseLaunch([]flowstore.FlowRecord{previous}, []flowstore.FlowRecord{current})
-	if cmd != nil {
-		t.Fatalf("prepareAutoFlowPhaseLaunch() returned command %T for suppressed source phase", cmd)
+	if cmd == nil {
+		t.Fatal("prepareAutoFlowPhaseLaunch() returned nil, want drain launch command")
 	}
-	if len(m.suppressedAutoFlowLaunches) != 0 {
-		t.Fatalf("suppressed auto-launches = %#v, want cleared", m.suppressedAutoFlowLaunches)
+	if len(updates) != 0 {
+		t.Fatalf("launch updates before command runs = %#v, want none", updates)
 	}
 }
 
@@ -313,14 +312,14 @@ func TestFlowPhaseLaunchCoordinatorDefersAutoLaunchUntilSourceTerminalCloses(t *
 	if len(updates) != 0 {
 		t.Fatalf("launch updates while source terminal was running = %#v, want none", updates)
 	}
-	if _, ok := m.deferredAutoFlowLaunches[deferredAutoFlowLaunchKey{FlowID: "flow-1", PhaseID: "plan-review"}]; !ok {
-		t.Fatalf("deferred auto-launches = %#v, want plan-review deferred", m.deferredAutoFlowLaunches)
+	if _, ok := m.autoAdvanceDrainFlows["flow-1"]; !ok {
+		t.Fatalf("autoAdvanceDrainFlows = %#v, want flow-1 armed", m.autoAdvanceDrainFlows)
 	}
 
 	m.embeddedTerminals = nil
-	m, cmd = m.prepareDeferredAutoFlowPhaseLaunchesFrom([]flowstore.FlowRecord{current})
+	m, cmd = m.prepareAutoAdvanceDrainLaunches([]flowstore.FlowRecord{current})
 	if cmd == nil {
-		t.Fatal("prepareDeferredAutoFlowPhaseLaunchesFrom() returned nil after source terminal closed")
+		t.Fatal("prepareAutoAdvanceDrainLaunches() returned nil after source terminal closed")
 	}
 	msg := cmd()
 	if batch, ok := msg.(tea.BatchMsg); ok && len(batch) == 1 {
@@ -331,9 +330,6 @@ func TestFlowPhaseLaunchCoordinatorDefersAutoLaunchUntilSourceTerminalCloses(t *
 	}
 	if len(updates) != 1 || !updates[0].AutoLaunch || updates[0].PhaseID != "implementation" {
 		t.Fatalf("launch updates after source terminal closed = %#v, want auto implementation launch", updates)
-	}
-	if len(m.deferredAutoFlowLaunches) != 0 {
-		t.Fatalf("deferred auto-launches after launch = %#v, want empty", m.deferredAutoFlowLaunches)
 	}
 }
 

--- a/model/flow_prompts.go
+++ b/model/flow_prompts.go
@@ -120,7 +120,7 @@ func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, pla
 	var prompt string
 	switch flowstore.SemanticKind(phase) {
 	case flowstore.KindPlan:
-		prompt = flowPlanPrompt(record, templates)
+		prompt = flowPlanPrompt(record, phase, templates)
 	case flowstore.KindPlanReview:
 		prompt = flowPlanReviewPrompt(record, phase, planPath, planBody)
 	case flowstore.KindImplementation:

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -168,6 +168,7 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 		PlanPhaseStatus:  phaseStatus,
 		FlowID:           flow.FlowID,
 		FlowPhaseID:      phaseID,
+		FlowPhaseKind:    flowstore.SemanticKind(phase),
 		InitialPrompt:    initialFlowLaunchPrompt(flowStartPromptRecord(flow, req, worktree, commit), phase, s.promptTemplatesForRequest(req)),
 	}
 	return result, nil

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -129,6 +129,9 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 	phase := initialFlowLaunchPhase(flow, req.PlanPhaseID)
 	phaseID := phase.PhaseID
 
+	if err := validateInitialFlowLaunchPhase(flow, phase); err != nil {
+		return result, err
+	}
 	launchID := s.newLaunchID()
 	launchedFlow, err := s.addPhaseLaunchID(flowstore.PhaseLaunchUpdate{
 		FlowID:   flow.FlowID,
@@ -172,6 +175,13 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 		InitialPrompt:    initialFlowLaunchPrompt(flowStartPromptRecord(flow, req, worktree, commit), phase, s.promptTemplatesForRequest(req)),
 	}
 	return result, nil
+}
+
+func validateInitialFlowLaunchPhase(flow flowstore.FlowRecord, phase flowstore.FlowPhase) error {
+	if flowstore.SemanticKind(phase) == flowstore.KindPlanReview && flow.PlanID == "" {
+		return fmt.Errorf("Plan Review needs a linked plan before launch")
+	}
+	return nil
 }
 
 func (s FlowStarter) promptTemplatesForRequest(req FlowStartRequest) FlowPromptTemplates {

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -196,7 +196,7 @@ func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) 
 
 	worktree, err := s.createWorktree(req.RepoPath, req.Title, req.BaseRef)
 	if err != nil {
-		return result, s.blockPlanPhase(flow.FlowID, phaseID, "Worktree creation failed: "+err.Error(), err.Error())
+		return result, s.blockWorktreeFailurePhases(flow, phaseID, "Worktree creation failed: "+err.Error(), err.Error())
 	}
 	result.Worktree = worktree
 
@@ -278,6 +278,40 @@ func (s FlowStarter) blockPlanPhase(flowID, phaseID, notes, resultErr string) er
 		return fmt.Errorf("%s; mark flow blocked: %v", resultErr, err)
 	}
 	return fmt.Errorf("%s", resultErr)
+}
+
+func (s FlowStarter) blockWorktreeFailurePhases(flow flowstore.FlowRecord, fallbackPhaseID, notes, resultErr string) error {
+	phaseIDs := launchablePhaseIDs(flow)
+	if len(phaseIDs) == 0 {
+		phaseIDs = []string{fallbackPhaseID}
+	}
+	for _, phaseID := range phaseIDs {
+		if _, err := s.setPhase(flowstore.PhaseUpdate{
+			FlowID:  flow.FlowID,
+			PhaseID: phaseID,
+			Status:  flowstore.PhaseBlocked,
+			Notes:   notes,
+		}); err != nil {
+			return fmt.Errorf("%s; mark flow blocked: %v", resultErr, err)
+		}
+	}
+	return fmt.Errorf("%s", resultErr)
+}
+
+func launchablePhaseIDs(flow flowstore.FlowRecord) []string {
+	ordered := flowstore.OrderedPhases(flow.Phases)
+	orderedFlow := flow
+	orderedFlow.Phases = ordered
+	var ids []string
+	seen := make(map[string]bool)
+	for i, phase := range ordered {
+		if !flowstore.PhaseLaunchEligible(orderedFlow, i) || seen[phase.PhaseID] {
+			continue
+		}
+		seen[phase.PhaseID] = true
+		ids = append(ids, phase.PhaseID)
+	}
+	return ids
 }
 
 func flowStartPromptRecord(flow flowstore.FlowRecord, req FlowStartRequest, worktree actions.FlowWorktreeCreateResult, commit string) flowstore.FlowRecord {

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -36,6 +36,7 @@ type FlowStartResult struct {
 	Worktree      actions.FlowWorktreeCreateResult
 	Commit        string
 	LaunchID      string
+	LaunchSkipped bool
 	LaunchContext actions.AgentLaunchContext
 }
 
@@ -126,7 +127,11 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 	flow := result.Flow
 	worktree := result.Worktree
 	commit := result.Commit
-	phase := initialFlowLaunchPhase(flow, req.PlanPhaseID)
+	phase, ok := initialFlowLaunchPhase(flow, req.PlanPhaseID)
+	if !ok {
+		result.LaunchSkipped = true
+		return result, nil
+	}
 	phaseID := phase.PhaseID
 
 	if err := validateInitialFlowLaunchPhase(flow, phase); err != nil {
@@ -201,7 +206,10 @@ func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) 
 	if err != nil {
 		return FlowStartResult{}, err
 	}
-	phaseID := initialFlowLaunchPhase(flow, req.PlanPhaseID).PhaseID
+	phaseID := ""
+	if phase, ok := initialFlowLaunchPhase(flow, req.PlanPhaseID); ok {
+		phaseID = phase.PhaseID
+	}
 	result := FlowStartResult{Flow: flow}
 
 	worktree, err := s.createWorktree(req.RepoPath, req.Title, req.BaseRef)
@@ -233,20 +241,20 @@ func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) 
 	return result, nil
 }
 
-func initialFlowLaunchPhase(flow flowstore.FlowRecord, requestedPhaseID string) flowstore.FlowPhase {
+func initialFlowLaunchPhase(flow flowstore.FlowRecord, requestedPhaseID string) (flowstore.FlowPhase, bool) {
 	if requestedPhaseID != "" {
 		if phase, ok := findFlowPhaseByID(flow, requestedPhaseID); ok {
-			return phase
+			return phase, true
 		}
-		return flowstore.FlowPhase{PhaseID: requestedPhaseID, Title: "Plan", Kind: flowstore.KindPlan}
+		return flowstore.FlowPhase{PhaseID: requestedPhaseID, Title: "Plan", Kind: flowstore.KindPlan}, true
+	}
+	if len(flow.Phases) == 0 {
+		return flowstore.FlowPhase{PhaseID: flowPlanPhaseID, Title: "Plan", Kind: flowstore.KindPlan}, true
 	}
 	if phase, _, ok := flowstore.FirstLaunchablePhase(flow); ok {
-		return phase
+		return phase, true
 	}
-	if phase, ok := findFlowPhaseByID(flow, flowPlanPhaseID); ok {
-		return phase
-	}
-	return flowstore.FlowPhase{PhaseID: flowPlanPhaseID, Title: "Plan", Kind: flowstore.KindPlan}
+	return flowstore.FlowPhase{}, false
 }
 
 func findFlowPhaseByID(flow flowstore.FlowRecord, phaseID string) (flowstore.FlowPhase, bool) {
@@ -293,6 +301,9 @@ func (s FlowStarter) blockPlanPhase(flowID, phaseID, notes, resultErr string) er
 func (s FlowStarter) blockStartupFailurePhases(flow flowstore.FlowRecord, fallbackPhaseID, notes, resultErr string) error {
 	phases := launchablePhases(flow)
 	if len(phases) == 0 {
+		if fallbackPhaseID == "" {
+			return fmt.Errorf("%s", resultErr)
+		}
 		if phase, ok := findFlowPhaseByID(flow, fallbackPhaseID); ok {
 			phases = []flowstore.FlowPhase{phase}
 		} else {

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -119,11 +119,6 @@ func NewFlowStarter(opts FlowStarterOptions) FlowStarter {
 }
 
 func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
-	phaseID := req.PlanPhaseID
-	if phaseID == "" {
-		phaseID = flowPlanPhaseID
-	}
-
 	result, err := s.PrepareFlow(req)
 	if err != nil {
 		return result, err
@@ -131,6 +126,8 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 	flow := result.Flow
 	worktree := result.Worktree
 	commit := result.Commit
+	phase := initialFlowLaunchPhase(flow, req.PlanPhaseID)
+	phaseID := phase.PhaseID
 
 	launchID := s.newLaunchID()
 	launchedFlow, err := s.addPhaseLaunchID(flowstore.PhaseLaunchUpdate{
@@ -147,7 +144,10 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 
 	phaseTitle := req.PlanPhaseTitle
 	if phaseTitle == "" {
-		phaseTitle = "Plan"
+		phaseTitle = phase.Title
+	}
+	if phaseTitle == "" {
+		phaseTitle = phaseID
 	}
 	phaseStatus := req.PlanPhaseStatus
 	if phaseStatus == "" {
@@ -168,7 +168,7 @@ func (s FlowStarter) StartPlan(req FlowStartRequest) (FlowStartResult, error) {
 		PlanPhaseStatus:  phaseStatus,
 		FlowID:           flow.FlowID,
 		FlowPhaseID:      phaseID,
-		InitialPrompt:    flowPlanPrompt(flowStartPromptRecord(flow, req, worktree, commit), s.promptTemplatesForRequest(req)),
+		InitialPrompt:    initialFlowLaunchPrompt(flowStartPromptRecord(flow, req, worktree, commit), phase, s.promptTemplatesForRequest(req)),
 	}
 	return result, nil
 }
@@ -181,11 +181,6 @@ func (s FlowStarter) promptTemplatesForRequest(req FlowStartRequest) FlowPromptT
 }
 
 func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) {
-	phaseID := req.PlanPhaseID
-	if phaseID == "" {
-		phaseID = flowPlanPhaseID
-	}
-
 	flow, err := s.createFlow(flowstore.FlowRecord{
 		Title:        req.Title,
 		Instructions: req.Instructions,
@@ -195,6 +190,7 @@ func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) 
 	if err != nil {
 		return FlowStartResult{}, err
 	}
+	phaseID := initialFlowLaunchPhase(flow, req.PlanPhaseID).PhaseID
 	result := FlowStartResult{Flow: flow}
 
 	worktree, err := s.createWorktree(req.RepoPath, req.Title, req.BaseRef)
@@ -224,6 +220,38 @@ func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) 
 	}
 
 	return result, nil
+}
+
+func initialFlowLaunchPhase(flow flowstore.FlowRecord, requestedPhaseID string) flowstore.FlowPhase {
+	if requestedPhaseID != "" {
+		if phase, ok := findFlowPhaseByID(flow, requestedPhaseID); ok {
+			return phase
+		}
+		return flowstore.FlowPhase{PhaseID: requestedPhaseID, Title: "Plan", Kind: flowstore.KindPlan}
+	}
+	if phase, _, ok := flowstore.FirstLaunchablePhase(flow); ok {
+		return phase
+	}
+	if phase, ok := findFlowPhaseByID(flow, flowPlanPhaseID); ok {
+		return phase
+	}
+	return flowstore.FlowPhase{PhaseID: flowPlanPhaseID, Title: "Plan", Kind: flowstore.KindPlan}
+}
+
+func findFlowPhaseByID(flow flowstore.FlowRecord, phaseID string) (flowstore.FlowPhase, bool) {
+	for _, phase := range flow.Phases {
+		if phase.PhaseID == phaseID {
+			return phase, true
+		}
+	}
+	return flowstore.FlowPhase{}, false
+}
+
+func initialFlowLaunchPrompt(flow flowstore.FlowRecord, phase flowstore.FlowPhase, templates FlowPromptTemplates) string {
+	if flowstore.SemanticKind(phase) == flowstore.KindPlan {
+		return flowPlanPrompt(flow, templates)
+	}
+	return flowPhasePrompt(flow, phase, flow.PlanPath, "", templates)
 }
 
 func (s FlowStarter) runBootstrap(repoPath string, worktree actions.FlowWorktreeCreateResult) error {

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -196,7 +196,7 @@ func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) 
 
 	worktree, err := s.createWorktree(req.RepoPath, req.Title, req.BaseRef)
 	if err != nil {
-		return result, s.blockWorktreeFailurePhases(flow, phaseID, "Worktree creation failed: "+err.Error(), err.Error())
+		return result, s.blockStartupFailurePhases(flow, phaseID, "Worktree creation failed: "+err.Error(), err.Error())
 	}
 	result.Worktree = worktree
 
@@ -217,7 +217,7 @@ func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) 
 
 	if err := s.runBootstrap(req.RepoPath, worktree); err != nil {
 		errText := "Bootstrap hook failed: " + err.Error()
-		return result, s.blockPlanPhase(flow.FlowID, phaseID, errText, errText)
+		return result, s.blockStartupFailurePhases(flow, phaseID, errText, errText)
 	}
 
 	return result, nil
@@ -280,38 +280,50 @@ func (s FlowStarter) blockPlanPhase(flowID, phaseID, notes, resultErr string) er
 	return fmt.Errorf("%s", resultErr)
 }
 
-func (s FlowStarter) blockWorktreeFailurePhases(flow flowstore.FlowRecord, fallbackPhaseID, notes, resultErr string) error {
-	phaseIDs := launchablePhaseIDs(flow)
-	if len(phaseIDs) == 0 {
-		phaseIDs = []string{fallbackPhaseID}
+func (s FlowStarter) blockStartupFailurePhases(flow flowstore.FlowRecord, fallbackPhaseID, notes, resultErr string) error {
+	phases := launchablePhases(flow)
+	if len(phases) == 0 {
+		if phase, ok := findFlowPhaseByID(flow, fallbackPhaseID); ok {
+			phases = []flowstore.FlowPhase{phase}
+		} else {
+			phases = []flowstore.FlowPhase{{PhaseID: fallbackPhaseID}}
+		}
 	}
-	for _, phaseID := range phaseIDs {
-		if _, err := s.setPhase(flowstore.PhaseUpdate{
-			FlowID:  flow.FlowID,
-			PhaseID: phaseID,
-			Status:  flowstore.PhaseBlocked,
-			Notes:   notes,
-		}); err != nil {
+	for _, phase := range phases {
+		if _, err := s.setPhase(blockedPhaseUpdate(flow.FlowID, phase, notes)); err != nil {
 			return fmt.Errorf("%s; mark flow blocked: %v", resultErr, err)
 		}
 	}
 	return fmt.Errorf("%s", resultErr)
 }
 
-func launchablePhaseIDs(flow flowstore.FlowRecord) []string {
+func launchablePhases(flow flowstore.FlowRecord) []flowstore.FlowPhase {
 	ordered := flowstore.OrderedPhases(flow.Phases)
 	orderedFlow := flow
 	orderedFlow.Phases = ordered
-	var ids []string
+	var phases []flowstore.FlowPhase
 	seen := make(map[string]bool)
 	for i, phase := range ordered {
 		if !flowstore.PhaseLaunchEligible(orderedFlow, i) || seen[phase.PhaseID] {
 			continue
 		}
 		seen[phase.PhaseID] = true
-		ids = append(ids, phase.PhaseID)
+		phases = append(phases, phase)
 	}
-	return ids
+	return phases
+}
+
+func blockedPhaseUpdate(flowID string, phase flowstore.FlowPhase, notes string) flowstore.PhaseUpdate {
+	update := flowstore.PhaseUpdate{
+		FlowID:  flowID,
+		PhaseID: phase.PhaseID,
+		Status:  flowstore.PhaseBlocked,
+		Notes:   notes,
+	}
+	if flowstore.SemanticKind(phase) == flowstore.KindPlanReview {
+		update.Outcome = flowstore.OutcomeBlocked
+	}
+	return update
 }
 
 func flowStartPromptRecord(flow flowstore.FlowRecord, req FlowStartRequest, worktree actions.FlowWorktreeCreateResult, commit string) flowstore.FlowRecord {

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -249,7 +249,7 @@ func findFlowPhaseByID(flow flowstore.FlowRecord, phaseID string) (flowstore.Flo
 
 func initialFlowLaunchPrompt(flow flowstore.FlowRecord, phase flowstore.FlowPhase, templates FlowPromptTemplates) string {
 	if flowstore.SemanticKind(phase) == flowstore.KindPlan {
-		return flowPlanPrompt(flow, templates)
+		return flowPlanPrompt(flow, phase, templates)
 	}
 	return flowPhasePrompt(flow, phase, flow.PlanPath, "", templates)
 }
@@ -304,9 +304,12 @@ func flowStartPromptRecord(flow flowstore.FlowRecord, req FlowStartRequest, work
 	return flow
 }
 
-func flowPlanPrompt(flow flowstore.FlowRecord, templates FlowPromptTemplates) string {
+func flowPlanPrompt(flow flowstore.FlowRecord, phase flowstore.FlowPhase, templates FlowPromptTemplates) string {
+	if strings.TrimSpace(phase.PhaseID) == "" {
+		phase = flowstore.FlowPhase{PhaseID: flowPlanPhaseID, Title: "Plan", Kind: flowstore.KindPlan}
+	}
 	if strings.TrimSpace(templates.Plan) != "" {
-		prompt := renderFlowPromptTemplate(templates.Plan, flow, flowstore.FlowPhase{PhaseID: flowPlanPhaseID, Title: "Plan"}, flow.PlanPath, "")
+		prompt := renderFlowPromptTemplate(templates.Plan, flow, phase, flow.PlanPath, "")
 		return ensureFlowPhaseDoneInstruction(prompt, templates.Plan)
 	}
 	var b strings.Builder

--- a/model/flow_start_test.go
+++ b/model/flow_start_test.go
@@ -272,6 +272,54 @@ func TestFlowStarterStartPlanRejectsPlanReviewRootWithoutLinkedPlan(t *testing.T
 	}
 }
 
+func TestFlowStarterStartPlanParksFlowWhenNoPhaseIsLaunchable(t *testing.T) {
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-1"
+			record.Phases = []flowstore.FlowPhase{
+				{PhaseID: "ship", Title: "Ship", Kind: flowstore.KindMerge, Status: flowstore.PhaseReady, Order: 1},
+			}
+			return record, nil
+		},
+		CreateWorktree: func(repoPath, title, baseRef string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{WorktreePath: "/repo/worktrees/ship", Branch: "flow/ship"}, nil
+		},
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{
+				FlowID:       update.FlowID,
+				WorktreePath: update.WorktreePath,
+				Branch:       update.Branch,
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "ship", Title: "Ship", Kind: flowstore.KindMerge, Status: flowstore.PhaseReady, Order: 1},
+				},
+			}, nil
+		},
+		AddPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			t.Fatalf("AddPhaseLaunchID() should not run when no phase is launchable: %#v", update)
+			return flowstore.FlowRecord{}, nil
+		},
+		NewLaunchID: func() string { return "launch-1" },
+	})
+
+	result, err := starter.StartPlan(model.FlowStartRequest{
+		RepoPath:     "/repo",
+		Title:        "Merge-only flow",
+		Instructions: "Track an externally merged change.",
+	})
+	if err != nil {
+		t.Fatalf("StartPlan() error = %v", err)
+	}
+	if !result.LaunchSkipped {
+		t.Fatal("StartPlan() LaunchSkipped = false, want parked Flow without launch")
+	}
+	if result.LaunchID != "" || result.LaunchContext.FlowID != "" {
+		t.Fatalf("launch result = id %q context %#v, want no launch", result.LaunchID, result.LaunchContext)
+	}
+	if result.Flow.FlowID != "flow-1" || result.Flow.WorktreePath != "/repo/worktrees/ship" {
+		t.Fatalf("result flow = %#v", result.Flow)
+	}
+}
+
 func TestFlowStarterStartPlanRequiresCreateFlow(t *testing.T) {
 	starter := model.NewFlowStarter(model.FlowStarterOptions{
 		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {

--- a/model/flow_start_test.go
+++ b/model/flow_start_test.go
@@ -135,6 +135,101 @@ func TestFlowStarterStartPlanReturnsLaunchContext(t *testing.T) {
 	}
 }
 
+func TestFlowStarterStartPlanLaunchesFirstReadyRoot(t *testing.T) {
+	var launchedPhase string
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-1"
+			record.Phases = []flowstore.FlowPhase{
+				{PhaseID: "research", Title: "Research", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady, Order: 1},
+				{PhaseID: "draft", Title: "Draft", Kind: flowstore.KindImplementation, Status: flowstore.PhasePending, Order: 2, DependsOn: []string{"research"}},
+			}
+			return record, nil
+		},
+		CreateWorktree: func(repoPath, title, baseRef string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{WorktreePath: "/repo/worktrees/research", Branch: "flow/research"}, nil
+		},
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{
+				FlowID: update.FlowID,
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "research", Title: "Research", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady, Order: 1},
+					{PhaseID: "draft", Title: "Draft", Kind: flowstore.KindImplementation, Status: flowstore.PhasePending, Order: 2, DependsOn: []string{"research"}},
+				},
+				WorktreePath: update.WorktreePath,
+				Branch:       update.Branch,
+			}, nil
+		},
+		AddPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			launchedPhase = update.PhaseID
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		NewLaunchID: func() string { return "launch-1" },
+		ResolveCommit: func(string) string {
+			return "abc123"
+		},
+	})
+
+	result, err := starter.StartPlan(model.FlowStartRequest{
+		RepoPath:     "/repo",
+		Title:        "Research flow",
+		Instructions: "Plan the research.",
+	})
+	if err != nil {
+		t.Fatalf("StartPlan() error = %v", err)
+	}
+	if launchedPhase != "research" {
+		t.Fatalf("launched phase = %q, want research", launchedPhase)
+	}
+	if result.LaunchContext.FlowPhaseID != "research" || result.LaunchContext.PlanPhaseID != "research" {
+		t.Fatalf("launch context phase IDs = flow %q plan %q, want research", result.LaunchContext.FlowPhaseID, result.LaunchContext.PlanPhaseID)
+	}
+}
+
+func TestFlowStarterStartPlanUsesGenericPromptForNonPlanRoot(t *testing.T) {
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-1"
+			record.Phases = []flowstore.FlowPhase{
+				{PhaseID: "triage", Title: "Triage", Kind: "", Status: flowstore.PhaseReady, Order: 1},
+			}
+			return record, nil
+		},
+		CreateWorktree: func(repoPath, title, baseRef string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{WorktreePath: "/repo/worktrees/triage", Branch: "flow/triage"}, nil
+		},
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{
+				FlowID: update.FlowID,
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "triage", Title: "Triage", Kind: "", Status: flowstore.PhaseReady, Order: 1},
+				},
+				WorktreePath: update.WorktreePath,
+				Branch:       update.Branch,
+			}, nil
+		},
+		AddPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		NewLaunchID: func() string { return "launch-1" },
+	})
+
+	result, err := starter.StartPlan(model.FlowStartRequest{
+		RepoPath:     "/repo",
+		Title:        "Triage flow",
+		Instructions: "Sort the task.",
+	})
+	if err != nil {
+		t.Fatalf("StartPlan() error = %v", err)
+	}
+	if !strings.Contains(result.LaunchContext.InitialPrompt, "Flow phase: Triage (triage).") {
+		t.Fatalf("initial prompt did not use generic phase prompt:\n%s", result.LaunchContext.InitialPrompt)
+	}
+	if strings.Contains(result.LaunchContext.InitialPrompt, "Produce a plan only") {
+		t.Fatalf("generic root prompt should not use plan-only wording:\n%s", result.LaunchContext.InitialPrompt)
+	}
+}
+
 func TestFlowStarterStartPlanRequiresCreateFlow(t *testing.T) {
 	starter := model.NewFlowStarter(model.FlowStarterOptions{
 		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {

--- a/model/flow_start_test.go
+++ b/model/flow_start_test.go
@@ -378,6 +378,58 @@ func TestFlowStarterStartPlanUsesConfiguredPromptTemplate(t *testing.T) {
 	}
 }
 
+func TestFlowStarterStartPlanTemplateUsesCustomRootPhase(t *testing.T) {
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-1"
+			record.Phases = []flowstore.FlowPhase{
+				{PhaseID: "research", Title: "Research", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady, Order: 1},
+				{PhaseID: "draft", Title: "Draft", Kind: flowstore.KindImplementation, Status: flowstore.PhasePending, Order: 2, DependsOn: []string{"research"}},
+			}
+			return record, nil
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{WorktreePath: "/dev/alpha-worktrees/research", Branch: "flow/research"}, nil
+		},
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{
+				FlowID:       update.FlowID,
+				Instructions: "Research it",
+				WorktreePath: update.WorktreePath,
+				Branch:       update.Branch,
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "research", Title: "Research", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady, Order: 1},
+					{PhaseID: "draft", Title: "Draft", Kind: flowstore.KindImplementation, Status: flowstore.PhasePending, Order: 2, DependsOn: []string{"research"}},
+				},
+			}, nil
+		},
+		AddPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+		NewLaunchID: func() string {
+			return "launch-1"
+		},
+		FlowPromptTemplates: model.FlowPromptTemplates{
+			Plan: "Start {phase_id}: {phase_title}",
+		},
+	})
+
+	result, err := starter.StartPlan(model.FlowStartRequest{
+		RepoPath:     "/dev/alpha",
+		Title:        "Research Flow",
+		Instructions: "Research it",
+		AgentCommand: "codex",
+	})
+	if err != nil {
+		t.Fatalf("StartPlan returned error: %v", err)
+	}
+
+	want := appendFlowDoneInstructionForTest("Start research: Research")
+	if result.LaunchContext.InitialPrompt != want {
+		t.Fatalf("plan prompt = %q, want %q", result.LaunchContext.InitialPrompt, want)
+	}
+}
+
 func TestFlowStarterStartPlanUsesRequestTimePromptTemplate(t *testing.T) {
 	starter := model.NewFlowStarter(model.FlowStarterOptions{
 		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
@@ -613,6 +665,41 @@ func TestFlowStarterStartPlanWorktreeFailureBlocksRequestedPlanPhase(t *testing.
 
 	if phaseUpdate.FlowID != "flow-1" ||
 		phaseUpdate.PhaseID != "custom-plan" ||
+		phaseUpdate.Status != flowstore.PhaseBlocked ||
+		!strings.Contains(phaseUpdate.Notes, "Worktree creation failed") ||
+		!strings.Contains(phaseUpdate.Notes, "branch exists") {
+		t.Fatalf("phase update = %#v", phaseUpdate)
+	}
+}
+
+func TestFlowStarterPrepareFlowWorktreeFailureBlocksFirstLaunchablePhase(t *testing.T) {
+	var phaseUpdate flowstore.PhaseUpdate
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-1"
+			record.Phases = []flowstore.FlowPhase{
+				{PhaseID: "research", Title: "Research", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady, Order: 1},
+				{PhaseID: "draft", Title: "Draft", Kind: flowstore.KindImplementation, Status: flowstore.PhasePending, Order: 2, DependsOn: []string{"research"}},
+			}
+			return record, nil
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{}, errors.New("branch exists")
+		},
+		SetPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+			phaseUpdate = update
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+
+	_, err := starter.PrepareFlow(model.FlowStartRequest{RepoPath: "/dev/alpha", Title: "Research Flow", Instructions: "Plan research"})
+	if err == nil {
+		t.Fatal("PrepareFlow returned nil error, want worktree failure")
+	}
+
+	if phaseUpdate.FlowID != "flow-1" ||
+		phaseUpdate.PhaseID != "research" ||
 		phaseUpdate.Status != flowstore.PhaseBlocked ||
 		!strings.Contains(phaseUpdate.Notes, "Worktree creation failed") ||
 		!strings.Contains(phaseUpdate.Notes, "branch exists") {

--- a/model/flow_start_test.go
+++ b/model/flow_start_test.go
@@ -707,6 +707,48 @@ func TestFlowStarterPrepareFlowWorktreeFailureBlocksFirstLaunchablePhase(t *test
 	}
 }
 
+func TestFlowStarterPrepareFlowWorktreeFailureBlocksAllLaunchableRootPhases(t *testing.T) {
+	var phaseUpdates []flowstore.PhaseUpdate
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-1"
+			record.Phases = []flowstore.FlowPhase{
+				{PhaseID: "research", Title: "Research", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady, Order: 1},
+				{PhaseID: "spike", Title: "Spike", Kind: flowstore.KindImplementation, Status: flowstore.PhaseReady, Order: 2},
+				{PhaseID: "draft", Title: "Draft", Kind: flowstore.KindImplementation, Status: flowstore.PhasePending, Order: 3, DependsOn: []string{"research"}},
+			}
+			return record, nil
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{}, errors.New("branch exists")
+		},
+		SetPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+			phaseUpdates = append(phaseUpdates, update)
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+
+	_, err := starter.PrepareFlow(model.FlowStartRequest{RepoPath: "/dev/alpha", Title: "Research Flow", Instructions: "Plan research"})
+	if err == nil {
+		t.Fatal("PrepareFlow returned nil error, want worktree failure")
+	}
+
+	if len(phaseUpdates) != 2 {
+		t.Fatalf("phase updates = %#v, want research and spike blocked", phaseUpdates)
+	}
+	for i, wantPhaseID := range []string{"research", "spike"} {
+		update := phaseUpdates[i]
+		if update.FlowID != "flow-1" ||
+			update.PhaseID != wantPhaseID ||
+			update.Status != flowstore.PhaseBlocked ||
+			!strings.Contains(update.Notes, "Worktree creation failed") ||
+			!strings.Contains(update.Notes, "branch exists") {
+			t.Fatalf("phase update %d = %#v, want blocked %s", i, update, wantPhaseID)
+		}
+	}
+}
+
 func TestFlowStarterStartPlanWorktreeFailureReportsBlockedPhaseUpdateFailure(t *testing.T) {
 	starter := model.NewFlowStarter(model.FlowStarterOptions{
 		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {

--- a/model/flow_start_test.go
+++ b/model/flow_start_test.go
@@ -641,6 +641,68 @@ func TestFlowStarterStartPlanBootstrapFailureBlocksPlanPhase(t *testing.T) {
 	}
 }
 
+func TestFlowStarterStartPlanBootstrapFailureBlocksAllLaunchableRootPhases(t *testing.T) {
+	var phaseUpdates []flowstore.PhaseUpdate
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-1"
+			record.Phases = []flowstore.FlowPhase{
+				{PhaseID: "research", Title: "Research", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady, Order: 1},
+				{PhaseID: "review", Title: "Review", Kind: flowstore.KindPlanReview, Status: flowstore.PhaseReady, Order: 2},
+				{PhaseID: "draft", Title: "Draft", Kind: flowstore.KindImplementation, Status: flowstore.PhasePending, Order: 3, DependsOn: []string{"research"}},
+			}
+			return record, nil
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{WorktreePath: "/dev/alpha-worktrees/flow-add-flow-mode", Branch: "flow/add-flow-mode"}, nil
+		},
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{
+				FlowID:       update.FlowID,
+				WorktreePath: update.WorktreePath,
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "research", Title: "Research", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady, Order: 1},
+					{PhaseID: "review", Title: "Review", Kind: flowstore.KindPlanReview, Status: flowstore.PhaseReady, Order: 2},
+					{PhaseID: "draft", Title: "Draft", Kind: flowstore.KindImplementation, Status: flowstore.PhasePending, Order: 3, DependsOn: []string{"research"}},
+				},
+			}, nil
+		},
+		BootstrapHookForRepo: func(string) (actions.BootstrapHook, bool) {
+			return actions.BootstrapHook{Script: ".wtui/bootstrap", TimeoutSeconds: 7}, true
+		},
+		RunBootstrapHook: func(actions.BootstrapContext, actions.BootstrapHook) error {
+			return errors.New("missing env file")
+		},
+		SetPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+			phaseUpdates = append(phaseUpdates, update)
+			return flowstore.FlowRecord{}, nil
+		},
+		AddPhaseLaunchID: func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			t.Fatal("launch ID should not be recorded after bootstrap failure")
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+
+	_, err := starter.StartPlan(model.FlowStartRequest{RepoPath: "/dev/alpha", Title: "Add Flow Mode", Instructions: "Build the thing"})
+	if err == nil {
+		t.Fatal("StartPlan returned nil error, want bootstrap failure")
+	}
+
+	if len(phaseUpdates) != 2 {
+		t.Fatalf("phase updates = %#v, want research and review blocked", phaseUpdates)
+	}
+	if phaseUpdates[0].PhaseID != "research" || phaseUpdates[0].Status != flowstore.PhaseBlocked || phaseUpdates[0].Outcome != "" {
+		t.Fatalf("first phase update = %#v, want blocked research", phaseUpdates[0])
+	}
+	if phaseUpdates[1].PhaseID != "review" ||
+		phaseUpdates[1].Status != flowstore.PhaseBlocked ||
+		phaseUpdates[1].Outcome != flowstore.OutcomeBlocked ||
+		!strings.Contains(phaseUpdates[1].Notes, "Bootstrap hook failed") {
+		t.Fatalf("second phase update = %#v, want blocked review with outcome", phaseUpdates[1])
+	}
+}
+
 func TestFlowStarterStartPlanWorktreeFailureBlocksRequestedPlanPhase(t *testing.T) {
 	var phaseUpdate flowstore.PhaseUpdate
 

--- a/model/flow_start_test.go
+++ b/model/flow_start_test.go
@@ -230,6 +230,48 @@ func TestFlowStarterStartPlanUsesGenericPromptForNonPlanRoot(t *testing.T) {
 	}
 }
 
+func TestFlowStarterStartPlanRejectsPlanReviewRootWithoutLinkedPlan(t *testing.T) {
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateFlow: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-1"
+			record.Phases = []flowstore.FlowPhase{
+				{PhaseID: "review", Title: "Review", Kind: flowstore.KindPlanReview, Status: flowstore.PhaseReady, Order: 1},
+			}
+			return record, nil
+		},
+		CreateWorktree: func(repoPath, title, baseRef string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{WorktreePath: "/repo/worktrees/review", Branch: "flow/review"}, nil
+		},
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{
+				FlowID:       update.FlowID,
+				WorktreePath: update.WorktreePath,
+				Branch:       update.Branch,
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "review", Title: "Review", Kind: flowstore.KindPlanReview, Status: flowstore.PhaseReady, Order: 1},
+				},
+			}, nil
+		},
+		AddPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			t.Fatalf("AddPhaseLaunchID() should not run for plan-review root without plan: %#v", update)
+			return flowstore.FlowRecord{}, nil
+		},
+		NewLaunchID: func() string { return "launch-1" },
+	})
+
+	_, err := starter.StartPlan(model.FlowStartRequest{
+		RepoPath:     "/repo",
+		Title:        "Review flow",
+		Instructions: "Review the plan.",
+	})
+	if err == nil {
+		t.Fatal("StartPlan() error = nil, want linked plan requirement")
+	}
+	if !strings.Contains(err.Error(), "Plan Review needs a linked plan before launch") {
+		t.Fatalf("StartPlan() error = %q, want linked plan requirement", err)
+	}
+}
+
 func TestFlowStarterStartPlanRequiresCreateFlow(t *testing.T) {
 	starter := model.NewFlowStarter(model.FlowStarterOptions{
 		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {

--- a/model/model.go
+++ b/model/model.go
@@ -26,128 +26,127 @@ const listRequestSlots = int(ui.ModeActiveFlows) + 1
 
 // Model is the bubbletea application model.
 type Model struct {
-	repos                      pane.Pane[scanner.Repo]
-	width                      int
-	height                     int
-	mode                       ui.Mode
-	lastGitMode                ui.Mode
-	rows                       pane.Pane[gitquery.BranchRow]
-	stashes                    pane.Pane[gitquery.Stash]
-	worktrees                  pane.Pane[gitquery.Worktree]
-	worktreeSessions           pane.Pane[sessions.SessionRecord]
-	commits                    pane.Pane[gitquery.Commit]
-	reflogs                    pane.Pane[gitquery.ReflogEntry]
-	sessions                   pane.Pane[sessions.SessionRecord]
-	plans                      pane.Pane[planstore.PlanRecord]
-	flows                      pane.Pane[flowstore.FlowRecord]
-	activeFlowRecords          []flowstore.FlowRecord
-	activeFlows                pane.Pane[flowstore.FlowRecord]
-	expandedPlanID             string
-	expandedFlowID             string
-	expandedActiveFlowID       string
-	selectedPlanPhaseID        string
-	selectedFlowPhaseID        string
-	selectedActiveFlowPhaseID  string
-	flowHeadless               bool
-	modal                      modal.Modal
-	diffRequestSeq             uint64
-	activeViewRequest          uint64
-	activeViewKind             FetchKind
-	activeViewMode             ui.Mode
-	listRequestSeq             uint64
-	worktreeSessionRequestSeq  uint64
-	activeWorktreeSessionReq   uint64
-	inlineWorktreeSessionRepo  string
-	inlineWorktreeSessionPath  string
-	pendingInlineSessionRepo   string
-	pendingInlineSessionPath   string
-	pendingInlineSessionList   uint64
-	worktreeCreateSeq          uint64
-	activeWorktreeCreate       uint64
-	repoCreateSeq              uint64
-	activeRepoCreate           uint64
-	flowCreateSeq              uint64
-	activeFlowCreate           uint64
-	repoRefreshSeq             uint64
-	activeRepoRefresh          uint64
-	pendingRepoSelection       string
-	listRequests               [listRequestSlots]uint64
-	activePane                 int // 0=left (repos), 1=right (content)
-	activeFlowsReturnMode      ui.Mode
-	destructive                bool
-	status                     statusError
-	statusSeq                  uint64
-	statusTimer                statusTimerFactory
-	pendingStatusCmds          []tea.Cmd
-	visibleRepoFetchSeq        uint64
-	visibleRepoFetch           visibleRepoFetchState
-	searchActive               bool
-	pendingBranchSelection     string
-	pendingWorktreeSelection   string
-	agentCommand               string
-	codexModel                 string
-	claudeModel                string
-	codexReasoningEffort       string
-	claudeReasoningEffort      string
-	defaultView                ui.Mode
-	planPromptTemplate         string
-	flowPromptTemplates        FlowPromptTemplates
-	repoCreateRoot             string
-	scanRepos                  func() ([]scanner.Repo, error)
-	createRepo                 func(actions.RepoCreateOptions) (actions.RepoCreateResult, error)
-	fetchRepo                  func(string) error
-	listSessions               func(sessions.SessionFilter) ([]sessions.SessionRecord, error)
-	readTranscript             func(sessions.Provider, string) ([]sessions.TranscriptEvent, error)
-	listPlans                  func(planstore.PlanFilter) ([]planstore.PlanRecord, error)
-	listFlows                  func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error)
-	createFlow                 func(FlowStartRequest) (FlowStartResult, error)
-	startFlowPlan              func(FlowStartRequest) (FlowStartResult, error)
-	setFlowPhase               func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
-	setFlowAutoMode            func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
-	lookupPRMerge              func(int, string) (actions.PullRequestMerge, error)
-	markFlowManualMerge        func(flowstore.ManualMergeUpdate) (flowstore.FlowRecord, error)
-	addFlowPhaseLaunchID       func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
-	resetFlowPhase             func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error)
-	deleteFlow                 func(string) error
-	readPlan                   func(string) (string, error)
-	planMarkdownPath           func(string) (string, error)
-	copyToClipboard            func(string) error
-	openCode                   func(string) error
-	openURL                    func(string) error
-	pageText                   func(string) (actions.TerminalLaunchSpec, error)
-	editFile                   func(string) (actions.TerminalLaunchSpec, error)
-	saveAgent                  func(string) error
-	saveAgentModel             func(string, string) error
-	saveAgentReasoningEffort   func(string, string) error
-	saveDefaultView            func(ui.Mode) error
-	savePromptTemplate         func(string, string, string) error
-	resetPromptTemplate        func(string, string) error
-	launchTerminal             func(string) (actions.TerminalLaunchSpec, error)
-	launchDetachedTerminal     func(string, string) (actions.TerminalLaunchSpec, error)
-	launchAgent                func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error)
-	startEmbeddedTerminal      EmbeddedTerminalStarter
-	embeddedTerminals          []embeddedTerminalSlot
-	nextEmbeddedTerminalID     int
-	activeEmbeddedTerminalNum  int
-	activeFlowTerminalNum      int
-	flowFocus                  flowFocus
-	deferredAutoFlowLaunches   map[deferredAutoFlowLaunchKey]struct{}
-	suppressedAutoFlowLaunches map[suppressedAutoFlowLaunchKey]struct{}
-	embeddedTerminalTickGen    uint64
-	flowRefreshTickGen         uint64
-	flowRefreshInFlight        uint64
-	flowRefreshInFlightMode    ui.Mode
-	autoAdvanceRequestSeq      uint64
-	autoAdvanceInFlight        uint64
-	autoAdvanceSnapshot        []flowstore.FlowRecord
-	autoAdvanceLaunchedPhases  []autoAdvanceLaunchedPhase
-	terminalPrefixActive       bool
-	terminalConfirmID          embeddedTerminalID
-	terminalConfirmScope       embeddedTerminalScope
-	finalizeAgentSession       func(actions.AgentLaunchContext) error
-	sessionStateRoot           string
-	bootstrapHookForRepo       func(string) (actions.BootstrapHook, bool)
-	runBootstrapHook           func(actions.BootstrapContext, actions.BootstrapHook) error
+	repos                     pane.Pane[scanner.Repo]
+	width                     int
+	height                    int
+	mode                      ui.Mode
+	lastGitMode               ui.Mode
+	rows                      pane.Pane[gitquery.BranchRow]
+	stashes                   pane.Pane[gitquery.Stash]
+	worktrees                 pane.Pane[gitquery.Worktree]
+	worktreeSessions          pane.Pane[sessions.SessionRecord]
+	commits                   pane.Pane[gitquery.Commit]
+	reflogs                   pane.Pane[gitquery.ReflogEntry]
+	sessions                  pane.Pane[sessions.SessionRecord]
+	plans                     pane.Pane[planstore.PlanRecord]
+	flows                     pane.Pane[flowstore.FlowRecord]
+	activeFlowRecords         []flowstore.FlowRecord
+	activeFlows               pane.Pane[flowstore.FlowRecord]
+	expandedPlanID            string
+	expandedFlowID            string
+	expandedActiveFlowID      string
+	selectedPlanPhaseID       string
+	selectedFlowPhaseID       string
+	selectedActiveFlowPhaseID string
+	flowHeadless              bool
+	modal                     modal.Modal
+	diffRequestSeq            uint64
+	activeViewRequest         uint64
+	activeViewKind            FetchKind
+	activeViewMode            ui.Mode
+	listRequestSeq            uint64
+	worktreeSessionRequestSeq uint64
+	activeWorktreeSessionReq  uint64
+	inlineWorktreeSessionRepo string
+	inlineWorktreeSessionPath string
+	pendingInlineSessionRepo  string
+	pendingInlineSessionPath  string
+	pendingInlineSessionList  uint64
+	worktreeCreateSeq         uint64
+	activeWorktreeCreate      uint64
+	repoCreateSeq             uint64
+	activeRepoCreate          uint64
+	flowCreateSeq             uint64
+	activeFlowCreate          uint64
+	repoRefreshSeq            uint64
+	activeRepoRefresh         uint64
+	pendingRepoSelection      string
+	listRequests              [listRequestSlots]uint64
+	activePane                int // 0=left (repos), 1=right (content)
+	activeFlowsReturnMode     ui.Mode
+	destructive               bool
+	status                    statusError
+	statusSeq                 uint64
+	statusTimer               statusTimerFactory
+	pendingStatusCmds         []tea.Cmd
+	visibleRepoFetchSeq       uint64
+	visibleRepoFetch          visibleRepoFetchState
+	searchActive              bool
+	pendingBranchSelection    string
+	pendingWorktreeSelection  string
+	agentCommand              string
+	codexModel                string
+	claudeModel               string
+	codexReasoningEffort      string
+	claudeReasoningEffort     string
+	defaultView               ui.Mode
+	planPromptTemplate        string
+	flowPromptTemplates       FlowPromptTemplates
+	repoCreateRoot            string
+	scanRepos                 func() ([]scanner.Repo, error)
+	createRepo                func(actions.RepoCreateOptions) (actions.RepoCreateResult, error)
+	fetchRepo                 func(string) error
+	listSessions              func(sessions.SessionFilter) ([]sessions.SessionRecord, error)
+	readTranscript            func(sessions.Provider, string) ([]sessions.TranscriptEvent, error)
+	listPlans                 func(planstore.PlanFilter) ([]planstore.PlanRecord, error)
+	listFlows                 func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error)
+	createFlow                func(FlowStartRequest) (FlowStartResult, error)
+	startFlowPlan             func(FlowStartRequest) (FlowStartResult, error)
+	setFlowPhase              func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
+	setFlowAutoMode           func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
+	lookupPRMerge             func(int, string) (actions.PullRequestMerge, error)
+	markFlowManualMerge       func(flowstore.ManualMergeUpdate) (flowstore.FlowRecord, error)
+	addFlowPhaseLaunchID      func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
+	resetFlowPhase            func(flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error)
+	deleteFlow                func(string) error
+	readPlan                  func(string) (string, error)
+	planMarkdownPath          func(string) (string, error)
+	copyToClipboard           func(string) error
+	openCode                  func(string) error
+	openURL                   func(string) error
+	pageText                  func(string) (actions.TerminalLaunchSpec, error)
+	editFile                  func(string) (actions.TerminalLaunchSpec, error)
+	saveAgent                 func(string) error
+	saveAgentModel            func(string, string) error
+	saveAgentReasoningEffort  func(string, string) error
+	saveDefaultView           func(ui.Mode) error
+	savePromptTemplate        func(string, string, string) error
+	resetPromptTemplate       func(string, string) error
+	launchTerminal            func(string) (actions.TerminalLaunchSpec, error)
+	launchDetachedTerminal    func(string, string) (actions.TerminalLaunchSpec, error)
+	launchAgent               func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error)
+	startEmbeddedTerminal     EmbeddedTerminalStarter
+	embeddedTerminals         []embeddedTerminalSlot
+	nextEmbeddedTerminalID    int
+	activeEmbeddedTerminalNum int
+	activeFlowTerminalNum     int
+	flowFocus                 flowFocus
+	autoAdvanceDrainFlows     map[string]struct{}
+	embeddedTerminalTickGen   uint64
+	flowRefreshTickGen        uint64
+	flowRefreshInFlight       uint64
+	flowRefreshInFlightMode   ui.Mode
+	autoAdvanceRequestSeq     uint64
+	autoAdvanceInFlight       uint64
+	autoAdvanceSnapshot       []flowstore.FlowRecord
+	autoAdvanceLaunchedPhases []autoAdvanceLaunchedPhase
+	terminalPrefixActive      bool
+	terminalConfirmID         embeddedTerminalID
+	terminalConfirmScope      embeddedTerminalScope
+	finalizeAgentSession      func(actions.AgentLaunchContext) error
+	sessionStateRoot          string
+	bootstrapHookForRepo      func(string) (actions.BootstrapHook, bool)
+	runBootstrapHook          func(actions.BootstrapContext, actions.BootstrapHook) error
 }
 
 type statusSource int
@@ -191,6 +190,8 @@ type Options struct {
 	StartupMode              ui.Mode
 	PlanPromptTemplate       string
 	FlowPromptTemplates      FlowPromptTemplates
+	FlowPresets              []flowstore.Preset
+	FlowPreset               *flowstore.Preset
 	RepoCreateRoot           string
 	ScanRepos                func() ([]scanner.Repo, error)
 	CreateRepo               func(actions.RepoCreateOptions) (actions.RepoCreateResult, error)
@@ -238,6 +239,12 @@ func New(repos []scanner.Repo) Model {
 
 // NewWithOptions creates a Model from discovered repos and startup options.
 func NewWithOptions(repos []scanner.Repo, opts Options) Model {
+	newFlowStore := func() (*flowstore.Store, error) {
+		return flowstore.NewStore(flowstore.StoreOptions{
+			Root:    opts.SessionStateRoot,
+			Presets: opts.FlowPresets,
+		})
+	}
 	saveAgent := opts.SaveAgentCommand
 	if saveAgent == nil {
 		saveAgent = func(string) error { return nil }
@@ -288,9 +295,8 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	}
 	setFlowPhase := opts.SetFlowPhase
 	if setFlowPhase == nil {
-		root := opts.SessionStateRoot
 		setFlowPhase = func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
-			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			store, err := newFlowStore()
 			if err != nil {
 				return flowstore.FlowRecord{}, err
 			}
@@ -299,9 +305,8 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	}
 	setFlowAutoMode := opts.SetFlowAutoMode
 	if setFlowAutoMode == nil {
-		root := opts.SessionStateRoot
 		setFlowAutoMode = func(update flowstore.AutoModeUpdate) (flowstore.FlowRecord, error) {
-			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			store, err := newFlowStore()
 			if err != nil {
 				return flowstore.FlowRecord{}, err
 			}
@@ -314,9 +319,8 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	}
 	markFlowManualMerge := opts.MarkFlowManualMerge
 	if markFlowManualMerge == nil {
-		root := opts.SessionStateRoot
 		markFlowManualMerge = func(update flowstore.ManualMergeUpdate) (flowstore.FlowRecord, error) {
-			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			store, err := newFlowStore()
 			if err != nil {
 				return flowstore.FlowRecord{}, err
 			}
@@ -325,9 +329,8 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	}
 	addFlowPhaseLaunchID := opts.AddFlowPhaseLaunchID
 	if addFlowPhaseLaunchID == nil {
-		root := opts.SessionStateRoot
 		addFlowPhaseLaunchID = func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
-			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			store, err := newFlowStore()
 			if err != nil {
 				return flowstore.FlowRecord{}, err
 			}
@@ -336,9 +339,8 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	}
 	resetFlowPhase := opts.ResetFlowPhase
 	if resetFlowPhase == nil {
-		root := opts.SessionStateRoot
 		resetFlowPhase = func(update flowstore.PhaseResetUpdate) (flowstore.FlowRecord, error) {
-			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			store, err := newFlowStore()
 			if err != nil {
 				return flowstore.FlowRecord{}, err
 			}
@@ -347,9 +349,8 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	}
 	deleteFlow := opts.DeleteFlow
 	if deleteFlow == nil {
-		root := opts.SessionStateRoot
 		deleteFlow = func(flowID string) error {
-			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			store, err := newFlowStore()
 			if err != nil {
 				return err
 			}
@@ -416,16 +417,15 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	createFlowForRepo := opts.CreateFlow
 	startFlowPlan := opts.StartFlowPlan
 	if createFlowForRepo == nil || startFlowPlan == nil {
-		root := opts.SessionStateRoot
 		createFlow := func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			store, err := newFlowStore()
 			if err != nil {
 				return flowstore.FlowRecord{}, err
 			}
-			return store.Create(record)
+			return store.CreateWithOptions(record, flowstore.CreateOptions{Preset: opts.FlowPreset})
 		}
 		setFlowStartMetadata := func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
-			store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+			store, err := newFlowStore()
 			if err != nil {
 				return flowstore.FlowRecord{}, err
 			}
@@ -1191,10 +1191,10 @@ func (m Model) Update(msg tea.Msg) (next tea.Model, cmd tea.Cmd) {
 		if msg.Generation != m.embeddedTerminalTickGen {
 			return m, nil
 		}
-		exitedFlowTerminals := m.exitedFlowEmbeddedTerminalAutoCloseKeys()
+		hadExitedFlowTerminals := m.hasExitedFlowEmbeddedTerminalAutoClose()
 		m = m.dismissExitedFlowEmbeddedTerminals()
 		var cmds []tea.Cmd
-		if len(exitedFlowTerminals) > 0 {
+		if hadExitedFlowTerminals {
 			var refreshCmd tea.Cmd
 			m, refreshCmd = m.startFlowSurfaceRefreshFetch()
 			cmds = append(cmds, refreshCmd)

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -475,9 +475,6 @@ func (m Model) createFlowAndLaunchPlanForRepo(repoPath, title, instructions, bas
 			SessionStateRoot:            m.sessionStateRoot,
 			FlowPromptTemplates:         m.flowPromptTemplates,
 			FlowPromptTemplatesProvided: true,
-			PlanPhaseID:                 flowPlanPhaseID,
-			PlanPhaseTitle:              "Plan",
-			PlanPhaseStatus:             flowstore.PhaseRunning,
 		})
 		if err != nil {
 			return FlowCreateFailedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title, Err: err.Error()}
@@ -493,7 +490,6 @@ func (m Model) createFlowForRepo(repoPath, title, instructions, baseRef string) 
 			Title:        title,
 			Instructions: instructions,
 			BaseRef:      baseRef,
-			PlanPhaseID:  flowPlanPhaseID,
 		})
 		if err != nil {
 			return FlowCreateFailedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title, Err: err.Error()}

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -479,6 +479,9 @@ func (m Model) createFlowAndLaunchPlanForRepo(repoPath, title, instructions, bas
 		if err != nil {
 			return FlowCreateFailedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title, Err: err.Error()}
 		}
+		if result.LaunchSkipped {
+			return FlowCreatedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title}
+		}
 		return flowPlanLaunchMessage(result.LaunchContext, headless)
 	}
 }

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -9903,11 +9903,11 @@ func TestModel_NewFlowDelegatesStartAndLaunchesPlanAgent(t *testing.T) {
 						Branch:           "flow/add-flow-mode",
 						Commit:           "abc123",
 						SessionStateRoot: req.SessionStateRoot,
-						PlanPhaseID:      req.PlanPhaseID,
-						PlanPhaseTitle:   req.PlanPhaseTitle,
-						PlanPhaseStatus:  req.PlanPhaseStatus,
+						PlanPhaseID:      "plan",
+						PlanPhaseTitle:   "Plan",
+						PlanPhaseStatus:  flowstore.PhaseRunning,
 						FlowID:           "flow-1",
-						FlowPhaseID:      req.PlanPhaseID,
+						FlowPhaseID:      "plan",
 						ReasoningEffort:  req.ReasoningEffort,
 						InitialPrompt:    "Use the wtui-flow skill for this launch.\n\nBuild\nthe thing\n\nCreate and persist the plan with wtui plan save, link it back with wtui flow plan set.",
 					}}, nil
@@ -9956,9 +9956,9 @@ func TestModel_NewFlowDelegatesStartAndLaunchesPlanAgent(t *testing.T) {
 			}
 			if startRequest.AgentCommand != command ||
 				startRequest.SessionStateRoot != "/state/wtui/sessions/v1" ||
-				startRequest.PlanPhaseID != "plan" ||
-				startRequest.PlanPhaseTitle != "Plan" ||
-				startRequest.PlanPhaseStatus != flowstore.PhaseRunning ||
+				startRequest.PlanPhaseID != "" ||
+				startRequest.PlanPhaseTitle != "" ||
+				startRequest.PlanPhaseStatus != "" ||
 				startRequest.ReasoningEffort != wantEffort {
 				t.Fatalf("start request metadata = %#v", startRequest)
 			}
@@ -9998,6 +9998,58 @@ func TestModel_NewFlowDelegatesStartAndLaunchesPlanAgent(t *testing.T) {
 				t.Fatalf("flow terminal view missing agent output:\n%s", view)
 			}
 		})
+	}
+}
+
+func TestModel_NewFlowPlanNowLetsStarterChooseCustomRootPhase(t *testing.T) {
+	var startRequest model.FlowStartRequest
+	var started actions.AgentLaunchContext
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		StartFlowPlan: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+			startRequest = req
+			return model.FlowStartResult{LaunchContext: actions.AgentLaunchContext{
+				Command:      req.AgentCommand,
+				LaunchID:     "launch-1",
+				RepoPath:     req.RepoPath,
+				WorktreePath: "/dev/alpha-worktrees/flow-research",
+				Branch:       "flow/research",
+				FlowID:       "flow-1",
+				FlowPhaseID:  "research",
+				PlanPhaseID:  "research",
+			}}, nil
+		},
+		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, width, height int) (model.EmbeddedTerminal, error) {
+			started = ctx
+			return &fakeEmbeddedTerminal{state: "running"}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			t.Fatal("CLI Flow launch should use embedded terminal")
+			return actions.TerminalLaunchSpec{}, nil
+		},
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return nil, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 20})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+
+	m, cmd := submitNewFlowPrompts(t, m, "Research Flow", "Plan research", "main")
+	if cmd == nil {
+		t.Fatal("expected flow creation command")
+	}
+	launchMsg, ok := cmd().(model.FlowEmbeddedLaunchRequestedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want FlowEmbeddedLaunchRequestedMsg", launchMsg)
+	}
+	m, _ = update(m, launchMsg)
+
+	if startRequest.PlanPhaseID != "" || startRequest.PlanPhaseTitle != "" || startRequest.PlanPhaseStatus != "" {
+		t.Fatalf("TUI create path forced phase metadata: %#v", startRequest)
+	}
+	if started.FlowPhaseID != "research" || started.PlanPhaseID != "research" {
+		t.Fatalf("started phase IDs = flow %q plan %q, want research", started.FlowPhaseID, started.PlanPhaseID)
 	}
 }
 
@@ -10097,7 +10149,7 @@ func TestModel_NewFlowLaunchNormalizesConfiguredAgentCommandForPlanAndTerminal(t
 				Branch:           "flow/add-flow-mode",
 				SessionStateRoot: req.SessionStateRoot,
 				FlowID:           "flow-1",
-				FlowPhaseID:      req.PlanPhaseID,
+				FlowPhaseID:      "plan",
 				ReasoningEffort:  req.ReasoningEffort,
 			}}, nil
 		},
@@ -10156,7 +10208,7 @@ func TestModel_NewFlowCLIPlanLaunchUsesCheckedHeadlessOption(t *testing.T) {
 						Branch:           "flow/interactive-plan",
 						SessionStateRoot: req.SessionStateRoot,
 						FlowID:           "flow-1",
-						FlowPhaseID:      req.PlanPhaseID,
+						FlowPhaseID:      "plan",
 					}}, nil
 				},
 				LaunchAgent: func(ctx actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
@@ -10223,7 +10275,7 @@ func TestModel_NewFlowInteractiveCLIPlanLaunchFocusesTerminalInput(t *testing.T)
 				Branch:           "flow/interactive-plan",
 				SessionStateRoot: req.SessionStateRoot,
 				FlowID:           "flow-1",
-				FlowPhaseID:      req.PlanPhaseID,
+				FlowPhaseID:      "plan",
 				InitialPrompt:    "Create and persist the plan.",
 			}}, nil
 		},
@@ -10294,11 +10346,11 @@ func TestModel_NewFlowWithCodexAppUsesExternalLaunchRoute(t *testing.T) {
 						Branch:           "flow/add-flow-mode",
 						Commit:           "abc123",
 						SessionStateRoot: req.SessionStateRoot,
-						PlanPhaseID:      req.PlanPhaseID,
-						PlanPhaseTitle:   req.PlanPhaseTitle,
-						PlanPhaseStatus:  req.PlanPhaseStatus,
+						PlanPhaseID:      "plan",
+						PlanPhaseTitle:   "Plan",
+						PlanPhaseStatus:  flowstore.PhaseRunning,
 						FlowID:           "flow-1",
-						FlowPhaseID:      req.PlanPhaseID,
+						FlowPhaseID:      "plan",
 						InitialPrompt:    "Use the wtui-flow skill for this launch.\n\nBuild\nthe thing\n\nCreate and persist the plan with wtui plan save, link it back with wtui flow plan set.",
 					}}, nil
 				},
@@ -10424,7 +10476,7 @@ func TestModel_NewFlowCodexAppStaleLaunchIgnoredAfterRepoChange(t *testing.T) {
 				WorktreePath: "/dev/alpha-worktrees/flow-stale",
 				Branch:       "flow/stale",
 				FlowID:       "flow-1",
-				FlowPhaseID:  req.PlanPhaseID,
+				FlowPhaseID:  "plan",
 			}}, nil
 		},
 		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
@@ -10475,7 +10527,7 @@ func TestModel_NewFlowLaunchesAfterStartPlanReturns(t *testing.T) {
 				WorktreePath: "/dev/alpha-worktrees/flow-add-flow-mode",
 				Branch:       "flow/add-flow-mode",
 				FlowID:       "flow-1",
-				FlowPhaseID:  req.PlanPhaseID,
+				FlowPhaseID:  "plan",
 			}}, nil
 		},
 		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
@@ -10526,7 +10578,7 @@ func TestModel_NewFlowStaleLaunchIgnoredAfterRepoChange(t *testing.T) {
 				WorktreePath: "/dev/alpha-worktrees/flow-stale",
 				Branch:       "flow/stale",
 				FlowID:       "flow-1",
-				FlowPhaseID:  req.PlanPhaseID,
+				FlowPhaseID:  "plan",
 			}}, nil
 		},
 		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
@@ -10822,7 +10874,7 @@ func TestModel_NewFlowLaunchFailureMarksPlanNeedsAttention(t *testing.T) {
 				WorktreePath: "/dev/alpha-worktrees/flow-add-flow-mode",
 				Branch:       "flow/add-flow-mode",
 				FlowID:       "flow-1",
-				FlowPhaseID:  req.PlanPhaseID,
+				FlowPhaseID:  "plan",
 			}}, nil
 		},
 		SetFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
@@ -10878,7 +10930,7 @@ func TestModel_NewFlowCodexAppLaunchFailureMarksPlanNeedsAttention(t *testing.T)
 				WorktreePath: "/dev/alpha-worktrees/flow-add-flow-mode",
 				Branch:       "flow/add-flow-mode",
 				FlowID:       "flow-1",
-				FlowPhaseID:  req.PlanPhaseID,
+				FlowPhaseID:  "plan",
 			}}, nil
 		},
 		SetFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
@@ -10938,7 +10990,7 @@ func TestModel_NewFlowAtEmbeddedTerminalCapMarksPlanNeedsAttention(t *testing.T)
 				WorktreePath: "/dev/alpha-worktrees/flow-add-flow-mode",
 				Branch:       "flow/add-flow-mode",
 				FlowID:       "flow-1",
-				FlowPhaseID:  req.PlanPhaseID,
+				FlowPhaseID:  "plan",
 			}}, nil
 		},
 		SetFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -10594,6 +10594,42 @@ func TestModel_NewFlowLaunchesAfterStartPlanReturns(t *testing.T) {
 	}
 }
 
+func TestModel_NewFlowPlanNowParksFlowWhenLaunchSkipped(t *testing.T) {
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AgentCommand: "codex",
+		StartFlowPlan: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+			return model.FlowStartResult{
+				Flow:          flowstore.FlowRecord{FlowID: "flow-parked", RepoPath: req.RepoPath, Title: req.Title},
+				LaunchSkipped: true,
+			}, nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			t.Fatal("launch-skipped Flow should not launch an external agent")
+			return actions.TerminalLaunchSpec{}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			t.Fatal("launch-skipped Flow should not start an embedded terminal")
+			return &fakeEmbeddedTerminal{}, nil
+		},
+	})
+	m = inRightPane(m)
+	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 20})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+
+	_, cmd := submitNewFlowPrompts(t, m, "Merge-only Flow", "Track the merge", "main")
+	if cmd == nil {
+		t.Fatal("expected flow creation command")
+	}
+	raw := cmd()
+	msg, ok := raw.(model.FlowCreatedMsg)
+	if !ok {
+		t.Fatalf("command returned %T, want FlowCreatedMsg", raw)
+	}
+	if msg.FlowID != "flow-parked" || msg.Title != "Merge-only Flow" || msg.Request == 0 {
+		t.Fatalf("FlowCreatedMsg = %#v", msg)
+	}
+}
+
 func TestModel_NewFlowStaleLaunchIgnoredAfterRepoChange(t *testing.T) {
 	embeddedStarts := 0
 	externalLaunches := 0

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -7788,7 +7788,10 @@ func TestModel_ActiveFlowCustomPlanReviewLaunchFailureMarksBlocked(t *testing.T)
 			phaseUpdate = update
 			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
 		},
-		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, _, _ int) (model.EmbeddedTerminal, error) {
+			if ctx.FlowPhaseKind != flowstore.KindPlanReview {
+				t.Fatalf("FlowPhaseKind = %q, want %q", ctx.FlowPhaseKind, flowstore.KindPlanReview)
+			}
 			return nil, errors.New("pty unavailable")
 		},
 	})
@@ -9783,6 +9786,38 @@ func TestModel_GUsesFlowPhaseOrderingForReadyLaunch(t *testing.T) {
 
 	if launchUpdate.PhaseID != "implementation-api" {
 		t.Fatalf("launched phase = %q, want child phase before review-loop", launchUpdate.PhaseID)
+	}
+}
+
+func TestModel_OffViewCustomPlanReviewLaunchFailureMarksBlocked(t *testing.T) {
+	var phaseUpdate flowstore.PhaseUpdate
+	m := model.NewWithOptions(testRepos(), model.Options{
+		SetFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+			phaseUpdate = update
+			return flowstore.FlowRecord{FlowID: update.FlowID}, nil
+		},
+	})
+
+	m, cmd := update(m, model.AgentResultMsg{
+		LaunchContext: actions.AgentLaunchContext{
+			FlowID:        "flow-1",
+			FlowPhaseID:   "design-review",
+			FlowPhaseKind: flowstore.KindPlanReview,
+			RepoPath:      "/dev/alpha",
+		},
+		Err: "terminal failed",
+	})
+	if cmd == nil {
+		t.Fatal("expected flow refresh command")
+	}
+	_ = cmd()
+
+	if phaseUpdate.FlowID != "flow-1" ||
+		phaseUpdate.PhaseID != "design-review" ||
+		phaseUpdate.Status != flowstore.PhaseBlocked ||
+		phaseUpdate.Outcome != flowstore.OutcomeBlocked ||
+		!strings.Contains(phaseUpdate.Notes, "terminal failed") {
+		t.Fatalf("phase update = %#v", phaseUpdate)
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -3059,7 +3059,7 @@ func TestModel_FlowAutoModeSuppressionDoesNotBlockLaterLaunchID(t *testing.T) {
 	}
 }
 
-func TestModel_FlowAutoModeStaleTerminalDoesNotBlockLaterLaunchID(t *testing.T) {
+func TestModel_FlowAutoModeStaleTerminalBlocksDrainUntilDismissed(t *testing.T) {
 	previous := autoFlowWithPhaseStatuses(map[string]string{
 		"plan":           flowstore.PhaseCompleted,
 		"plan-review":    flowstore.PhaseRunning,
@@ -3121,8 +3121,16 @@ func TestModel_FlowAutoModeStaleTerminalDoesNotBlockLaterLaunchID(t *testing.T) 
 		t.Fatalf("new launch running advance returned command %T, want nil", cmd)
 	}
 	m, cmd = model.AutoAdvanceLaunchCommandForTest(m, []flowstore.FlowRecord{completed})
+	if cmd != nil {
+		t.Fatalf("completion with stale flow terminal returned command %T, want nil", cmd)
+	}
+	if !strings.Contains(m.View(), "old failed output") {
+		t.Fatalf("stale failed terminal should remain visible while it blocks the drain:\n%s", m.View())
+	}
+	m = model.ClearFlowEmbeddedTerminalsForTest(m)
+	m, cmd = model.AutoAdvanceLaunchCommandForTest(m, []flowstore.FlowRecord{completed})
 	if cmd == nil {
-		t.Fatal("completion for newer launch ID should auto-launch next phase despite stale terminal")
+		t.Fatal("completion should drain after stale terminal is dismissed")
 	}
 	launches := flowEmbeddedLaunchesFromCommand(t, cmd)
 	if len(launches) != 1 {
@@ -3130,9 +3138,6 @@ func TestModel_FlowAutoModeStaleTerminalDoesNotBlockLaterLaunchID(t *testing.T) 
 	}
 	if len(updates) != 1 || !updates[0].AutoLaunch || updates[0].PhaseID != "implementation" {
 		t.Fatalf("launch updates after newer completion = %#v, want implementation auto launch", updates)
-	}
-	if !strings.Contains(m.View(), "old failed output") {
-		t.Fatalf("stale failed terminal should remain visible:\n%s", m.View())
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1769,13 +1769,6 @@ func (m Model) hasAutoClosingFlowEmbeddedTerminalForPhaseLaunch(flowID, phaseID,
 	return false
 }
 
-func (m Model) clearDeferredAutoFlowLaunchForTerminal(slot embeddedTerminalSlot) Model {
-	if slot.Scope != embeddedTerminalScopeFlow || slot.Terminal == nil || flowEmbeddedTerminalAutoCloses(slot.Terminal.State()) {
-		return m
-	}
-	return m.suppressAutoFlowPhaseLaunch(slot.FlowID, slot.FlowPhaseID, slot.LaunchID)
-}
-
 func flowEmbeddedTerminalSlotMatchesPhase(slot embeddedTerminalSlot, flowID, normalizedPhaseID string) bool {
 	return slot.Scope == embeddedTerminalScopeFlow &&
 		slot.FlowID == flowID &&

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1966,6 +1966,7 @@ func (m Model) flowPhaseSessionResumeLaunchContext(record flowstore.FlowRecord, 
 		PlanPath:          record.PlanPath,
 		FlowID:            record.FlowID,
 		FlowPhaseID:       phase.PhaseID,
+		FlowPhaseKind:     flowstore.SemanticKind(phase),
 		FlowPhaseTerminal: flowstore.PhaseStatusTerminal(phase.Status),
 	}
 	return ctx, true, m
@@ -2296,7 +2297,10 @@ func (m Model) markFlowLaunchNeedsAttention(ctx actions.AgentLaunchContext, errT
 	}
 	status := flowstore.PhaseNeedsAttention
 	outcome := ""
-	if _, phase, ok := m.flowPhaseByID(ctx.FlowID, ctx.FlowPhaseID); ok && flowstore.SemanticKind(phase) == flowstore.KindPlanReview {
+	if ctx.FlowPhaseKind == flowstore.KindPlanReview {
+		status = flowstore.PhaseBlocked
+		outcome = flowstore.OutcomeBlocked
+	} else if _, phase, ok := m.flowPhaseByID(ctx.FlowID, ctx.FlowPhaseID); ok && flowstore.SemanticKind(phase) == flowstore.KindPlanReview {
 		status = flowstore.PhaseBlocked
 		outcome = flowstore.OutcomeBlocked
 	} else if ctx.FlowPhaseID == "plan-review" {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -508,11 +508,10 @@ type FetchErrorMsg struct {
 }
 
 // ActionFailedMsg carries an async action error so the failure can be surfaced
-// via the transient error line and any retry bookkeeping can be restored.
+// via the transient error line.
 type ActionFailedMsg struct {
 	RepoPath                string
 	Err                     string
-	AutoAdvanceRetryRecord  flowstore.FlowRecord
 	AutoAdvanceRetryFlowID  string
 	AutoAdvanceRetryPhaseID string
 }
@@ -1198,11 +1197,10 @@ func (m Model) handleFetchError(msg FetchErrorMsg) Model {
 }
 
 func (m Model) handleActionFailed(msg ActionFailedMsg) (Model, tea.Cmd) {
-	m = m.restoreAutoAdvanceRetrySnapshot(msg.AutoAdvanceRetryRecord)
 	autoAdvanceRetry := msg.AutoAdvanceRetryFlowID != "" && msg.AutoAdvanceRetryPhaseID != ""
-	autoAdvanceFailure := autoAdvanceRetry || msg.AutoAdvanceRetryRecord.FlowID != ""
-	if msg.AutoAdvanceRetryFlowID != "" && msg.AutoAdvanceRetryPhaseID != "" {
-		m = m.deferAutoFlowPhaseLaunch(msg.AutoAdvanceRetryFlowID, msg.AutoAdvanceRetryPhaseID)
+	autoAdvanceFailure := autoAdvanceRetry
+	if msg.AutoAdvanceRetryFlowID != "" {
+		m = m.armAutoAdvanceDrain(msg.AutoAdvanceRetryFlowID)
 	}
 	if m.activeFlowSurfaceVisible() || m.isCurrentRepo(msg.RepoPath) {
 		m = m.setStatus(statusOther, msg.Err)
@@ -1211,7 +1209,7 @@ func (m Model) handleActionFailed(msg ActionFailedMsg) (Model, tea.Cmd) {
 	if !autoAdvanceFailure {
 		return m, nil
 	}
-	title := flowTitleForStatus(msg.AutoAdvanceRetryRecord)
+	title := ""
 	if strings.TrimSpace(title) == "" {
 		title = msg.AutoAdvanceRetryFlowID
 	}

--- a/model/prompt_templates.go
+++ b/model/prompt_templates.go
@@ -296,7 +296,7 @@ func (m Model) builtInPromptTemplatePreview(target promptTemplateTarget) string 
 		},
 	}
 	if target.Key == "plan" {
-		return flowPlanPrompt(record, FlowPromptTemplates{})
+		return flowPlanPrompt(record, flowstore.FlowPhase{PhaseID: flowPlanPhaseID, Title: "Plan", Kind: flowstore.KindPlan}, FlowPromptTemplates{})
 	}
 	phase := flowstore.FlowPhase{PhaseID: flowPhaseIDForPromptTemplateKey(target.Key), Title: "{phase_title}"}
 	return flowPhasePrompt(record, phase, "{plan_path}", "{plan_body}", FlowPromptTemplates{})

--- a/sessions/ingest.go
+++ b/sessions/ingest.go
@@ -15,6 +15,7 @@ import (
 type IngestOptions struct {
 	StateRoot          string
 	CopyRawTranscripts bool
+	FlowPresets        []flowstore.Preset
 	Env                map[string]string
 }
 
@@ -206,7 +207,7 @@ func attachFlowSession(record SessionRecord, opts IngestOptions) {
 	if root == "" {
 		root = opts.Env["WTUI_SESSION_STATE_ROOT"]
 	}
-	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Presets: opts.FlowPresets})
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- Add configurable Flow phase graph presets from TOML, including reserved/duplicate preset validation and `wtui flow create --preset` support.
- Generalize Flow startup and launch behavior around first-ready root phases and preset-derived phase graphs.
- Redesign AutoMode DAG drain behavior and update README, config docs, Flow phase docs, and agent skill docs for custom graphs.

## Implementation notes
- Extends Flow preset parsing/storage and CLI creation paths while preserving existing default phase graph behavior.
- Updates TUI Flow creation and phase launch prompts to work with custom phase IDs and root readiness.
- Adds regression coverage across config validation, CLI preset handling, Flow store preset recovery, TUI launch behavior, and AutoMode advancement.

## Verification
- `gofmt -l .`
- `make test`
- `make build`

Closes #269