### PR TITLE
Create Flow records from ready beads

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Repos on the left, content on the right. The essentials:
 | `←`/`→` | Wrap within Git or Beads subviews; elsewhere step through Git, sessions, plans, flows, and Beads, after which the arrows stay inside whichever group they entered |
 | `ctrl+a` | Toggle Active Flows (all repos) |
 | `/` | Fuzzy filter the active pane |
-| `f` | Fetch in eligible repo/Git contexts; in a settled Beads Ready pane, create a parked Flow record for the selected Bead |
+| `f` | Fetch in eligible repo/Git contexts; in a settled Beads Ready pane, create a record-only Flow for the selected Bead |
 | `f5` | Rescan repositories and refresh the current view, including the active Beads subview |
 | `D` | Toggle destructive mode — deletion keys stay disabled until this is on |
 | `a` | Launch the configured coding agent |
@@ -118,14 +118,22 @@ page the raw human-readable output of `bd show <id> --readonly` through
 invalidates an older result; delivery also requires the same bead to remain the
 visible selection.
 
-In Ready only, press `f` on a settled visible selection to create one parked,
-Approach-owned Flow record in the selected repository. Its title is
-`<trimmed bead ID>: <trimmed bead title>` and its instructions are
+In Ready only, press `f` on a settled visible selection whose Bead has a usable
+ID to create one record-only, Approach-owned Flow in the selected repository.
+Its title is `<trimmed bead ID>: <trimmed bead title>` and its instructions are
 ``Use Bead <id> as the durable source of requirements. Read it with `bd show <id>` before planning or implementation.`` The configured Flow preset supplies
 the phase graph, with normal creation defaults, but this shortcut supplies no
 worktree, branch, base ref, commit, plan/link, launch, session, agent, issue, or
 PR metadata. It does not run a bootstrap hook, start a phase, launch an agent,
 or invoke `bd`; the Bead remains untouched.
+
+A record-only Flow is not the same as the parked Flow the Flows-pane `n` form
+creates: it has no worktree, so the Flows pane shows it with the
+`missing-worktree` branch label and a `recover-worktree` phase state, and
+launching its first phase with `g` runs the agent in the repository root rather
+than an isolated worktree. No operation currently attaches a worktree to this
+existing record; if isolation is required, create a separate Flow through the
+normal `n` path instead of launching this one.
 
 ## Agents, Plans, and Flows
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Repos on the left, content on the right. The essentials:
 | `←`/`→` | Wrap within Git or Beads subviews; elsewhere step through Git, sessions, plans, flows, and Beads, after which the arrows stay inside whichever group they entered |
 | `ctrl+a` | Toggle Active Flows (all repos) |
 | `/` | Fuzzy filter the active pane |
+| `f` | Fetch in eligible repo/Git contexts; in a settled Beads Ready pane, create a parked Flow record for the selected Bead |
 | `f5` | Rescan repositories and refresh the current view, including the active Beads subview |
 | `D` | Toggle destructive mode — deletion keys stay disabled until this is on |
 | `a` | Launch the configured coding agent |
@@ -75,8 +76,9 @@ plans, Flows, embedded terminals, recovery states — is in
 ### Beads
 
 With the content pane focused, press `5` to enter the selected repository's
-read-only Beads group at its last-used subview, defaulting to Open on first
-entry. Pressing `5` again inside Beads is a no-op. While Beads is active,
+Beads group at its last-used subview, defaulting to Open on first entry.
+All Beads queries and detail reads are read-only, and Approach never mutates
+tracker state. Pressing `5` again inside Beads is a no-op. While Beads is active,
 `r`/`b`/`o`/`i`/`c` switch directly to Ready, Blocked, Open, In-Progress, and
 Closed, and `←`/`→` step and wrap through those five subviews. The letters
 remain scoped to Beads, so Git and other views keep their existing meanings.
@@ -115,6 +117,15 @@ page the raw human-readable output of `bd show <id> --readonly` through
 `less -R`. A newer detail request, subview or repo change, or Beads refresh
 invalidates an older result; delivery also requires the same bead to remain the
 visible selection.
+
+In Ready only, press `f` on a settled visible selection to create one parked,
+Approach-owned Flow record in the selected repository. Its title is
+`<trimmed bead ID>: <trimmed bead title>` and its instructions are
+``Use Bead <id> as the durable source of requirements. Read it with `bd show <id>` before planning or implementation.`` The configured Flow preset supplies
+the phase graph, with normal creation defaults, but this shortcut supplies no
+worktree, branch, base ref, commit, plan/link, launch, session, agent, issue, or
+PR metadata. It does not run a bootstrap hook, start a phase, launch an agent,
+or invoke `bd`; the Bead remains untouched.
 
 ## Agents, Plans, and Flows
 

--- a/docs/beads-view-spec.md
+++ b/docs/beads-view-spec.md
@@ -36,7 +36,7 @@ repo cursor. Repos without beads show a calm "beads not configured" message;
 configured repos where `bd` fails show a real error. The view is read-only in
 its Beads access and tracker state, with `enter` paging a bead's detail through
 the pager. A settled Ready selection also exposes `f` to create an
-Approach-owned parked Flow record without invoking `bd` or mutating the Bead.
+Approach-owned record-only Flow without invoking `bd` or mutating the Bead.
 
 ## User Stories
 
@@ -69,7 +69,7 @@ Approach-owned parked Flow record without invoking `bd` or mutating the Bead.
 27. As an Approach user, I want the frozen `default_view` vocabulary (1–9) untouched, so that existing configs keep their meaning.
 28. As an Approach user, I want a manual way to refetch beads via the app's existing refresh affordance, so that I can pull in changes an agent made without bouncing the repo cursor.
 29. As an agent operator, I want issue state visible next to Sessions, Plans, and Flows, so that I can see what my agents should pick up next and what they have finished.
-30. As an Approach user, I want `f` on a settled visible Ready selection to create a parked Flow record for that Bead, so that I can carry the durable requirement into the Flow workflow without creating a worktree, launching an agent, or changing the Bead.
+30. As an Approach user, I want `f` on a settled visible Ready selection to create a record-only Flow for that Bead, so that I can carry the durable requirement into the Flow workflow without creating a worktree, launching an agent, or changing the Bead.
 
 ## Implementation Decisions
 
@@ -113,19 +113,28 @@ Approach-owned parked Flow record without invoking `bd` or mutating the Bead.
   stale-result protection, the same pattern as the app's other read-only
   detail views.
 - `f` is a Ready-only record-persistence action. It requires right-pane focus,
-  an available settled filtered selection, a selected repo, and no existing
-  Ready Flow request. It creates a Flow titled
-  `<trimmed bead ID>: <trimmed bead title>` with instructions directing agents
-  to use `bd show <id>` as the durable source of requirements. Creation uses
-  the configured preset but supplies only title, instructions, and repo path:
-  no worktree, branch, base ref, commit, plan/link, launch/session, agent,
+  an available settled filtered selection whose Bead has a non-empty trimmed
+  ID, a selected repo, and no existing Ready Flow request. It creates a Flow
+  titled `<trimmed bead ID>: <trimmed bead title>` with instructions directing
+  agents to use `bd show <id>` as the durable source of requirements. Creation
+  uses the configured preset but supplies only title, instructions, and repo
+  path: no worktree, branch, base ref, commit, plan/link, launch/session, agent,
   issue, or PR metadata. It never invokes the Flow starter, bootstrap hooks,
   agent launchers, or `bd`.
 - Ready Flow persistence has its own monotonically increasing request token.
-  Duplicate keypresses are ignored while it is active, and repo changes
-  invalidate it before either normal or Active-Flows repo reset logic. Accepted
-  success or failure updates status and refreshes exactly the currently visible
-  Flow surface, if any; Beads and other surfaces do not refresh.
+  Duplicate keypresses are ignored while it is active. Cursor-driven repo
+  changes invalidate it at the top of `handleRepoSelectionChanged`, before
+  either the normal or Active-Flows reset branch; rescan-driven repo changes
+  reach it through `resetRightPaneCursors`, which `handleRepoRefreshResult`
+  uses on every selection-changing path. Completion handlers release the token
+  before checking the repo, so no repo-change route can strand the shortcut.
+  Accepted success or failure updates status and refreshes exactly the
+  currently visible Flow surface, if any; Beads and other surfaces do not
+  refresh.
+- The resulting Flow is record-only, not the Flows-pane form's parked Flow: it
+  has no worktree, so existing Flow rendering labels it `missing-worktree` /
+  `recover-worktree`, and phase launch falls back to the repository root. The
+  docs state this explicitly rather than implying an isolated worktree exists.
 - Config: `default_view` gains frozen numbers 10 (ready), 11 (blocked),
   12 (open), 13 (in-progress), 14 (closed), parallel to the git subviews'
   1–5. Numbers 1–9 keep their existing frozen meanings.

--- a/docs/beads-view-spec.md
+++ b/docs/beads-view-spec.md
@@ -5,7 +5,8 @@ five visible query/header subviews, sticky group re-entry, arrow navigation, and
 per-subview filter/cursor preservation with refetch clamping, plus
 configured/not-configured/error classification are shipped, as are the
 newest-100 Closed cap with its plain/truncated header count and `default_view`
-10–14 startup routing and read-only detail paging. Companion docs:
+10–14 startup routing, read-only detail paging, and record-only Flow creation
+from a settled Ready selection. Companion docs:
 `architecture.md`
 (package map, invariants), `config.md` (config vocabulary), `README.md` (current
 key bindings).
@@ -33,7 +34,9 @@ the selected repo's beads one status at a time. Data comes from the `bd` CLI in
 JSON mode, fetched asynchronously when the user enters the group or moves the
 repo cursor. Repos without beads show a calm "beads not configured" message;
 configured repos where `bd` fails show a real error. The view is read-only in
-v1, with `enter` paging a bead's detail through the pager.
+its Beads access and tracker state, with `enter` paging a bead's detail through
+the pager. A settled Ready selection also exposes `f` to create an
+Approach-owned parked Flow record without invoking `bd` or mutating the Bead.
 
 ## User Stories
 
@@ -61,11 +64,12 @@ v1, with `enter` paging a bead's detail through the pager.
 22. As an Approach user, I want bead data fetched asynchronously on group entry and repo-cursor change, so that the UI never blocks on a `bd` subprocess.
 23. As an Approach user, I want stale-result protection on bead fetches, so that moving quickly across repos never shows one repo's beads under another repo's name.
 24. As an Approach user, I want `enter` on a bead to page its full detail (`bd show`) through the pager, so that I can read descriptions and dependencies without leaving the TUI.
-25. As an Approach user, I want the Beads view to be read-only, so that browsing can never mutate the tracker by accident.
+25. As an Approach user, I want Beads queries and tracker state to remain read-only, so that browsing or creating a Flow can never mutate the tracker by accident.
 26. As an Approach user, I want `default_view` numbers 10–14 pinning each beads subview, so that I can start the app directly in any of them, mirroring the git subview numbers.
 27. As an Approach user, I want the frozen `default_view` vocabulary (1–9) untouched, so that existing configs keep their meaning.
 28. As an Approach user, I want a manual way to refetch beads via the app's existing refresh affordance, so that I can pull in changes an agent made without bouncing the repo cursor.
 29. As an agent operator, I want issue state visible next to Sessions, Plans, and Flows, so that I can see what my agents should pick up next and what they have finished.
+30. As an Approach user, I want `f` on a settled visible Ready selection to create a parked Flow record for that Bead, so that I can carry the durable requirement into the Flow workflow without creating a worktree, launching an agent, or changing the Bead.
 
 ## Implementation Decisions
 
@@ -108,6 +112,20 @@ v1, with `enter` paging a bead's detail through the pager.
 - `enter` on a bead pages `bd show <id> --readonly` output through the pager with
   stale-result protection, the same pattern as the app's other read-only
   detail views.
+- `f` is a Ready-only record-persistence action. It requires right-pane focus,
+  an available settled filtered selection, a selected repo, and no existing
+  Ready Flow request. It creates a Flow titled
+  `<trimmed bead ID>: <trimmed bead title>` with instructions directing agents
+  to use `bd show <id>` as the durable source of requirements. Creation uses
+  the configured preset but supplies only title, instructions, and repo path:
+  no worktree, branch, base ref, commit, plan/link, launch/session, agent,
+  issue, or PR metadata. It never invokes the Flow starter, bootstrap hooks,
+  agent launchers, or `bd`.
+- Ready Flow persistence has its own monotonically increasing request token.
+  Duplicate keypresses are ignored while it is active, and repo changes
+  invalidate it before either normal or Active-Flows repo reset logic. Accepted
+  success or failure updates status and refreshes exactly the currently visible
+  Flow surface, if any; Beads and other surfaces do not refresh.
 - Config: `default_view` gains frozen numbers 10 (ready), 11 (blocked),
   12 (open), 13 (in-progress), 14 (closed), parallel to the git subviews'
   1–5. Numbers 1–9 keep their existing frozen meanings.
@@ -133,13 +151,15 @@ v1, with `enter` paging a bead's detail through the pager.
   and list-fetch model tests.
 - ui: stateless render tests from a `RenderParams` snapshot — beads header
   letter row, row formatting, the "100 of N" closed header, empty-subview
-  messages, and not-configured vs error rendering. Prior art: the git header
+  messages, not-configured vs error rendering, and the Ready `f: new flow`
+  hint only when its model predicate is executable. Prior art: the git header
   and ui render tests.
 
 ## Out of Scope
 
 - Any mutation of beads (create, start, close, reopen, edit, dependency
-  changes). The view is strictly read-only in v1.
+  changes). Beads access and tracker state remain strictly read-only; creating
+  an Approach-owned Flow artifact is not a Beads mutation.
 - Background polling or auto-refresh while the view is visible.
 - Reading beads storage files directly, or any fallback path that bypasses the
   `bd` CLI.

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -88,7 +88,7 @@ title, and assignee; repo filtering remains available from the left pane.
 | `d` | Delete worktree/branch, drop stash, or delete Flow data — requires destructive mode |
 | `p` | Prune stale worktree — requires destructive mode (worktrees view), or open the linked PR (flows and active flows views, when PR metadata exists) |
 | `u` | Unlock a locked worktree (worktrees view) |
-| `f` | Fetch with `--prune` (worktrees and branches views) |
+| `f` | Fetch with `--prune` (worktrees and branches views), or create a parked Flow record for the selected Bead in a settled Ready subview |
 | `F` | Pull with `--ff-only` (worktrees, and branches with a checked-out worktree) |
 | `t` | Open or attach to a tmux/Zellij session for the worktree |
 | `c` | Open VSCode at worktree path outside Flow surfaces, or copy the selected Flow ID in flows and active flows views |
@@ -324,8 +324,10 @@ plans. v1 has no TUI plan deletion.
 ## Beads View (`5`)
 
 With the content pane focused, press `5` to enter the selected repository's
-read-only Beads group at its last-used subview, defaulting to Open before first
-use. Pressing `5` while already in any Beads subview is a no-op. Press `r` for
+Beads group at its last-used subview, defaulting to Open before first use.
+Beads queries and detail reads are read-only, and no action in this group
+mutates tracker state. Pressing `5` while already in any Beads subview is a
+no-op. Press `r` for
 Ready, `b` for Blocked, `o` for Open, `i` for In-Progress, or `c` for Closed;
 pressing the already-active letter is also a no-op. `←`/`→` step and wrap
 Ready ↔ Blocked ↔ Open ↔ In-Progress ↔ Closed without leaving the group. From
@@ -375,6 +377,20 @@ while Active Flows is open.
 Per-mode request tokens reject results for an old repo, an older refresh, or a
 subview that is no longer active. Every query is read-only, and `bd -C` plus the
 selected process directory are owned by the query runner.
+
+In Ready only, `f` is available when the content pane is focused, the query is
+settled and available, a filtered visible Bead is selected, and no Ready Flow
+creation is already in flight. It asynchronously creates exactly one parked
+Approach Flow record in the selected repo. The record title is
+`<trimmed bead ID>: <trimmed bead title>` and its instructions are
+``Use Bead <id> as the durable source of requirements. Read it with `bd show <id>` before planning or implementation.`` The configured Flow preset seeds the
+phase graph and normal Flow creation defaults still apply, but the shortcut
+supplies no worktree, branch, base ref, commit, plan/link, launch, session,
+agent, issue, or PR metadata. It does not run bootstrap hooks, start a Flow
+phase, launch an agent, or invoke `bd`, so the selected Bead and all other
+tracker state remain untouched. The shortcut is hidden in every context where
+that exact action cannot run; duplicate keypresses are ignored until the
+current persistence request finishes.
 
 After the active subview settles, `enter` on its visible selected row
 asynchronously loads the raw human-readable output of

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -88,7 +88,7 @@ title, and assignee; repo filtering remains available from the left pane.
 | `d` | Delete worktree/branch, drop stash, or delete Flow data — requires destructive mode |
 | `p` | Prune stale worktree — requires destructive mode (worktrees view), or open the linked PR (flows and active flows views, when PR metadata exists) |
 | `u` | Unlock a locked worktree (worktrees view) |
-| `f` | Fetch with `--prune` (worktrees and branches views), or create a parked Flow record for the selected Bead in a settled Ready subview |
+| `f` | Fetch with `--prune` (worktrees and branches views), or create a record-only Flow for the selected Bead in a settled Ready subview |
 | `F` | Pull with `--ff-only` (worktrees, and branches with a checked-out worktree) |
 | `t` | Open or attach to a tmux/Zellij session for the worktree |
 | `c` | Open VSCode at worktree path outside Flow surfaces, or copy the selected Flow ID in flows and active flows views |
@@ -379,9 +379,9 @@ subview that is no longer active. Every query is read-only, and `bd -C` plus the
 selected process directory are owned by the query runner.
 
 In Ready only, `f` is available when the content pane is focused, the query is
-settled and available, a filtered visible Bead is selected, and no Ready Flow
-creation is already in flight. It asynchronously creates exactly one parked
-Approach Flow record in the selected repo. The record title is
+settled and available, a filtered visible Bead with a non-empty ID is selected,
+and no Ready Flow creation is already in flight. It asynchronously creates
+exactly one record-only Approach Flow in the selected repo. The record title is
 `<trimmed bead ID>: <trimmed bead title>` and its instructions are
 ``Use Bead <id> as the durable source of requirements. Read it with `bd show <id>` before planning or implementation.`` The configured Flow preset seeds the
 phase graph and normal Flow creation defaults still apply, but the shortcut
@@ -390,7 +390,16 @@ agent, issue, or PR metadata. It does not run bootstrap hooks, start a Flow
 phase, launch an agent, or invoke `bd`, so the selected Bead and all other
 tracker state remain untouched. The shortcut is hidden in every context where
 that exact action cannot run; duplicate keypresses are ignored until the
-current persistence request finishes.
+current persistence request finishes, and any repo change — cursor move or
+rescan — releases the shortcut and discards the pending result.
+
+Because the record carries no worktree or branch, the Flows pane renders it with
+the `missing-worktree` branch label and a `recover-worktree` phase state, and
+`g` on its first phase launches the agent in the repository root instead of an
+isolated worktree. This is a deliberately different artifact from the parked
+Flow produced by a successful `n` form submission, which has a worktree; a
+normal startup failure before worktree creation can still leave a partial Flow
+record without one.
 
 After the active subview settles, `enter` on its visible selected row
 asynchronously loads the raw human-readable output of

--- a/model/bead_flow_create_test.go
+++ b/model/bead_flow_create_test.go
@@ -1,0 +1,500 @@
+package model_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/beadsquery"
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/model"
+	"github.com/approachcontrol/approach/ui"
+)
+
+func TestBeadsReadyCreateFlowPersistsSelectedVisibleBeadRecordOnly(t *testing.T) {
+	readyCalls := 0
+	showCalls := 0
+	createCalls := 0
+	var createdInput flowstore.FlowRecord
+	m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+		ListReadyBeads: func(repoPath string) ([]beadsquery.Bead, error) {
+			readyCalls++
+			if repoPath != "/dev/alpha" {
+				t.Fatalf("Ready repo path = %q, want /dev/alpha", repoPath)
+			}
+			return []beadsquery.Bead{
+				{ID: "bd-hidden", Title: "Other work"},
+				{ID: "  bd-selected  ", Title: "  Selected work  "},
+			}, nil
+		},
+		ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+		ShowBead: func(string, string) (string, error) {
+			showCalls++
+			return "", nil
+		},
+		CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			createCalls++
+			createdInput = record
+			record.FlowID = "flow-selected"
+			return record, nil
+		},
+		CreateFlow: func(model.FlowStartRequest) (model.FlowStartResult, error) {
+			t.Fatal("Ready shortcut called legacy CreateFlow")
+			return model.FlowStartResult{}, nil
+		},
+		StartFlowPlan: func(model.FlowStartRequest) (model.FlowStartResult, error) {
+			t.Fatal("Ready shortcut called StartFlowPlan")
+			return model.FlowStartResult{}, nil
+		},
+		BootstrapHookForRepo: func(string) (actions.BootstrapHook, bool) {
+			t.Fatal("Ready shortcut looked up a bootstrap hook")
+			return actions.BootstrapHook{}, false
+		},
+		RunBootstrapHook: func(actions.BootstrapContext, actions.BootstrapHook) error {
+			t.Fatal("Ready shortcut ran a bootstrap hook")
+			return nil
+		},
+		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
+			t.Fatal("Ready shortcut launched an external agent")
+			return actions.TerminalLaunchSpec{}, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (model.EmbeddedTerminal, error) {
+			t.Fatal("Ready shortcut launched an embedded agent")
+			return nil, nil
+		},
+	}))
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	m, readyCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if readyCmd == nil {
+		t.Fatal("entering Ready returned nil query command")
+	}
+	m, _ = update(m, readyCmd())
+	m = setBeadsQuery(t, m, "Selected")
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if cmd == nil {
+		t.Fatal("Ready f returned nil create command")
+	}
+	msg := cmd()
+	if _, ok := msg.(model.ReadyBeadFlowCreatedMsg); !ok {
+		t.Fatalf("Ready create command returned %T, want ReadyBeadFlowCreatedMsg", msg)
+	}
+	m, _ = update(m, msg)
+
+	if createCalls != 1 {
+		t.Fatalf("CreateFlowRecord calls = %d, want 1", createCalls)
+	}
+	if readyCalls != 1 || showCalls != 0 {
+		t.Fatalf("Beads calls after f = Ready %d Show %d, want 1 and 0", readyCalls, showCalls)
+	}
+	if createdInput.Title != "bd-selected: Selected work" {
+		t.Fatalf("Flow title = %q", createdInput.Title)
+	}
+	wantInstructions := "Use Bead bd-selected as the durable source of requirements. Read it with `bd show bd-selected` before planning or implementation."
+	if createdInput.Instructions != wantInstructions {
+		t.Fatalf("Flow instructions = %q, want %q", createdInput.Instructions, wantInstructions)
+	}
+	if createdInput.RepoPath != "/dev/alpha" || createdInput.WorktreePath != "" || createdInput.Branch != "" ||
+		createdInput.BaseRef != "" || createdInput.Commit != "" || createdInput.PlanID != "" || createdInput.PlanPath != "" ||
+		createdInput.Issue != (flowstore.Issue{}) || createdInput.PR != (flowstore.PullRequest{}) || len(createdInput.Phases) != 0 {
+		t.Fatalf("record-only Flow input = %#v", createdInput)
+	}
+	if got := m.TransientError(); got != "Created flow: bd-selected: Selected work" {
+		t.Fatalf("status = %q", got)
+	}
+	if m.Mode() != ui.ModeBeadsReady {
+		t.Fatalf("mode = %v, want Ready", m.Mode())
+	}
+}
+
+func TestBeadsReadyCreateFlowRejectsInvalidAndDuplicateRequests(t *testing.T) {
+	newReadyModel := func(t *testing.T, beads []beadsquery.Bead, available bool, create func(flowstore.FlowRecord) (flowstore.FlowRecord, error)) model.Model {
+		t.Helper()
+		m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+			ListReadyBeads:   func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			ListOpenBeads:    func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			CreateFlowRecord: create,
+			FetchRepo:        func(string) error { return nil },
+		}))
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+		return applyBeadsResult(t, m, ui.ModeBeadsReady, available, beads)
+	}
+
+	t.Run("invalid contexts", func(t *testing.T) {
+		createCalls := 0
+		create := func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			createCalls++
+			return record, nil
+		}
+		assertNoCreate := func(t *testing.T, m model.Model, allowExistingCommand bool) {
+			t.Helper()
+			_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+			if cmd != nil && !allowExistingCommand {
+				t.Fatalf("invalid Ready context returned command %T", cmd)
+			}
+			if cmd != nil {
+				_ = immediateTestCommandMessages(cmd)
+			}
+			if createCalls != 0 {
+				t.Fatalf("CreateFlowRecord calls = %d, want 0", createCalls)
+			}
+		}
+
+		m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, create)
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+		assertNoCreate(t, m, true)
+
+		for _, subview := range []rune{'b', 'o', 'i', 'c'} {
+			m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, create)
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{subview}})
+			assertNoCreate(t, m, false)
+		}
+
+		m = inRightPane(model.NewWithOptions(testRepos(), model.Options{
+			ListReadyBeads:   func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			ListOpenBeads:    func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			CreateFlowRecord: create,
+		}))
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+		assertNoCreate(t, m, false) // loading
+		assertNoCreate(t, newReadyModel(t, nil, false, create), false)
+		assertNoCreate(t, newReadyModel(t, nil, true, create), false)
+		m = newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, create)
+		m = setBeadsQuery(t, m, "no-match")
+		assertNoCreate(t, m, false)
+	})
+
+	t.Run("duplicate in flight", func(t *testing.T) {
+		createCalls := 0
+		m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			createCalls++
+			record.FlowID = "flow-1"
+			return record, nil
+		})
+		m, first := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+		m, duplicate := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+		if first == nil || duplicate != nil {
+			t.Fatalf("create commands = first %T duplicate %T, want non-nil then nil", first, duplicate)
+		}
+		msg := first()
+		m, _ = update(m, msg)
+		if createCalls != 1 {
+			t.Fatalf("CreateFlowRecord calls = %d, want 1", createCalls)
+		}
+		_, retry := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+		if retry == nil {
+			t.Fatal("accepted completion did not release Ready create")
+		}
+	})
+
+	t.Run("failure releases request", func(t *testing.T) {
+		m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{}, errors.New("flow store unavailable")
+		})
+		m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+		failed := cmd().(model.ReadyBeadFlowCreateFailedMsg)
+		m, _ = update(m, failed)
+		if got := m.TransientError(); got != "flow store unavailable" {
+			t.Fatalf("failure status = %q", got)
+		}
+		_, retry := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+		if retry == nil {
+			t.Fatal("accepted failure did not release Ready create")
+		}
+	})
+}
+
+func TestBeadsReadyCreateFlowRepoRoundTripInvalidatesStaleCompletion(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		activeFlows bool
+	}{
+		{name: "selected repo surface"},
+		{name: "active flows surface", activeFlows: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			createCalls := 0
+			m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+				ListReadyBeads: func(string) ([]beadsquery.Bead, error) {
+					return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
+				},
+				ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+				ListFlows:     func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) { return nil, nil },
+				CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+					createCalls++
+					record.FlowID = "flow-1"
+					return record, nil
+				},
+			}))
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+			m, readyCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+			m, _ = update(m, readyCmd())
+			m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+			stale := createCmd().(model.ReadyBeadFlowCreatedMsg)
+			if createCalls != 1 {
+				t.Fatalf("initial CreateFlowRecord calls = %d, want 1", createCalls)
+			}
+
+			if tt.activeFlows {
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlA})
+			}
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyUp})
+			m, staleCmd := update(m, stale)
+			if staleCmd != nil || m.TransientError() != "" {
+				t.Fatalf("stale completion changed UI: status=%q cmd=%T", m.TransientError(), staleCmd)
+			}
+			m, staleCmd = update(m, model.ReadyBeadFlowCreateFailedMsg{
+				RepoPath: stale.RepoPath,
+				Title:    stale.Title,
+				Err:      "stale failure",
+				Request:  stale.Request,
+			})
+			if staleCmd != nil || m.TransientError() != "" {
+				t.Fatalf("stale failure changed UI: status=%q cmd=%T", m.TransientError(), staleCmd)
+			}
+
+			if tt.activeFlows {
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlA})
+			} else {
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+			}
+			m = applyBeadsResultFor(t, m, ui.ModeBeadsReady, "/dev/alpha", m.ListRequest(ui.ModeBeadsReady), true, []beadsquery.Bead{{ID: "bd-1", Title: "One"}})
+			_, retryCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+			if retryCmd == nil {
+				t.Fatal("repo round trip stranded Ready Flow creation")
+			}
+		})
+	}
+}
+
+func TestBeadsReadyCreateFlowCompletionRefreshesOnlyVisibleFlowSurface(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		key         tea.KeyMsg
+		wantRefresh int
+	}{
+		{name: "beads ready", key: tea.KeyMsg{}, wantRefresh: 0},
+		{name: "selected repo flows", key: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}}, wantRefresh: 1},
+		{name: "active flows", key: tea.KeyMsg{Type: tea.KeyCtrlA}, wantRefresh: 1},
+		{name: "other surface", key: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}, wantRefresh: 0},
+	} {
+		for _, failed := range []bool{false, true} {
+			outcome := "success"
+			if failed {
+				outcome = "failure"
+			}
+			t.Run(tt.name+"/"+outcome, func(t *testing.T) {
+				listCalls := 0
+				m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+					ListReadyBeads: func(string) ([]beadsquery.Bead, error) {
+						return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
+					},
+					ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+					ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+						listCalls++
+						return nil, nil
+					},
+					CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+						if failed {
+							return flowstore.FlowRecord{}, errors.New("persist failed")
+						}
+						record.FlowID = "flow-1"
+						return record, nil
+					},
+				}))
+				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+				m, readyCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+				m, _ = update(m, readyCmd())
+				m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+				completion := createCmd()
+				if tt.key.Type != 0 {
+					m, _ = update(m, tt.key)
+				}
+				m, cmd := update(m, completion)
+				_ = immediateTestCommandMessages(cmd)
+				if listCalls != tt.wantRefresh {
+					t.Fatalf("ListFlows calls = %d, want %d", listCalls, tt.wantRefresh)
+				}
+				wantStatus := "Created flow: bd-1: One"
+				if failed {
+					wantStatus = "persist failed"
+				}
+				if got := m.TransientError(); got != wantStatus {
+					t.Fatalf("status = %q, want %q", got, wantStatus)
+				}
+			})
+		}
+	}
+}
+
+func TestBeadsReadyCreateFlowSameRepoFilterAndCursorChangesKeepRequestCurrent(t *testing.T) {
+	m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+		ListReadyBeads: func(string) ([]beadsquery.Bead, error) {
+			return []beadsquery.Bead{{ID: "bd-1", Title: "One"}, {ID: "bd-2", Title: "Two"}}, nil
+		},
+		ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+		CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-1"
+			return record, nil
+		},
+	}))
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	m, readyCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, _ = update(m, readyCmd())
+	m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m = setBeadsQuery(t, m, "Two")
+	m, _ = update(m, createCmd())
+	if got := m.TransientError(); got != "Created flow: bd-1: One" {
+		t.Fatalf("completion after same-repo selection changes = %q", got)
+	}
+}
+
+func TestBeadsReadyFlowCreateShortcutMatchesExecutablePredicate(t *testing.T) {
+	newModel := func(t *testing.T) model.Model {
+		t.Helper()
+		m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+			ListReadyBeads: func(string) ([]beadsquery.Bead, error) {
+				return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
+			},
+			ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+				record.FlowID = "flow-1"
+				return record, nil
+			},
+		}))
+		m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 20})
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+		m, readyCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+		m, _ = update(m, readyCmd())
+		return m
+	}
+
+	tests := []struct {
+		name      string
+		transform func(model.Model) model.Model
+		want      bool
+	}{
+		{name: "available", transform: func(m model.Model) model.Model { return m }, want: true},
+		{name: "left focused", transform: func(m model.Model) model.Model {
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
+			return m
+		}},
+		{name: "non ready", transform: func(m model.Model) model.Model {
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}})
+			return m
+		}},
+		{name: "loading", transform: func(m model.Model) model.Model {
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'b'}})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+			return m
+		}},
+		{name: "unavailable", transform: func(m model.Model) model.Model {
+			return applyBeadsResult(t, m, ui.ModeBeadsReady, false, nil)
+		}},
+		{name: "empty", transform: func(m model.Model) model.Model {
+			return applyBeadsResult(t, m, ui.ModeBeadsReady, true, nil)
+		}},
+		{name: "filtered empty", transform: func(m model.Model) model.Model {
+			return setBeadsQuery(t, m, "no-match")
+		}},
+		{name: "creating", transform: func(m model.Model) model.Model {
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+			return m
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.transform(newModel(t))
+			got := strings.Contains(ansi.Strip(m.View()), "new flow")
+			if got != tt.want {
+				t.Fatalf("new flow shortcut visible = %v, want %v:\n%s", got, tt.want, ansi.Strip(m.View()))
+			}
+		})
+	}
+}
+
+func TestBeadsReadyCreateFlowProductionWiringPersistsConfiguredPresetWithoutStartMetadata(t *testing.T) {
+	root := t.TempDir()
+	preset := flowstore.Preset{
+		Name: "ready-bead",
+		Phases: []flowstore.PhaseSpec{
+			{ID: "research", Title: "Research", Kind: flowstore.KindPlan},
+			{ID: "execute", Title: "Execute", Kind: flowstore.KindImplementation, DependsOn: []string{"research"}},
+			{ID: "deliver", Title: "Deliver", Kind: flowstore.KindPRCreation, DependsOn: []string{"execute"}},
+		},
+	}
+	m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+		SessionStateRoot: root,
+		FlowPresets:      []flowstore.Preset{preset},
+		FlowPreset:       &preset,
+		ListReadyBeads: func(string) ([]beadsquery.Bead, error) {
+			return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
+		},
+		ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+	}))
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	m, readyCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, _ = update(m, readyCmd())
+	_, createCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	created := createCmd().(model.ReadyBeadFlowCreatedMsg)
+
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Presets: []flowstore.Preset{preset}})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Read(created.FlowID)
+	if err != nil {
+		t.Fatalf("Read(%q) error = %v", created.FlowID, err)
+	}
+	if record.PresetName != "ready-bead" || record.Title != "bd-1: One" || record.RepoPath != "/dev/alpha" {
+		t.Fatalf("persisted Flow identity = %#v", record)
+	}
+	if record.WorktreePath != "" || record.Branch != "" || record.BaseRef != "" || record.Commit != "" ||
+		record.PlanID != "" || record.PlanPath != "" || record.Issue != (flowstore.Issue{}) || record.PR != (flowstore.PullRequest{}) {
+		t.Fatalf("persisted Flow has start/plan/link metadata: %#v", record)
+	}
+	if !record.AutoMode || record.Merge.Status != flowstore.MergePending {
+		t.Fatalf("creation defaults = auto %v merge %#v", record.AutoMode, record.Merge)
+	}
+	phases := flowstore.OrderedPhases(record.Phases)
+	if len(phases) != len(preset.Phases) {
+		t.Fatalf("persisted phases = %#v", phases)
+	}
+	for i, spec := range preset.Phases {
+		phase := phases[i]
+		wantStatus := flowstore.PhasePending
+		if i == 0 {
+			wantStatus = flowstore.PhaseReady
+		}
+		if phase.PhaseID != spec.ID || phase.Title != spec.Title || phase.Kind != spec.Kind || phase.Status != wantStatus ||
+			!equalStrings(phase.DependsOn, spec.DependsOn) {
+			t.Fatalf("phase %d = %#v, want spec %#v status %q", i, phase, spec, wantStatus)
+		}
+		if len(phase.LaunchIDs) != 0 || len(phase.Sessions) != 0 || phase.Status == flowstore.PhaseRunning ||
+			phase.Status == flowstore.PhaseNeedsAttention || phase.Status == flowstore.PhaseBlocked {
+			t.Fatalf("phase %d has launch/session/startup-failure state: %#v", i, phase)
+		}
+	}
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/model/bead_flow_create_test.go
+++ b/model/bead_flow_create_test.go
@@ -2,6 +2,9 @@ package model_test
 
 import (
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -12,8 +15,287 @@ import (
 	"github.com/approachcontrol/approach/beadsquery"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/model"
+	"github.com/approachcontrol/approach/scanner"
 	"github.com/approachcontrol/approach/ui"
 )
+
+// A rescan-driven repo change never routes through handleRepoSelectionChanged,
+// so it must still release the Ready create token instead of stranding `f`.
+func TestBeadsReadyCreateFlowRescanRepoChangeDoesNotStrandShortcut(t *testing.T) {
+	createCalls := 0
+	var readyRepos []string
+	m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+		ScanRepos: func() ([]scanner.Repo, error) {
+			return []scanner.Repo{
+				{Path: "/dev/bravo", DisplayName: "bravo"},
+				{Path: "/dev/charlie", DisplayName: "charlie"},
+			}, nil
+		},
+		ListReadyBeads: func(repoPath string) ([]beadsquery.Bead, error) {
+			readyRepos = append(readyRepos, repoPath)
+			return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
+		},
+		ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+		CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			createCalls++
+			record.FlowID = "flow-1"
+			return record, nil
+		},
+	}))
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	m, readyCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, _ = update(m, readyCmd())
+
+	m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if createCmd == nil {
+		t.Fatal("Ready f returned nil create command")
+	}
+	stale := createCmd().(model.ReadyBeadFlowCreatedMsg)
+	if createCalls != 1 {
+		t.Fatalf("CreateFlowRecord calls = %d, want 1", createCalls)
+	}
+
+	m, refreshCmd := update(m, tea.KeyMsg{Type: tea.KeyF5})
+	if refreshCmd == nil {
+		t.Fatal("f5 returned nil refresh command")
+	}
+	m, afterRefresh := update(m, repoRefreshResultFromBatch(t, immediateTestCommandMessages(refreshCmd)))
+	if afterRefresh != nil {
+		_ = immediateTestCommandMessages(afterRefresh)
+	}
+	if len(readyRepos) == 0 || readyRepos[len(readyRepos)-1] != "/dev/bravo" {
+		t.Fatalf("rescan did not move the Ready query to the new repo: %#v", readyRepos)
+	}
+
+	m, staleCmd := update(m, stale)
+	if staleCmd != nil || strings.Contains(m.TransientError(), "Created flow") {
+		t.Fatalf("stale completion changed UI: status=%q cmd=%T", m.TransientError(), staleCmd)
+	}
+
+	m = applyBeadsResultFor(t, m, ui.ModeBeadsReady, "/dev/bravo", m.ListRequest(ui.ModeBeadsReady), true,
+		[]beadsquery.Bead{{ID: "bd-2", Title: "Two"}})
+	_, retryCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if retryCmd == nil {
+		t.Fatal("rescan-driven repo change stranded Ready Flow creation")
+	}
+}
+
+func TestBeadsReadyCreateFlowRequiresUsableBeadIDAndToleratesEmptyTitle(t *testing.T) {
+	newReadyModel := func(t *testing.T, beads []beadsquery.Bead, create func(flowstore.FlowRecord) (flowstore.FlowRecord, error)) model.Model {
+		t.Helper()
+		m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+			ListReadyBeads:   func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			ListOpenBeads:    func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			CreateFlowRecord: create,
+		}))
+		m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 20})
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+		return applyBeadsResult(t, m, ui.ModeBeadsReady, true, beads)
+	}
+
+	for _, tt := range []struct {
+		name string
+		bead beadsquery.Bead
+	}{
+		{name: "empty id", bead: beadsquery.Bead{ID: "", Title: "No identifier"}},
+		{name: "whitespace id", bead: beadsquery.Bead{ID: "   ", Title: "No identifier"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			createCalls := 0
+			m := newReadyModel(t, []beadsquery.Bead{tt.bead}, func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+				createCalls++
+				return record, nil
+			})
+			if strings.Contains(ansi.Strip(m.View()), "new flow") {
+				t.Fatalf("unusable Bead ID advertised the Flow shortcut:\n%s", ansi.Strip(m.View()))
+			}
+			_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+			if cmd != nil {
+				t.Fatalf("unusable Bead ID returned create command %T", cmd)
+			}
+			if createCalls != 0 {
+				t.Fatalf("CreateFlowRecord calls = %d, want 0", createCalls)
+			}
+		})
+	}
+
+	t.Run("empty title preserves the exact mapping", func(t *testing.T) {
+		var createdInput flowstore.FlowRecord
+		m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "   "}}, func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			createdInput = record
+			record.FlowID = "flow-1"
+			return record, nil
+		})
+		m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+		if cmd == nil {
+			t.Fatal("titleless Bead returned nil create command")
+		}
+		m, _ = update(m, cmd())
+		if createdInput.Title != "bd-1: " {
+			t.Fatalf("Flow title = %q, want %q", createdInput.Title, "bd-1: ")
+		}
+		if got := m.TransientError(); got != "Created flow: bd-1:" {
+			t.Fatalf("status = %q", got)
+		}
+	})
+}
+
+func TestBeadsReadyCreateFlowAdaptersAreIndependentWhenInjectedAlone(t *testing.T) {
+	for _, injected := range []string{"CreateFlowRecord", "CreateFlow", "StartFlowPlan"} {
+		t.Run(injected, func(t *testing.T) {
+			testRoot := t.TempDir()
+			repoPath := filepath.Join(testRoot, "repo")
+			if err := os.MkdirAll(repoPath, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			for _, args := range [][]string{
+				{"init", "-b", "main"},
+				{"config", "user.email", "test@example.com"},
+				{"config", "user.name", "Test User"},
+			} {
+				cmd := exec.Command("git", args...)
+				cmd.Dir = repoPath
+				if output, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("git %v failed: %v\n%s", args, err, output)
+				}
+			}
+			if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("fixture\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			for _, args := range [][]string{{"add", "README.md"}, {"commit", "-m", "fixture"}} {
+				cmd := exec.Command("git", args...)
+				cmd.Dir = repoPath
+				if output, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("git %v failed: %v\n%s", args, err, output)
+				}
+			}
+
+			var calls []string
+			opts := model.Options{
+				AgentCommand:     "codex",
+				SessionStateRoot: filepath.Join(testRoot, "state"),
+				ListReadyBeads: func(string) ([]beadsquery.Bead, error) {
+					return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
+				},
+				ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			}
+			switch injected {
+			case "CreateFlowRecord":
+				opts.CreateFlowRecord = func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+					calls = append(calls, "record")
+					record.FlowID = "custom-record"
+					return record, nil
+				}
+			case "CreateFlow":
+				opts.CreateFlow = func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+					calls = append(calls, "create")
+					return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "custom-create", RepoPath: req.RepoPath, Title: req.Title}}, nil
+				}
+			case "StartFlowPlan":
+				opts.StartFlowPlan = func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+					calls = append(calls, "start")
+					return model.FlowStartResult{
+						Flow:          flowstore.FlowRecord{FlowID: "custom-start", RepoPath: req.RepoPath, Title: req.Title},
+						LaunchSkipped: true,
+					}, nil
+				}
+			}
+			repos := []scanner.Repo{{Path: repoPath, DisplayName: "repo"}}
+
+			ready := inRightPane(model.NewWithOptions(repos, opts))
+			ready, _ = update(ready, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+			ready, readyCmd := update(ready, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+			if readyCmd == nil {
+				t.Fatal("entering Ready returned nil query command")
+			}
+			ready, _ = update(ready, readyCmd())
+			_, recordCmd := update(ready, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+			if recordCmd == nil {
+				t.Fatal("Ready f returned nil create command")
+			}
+			if msg := recordCmd(); func() bool {
+				_, ok := msg.(model.ReadyBeadFlowCreatedMsg)
+				return ok
+			}() == false {
+				t.Fatalf("Ready command returned %T, want ReadyBeadFlowCreatedMsg", msg)
+			}
+			wantCalls := ""
+			if injected == "CreateFlowRecord" {
+				wantCalls = "record"
+			}
+			if got := strings.Join(calls, ","); got != wantCalls {
+				t.Fatalf("calls after Ready path = %q, want %q", got, wantCalls)
+			}
+
+			parked := inRightPane(model.NewWithOptions(repos, opts))
+			parked, _ = update(parked, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+			_, parkedCmd := submitNewFlowPromptsWithCreateOptions(t, parked, "Parked "+injected, "Plan later", "main", true, false)
+			if parkedCmd == nil {
+				t.Fatal("Plan Now off returned nil command")
+			}
+			if msg := parkedCmd(); func() bool {
+				_, failed := msg.(model.FlowCreateFailedMsg)
+				return failed
+			}() {
+				t.Fatalf("Plan Now off failed: %#v", msg)
+			}
+			if injected == "CreateFlow" {
+				wantCalls = "create"
+			}
+			if got := strings.Join(calls, ","); got != wantCalls {
+				t.Fatalf("calls after parked path = %q, want %q", got, wantCalls)
+			}
+
+			planned := inRightPane(model.NewWithOptions(repos, opts))
+			planned, _ = update(planned, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+			_, plannedCmd := submitNewFlowPrompts(t, planned, "Planned "+injected, "Plan now", "main")
+			if plannedCmd == nil {
+				t.Fatal("Plan Now returned nil command")
+			}
+			if msg := plannedCmd(); func() bool {
+				_, failed := msg.(model.FlowCreateFailedMsg)
+				return failed
+			}() {
+				t.Fatalf("Plan Now failed: %#v", msg)
+			}
+			if injected == "StartFlowPlan" {
+				wantCalls = "start"
+			}
+			if got := strings.Join(calls, ","); got != wantCalls {
+				t.Fatalf("calls after Plan Now path = %q, want %q", got, wantCalls)
+			}
+		})
+	}
+}
+
+func TestBeadsReadyCreateFlowFailureWithoutDetailReportsFallback(t *testing.T) {
+	m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+		ListReadyBeads: func(string) ([]beadsquery.Bead, error) {
+			return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
+		},
+		ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+		CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			record.FlowID = "flow-1"
+			return record, nil
+		},
+	}))
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	m, readyCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, _ = update(m, readyCmd())
+	m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	created := createCmd().(model.ReadyBeadFlowCreatedMsg)
+
+	m, _ = update(m, model.ReadyBeadFlowCreateFailedMsg{
+		RepoPath: created.RepoPath,
+		Title:    created.Title,
+		Err:      "   ",
+		Request:  created.Request,
+	})
+	if got := m.TransientError(); got != "Unable to create flow" {
+		t.Fatalf("detail-free failure status = %q, want %q", got, "Unable to create flow")
+	}
+}
 
 func TestBeadsReadyCreateFlowPersistsSelectedVisibleBeadRecordOnly(t *testing.T) {
 	readyCalls := 0
@@ -131,28 +413,42 @@ func TestBeadsReadyCreateFlowRejectsInvalidAndDuplicateRequests(t *testing.T) {
 			createCalls++
 			return record, nil
 		}
-		assertNoCreate := func(t *testing.T, m model.Model, allowExistingCommand bool) {
+		assertNoCreate := func(t *testing.T, m model.Model) {
 			t.Helper()
 			_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
-			if cmd != nil && !allowExistingCommand {
-				t.Fatalf("invalid Ready context returned command %T", cmd)
-			}
 			if cmd != nil {
-				_ = immediateTestCommandMessages(cmd)
+				t.Fatalf("invalid Ready context returned command %T", cmd)
 			}
 			if createCalls != 0 {
 				t.Fatalf("CreateFlowRecord calls = %d, want 0", createCalls)
 			}
 		}
 
+		// Left-pane focus must keep `f` on the repo-fetch binding, not merely
+		// avoid Flow creation.
 		m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, create)
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
-		assertNoCreate(t, m, true)
+		_, leftCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+		if leftCmd == nil {
+			t.Fatal("left-pane f lost the repo fetch binding")
+		}
+		fetched := false
+		for _, msg := range immediateTestCommandMessages(leftCmd) {
+			if _, ok := msg.(model.VisibleRepoFetchResultMsg); ok {
+				fetched = true
+			}
+		}
+		if !fetched {
+			t.Fatal("left-pane f did not run the visible repo fetch")
+		}
+		if createCalls != 0 {
+			t.Fatalf("CreateFlowRecord calls = %d, want 0", createCalls)
+		}
 
 		for _, subview := range []rune{'b', 'o', 'i', 'c'} {
 			m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, create)
 			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{subview}})
-			assertNoCreate(t, m, false)
+			assertNoCreate(t, m)
 		}
 
 		m = inRightPane(model.NewWithOptions(testRepos(), model.Options{
@@ -162,12 +458,12 @@ func TestBeadsReadyCreateFlowRejectsInvalidAndDuplicateRequests(t *testing.T) {
 		}))
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
-		assertNoCreate(t, m, false) // loading
-		assertNoCreate(t, newReadyModel(t, nil, false, create), false)
-		assertNoCreate(t, newReadyModel(t, nil, true, create), false)
+		assertNoCreate(t, m) // loading
+		assertNoCreate(t, newReadyModel(t, nil, false, create))
+		assertNoCreate(t, newReadyModel(t, nil, true, create))
 		m = newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, create)
 		m = setBeadsQuery(t, m, "no-match")
-		assertNoCreate(t, m, false)
+		assertNoCreate(t, m)
 	})
 
 	t.Run("duplicate in flight", func(t *testing.T) {
@@ -279,13 +575,13 @@ func TestBeadsReadyCreateFlowRepoRoundTripInvalidatesStaleCompletion(t *testing.
 func TestBeadsReadyCreateFlowCompletionRefreshesOnlyVisibleFlowSurface(t *testing.T) {
 	for _, tt := range []struct {
 		name        string
-		key         tea.KeyMsg
+		key         *tea.KeyMsg
 		wantRefresh int
 	}{
-		{name: "beads ready", key: tea.KeyMsg{}, wantRefresh: 0},
-		{name: "selected repo flows", key: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}}, wantRefresh: 1},
-		{name: "active flows", key: tea.KeyMsg{Type: tea.KeyCtrlA}, wantRefresh: 1},
-		{name: "other surface", key: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}, wantRefresh: 0},
+		{name: "beads ready", key: nil, wantRefresh: 0},
+		{name: "selected repo flows", key: &tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}}, wantRefresh: 1},
+		{name: "active flows", key: &tea.KeyMsg{Type: tea.KeyCtrlA}, wantRefresh: 1},
+		{name: "other surface", key: &tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}, wantRefresh: 0},
 	} {
 		for _, failed := range []bool{false, true} {
 			outcome := "success"
@@ -316,8 +612,8 @@ func TestBeadsReadyCreateFlowCompletionRefreshesOnlyVisibleFlowSurface(t *testin
 				m, _ = update(m, readyCmd())
 				m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 				completion := createCmd()
-				if tt.key.Type != 0 {
-					m, _ = update(m, tt.key)
+				if tt.key != nil {
+					m, _ = update(m, *tt.key)
 				}
 				m, cmd := update(m, completion)
 				_ = immediateTestCommandMessages(cmd)
@@ -411,6 +707,14 @@ func TestBeadsReadyFlowCreateShortcutMatchesExecutablePredicate(t *testing.T) {
 			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 			return m
 		}},
+		{name: "search active", transform: func(m model.Model) model.Model {
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+			return m
+		}},
+		{name: "agent picker open", transform: func(m model.Model) model.Model {
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+			return m
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -420,6 +724,33 @@ func TestBeadsReadyFlowCreateShortcutMatchesExecutablePredicate(t *testing.T) {
 				t.Fatalf("new flow shortcut visible = %v, want %v:\n%s", got, tt.want, ansi.Strip(m.View()))
 			}
 		})
+	}
+}
+
+func TestBeadsReadyCreateFlowPickerConsumesFWithoutCreating(t *testing.T) {
+	createCalls := 0
+	m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+		ListReadyBeads: func(string) ([]beadsquery.Bead, error) {
+			return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
+		},
+		ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+		CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			createCalls++
+			return record, nil
+		},
+	}))
+	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 20})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	m, readyCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, _ = update(m, readyCmd())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'A'}})
+
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	if cmd != nil {
+		_ = immediateTestCommandMessages(cmd)
+	}
+	if createCalls != 0 {
+		t.Fatalf("CreateFlowRecord calls = %d, want 0", createCalls)
 	}
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -86,6 +86,8 @@ type Model struct {
 	activeRepoCreate          uint64
 	flowCreateSeq             uint64
 	activeFlowCreate          uint64
+	readyBeadFlowCreateSeq    uint64
+	activeReadyBeadFlowCreate uint64
 	repoRefreshSeq            uint64
 	activeRepoRefresh         uint64
 	pendingRepoSelection      string
@@ -122,6 +124,7 @@ type Model struct {
 	listBeads                 [beadSubviewCount]func(string) ([]beadsquery.Bead, error)
 	showBead                  func(repoPath, beadID string) (string, error)
 	countClosedBeads          func(string) (int, error)
+	createFlowRecord          func(flowstore.FlowRecord) (flowstore.FlowRecord, error)
 	createFlow                func(FlowStartRequest) (FlowStartResult, error)
 	startFlowPlan             func(FlowStartRequest) (FlowStartResult, error)
 	setFlowPhase              func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
@@ -234,6 +237,7 @@ type Options struct {
 	ListClosedBeads          func(repoPath string) ([]beadsquery.Bead, error)
 	ShowBead                 func(repoPath, beadID string) (string, error)
 	CountClosedBeads         func(repoPath string) (int, error)
+	CreateFlowRecord         func(flowstore.FlowRecord) (flowstore.FlowRecord, error)
 	CreateFlow               func(FlowStartRequest) (FlowStartResult, error)
 	StartFlowPlan            func(FlowStartRequest) (FlowStartResult, error)
 	SetFlowPhase             func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
@@ -476,6 +480,16 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if runBootstrapHook == nil {
 		runBootstrapHook = actions.RunBootstrapHook
 	}
+	createFlowRecord := opts.CreateFlowRecord
+	if createFlowRecord == nil {
+		createFlowRecord = func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			store, err := newFlowStore()
+			if err != nil {
+				return flowstore.FlowRecord{}, err
+			}
+			return store.CreateWithOptions(record, flowstore.CreateOptions{Preset: opts.FlowPreset})
+		}
+	}
 	createFlowForRepo := opts.CreateFlow
 	startFlowPlan := opts.StartFlowPlan
 	if createFlowForRepo == nil || startFlowPlan == nil {
@@ -559,6 +573,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		},
 		showBead:                 showBead,
 		countClosedBeads:         countClosedBeads,
+		createFlowRecord:         createFlowRecord,
 		createFlow:               createFlowForRepo,
 		startFlowPlan:            startFlowPlan,
 		setFlowPhase:             setFlowPhase,
@@ -1013,6 +1028,7 @@ func (m Model) View() string {
 		BeadsOpenScroll:              beadsScroll,
 		BeadsOpenAvailable:           beadsAvailable,
 		BeadsOpenPending:             beadsPending,
+		ReadyBeadFlowCreateAvailable: m.canCreateReadyBeadFlow(),
 		BeadsError:                   beadsError,
 		BeadsSourceCount:             beadsSourceCount,
 		BeadsClosedTotal:             beadsClosedTotal,
@@ -1632,6 +1648,10 @@ func (m Model) Update(msg tea.Msg) (next tea.Model, cmd tea.Cmd) {
 		return m.handleFlowCreated(msg)
 	case FlowCreateFailedMsg:
 		return m.handleFlowCreateFailed(msg)
+	case ReadyBeadFlowCreatedMsg:
+		return m.handleReadyBeadFlowCreated(msg)
+	case ReadyBeadFlowCreateFailedMsg:
+		return m.handleReadyBeadFlowCreateFailed(msg)
 	case AgentResultMsg:
 		// Detached launches only start the agent in an external
 		// terminal/multiplexer session and return while it keeps running, so the

--- a/model/model.go
+++ b/model/model.go
@@ -480,26 +480,25 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if runBootstrapHook == nil {
 		runBootstrapHook = actions.RunBootstrapHook
 	}
+	// storeCreateFlowRecord is the store-backed default for both the Ready-Bead
+	// record seam and the Flow starter. The starter always keeps this private
+	// callback so injecting Options.CreateFlowRecord cannot change the legacy
+	// Flows-pane create/plan paths.
+	storeCreateFlowRecord := func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+		store, err := newFlowStore()
+		if err != nil {
+			return flowstore.FlowRecord{}, err
+		}
+		return store.CreateWithOptions(record, flowstore.CreateOptions{Preset: opts.FlowPreset})
+	}
 	createFlowRecord := opts.CreateFlowRecord
 	if createFlowRecord == nil {
-		createFlowRecord = func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-			store, err := newFlowStore()
-			if err != nil {
-				return flowstore.FlowRecord{}, err
-			}
-			return store.CreateWithOptions(record, flowstore.CreateOptions{Preset: opts.FlowPreset})
-		}
+		createFlowRecord = storeCreateFlowRecord
 	}
 	createFlowForRepo := opts.CreateFlow
 	startFlowPlan := opts.StartFlowPlan
 	if createFlowForRepo == nil || startFlowPlan == nil {
-		createFlow := func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-			store, err := newFlowStore()
-			if err != nil {
-				return flowstore.FlowRecord{}, err
-			}
-			return store.CreateWithOptions(record, flowstore.CreateOptions{Preset: opts.FlowPreset})
-		}
+		createFlow := storeCreateFlowRecord
 		setFlowStartMetadata := func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
 			store, err := newFlowStore()
 			if err != nil {

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -191,6 +191,29 @@ func (m Model) clearFlowCreateRequest(request uint64) Model {
 	return m
 }
 
+func (m Model) nextReadyBeadFlowCreateRequest() (Model, uint64) {
+	m.readyBeadFlowCreateSeq++
+	m.activeReadyBeadFlowCreate = m.readyBeadFlowCreateSeq
+	return m, m.activeReadyBeadFlowCreate
+}
+
+func (m Model) isCurrentReadyBeadFlowCreateRequest(request uint64) bool {
+	return request != 0 && request == m.activeReadyBeadFlowCreate
+}
+
+func (m Model) clearReadyBeadFlowCreateRequest(request uint64) Model {
+	if m.isCurrentReadyBeadFlowCreateRequest(request) {
+		m.activeReadyBeadFlowCreate = 0
+	}
+	return m
+}
+
+func (m Model) invalidateReadyBeadFlowCreateRequest() Model {
+	m.readyBeadFlowCreateSeq++
+	m.activeReadyBeadFlowCreate = 0
+	return m
+}
+
 func (m Model) startFetchVisibleRepos() (Model, tea.Cmd) {
 	if m.visibleRepoFetch.Request != 0 {
 		return m, nil
@@ -506,6 +529,20 @@ func (m Model) createFlowForRepo(repoPath, title, instructions, baseRef string) 
 			return FlowCreateFailedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title, Err: err.Error()}
 		}
 		return FlowCreatedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title}
+	}
+}
+
+func (m Model) createReadyBeadFlow(repoPath, title, instructions string, request uint64) tea.Cmd {
+	return func() tea.Msg {
+		record, err := m.createFlowRecord(flowstore.FlowRecord{
+			Title:        title,
+			Instructions: instructions,
+			RepoPath:     repoPath,
+		})
+		if err != nil {
+			return ReadyBeadFlowCreateFailedMsg{RepoPath: repoPath, Title: title, Err: err.Error(), Request: request}
+		}
+		return ReadyBeadFlowCreatedMsg{RepoPath: repoPath, FlowID: record.FlowID, Title: title, Request: request}
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -10875,6 +10875,10 @@ func TestModel_NewFlowDelegatesStartAndLaunchesPlanAgent(t *testing.T) {
 				CodexReasoningEffort:  "xhigh",
 				ClaudeReasoningEffort: "max",
 				SessionStateRoot:      "/state/approach/sessions/v1",
+				CreateFlowRecord: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+					t.Fatal("Plan Now should not call the Ready-Bead record adapter")
+					return flowstore.FlowRecord{}, nil
+				},
 				StartFlowPlan: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
 					calls = append(calls, "start-flow")
 					startRequest = req
@@ -11048,6 +11052,10 @@ func TestModel_NewFlowPlanNowOffCreatesFlowWithoutLaunch(t *testing.T) {
 	externalCalls := 0
 	listed := false
 	m := model.NewWithOptions(testRepos(), model.Options{
+		CreateFlowRecord: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			t.Fatal("Plan Now off should not call the Ready-Bead record adapter")
+			return flowstore.FlowRecord{}, nil
+		},
 		CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
 			createRequest = req
 			return model.FlowStartResult{Flow: flowstore.FlowRecord{
@@ -11060,10 +11068,6 @@ func TestModel_NewFlowPlanNowOffCreatesFlowWithoutLaunch(t *testing.T) {
 				Commit:       "abc123",
 				Phases:       []flowstore.FlowPhase{{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseReady}},
 			}}, nil
-		},
-		StartFlowPlan: func(model.FlowStartRequest) (model.FlowStartResult, error) {
-			t.Fatal("Plan Now off should not start the plan phase")
-			return model.FlowStartResult{}, nil
 		},
 		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
 			externalCalls++

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -11069,6 +11069,10 @@ func TestModel_NewFlowPlanNowOffCreatesFlowWithoutLaunch(t *testing.T) {
 				Phases:       []flowstore.FlowPhase{{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseReady}},
 			}}, nil
 		},
+		StartFlowPlan: func(model.FlowStartRequest) (model.FlowStartResult, error) {
+			t.Fatal("Plan Now off should not start the plan phase")
+			return model.FlowStartResult{}, nil
+		},
 		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
 			externalCalls++
 			return actions.TerminalLaunchSpec{Cmd: exec.Command("true")}, nil

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -529,14 +529,18 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) canCreateReadyBeadFlow() bool {
-	if m.activePane != 1 || m.mode != ui.ModeBeadsReady || m.activeReadyBeadFlowCreate != 0 {
+	terminalInputFocused := m.terminalDockVisible && m.activePane == 1 && m.terminalFocus == terminalFocusTerminal && m.hasActiveEmbeddedTerminal()
+	if m.modal.IsOpen() || m.searchActive || terminalInputFocused ||
+		m.activePane != 1 || m.mode != ui.ModeBeadsReady || m.activeReadyBeadFlowCreate != 0 {
 		return false
 	}
 	if _, ok := m.currentRepoPath(); !ok {
 		return false
 	}
-	_, ok := m.selectedVisibleBead()
-	return ok
+	bead, ok := m.selectedVisibleBead()
+	// An empty ID would produce an unrunnable `bd show ` instruction, so the
+	// action is not offered for rows that carry no usable Bead ID.
+	return ok && strings.TrimSpace(bead.ID) != ""
 }
 
 func (m Model) handleReadyBeadFlowCreate() (Model, tea.Cmd) {
@@ -1587,11 +1591,20 @@ func (m Model) handleFlowCreated(msg FlowCreatedMsg) (Model, tea.Cmd) {
 }
 
 func (m Model) handleReadyBeadFlowCreated(msg ReadyBeadFlowCreatedMsg) (Model, tea.Cmd) {
-	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentReadyBeadFlowCreateRequest(msg.Request) {
+	if !m.isCurrentReadyBeadFlowCreateRequest(msg.Request) {
 		return m, nil
 	}
+	// Release the request before the repo check so a repo change that bypassed
+	// invalidation can never strand the shortcut.
 	m = m.clearReadyBeadFlowCreateRequest(msg.Request)
-	m = m.setStatus(statusOther, "Created flow: "+strings.TrimSpace(msg.Title))
+	if !m.isCurrentRepo(msg.RepoPath) {
+		return m, nil
+	}
+	title := strings.TrimSpace(msg.Title)
+	if title == "" {
+		title = "Flow"
+	}
+	m = m.setStatus(statusOther, "Created flow: "+title)
 	if m.flowSurfaceVisible() {
 		return m.startFlowSurfaceFetch()
 	}
@@ -1599,10 +1612,13 @@ func (m Model) handleReadyBeadFlowCreated(msg ReadyBeadFlowCreatedMsg) (Model, t
 }
 
 func (m Model) handleReadyBeadFlowCreateFailed(msg ReadyBeadFlowCreateFailedMsg) (Model, tea.Cmd) {
-	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentReadyBeadFlowCreateRequest(msg.Request) {
+	if !m.isCurrentReadyBeadFlowCreateRequest(msg.Request) {
 		return m, nil
 	}
 	m = m.clearReadyBeadFlowCreateRequest(msg.Request)
+	if !m.isCurrentRepo(msg.RepoPath) {
+		return m, nil
+	}
 	errText := strings.TrimSpace(msg.Err)
 	if errText == "" {
 		errText = "Unable to create flow"
@@ -2927,6 +2943,9 @@ func (m Model) resetBeadsForRepoChange() Model {
 
 func (m Model) resetRightPaneCursors() Model {
 	m = m.invalidateListRequests()
+	// Covers the rescan-driven repo changes in handleRepoRefreshResult, which
+	// never route through handleRepoSelectionChanged.
+	m = m.invalidateReadyBeadFlowCreateRequest()
 	m.pendingBranchSelection = ""
 	m.pendingWorktreeSelection = ""
 	m.rows = m.rows.SetItems(nil).ResetSelection()

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -363,6 +363,7 @@ func (m Model) moveRepoSelection(delta int) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleRepoSelectionChanged(repoSelected bool) (tea.Model, tea.Cmd) {
+	m = m.invalidateReadyBeadFlowCreateRequest()
 	if m.activeFlowSurfaceVisible() {
 		m = m.resetBeadsForRepoChange()
 		m = m.syncActiveFlowsFromCache()
@@ -508,6 +509,9 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 	case "u":
 		return m.handleUnlock()
 	case "f":
+		if m.mode == ui.ModeBeadsReady {
+			return m.handleReadyBeadFlowCreate()
+		}
 		return m.handleFetch()
 	case "F":
 		return m.handlePull()
@@ -522,6 +526,31 @@ func (m Model) handleRightPaneKey(key string) (tea.Model, tea.Cmd) {
 		return m.handleEmbeddedTerminalQuitPrefix()
 	}
 	return m, nil
+}
+
+func (m Model) canCreateReadyBeadFlow() bool {
+	if m.activePane != 1 || m.mode != ui.ModeBeadsReady || m.activeReadyBeadFlowCreate != 0 {
+		return false
+	}
+	if _, ok := m.currentRepoPath(); !ok {
+		return false
+	}
+	_, ok := m.selectedVisibleBead()
+	return ok
+}
+
+func (m Model) handleReadyBeadFlowCreate() (Model, tea.Cmd) {
+	if !m.canCreateReadyBeadFlow() {
+		return m, nil
+	}
+	repoPath, _ := m.currentRepoPath()
+	bead, _ := m.selectedVisibleBead()
+	beadID := strings.TrimSpace(bead.ID)
+	title := beadID + ": " + strings.TrimSpace(bead.Title)
+	instructions := fmt.Sprintf("Use Bead %s as the durable source of requirements. Read it with `bd show %s` before planning or implementation.", beadID, beadID)
+	var request uint64
+	m, request = m.nextReadyBeadFlowCreateRequest()
+	return m, m.createReadyBeadFlow(repoPath, title, instructions, request)
 }
 
 func (m Model) togglePrimaryPaneFocus() Model {
@@ -1551,6 +1580,34 @@ func (m Model) handleFlowCreated(msg FlowCreatedMsg) (Model, tea.Cmd) {
 		title = "Flow"
 	}
 	m = m.setStatus(statusOther, "Created flow: "+title)
+	if m.flowSurfaceVisible() {
+		return m.startFlowSurfaceFetch()
+	}
+	return m, nil
+}
+
+func (m Model) handleReadyBeadFlowCreated(msg ReadyBeadFlowCreatedMsg) (Model, tea.Cmd) {
+	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentReadyBeadFlowCreateRequest(msg.Request) {
+		return m, nil
+	}
+	m = m.clearReadyBeadFlowCreateRequest(msg.Request)
+	m = m.setStatus(statusOther, "Created flow: "+strings.TrimSpace(msg.Title))
+	if m.flowSurfaceVisible() {
+		return m.startFlowSurfaceFetch()
+	}
+	return m, nil
+}
+
+func (m Model) handleReadyBeadFlowCreateFailed(msg ReadyBeadFlowCreateFailedMsg) (Model, tea.Cmd) {
+	if !m.isCurrentRepo(msg.RepoPath) || !m.isCurrentReadyBeadFlowCreateRequest(msg.Request) {
+		return m, nil
+	}
+	m = m.clearReadyBeadFlowCreateRequest(msg.Request)
+	errText := strings.TrimSpace(msg.Err)
+	if errText == "" {
+		errText = "Unable to create flow"
+	}
+	m = m.setStatus(statusOther, errText)
 	if m.flowSurfaceVisible() {
 		return m.startFlowSurfaceFetch()
 	}

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -494,6 +494,20 @@ type FlowCreateFailedMsg struct {
 	Request  uint64
 }
 
+type ReadyBeadFlowCreatedMsg struct {
+	RepoPath string
+	FlowID   string
+	Title    string
+	Request  uint64
+}
+
+type ReadyBeadFlowCreateFailedMsg struct {
+	RepoPath string
+	Title    string
+	Err      string
+	Request  uint64
+}
+
 type FlowDeletedMsg struct {
 	RepoPath string
 	FlowID   string

--- a/ui/beads_test.go
+++ b/ui/beads_test.go
@@ -389,6 +389,56 @@ func TestRender_BeadsOpenShortcutsAdvertiseArrowAndSubviewNavigation(t *testing.
 	}
 }
 
+func TestRender_BeadsReadyFlowCreateShortcutUsesAvailabilitySnapshot(t *testing.T) {
+	base := RenderParams{
+		Repos:                        []scanner.Repo{{Path: "/a", DisplayName: "alpha"}},
+		Selected:                     0,
+		Height:                       20,
+		Mode:                         ModeBeadsReady,
+		ActivePane:                   1,
+		BeadsOpen:                    []beadsquery.Bead{{ID: "bd-1", Title: "One"}},
+		ReadyBeadFlowCreateAvailable: true,
+	}
+
+	base.Width = 80
+	footerView := ansi.Strip(Render(base))
+	if !strings.Contains(footerView, "f: new flow") {
+		t.Fatalf("Ready footer missing executable Flow shortcut:\n%s", footerView)
+	}
+
+	base.Width = 140
+	pane := ansi.Strip(shortcutPaneText(Render(base)))
+	if !strings.Contains(pane, "f      new flow") {
+		t.Fatalf("Ready shortcut pane missing executable Flow shortcut:\n%s", pane)
+	}
+
+	for _, tt := range []struct {
+		name   string
+		mutate func(*RenderParams)
+	}{
+		{name: "left focused", mutate: func(p *RenderParams) { p.ActivePane = 0 }},
+		{name: "loading", mutate: func(p *RenderParams) { p.BeadsOpenPending = true }},
+		{name: "unavailable", mutate: func(p *RenderParams) { p.BeadsOpenAvailable = false }},
+		{name: "empty", mutate: func(p *RenderParams) { p.BeadsOpen = nil }},
+		{name: "filtered empty", mutate: func(p *RenderParams) { p.BeadsOpen = nil; p.ItemSearch = "no-match" }},
+		{name: "non ready", mutate: func(p *RenderParams) { p.Mode = ModeBeadsBlocked }},
+		{name: "creating"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			params := base
+			params.Width = 140
+			params.ReadyBeadFlowCreateAvailable = false
+			if tt.mutate != nil {
+				tt.mutate(&params)
+			}
+			view := ansi.Strip(Render(params))
+			if strings.Contains(view, "new flow") {
+				t.Fatalf("unavailable Ready action advertised:\n%s", view)
+			}
+		})
+	}
+}
+
 func TestRender_BeadsQuietStatesAreSubviewSpecific(t *testing.T) {
 	for _, tt := range []struct {
 		mode Mode

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -332,6 +332,7 @@ type RenderParams struct {
 	BeadsOpenScroll              int
 	BeadsOpenAvailable           bool
 	BeadsOpenPending             bool
+	ReadyBeadFlowCreateAvailable bool
 	BeadsError                   string
 	BeadsSourceCount             int
 	BeadsClosedTotal             int
@@ -630,6 +631,7 @@ func renderApplication(p RenderParams) string {
 		PullAvailable:                p.PullAvailable,
 		AgentAvailable:               p.AgentAvailable,
 		NewAgent:                     p.NewAgentAvailable,
+		ReadyBeadFlowCreateAvailable: p.ReadyBeadFlowCreateAvailable,
 	}
 	innerHeight := p.Height - 3 // status bar + top/bottom borders
 	dockState := EmbeddedTerminalDockCollapsed
@@ -1061,6 +1063,7 @@ type statusBarParams struct {
 	PullAvailable                bool
 	AgentAvailable               bool
 	NewAgent                     bool
+	ReadyBeadFlowCreateAvailable bool
 }
 
 type shortcutHint struct {
@@ -1378,6 +1381,9 @@ func shortcutSections(sp statusBarParams) []shortcutSection {
 	}
 	if sp.ActivePane == 0 && sp.RepoCreateAvailable {
 		actions = append(actions, shortcutHint{Key: "n", Label: "new repo"})
+	}
+	if sp.Mode == ModeBeadsReady && sp.ReadyBeadFlowCreateAvailable {
+		actions = append(actions, shortcutHint{Key: "f", Label: "new flow"})
 	}
 	if flowSurfaceActive {
 		return flowShortcutSections(sp, actions, navigation, global)

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1129,6 +1129,7 @@ func renderStatusBarWithState(sp statusBarParams) string {
 	itemSearch := sp.ItemSearch
 
 	if transientError != "" {
+		transientError = terminalSafeSingleLine(transientError)
 		return statusStyle.Width(width).Render("  " + transientStatusStyle(sp.TransientErrorFadeStep).Render(transientError))
 	}
 
@@ -3017,7 +3018,8 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 		planCell := statusStyle.Render(fitSessionColumn(plan, flowPlanWidth))
 		prCell := statusStyle.Render(fitSessionColumn(pr, flowPRWidth))
 		updatedCell := stashDateStyle.Render(fitSessionColumn(updated, flowUpdatedWidth))
-		titleCell := stashMsgStyle.Render(record.Title)
+		title := terminalSafeSingleLine(record.Title)
+		titleCell := stashMsgStyle.Render(title)
 		line := formatFlowColumns(showRepo, flowRowPrefix(false, active.hasFlow(record.FlowID)),
 			statusCell,
 			repoCell,
@@ -3039,7 +3041,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 				plan,
 				pr,
 				updated,
-				record.Title,
+				title,
 				width)
 		}
 		rows = append(rows, truncateToWidth(line, width))
@@ -3952,6 +3954,7 @@ func renderFormDialogOverApplication(p RenderParams, contentHeight int) []string
 }
 
 func renderConfirmDialog(prompt string, force bool, width, height int) []string {
+	prompt = terminalSafeSingleLine(prompt)
 	lines := make([]string, height)
 	mid := height / 2
 	if mid < len(lines) {

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -57,6 +57,45 @@ func TestRender_FlowsModeShowsHeaderAndRows(t *testing.T) {
 	}
 }
 
+func TestRender_FlowTitleIsTerminalSafeSingleLine(t *testing.T) {
+	const unsafeTitle = "bd-1: \x1b]52;c;dGVzdA==\aUnsafe\nTitle"
+	for _, tt := range []struct {
+		name     string
+		selected int
+	}{
+		{name: "unselected", selected: -1},
+		{name: "selected", selected: 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rows := renderFlowPane(
+				[]flowstore.FlowRecord{{FlowID: "flow-1", Title: unsafeTitle, Status: flowstore.StatusPending}},
+				tt.selected,
+				0,
+				200,
+				3,
+				"",
+				"",
+				nil,
+				false,
+				nil,
+			)
+			if len(rows) < 2 {
+				t.Fatalf("flow rows = %d, want header and record", len(rows))
+			}
+			row := rows[1]
+			if strings.Contains(row, "\x1b]52;") {
+				t.Fatalf("flow row retained OSC sequence: %q", row)
+			}
+			if strings.Contains(row, "\n") {
+				t.Fatalf("flow row retained embedded newline: %q", row)
+			}
+			if got := ansi.Strip(row); !strings.Contains(got, "bd-1: Unsafe Title") {
+				t.Fatalf("flow row text = %q, want sanitized single-line title", got)
+			}
+		})
+	}
+}
+
 func TestRender_FlowsModeShowsMissingIssueCell(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -143,6 +143,37 @@ func TestStatusBar_BranchesModeContainsIndicatorLegend(t *testing.T) {
 	}
 }
 
+func TestStatusBar_TransientStatusIsTerminalSafeSingleLine(t *testing.T) {
+	const unsafeTitle = "bd-1: \x1b]52;c;dGVzdA==\aUnsafe\nTitle"
+	bar := renderStatusBarWithState(statusBarParams{
+		Width:          120,
+		TransientError: "Created flow: " + unsafeTitle,
+	})
+
+	if strings.Contains(bar, "\x1b]52;") {
+		t.Fatalf("status bar retained OSC sequence: %q", bar)
+	}
+	if strings.Contains(bar, "\n") {
+		t.Fatalf("status bar retained embedded newline: %q", bar)
+	}
+	if got := ansi.Strip(bar); !strings.Contains(got, "Created flow: bd-1: Unsafe Title") {
+		t.Fatalf("status bar text = %q, want sanitized single-line title", got)
+	}
+}
+
+func TestRenderConfirmDialogPromptIsTerminalSafeSingleLine(t *testing.T) {
+	const unsafePrompt = "Delete Flow bd-1: \x1b]52;c;dGVzdA==\aUnsafe\nTitle?"
+	lines := renderConfirmDialog(unsafePrompt, false, 120, 5)
+	view := strings.Join(lines, "\n")
+
+	if strings.Contains(view, "\x1b]52;") {
+		t.Fatalf("confirmation retained OSC sequence: %q", view)
+	}
+	if got := ansi.Strip(lines[2]); !strings.Contains(got, "Delete Flow bd-1: Unsafe Title?") {
+		t.Fatalf("confirmation text = %q, want sanitized single-line prompt", got)
+	}
+}
+
 func TestStatusBar_IndicatorLegendSpacing(t *testing.T) {
 	bar := RenderStatusBar(120, 2, 0, 1, true, false, false)
 	for _, pair := range [][2]string{


### PR DESCRIPTION
## Summary

- add an f shortcut in the Ready Beads view that creates a new Flow record from the selected bead
- keep creation record-only: no worktree bootstrap, plan launch, agent execution, or Beads mutation
- refresh the affected Flow and repository surfaces, harden adapter/error handling, and document the interaction
- sanitize tracker-derived titles at terminal rendering boundaries while preserving persisted values

## Verification

- gofmt -l .
- make test
- make build
- git diff --check 3913b48559680e21891cf3b4dac4d3ed9a5cab70..HEAD