### PR TITLE
Create the Flow worktree from the Ready Beads shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Repos on the left, content on the right. The essentials:
 | `←`/`→` | Wrap within Git or Beads subviews; elsewhere step through Git, sessions, plans, flows, and Beads, after which the arrows stay inside whichever group they entered |
 | `ctrl+a` | Toggle Active Flows (all repos) |
 | `/` | Fuzzy filter the active pane |
-| `f` | Fetch in eligible repo/Git contexts; in a settled Beads Ready pane, create a record-only Flow for the selected Bead |
+| `f` | Fetch in eligible repo/Git contexts; in a settled Beads Ready pane, create a parked Flow with its worktree for the selected Bead |
 | `f5` | Rescan repositories and refresh the current view, including the active Beads subview |
 | `D` | Toggle destructive mode — deletion keys stay disabled until this is on |
 | `a` | Launch the configured coding agent |
@@ -119,21 +119,19 @@ invalidates an older result; delivery also requires the same bead to remain the
 visible selection.
 
 In Ready only, press `f` on a settled visible selection whose Bead has a usable
-ID to create one record-only, Approach-owned Flow in the selected repository.
+ID to create one Approach-owned Flow in the selected repository.
 Its title is `<trimmed bead ID>: <trimmed bead title>` and its instructions are
 ``Use Bead <id> as the durable source of requirements. Read it with `bd show <id>` before planning or implementation.`` The configured Flow preset supplies
-the phase graph, with normal creation defaults, but this shortcut supplies no
-worktree, branch, base ref, commit, plan/link, launch, session, agent, issue, or
-PR metadata. It does not run a bootstrap hook, start a phase, launch an agent,
-or invoke `bd`; the Bead remains untouched.
+the phase graph, and the shortcut prepares the Flow exactly like a Flows-pane
+`n` submission with Plan Now off: it creates the `flow/<slug>` branch and
+worktree from the repository's current HEAD, records the start metadata, and
+runs the bootstrap hook. It does not link a plan or issue, start a phase,
+launch an agent, or invoke `bd`; the Bead remains untouched.
 
-A record-only Flow is not the same as the parked Flow the Flows-pane `n` form
-creates: it has no worktree, so the Flows pane shows it with the
-`missing-worktree` branch label and a `recover-worktree` phase state, and
-launching its first phase with `g` runs the agent in the repository root rather
-than an isolated worktree. No operation currently attaches a worktree to this
-existing record; if isolation is required, create a separate Flow through the
-normal `n` path instead of launching this one.
+The result is the same parked Flow the Flows-pane `n` form creates, so `g` on
+its first phase launches the agent inside the Flow's isolated worktree. If the
+worktree cannot be created, the Flow record is still persisted with its
+launchable phases blocked and the error is shown in the status line.
 
 ## Agents, Plans, and Flows
 

--- a/docs/beads-view-spec.md
+++ b/docs/beads-view-spec.md
@@ -5,8 +5,8 @@ five visible query/header subviews, sticky group re-entry, arrow navigation, and
 per-subview filter/cursor preservation with refetch clamping, plus
 configured/not-configured/error classification are shipped, as are the
 newest-100 Closed cap with its plain/truncated header count and `default_view`
-10–14 startup routing, read-only detail paging, and record-only Flow creation
-from a settled Ready selection. Companion docs:
+10–14 startup routing, read-only detail paging, and parked-Flow creation (record
+plus worktree) from a settled Ready selection. Companion docs:
 `architecture.md`
 (package map, invariants), `config.md` (config vocabulary), `README.md` (current
 key bindings).
@@ -36,7 +36,8 @@ repo cursor. Repos without beads show a calm "beads not configured" message;
 configured repos where `bd` fails show a real error. The view is read-only in
 its Beads access and tracker state, with `enter` paging a bead's detail through
 the pager. A settled Ready selection also exposes `f` to create an
-Approach-owned record-only Flow without invoking `bd` or mutating the Bead.
+Approach-owned parked Flow — record, branch, and worktree — without invoking
+`bd` or mutating the Bead.
 
 ## User Stories
 
@@ -69,7 +70,7 @@ Approach-owned record-only Flow without invoking `bd` or mutating the Bead.
 27. As an Approach user, I want the frozen `default_view` vocabulary (1–9) untouched, so that existing configs keep their meaning.
 28. As an Approach user, I want a manual way to refetch beads via the app's existing refresh affordance, so that I can pull in changes an agent made without bouncing the repo cursor.
 29. As an agent operator, I want issue state visible next to Sessions, Plans, and Flows, so that I can see what my agents should pick up next and what they have finished.
-30. As an Approach user, I want `f` on a settled visible Ready selection to create a record-only Flow for that Bead, so that I can carry the durable requirement into the Flow workflow without creating a worktree, launching an agent, or changing the Bead.
+30. As an Approach user, I want `f` on a settled visible Ready selection to create a parked Flow with its worktree for that Bead, so that I can carry the durable requirement into the Flow workflow with isolation ready, without launching an agent or changing the Bead.
 
 ## Implementation Decisions
 
@@ -112,15 +113,17 @@ Approach-owned record-only Flow without invoking `bd` or mutating the Bead.
 - `enter` on a bead pages `bd show <id> --readonly` output through the pager with
   stale-result protection, the same pattern as the app's other read-only
   detail views.
-- `f` is a Ready-only record-persistence action. It requires right-pane focus,
+- `f` is a Ready-only Flow-preparation action. It requires right-pane focus,
   an available settled filtered selection whose Bead has a non-empty trimmed
   ID, a selected repo, and no existing Ready Flow request. It creates a Flow
   titled `<trimmed bead ID>: <trimmed bead title>` with instructions directing
   agents to use `bd show <id>` as the durable source of requirements. Creation
-  uses the configured preset but supplies only title, instructions, and repo
-  path: no worktree, branch, base ref, commit, plan/link, launch/session, agent,
-  issue, or PR metadata. It never invokes the Flow starter, bootstrap hooks,
-  agent launchers, or `bd`.
+  routes through the same Flow-starter prepare path as the Flows-pane `n` form
+  with Plan Now off: the configured preset seeds the phase graph, the
+  `flow/<slug>` branch and worktree are created from the repository's current
+  HEAD (no base ref is supplied), start metadata is recorded, and the
+  repository's bootstrap hook runs. It supplies no plan/link, launch/session,
+  agent, issue, or PR metadata and never invokes agent launchers or `bd`.
 - Ready Flow persistence has its own monotonically increasing request token.
   Duplicate keypresses are ignored while it is active. Cursor-driven repo
   changes invalidate it at the top of `handleRepoSelectionChanged`, before
@@ -131,10 +134,12 @@ Approach-owned record-only Flow without invoking `bd` or mutating the Bead.
   Accepted success or failure updates status and refreshes exactly the
   currently visible Flow surface, if any; Beads and other surfaces do not
   refresh.
-- The resulting Flow is record-only, not the Flows-pane form's parked Flow: it
-  has no worktree, so existing Flow rendering labels it `missing-worktree` /
-  `recover-worktree`, and phase launch falls back to the repository root. The
-  docs state this explicitly rather than implying an isolated worktree exists.
+- The resulting Flow is the same parked Flow the Flows-pane form produces, so
+  phase launch runs in the Flow's isolated worktree. On worktree or bootstrap
+  failure the persisted record's launchable phases are blocked with the failure
+  noted; existing Flow rendering then labels the worktree-less record
+  `missing-worktree` / `recover-worktree`, and phase launch falls back to the
+  repository root.
 - Config: `default_view` gains frozen numbers 10 (ready), 11 (blocked),
   12 (open), 13 (in-progress), 14 (closed), parallel to the git subviews'
   1–5. Numbers 1–9 keep their existing frozen meanings.

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -88,7 +88,7 @@ title, and assignee; repo filtering remains available from the left pane.
 | `d` | Delete worktree/branch, drop stash, or delete Flow data — requires destructive mode |
 | `p` | Prune stale worktree — requires destructive mode (worktrees view), or open the linked PR (flows and active flows views, when PR metadata exists) |
 | `u` | Unlock a locked worktree (worktrees view) |
-| `f` | Fetch with `--prune` (worktrees and branches views), or create a record-only Flow for the selected Bead in a settled Ready subview |
+| `f` | Fetch with `--prune` (worktrees and branches views), or create a parked Flow with its worktree for the selected Bead in a settled Ready subview |
 | `F` | Pull with `--ff-only` (worktrees, and branches with a checked-out worktree) |
 | `t` | Open or attach to a tmux/Zellij session for the worktree |
 | `c` | Open VSCode at worktree path outside Flow surfaces, or copy the selected Flow ID in flows and active flows views |
@@ -381,25 +381,27 @@ selected process directory are owned by the query runner.
 In Ready only, `f` is available when the content pane is focused, the query is
 settled and available, a filtered visible Bead with a non-empty ID is selected,
 and no Ready Flow creation is already in flight. It asynchronously creates
-exactly one record-only Approach Flow in the selected repo. The record title is
+exactly one Approach Flow in the selected repo. The record title is
 `<trimmed bead ID>: <trimmed bead title>` and its instructions are
 ``Use Bead <id> as the durable source of requirements. Read it with `bd show <id>` before planning or implementation.`` The configured Flow preset seeds the
-phase graph and normal Flow creation defaults still apply, but the shortcut
-supplies no worktree, branch, base ref, commit, plan/link, launch, session,
-agent, issue, or PR metadata. It does not run bootstrap hooks, start a Flow
-phase, launch an agent, or invoke `bd`, so the selected Bead and all other
-tracker state remain untouched. The shortcut is hidden in every context where
-that exact action cannot run; duplicate keypresses are ignored until the
-current persistence request finishes, and any repo change — cursor move or
-rescan — releases the shortcut and discards the pending result.
+phase graph and normal Flow creation defaults apply. The shortcut prepares the
+Flow exactly like an `n` form submission with Plan Now off: it creates the
+`flow/<slug>` branch and worktree from the repository's current HEAD, records
+the worktree, branch, and commit start metadata, and runs the repository's
+bootstrap hook. It does not link a plan or issue, start a Flow phase, launch an
+agent, or invoke `bd`, so the selected Bead and all other tracker state remain
+untouched. The shortcut is hidden in every context where that exact action
+cannot run; duplicate keypresses are ignored until the current creation request
+finishes, and any repo change — cursor move or rescan — releases the shortcut
+and discards the pending result.
 
-Because the record carries no worktree or branch, the Flows pane renders it with
-the `missing-worktree` branch label and a `recover-worktree` phase state, and
-`g` on its first phase launches the agent in the repository root instead of an
-isolated worktree. This is a deliberately different artifact from the parked
-Flow produced by a successful `n` form submission, which has a worktree; a
-normal startup failure before worktree creation can still leave a partial Flow
-record without one.
+The result is the same parked Flow a successful `n` form submission produces,
+so `g` on its first phase launches the agent inside the Flow's isolated
+worktree. If worktree creation or the bootstrap hook fails, the persisted Flow
+record keeps its launchable phases blocked with the failure noted, the Flows
+pane renders the worktree-less record with the `missing-worktree` branch label
+and a `recover-worktree` phase state, and the error is reported in the status
+line.
 
 After the active subview settles, `enter` on its visible selected row
 asynchronously loads the raw human-readable output of

--- a/model/bead_flow_create_test.go
+++ b/model/bead_flow_create_test.go
@@ -36,10 +36,9 @@ func TestBeadsReadyCreateFlowRescanRepoChangeDoesNotStrandShortcut(t *testing.T)
 			return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
 		},
 		ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
-		CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+		CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
 			createCalls++
-			record.FlowID = "flow-1"
-			return record, nil
+			return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "flow-1", RepoPath: req.RepoPath, Title: req.Title}}, nil
 		},
 	}))
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
@@ -52,7 +51,7 @@ func TestBeadsReadyCreateFlowRescanRepoChangeDoesNotStrandShortcut(t *testing.T)
 	}
 	stale := createCmd().(model.ReadyBeadFlowCreatedMsg)
 	if createCalls != 1 {
-		t.Fatalf("CreateFlowRecord calls = %d, want 1", createCalls)
+		t.Fatalf("CreateFlow calls = %d, want 1", createCalls)
 	}
 
 	m, refreshCmd := update(m, tea.KeyMsg{Type: tea.KeyF5})
@@ -81,12 +80,12 @@ func TestBeadsReadyCreateFlowRescanRepoChangeDoesNotStrandShortcut(t *testing.T)
 }
 
 func TestBeadsReadyCreateFlowRequiresUsableBeadIDAndToleratesEmptyTitle(t *testing.T) {
-	newReadyModel := func(t *testing.T, beads []beadsquery.Bead, create func(flowstore.FlowRecord) (flowstore.FlowRecord, error)) model.Model {
+	newReadyModel := func(t *testing.T, beads []beadsquery.Bead, create func(model.FlowStartRequest) (model.FlowStartResult, error)) model.Model {
 		t.Helper()
 		m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
-			ListReadyBeads:   func(string) ([]beadsquery.Bead, error) { return nil, nil },
-			ListOpenBeads:    func(string) ([]beadsquery.Bead, error) { return nil, nil },
-			CreateFlowRecord: create,
+			ListReadyBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			ListOpenBeads:  func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			CreateFlow:     create,
 		}))
 		m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 20})
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
@@ -103,9 +102,9 @@ func TestBeadsReadyCreateFlowRequiresUsableBeadIDAndToleratesEmptyTitle(t *testi
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			createCalls := 0
-			m := newReadyModel(t, []beadsquery.Bead{tt.bead}, func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			m := newReadyModel(t, []beadsquery.Bead{tt.bead}, func(model.FlowStartRequest) (model.FlowStartResult, error) {
 				createCalls++
-				return record, nil
+				return model.FlowStartResult{}, nil
 			})
 			if strings.Contains(ansi.Strip(m.View()), "new flow") {
 				t.Fatalf("unusable Bead ID advertised the Flow shortcut:\n%s", ansi.Strip(m.View()))
@@ -115,25 +114,24 @@ func TestBeadsReadyCreateFlowRequiresUsableBeadIDAndToleratesEmptyTitle(t *testi
 				t.Fatalf("unusable Bead ID returned create command %T", cmd)
 			}
 			if createCalls != 0 {
-				t.Fatalf("CreateFlowRecord calls = %d, want 0", createCalls)
+				t.Fatalf("CreateFlow calls = %d, want 0", createCalls)
 			}
 		})
 	}
 
 	t.Run("empty title preserves the exact mapping", func(t *testing.T) {
-		var createdInput flowstore.FlowRecord
-		m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "   "}}, func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-			createdInput = record
-			record.FlowID = "flow-1"
-			return record, nil
+		var createdRequest model.FlowStartRequest
+		m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "   "}}, func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+			createdRequest = req
+			return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "flow-1", RepoPath: req.RepoPath, Title: req.Title}}, nil
 		})
 		m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 		if cmd == nil {
 			t.Fatal("titleless Bead returned nil create command")
 		}
 		m, _ = update(m, cmd())
-		if createdInput.Title != "bd-1: " {
-			t.Fatalf("Flow title = %q, want %q", createdInput.Title, "bd-1: ")
+		if createdRequest.Title != "bd-1: " {
+			t.Fatalf("Flow title = %q, want %q", createdRequest.Title, "bd-1: ")
 		}
 		if got := m.TransientError(); got != "Created flow: bd-1:" {
 			t.Fatalf("status = %q", got)
@@ -142,7 +140,7 @@ func TestBeadsReadyCreateFlowRequiresUsableBeadIDAndToleratesEmptyTitle(t *testi
 }
 
 func TestBeadsReadyCreateFlowAdaptersAreIndependentWhenInjectedAlone(t *testing.T) {
-	for _, injected := range []string{"CreateFlowRecord", "CreateFlow", "StartFlowPlan"} {
+	for _, injected := range []string{"CreateFlow", "StartFlowPlan"} {
 		t.Run(injected, func(t *testing.T) {
 			testRoot := t.TempDir()
 			repoPath := filepath.Join(testRoot, "repo")
@@ -181,12 +179,6 @@ func TestBeadsReadyCreateFlowAdaptersAreIndependentWhenInjectedAlone(t *testing.
 				ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
 			}
 			switch injected {
-			case "CreateFlowRecord":
-				opts.CreateFlowRecord = func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-					calls = append(calls, "record")
-					record.FlowID = "custom-record"
-					return record, nil
-				}
 			case "CreateFlow":
 				opts.CreateFlow = func(req model.FlowStartRequest) (model.FlowStartResult, error) {
 					calls = append(calls, "create")
@@ -221,8 +213,8 @@ func TestBeadsReadyCreateFlowAdaptersAreIndependentWhenInjectedAlone(t *testing.
 				t.Fatalf("Ready command returned %T, want ReadyBeadFlowCreatedMsg", msg)
 			}
 			wantCalls := ""
-			if injected == "CreateFlowRecord" {
-				wantCalls = "record"
+			if injected == "CreateFlow" {
+				wantCalls = "create"
 			}
 			if got := strings.Join(calls, ","); got != wantCalls {
 				t.Fatalf("calls after Ready path = %q, want %q", got, wantCalls)
@@ -241,7 +233,7 @@ func TestBeadsReadyCreateFlowAdaptersAreIndependentWhenInjectedAlone(t *testing.
 				t.Fatalf("Plan Now off failed: %#v", msg)
 			}
 			if injected == "CreateFlow" {
-				wantCalls = "create"
+				wantCalls = "create,create"
 			}
 			if got := strings.Join(calls, ","); got != wantCalls {
 				t.Fatalf("calls after parked path = %q, want %q", got, wantCalls)
@@ -275,9 +267,8 @@ func TestBeadsReadyCreateFlowFailureWithoutDetailReportsFallback(t *testing.T) {
 			return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
 		},
 		ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
-		CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-			record.FlowID = "flow-1"
-			return record, nil
+		CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+			return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "flow-1", RepoPath: req.RepoPath, Title: req.Title}}, nil
 		},
 	}))
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
@@ -297,11 +288,11 @@ func TestBeadsReadyCreateFlowFailureWithoutDetailReportsFallback(t *testing.T) {
 	}
 }
 
-func TestBeadsReadyCreateFlowPersistsSelectedVisibleBeadRecordOnly(t *testing.T) {
+func TestBeadsReadyCreateFlowPreparesSelectedVisibleBeadWithoutLaunch(t *testing.T) {
 	readyCalls := 0
 	showCalls := 0
 	createCalls := 0
-	var createdInput flowstore.FlowRecord
+	var createdRequest model.FlowStartRequest
 	m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
 		ListReadyBeads: func(repoPath string) ([]beadsquery.Bead, error) {
 			readyCalls++
@@ -318,27 +309,19 @@ func TestBeadsReadyCreateFlowPersistsSelectedVisibleBeadRecordOnly(t *testing.T)
 			showCalls++
 			return "", nil
 		},
-		CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+		CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
 			createCalls++
-			createdInput = record
-			record.FlowID = "flow-selected"
-			return record, nil
-		},
-		CreateFlow: func(model.FlowStartRequest) (model.FlowStartResult, error) {
-			t.Fatal("Ready shortcut called legacy CreateFlow")
-			return model.FlowStartResult{}, nil
+			createdRequest = req
+			return model.FlowStartResult{Flow: flowstore.FlowRecord{
+				FlowID:       "flow-selected",
+				Title:        req.Title,
+				Instructions: req.Instructions,
+				RepoPath:     req.RepoPath,
+			}}, nil
 		},
 		StartFlowPlan: func(model.FlowStartRequest) (model.FlowStartResult, error) {
 			t.Fatal("Ready shortcut called StartFlowPlan")
 			return model.FlowStartResult{}, nil
-		},
-		BootstrapHookForRepo: func(string) (actions.BootstrapHook, bool) {
-			t.Fatal("Ready shortcut looked up a bootstrap hook")
-			return actions.BootstrapHook{}, false
-		},
-		RunBootstrapHook: func(actions.BootstrapContext, actions.BootstrapHook) error {
-			t.Fatal("Ready shortcut ran a bootstrap hook")
-			return nil
 		},
 		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
 			t.Fatal("Ready shortcut launched an external agent")
@@ -368,22 +351,22 @@ func TestBeadsReadyCreateFlowPersistsSelectedVisibleBeadRecordOnly(t *testing.T)
 	m, _ = update(m, msg)
 
 	if createCalls != 1 {
-		t.Fatalf("CreateFlowRecord calls = %d, want 1", createCalls)
+		t.Fatalf("CreateFlow calls = %d, want 1", createCalls)
 	}
 	if readyCalls != 1 || showCalls != 0 {
 		t.Fatalf("Beads calls after f = Ready %d Show %d, want 1 and 0", readyCalls, showCalls)
 	}
-	if createdInput.Title != "bd-selected: Selected work" {
-		t.Fatalf("Flow title = %q", createdInput.Title)
+	if createdRequest.Title != "bd-selected: Selected work" {
+		t.Fatalf("Flow title = %q", createdRequest.Title)
 	}
 	wantInstructions := "Use Bead bd-selected as the durable source of requirements. Read it with `bd show bd-selected` before planning or implementation."
-	if createdInput.Instructions != wantInstructions {
-		t.Fatalf("Flow instructions = %q, want %q", createdInput.Instructions, wantInstructions)
+	if createdRequest.Instructions != wantInstructions {
+		t.Fatalf("Flow instructions = %q, want %q", createdRequest.Instructions, wantInstructions)
 	}
-	if createdInput.RepoPath != "/dev/alpha" || createdInput.WorktreePath != "" || createdInput.Branch != "" ||
-		createdInput.BaseRef != "" || createdInput.Commit != "" || createdInput.PlanID != "" || createdInput.PlanPath != "" ||
-		createdInput.Issue != (flowstore.Issue{}) || createdInput.PR != (flowstore.PullRequest{}) || len(createdInput.Phases) != 0 {
-		t.Fatalf("record-only Flow input = %#v", createdInput)
+	if createdRequest.RepoPath != "/dev/alpha" || createdRequest.BaseRef != "" ||
+		createdRequest.AgentCommand != "" || createdRequest.Model != "" || createdRequest.ReasoningEffort != "" ||
+		createdRequest.PlanPhaseID != "" || createdRequest.PlanPhaseTitle != "" || createdRequest.PlanPhaseStatus != "" {
+		t.Fatalf("Ready create request carried launch metadata: %#v", createdRequest)
 	}
 	if got := m.TransientError(); got != "Created flow: bd-selected: Selected work" {
 		t.Fatalf("status = %q", got)
@@ -394,13 +377,13 @@ func TestBeadsReadyCreateFlowPersistsSelectedVisibleBeadRecordOnly(t *testing.T)
 }
 
 func TestBeadsReadyCreateFlowRejectsInvalidAndDuplicateRequests(t *testing.T) {
-	newReadyModel := func(t *testing.T, beads []beadsquery.Bead, available bool, create func(flowstore.FlowRecord) (flowstore.FlowRecord, error)) model.Model {
+	newReadyModel := func(t *testing.T, beads []beadsquery.Bead, available bool, create func(model.FlowStartRequest) (model.FlowStartResult, error)) model.Model {
 		t.Helper()
 		m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
-			ListReadyBeads:   func(string) ([]beadsquery.Bead, error) { return nil, nil },
-			ListOpenBeads:    func(string) ([]beadsquery.Bead, error) { return nil, nil },
-			CreateFlowRecord: create,
-			FetchRepo:        func(string) error { return nil },
+			ListReadyBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			ListOpenBeads:  func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			CreateFlow:     create,
+			FetchRepo:      func(string) error { return nil },
 		}))
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
@@ -409,9 +392,9 @@ func TestBeadsReadyCreateFlowRejectsInvalidAndDuplicateRequests(t *testing.T) {
 
 	t.Run("invalid contexts", func(t *testing.T) {
 		createCalls := 0
-		create := func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+		create := func(model.FlowStartRequest) (model.FlowStartResult, error) {
 			createCalls++
-			return record, nil
+			return model.FlowStartResult{}, nil
 		}
 		assertNoCreate := func(t *testing.T, m model.Model) {
 			t.Helper()
@@ -420,7 +403,7 @@ func TestBeadsReadyCreateFlowRejectsInvalidAndDuplicateRequests(t *testing.T) {
 				t.Fatalf("invalid Ready context returned command %T", cmd)
 			}
 			if createCalls != 0 {
-				t.Fatalf("CreateFlowRecord calls = %d, want 0", createCalls)
+				t.Fatalf("CreateFlow calls = %d, want 0", createCalls)
 			}
 		}
 
@@ -442,7 +425,7 @@ func TestBeadsReadyCreateFlowRejectsInvalidAndDuplicateRequests(t *testing.T) {
 			t.Fatal("left-pane f did not run the visible repo fetch")
 		}
 		if createCalls != 0 {
-			t.Fatalf("CreateFlowRecord calls = %d, want 0", createCalls)
+			t.Fatalf("CreateFlow calls = %d, want 0", createCalls)
 		}
 
 		for _, subview := range []rune{'b', 'o', 'i', 'c'} {
@@ -452,9 +435,9 @@ func TestBeadsReadyCreateFlowRejectsInvalidAndDuplicateRequests(t *testing.T) {
 		}
 
 		m = inRightPane(model.NewWithOptions(testRepos(), model.Options{
-			ListReadyBeads:   func(string) ([]beadsquery.Bead, error) { return nil, nil },
-			ListOpenBeads:    func(string) ([]beadsquery.Bead, error) { return nil, nil },
-			CreateFlowRecord: create,
+			ListReadyBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			ListOpenBeads:  func(string) ([]beadsquery.Bead, error) { return nil, nil },
+			CreateFlow:     create,
 		}))
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
 		m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
@@ -468,10 +451,9 @@ func TestBeadsReadyCreateFlowRejectsInvalidAndDuplicateRequests(t *testing.T) {
 
 	t.Run("duplicate in flight", func(t *testing.T) {
 		createCalls := 0
-		m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+		m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, func(req model.FlowStartRequest) (model.FlowStartResult, error) {
 			createCalls++
-			record.FlowID = "flow-1"
-			return record, nil
+			return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "flow-1", RepoPath: req.RepoPath, Title: req.Title}}, nil
 		})
 		m, first := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 		m, duplicate := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
@@ -481,7 +463,7 @@ func TestBeadsReadyCreateFlowRejectsInvalidAndDuplicateRequests(t *testing.T) {
 		msg := first()
 		m, _ = update(m, msg)
 		if createCalls != 1 {
-			t.Fatalf("CreateFlowRecord calls = %d, want 1", createCalls)
+			t.Fatalf("CreateFlow calls = %d, want 1", createCalls)
 		}
 		_, retry := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 		if retry == nil {
@@ -490,8 +472,8 @@ func TestBeadsReadyCreateFlowRejectsInvalidAndDuplicateRequests(t *testing.T) {
 	})
 
 	t.Run("failure releases request", func(t *testing.T) {
-		m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-			return flowstore.FlowRecord{}, errors.New("flow store unavailable")
+		m := newReadyModel(t, []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, true, func(model.FlowStartRequest) (model.FlowStartResult, error) {
+			return model.FlowStartResult{}, errors.New("flow store unavailable")
 		})
 		m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 		failed := cmd().(model.ReadyBeadFlowCreateFailedMsg)
@@ -522,10 +504,9 @@ func TestBeadsReadyCreateFlowRepoRoundTripInvalidatesStaleCompletion(t *testing.
 				},
 				ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
 				ListFlows:     func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) { return nil, nil },
-				CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+				CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
 					createCalls++
-					record.FlowID = "flow-1"
-					return record, nil
+					return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "flow-1", RepoPath: req.RepoPath, Title: req.Title}}, nil
 				},
 			}))
 			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
@@ -534,7 +515,7 @@ func TestBeadsReadyCreateFlowRepoRoundTripInvalidatesStaleCompletion(t *testing.
 			m, createCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 			stale := createCmd().(model.ReadyBeadFlowCreatedMsg)
 			if createCalls != 1 {
-				t.Fatalf("initial CreateFlowRecord calls = %d, want 1", createCalls)
+				t.Fatalf("initial CreateFlow calls = %d, want 1", createCalls)
 			}
 
 			if tt.activeFlows {
@@ -599,12 +580,11 @@ func TestBeadsReadyCreateFlowCompletionRefreshesOnlyVisibleFlowSurface(t *testin
 						listCalls++
 						return nil, nil
 					},
-					CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+					CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
 						if failed {
-							return flowstore.FlowRecord{}, errors.New("persist failed")
+							return model.FlowStartResult{}, errors.New("persist failed")
 						}
-						record.FlowID = "flow-1"
-						return record, nil
+						return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "flow-1", RepoPath: req.RepoPath, Title: req.Title}}, nil
 					},
 				}))
 				m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
@@ -638,9 +618,8 @@ func TestBeadsReadyCreateFlowSameRepoFilterAndCursorChangesKeepRequestCurrent(t 
 			return []beadsquery.Bead{{ID: "bd-1", Title: "One"}, {ID: "bd-2", Title: "Two"}}, nil
 		},
 		ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
-		CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-			record.FlowID = "flow-1"
-			return record, nil
+		CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+			return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "flow-1", RepoPath: req.RepoPath, Title: req.Title}}, nil
 		},
 	}))
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
@@ -663,9 +642,8 @@ func TestBeadsReadyFlowCreateShortcutMatchesExecutablePredicate(t *testing.T) {
 				return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
 			},
 			ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
-			CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-				record.FlowID = "flow-1"
-				return record, nil
+			CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
+				return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "flow-1", RepoPath: req.RepoPath, Title: req.Title}}, nil
 			},
 		}))
 		m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 20})
@@ -734,9 +712,9 @@ func TestBeadsReadyCreateFlowPickerConsumesFWithoutCreating(t *testing.T) {
 			return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
 		},
 		ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
-		CreateFlowRecord: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+		CreateFlow: func(model.FlowStartRequest) (model.FlowStartResult, error) {
 			createCalls++
-			return record, nil
+			return model.FlowStartResult{}, nil
 		},
 	}))
 	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 20})
@@ -750,11 +728,11 @@ func TestBeadsReadyCreateFlowPickerConsumesFWithoutCreating(t *testing.T) {
 		_ = immediateTestCommandMessages(cmd)
 	}
 	if createCalls != 0 {
-		t.Fatalf("CreateFlowRecord calls = %d, want 0", createCalls)
+		t.Fatalf("CreateFlow calls = %d, want 0", createCalls)
 	}
 }
 
-func TestBeadsReadyCreateFlowProductionWiringPersistsConfiguredPresetWithoutStartMetadata(t *testing.T) {
+func TestBeadsReadyCreateFlowProductionWiringCreatesWorktreeWithStartMetadata(t *testing.T) {
 	root := t.TempDir()
 	preset := flowstore.Preset{
 		Name: "ready-bead",
@@ -764,7 +742,7 @@ func TestBeadsReadyCreateFlowProductionWiringPersistsConfiguredPresetWithoutStar
 			{ID: "deliver", Title: "Deliver", Kind: flowstore.KindPRCreation, DependsOn: []string{"execute"}},
 		},
 	}
-	m := inRightPane(model.NewWithOptions(testRepos(), model.Options{
+	m, repoPath := setupModelRepoWithOptions(t, model.Options{
 		SessionStateRoot: root,
 		FlowPresets:      []flowstore.Preset{preset},
 		FlowPreset:       &preset,
@@ -772,12 +750,16 @@ func TestBeadsReadyCreateFlowProductionWiringPersistsConfiguredPresetWithoutStar
 			return []beadsquery.Bead{{ID: "bd-1", Title: "One"}}, nil
 		},
 		ListOpenBeads: func(string) ([]beadsquery.Bead, error) { return nil, nil },
-	}))
+	})
+	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
 	m, readyCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	m, _ = update(m, readyCmd())
 	_, createCmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
-	created := createCmd().(model.ReadyBeadFlowCreatedMsg)
+	created, ok := createCmd().(model.ReadyBeadFlowCreatedMsg)
+	if !ok {
+		t.Fatalf("Ready create command did not return ReadyBeadFlowCreatedMsg")
+	}
 
 	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root, Presets: []flowstore.Preset{preset}})
 	if err != nil {
@@ -787,12 +769,22 @@ func TestBeadsReadyCreateFlowProductionWiringPersistsConfiguredPresetWithoutStar
 	if err != nil {
 		t.Fatalf("Read(%q) error = %v", created.FlowID, err)
 	}
-	if record.PresetName != "ready-bead" || record.Title != "bd-1: One" || record.RepoPath != "/dev/alpha" {
+	if record.PresetName != "ready-bead" || record.Title != "bd-1: One" || record.RepoPath != repoPath {
 		t.Fatalf("persisted Flow identity = %#v", record)
 	}
-	if record.WorktreePath != "" || record.Branch != "" || record.BaseRef != "" || record.Commit != "" ||
+	wantWorktree := filepath.Join(filepath.Dir(repoPath), filepath.Base(repoPath)+"-worktrees", "flow-bd-1-one")
+	if record.WorktreePath != wantWorktree || record.Branch != "flow/bd-1-one" {
+		t.Fatalf("persisted Flow worktree = %q branch = %q, want %q and %q", record.WorktreePath, record.Branch, wantWorktree, "flow/bd-1-one")
+	}
+	if info, err := os.Stat(record.WorktreePath); err != nil || !info.IsDir() {
+		t.Fatalf("Flow worktree missing on disk: %v", err)
+	}
+	if head := gitOut(t, repoPath, "rev-parse", "HEAD"); record.Commit != head {
+		t.Fatalf("persisted Flow commit = %q, want repo HEAD %q", record.Commit, head)
+	}
+	if record.BaseRef != "" ||
 		record.PlanID != "" || record.PlanPath != "" || record.Issue != (flowstore.Issue{}) || record.PR != (flowstore.PullRequest{}) {
-		t.Fatalf("persisted Flow has start/plan/link metadata: %#v", record)
+		t.Fatalf("persisted Flow has base-ref/plan/link metadata: %#v", record)
 	}
 	if !record.AutoMode || record.Merge.Status != flowstore.MergePending {
 		t.Fatalf("creation defaults = auto %v merge %#v", record.AutoMode, record.Merge)

--- a/model/model.go
+++ b/model/model.go
@@ -124,7 +124,6 @@ type Model struct {
 	listBeads                 [beadSubviewCount]func(string) ([]beadsquery.Bead, error)
 	showBead                  func(repoPath, beadID string) (string, error)
 	countClosedBeads          func(string) (int, error)
-	createFlowRecord          func(flowstore.FlowRecord) (flowstore.FlowRecord, error)
 	createFlow                func(FlowStartRequest) (FlowStartResult, error)
 	startFlowPlan             func(FlowStartRequest) (FlowStartResult, error)
 	setFlowPhase              func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
@@ -237,7 +236,6 @@ type Options struct {
 	ListClosedBeads          func(repoPath string) ([]beadsquery.Bead, error)
 	ShowBead                 func(repoPath, beadID string) (string, error)
 	CountClosedBeads         func(repoPath string) (int, error)
-	CreateFlowRecord         func(flowstore.FlowRecord) (flowstore.FlowRecord, error)
 	CreateFlow               func(FlowStartRequest) (FlowStartResult, error)
 	StartFlowPlan            func(FlowStartRequest) (FlowStartResult, error)
 	SetFlowPhase             func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
@@ -480,25 +478,16 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if runBootstrapHook == nil {
 		runBootstrapHook = actions.RunBootstrapHook
 	}
-	// storeCreateFlowRecord is the store-backed default for both the Ready-Bead
-	// record seam and the Flow starter. The starter always keeps this private
-	// callback so injecting Options.CreateFlowRecord cannot change the legacy
-	// Flows-pane create/plan paths.
-	storeCreateFlowRecord := func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-		store, err := newFlowStore()
-		if err != nil {
-			return flowstore.FlowRecord{}, err
-		}
-		return store.CreateWithOptions(record, flowstore.CreateOptions{Preset: opts.FlowPreset})
-	}
-	createFlowRecord := opts.CreateFlowRecord
-	if createFlowRecord == nil {
-		createFlowRecord = storeCreateFlowRecord
-	}
 	createFlowForRepo := opts.CreateFlow
 	startFlowPlan := opts.StartFlowPlan
 	if createFlowForRepo == nil || startFlowPlan == nil {
-		createFlow := storeCreateFlowRecord
+		createFlow := func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			store, err := newFlowStore()
+			if err != nil {
+				return flowstore.FlowRecord{}, err
+			}
+			return store.CreateWithOptions(record, flowstore.CreateOptions{Preset: opts.FlowPreset})
+		}
 		setFlowStartMetadata := func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
 			store, err := newFlowStore()
 			if err != nil {
@@ -572,7 +561,6 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		},
 		showBead:                 showBead,
 		countClosedBeads:         countClosedBeads,
-		createFlowRecord:         createFlowRecord,
 		createFlow:               createFlowForRepo,
 		startFlowPlan:            startFlowPlan,
 		setFlowPhase:             setFlowPhase,

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -534,15 +534,15 @@ func (m Model) createFlowForRepo(repoPath, title, instructions, baseRef string) 
 
 func (m Model) createReadyBeadFlow(repoPath, title, instructions string, request uint64) tea.Cmd {
 	return func() tea.Msg {
-		record, err := m.createFlowRecord(flowstore.FlowRecord{
+		result, err := m.createFlow(FlowStartRequest{
+			RepoPath:     repoPath,
 			Title:        title,
 			Instructions: instructions,
-			RepoPath:     repoPath,
 		})
 		if err != nil {
 			return ReadyBeadFlowCreateFailedMsg{RepoPath: repoPath, Title: title, Err: err.Error(), Request: request}
 		}
-		return ReadyBeadFlowCreatedMsg{RepoPath: repoPath, FlowID: record.FlowID, Title: title, Request: request}
+		return ReadyBeadFlowCreatedMsg{RepoPath: repoPath, FlowID: result.Flow.FlowID, Title: title, Request: request}
 	}
 }
 

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -10875,10 +10875,6 @@ func TestModel_NewFlowDelegatesStartAndLaunchesPlanAgent(t *testing.T) {
 				CodexReasoningEffort:  "xhigh",
 				ClaudeReasoningEffort: "max",
 				SessionStateRoot:      "/state/approach/sessions/v1",
-				CreateFlowRecord: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-					t.Fatal("Plan Now should not call the Ready-Bead record adapter")
-					return flowstore.FlowRecord{}, nil
-				},
 				StartFlowPlan: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
 					calls = append(calls, "start-flow")
 					startRequest = req
@@ -11052,10 +11048,6 @@ func TestModel_NewFlowPlanNowOffCreatesFlowWithoutLaunch(t *testing.T) {
 	externalCalls := 0
 	listed := false
 	m := model.NewWithOptions(testRepos(), model.Options{
-		CreateFlowRecord: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-			t.Fatal("Plan Now off should not call the Ready-Bead record adapter")
-			return flowstore.FlowRecord{}, nil
-		},
 		CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
 			createRequest = req
 			return model.FlowStartResult{Flow: flowstore.FlowRecord{


### PR DESCRIPTION
## Summary
- The Ready Beads `f` shortcut previously created a record-only Flow through a bare flowstore write, so bead-created Flows had no worktree, branch, or start metadata, rendered as `missing-worktree`/`recover-worktree`, and launched phases in the repository root.
- `createReadyBeadFlow` now routes through the Flow starter's prepare path (`m.createFlow` → `FlowStarter.PrepareFlow`), matching the Flows-pane `n` form with Plan Now off: it creates the `flow/<slug>` branch and worktree from the repo's current HEAD, records worktree/branch/commit start metadata, and runs the repository bootstrap hook. No agent launch, no `bd` mutation.
- Worktree or bootstrap failure keeps the persisted record's launchable phases blocked with the failure noted, the same behavior as the Flows-pane path.
- Removed the now-dead `Options.CreateFlowRecord` seam; the Ready-Bead path shares the `CreateFlow` seam with the parked-flow create.
- Updated README, docs/tui-guide.md, and docs/beads-view-spec.md, which all documented the record-only design.

## Testing
- TDD: rewrote the production-wiring test against a real git repo fixture (`TestBeadsReadyCreateFlowProductionWiringCreatesWorktreeWithStartMetadata`) asserting the worktree exists on disk, the branch is `flow/<slug>`, and the commit matches HEAD — red on the old code, green after the fix.
- Migrated the remaining Ready-Bead tests to the `CreateFlow` seam; `TestBeadsReadyCreateFlowPreparesSelectedVisibleBeadWithoutLaunch` pins the title/instructions mapping and that no plan/launch metadata is sent.
- `gofmt -l .` clean, `make test` green across all packages, `make build` succeeds.