### PR TITLE
Fix Tab navigation from embedded Flow terminals

### DIFF
--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -378,7 +378,8 @@ number, `x` closes, `d` detaches to tmux when available and opens the detached
 session in an external terminal, `q`/`esc` quits, unknown ordinary keys do not
 pass through to the PTY, `ctrl+]` sends a literal `ctrl+]`, and `i` enters
 terminal input mode. In input mode, keys pass through to the PTY (including
-agent shortcuts like `ctrl+g`) and `ctrl+]` returns to command mode.
+agent shortcuts like `ctrl+g`) except `tab`, which cycles pane focus, and
+`ctrl+]`, which returns to command mode.
 
 ### Recovery labels
 

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -709,10 +709,11 @@ func (m Model) handleEmbeddedTerminalKey(msg tea.KeyMsg) (Model, tea.Cmd, bool) 
 func (m Model) handleEmbeddedTerminalKeyForScope(msg tea.KeyMsg, scope embeddedTerminalScope) (Model, tea.Cmd, bool) {
 	key := msg.String()
 	if scope == embeddedTerminalScopeFlow {
+		if key == "tab" {
+			return m.cyclePaneFocusForward(), nil, true
+		}
 		if m.terminalPrefixActive {
 			switch key {
-			case "tab":
-				return m.cyclePaneFocusForward(), nil, true
 			case "left":
 				return m.cycleEmbeddedTerminalForScope(scope, -1), nil, true
 			case "right":

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -8477,6 +8477,47 @@ func TestModel_FlowTerminalCommandModeCanEnterInputMode(t *testing.T) {
 	}
 }
 
+func TestModel_FlowTerminalInputModeTabCyclesPaneFocus(t *testing.T) {
+	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
+	m := model.NewWithOptions(testRepos(), model.Options{
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			return fakeTerm, nil
+		},
+	})
+	m = flowsInRightPane(t, m, []flowstore.FlowRecord{flowWithPhaseDetails()})
+
+	m, _ = update(m, model.FlowEmbeddedLaunchRequestedMsg{LaunchContext: actions.AgentLaunchContext{
+		Command:     "codex",
+		FlowID:      "flow-1",
+		FlowPhaseID: "implementation",
+	}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	if len(fakeTerm.writes) != 1 || fakeTerm.writes[0] != "z" {
+		t.Fatalf("interactive Flow launch should focus terminal input, writes = %#v", fakeTerm.writes)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if m.ActivePane() != 0 {
+		t.Fatalf("tab from input-mode Flow terminal active pane = %d, want left pane", m.ActivePane())
+	}
+	if len(fakeTerm.writes) != 1 {
+		t.Fatalf("tab from input-mode Flow terminal should not write to PTY: %#v", fakeTerm.writes)
+	}
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	if m.ActivePane() != 1 {
+		t.Fatalf("tab from left pane active pane = %d, want Flow list", m.ActivePane())
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}})
+	if len(fakeTerm.writes) != 1 {
+		t.Fatalf("returning to Flow terminal should restore command mode: %#v", fakeTerm.writes)
+	}
+	if got := m.TransientError(); !strings.Contains(got, "Unknown terminal prefix command") {
+		t.Fatalf("status = %q, want command-mode unknown-key error", got)
+	}
+}
+
 func TestModel_FlowTerminalInputModeForwardsCtrlGToAgent(t *testing.T) {
 	fakeTerm := &fakeEmbeddedTerminal{lines: []string{"agent output"}, state: "running"}
 	m := model.NewWithOptions(testRepos(), model.Options{


### PR DESCRIPTION
## Summary

- reserve Tab for pane navigation in embedded Flow terminals, including terminal input mode
- prevent Tab from being forwarded to the active Flow PTY
- cover the terminal-to-repo-to-Flow-list focus cycle with a regression test
- document Tab and ctrl+] as reserved input-mode keys

## Verification

- gofmt -l .
- make test
- make build