### PR TITLE
Add claude-opus-5 and gpt-5.6-sol model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,9 +677,10 @@ for compatibility. The same root is resolved to an absolute path when used as
 the parent directory for left-pane repo creation.
 `[agent].codex_reasoning_effort` and `[agent].claude_reasoning_effort`
 configure provider-specific effort for new CLI agent launches; empty or
-`default` keeps provider defaults. `[agent].codex_model` supports `default` and
-`gpt-5.5`; `[agent].claude_model` supports `default`, `claude-opus-4-8`,
-`claude-sonnet-5`, and `claude-fable-5`. Empty or `default` omits the model
+`default` keeps provider defaults. `[agent].codex_model` supports `default`,
+`gpt-5.5`, and `gpt-5.6-sol`; `[agent].claude_model` supports `default`,
+`claude-opus-4-8`, `claude-opus-5`, `claude-sonnet-5`, and `claude-fable-5`.
+Empty or `default` omits the model
 override and keeps provider defaults. `[ui].default_view` accepts `1` through `9`
 and controls the startup view; omitting it keeps the built-in Flows default.
 The config numbers keep their original meanings (`1` worktrees … `9` active

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -24,7 +24,9 @@ const (
 const (
 	ModelDefault       = "default"
 	ModelGPT55         = "gpt-5.5"
+	ModelGPT56Sol      = "gpt-5.6-sol"
 	ModelClaudeOpus48  = "claude-opus-4-8"
+	ModelClaudeOpus5   = "claude-opus-5"
 	ModelClaudeSonnet5 = "claude-sonnet-5"
 	ModelClaudeFable5  = "claude-fable-5"
 )
@@ -76,9 +78,9 @@ func ReasoningEffortChoices(command string) []string {
 func ModelChoices(command string) []string {
 	switch Normalize(command) {
 	case CommandCodex:
-		return []string{ModelDefault, ModelGPT55}
+		return []string{ModelDefault, ModelGPT55, ModelGPT56Sol}
 	case CommandClaude:
-		return []string{ModelDefault, ModelClaudeOpus48, ModelClaudeSonnet5, ModelClaudeFable5}
+		return []string{ModelDefault, ModelClaudeOpus48, ModelClaudeOpus5, ModelClaudeSonnet5, ModelClaudeFable5}
 	case CommandCodexApp:
 		return []string{ModelDefault}
 	default:

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -81,8 +81,8 @@ func TestModelChoicesAreProviderSpecific(t *testing.T) {
 		command string
 		want    []string
 	}{
-		{agent.CommandCodex, []string{"default", "gpt-5.5"}},
-		{agent.CommandClaude, []string{"default", "claude-opus-4-8", "claude-sonnet-5", "claude-fable-5"}},
+		{agent.CommandCodex, []string{"default", "gpt-5.5", "gpt-5.6-sol"}},
+		{agent.CommandClaude, []string{"default", "claude-opus-4-8", "claude-opus-5", "claude-sonnet-5", "claude-fable-5"}},
 		{agent.CommandCodexApp, []string{"default"}},
 	}
 
@@ -105,6 +105,15 @@ func TestValidateModelRejectsUnsupportedProviderValues(t *testing.T) {
 	}
 	if err := agent.ValidateModel(agent.CommandClaude, "claude-fable-5"); err != nil {
 		t.Fatalf("expected claude-fable-5 model to be accepted, got %v", err)
+	}
+	if err := agent.ValidateModel(agent.CommandClaude, "claude-opus-5"); err != nil {
+		t.Fatalf("expected claude-opus-5 model to be accepted, got %v", err)
+	}
+	if err := agent.ValidateModel(agent.CommandCodex, "gpt-5.6-sol"); err != nil {
+		t.Fatalf("expected codex gpt-5.6-sol model to be accepted, got %v", err)
+	}
+	if err := agent.ValidateModel(agent.CommandClaude, "gpt-5.6-sol"); err == nil {
+		t.Fatal("expected claude gpt-5.6-sol model to be rejected")
 	}
 	if err := agent.ValidateModel(agent.CommandCodex, ""); err != nil {
 		t.Fatalf("expected empty codex model to mean default, got %v", err)

--- a/docs/config.md
+++ b/docs/config.md
@@ -237,8 +237,8 @@ value immediately, creating the config file if needed.
 | Key | Type | Description |
 |-----|------|-------------|
 | `command` | string | Supported values: `codex`, `codex-app`, or `claude`. |
-| `codex_model` | string | Optional Codex CLI model for new launches. Supported values: `default`, `gpt-5.5`. Empty or `default` omits the Codex override and keeps provider defaults. |
-| `claude_model` | string | Optional Claude Code model for new launches. Supported values: `default`, `claude-opus-4-8`, `claude-sonnet-5`, `claude-fable-5`. Empty or `default` omits the Claude override and keeps provider defaults. |
+| `codex_model` | string | Optional Codex CLI model for new launches. Supported values: `default`, `gpt-5.5`, `gpt-5.6-sol`. Empty or `default` omits the Codex override and keeps provider defaults. |
+| `claude_model` | string | Optional Claude Code model for new launches. Supported values: `default`, `claude-opus-4-8`, `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`. Empty or `default` omits the Claude override and keeps provider defaults. |
 | `codex_reasoning_effort` | string | Optional Codex CLI reasoning effort for new launches. Supported values: `default`, `minimal`, `low`, `medium`, `high`, `xhigh`. Empty or `default` omits the Codex override and keeps provider defaults. |
 | `claude_reasoning_effort` | string | Optional Claude Code reasoning effort for new launches. Supported values: `default`, `low`, `medium`, `high`, `xhigh`, `max`. Empty or `default` omits the Claude override and keeps provider defaults. |
 | `plan_prompt` | string | Optional template for the editable instructions opened by `i` in the plans pane. Supports `{title}`, `{plan_id}`, `{plan_path}`, `{repo_path}`, and `{worktree_path}`. When a saved-plan phase row is selected, it also supports `{phase_id}`, `{phase_title}`, and `{phase_status}`. Unknown placeholders remain literal. Blank or omitted uses the built-in prompt. |


### PR DESCRIPTION
## Summary

Adds two new model choices for CLI agent launches: `gpt-5.6-sol` for the `codex` agent and `claude-opus-5` for the `claude` agent. They appear in the flows-pane model picker (`M`), are accepted by `[agent].codex_model` / `[agent].claude_model` config validation, and are passed to new launches via `--model`.

## Implementation

- `agent/agent.go`: new `ModelGPT56Sol` and `ModelClaudeOpus5` constants, added to their provider's `ModelChoices` list (`claude-opus-5` placed next to `claude-opus-4-8` to keep the picker grouped by model family). All downstream consumers — the model picker, config validation, and launch flag wiring — read from `ModelChoices`/`ValidateModel`, so no other code changes were needed.
- `agent/agent_test.go`: updated expected choice lists and added validation cases — both new models accepted by their own provider, `gpt-5.6-sol` rejected for `claude`.
- `README.md`, `docs/config.md`: updated the documented supported values for both config keys.

## Verification

- `go test ./agent/` — new cases written first and confirmed failing before the implementation change.
- `go build ./...`, `go vet ./...`, `go test ./...` — all 18 packages pass.