### PR TITLE
Exclude dangling linked-worktree checkouts from repo scan

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -177,6 +177,12 @@ func isLinkedWorktreeGitFile(checkoutDir, gitPath string) bool {
 	if filepath.Base(filepath.Dir(adminDir)) != "worktrees" {
 		return false
 	}
+	// A worktrees-shaped pointer whose admin dir is gone entirely is a
+	// dangling linked worktree (parent repo deleted or worktree pruned);
+	// git cannot operate on the checkout, so exclude it like a live one.
+	if _, err := os.Stat(adminDir); os.IsNotExist(err) {
+		return true
+	}
 	if !isRegularFile(filepath.Join(adminDir, "gitdir")) ||
 		!isRegularFile(filepath.Join(adminDir, "commondir")) {
 		return false

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -376,6 +376,44 @@ func TestScan_ExcludesNestedLinkedWorktreeCheckout(t *testing.T) {
 	assertOnlyRepo(t, repos, scanner.Repo{Path: repoDir, DisplayName: "org/wtui", IsBare: false})
 }
 
+func TestScan_ExcludesDanglingLinkedWorktreeCheckoutAfterRepoDeleted(t *testing.T) {
+	root := t.TempDir()
+	repoDir := filepath.Join(root, "flowstate")
+	worktreeDir := filepath.Join(root, "flowstate-pr7")
+
+	makeCommittedGitRepo(t, repoDir)
+	addLinkedWorktree(t, repoDir, worktreeDir, "pr7")
+	if err := os.RemoveAll(repoDir); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := scanner.Scan(scanner.ScanOptions{Root: root})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repos) != 0 {
+		t.Fatalf("expected dangling linked worktree to be excluded, got %+v", repos)
+	}
+}
+
+func TestScan_ExcludesDanglingLinkedWorktreeCheckoutAfterPrune(t *testing.T) {
+	root := t.TempDir()
+	repoDir := filepath.Join(root, "flowstate")
+	worktreeDir := filepath.Join(root, "flowstate-pr7")
+
+	makeCommittedGitRepo(t, repoDir)
+	addLinkedWorktree(t, repoDir, worktreeDir, "pr7")
+	if err := os.RemoveAll(filepath.Join(repoDir, ".git", "worktrees")); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := scanner.Scan(scanner.ScanOptions{Root: root})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertOnlyRepo(t, repos, scanner.Repo{Path: repoDir, DisplayName: "flowstate", IsBare: false})
+}
+
 func TestScan_GitFileNonWorktreeRepoDiscovered(t *testing.T) {
 	root := t.TempDir()
 	repoDir := filepath.Join(root, "separate")


### PR DESCRIPTION
## Problem

Directories like `~/dev/eddy-completed-todos` and `~/dev/flowstate-pr7` appeared in the repo list even though git can't operate on them. Both are linked-worktree checkouts whose `.git` file points at a `.git/worktrees/<name>` admin dir that no longer exists (the parent repos were deleted). Selecting them failed with **"failed to load worktrees"** because `git worktree list --porcelain` errors in a checkout with a dangling gitdir pointer.

## Root cause

`isLinkedWorktreeGitFile` only recognizes *healthy* linked worktrees: it requires the admin dir's `gitdir`/`commondir` files to exist and validate. When the admin dir is gone entirely, every check fails, the function returns `false`, and `repoInfo` concludes "not a worktree → include as a repo". A broken worktree pointer was thus treated as a normal repository.

## Fix

Once a `.git` file's pointer resolves to a `worktrees/`-shaped path, a target admin dir that is missing entirely is now treated as a dangling linked worktree and excluded — same treatment as a live linked worktree.

The fix is deliberately narrow: worktrees-shaped pointers whose admin dir *exists* but is malformed still fail open and are discovered, preserving the scanner's existing "when in doubt, show it" behavior (all `TestScan_WorktreesShapedGitFile*Discovered` tests unchanged and passing).

## Testing

- TDD: two new red→green tests through the public `Scan` API:
  - `TestScan_ExcludesDanglingLinkedWorktreeCheckoutAfterRepoDeleted` — real linked worktree whose parent repo is then deleted (the reported scenario; failed before the fix)
  - `TestScan_ExcludesDanglingLinkedWorktreeCheckoutAfterPrune` — parent repo survives but `.git/worktrees/` metadata is removed; the parent stays listed, the orphan doesn't
- Full `go build ./... && go vet ./... && go test ./...` passes
- Verified end-to-end against a real `~/dev` scan: the two dangling entries no longer appear