### PR TITLE
Fix issue #277 P0 concurrency and transcript safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,13 @@ Session data is stored under the user state directory by default:
 may contain secrets or private prompts; wtui keeps them outside repositories and
 uses restrictive file permissions for created session files. Provider session IDs
 are stored in hashed directory names instead of raw path components.
+Hook transcript paths must resolve to regular files inside the provider-owned
+transcript root. Codex uses `$CODEX_HOME/sessions` (default
+`$HOME/.codex/sessions`); Claude uses `$CLAUDE_CONFIG_DIR/projects` (default
+`$HOME/.claude/projects`). Set those existing provider environment variables
+when the provider itself uses a custom home or config directory. Relative paths,
+paths outside the expected root, and symlink escapes are rejected before wtui
+creates session artifacts.
 When resuming a session, wtui runs the provider resume command from the recorded
 session `cwd` when present, falling back to the captured worktree path, while
 preserving the stored worktree metadata for subsequent hooks. `codex-app`

--- a/cmd/wtui/main.go
+++ b/cmd/wtui/main.go
@@ -274,6 +274,9 @@ func runSessionHook(args []string, deps runDeps) error {
 		CopyRawTranscripts: cfg.Sessions.CopyRawTranscripts,
 		FlowPresets:        cfg.Flow.Presets,
 		Env: map[string]string{
+			"HOME":                    deps.getenv("HOME"),
+			"CODEX_HOME":              deps.getenv("CODEX_HOME"),
+			"CLAUDE_CONFIG_DIR":       deps.getenv("CLAUDE_CONFIG_DIR"),
 			"WTUI_LAUNCH_ID":          deps.getenv("WTUI_LAUNCH_ID"),
 			"WTUI_REPO_PATH":          deps.getenv("WTUI_REPO_PATH"),
 			"WTUI_WORKTREE_PATH":      deps.getenv("WTUI_WORKTREE_PATH"),

--- a/cmd/wtui/main_test.go
+++ b/cmd/wtui/main_test.go
@@ -743,7 +743,11 @@ func putCommandOnPath(t *testing.T, name string) string {
 
 func TestRunSessionHookWritesSessionMetadata(t *testing.T) {
 	root := t.TempDir()
-	transcriptPath := filepath.Join(root, "claude.jsonl")
+	claudeConfigDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(claudeConfigDir, "projects"), 0o700); err != nil {
+		t.Fatalf("create Claude transcript root: %v", err)
+	}
+	transcriptPath := filepath.Join(claudeConfigDir, "projects", "claude.jsonl")
 	if err := os.WriteFile(transcriptPath, []byte(`{"timestamp":"2026-06-06T14:01:00Z","role":"user","kind":"message","text":"Fix scanner tests"}`+"\n"), 0o600); err != nil {
 		t.Fatalf("write transcript: %v", err)
 	}
@@ -762,6 +766,12 @@ func TestRunSessionHookWritesSessionMetadata(t *testing.T) {
 		scan: func(scanner.ScanOptions) ([]scanner.Repo, error) {
 			t.Fatal("scan should not run for session-hook")
 			return nil, nil
+		},
+		getenv: func(key string) string {
+			if key == "CLAUDE_CONFIG_DIR" {
+				return claudeConfigDir
+			}
+			return ""
 		},
 		stdin: stdin,
 	})
@@ -901,13 +911,23 @@ func TestRunSessionHookRejectsUnsupportedProvider(t *testing.T) {
 
 func TestRunSessionHookHonorsCopyRawTranscriptConfig(t *testing.T) {
 	root := t.TempDir()
-	transcriptPath := filepath.Join(root, "codex.jsonl")
+	codexHome := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(codexHome, "sessions"), 0o700); err != nil {
+		t.Fatalf("create Codex transcript root: %v", err)
+	}
+	transcriptPath := filepath.Join(codexHome, "sessions", "codex.jsonl")
 	if err := os.WriteFile(transcriptPath, []byte(`{"role":"user","kind":"message","text":"secret"}`+"\n"), 0o600); err != nil {
 		t.Fatalf("write transcript: %v", err)
 	}
 	err := run([]string{"wtui", "session-hook", "--provider", "codex", "--state-root", root}, runDeps{
 		loadConfig: func() (config.Config, error) {
 			return config.Config{Sessions: config.SessionsConfig{CopyRawTranscripts: false}}, nil
+		},
+		getenv: func(key string) string {
+			if key == "CODEX_HOME" {
+				return codexHome
+			}
+			return ""
 		},
 		stdin: strings.NewReader(`{
 			"session_id": "codex-session-1",
@@ -920,6 +940,48 @@ func TestRunSessionHookHonorsCopyRawTranscriptConfig(t *testing.T) {
 	}
 	if matches, err := filepath.Glob(filepath.Join(root, "sessions", "codex", "*", "raw.jsonl")); err != nil || len(matches) != 0 {
 		t.Fatalf("expected no copied raw transcript, matches=%#v err=%v", matches, err)
+	}
+}
+
+func TestRunSessionHookRejectsOutOfRootTranscriptBeforeCreatingArtifacts(t *testing.T) {
+	for _, provider := range []sessions.Provider{sessions.ProviderCodex, sessions.ProviderClaude} {
+		t.Run(string(provider), func(t *testing.T) {
+			stateRoot := t.TempDir()
+			providerHome := t.TempDir()
+			outside := filepath.Join(t.TempDir(), "outside.jsonl")
+			if err := os.WriteFile(outside, []byte("{}\n"), 0o600); err != nil {
+				t.Fatalf("write outside transcript: %v", err)
+			}
+			getenv := func(key string) string {
+				switch {
+				case provider == sessions.ProviderCodex && key == "CODEX_HOME":
+					return providerHome
+				case provider == sessions.ProviderClaude && key == "CLAUDE_CONFIG_DIR":
+					return providerHome
+				default:
+					return ""
+				}
+			}
+			rootName := "sessions"
+			if provider == sessions.ProviderClaude {
+				rootName = "projects"
+			}
+			if err := os.MkdirAll(filepath.Join(providerHome, rootName), 0o700); err != nil {
+				t.Fatalf("create provider root: %v", err)
+			}
+			err := run([]string{"wtui", "session-hook", "--provider", string(provider), "--state-root", stateRoot}, runDeps{
+				loadConfig: func() (config.Config, error) { return config.Config{}, nil },
+				getenv:     getenv,
+				stdin:      strings.NewReader(`{"session_id":"reject-me","transcript_path":` + quoteJSON(outside) + `}`),
+			})
+			if err == nil || !strings.Contains(err.Error(), "outside expected") {
+				t.Fatalf("run() error = %v, want out-of-root rejection", err)
+			}
+			matches, globErr := filepath.Glob(filepath.Join(stateRoot, "sessions", string(provider), "*", "meta.json"))
+			if globErr != nil || len(matches) != 0 {
+				t.Fatalf("rejected hook created metadata: matches=%#v err=%v", matches, globErr)
+			}
+		})
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,9 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/brian-bell/wtui/agent"
 	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/internal/artifacts"
 	"github.com/pelletier/go-toml/v2"
 )
 
@@ -109,8 +111,9 @@ type BootstrapHookConfig struct {
 }
 
 type loadOptions struct {
-	getenv  getenvFunc
-	homeDir homeDirFunc
+	getenv      getenvFunc
+	homeDir     homeDirFunc
+	lockTimeout time.Duration
 }
 
 // Option customizes config loading. It is primarily useful in tests.
@@ -127,6 +130,14 @@ func WithGetenv(getenv func(string) string) Option {
 func WithHomeDir(homeDir func() (string, error)) Option {
 	return func(opts *loadOptions) {
 		opts.homeDir = homeDir
+	}
+}
+
+// WithLockTimeout bounds config mutation lock waits. Production uses five
+// seconds; tests may select a shorter deterministic timeout.
+func WithLockTimeout(timeout time.Duration) Option {
+	return func(opts *loadOptions) {
+		opts.lockTimeout = timeout
 	}
 }
 
@@ -533,44 +544,43 @@ func savePromptTemplateTo(path, section, key, value string, options ...Option) e
 }
 
 func resetPromptTemplateTo(path, section, key string, options ...Option) error {
-	opts := defaultOptions(options...)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("read config %s: %w", path, err)
-	}
-	if _, err := parseConfigData(path, data, opts); err != nil {
-		return err
-	}
-
-	patched := removeSectionAssignment(data, section, key)
-	if bytes.Equal(patched, data) {
-		return nil
-	}
-	if err := os.WriteFile(path, patched, 0o644); err != nil {
-		return fmt.Errorf("write config %s: %w", path, err)
-	}
-	return nil
+	return lockedConfigUpdate(path, options, false, func(data []byte) []byte {
+		return removeSectionAssignment(data, section, key)
+	})
 }
 
 func saveAgentConfigTo(path string, options []Option, patch func([]byte) []byte) error {
+	return lockedConfigUpdate(path, options, true, patch)
+}
+
+func lockedConfigUpdate(path string, options []Option, createIfMissing bool, patch func([]byte) []byte) error {
 	opts := defaultOptions(options...)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config dir %s: %w", filepath.Dir(path), err)
+	}
+	release, err := artifacts.AcquireFileLock(path+".lock", fmt.Sprintf("config lock %q", path), opts.lockTimeout)
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("read config %s: %w", path, err)
 		}
+		if !createIfMissing {
+			return nil
+		}
 	} else if _, err := parseConfigData(path, data, opts); err != nil {
 		return err
 	}
 
-	data = patch(data)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create config dir %s: %w", filepath.Dir(path), err)
+	patched := patch(data)
+	if bytes.Equal(patched, data) {
+		return nil
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := os.WriteFile(path, patched, 0o644); err != nil {
 		return fmt.Errorf("write config %s: %w", path, err)
 	}
 	return nil
@@ -835,8 +845,9 @@ func defaultPaths(opts loadOptions) ([]string, error) {
 
 func defaultOptions(options ...Option) loadOptions {
 	opts := loadOptions{
-		getenv:  os.Getenv,
-		homeDir: os.UserHomeDir,
+		getenv:      os.Getenv,
+		homeDir:     os.UserHomeDir,
+		lockTimeout: 5 * time.Second,
 	}
 	for _, option := range options {
 		option(&opts)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,10 +6,87 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/brian-bell/wtui/config"
 	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/internal/artifacts"
 )
+
+func TestConfigMutationsSerializeAndPreserveConcurrentAssignments(t *testing.T) {
+	configHome := t.TempDir()
+	getenv := func(key string) string {
+		if key == "XDG_CONFIG_HOME" {
+			return configHome
+		}
+		return ""
+	}
+	opts := []config.Option{config.WithGetenv(getenv), config.WithLockTimeout(time.Second)}
+	path := filepath.Join(configHome, "wtui", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("[agent]\nplan_prompt = \"remove me\"\n"), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	release, err := artifacts.AcquireFileLock(path+".lock", "test config lock", time.Second)
+	if err != nil {
+		t.Fatalf("hold config lock: %v", err)
+	}
+	results := make(chan error, 3)
+	go func() { results <- config.SaveAgentCommand("codex", opts...) }()
+	go func() { results <- config.SaveAgentModel("codex", "gpt-5.5", opts...) }()
+	go func() { results <- config.ResetPromptTemplate("agent", "plan_prompt", opts...) }()
+	select {
+	case err := <-results:
+		release()
+		t.Fatalf("config mutation completed while lock was held: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	release()
+	for range 3 {
+		if err := <-results; err != nil {
+			t.Fatalf("concurrent config mutation error = %v", err)
+		}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(config) error = %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `command = "codex"`) || !strings.Contains(text, `codex_model = "gpt-5.5"`) || strings.Contains(text, "plan_prompt") {
+		t.Fatalf("concurrent config result lost an update:\n%s", text)
+	}
+	if _, err := config.LoadFrom(path, opts...); err != nil {
+		t.Fatalf("concurrent config result is invalid TOML: %v", err)
+	}
+}
+
+func TestConfigMutationReportsBoundedLockTimeout(t *testing.T) {
+	configHome := t.TempDir()
+	path := filepath.Join(configHome, "wtui", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	getenv := func(key string) string {
+		if key == "XDG_CONFIG_HOME" {
+			return configHome
+		}
+		return ""
+	}
+	release, err := artifacts.AcquireFileLock(path+".lock", "test config lock", time.Second)
+	if err != nil {
+		t.Fatalf("hold config lock: %v", err)
+	}
+	defer release()
+	err = config.SaveAgentCommand("codex", config.WithGetenv(getenv), config.WithLockTimeout(10*time.Millisecond))
+	if err == nil || !strings.Contains(err.Error(), "timed out waiting for config lock") {
+		t.Fatalf("SaveAgentCommand() error = %v, want bounded config lock timeout", err)
+	}
+}
 
 func TestLoadFrom_AllowsMissingConfig(t *testing.T) {
 	cfg, err := config.LoadFrom(filepath.Join(t.TempDir(), "missing.toml"))

--- a/flowstore/session_select.go
+++ b/flowstore/session_select.go
@@ -138,7 +138,10 @@ func LatestPhaseLaunchID(phase FlowPhase) string {
 }
 
 func sessionEnded(session Session) bool {
-	return strings.TrimSpace(session.Status) == "ended" || !session.EndedAt.IsZero()
+	if status := strings.TrimSpace(session.Status); status != "" {
+		return status == "ended"
+	}
+	return !session.EndedAt.IsZero()
 }
 
 func sessionNewer(a, b Session) bool {

--- a/flowstore/session_select_test.go
+++ b/flowstore/session_select_test.go
@@ -202,6 +202,14 @@ func TestRecoverableRunningPhaseResetReasonClassifiesLatestLaunchOnly(t *testing
 			},
 		},
 		{
+			name: "resumed live session retains prior end timestamp",
+			phase: flowstore.FlowPhase{
+				Status:    flowstore.PhaseRunning,
+				LaunchIDs: []string{"launch-new"},
+				Sessions:  []flowstore.Session{{Provider: "codex", SessionID: "session-new", LaunchID: "launch-new", Status: "last_seen", EndedAt: endedAt}},
+			},
+		},
+		{
 			name: "latest launch with mixed ended and live sessions",
 			phase: flowstore.FlowPhase{
 				Status:    flowstore.PhaseRunning,

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/brian-bell/wtui/internal/artifacts"
@@ -1351,48 +1350,7 @@ func (s *Store) acquireFlowLock(flowID string) (func(), error) {
 		return nil, fmt.Errorf("secure flow lock directory: %w", err)
 	}
 	lockPath := filepath.Join(lockDir, flowID+".lock")
-	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, artifacts.FilePerm)
-	if err != nil {
-		return nil, fmt.Errorf("open flow lock: %w", err)
-	}
-	if err := file.Chmod(artifacts.FilePerm); err != nil {
-		_ = file.Close()
-		return nil, fmt.Errorf("secure flow lock: %w", err)
-	}
-	deadline := time.Now().Add(s.lockTimeout)
-	for {
-		err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
-		if err == nil {
-			if err := file.Truncate(0); err != nil {
-				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
-				_ = file.Close()
-				return nil, fmt.Errorf("truncate flow lock: %w", err)
-			}
-			if _, err := file.Seek(0, 0); err != nil {
-				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
-				_ = file.Close()
-				return nil, fmt.Errorf("seek flow lock: %w", err)
-			}
-			if _, err := fmt.Fprintf(file, "%d\n", os.Getpid()); err != nil {
-				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
-				_ = file.Close()
-				return nil, fmt.Errorf("write flow lock: %w", err)
-			}
-			return func() {
-				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
-				_ = file.Close()
-			}, nil
-		}
-		if err != syscall.EWOULDBLOCK && err != syscall.EAGAIN {
-			_ = file.Close()
-			return nil, fmt.Errorf("acquire flow lock: %w", err)
-		}
-		if !time.Now().Before(deadline) {
-			_ = file.Close()
-			return nil, fmt.Errorf("timed out waiting for flow lock %q", flowID)
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	return artifacts.AcquireFileLock(lockPath, fmt.Sprintf("flow lock %q", flowID), s.lockTimeout)
 }
 
 // List returns records matching filter, sorted by UpdatedAt descending.

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -1194,8 +1194,9 @@ func (s *Store) MarkPhaseLaunchEnded(update PhaseLaunchEndUpdate) (FlowRecord, e
 			if phase.Sessions[i].LaunchID != launchID {
 				continue
 			}
+			wasEnded := strings.TrimSpace(phase.Sessions[i].Status) == "ended"
 			phase.Sessions[i].Status = "ended"
-			if phase.Sessions[i].EndedAt.IsZero() {
+			if phase.Sessions[i].EndedAt.IsZero() || (!wasEnded && update.EndedAt.After(phase.Sessions[i].EndedAt)) {
 				phase.Sessions[i].EndedAt = update.EndedAt
 			}
 			changed = true
@@ -1244,6 +1245,9 @@ func (s *Store) AttachSession(update SessionAttachUpdate) (FlowRecord, error) {
 		replaced := false
 		for i, existing := range phase.Sessions {
 			if sameSession(existing, session) {
+				if launchPrecedes(phase.LaunchIDs, session.LaunchID, existing.LaunchID) {
+					return record, nil
+				}
 				phase.Sessions[i] = session
 				replaced = true
 				break
@@ -1259,6 +1263,19 @@ func (s *Store) AttachSession(update SessionAttachUpdate) (FlowRecord, error) {
 		record.UpdatedAt = now
 		return record, nil
 	})
+}
+
+func launchPrecedes(launchIDs []string, candidate, current string) bool {
+	candidateIndex, currentIndex := -1, -1
+	for i, launchID := range launchIDs {
+		if launchID == candidate {
+			candidateIndex = i
+		}
+		if launchID == current {
+			currentIndex = i
+		}
+	}
+	return candidateIndex >= 0 && currentIndex >= 0 && candidateIndex < currentIndex
 }
 
 // Delete removes only the persisted Flow record directory.

--- a/flowstore/store_test.go
+++ b/flowstore/store_test.go
@@ -1573,6 +1573,51 @@ func TestStoreMarkPhaseLaunchEndedUpdatesAttachedFlowSession(t *testing.T) {
 	}
 }
 
+func TestStoreMarkPhaseLaunchEndedAdvancesResumedSessionEndTime(t *testing.T) {
+	root := t.TempDir()
+	previousEnd := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
+	resumedEnd := previousEnd.Add(time.Hour)
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := mustCreateFlow(t, store, "Finalize resumed Flow session")
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review")
+	record, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{FlowID: record.FlowID, PhaseID: "implementation", LaunchID: "launch-2"})
+	if err != nil {
+		t.Fatalf("AddPhaseLaunchID() error = %v", err)
+	}
+	record, err = store.AttachSession(flowstore.SessionAttachUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "implementation",
+		Session: flowstore.Session{
+			Provider:  "codex",
+			SessionID: "session-1",
+			LaunchID:  "launch-2",
+			Status:    "last_seen",
+			EndedAt:   previousEnd,
+		},
+	})
+	if err != nil {
+		t.Fatalf("AttachSession() error = %v", err)
+	}
+
+	record, err = store.MarkPhaseLaunchEnded(flowstore.PhaseLaunchEndUpdate{
+		FlowID:   record.FlowID,
+		PhaseID:  "implementation",
+		LaunchID: "launch-2",
+		EndedAt:  resumedEnd,
+	})
+	if err != nil {
+		t.Fatalf("MarkPhaseLaunchEnded() error = %v", err)
+	}
+
+	phase := phaseByID(t, record, "implementation")
+	if len(phase.Sessions) != 1 || phase.Sessions[0].Status != "ended" || !phase.Sessions[0].EndedAt.Equal(resumedEnd) {
+		t.Fatalf("resumed session = %#v, want ended at %s", phase.Sessions, resumedEnd)
+	}
+}
+
 func TestStoreMarkPhaseLaunchEndedUpdatesSessionMergedFromDuplicateRow(t *testing.T) {
 	root := t.TempDir()
 	endedAt := time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC)
@@ -5029,6 +5074,46 @@ func TestStoreAddPhaseLaunchIDResumePrefersRawExactRowBeforeNormalizedDuplicate(
 	}
 	if len(phase.LaunchIDs) != 2 || phase.LaunchIDs[0] != "launch-1" || phase.LaunchIDs[1] != "launch-2" {
 		t.Fatalf("launch ids = %#v, want [launch-1 launch-2]", phase.LaunchIDs)
+	}
+}
+
+func TestStoreAttachSessionDoesNotReplaceNewerLaunchWithStaleLaunch(t *testing.T) {
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record := mustCreateFlow(t, store, "Fence stale session attachment")
+	mustCompleteFlowPhases(t, store, &record, "plan", "plan-review")
+	for _, launchID := range []string{"launch-1", "launch-2"} {
+		record, err = store.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+			FlowID:   record.FlowID,
+			PhaseID:  "implementation",
+			LaunchID: launchID,
+		})
+		if err != nil {
+			t.Fatalf("AddPhaseLaunchID(%s) error = %v", launchID, err)
+		}
+		record, err = store.AttachSession(flowstore.SessionAttachUpdate{
+			FlowID:  record.FlowID,
+			PhaseID: "implementation",
+			Session: flowstore.Session{Provider: "codex", SessionID: "session-1", LaunchID: launchID, Status: "last_seen"},
+		})
+		if err != nil {
+			t.Fatalf("AttachSession(%s) error = %v", launchID, err)
+		}
+	}
+	record, err = store.AttachSession(flowstore.SessionAttachUpdate{
+		FlowID:  record.FlowID,
+		PhaseID: "implementation",
+		Session: flowstore.Session{Provider: "codex", SessionID: "session-1", LaunchID: "launch-1", Status: "ended"},
+	})
+	if err != nil {
+		t.Fatalf("AttachSession(stale) error = %v", err)
+	}
+
+	phase := phaseByID(t, record, "implementation")
+	if len(phase.Sessions) != 1 || phase.Sessions[0].LaunchID != "launch-2" || phase.Sessions[0].Status != "last_seen" {
+		t.Fatalf("session regressed after stale attachment: %#v", phase.Sessions)
 	}
 }
 

--- a/internal/artifacts/artifacts_test.go
+++ b/internal/artifacts/artifacts_test.go
@@ -157,6 +157,33 @@ func TestAllocateTimestampedIDSlugFallbackAndCollisionSuffix(t *testing.T) {
 	}
 }
 
+func TestAcquireFileLockIsBoundedAndReusable(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "session.lock")
+	release, err := artifacts.AcquireFileLock(lockPath, "session lock session-1", 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("AcquireFileLock(first) error = %v", err)
+	}
+	defer release()
+	assertMode(t, lockPath, 0o600)
+
+	started := time.Now()
+	_, err = artifacts.AcquireFileLock(lockPath, "session lock session-1", 15*time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "timed out") || !strings.Contains(err.Error(), "session lock session-1") {
+		t.Fatalf("AcquireFileLock(contended) error = %v, want descriptive timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed < 10*time.Millisecond {
+		t.Fatalf("contended lock returned after %v, want bounded retry wait", elapsed)
+	}
+
+	release()
+	release = func() {}
+	releaseAgain, err := artifacts.AcquireFileLock(lockPath, "session lock session-1", 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("AcquireFileLock(after release) error = %v", err)
+	}
+	releaseAgain()
+}
+
 type errReader struct{}
 
 func (errReader) Read([]byte) (int, error) {

--- a/internal/artifacts/lock.go
+++ b/internal/artifacts/lock.go
@@ -1,0 +1,66 @@
+package artifacts
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const fileLockRetryInterval = 5 * time.Millisecond
+
+// AcquireFileLock acquires an exclusive advisory lock with a bounded retry
+// window. The lock parent directory remains the caller's responsibility.
+func AcquireFileLock(path, label string, timeout time.Duration) (func(), error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, FilePerm)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", label, err)
+	}
+	closeFile := func() { _ = file.Close() }
+	if err := file.Chmod(FilePerm); err != nil {
+		closeFile()
+		return nil, fmt.Errorf("secure %s: %w", label, err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			if err := writeLockOwner(file, label); err != nil {
+				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				closeFile()
+				return nil, err
+			}
+			var once sync.Once
+			return func() {
+				once.Do(func() {
+					_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+					closeFile()
+				})
+			}, nil
+		}
+		if err != syscall.EWOULDBLOCK && err != syscall.EAGAIN {
+			closeFile()
+			return nil, fmt.Errorf("acquire %s: %w", label, err)
+		}
+		if !time.Now().Before(deadline) {
+			closeFile()
+			return nil, fmt.Errorf("timed out waiting for %s", label)
+		}
+		time.Sleep(fileLockRetryInterval)
+	}
+}
+
+func writeLockOwner(file *os.File, label string) error {
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("truncate %s: %w", label, err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		return fmt.Errorf("seek %s: %w", label, err)
+	}
+	if _, err := fmt.Fprintf(file, "%d\n", os.Getpid()); err != nil {
+		return fmt.Errorf("write %s: %w", label, err)
+	}
+	return nil
+}

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -82,18 +82,19 @@ const (
 type embeddedTerminalID int
 
 type embeddedTerminalSlot struct {
-	Number       int
-	Scope        embeddedTerminalScope
-	Provider     string
-	Identity     string
-	RepoPath     string
-	WorktreePath string
-	WorkingDir   string
-	FlowID       string
-	FlowPhaseID  string
-	LaunchID     string
-	Terminal     EmbeddedTerminal
-	ID           embeddedTerminalID
+	Number         int
+	Scope          embeddedTerminalScope
+	Provider       string
+	Identity       string
+	RepoPath       string
+	WorktreePath   string
+	WorkingDir     string
+	FlowID         string
+	FlowPhaseID    string
+	LaunchID       string
+	Terminal       EmbeddedTerminal
+	ID             embeddedTerminalID
+	PrefillPending bool
 }
 
 type embeddedSessionPickerSelectedMsg struct {
@@ -108,6 +109,12 @@ type quitEmbeddedTerminalsMsg struct{}
 
 type embeddedTerminalTickMsg struct {
 	Generation uint64
+}
+
+type embeddedPromptPrefillResultMsg struct {
+	ID            embeddedTerminalID
+	LaunchContext actions.AgentLaunchContext
+	Err           error
 }
 
 type realEmbeddedTerminal struct {
@@ -213,12 +220,12 @@ func (m Model) embeddedTerminalTickCmd() tea.Cmd {
 func (m Model) activeEmbeddedTerminalForScope(scope embeddedTerminalScope) (embeddedTerminalSlot, int, bool) {
 	activeNum := m.activeEmbeddedTerminalNumber(scope)
 	for i, slot := range m.embeddedTerminals {
-		if slot.Scope == scope && slot.Number == activeNum {
+		if slot.Scope == scope && !slot.PrefillPending && slot.Number == activeNum {
 			return slot, i, true
 		}
 	}
 	for i, slot := range m.embeddedTerminals {
-		if slot.Scope == scope {
+		if slot.Scope == scope && !slot.PrefillPending {
 			return slot, i, true
 		}
 	}
@@ -277,7 +284,7 @@ func (m Model) syncActiveFlowTerminalToSelectedFlow() Model {
 	activeNum := m.activeFlowTerminalNum
 	newestMatchingNum := 0
 	for _, slot := range m.embeddedTerminals {
-		if slot.Scope != embeddedTerminalScopeFlow || slot.FlowID != flowID || !embeddedTerminalRunning(slot.Terminal) {
+		if slot.Scope != embeddedTerminalScopeFlow || slot.PrefillPending || slot.FlowID != flowID || !embeddedTerminalRunning(slot.Terminal) {
 			continue
 		}
 		if slot.Number == activeNum {
@@ -384,58 +391,87 @@ func (m Model) nextEmbeddedTerminalNumber(scope embeddedTerminalScope) (int, boo
 }
 
 func (m Model) openEmbeddedTerminal(ctx actions.AgentLaunchContext, record sessions.SessionRecord) (Model, bool, error) {
-	return m.openEmbeddedTerminalWithLabel(ctx, embeddedTerminalScopeSession, string(record.Provider), embeddedTerminalIdentity(record), "", "", m.embeddedTerminalWidth(), m.embeddedTerminalContentHeight())
-}
-
-func (m Model) openFlowEmbeddedTerminal(ctx actions.AgentLaunchContext) (Model, bool, error) {
-	activeNum := m.activeFlowTerminalNum
-	next, opened, err := m.openEmbeddedTerminalWithLabel(ctx, embeddedTerminalScopeFlow, ctx.Command, flowEmbeddedTerminalIdentity(ctx), ctx.FlowID, ctx.FlowPhaseID, m.embeddedTerminalWidth(), m.flowEmbeddedTerminalContentHeight())
-	if opened && ctx.FlowAutoLaunch && activeNum != 0 {
-		next.activeFlowTerminalNum = activeNum
-	}
+	next, opened, err, _ := m.openEmbeddedTerminalWithLabel(ctx, embeddedTerminalScopeSession, string(record.Provider), embeddedTerminalIdentity(record), "", "", m.embeddedTerminalWidth(), m.embeddedTerminalContentHeight())
 	return next, opened, err
 }
 
-func (m Model) openEmbeddedTerminalWithLabel(ctx actions.AgentLaunchContext, scope embeddedTerminalScope, provider, identity, flowID, flowPhaseID string, width, height int) (Model, bool, error) {
+func (m Model) openFlowEmbeddedTerminal(ctx actions.AgentLaunchContext) (Model, bool, error, tea.Cmd) {
+	activeNum := m.activeFlowTerminalNum
+	next, opened, err, prefillCmd := m.openEmbeddedTerminalWithLabel(ctx, embeddedTerminalScopeFlow, ctx.Command, flowEmbeddedTerminalIdentity(ctx), ctx.FlowID, ctx.FlowPhaseID, m.embeddedTerminalWidth(), m.flowEmbeddedTerminalContentHeight())
+	if opened && prefillCmd == nil && ctx.FlowAutoLaunch && activeNum != 0 {
+		next.activeFlowTerminalNum = activeNum
+	}
+	return next, opened, err, prefillCmd
+}
+
+func (m Model) openEmbeddedTerminalWithLabel(ctx actions.AgentLaunchContext, scope embeddedTerminalScope, provider, identity, flowID, flowPhaseID string, width, height int) (Model, bool, error, tea.Cmd) {
 	number, ok := m.nextEmbeddedTerminalNumber(scope)
 	if !ok {
 		m = m.setStatus(statusOther, "Maximum embedded terminals reached")
-		return m, false, nil
+		return m, false, nil, nil
 	}
 	ctx.Embedded = true
 	term, err := m.startEmbeddedTerminal(ctx, width, height)
 	if err != nil {
 		m = m.setStatus(statusOther, err.Error())
-		return m, false, err
-	}
-	if err := prefillEmbeddedPromptIfNeeded(term, ctx); err != nil {
-		if terminateErr := term.Terminate(); terminateErr != nil {
-			err = errors.Join(err, fmt.Errorf("terminate embedded terminal after prefill failure: %w", terminateErr))
-		}
-		m = m.setStatus(statusOther, err.Error())
-		return m, false, err
+		return m, false, err, nil
 	}
 	m.nextEmbeddedTerminalID++
+	id := embeddedTerminalID(m.nextEmbeddedTerminalID)
 	m.embeddedTerminals = append(m.embeddedTerminals, embeddedTerminalSlot{
-		Number:       number,
-		Scope:        scope,
-		Provider:     provider,
-		Identity:     identity,
-		RepoPath:     cleanEmbeddedTerminalRepoPath(ctx.RepoPath),
-		WorktreePath: cleanEmbeddedTerminalPath(ctx.WorktreePath),
-		WorkingDir:   cleanEmbeddedTerminalPath(ctx.WorkingDir),
-		FlowID:       flowID,
-		FlowPhaseID:  flowPhaseID,
-		LaunchID:     strings.TrimSpace(ctx.LaunchID),
-		Terminal:     term,
-		ID:           embeddedTerminalID(m.nextEmbeddedTerminalID),
+		Number:         number,
+		Scope:          scope,
+		Provider:       provider,
+		Identity:       identity,
+		RepoPath:       cleanEmbeddedTerminalRepoPath(ctx.RepoPath),
+		WorktreePath:   cleanEmbeddedTerminalPath(ctx.WorktreePath),
+		WorkingDir:     cleanEmbeddedTerminalPath(ctx.WorkingDir),
+		FlowID:         flowID,
+		FlowPhaseID:    flowPhaseID,
+		LaunchID:       strings.TrimSpace(ctx.LaunchID),
+		Terminal:       term,
+		ID:             id,
+		PrefillPending: actions.ShouldPrefillEmbeddedPrompt(ctx),
 	})
-	if scope == embeddedTerminalScopeFlow {
-		m.activeFlowTerminalNum = number
-	} else {
-		m.activeEmbeddedTerminalNum = number
+	if actions.ShouldPrefillEmbeddedPrompt(ctx) {
+		return m, true, nil, func() tea.Msg {
+			err := prefillEmbeddedPromptIfNeeded(term, ctx)
+			if err != nil {
+				if terminateErr := term.Terminate(); terminateErr != nil {
+					err = errors.Join(err, fmt.Errorf("terminate embedded terminal after prefill failure: %w", terminateErr))
+				}
+			}
+			return embeddedPromptPrefillResultMsg{ID: id, LaunchContext: ctx, Err: err}
+		}
 	}
-	return m, true, nil
+	m = m.activateEmbeddedTerminal(id)
+	return m, true, nil, nil
+}
+
+func (m Model) activateEmbeddedTerminal(id embeddedTerminalID) Model {
+	for i := range m.embeddedTerminals {
+		slot := &m.embeddedTerminals[i]
+		if slot.ID != id {
+			continue
+		}
+		slot.PrefillPending = false
+		if slot.Scope == embeddedTerminalScopeFlow {
+			m.activeFlowTerminalNum = slot.Number
+		} else {
+			m.activeEmbeddedTerminalNum = slot.Number
+		}
+		break
+	}
+	return m
+}
+
+func (m Model) hasEmbeddedTerminalID(id embeddedTerminalID) bool {
+	for _, slot := range m.embeddedTerminals {
+		if slot.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func prefillEmbeddedPromptIfNeeded(term EmbeddedTerminal, ctx actions.AgentLaunchContext) error {
@@ -610,7 +646,7 @@ func shortSessionID(sessionID string) string {
 
 func (m Model) switchEmbeddedTerminalForScope(scope embeddedTerminalScope, number int) Model {
 	for _, slot := range m.embeddedTerminals {
-		if slot.Scope == scope && slot.Number == number {
+		if slot.Scope == scope && !slot.PrefillPending && slot.Number == number {
 			if scope == embeddedTerminalScopeFlow {
 				m.activeFlowTerminalNum = number
 				return m
@@ -630,7 +666,7 @@ func (m Model) cycleEmbeddedTerminalForScope(scope embeddedTerminalScope, direct
 	numbers := make([]int, 0, len(m.embeddedTerminals))
 	activeIndex := -1
 	for _, slot := range m.embeddedTerminals {
-		if slot.Scope != scope {
+		if slot.Scope != scope || slot.PrefillPending {
 			continue
 		}
 		if slot.Number == activeNum {
@@ -655,10 +691,10 @@ func (m Model) cycleEmbeddedTerminalForScope(scope embeddedTerminalScope, direct
 }
 
 func (m Model) handleEmbeddedTerminalKey(msg tea.KeyMsg) (Model, tea.Cmd, bool) {
-	if m.flowSurfaceVisible() && m.activePane == 1 && m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
+	if m.flowSurfaceVisible() && m.activePane == 1 && m.flowFocus == flowFocusTerminal && m.hasActiveEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
 		return m.handleEmbeddedTerminalKeyForScope(msg, embeddedTerminalScopeFlow)
 	}
-	if m.mode == ui.ModeSessions && !m.activeFlowSurfaceVisible() && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeSession) {
+	if m.mode == ui.ModeSessions && !m.activeFlowSurfaceVisible() && m.hasActiveEmbeddedTerminalForScope(embeddedTerminalScopeSession) {
 		if msg.String() == "tab" {
 			m.terminalPrefixActive = false
 			return m.cyclePaneFocusForward(), nil, true
@@ -740,6 +776,15 @@ func (m Model) handleEmbeddedTerminalKeyForScope(msg tea.KeyMsg, scope embeddedT
 func (m Model) hasEmbeddedTerminalForScope(scope embeddedTerminalScope) bool {
 	for _, slot := range m.embeddedTerminals {
 		if slot.Scope == scope {
+			return true
+		}
+	}
+	return false
+}
+
+func (m Model) hasActiveEmbeddedTerminalForScope(scope embeddedTerminalScope) bool {
+	for _, slot := range m.embeddedTerminals {
+		if slot.Scope == scope && !slot.PrefillPending {
 			return true
 		}
 	}
@@ -972,10 +1017,10 @@ func (m Model) embeddedTerminalPrefixScope() (embeddedTerminalScope, bool) {
 	if !m.terminalPrefixActive {
 		return "", false
 	}
-	if m.mode == ui.ModeSessions && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeSession) {
+	if m.mode == ui.ModeSessions && m.hasActiveEmbeddedTerminalForScope(embeddedTerminalScopeSession) {
 		return embeddedTerminalScopeSession, true
 	}
-	if m.flowSurfaceVisible() && m.activePane == 1 && m.flowFocus == flowFocusTerminal && m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
+	if m.flowSurfaceVisible() && m.activePane == 1 && m.flowFocus == flowFocusTerminal && m.hasActiveEmbeddedTerminalForScope(embeddedTerminalScopeFlow) {
 		return embeddedTerminalScopeFlow, true
 	}
 	return "", false

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -120,6 +120,111 @@ func TestPrefillEmbeddedPromptWaitsForVisibleTerminalOutput(t *testing.T) {
 	}
 }
 
+func TestFlowEmbeddedInteractivePrefillRunsAfterUpdateAndActivatesByStableID(t *testing.T) {
+	originalInterval := embeddedPromptPrefillPollInterval
+	embeddedPromptPrefillPollInterval = 0
+	t.Cleanup(func() {
+		embeddedPromptPrefillPollInterval = originalInterval
+	})
+
+	term := &prefillReadyFakeEmbeddedTerminal{lines: [][]string{{""}, {"Codex ready"}}}
+	m := Model{
+		mode:       ui.ModeFlows,
+		activePane: 1,
+		flowFocus:  flowFocusList,
+		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
+			return term, nil
+		},
+	}
+	ctx := actions.AgentLaunchContext{
+		Command:           "codex",
+		FlowID:            "flow-1",
+		FlowPhaseID:       "implementation",
+		FlowLaunchTracked: true,
+		InitialPrompt:     "Build it",
+	}
+
+	nextModel, cmd := m.Update(FlowEmbeddedLaunchRequestedMsg{LaunchContext: ctx})
+	next := nextModel.(Model)
+	if cmd == nil {
+		t.Fatal("interactive Flow launch returned nil command, want asynchronous prefill command")
+	}
+	if term.visibleHits != 0 || len(term.writes) != 0 {
+		t.Fatalf("Update performed prefill work: visible calls=%d writes=%#v", term.visibleHits, term.writes)
+	}
+	if len(next.embeddedTerminals) != 1 || next.embeddedTerminals[0].ID == 0 {
+		t.Fatalf("pending terminal slots = %#v, want one slot with stable ID", next.embeddedTerminals)
+	}
+	if next.activeFlowTerminalNum != 0 || next.flowFocus != flowFocusList {
+		t.Fatalf("pending terminal stole focus: active=%d focus=%v", next.activeFlowTerminalNum, next.flowFocus)
+	}
+	if number, ok := next.nextEmbeddedTerminalNumber(embeddedTerminalScopeFlow); !ok || number != 2 {
+		t.Fatalf("next Flow terminal number = %d, %v; want reserved slot 1 and next number 2", number, ok)
+	}
+	beforeReadyModel, _ := next.Update(tea.KeyMsg{Type: tea.KeyTab})
+	beforeReady := beforeReadyModel.(Model)
+	beforeReadyModel, _ = beforeReady.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	beforeReady = beforeReadyModel.(Model)
+	if len(term.writes) != 0 || beforeReady.flowFocus == flowFocusTerminal {
+		t.Fatalf("pending terminal accepted focus/input before prefill: writes=%#v focus=%v", term.writes, beforeReady.flowFocus)
+	}
+
+	msg := commandMessageOfType[embeddedPromptPrefillResultMsg](t, cmd)
+	activatedModel, _ := next.Update(msg)
+	activated := activatedModel.(Model)
+	wantWrite := embeddedPromptPasteStart + "Build it" + embeddedPromptPasteEnd
+	if term.visibleHits != 2 || len(term.writes) != 1 || term.writes[0] != wantWrite {
+		t.Fatalf("async prefill calls=%d writes=%#v, want two polls and %q", term.visibleHits, term.writes, wantWrite)
+	}
+	if activated.activeFlowTerminalNum != 1 || activated.flowFocus != flowFocusTerminal {
+		t.Fatalf("successful prefill did not activate terminal: active=%d focus=%v", activated.activeFlowTerminalNum, activated.flowFocus)
+	}
+}
+
+func TestStaleEmbeddedPromptPrefillResultIsIgnoredAfterSlotRemoval(t *testing.T) {
+	phaseMutationRan := false
+	m := Model{
+		mode:       ui.ModeFlows,
+		activePane: 1,
+		flowFocus:  flowFocusList,
+		setFlowPhase: func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+			phaseMutationRan = true
+			return flowstore.FlowRecord{}, nil
+		},
+	}
+
+	nextModel, cmd := m.Update(embeddedPromptPrefillResultMsg{
+		ID:            42,
+		LaunchContext: actions.AgentLaunchContext{FlowID: "flow-1", FlowPhaseID: "implementation"},
+		Err:           errors.New("late failure"),
+	})
+	next := nextModel.(Model)
+	if cmd != nil || phaseMutationRan || next.activeFlowTerminalNum != 0 || next.flowFocus != flowFocusList {
+		t.Fatalf("stale prefill result changed model: cmd=%T mutation=%v active=%d focus=%v", cmd, phaseMutationRan, next.activeFlowTerminalNum, next.flowFocus)
+	}
+}
+
+func commandMessageOfType[T any](t *testing.T, cmd tea.Cmd) T {
+	t.Helper()
+	var zero T
+	if cmd == nil {
+		t.Fatal("expected command")
+	}
+	msg := cmd()
+	if typed, ok := msg.(T); ok {
+		return typed
+	}
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, child := range batch {
+			if typed, ok := child().(T); ok {
+				return typed
+			}
+		}
+	}
+	t.Fatalf("command returned %T, want message %T", msg, zero)
+	return zero
+}
+
 func internalFlowsModel(records ...flowstore.FlowRecord) Model {
 	return Model{
 		mode:       ui.ModeFlows,
@@ -372,7 +477,7 @@ func TestOpenFlowEmbeddedTerminalStoresFlowRepoPath(t *testing.T) {
 		},
 	}
 
-	next, opened, err := m.openFlowEmbeddedTerminal(actions.AgentLaunchContext{
+	next, opened, err, _ := m.openFlowEmbeddedTerminal(actions.AgentLaunchContext{
 		Command:       "codex",
 		RepoPath:      "/dev/alpha",
 		WorktreePath:  "/dev/alpha-worktrees/feature",

--- a/model/model.go
+++ b/model/model.go
@@ -1187,6 +1187,16 @@ func (m Model) Update(msg tea.Msg) (next tea.Model, cmd tea.Cmd) {
 		return m.handleTerminateEmbeddedTerminal(msg)
 	case quitEmbeddedTerminalsMsg:
 		return m.handleQuitEmbeddedTerminals()
+	case embeddedPromptPrefillResultMsg:
+		if !m.hasEmbeddedTerminalID(msg.ID) {
+			return m, nil
+		}
+		if msg.Err != nil {
+			m = m.dismissEmbeddedTerminal(msg.ID)
+			return m.startFlowLaunchFailure(msg.LaunchContext, msg.Err.Error())
+		}
+		m = m.activateEmbeddedTerminal(msg.ID)
+		return m.updateFlowTerminalFocusAfterLaunch(msg.LaunchContext), nil
 	case embeddedTerminalTickMsg:
 		if msg.Generation != m.embeddedTerminalTickGen {
 			return m, nil
@@ -1408,34 +1418,28 @@ func (m Model) Update(msg tea.Msg) (next tea.Model, cmd tea.Cmd) {
 			return next, tea.Batch(fetchCmd, launchCmd)
 		}
 		return next, launchCmd
+	case flowPhaseResumePersistedMsg:
+		return m.handleFlowPhaseResumePersisted(msg)
+	case flowPhaseResumePersistFailedMsg:
+		return m.handleFlowPhaseResumePersistFailed(msg)
 	case FlowCreatedMsg:
 		return m.handleFlowCreated(msg)
 	case FlowCreateFailedMsg:
 		return m.handleFlowCreateFailed(msg)
 	case AgentResultMsg:
-		resultErr := msg.Err
 		// Detached launches only start the agent in an external
 		// terminal/multiplexer session and return while it keeps running, so the
 		// captured session must not be finalized here; provider hooks own that.
 		if !msg.Detached && msg.LaunchContext.LaunchID != "" {
-			if err := m.finalizeAgentSession(msg.LaunchContext); err != nil {
-				if resultErr != "" {
-					resultErr = fmt.Sprintf("%s; finalize session: %v", resultErr, err)
-				} else {
-					resultErr = fmt.Sprintf("finalize session: %v", err)
-				}
+			return m, func() tea.Msg {
+				return agentSessionFinalizedMsg{Result: msg, Err: m.finalizeAgentSession(msg.LaunchContext)}
 			}
 		}
-		if resultErr != "" {
-			m, resultErr = m.markFlowLaunchNeedsAttention(msg.LaunchContext, resultErr)
-			m = m.setStatus(statusOther, resultErr)
-			if msg.LaunchContext.FlowID != "" && m.flowSurfaceVisible() {
-				return m.startFlowSurfaceFetch()
-			}
-		} else if msg.Detached {
-			m = m.setStatus(statusOther, agentLaunchedStatus(msg.LaunchContext.Command))
-		}
-		return m, nil
+		return m.handleAgentResultAfterFinalization(msg, nil)
+	case agentSessionFinalizedMsg:
+		return m.handleAgentResultAfterFinalization(msg.Result, msg.Err)
+	case flowLaunchFailurePersistedMsg:
+		return m.handleFlowLaunchFailurePersisted(msg)
 	case DeleteFailedMsg:
 		return m.handleDeleteFailed(msg), nil
 	case ForceDeleteFailedMsg:
@@ -1451,6 +1455,23 @@ func (m Model) Update(msg tea.Msg) (next tea.Model, cmd tea.Cmd) {
 			return next, batchNonNil(statusCmd, refreshCmd)
 		}
 		return next, statusCmd
+	}
+	return m, nil
+}
+
+func (m Model) handleAgentResultAfterFinalization(msg AgentResultMsg, finalizeErr error) (Model, tea.Cmd) {
+	resultErr := msg.Err
+	if finalizeErr != nil {
+		if resultErr != "" {
+			resultErr = fmt.Sprintf("%s; finalize session: %v", resultErr, finalizeErr)
+		} else {
+			resultErr = fmt.Sprintf("finalize session: %v", finalizeErr)
+		}
+	}
+	if resultErr != "" {
+		return m.startFlowLaunchFailure(msg.LaunchContext, resultErr)
+	} else if msg.Detached {
+		m = m.setStatus(statusOther, agentLaunchedStatus(msg.LaunchContext.Command))
 	}
 	return m, nil
 }

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -4408,7 +4408,18 @@ func TestModel_AgentResultFinalizesLaunchedSession(t *testing.T) {
 		Branch:       "main",
 	}
 
-	m, _ = update(m, model.AgentResultMsg{LaunchContext: ctx})
+	m, cmd := update(m, model.AgentResultMsg{LaunchContext: ctx})
+	if got.LaunchID != "" {
+		t.Fatalf("FinalizeAgentSession ran inside Update with %#v", got)
+	}
+	if cmd == nil {
+		t.Fatal("AgentResultMsg returned nil command, want asynchronous finalization")
+	}
+	finalized := cmd()
+	if got != ctx {
+		t.Fatalf("finalize command got context %#v, want %#v", got, ctx)
+	}
+	m, _ = update(m, finalized)
 	if got != ctx {
 		t.Fatalf("finalized context = %#v, want %#v", got, ctx)
 	}
@@ -4422,7 +4433,11 @@ func TestModel_AgentResultShowsFinalizeError(t *testing.T) {
 	})
 	ctx := actions.AgentLaunchContext{Command: "codex", LaunchID: "launch-1"}
 
-	m, _ = update(m, model.AgentResultMsg{LaunchContext: ctx})
+	m, cmd := update(m, model.AgentResultMsg{LaunchContext: ctx})
+	if cmd == nil {
+		t.Fatal("AgentResultMsg returned nil command, want asynchronous finalization")
+	}
+	m, _ = update(m, cmd())
 	if !strings.Contains(m.View(), "finalize session: state unavailable") {
 		t.Fatal("expected finalize error in status bar")
 	}

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -50,6 +50,59 @@ func activeFlowResultFromCommand(t *testing.T, cmd tea.Cmd) model.ActiveFlowResu
 	return model.ActiveFlowResultMsg{}
 }
 
+func settleModelCommands(t *testing.T, m model.Model, cmd tea.Cmd, rounds int) model.Model {
+	t.Helper()
+	pending := []tea.Cmd{cmd}
+	for range rounds {
+		var nextPending []tea.Cmd
+		for _, current := range pending {
+			if current == nil {
+				continue
+			}
+			messages := immediateTestCommandMessages(current)
+			for _, msg := range messages {
+				var next tea.Cmd
+				m, next = update(m, msg)
+				if next != nil {
+					nextPending = append(nextPending, next)
+				}
+			}
+		}
+		pending = nextPending
+		if len(pending) == 0 {
+			break
+		}
+	}
+	return m
+}
+
+func immediateTestCommandMessages(cmd tea.Cmd) []tea.Msg {
+	raw, ok := runImmediateTestCommand(cmd)
+	if !ok {
+		return nil
+	}
+	batch, ok := raw.(tea.BatchMsg)
+	if !ok {
+		return []tea.Msg{raw}
+	}
+	var messages []tea.Msg
+	for _, child := range batch {
+		messages = append(messages, immediateTestCommandMessages(child)...)
+	}
+	return messages
+}
+
+func runImmediateTestCommand(cmd tea.Cmd) (tea.Msg, bool) {
+	result := make(chan tea.Msg, 1)
+	go func() { result <- cmd() }()
+	select {
+	case msg := <-result:
+		return msg, true
+	case <-time.After(20 * time.Millisecond):
+		return nil, false
+	}
+}
+
 func enterActiveFlowsWithRecords(t *testing.T, m model.Model, records []flowstore.FlowRecord) model.Model {
 	t.Helper()
 	if m.ActivePane() == 0 {
@@ -514,6 +567,9 @@ func TestModel_ActiveFlowsTabWithTerminalCyclesListTerminalLeft(t *testing.T) {
 	flowTwo.Title = "Second active flow"
 	m := model.NewWithOptions(testRepos(), model.Options{
 		AgentCommand: "codex",
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{flowOne, flowTwo}, nil
+		},
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
 			updated := flowOne
 			for i := range updated.Phases {
@@ -535,7 +591,8 @@ func TestModel_ActiveFlowsTabWithTerminalCyclesListTerminalLeft(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("g on active Flow should prepare an embedded launch")
 	}
-	m, _ = update(m, cmd())
+	m, asyncCmd := update(m, cmd())
+	m = settleModelCommands(t, m, asyncCmd, 2)
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
@@ -804,10 +861,11 @@ func TestModel_RKeyResumesActiveFlowPhaseSession(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
-	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	if cmd == nil {
 		t.Fatal("expected active Flow phase resume command")
 	}
+	m = settleModelCommands(t, m, cmd, 2)
 	if started.ResumeSessionID != "codex-review" ||
 		started.FlowID != "flow-1" ||
 		started.FlowPhaseID != "review-loop" ||
@@ -856,7 +914,8 @@ func TestModel_InteractiveActiveFlowLaunchFocusesEmbeddedTerminal(t *testing.T) 
 	if !ok {
 		t.Fatalf("command returned %T, want FlowEmbeddedLaunchRequestedMsg", msg)
 	}
-	m, _ = update(m, launchMsg)
+	m, cmd = update(m, launchMsg)
+	m = settleModelCommands(t, m, cmd, 2)
 	if started.FlowID != "flow-1" || started.FlowPhaseID != "implementation" || started.Headless {
 		t.Fatalf("unexpected active Flow launch context: %#v", started)
 	}
@@ -898,7 +957,8 @@ func TestModel_F3PassesThroughFocusedActiveFlowTerminal(t *testing.T) {
 	if !ok {
 		t.Fatalf("command returned non-launch message")
 	}
-	m, _ = update(m, launchMsg)
+	m, cmd = update(m, launchMsg)
+	m = settleModelCommands(t, m, cmd, 2)
 	writeCount := len(fakeTerm.writes)
 
 	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyF3})
@@ -955,7 +1015,8 @@ func TestModel_ActiveFlowLaunchOverSessionsUsesFlowTerminal(t *testing.T) {
 	if !ok {
 		t.Fatalf("command returned %T, want FlowEmbeddedLaunchRequestedMsg", msg)
 	}
-	m, _ = update(m, launchMsg)
+	m, cmd = update(m, launchMsg)
+	m = settleModelCommands(t, m, cmd, 2)
 	if flowTerm == nil {
 		t.Fatal("expected active Flow launch to start a flow embedded terminal")
 	}
@@ -3905,6 +3966,7 @@ func TestModel_GOnFlowPhaseWithHeadlessOffLaunchesEmbeddedInteractiveCLI(t *test
 			if cmd == nil {
 				t.Fatal("expected embedded Flow launch to return repaint/fetch command")
 			}
+			m = settleModelCommands(t, m, cmd, 2)
 			if started.Command != command ||
 				started.FlowID != "flow-1" ||
 				started.FlowPhaseID != "implementation" ||
@@ -3982,6 +4044,7 @@ func TestModel_GOnFlowPhaseEmbeddedInteractivePrefillSanitizesTerminalControls(t
 	if cmd == nil {
 		t.Fatal("expected embedded Flow launch to return repaint/fetch command")
 	}
+	m = settleModelCommands(t, m, cmd, 2)
 
 	wantWrite := "\x1b[200~" + appendFlowDoneInstructionForTest("Alpha\nBeta\tOmegaDone") + "\x1b[201~"
 	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != wantWrite {
@@ -5859,7 +5922,14 @@ func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected selected Flow phase resume command")
 	}
-	_ = cmd()
+	if launchUpdate.FlowID != "" || started.Command != "" {
+		t.Fatalf("resume persistence or terminal start ran inside Update: update=%#v started=%#v", launchUpdate, started)
+	}
+	persisted := cmd()
+	if launchUpdate.FlowID != "flow-1" || started.Command != "" {
+		t.Fatalf("resume command sequencing = update %#v started %#v; want persistence only", launchUpdate, started)
+	}
+	m, _ = update(m, persisted)
 	if started.Command != "codex" ||
 		started.ResumeSessionID != "codex-new" ||
 		started.FlowID != "flow-1" ||
@@ -5892,6 +5962,51 @@ func TestModel_RKeyOnSelectedFlowPhaseResumesLatestSession(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
 	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "z" {
 		t.Fatalf("interactive Flow phase resume should focus terminal input and forward z: %#v", fakeTerm.writes)
+	}
+}
+
+func TestModel_RKeyOnSelectedFlowPhasePersistenceFailureDoesNotStartTerminal(t *testing.T) {
+	persisted := false
+	started := false
+	m := model.NewWithOptions(testRepos(), model.Options{
+		AddFlowPhaseLaunchID: func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			persisted = true
+			return flowstore.FlowRecord{}, errors.New("state root locked")
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			started = true
+			return &fakeEmbeddedTerminal{}, nil
+		},
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return nil, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{{
+		FlowID:       "flow-1",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktrees/resume-failure",
+		Status:       flowstore.StatusInProgress,
+		Phases: []flowstore.FlowPhase{{
+			PhaseID: "implementation",
+			Status:  flowstore.PhaseCompleted,
+			Sessions: []flowstore.Session{{
+				Provider: "codex", SessionID: "codex-session", Status: "ended",
+			}},
+		}},
+	}})
+	m = selectFlowPhaseByID(t, m, "implementation")
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil || persisted || started {
+		t.Fatalf("resume Update sequencing: cmd=%T persisted=%v started=%v", cmd, persisted, started)
+	}
+	result := cmd()
+	if !persisted || started {
+		t.Fatalf("resume persistence command sequencing: persisted=%v started=%v", persisted, started)
+	}
+	m, refreshCmd := update(m, result)
+	if started || refreshCmd == nil || !strings.Contains(m.TransientError(), "failed to mark flow phase resume: state root locked") {
+		t.Fatalf("persistence failure state: started=%v refresh=%T status=%q", started, refreshCmd, m.TransientError())
 	}
 }
 
@@ -6178,11 +6293,11 @@ func TestModel_RKeyOnFlowPhaseNeedsAttentionCanResumeOlderValidSession(t *testin
 	if !strings.Contains(m.View(), "r      resume") {
 		t.Fatalf("needs_attention phase should advertise Flow phase resume:\n%s", m.View())
 	}
-	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	if cmd == nil {
 		t.Fatal("expected needs_attention phase to resume older valid session")
 	}
-	_ = cmd()
+	m = settleModelCommands(t, m, cmd, 2)
 	if started.ResumeSessionID != "codex-old" || !started.Embedded || started.Headless || !started.FlowLaunchTracked {
 		t.Fatalf("embedded resume context = %#v, want older valid interactive session", started)
 	}
@@ -6234,7 +6349,7 @@ func TestModel_RKeyOnFlowPhaseResumeSetupFailureKeepsCompletedPhase(t *testing.T
 	if cmd == nil {
 		t.Fatal("resume start failure should refresh flows")
 	}
-	_ = cmd()
+	m = settleModelCommands(t, m, cmd, 3)
 	if launchUpdate.FlowID != "flow-1" || launchUpdate.PhaseID != "review-loop" || launchUpdate.LaunchID == "" {
 		t.Fatalf("launch update = %#v", launchUpdate)
 	}
@@ -6286,7 +6401,8 @@ func TestModel_RKeyOnFlowPhaseResumeSetupFailureStillFlagsNonTerminalPhase(t *te
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m = settleModelCommands(t, m, cmd, 3)
 	if len(phaseUpdates) != 1 {
 		t.Fatalf("phase updates = %#v, want one launch failure update", phaseUpdates)
 	}
@@ -6340,7 +6456,8 @@ func TestModel_RKeyOnFlowPhaseResumeFailureFlagsPhaseReopenedByStore(t *testing.
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m = settleModelCommands(t, m, cmd, 3)
 	if len(phaseUpdates) != 1 {
 		t.Fatalf("phase updates = %#v, want one; the store reopened the phase, so a failed launch must flag it", phaseUpdates)
 	}
@@ -6392,7 +6509,8 @@ func TestModel_RKeyOnFlowPhaseResumeFailureUsesNormalizedPersistedPhaseID(t *tes
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m = settleModelCommands(t, m, cmd, 3)
 	if len(phaseUpdates) != 1 {
 		t.Fatalf("phase updates = %#v, want one; normalized persisted running phase must override terminal snapshot", phaseUpdates)
 	}
@@ -6444,7 +6562,8 @@ func TestModel_RKeyOnFlowPhaseResumeFailurePrefersExactPersistedDuplicate(t *tes
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m = settleModelCommands(t, m, cmd, 3)
 	if len(phaseUpdates) != 1 {
 		t.Fatalf("phase updates = %#v, want one; exact persisted running phase must override stale terminal duplicate", phaseUpdates)
 	}
@@ -6498,7 +6617,8 @@ func TestModel_RKeyOnFlowPhaseResumeFailureKeepsPhaseCompletedInStore(t *testing
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEnter})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
 
-	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m = settleModelCommands(t, m, cmd, 3)
 	if len(phaseUpdates) != 0 {
 		t.Fatalf("phase updates = %#v, want none; the store preserved the completed phase, so a failed launch must not regress it", phaseUpdates)
 	}
@@ -6554,7 +6674,7 @@ func TestModel_RKeyOnFlowPhaseResumeStartFailureKeepsSkippedPhase(t *testing.T) 
 	if cmd == nil {
 		t.Fatal("expected resume launch command")
 	}
-	_ = cmd()
+	m = settleModelCommands(t, m, cmd, 3)
 
 	if launchUpdate.FlowID != "flow-1" || launchUpdate.PhaseID != "review-loop" || launchUpdate.LaunchID == "" {
 		t.Fatalf("launch update = %#v", launchUpdate)
@@ -7764,7 +7884,8 @@ func TestModel_GFlowPhaseEmbeddedTerminalStartFailureMarksPhaseNeedsAttention(t 
 	if cmd == nil {
 		t.Fatal("g should prepare an embedded launch")
 	}
-	m, _ = update(m, cmd())
+	m, asyncCmd := update(m, cmd())
+	m = settleModelCommands(t, m, asyncCmd, 2)
 
 	if phaseUpdate.FlowID != "flow-1" ||
 		phaseUpdate.PhaseID != "implementation" ||
@@ -7820,7 +7941,8 @@ func TestModel_ActiveFlowCustomPlanReviewLaunchFailureMarksBlocked(t *testing.T)
 	if cmd == nil {
 		t.Fatal("g should prepare an embedded launch")
 	}
-	m, _ = update(m, cmd())
+	m, asyncCmd := update(m, cmd())
+	m = settleModelCommands(t, m, asyncCmd, 2)
 
 	if phaseUpdate.FlowID != "flow-1" ||
 		phaseUpdate.PhaseID != "design-review" ||
@@ -7908,6 +8030,7 @@ func TestModel_GFlowPhaseEmbeddedInteractivePrefillFailureCleansUpTerminal(t *te
 			if cmd == nil {
 				t.Fatal("failed embedded prefill should still refresh Flow state")
 			}
+			m = settleModelCommands(t, m, cmd, 3)
 
 			if tt.term.terminates != 1 || tt.term.State() != "terminated" {
 				t.Fatalf("terminal cleanup = terminates %d state %q, want one terminated cleanup", tt.term.terminates, tt.term.State())
@@ -8842,7 +8965,8 @@ func TestModel_GOnFlowPhaseAtEmbeddedTerminalCapMarksPhaseNeedsAttention(t *test
 	if cmd == nil {
 		t.Fatal("g at cap should still prepare a launch attempt")
 	}
-	m, _ = update(m, cmd())
+	m, asyncCmd := update(m, cmd())
+	m = settleModelCommands(t, m, asyncCmd, 2)
 	if starts != 9 {
 		t.Fatalf("embedded terminal starts after cap = %d, want 9", starts)
 	}
@@ -9841,7 +9965,7 @@ func TestModel_FlowAgentResultFailureMarksPlanReviewBlocked(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected flow refresh command")
 	}
-	_ = cmd()
+	m = settleModelCommands(t, m, cmd, 2)
 
 	if phaseUpdate.FlowID != "flow-1" ||
 		phaseUpdate.PhaseID != "plan-review" ||
@@ -10343,6 +10467,7 @@ func TestModel_NewFlowInteractiveCLIPlanLaunchFocusesTerminalInput(t *testing.T)
 	if cmd == nil {
 		t.Fatal("expected embedded launch repaint/fetch command")
 	}
+	m = settleModelCommands(t, m, cmd, 2)
 	if started.FlowPhaseID != "plan" || started.Headless || !started.Embedded || !started.FlowLaunchTracked {
 		t.Fatalf("interactive new Flow plan launch context = %#v", started)
 	}
@@ -10972,7 +11097,8 @@ func TestModel_NewFlowLaunchFailureMarksPlanNeedsAttention(t *testing.T) {
 	if !ok {
 		t.Fatalf("command returned %T, want FlowEmbeddedLaunchRequestedMsg", msg)
 	}
-	m, _ = update(m, launchMsg)
+	m, asyncCmd := update(m, launchMsg)
+	m = settleModelCommands(t, m, asyncCmd, 2)
 
 	if len(phaseUpdates) != 1 {
 		t.Fatalf("phase updates = %#v, want one launch failure update", phaseUpdates)
@@ -11028,7 +11154,8 @@ func TestModel_NewFlowCodexAppLaunchFailureMarksPlanNeedsAttention(t *testing.T)
 	if !ok {
 		t.Fatalf("command returned %T, want PlanLaunchRequestedMsg", msg)
 	}
-	m, _ = update(m, launchMsg)
+	m, asyncCmd := update(m, launchMsg)
+	m = settleModelCommands(t, m, asyncCmd, 2)
 
 	if len(phaseUpdates) != 1 {
 		t.Fatalf("phase updates = %#v, want one launch failure update", phaseUpdates)
@@ -11108,7 +11235,8 @@ func TestModel_NewFlowAtEmbeddedTerminalCapMarksPlanNeedsAttention(t *testing.T)
 	if !ok {
 		t.Fatalf("command returned %T, want FlowEmbeddedLaunchRequestedMsg", msg)
 	}
-	m, _ = update(m, launchMsg)
+	m, asyncCmd := update(m, launchMsg)
+	m = settleModelCommands(t, m, asyncCmd, 2)
 
 	if starts != 9 {
 		t.Fatalf("embedded terminal starts after cap = %d, want 9", starts)
@@ -11154,14 +11282,12 @@ func TestModel_FlowAgentResultFailureMarksPhaseAndRefreshesFlows(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected flow refresh command")
 	}
+	m = settleModelCommands(t, m, cmd, 2)
 	if phaseUpdate.FlowID != "flow-1" ||
 		phaseUpdate.PhaseID != "plan" ||
 		phaseUpdate.Status != flowstore.PhaseNeedsAttention ||
 		!strings.Contains(phaseUpdate.Notes, "agent exited") {
 		t.Fatalf("phase update = %#v", phaseUpdate)
-	}
-	for _, refreshMsg := range runLeadingBatchCmdWithCount(t, cmd, 2) {
-		m, _ = update(m, refreshMsg)
 	}
 	if !listed {
 		t.Fatal("expected ListFlows to run")
@@ -11191,6 +11317,7 @@ func TestModel_FlowAgentResultFailureReportsPhaseUpdateFailure(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("expected flow refresh command")
 	}
+	m = settleModelCommands(t, m, cmd, 2)
 	if got := m.TransientError(); !strings.Contains(got, "agent exited") || !strings.Contains(got, "update flow phase: state root locked") {
 		t.Fatalf("status = %q, want launch and phase-update failures", got)
 	}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -516,7 +516,7 @@ func (m Model) cyclePaneFocusForward() Model {
 		return m.syncActiveFlowTerminalToSelectedFlow()
 	}
 
-	if m.hasEmbeddedTerminalForScope(embeddedTerminalScopeFlow) && m.flowFocus != flowFocusTerminal {
+	if m.hasActiveEmbeddedTerminalForScope(embeddedTerminalScopeFlow) && m.flowFocus != flowFocusTerminal {
 		m.flowFocus = flowFocusTerminal
 		m.terminalPrefixActive = true
 		return m
@@ -2159,10 +2159,7 @@ func (m Model) launchAgentAtPathWithBranch(path string, branch *string) (Model, 
 func (m Model) launchAgentWithContext(ctx actions.AgentLaunchContext) (Model, tea.Cmd) {
 	launch, err := m.launchAgent(ctx)
 	if err != nil {
-		errText := err.Error()
-		m, errText = m.markFlowLaunchNeedsAttention(ctx, errText)
-		m = m.setStatus(statusOther, errText)
-		return m, nil
+		return m.startFlowLaunchFailure(ctx, err.Error())
 	}
 	return m.runAgentLaunchWithContext(ctx, launch)
 }
@@ -2171,21 +2168,22 @@ func (m Model) launchFlowEmbeddedWithContext(ctx actions.AgentLaunchContext) (Mo
 	ctx.Embedded = true
 	ctx.FlowLaunchTracked = true
 	needsTick := !m.hasRunningEmbeddedTerminal()
-	next, opened, err := m.openFlowEmbeddedTerminal(ctx)
+	next, opened, err, prefillCmd := m.openFlowEmbeddedTerminal(ctx)
 	if err != nil || !opened {
 		errText := "Maximum embedded terminals reached"
 		if err != nil {
 			errText = err.Error()
 		}
-		next, errText = next.markFlowLaunchNeedsAttention(ctx, errText)
-		next = next.setStatus(statusOther, errText)
-		return next, nil
+		return next.startFlowLaunchFailure(ctx, errText)
 	}
-	next = next.updateFlowTerminalFocusAfterLaunch(ctx)
+	if prefillCmd == nil {
+		next = next.updateFlowTerminalFocusAfterLaunch(ctx)
+	}
+	var tickCmd tea.Cmd
 	if needsTick {
-		return next.startEmbeddedTerminalTick()
+		next, tickCmd = next.startEmbeddedTerminalTick()
 	}
-	return next, nil
+	return next, batchNonNil(prefillCmd, tickCmd)
 }
 
 func (m Model) updateFlowTerminalFocusAfterLaunch(ctx actions.AgentLaunchContext) Model {
@@ -2210,48 +2208,59 @@ func (m Model) launchTrackedFlowPhaseResumeWithContext(ctx actions.AgentLaunchCo
 	ctx.FlowLaunchTracked = true
 	ctx.Embedded = true
 	ctx.Headless = false
-	updated, err := m.addFlowPhaseLaunchID(flowstore.PhaseLaunchUpdate{
-		FlowID:   ctx.FlowID,
-		PhaseID:  ctx.FlowPhaseID,
-		LaunchID: ctx.LaunchID,
-		Resume:   true,
-	})
-	if err != nil {
-		m = m.setStatus(statusOther, fmt.Sprintf("failed to mark flow phase resume: %v", err))
-		return m, nil
+	return m, func() tea.Msg {
+		updated, err := m.addFlowPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+			FlowID:   ctx.FlowID,
+			PhaseID:  ctx.FlowPhaseID,
+			LaunchID: ctx.LaunchID,
+			Resume:   true,
+		})
+		if err != nil {
+			return flowPhaseResumePersistFailedMsg{LaunchContext: ctx, Err: err}
+		}
+		return flowPhaseResumePersistedMsg{LaunchContext: ctx, Flow: updated}
 	}
+}
+
+func (m Model) handleFlowPhaseResumePersisted(msg flowPhaseResumePersistedMsg) (Model, tea.Cmd) {
+	ctx := msg.LaunchContext
 	// The store decided from the persisted record whether this resume preserved
 	// a terminal phase or reopened a running one; the snapshot the launch
 	// context was built from may be stale, so failure handling must follow the
 	// persisted status.
-	if phase, ok := flowPhaseByID(updated, ctx.FlowPhaseID); ok {
+	if phase, ok := flowPhaseByID(msg.Flow, ctx.FlowPhaseID); ok {
 		ctx.FlowPhaseTerminal = flowstore.PhaseStatusTerminal(phase.Status)
 	}
 	needsTick := !m.hasRunningEmbeddedTerminal()
-	next, opened, err := m.openFlowEmbeddedTerminal(ctx)
+	next, opened, err, prefillCmd := m.openFlowEmbeddedTerminal(ctx)
 	if err != nil || !opened {
 		errText := "Maximum embedded terminals reached"
 		if err != nil {
 			errText = err.Error()
 		}
-		next, errText = next.markFlowLaunchNeedsAttention(ctx, errText)
-		next = next.setStatus(statusOther, errText)
-		if next.flowSurfaceVisible() {
-			next, fetchCmd := next.startFlowSurfaceFetch()
-			return next, fetchCmd
-		}
-		return next, nil
+		return next.startFlowLaunchFailure(ctx, errText)
 	}
-	next = next.updateFlowTerminalFocusAfterLaunch(ctx)
+	if prefillCmd == nil {
+		next = next.updateFlowTerminalFocusAfterLaunch(ctx)
+	}
 	var launchCmd tea.Cmd
 	if needsTick {
 		next, launchCmd = next.startEmbeddedTerminalTick()
 	}
+	launchCmd = batchNonNil(prefillCmd, launchCmd)
 	if next.flowSurfaceVisible() {
 		next, fetchCmd := next.startFlowSurfaceFetch()
 		return next, tea.Batch(fetchCmd, launchCmd)
 	}
 	return next, launchCmd
+}
+
+func (m Model) handleFlowPhaseResumePersistFailed(msg flowPhaseResumePersistFailedMsg) (Model, tea.Cmd) {
+	m = m.setStatus(statusOther, fmt.Sprintf("failed to mark flow phase resume: %v", msg.Err))
+	if msg.LaunchContext.FlowID != "" && m.flowSurfaceVisible() {
+		return m.startFlowSurfaceFetch()
+	}
+	return m, nil
 }
 
 func (m Model) runAgentLaunchWithContext(ctx actions.AgentLaunchContext, launch actions.TerminalLaunchSpec) (Model, tea.Cmd) {
@@ -2282,14 +2291,14 @@ func (m Model) runAgentLaunchWithContext(ctx actions.AgentLaunchContext, launch 
 	}
 }
 
-func (m Model) markFlowLaunchNeedsAttention(ctx actions.AgentLaunchContext, errText string) (Model, string) {
+func (m Model) flowLaunchFailureUpdate(ctx actions.AgentLaunchContext, errText string) (flowstore.PhaseUpdate, bool) {
 	if ctx.FlowID == "" || ctx.FlowPhaseID == "" || (ctx.ResumeSessionID != "" && !ctx.FlowLaunchTracked) {
-		return m, errText
+		return flowstore.PhaseUpdate{}, false
 	}
 	if ctx.FlowPhaseTerminal {
 		// The phase had already finished when this launch (a session resume)
 		// started; a failed resume must not regress it to needs_attention.
-		return m, errText
+		return flowstore.PhaseUpdate{}, false
 	}
 	notes := "Agent launch failed"
 	if errText != "" {
@@ -2307,16 +2316,43 @@ func (m Model) markFlowLaunchNeedsAttention(ctx actions.AgentLaunchContext, errT
 		status = flowstore.PhaseBlocked
 		outcome = flowstore.OutcomeBlocked
 	}
-	if _, err := m.setFlowPhase(flowstore.PhaseUpdate{
+	return flowstore.PhaseUpdate{
 		FlowID:  ctx.FlowID,
 		PhaseID: ctx.FlowPhaseID,
 		Status:  status,
 		Outcome: outcome,
 		Notes:   notes,
-	}); err != nil && errText != "" {
-		return m, errText + "; update flow phase: " + err.Error()
+	}, true
+}
+
+func (m Model) startFlowLaunchFailure(ctx actions.AgentLaunchContext, errText string) (Model, tea.Cmd) {
+	update, ok := m.flowLaunchFailureUpdate(ctx, errText)
+	if !ok {
+		return m.setStatus(statusOther, errText), nil
 	}
-	return m, errText
+	return m, func() tea.Msg {
+		_, err := m.setFlowPhase(update)
+		return flowLaunchFailurePersistedMsg{
+			LaunchContext: ctx,
+			OriginalErr:   errText,
+			PersistErr:    err,
+		}
+	}
+}
+
+func (m Model) handleFlowLaunchFailurePersisted(msg flowLaunchFailurePersistedMsg) (Model, tea.Cmd) {
+	errText := msg.OriginalErr
+	if msg.PersistErr != nil {
+		if errText != "" {
+			errText += "; "
+		}
+		errText += "update flow phase: " + msg.PersistErr.Error()
+	}
+	m = m.setStatus(statusOther, errText)
+	if msg.LaunchContext.FlowID != "" && m.flowSurfaceVisible() {
+		return m.startFlowSurfaceFetch()
+	}
+	return m, nil
 }
 
 // agentLaunchedStatus describes a successful detached launch without implying

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -398,6 +398,17 @@ type AgentResultMsg struct {
 	Detached bool
 }
 
+type agentSessionFinalizedMsg struct {
+	Result AgentResultMsg
+	Err    error
+}
+
+type flowLaunchFailurePersistedMsg struct {
+	LaunchContext actions.AgentLaunchContext
+	OriginalErr   string
+	PersistErr    error
+}
+
 type PlanLaunchRequestedMsg struct {
 	LaunchContext actions.AgentLaunchContext
 	Request       uint64
@@ -406,6 +417,16 @@ type PlanLaunchRequestedMsg struct {
 type FlowEmbeddedLaunchRequestedMsg struct {
 	LaunchContext actions.AgentLaunchContext
 	Request       uint64
+}
+
+type flowPhaseResumePersistedMsg struct {
+	LaunchContext actions.AgentLaunchContext
+	Flow          flowstore.FlowRecord
+}
+
+type flowPhaseResumePersistFailedMsg struct {
+	LaunchContext actions.AgentLaunchContext
+	Err           error
 }
 
 type FlowCreatedMsg struct {

--- a/planstore/store.go
+++ b/planstore/store.go
@@ -19,6 +19,7 @@ import (
 )
 
 const schemaVersion = 1
+const defaultLockTimeout = 5 * time.Second
 
 var validStatuses = map[string]bool{
 	"draft":       true,
@@ -39,8 +40,9 @@ var validPhaseStatuses = map[string]bool{
 
 // Store reads and writes saved plans under an artifact root.
 type Store struct {
-	root string
-	now  func() time.Time
+	root        string
+	now         func() time.Time
+	lockTimeout time.Duration
 }
 
 // StoreOptions configures a Store.
@@ -49,6 +51,9 @@ type StoreOptions struct {
 	// Now overrides the clock used for generated IDs and timestamps. Tests use
 	// it for deterministic output; production leaves it nil (UTC wall clock).
 	Now func() time.Time
+	// LockTimeout bounds waits for another plan writer. Production defaults to
+	// five seconds; tests may use a shorter deterministic timeout.
+	LockTimeout time.Duration
 }
 
 // PlanPhase is one ordered step within a plan.
@@ -116,7 +121,11 @@ func NewStore(opts StoreOptions) (*Store, error) {
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
 	}
-	return &Store{root: root, now: now}, nil
+	lockTimeout := opts.LockTimeout
+	if lockTimeout <= 0 {
+		lockTimeout = defaultLockTimeout
+	}
+	return &Store{root: root, now: now, lockTimeout: lockTimeout}, nil
 }
 
 // DefaultRoot returns the default artifact root, matching sessions.DefaultRoot.
@@ -175,6 +184,11 @@ func (s *Store) Save(record PlanRecord) (string, error) {
 	if record.Status != "" && !validStatuses[record.Status] {
 		return "", fmt.Errorf("invalid plan status %q", record.Status)
 	}
+	release, err := s.acquireMutationLock()
+	if err != nil {
+		return "", err
+	}
+	defer release()
 	if record.PlanID == "" {
 		generated, err := s.generateID(record.Title)
 		if err != nil {
@@ -226,6 +240,11 @@ func (s *Store) SetPhase(planID string, phase PlanPhase) error {
 	if phase.PhaseID == "" {
 		return fmt.Errorf("phase id is required")
 	}
+	release, err := s.acquireMutationLock()
+	if err != nil {
+		return err
+	}
+	defer release()
 	record, ok := s.readRecord(planID)
 	if !ok {
 		return fmt.Errorf("plan %q not found", planID)
@@ -404,6 +423,21 @@ func (s *Store) readMetadataStrict(planID string) (PlanRecord, error) {
 
 func (s *Store) planDir(planID string) string {
 	return artifacts.RecordDir(s.root, "plans", planID)
+}
+
+// acquireMutationLock serializes all plan writes, including generated-ID
+// allocation. Flow mutations may acquire a Flow lock and then this plan lock
+// for linked-plan synchronization; plan operations must never acquire Flow
+// locks, preserving that one-way lock order.
+func (s *Store) acquireMutationLock() (func(), error) {
+	lockDir := filepath.Join(s.root, "plans", ".locks")
+	if err := os.MkdirAll(lockDir, artifacts.DirPerm); err != nil {
+		return nil, fmt.Errorf("create plan lock directory: %w", err)
+	}
+	if err := os.Chmod(lockDir, artifacts.DirPerm); err != nil {
+		return nil, fmt.Errorf("secure plan lock directory: %w", err)
+	}
+	return artifacts.AcquireFileLock(filepath.Join(lockDir, "mutations.lock"), "plan mutation lock", s.lockTimeout)
 }
 
 func validatePlanID(planID string) error {

--- a/planstore/store_test.go
+++ b/planstore/store_test.go
@@ -3,11 +3,106 @@ package planstore_test
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/brian-bell/wtui/internal/artifacts"
 	"github.com/brian-bell/wtui/planstore"
 )
+
+func TestStoreMutationsSerializeAndPreserveConcurrentChanges(t *testing.T) {
+	root := t.TempDir()
+	store1, err := planstore.NewStore(planstore.StoreOptions{Root: root, LockTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("NewStore(first) error = %v", err)
+	}
+	store2, err := planstore.NewStore(planstore.StoreOptions{Root: root, LockTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("NewStore(second) error = %v", err)
+	}
+	if _, err := store1.Save(planstore.PlanRecord{PlanID: "shared", Title: "Shared", Markdown: "old"}); err != nil {
+		t.Fatalf("seed Save() error = %v", err)
+	}
+
+	lockPath := filepath.Join(root, "plans", ".locks", "mutations.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		t.Fatalf("create lock dir: %v", err)
+	}
+	release, err := artifacts.AcquireFileLock(lockPath, "test plan mutation lock", time.Second)
+	if err != nil {
+		t.Fatalf("hold plan mutation lock: %v", err)
+	}
+	results := make(chan error, 2)
+	go func() {
+		_, err := store1.Save(planstore.PlanRecord{PlanID: "shared", Title: "Shared updated", Markdown: "new", Summary: "saved concurrently"})
+		results <- err
+	}()
+	go func() {
+		results <- store2.SetPhase("shared", planstore.PlanPhase{PhaseID: "implementation", Title: "Implementation", Status: "in_progress"})
+	}()
+	select {
+	case err := <-results:
+		release()
+		t.Fatalf("plan mutation completed while lock was held: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	release()
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatalf("concurrent plan mutation error = %v", err)
+		}
+	}
+	got, err := store1.ReadMetadata("shared")
+	if err != nil {
+		t.Fatalf("ReadMetadata() error = %v", err)
+	}
+	if got.Summary != "saved concurrently" || len(got.Phases) != 1 || got.Phases[0].PhaseID != "implementation" {
+		t.Fatalf("concurrent plan changes were not merged: %#v", got)
+	}
+}
+
+func TestStoreConcurrentGeneratedIDSavesAreUnique(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	stores := make([]*planstore.Store, 2)
+	for i := range stores {
+		store, err := planstore.NewStore(planstore.StoreOptions{Root: root, Now: func() time.Time { return now }, LockTimeout: time.Second})
+		if err != nil {
+			t.Fatalf("NewStore(%d) error = %v", i, err)
+		}
+		stores[i] = store
+	}
+	start := make(chan struct{})
+	ids := make(chan string, 2)
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, store := range stores {
+		wg.Add(1)
+		go func(store *planstore.Store) {
+			defer wg.Done()
+			<-start
+			id, err := store.Save(planstore.PlanRecord{Title: "Same title", Markdown: "body"})
+			ids <- id
+			errs <- err
+		}(store)
+	}
+	close(start)
+	wg.Wait()
+	close(ids)
+	for range 2 {
+		if err := <-errs; err != nil {
+			t.Fatalf("generated Save() error = %v", err)
+		}
+	}
+	got := make(map[string]bool)
+	for id := range ids {
+		got[id] = true
+	}
+	if len(got) != 2 {
+		t.Fatalf("generated plan IDs = %#v, want two unique IDs", got)
+	}
+}
 
 func TestStoreListSkipsCorruptAndNonDirEntries(t *testing.T) {
 	root := t.TempDir()

--- a/sessions/ingest.go
+++ b/sessions/ingest.go
@@ -58,17 +58,26 @@ func IngestHook(provider Provider, input io.Reader, opts IngestOptions) (Session
 	}
 	applyEnvMetadata(&record, opts.Env)
 	resolveGitMetadata(&record)
+	if record.TranscriptPath != "" {
+		canonical, err := ValidateTranscriptPath(provider, record.TranscriptPath, opts.Env)
+		if err != nil {
+			return SessionRecord{}, err
+		}
+		record.TranscriptPath = canonical
+	}
 	stateRoot := opts.StateRoot
 	if stateRoot == "" {
 		stateRoot = opts.Env["WTUI_SESSION_STATE_ROOT"]
 	}
-	store, err := NewStore(StoreOptions{Root: stateRoot, CopyRawTranscripts: opts.CopyRawTranscripts})
+	store, err := NewStore(StoreOptions{Root: stateRoot, CopyRawTranscripts: opts.CopyRawTranscripts, Env: opts.Env})
 	if err != nil {
 		return SessionRecord{}, err
 	}
 	if err := store.Upsert(record); err != nil {
 		return SessionRecord{}, err
 	}
+	// Upsert releases the per-session lock before Flow attachment. Keeping that
+	// boundary prevents a session-lock -> Flow-lock edge in the store lock order.
 	attachFlowSession(record, opts)
 	return record, nil
 }

--- a/sessions/ingest.go
+++ b/sessions/ingest.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/brian-bell/wtui/flowstore"
+	"github.com/brian-bell/wtui/internal/artifacts"
 )
 
 type IngestOptions struct {
@@ -73,7 +74,9 @@ func IngestHook(provider Provider, input io.Reader, opts IngestOptions) (Session
 	if err != nil {
 		return SessionRecord{}, err
 	}
-	if err := store.Upsert(record); err != nil {
+	store.launchStale = flowLaunchStaleResolver(record, opts)
+	record, err = store.upsert(record)
+	if err != nil {
 		return SessionRecord{}, err
 	}
 	// Upsert releases the per-session lock before Flow attachment. Keeping that
@@ -206,16 +209,7 @@ func attachFlowSession(record SessionRecord, opts IngestOptions) {
 	if record.FlowID == "" || record.FlowPhaseID == "" || strings.TrimSpace(record.SessionID) == "" {
 		return
 	}
-	root := opts.Env["WTUI_FLOW_STATE_ROOT"]
-	if root == "" {
-		root = opts.Env["WTUI_PLAN_STATE_ROOT"]
-	}
-	if root == "" {
-		root = opts.StateRoot
-	}
-	if root == "" {
-		root = opts.Env["WTUI_SESSION_STATE_ROOT"]
-	}
+	root := flowStateRoot(opts)
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Presets: opts.FlowPresets})
 	if err != nil {
 		return
@@ -233,6 +227,60 @@ func attachFlowSession(record SessionRecord, opts IngestOptions) {
 			TranscriptPath: record.TranscriptPath,
 		},
 	})
+}
+
+func flowLaunchStaleResolver(record SessionRecord, opts IngestOptions) launchStaleFunc {
+	if record.FlowID == "" || record.FlowPhaseID == "" {
+		return nil
+	}
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: flowStateRoot(opts), Presets: opts.FlowPresets})
+	if err != nil {
+		return nil
+	}
+	// This resolver runs while the session lock is held. Keep it read-only:
+	// taking a Flow lock here would create a session-lock -> Flow-lock edge.
+	return func(existing, incoming SessionRecord) (bool, bool) {
+		if existing.FlowID == "" || existing.FlowID != incoming.FlowID ||
+			existing.FlowPhaseID == "" || artifacts.NormalizePhaseID(existing.FlowPhaseID) != artifacts.NormalizePhaseID(incoming.FlowPhaseID) {
+			return false, false
+		}
+		flow, err := store.Read(incoming.FlowID)
+		if err != nil {
+			return false, false
+		}
+		phaseID := artifacts.NormalizePhaseID(incoming.FlowPhaseID)
+		for _, phase := range flow.Phases {
+			if artifacts.NormalizePhaseID(phase.PhaseID) != phaseID {
+				continue
+			}
+			incomingIndex, existingIndex := -1, -1
+			for i, launchID := range phase.LaunchIDs {
+				if launchID == incoming.LaunchID {
+					incomingIndex = i
+				}
+				if launchID == existing.LaunchID {
+					existingIndex = i
+				}
+			}
+			if incomingIndex >= 0 && existingIndex >= 0 {
+				return incomingIndex < existingIndex, true
+			}
+		}
+		return false, false
+	}
+}
+
+func flowStateRoot(opts IngestOptions) string {
+	if root := opts.Env["WTUI_FLOW_STATE_ROOT"]; root != "" {
+		return root
+	}
+	if root := opts.Env["WTUI_PLAN_STATE_ROOT"]; root != "" {
+		return root
+	}
+	if opts.StateRoot != "" {
+		return opts.StateRoot
+	}
+	return opts.Env["WTUI_SESSION_STATE_ROOT"]
 }
 
 func repoPathFromGitMetadata(worktreePath, gitDir, commonDir string, isBare, commonDirIsBare bool) string {

--- a/sessions/ingest_test.go
+++ b/sessions/ingest_test.go
@@ -314,6 +314,75 @@ func TestIngestHookPersistsFlowMetadataAndAttachesSession(t *testing.T) {
 	}
 }
 
+func TestIngestHookUsesFlowLaunchOrderToRejectStaleSessionUpdate(t *testing.T) {
+	root := t.TempDir()
+	flowStore, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	flow, err := flowStore.Create(flowstore.FlowRecord{
+		FlowID:       "flow-launch-order",
+		Title:        "Fence stale hook",
+		Instructions: "Keep the resumed launch current",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	for _, launchID := range []string{"launch-1", "launch-2"} {
+		flow, err = flowStore.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+			FlowID:   flow.FlowID,
+			PhaseID:  "plan",
+			LaunchID: launchID,
+		})
+		if err != nil {
+			t.Fatalf("AddPhaseLaunchID(%s) error = %v", launchID, err)
+		}
+	}
+	envForLaunch := func(launchID string) map[string]string {
+		return map[string]string{
+			"WTUI_LAUNCH_ID":          launchID,
+			"WTUI_SESSION_STATE_ROOT": root,
+			"WTUI_FLOW_STATE_ROOT":    root,
+			"WTUI_FLOW_ID":            flow.FlowID,
+			"WTUI_FLOW_PHASE_ID":      "plan",
+		}
+	}
+	if _, err := sessions.IngestHook(sessions.ProviderCodex, bytes.NewReader([]byte(`{
+		"session_id": "shared-session",
+		"timestamp": "2026-07-15T14:20:00Z"
+	}`)), sessions.IngestOptions{Env: envForLaunch("launch-2")}); err != nil {
+		t.Fatalf("current IngestHook() error = %v", err)
+	}
+	if _, err := sessions.IngestHook(sessions.ProviderCodex, bytes.NewReader([]byte(`{
+		"session_id": "shared-session",
+		"timestamp": "2026-07-15T14:30:00Z",
+		"hook_event_name": "Stop"
+	}`)), sessions.IngestOptions{Env: envForLaunch("launch-1")}); err != nil {
+		t.Fatalf("stale IngestHook() error = %v", err)
+	}
+
+	sessionStore, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	records, err := sessionStore.List(sessions.SessionFilter{})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(records) != 1 || records[0].LaunchID != "launch-2" || records[0].Status != "last_seen" {
+		t.Fatalf("session regressed after stale hook: %#v", records)
+	}
+	flow, err = flowStore.Read(flow.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	phase := flowPhaseByID(t, flow, "plan")
+	if len(phase.Sessions) != 1 || phase.Sessions[0].LaunchID != "launch-2" || phase.Sessions[0].Status != "last_seen" {
+		t.Fatalf("Flow session regressed after stale hook: %#v", phase.Sessions)
+	}
+}
+
 func TestIngestHookPersistsToDefaultRootWhenNoStateRootProvided(t *testing.T) {
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)

--- a/sessions/ingest_test.go
+++ b/sessions/ingest_test.go
@@ -383,6 +383,85 @@ func TestIngestHookUsesFlowLaunchOrderToRejectStaleSessionUpdate(t *testing.T) {
 	}
 }
 
+func TestIngestHookDoesNotRestoreFlowLinkForOrdinarySessionResume(t *testing.T) {
+	root := t.TempDir()
+	trackedLaunchID := "wtui-100-aaaaaaaaaaaa"
+	resumeLaunchID := "wtui-200-bbbbbbbbbbbb"
+	flowStore, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	flow, err := flowStore.Create(flowstore.FlowRecord{
+		FlowID:       "flow-untracked-resume",
+		Title:        "Keep ordinary resume untracked",
+		Instructions: "Do not restore old Flow metadata",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	flow, err = flowStore.AddPhaseLaunchID(flowstore.PhaseLaunchUpdate{
+		FlowID:   flow.FlowID,
+		PhaseID:  "plan",
+		LaunchID: trackedLaunchID,
+	})
+	if err != nil {
+		t.Fatalf("AddPhaseLaunchID() error = %v", err)
+	}
+	if _, err := sessions.IngestHook(sessions.ProviderCodex, bytes.NewReader([]byte(`{
+		"session_id": "shared-session",
+		"timestamp": "2026-07-15T14:10:00Z"
+	}`)), sessions.IngestOptions{Env: map[string]string{
+		"WTUI_LAUNCH_ID":          trackedLaunchID,
+		"WTUI_SESSION_STATE_ROOT": root,
+		"WTUI_FLOW_STATE_ROOT":    root,
+		"WTUI_FLOW_ID":            flow.FlowID,
+		"WTUI_FLOW_PHASE_ID":      "plan",
+	}}); err != nil {
+		t.Fatalf("tracked IngestHook() error = %v", err)
+	}
+
+	record, err := sessions.IngestHook(sessions.ProviderCodex, bytes.NewReader([]byte(`{
+		"session_id": "shared-session",
+		"timestamp": "2026-07-15T14:20:00Z"
+	}`)), sessions.IngestOptions{Env: map[string]string{
+		"WTUI_LAUNCH_ID":          resumeLaunchID,
+		"WTUI_SESSION_STATE_ROOT": root,
+	}})
+	if err != nil {
+		t.Fatalf("ordinary resume IngestHook() error = %v", err)
+	}
+	if record.LaunchID != resumeLaunchID || record.FlowID != "" || record.FlowPhaseID != "" {
+		t.Fatalf("ordinary resume restored Flow metadata: %#v", record)
+	}
+	record, err = sessions.IngestHook(sessions.ProviderCodex, bytes.NewReader([]byte(`{
+		"session_id": "shared-session",
+		"timestamp": "2026-07-15T14:30:00Z",
+		"hook_event_name": "Stop"
+	}`)), sessions.IngestOptions{Env: map[string]string{
+		"WTUI_LAUNCH_ID":          trackedLaunchID,
+		"WTUI_SESSION_STATE_ROOT": root,
+		"WTUI_FLOW_STATE_ROOT":    root,
+		"WTUI_FLOW_ID":            flow.FlowID,
+		"WTUI_FLOW_PHASE_ID":      "plan",
+	}})
+	if err != nil {
+		t.Fatalf("delayed tracked IngestHook() error = %v", err)
+	}
+	if record.LaunchID != resumeLaunchID || record.FlowID != "" || record.FlowPhaseID != "" || record.Status != "last_seen" {
+		t.Fatalf("delayed tracked hook regressed ordinary resume: %#v", record)
+	}
+
+	flow, err = flowStore.Read(flow.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	phase := flowPhaseByID(t, flow, "plan")
+	if len(phase.Sessions) != 1 || phase.Sessions[0].LaunchID != trackedLaunchID {
+		t.Fatalf("ordinary resume changed Flow attachment: %#v", phase.Sessions)
+	}
+}
+
 func TestIngestHookPersistsToDefaultRootWhenNoStateRootProvided(t *testing.T) {
 	stateHome := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", stateHome)

--- a/sessions/ingest_test.go
+++ b/sessions/ingest_test.go
@@ -203,9 +203,13 @@ func TestIngestHookCreatesEndedClaudeRecordFromSessionEnd(t *testing.T) {
 	root := t.TempDir()
 	cwd := filepath.Join(root, "worktree")
 	repoPath := filepath.Join(root, "repo")
-	transcriptPath := filepath.Join(root, "claude-transcript.jsonl")
+	transcriptPath := providerTranscriptPath(t, sessions.ProviderClaude, "claude-transcript.jsonl")
 	if err := os.WriteFile(transcriptPath, []byte(`{"timestamp":"2026-06-06T14:01:00Z","role":"user","kind":"message","text":"Fix scanner tests"}`+"\n"), 0o600); err != nil {
 		t.Fatalf("write transcript: %v", err)
+	}
+	canonicalTranscriptPath, err := filepath.EvalSymlinks(transcriptPath)
+	if err != nil {
+		t.Fatalf("canonicalize transcript: %v", err)
 	}
 	payload := []byte(`{
 		"session_id": "claude-session-1",
@@ -241,7 +245,7 @@ func TestIngestHookCreatesEndedClaudeRecordFromSessionEnd(t *testing.T) {
 		record.WorktreePath != cwd ||
 		record.Branch != "feature/sessions" ||
 		record.Commit != "abcdef123456" ||
-		record.TranscriptPath != transcriptPath ||
+		record.TranscriptPath != canonicalTranscriptPath ||
 		record.Summary != "Fix scanner tests" ||
 		record.CaptureSource != "hook" ||
 		!record.EndedAt.Equal(wantEndedAt) ||
@@ -368,7 +372,7 @@ func TestIngestHookFallsBackClaudeSessionEndTimesAndSummary(t *testing.T) {
 func TestIngestHookPersistsCodexStopSnapshotsInPlace(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")
-	transcriptPath := filepath.Join(root, "codex.jsonl")
+	transcriptPath := providerTranscriptPath(t, sessions.ProviderCodex, "codex.jsonl")
 	if err := os.WriteFile(transcriptPath, []byte(`{"timestamp":"2026-06-06T14:10:00Z","role":"user","kind":"message","text":"first prompt"}`+"\n"), 0o600); err != nil {
 		t.Fatalf("write transcript: %v", err)
 	}

--- a/sessions/store.go
+++ b/sessions/store.go
@@ -116,22 +116,13 @@ func (s *Store) Upsert(record SessionRecord) error {
 	}
 	var transcript *os.File
 	if record.TranscriptPath != "" {
-		canonical, err := ValidateTranscriptPath(record.Provider, record.TranscriptPath, s.env)
+		var canonical string
+		var err error
+		transcript, canonical, err = openValidatedTranscript(record.Provider, record.TranscriptPath, s.env)
 		if err != nil {
 			return err
 		}
-		transcript, err = os.Open(canonical)
-		if err != nil {
-			return fmt.Errorf("open provider transcript %q: %w", canonical, err)
-		}
 		defer transcript.Close()
-		info, err := transcript.Stat()
-		if err != nil {
-			return fmt.Errorf("stat open provider transcript %q: %w", canonical, err)
-		}
-		if !info.Mode().IsRegular() {
-			return fmt.Errorf("provider transcript %q is not a regular file", canonical)
-		}
 		record.TranscriptPath = canonical
 	}
 	release, err := s.acquireSessionLock(record.Provider, record.SessionID)

--- a/sessions/store.go
+++ b/sessions/store.go
@@ -18,6 +18,7 @@ import (
 
 const schemaVersion = 1
 const maxTranscriptLineBytes = 16 * 1024 * 1024
+const defaultLockTimeout = 5 * time.Second
 
 type Provider string
 
@@ -29,11 +30,15 @@ const (
 type Store struct {
 	root               string
 	copyRawTranscripts bool
+	lockTimeout        time.Duration
+	env                map[string]string
 }
 
 type StoreOptions struct {
 	Root               string
 	CopyRawTranscripts bool
+	LockTimeout        time.Duration
+	Env                map[string]string
 }
 
 type SessionRecord struct {
@@ -90,7 +95,11 @@ func NewStore(opts StoreOptions) (*Store, error) {
 	if err := artifacts.EnsureCollection(root, "sessions"); err != nil {
 		return nil, fmt.Errorf("create session store: %w", err)
 	}
-	return &Store{root: root, copyRawTranscripts: opts.CopyRawTranscripts}, nil
+	lockTimeout := opts.LockTimeout
+	if lockTimeout <= 0 {
+		lockTimeout = defaultLockTimeout
+	}
+	return &Store{root: root, copyRawTranscripts: opts.CopyRawTranscripts, lockTimeout: lockTimeout, env: opts.Env}, nil
 }
 
 func DefaultRoot() (string, error) {
@@ -105,14 +114,47 @@ func (s *Store) Upsert(record SessionRecord) error {
 	if err := validateRecordKey(record.Provider, record.SessionID); err != nil {
 		return err
 	}
+	var transcript *os.File
+	if record.TranscriptPath != "" {
+		canonical, err := ValidateTranscriptPath(record.Provider, record.TranscriptPath, s.env)
+		if err != nil {
+			return err
+		}
+		transcript, err = os.Open(canonical)
+		if err != nil {
+			return fmt.Errorf("open provider transcript %q: %w", canonical, err)
+		}
+		defer transcript.Close()
+		info, err := transcript.Stat()
+		if err != nil {
+			return fmt.Errorf("stat open provider transcript %q: %w", canonical, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("provider transcript %q is not a regular file", canonical)
+		}
+		record.TranscriptPath = canonical
+	}
+	release, err := s.acquireSessionLock(record.Provider, record.SessionID)
+	if err != nil {
+		return err
+	}
+	defer release()
+	existing, ok, err := s.readMetadata(record.Provider, record.SessionID)
+	if err != nil {
+		return err
+	}
+	hasIncomingTranscript := record.TranscriptPath != ""
+	if ok {
+		record = mergeSessionRecord(existing, record)
+	}
 	if record.SchemaVersion == 0 {
 		record.SchemaVersion = schemaVersion
 	}
 	if err := s.writeMetadata(record); err != nil {
 		return err
 	}
-	if record.TranscriptPath != "" {
-		if err := s.writeTranscriptFiles(record); err != nil {
+	if hasIncomingTranscript {
+		if err := s.writeTranscriptFiles(record, transcript); err != nil {
 			return err
 		}
 	}
@@ -195,21 +237,36 @@ func (s *Store) MarkLaunchEnded(launchID string, endedAt time.Time) error {
 		if record.LaunchID != launchID {
 			continue
 		}
-		record.Status = "ended"
-		if record.EndedAt.IsZero() {
-			record.EndedAt = endedAt
-		}
-		if record.LastSeenAt.IsZero() || endedAt.After(record.LastSeenAt) {
-			record.LastSeenAt = endedAt
-		}
 		if err := validateRecordKey(record.Provider, record.SessionID); err != nil {
 			// Legacy records with unusable keys cannot be rewritten in place;
 			// skip them rather than abort updates for the remaining records.
 			continue
 		}
-		if err := s.writeMetadata(record); err != nil {
+		release, err := s.acquireSessionLock(record.Provider, record.SessionID)
+		if err != nil {
 			return err
 		}
+		current, ok, err := s.readMetadata(record.Provider, record.SessionID)
+		if err != nil {
+			release()
+			return err
+		}
+		if !ok || current.LaunchID != launchID {
+			release()
+			continue
+		}
+		current.Status = "ended"
+		if current.EndedAt.IsZero() {
+			current.EndedAt = endedAt
+		}
+		if current.LastSeenAt.IsZero() || endedAt.After(current.LastSeenAt) {
+			current.LastSeenAt = endedAt
+		}
+		if err := s.writeMetadata(current); err != nil {
+			release()
+			return err
+		}
+		release()
 	}
 	return nil
 }
@@ -225,6 +282,85 @@ func (s *Store) sessionDir(provider Provider, sessionID string) string {
 func safeSessionDirName(sessionID string) string {
 	sum := sha256.Sum256([]byte(sessionID))
 	return hex.EncodeToString(sum[:])
+}
+
+func (s *Store) acquireSessionLock(provider Provider, sessionID string) (func(), error) {
+	lockDir := filepath.Join(s.root, "sessions", ".locks")
+	if err := os.MkdirAll(lockDir, artifacts.DirPerm); err != nil {
+		return nil, fmt.Errorf("create session lock directory: %w", err)
+	}
+	if err := os.Chmod(lockDir, artifacts.DirPerm); err != nil {
+		return nil, fmt.Errorf("secure session lock directory: %w", err)
+	}
+	lockName := providerPathPart(provider) + "-" + safeSessionDirName(sessionID) + ".lock"
+	label := fmt.Sprintf("session lock %q/%q", provider, sessionID)
+	return artifacts.AcquireFileLock(filepath.Join(lockDir, lockName), label, s.lockTimeout)
+}
+
+func (s *Store) readMetadata(provider Provider, sessionID string) (SessionRecord, bool, error) {
+	data, err := os.ReadFile(filepath.Join(s.sessionDir(provider, sessionID), "meta.json"))
+	if os.IsNotExist(err) {
+		return SessionRecord{}, false, nil
+	}
+	if err != nil {
+		return SessionRecord{}, false, fmt.Errorf("read session metadata: %w", err)
+	}
+	var record SessionRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return SessionRecord{}, false, fmt.Errorf("decode session metadata: %w", err)
+	}
+	return record, true, nil
+}
+
+func mergeSessionRecord(existing, incoming SessionRecord) SessionRecord {
+	incoming.Provider = existing.Provider
+	incoming.SessionID = existing.SessionID
+	if incoming.SchemaVersion == 0 {
+		incoming.SchemaVersion = existing.SchemaVersion
+	}
+	preserveBlank := func(value *string, old string) {
+		if *value == "" {
+			*value = old
+		}
+	}
+	preserveBlank(&incoming.LaunchID, existing.LaunchID)
+	preserveBlank(&incoming.Status, existing.Status)
+	preserveBlank(&incoming.CWD, existing.CWD)
+	preserveBlank(&incoming.RepoPath, existing.RepoPath)
+	preserveBlank(&incoming.WorktreePath, existing.WorktreePath)
+	preserveBlank(&incoming.PlanID, existing.PlanID)
+	preserveBlank(&incoming.PlanPath, existing.PlanPath)
+	preserveBlank(&incoming.FlowID, existing.FlowID)
+	preserveBlank(&incoming.FlowPhaseID, existing.FlowPhaseID)
+	preserveBlank(&incoming.Branch, existing.Branch)
+	preserveBlank(&incoming.Commit, existing.Commit)
+	preserveBlank(&incoming.Model, existing.Model)
+	preserveBlank(&incoming.Summary, existing.Summary)
+	preserveBlank(&incoming.TranscriptPath, existing.TranscriptPath)
+	preserveBlank(&incoming.CaptureSource, existing.CaptureSource)
+	if existing.Status == "ended" {
+		incoming.Status = "ended"
+	}
+	incoming.StartedAt = earliestNonzero(existing.StartedAt, incoming.StartedAt)
+	incoming.LastSeenAt = latestTime(existing.LastSeenAt, incoming.LastSeenAt)
+	if !existing.EndedAt.IsZero() {
+		incoming.EndedAt = existing.EndedAt
+	}
+	return incoming
+}
+
+func earliestNonzero(a, b time.Time) time.Time {
+	if a.IsZero() || (!b.IsZero() && b.Before(a)) {
+		return b
+	}
+	return a
+}
+
+func latestTime(a, b time.Time) time.Time {
+	if b.After(a) {
+		return b
+	}
+	return a
 }
 
 func validateRecordKey(provider Provider, sessionID string) error {
@@ -283,34 +419,22 @@ func sortTime(record SessionRecord) time.Time {
 	return record.StartedAt
 }
 
-func (s *Store) writeTranscriptFiles(record SessionRecord) error {
-	input, err := os.Open(record.TranscriptPath)
-	if err != nil {
-		return fmt.Errorf("read provider transcript: %w", err)
-	}
-	defer input.Close()
-
+func (s *Store) writeTranscriptFiles(record SessionRecord, input *os.File) error {
 	dir := s.sessionDir(record.Provider, record.SessionID)
 	if s.copyRawTranscripts {
-		if err := copyFile(record.TranscriptPath, filepath.Join(dir, "raw.jsonl")); err != nil {
-			return err
+		if _, err := input.Seek(0, 0); err != nil {
+			return fmt.Errorf("rewind provider transcript for raw copy: %w", err)
 		}
+		if err := artifacts.WriteFileAtomicFromReader(filepath.Join(dir, "raw.jsonl"), input); err != nil {
+			return fmt.Errorf("write raw transcript: %w", err)
+		}
+	}
+	if _, err := input.Seek(0, 0); err != nil {
+		return fmt.Errorf("rewind provider transcript for normalization: %w", err)
 	}
 
 	if err := writeNormalizedTranscript(filepath.Join(dir, "transcript.jsonl"), input); err != nil {
 		return fmt.Errorf("write normalized transcript: %w", err)
-	}
-	return nil
-}
-
-func copyFile(src, dst string) error {
-	input, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("read raw transcript: %w", err)
-	}
-	defer input.Close()
-	if err := artifacts.WriteFileAtomicFromReader(dst, input); err != nil {
-		return fmt.Errorf("write raw transcript: %w", err)
 	}
 	return nil
 }

--- a/sessions/store.go
+++ b/sessions/store.go
@@ -32,7 +32,10 @@ type Store struct {
 	copyRawTranscripts bool
 	lockTimeout        time.Duration
 	env                map[string]string
+	launchStale        launchStaleFunc
 }
+
+type launchStaleFunc func(existing, incoming SessionRecord) (stale, known bool)
 
 type StoreOptions struct {
 	Root               string
@@ -111,8 +114,13 @@ func DefaultRoot() (string, error) {
 }
 
 func (s *Store) Upsert(record SessionRecord) error {
+	_, err := s.upsert(record)
+	return err
+}
+
+func (s *Store) upsert(record SessionRecord) (SessionRecord, error) {
 	if err := validateRecordKey(record.Provider, record.SessionID); err != nil {
-		return err
+		return SessionRecord{}, err
 	}
 	var transcript *os.File
 	if record.TranscriptPath != "" {
@@ -120,36 +128,39 @@ func (s *Store) Upsert(record SessionRecord) error {
 		var err error
 		transcript, canonical, err = openValidatedTranscript(record.Provider, record.TranscriptPath, s.env)
 		if err != nil {
-			return err
+			return SessionRecord{}, err
 		}
 		defer transcript.Close()
 		record.TranscriptPath = canonical
 	}
 	release, err := s.acquireSessionLock(record.Provider, record.SessionID)
 	if err != nil {
-		return err
+		return SessionRecord{}, err
 	}
 	defer release()
 	existing, ok, err := s.readMetadata(record.Provider, record.SessionID)
 	if err != nil {
-		return err
+		return SessionRecord{}, err
 	}
 	hasIncomingTranscript := record.TranscriptPath != ""
 	if ok {
+		if s.isStaleLaunchUpdate(existing, record) {
+			return existing, nil
+		}
 		record = mergeSessionRecord(existing, record)
 	}
 	if record.SchemaVersion == 0 {
 		record.SchemaVersion = schemaVersion
 	}
 	if err := s.writeMetadata(record); err != nil {
-		return err
+		return SessionRecord{}, err
 	}
 	if hasIncomingTranscript {
 		if err := s.writeTranscriptFiles(record, transcript); err != nil {
-			return err
+			return SessionRecord{}, err
 		}
 	}
-	return nil
+	return record, nil
 }
 
 func (s *Store) writeMetadata(record SessionRecord) error {
@@ -246,9 +257,10 @@ func (s *Store) MarkLaunchEnded(launchID string, endedAt time.Time) error {
 			release()
 			continue
 		}
+		wasEnded := current.Status == "ended"
 		current.Status = "ended"
-		if current.EndedAt.IsZero() {
-			current.EndedAt = endedAt
+		if current.EndedAt.IsZero() || !wasEnded {
+			current.EndedAt = latestTime(current.EndedAt, endedAt)
 		}
 		if current.LastSeenAt.IsZero() || endedAt.After(current.LastSeenAt) {
 			current.LastSeenAt = endedAt
@@ -306,6 +318,7 @@ func (s *Store) readMetadata(provider Provider, sessionID string) (SessionRecord
 func mergeSessionRecord(existing, incoming SessionRecord) SessionRecord {
 	incoming.Provider = existing.Provider
 	incoming.SessionID = existing.SessionID
+	newerLaunch := incoming.LaunchID != "" && incoming.LaunchID != existing.LaunchID
 	if incoming.SchemaVersion == 0 {
 		incoming.SchemaVersion = existing.SchemaVersion
 	}
@@ -329,15 +342,25 @@ func mergeSessionRecord(existing, incoming SessionRecord) SessionRecord {
 	preserveBlank(&incoming.Summary, existing.Summary)
 	preserveBlank(&incoming.TranscriptPath, existing.TranscriptPath)
 	preserveBlank(&incoming.CaptureSource, existing.CaptureSource)
-	if existing.Status == "ended" {
+	if existing.Status == "ended" && !newerLaunch {
 		incoming.Status = "ended"
 	}
 	incoming.StartedAt = earliestNonzero(existing.StartedAt, incoming.StartedAt)
 	incoming.LastSeenAt = latestTime(existing.LastSeenAt, incoming.LastSeenAt)
-	if !existing.EndedAt.IsZero() {
-		incoming.EndedAt = existing.EndedAt
-	}
+	incoming.EndedAt = latestTime(existing.EndedAt, incoming.EndedAt)
 	return incoming
+}
+
+func (s *Store) isStaleLaunchUpdate(existing, incoming SessionRecord) bool {
+	if incoming.LaunchID == "" || incoming.LaunchID == existing.LaunchID {
+		return false
+	}
+	if s.launchStale != nil {
+		if stale, known := s.launchStale(existing, incoming); known {
+			return stale
+		}
+	}
+	return !sortTime(incoming).After(sortTime(existing))
 }
 
 func earliestNonzero(a, b time.Time) time.Time {

--- a/sessions/store.go
+++ b/sessions/store.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -334,8 +335,10 @@ func mergeSessionRecord(existing, incoming SessionRecord) SessionRecord {
 	preserveBlank(&incoming.WorktreePath, existing.WorktreePath)
 	preserveBlank(&incoming.PlanID, existing.PlanID)
 	preserveBlank(&incoming.PlanPath, existing.PlanPath)
-	preserveBlank(&incoming.FlowID, existing.FlowID)
-	preserveBlank(&incoming.FlowPhaseID, existing.FlowPhaseID)
+	if !newerLaunch {
+		preserveBlank(&incoming.FlowID, existing.FlowID)
+		preserveBlank(&incoming.FlowPhaseID, existing.FlowPhaseID)
+	}
 	preserveBlank(&incoming.Branch, existing.Branch)
 	preserveBlank(&incoming.Commit, existing.Commit)
 	preserveBlank(&incoming.Model, existing.Model)
@@ -360,7 +363,24 @@ func (s *Store) isStaleLaunchUpdate(existing, incoming SessionRecord) bool {
 			return stale
 		}
 	}
+	existingOrder, existingOrdered := wtuiLaunchOrder(existing.LaunchID)
+	incomingOrder, incomingOrdered := wtuiLaunchOrder(incoming.LaunchID)
+	if existingOrdered && incomingOrdered && existingOrder != incomingOrder {
+		return incomingOrder < existingOrder
+	}
 	return !sortTime(incoming).After(sortTime(existing))
+}
+
+func wtuiLaunchOrder(launchID string) (int64, bool) {
+	value, ok := strings.CutPrefix(launchID, "wtui-")
+	if !ok {
+		return 0, false
+	}
+	if timestamp, _, found := strings.Cut(value, "-"); found {
+		value = timestamp
+	}
+	order, err := strconv.ParseInt(value, 10, 64)
+	return order, err == nil
 }
 
 func earliestNonzero(a, b time.Time) time.Time {

--- a/sessions/store_test.go
+++ b/sessions/store_test.go
@@ -115,6 +115,129 @@ func TestStoreUpsertUpdatesExistingSession(t *testing.T) {
 	}
 }
 
+func TestStoreUpsertUsesLatestEndTimeAcrossResumedLaunches(t *testing.T) {
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	firstEnd := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	secondEnd := firstEnd.Add(time.Hour)
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:   sessions.ProviderCodex,
+		SessionID:  "resumed-session",
+		LaunchID:   "launch-1",
+		Status:     "ended",
+		EndedAt:    firstEnd,
+		LastSeenAt: firstEnd,
+	}); err != nil {
+		t.Fatalf("first Upsert() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:   sessions.ProviderCodex,
+		SessionID:  "resumed-session",
+		LaunchID:   "launch-2",
+		Status:     "ended",
+		EndedAt:    secondEnd,
+		LastSeenAt: secondEnd,
+	}); err != nil {
+		t.Fatalf("resumed Upsert() error = %v", err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("List() returned %d records, want 1", len(records))
+	}
+	got := records[0]
+	if got.LaunchID != "launch-2" || !got.EndedAt.Equal(secondEnd) {
+		t.Fatalf("resumed session launch/end = %q/%s, want launch-2/%s", got.LaunchID, got.EndedAt, secondEnd)
+	}
+}
+
+func TestStoreUpsertDoesNotRegressToStaleLaunch(t *testing.T) {
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	firstEnd := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	secondEnd := firstEnd.Add(time.Hour)
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:   sessions.ProviderCodex,
+		SessionID:  "shared-session",
+		LaunchID:   "launch-2",
+		Status:     "ended",
+		EndedAt:    secondEnd,
+		LastSeenAt: secondEnd,
+	}); err != nil {
+		t.Fatalf("current Upsert() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:   sessions.ProviderCodex,
+		SessionID:  "shared-session",
+		LaunchID:   "launch-1",
+		Status:     "last_seen",
+		LastSeenAt: firstEnd,
+	}); err != nil {
+		t.Fatalf("stale Upsert() error = %v", err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("List() returned %d records, want 1", len(records))
+	}
+	got := records[0]
+	if got.LaunchID != "launch-2" || got.Status != "ended" || !got.EndedAt.Equal(secondEnd) {
+		t.Fatalf("session regressed after stale launch update: %#v", got)
+	}
+}
+
+func TestStoreUpsertIgnoresStaleEndedLaunchWhileResumeIsActive(t *testing.T) {
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	oldEnd := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	resumeSeen := oldEnd.Add(time.Hour)
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:   sessions.ProviderClaude,
+		SessionID:  "shared-session",
+		LaunchID:   "launch-2",
+		Status:     "last_seen",
+		LastSeenAt: resumeSeen,
+		Summary:    "current launch",
+	}); err != nil {
+		t.Fatalf("current Upsert() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:   sessions.ProviderClaude,
+		SessionID:  "shared-session",
+		LaunchID:   "launch-1",
+		Status:     "ended",
+		EndedAt:    oldEnd,
+		LastSeenAt: oldEnd,
+		Summary:    "stale launch",
+	}); err != nil {
+		t.Fatalf("stale Upsert() error = %v", err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("List() returned %d records, want 1", len(records))
+	}
+	got := records[0]
+	if got.LaunchID != "launch-2" || got.Status != "last_seen" || !got.EndedAt.IsZero() || got.Summary != "current launch" {
+		t.Fatalf("active resume changed after stale ended update: %#v", got)
+	}
+}
+
 func TestStoreConcurrentUpsertAndMarkLaunchEndedMergeWithoutLostUpdate(t *testing.T) {
 	root := t.TempDir()
 	store1, err := sessions.NewStore(sessions.StoreOptions{Root: root, LockTimeout: time.Second})
@@ -370,6 +493,50 @@ func TestStoreMarksLaunchEnded(t *testing.T) {
 	got := records[0]
 	if got.Status != "ended" || !got.EndedAt.Equal(endedAt) || !got.LastSeenAt.Equal(endedAt) {
 		t.Fatalf("launch was not ended: %#v", got)
+	}
+}
+
+func TestStoreMarkLaunchEndedAdvancesResumedLaunch(t *testing.T) {
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	firstEnd := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	resumeSeen := firstEnd.Add(30 * time.Minute)
+	secondEnd := firstEnd.Add(time.Hour)
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:   sessions.ProviderClaude,
+		SessionID:  "resumed-session",
+		LaunchID:   "launch-1",
+		Status:     "ended",
+		EndedAt:    firstEnd,
+		LastSeenAt: firstEnd,
+	}); err != nil {
+		t.Fatalf("first Upsert() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:   sessions.ProviderClaude,
+		SessionID:  "resumed-session",
+		LaunchID:   "launch-2",
+		Status:     "last_seen",
+		LastSeenAt: resumeSeen,
+	}); err != nil {
+		t.Fatalf("resumed Upsert() error = %v", err)
+	}
+	if err := store.MarkLaunchEnded("launch-2", secondEnd); err != nil {
+		t.Fatalf("MarkLaunchEnded() error = %v", err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("List() returned %d records, want 1", len(records))
+	}
+	got := records[0]
+	if got.LaunchID != "launch-2" || got.Status != "ended" || !got.EndedAt.Equal(secondEnd) || !got.LastSeenAt.Equal(secondEnd) {
+		t.Fatalf("finalized resumed session = %#v, want launch-2 ended at %s", got, secondEnd)
 	}
 }
 

--- a/sessions/store_test.go
+++ b/sessions/store_test.go
@@ -1,12 +1,15 @@
 package sessions_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/brian-bell/wtui/internal/artifacts"
 	"github.com/brian-bell/wtui/sessions"
 )
 
@@ -112,6 +115,158 @@ func TestStoreUpsertUpdatesExistingSession(t *testing.T) {
 	}
 }
 
+func TestStoreConcurrentUpsertAndMarkLaunchEndedMergeWithoutLostUpdate(t *testing.T) {
+	root := t.TempDir()
+	store1, err := sessions.NewStore(sessions.StoreOptions{Root: root, LockTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("NewStore(first) error = %v", err)
+	}
+	store2, err := sessions.NewStore(sessions.StoreOptions{Root: root, LockTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("NewStore(second) error = %v", err)
+	}
+	started := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	if err := store1.Upsert(sessions.SessionRecord{
+		Provider:   sessions.ProviderCodex,
+		SessionID:  "shared-session",
+		LaunchID:   "launch-1",
+		Status:     "last_seen",
+		StartedAt:  started,
+		LastSeenAt: started.Add(time.Minute),
+		Summary:    "old summary",
+	}); err != nil {
+		t.Fatalf("seed Upsert() error = %v", err)
+	}
+
+	sum := sha256.Sum256([]byte("shared-session"))
+	lockDir := filepath.Join(root, "sessions", ".locks")
+	if err := os.MkdirAll(lockDir, 0o700); err != nil {
+		t.Fatalf("create lock dir: %v", err)
+	}
+	lockPath := filepath.Join(lockDir, "codex-"+hex.EncodeToString(sum[:])+".lock")
+	release, err := artifacts.AcquireFileLock(lockPath, "test session lock", time.Second)
+	if err != nil {
+		t.Fatalf("hold session lock: %v", err)
+	}
+
+	results := make(chan error, 2)
+	go func() {
+		results <- store1.Upsert(sessions.SessionRecord{
+			Provider:   sessions.ProviderCodex,
+			SessionID:  "shared-session",
+			LaunchID:   "launch-1",
+			Status:     "last_seen",
+			StartedAt:  started.Add(-time.Hour),
+			LastSeenAt: started.Add(2 * time.Minute),
+			Summary:    "new summary",
+		})
+	}()
+	go func() {
+		results <- store2.MarkLaunchEnded("launch-1", started.Add(3*time.Minute))
+	}()
+	select {
+	case err := <-results:
+		release()
+		t.Fatalf("session mutation completed while lock was held: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	release()
+	for range 2 {
+		if err := <-results; err != nil {
+			t.Fatalf("concurrent session mutation error = %v", err)
+		}
+	}
+
+	records, err := store1.List(sessions.SessionFilter{})
+	if err != nil || len(records) != 1 {
+		t.Fatalf("List() = %#v, %v; want one record", records, err)
+	}
+	got := records[0]
+	if got.Summary != "new summary" || got.Status != "ended" {
+		t.Fatalf("merged session summary/status = %q/%q", got.Summary, got.Status)
+	}
+	if !got.StartedAt.Equal(started.Add(-time.Hour)) || !got.EndedAt.Equal(started.Add(3*time.Minute)) || !got.LastSeenAt.Equal(started.Add(3*time.Minute)) {
+		t.Fatalf("merged session timestamps = started %v ended %v last-seen %v", got.StartedAt, got.EndedAt, got.LastSeenAt)
+	}
+}
+
+func TestStoreTranscriptPathMustBeRegularFileInsideProviderRoot(t *testing.T) {
+	stateRoot := t.TempDir()
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	transcriptRoot := filepath.Join(codexHome, "sessions")
+	if err := os.MkdirAll(transcriptRoot, 0o700); err != nil {
+		t.Fatalf("create transcript root: %v", err)
+	}
+	validPath := filepath.Join(transcriptRoot, "session.jsonl")
+	if err := os.WriteFile(validPath, []byte(`{"role":"user","kind":"message","text":"hello"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write valid transcript: %v", err)
+	}
+	store, err := sessions.NewStore(sessions.StoreOptions{
+		Root: stateRoot,
+		Env:  map[string]string{"CODEX_HOME": codexHome, "HOME": t.TempDir()},
+	})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{Provider: sessions.ProviderCodex, SessionID: "valid", TranscriptPath: validPath}); err != nil {
+		t.Fatalf("valid in-root Upsert() error = %v", err)
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside.jsonl")
+	if err := os.WriteFile(outside, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write outside transcript: %v", err)
+	}
+	symlink := filepath.Join(transcriptRoot, "escape.jsonl")
+	if err := os.Symlink(outside, symlink); err != nil {
+		t.Fatalf("create transcript symlink: %v", err)
+	}
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "relative", path: "session.jsonl"},
+		{name: "outside", path: outside},
+		{name: "symlink escape", path: symlink},
+		{name: "directory", path: transcriptRoot},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessionID := "rejected-" + strings.ReplaceAll(tt.name, " ", "-")
+			err := store.Upsert(sessions.SessionRecord{Provider: sessions.ProviderCodex, SessionID: sessionID, TranscriptPath: tt.path})
+			if err == nil {
+				t.Fatalf("Upsert(%q) error = nil, want transcript rejection", tt.path)
+			}
+			sum := sha256.Sum256([]byte(sessionID))
+			dir := filepath.Join(stateRoot, "sessions", "codex", hex.EncodeToString(sum[:]))
+			if _, statErr := os.Stat(dir); !os.IsNotExist(statErr) {
+				t.Fatalf("rejected transcript created session artifacts at %s: %v", dir, statErr)
+			}
+		})
+	}
+}
+
+func TestStoreUpsertReportsSessionLockTimeout(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root, LockTimeout: 10 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{Provider: sessions.ProviderCodex, SessionID: "locked"}); err != nil {
+		t.Fatalf("seed Upsert() error = %v", err)
+	}
+	sum := sha256.Sum256([]byte("locked"))
+	lockPath := filepath.Join(root, "sessions", ".locks", "codex-"+hex.EncodeToString(sum[:])+".lock")
+	release, err := artifacts.AcquireFileLock(lockPath, "test session lock", time.Second)
+	if err != nil {
+		t.Fatalf("hold session lock: %v", err)
+	}
+	defer release()
+	err = store.Upsert(sessions.SessionRecord{Provider: sessions.ProviderCodex, SessionID: "locked", Summary: "new"})
+	if err == nil || !strings.Contains(err.Error(), "timed out waiting for session lock") {
+		t.Fatalf("Upsert() error = %v, want bounded session lock timeout", err)
+	}
+}
+
 func TestStoreListSkipsCorruptMetadata(t *testing.T) {
 	root := t.TempDir()
 	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
@@ -145,7 +300,7 @@ func TestStoreListSkipsCorruptMetadata(t *testing.T) {
 
 func TestStoreWritesArtifactsWithRestrictivePermissions(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "state")
-	providerTranscript := filepath.Join(t.TempDir(), "provider.jsonl")
+	providerTranscript := providerTranscriptPath(t, sessions.ProviderCodex, "provider.jsonl")
 	if err := os.WriteFile(providerTranscript, []byte(`{"role":"user","kind":"message","text":"hello"}`+"\n"), 0o600); err != nil {
 		t.Fatalf("write provider transcript: %v", err)
 	}
@@ -177,7 +332,7 @@ func TestStoreWritesArtifactsWithRestrictivePermissions(t *testing.T) {
 func TestStoreMarksLaunchEnded(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")
-	transcriptPath := filepath.Join(root, "codex.jsonl")
+	transcriptPath := providerTranscriptPath(t, sessions.ProviderCodex, "codex.jsonl")
 	if err := os.WriteFile(transcriptPath, []byte(`{"role":"user","kind":"message","text":"hello"}`+"\n"), 0o600); err != nil {
 		t.Fatalf("write transcript: %v", err)
 	}
@@ -374,7 +529,7 @@ func TestNewStoreRejectsRelativeRoot(t *testing.T) {
 
 func TestStoreCopiesRawTranscriptAndReadsNormalizedEvents(t *testing.T) {
 	root := t.TempDir()
-	providerTranscript := filepath.Join(root, "provider.jsonl")
+	providerTranscript := providerTranscriptPath(t, sessions.ProviderCodex, "provider.jsonl")
 	providerData := []byte(`{"timestamp":"2026-06-06T14:01:00Z","role":"user","kind":"message","text":"Implement the sessions view"}
 {"timestamp":"2026-06-06T14:02:00Z","role":"assistant","kind":"internal","text":"hidden provider-private note"}
 {"timestamp":"2026-06-06T14:03:00Z","role":"assistant","kind":"message","text":"Done"}
@@ -471,7 +626,7 @@ func TestStoreRejectsUnsupportedProviderAndCannotEscapeStateRoot(t *testing.T) {
 
 func TestStoreNormalizesProviderNativeTranscriptLines(t *testing.T) {
 	root := t.TempDir()
-	providerTranscript := filepath.Join(root, "provider.jsonl")
+	providerTranscript := providerTranscriptPath(t, sessions.ProviderClaude, "provider.jsonl")
 	providerData := []byte(`{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}
 {"type":"assistant","message":{"role":"assistant","content":"hi there"}}
 {"type":"system","content":"hidden"}
@@ -505,7 +660,7 @@ func TestStoreNormalizesProviderNativeTranscriptLines(t *testing.T) {
 
 func TestStoreNormalizesRoleContentTranscriptLines(t *testing.T) {
 	root := t.TempDir()
-	providerTranscript := filepath.Join(root, "provider.jsonl")
+	providerTranscript := providerTranscriptPath(t, sessions.ProviderCodex, "provider.jsonl")
 	providerData := []byte(`{"role":"user","content":"hello from content"}
 {"role":"assistant","content":[{"type":"text","text":"hi from array"},{"type":"text","text":"second part"}]}
 `)
@@ -541,7 +696,7 @@ func TestStoreNormalizesRoleContentTranscriptLines(t *testing.T) {
 
 func TestStoreReadsTranscriptLinesLargerThanScannerDefault(t *testing.T) {
 	root := t.TempDir()
-	providerTranscript := filepath.Join(root, "large.jsonl")
+	providerTranscript := providerTranscriptPath(t, sessions.ProviderCodex, "large.jsonl")
 	largeText := strings.Repeat("x", 70*1024)
 	if err := os.WriteFile(providerTranscript, []byte(`{"role":"assistant","kind":"message","text":`+quoteJSON(largeText)+`}`+"\n"), 0o600); err != nil {
 		t.Fatalf("write provider transcript: %v", err)
@@ -588,4 +743,24 @@ func assertMode(t *testing.T, path string, want os.FileMode) {
 	if got := info.Mode().Perm(); got != want {
 		t.Fatalf("%s mode = %o, want %o", path, got, want)
 	}
+}
+
+func providerTranscriptPath(t *testing.T, provider sessions.Provider, name string) string {
+	t.Helper()
+	base := t.TempDir()
+	var root string
+	switch provider {
+	case sessions.ProviderCodex:
+		t.Setenv("CODEX_HOME", base)
+		root = filepath.Join(base, "sessions")
+	case sessions.ProviderClaude:
+		t.Setenv("CLAUDE_CONFIG_DIR", base)
+		root = filepath.Join(base, "projects")
+	default:
+		t.Fatalf("unsupported test provider %q", provider)
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("create provider transcript root: %v", err)
+	}
+	return filepath.Join(root, name)
 }

--- a/sessions/transcript_path.go
+++ b/sessions/transcript_path.go
@@ -5,47 +5,86 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
 
 // ValidateTranscriptPath canonicalizes an existing provider transcript and
 // rejects paths outside that provider's configured transcript root.
 func ValidateTranscriptPath(provider Provider, path string, env map[string]string) (string, error) {
+	canonicalPath, _, err := validateTranscriptPath(provider, path, env)
+	return canonicalPath, err
+}
+
+func validateTranscriptPath(provider Provider, path string, env map[string]string) (string, os.FileInfo, error) {
 	if path == "" {
-		return "", nil
+		return "", nil, nil
 	}
 	if !filepath.IsAbs(path) {
-		return "", fmt.Errorf("provider transcript path must be absolute: %q", path)
+		return "", nil, fmt.Errorf("provider transcript path must be absolute: %q", path)
 	}
 	root, err := providerTranscriptRoot(provider, env)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if !filepath.IsAbs(root) {
-		return "", fmt.Errorf("%s transcript root must be absolute: %q", provider, root)
+		return "", nil, fmt.Errorf("%s transcript root must be absolute: %q", provider, root)
 	}
 	canonicalRoot, err := filepath.EvalSymlinks(root)
 	if err != nil {
-		return "", fmt.Errorf("resolve %s transcript root %q: %w", provider, root, err)
+		return "", nil, fmt.Errorf("resolve %s transcript root %q: %w", provider, root, err)
 	}
 	canonicalPath, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return "", fmt.Errorf("resolve provider transcript %q: %w", path, err)
+		return "", nil, fmt.Errorf("resolve provider transcript %q: %w", path, err)
 	}
 	rel, err := filepath.Rel(canonicalRoot, canonicalPath)
 	if err != nil {
-		return "", fmt.Errorf("check provider transcript containment: %w", err)
+		return "", nil, fmt.Errorf("check provider transcript containment: %w", err)
 	}
 	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
-		return "", fmt.Errorf("provider transcript %q is outside expected %s root %q", path, provider, canonicalRoot)
+		return "", nil, fmt.Errorf("provider transcript %q is outside expected %s root %q", path, provider, canonicalRoot)
 	}
 	info, err := os.Stat(canonicalPath)
 	if err != nil {
-		return "", fmt.Errorf("stat provider transcript %q: %w", canonicalPath, err)
+		return "", nil, fmt.Errorf("stat provider transcript %q: %w", canonicalPath, err)
 	}
 	if !info.Mode().IsRegular() {
-		return "", fmt.Errorf("provider transcript %q is not a regular file", canonicalPath)
+		return "", nil, fmt.Errorf("provider transcript %q is not a regular file", canonicalPath)
 	}
-	return canonicalPath, nil
+	return canonicalPath, info, nil
+}
+
+func openValidatedTranscript(provider Provider, path string, env map[string]string) (*os.File, string, error) {
+	canonicalPath, validatedInfo, err := validateTranscriptPath(provider, path, env)
+	if err != nil {
+		return nil, "", err
+	}
+	file, err := openValidatedTranscriptFile(canonicalPath, validatedInfo)
+	if err != nil {
+		return nil, "", err
+	}
+	return file, canonicalPath, nil
+}
+
+func openValidatedTranscriptFile(path string, validatedInfo os.FileInfo) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open validated provider transcript %q: %w", path, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, fmt.Errorf("stat open provider transcript %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		file.Close()
+		return nil, fmt.Errorf("provider transcript %q is not a regular file", path)
+	}
+	if validatedInfo == nil || !os.SameFile(validatedInfo, info) {
+		file.Close()
+		return nil, fmt.Errorf("provider transcript %q changed after validation", path)
+	}
+	return file, nil
 }
 
 func providerTranscriptRoot(provider Provider, env map[string]string) (string, error) {

--- a/sessions/transcript_path.go
+++ b/sessions/transcript_path.go
@@ -1,0 +1,81 @@
+package sessions
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ValidateTranscriptPath canonicalizes an existing provider transcript and
+// rejects paths outside that provider's configured transcript root.
+func ValidateTranscriptPath(provider Provider, path string, env map[string]string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("provider transcript path must be absolute: %q", path)
+	}
+	root, err := providerTranscriptRoot(provider, env)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsAbs(root) {
+		return "", fmt.Errorf("%s transcript root must be absolute: %q", provider, root)
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s transcript root %q: %w", provider, root, err)
+	}
+	canonicalPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve provider transcript %q: %w", path, err)
+	}
+	rel, err := filepath.Rel(canonicalRoot, canonicalPath)
+	if err != nil {
+		return "", fmt.Errorf("check provider transcript containment: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("provider transcript %q is outside expected %s root %q", path, provider, canonicalRoot)
+	}
+	info, err := os.Stat(canonicalPath)
+	if err != nil {
+		return "", fmt.Errorf("stat provider transcript %q: %w", canonicalPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("provider transcript %q is not a regular file", canonicalPath)
+	}
+	return canonicalPath, nil
+}
+
+func providerTranscriptRoot(provider Provider, env map[string]string) (string, error) {
+	value := func(key string) string {
+		if env != nil {
+			if value, ok := env[key]; ok {
+				return value
+			}
+		}
+		return os.Getenv(key)
+	}
+	home := value("HOME")
+	switch provider {
+	case ProviderCodex:
+		if codexHome := value("CODEX_HOME"); codexHome != "" {
+			return filepath.Join(codexHome, "sessions"), nil
+		}
+		if home == "" {
+			return "", fmt.Errorf("resolve Codex transcript root: HOME is unset")
+		}
+		return filepath.Join(home, ".codex", "sessions"), nil
+	case ProviderClaude:
+		if claudeConfigDir := value("CLAUDE_CONFIG_DIR"); claudeConfigDir != "" {
+			return filepath.Join(claudeConfigDir, "projects"), nil
+		}
+		if home == "" {
+			return "", fmt.Errorf("resolve Claude transcript root: HOME is unset")
+		}
+		return filepath.Join(home, ".claude", "projects"), nil
+	default:
+		return "", fmt.Errorf("unsupported session provider %q", provider)
+	}
+}

--- a/sessions/transcript_path_internal_test.go
+++ b/sessions/transcript_path_internal_test.go
@@ -1,0 +1,75 @@
+package sessions
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestOpenValidatedTranscriptFileRejectsReplacementAfterValidation(t *testing.T) {
+	root := t.TempDir()
+	validatedPath := filepath.Join(root, "transcript.jsonl")
+	if err := os.WriteFile(validatedPath, []byte("validated\n"), 0o600); err != nil {
+		t.Fatalf("write validated transcript: %v", err)
+	}
+	validatedInfo, err := os.Stat(validatedPath)
+	if err != nil {
+		t.Fatalf("stat validated transcript: %v", err)
+	}
+
+	outsidePath := filepath.Join(t.TempDir(), "outside.jsonl")
+	if err := os.WriteFile(outsidePath, []byte("outside\n"), 0o600); err != nil {
+		t.Fatalf("write outside transcript: %v", err)
+	}
+	if err := os.Remove(validatedPath); err != nil {
+		t.Fatalf("remove validated transcript: %v", err)
+	}
+	if err := os.Symlink(outsidePath, validatedPath); err != nil {
+		t.Fatalf("replace transcript with symlink: %v", err)
+	}
+
+	file, err := openValidatedTranscriptFile(validatedPath, validatedInfo)
+	if file != nil {
+		file.Close()
+	}
+	if err == nil {
+		t.Fatal("openValidatedTranscriptFile() error = nil, want replacement rejection")
+	}
+}
+
+func TestOpenValidatedTranscriptFileDoesNotBlockOnFIFOReplacement(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	if err := os.WriteFile(path, []byte("validated\n"), 0o600); err != nil {
+		t.Fatalf("write validated transcript: %v", err)
+	}
+	validatedInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat validated transcript: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove validated transcript: %v", err)
+	}
+	if err := syscall.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("replace transcript with FIFO: %v", err)
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		file, err := openValidatedTranscriptFile(path, validatedInfo)
+		if file != nil {
+			file.Close()
+		}
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("openValidatedTranscriptFile() error = nil, want FIFO rejection")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("openValidatedTranscriptFile() blocked on FIFO replacement")
+	}
+}


### PR DESCRIPTION
## Summary

Addresses all four P0 findings in #277, including the config lost-update path associated with P0 #3.

- keeps Bubble Tea responsive while an interactive Flow terminal waits for prompt readiness and receives its prefill
- moves Flow resume tracking, session finalization, and launch-failure persistence out of `Model.Update`
- prevents cross-process lost updates in Flow, session, plan, and config artifacts with a shared bounded file-lock primitive
- rejects untrusted transcript paths unless they resolve to regular files inside the configured Codex or Claude transcript root

No artifact schema or CLI syntax migration is required.

## Implementation

- Reserves embedded-terminal slots by stable ID before asynchronous prefill, leaves pending terminals unfocused and non-selectable, starts repaint ticks immediately, and handles stale results idempotently.
- Sequences Flow resume persistence before terminal startup and routes finalization/failure mutations through `tea.Cmd` result messages.
- Extracts bounded advisory locking into `internal/artifacts`, preserving restrictive lock permissions, PID diagnostics, bounded retries, and Flow lock error behavior.
- Adds deterministic session merge rules for identity, status, and timestamps; session writers reread metadata while holding the per-session lock.
- Serializes plan mutations collection-wide so generated IDs and concurrent `Save`/`SetPhase` calls cannot collide or overwrite one another.
- Serializes config save/reset read-modify-write operations through a sibling lock.
- Resolves transcript roots from `CODEX_HOME` and `CLAUDE_CONFIG_DIR` with documented defaults, canonicalizes paths, prevents symlink escapes, validates again in the store, and reuses one open descriptor for normalized and optional raw copies.

## Verification

- `go test -race ./model ./sessions ./planstore ./config ./flowstore`
- `gofmt -l .`
- `make test`
- `make build`
- `git diff --check`

Autoreview completed with no accepted findings. One proposed P2 was rejected as unreachable: AutoMode launches are forced headless, while interactive prefill requires a non-headless launch; focused tests pin both invariants.
