### PR TITLE
Document Ghostty terminal configuration; untrack interactions.jsonl

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -194,6 +194,11 @@ command = "wezterm start"
 
 ```toml
 [terminal]
+command = "ghostty"
+```
+
+```toml
+[terminal]
 command = "iTerm"
 ```
 
@@ -210,6 +215,15 @@ an unsupported GUI app name can open a plain worktree terminal with
 `open -a <app> <path>`, but it cannot run detached agent scripts or detach
 handoff. Use a supported GUI alias or a CLI terminal command for agent launches
 and embedded detach handoff.
+
+Ghostty works through the CLI command path because it accepts `-e`:
+`command = "ghostty"` covers plain worktree terminals, agent launches, and
+detach handoff. The `ghostty` binary must be on `PATH` (the macOS app bundle
+ships it at `Ghostty.app/Contents/MacOS/ghostty`). On macOS each launch starts
+a separate Ghostty app instance rather than a window in the running one.
+Ghostty accepts any of its config keys as flags, so
+`command = "ghostty --wait-after-command=true"` keeps windows open after a
+launched agent exits instead of closing before the output can be read.
 
 ### `[provider]`
 


### PR DESCRIPTION
## Summary

Two small housekeeping changes shipped together:

**Ghostty documentation** — `docs/config.md` `[terminal]` section now documents how Ghostty fits the existing terminal transport model:
- `command = "ghostty"` works through the generic CLI path (Ghostty accepts `-e`), covering plain worktree terminals, detached agent launches, and embedded detach handoff. No code changes were needed.
- Notes the `PATH` requirement (the macOS app bundle ships the binary at `Ghostty.app/Contents/MacOS/ghostty`), that each launch starts a separate app instance on macOS, and that `--wait-after-command=true` keeps agent windows open after exit so output stays readable.
- Only current behavior is documented. First-class alias support via Ghostty 1.3's new AppleScript dictionary is tracked separately as bead `approach-4wu`.

**Untrack `.beads/interactions.jsonl`** — this runtime beads state file was already listed in `.beads/.gitignore`, but the ignore rule never took effect because the file was committed before the rule existed. Removed it from the index (`git rm --cached`); local copies are untouched and now properly ignored.

## Verification

Docs-only plus an index removal — no code paths changed. `git status` confirms `interactions.jsonl` no longer appears as tracked or untracked after the change.