### PR TITLE
refactor(flowstore): extract internal storage seam

### DIFF
--- a/flowstore/backend.go
+++ b/flowstore/backend.go
@@ -1,0 +1,68 @@
+package flowstore
+
+import "time"
+
+// storedFlow is one decoded record plus the raw-encoding hints the read path
+// still needs for depends_on archaeology.
+//
+// dependsOnPresence is positional against record.Phases. A backend that does
+// not decode JSON must still return a slice of len(record.Phases) with
+// Present: true in every element: a nil slice is NOT neutral, it reads as
+// "depends_on absent everywhere" and drives every read into graph recovery.
+//
+// headlessPresent reports whether the stored encoding carried a headless field
+// at all. Records written before headless became per-flow carry none, and the
+// read path defaults those to headless. A backend that does not decode JSON
+// must report true, or every record reads back as headless.
+type storedFlow struct {
+	record            FlowRecord
+	dependsOnPresence []rawDependsOnState
+	headlessPresent   bool
+}
+
+// backend is the per-flow storage seam. Implementations own record durability,
+// the per-flow critical section, and record encoding. They own no domain rules:
+// no validation, no normalization, no readiness derivation.
+type backend interface {
+	// get and list acquire no lock, matching today's Read/List. Any read
+	// failure is reported as a miss.
+	get(flowID string) (storedFlow, bool)
+	list() ([]storedFlow, error)
+
+	// save persists one record WITHOUT acquiring the critical section. The
+	// caller must already hold it, or must not need it. Used only by
+	// Store.write, which exists only for test seeding.
+	save(record FlowRecord) error
+
+	// delete acquires the same critical section as update, then removes the
+	// record. It returns flowNotFoundError(flowID) when the record is absent.
+	delete(flowID string) error
+
+	// update runs mutate inside the per-flow critical section.
+	//
+	// CONTRACT — binding on every implementation:
+	//   1. Every tx.save performed by mutate is DURABLE once update returns,
+	//      REGARDLESS of whether mutate returned an error. A non-nil error from
+	//      mutate is a caller-visible outcome, NOT a rollback signal. A backend
+	//      with transactional rollback MUST commit before propagating. SetPhase
+	//      and MarkManualMerge rely on this: they persist needs_attention
+	//      compensation and *then* return the sync error.
+	//   2. mutate's error is returned VERBATIM — never wrapped, never replaced.
+	//      errors.Is against errFlowNotFound / errAutoLaunchOutdated and the
+	//      literal error substrings asserted throughout store_test.go both
+	//      depend on this.
+	//   3. tx.save may be called zero, one, or many times.
+	update(flowID string, mutate func(tx flowTx) error) error
+
+	// allocateID is called OUTSIDE the critical section, before update. Its now
+	// argument must be a fresh clock read taken at the call site, because
+	// Create reads the clock twice and the existing tests count those reads.
+	allocateID(title string, now time.Time) (string, error)
+}
+
+// flowTx is the handle a mutate closure uses inside the critical section.
+type flowTx interface {
+	get() (storedFlow, bool)
+	exists() (bool, error)
+	save(record FlowRecord) error
+}

--- a/flowstore/backend.go
+++ b/flowstore/backend.go
@@ -5,64 +5,145 @@ import "time"
 // storedFlow is one decoded record plus the raw-encoding hints the read path
 // still needs for depends_on archaeology.
 //
-// dependsOnPresence is positional against record.Phases. A backend that does
-// not decode JSON must still return a slice of len(record.Phases) with
-// Present: true in every element: a nil slice is NOT neutral, it reads as
-// "depends_on absent everywhere" and drives every read into graph recovery.
-//
-// headlessPresent reports whether the stored encoding carried a headless field
-// at all. Records written before headless became per-flow carry none, and the
-// read path defaults those to headless. A backend that does not decode JSON
-// must report true, or every record reads back as headless.
+// legacyEncoding is what makes the zero value safe. Only a backend that
+// persists records as the historical JSON documents — where a phase object
+// could omit depends_on entirely, and the record itself could omit headless —
+// sets it, and only such a backend is asked for dependsOnPresence or
+// headlessPresent. Every other backend leaves those fields alone and is read as
+// "depends_on present on every phase, headless present": the neutral answer,
+// because the archaeology exists to date legacy files, not to run on stores
+// that have real depends_on and headless columns.
 type storedFlow struct {
-	record            FlowRecord
+	record FlowRecord
+
+	// legacyEncoding marks a record that came from an encoding where
+	// depends_on could be absent. When false, dependsOnPresence is ignored.
+	//
+	// A backend that MIGRATES legacy records inherits this obligation: it must
+	// persist "depends_on was absent for this phase" as real state, set this
+	// flag, and rebuild dependsOnPresence below. Dropping the distinction on
+	// migration silently rewrites those records' edges on the next read.
+	legacyEncoding bool
+
+	// dependsOnPresence is positional against record.Phases and is read only
+	// when legacyEncoding is true. len(dependsOnPresence) MUST equal
+	// len(record.Phases), in the same order the backend returns the phases —
+	// natural for a JSON document, a trap for anything reconstructing phases
+	// with ORDER BY. Entries past the end are read as absent.
 	dependsOnPresence []rawDependsOnState
-	headlessPresent   bool
+
+	// headlessPresent reports whether the stored encoding carried a headless
+	// field at all, and is read only when legacyEncoding is true. Records
+	// written before headless became per-flow have none, and those default to
+	// headless on read rather than to Go's zero value.
+	headlessPresent bool
+}
+
+// dependsOnHints returns the positional presence slice hydrate should use. A
+// non-legacy backend gets "present everywhere" rather than the nil slice, which
+// would otherwise read as "depends_on absent everywhere" and drive every read
+// into graph recovery.
+func (s storedFlow) dependsOnHints() []rawDependsOnState {
+	if s.legacyEncoding {
+		return s.dependsOnPresence
+	}
+	hints := make([]rawDependsOnState, len(s.record.Phases))
+	for i := range hints {
+		hints[i] = rawDependsOnState{Present: true}
+	}
+	return hints
 }
 
 // backend is the per-flow storage seam. Implementations own record durability,
-// the per-flow critical section, and record encoding. They own no domain rules:
-// no validation, no normalization, no readiness derivation.
+// the per-flow critical section, and record encoding.
+//
+// They own no DOMAIN rules — no phase validation, no normalization, no
+// readiness derivation, no status derivation. Admissibility is still theirs:
+// see the ID and schema-version clauses on get.
 type backend interface {
-	// get and list acquire no lock, matching today's Read/List. Any read
-	// failure is reported as a miss.
+	// get and list acquire no lock, matching today's Read/List.
+	//
+	// get reports ANY read failure as a miss: a record that is absent, corrupt,
+	// or unreadable is all one outcome. That is the file store's historical
+	// behavior, preserved here deliberately. It is a poor fit for a networked or
+	// transactional store, where an I/O error would be indistinguishable from
+	// data loss; revisit the signature when the second backend lands rather than
+	// widening it blind.
+	//
+	// Two admissibility rules are load-bearing and MUST be enforced here,
+	// because nothing above the seam repeats them:
+	//   - a record whose stored flow id does not match flowID is a miss;
+	//   - a record whose stored schema version is not schemaVersion is a miss,
+	//     which is what makes records written by a future version invisible
+	//     rather than half-decoded. A plain row fetch that skips this check
+	//     silently changes Read and List.
 	get(flowID string) (storedFlow, bool)
-	list() ([]storedFlow, error)
 
-	// save persists one record WITHOUT acquiring the critical section. The
-	// caller must already hold it, or must not need it. Used only by
-	// Store.write, which exists only for test seeding.
-	save(record FlowRecord) error
+	// list returns every readable record, skipping unreadable ones rather than
+	// failing the call. Order is load-bearing: Store.List sorts STABLY on
+	// UpdatedAt, so records with equal timestamps keep the order returned here.
+	// Implementations must therefore return a stable, insertion-consistent
+	// order; reordering between calls silently reorders ties for the caller.
+	list() ([]storedFlow, error)
 
 	// delete acquires the same critical section as update, then removes the
 	// record. It returns flowNotFoundError(flowID) when the record is absent.
 	delete(flowID string) error
 
-	// update runs mutate inside the per-flow critical section.
+	// update runs mutate inside the per-flow critical section and returns what
+	// mutate returned.
 	//
 	// CONTRACT — binding on every implementation:
-	//   1. Every tx.save performed by mutate is DURABLE once update returns,
+	//   1. mutate is invoked EXACTLY ONCE. Implementations MUST NOT retry it,
+	//      not even on a spurious lock or transient store error, because the
+	//      closures are not idempotent: CreateWithOptions rewrites depends_on
+	//      through the caller's shared phase array, so a second pass sees the
+	//      first pass's edges and takes a different validation branch. Retry
+	//      the acquisition if you must, but never a mutate that has begun.
+	//   2. Every sess.save performed by mutate is DURABLE once update returns,
 	//      REGARDLESS of whether mutate returned an error. A non-nil error from
-	//      mutate is a caller-visible outcome, NOT a rollback signal. A backend
-	//      with transactional rollback MUST commit before propagating. SetPhase
+	//      mutate is a caller-visible outcome, NOT a rollback signal. SetPhase
 	//      and MarkManualMerge rely on this: they persist needs_attention
-	//      compensation and *then* return the sync error.
-	//   2. mutate's error is returned VERBATIM — never wrapped, never replaced.
-	//      errors.Is against errFlowNotFound / errAutoLaunchOutdated and the
-	//      literal error substrings asserted throughout store_test.go both
-	//      depend on this.
-	//   3. tx.save may be called zero, one, or many times.
-	update(flowID string, mutate func(tx flowTx) error) error
+	//      compensation and *then* return the sync error. This is why the
+	//      handle below is a session and not a transaction — see flowSession.
+	//   3. mutate's record AND error are returned VERBATIM — never wrapped,
+	//      never replaced, never zeroed. The two callers differ on purpose:
+	//      SetPhase returns a zero record beside its sync error while
+	//      MarkManualMerge returns the compensated record beside the same kind
+	//      of error, and errors.Is against errFlowNotFound / errAutoLaunchOutdated
+	//      plus the literal error substrings asserted throughout store_test.go
+	//      all depend on this clause.
+	//   4. sess.save may be called zero, one, or many times.
+	//   5. Concurrent updates to the SAME flowID are mutually exclusive; the
+	//      whole point of the call is that mutate runs alone. Updates to
+	//      different flow IDs must not block each other.
+	update(flowID string, mutate func(sess flowSession) (FlowRecord, error)) (FlowRecord, error)
 
-	// allocateID is called OUTSIDE the critical section, before update. Its now
-	// argument must be a fresh clock read taken at the call site, because
-	// Create reads the clock twice and the existing tests count those reads.
+	// allocateID returns an id no existing record is using, derived from title
+	// and now. It is called OUTSIDE the critical section, before update, so two
+	// concurrent Creates can still race for an id exactly as they do today.
 	allocateID(title string, now time.Time) (string, error)
 }
 
-// flowTx is the handle a mutate closure uses inside the critical section.
-type flowTx interface {
+// flowSession is the handle a mutate closure uses inside the critical section.
+//
+// It is deliberately NOT called a transaction. Clause 2 on update requires
+// every save to be durable even when the closure then fails, so an
+// implementation may never wrap the closure in a rollback-on-error
+// transaction; the most it can do is commit each save as it happens. Naming
+// this flowTx would promise atomicity the contract forbids.
+type flowSession interface {
+	// get reads the record as it stands inside the section, including anything
+	// an earlier save in this same session wrote. It must not re-acquire the
+	// section.
 	get() (storedFlow, bool)
+
+	// exists reports whether the record is present without decoding it, so
+	// CreateWithOptions can detect an id collision it would otherwise clobber.
 	exists() (bool, error)
+
+	// save persists one record inside the section. It must not re-acquire the
+	// section either: fileBackend's flock is not re-entrant, and a second
+	// acquire would block until it timed out.
 	save(record FlowRecord) error
 }

--- a/flowstore/backend_file.go
+++ b/flowstore/backend_file.go
@@ -41,7 +41,15 @@ func (b *fileBackend) get(flowID string) (storedFlow, bool) {
 	if record.FlowID != flowID || record.SchemaVersion != schemaVersion {
 		return storedFlow{}, false
 	}
-	return storedFlow{record: record, dependsOnPresence: presence, headlessPresent: headlessPresent}, true
+	// legacyEncoding: meta.json is the encoding where a phase object could omit
+	// depends_on entirely and the record could omit headless, so this backend is
+	// the one that owes real hints.
+	return storedFlow{
+		record:            record,
+		legacyEncoding:    true,
+		dependsOnPresence: presence,
+		headlessPresent:   headlessPresent,
+	}, true
 }
 
 // list preserves os.ReadDir order. Store.List sorts stably on UpdatedAt, so
@@ -61,8 +69,8 @@ func (b *fileBackend) list() ([]storedFlow, error) {
 		if !entry.IsDir() {
 			continue
 		}
-		// get's validateFlowID is what keeps .locks and other unsafe-ID
-		// directories out of the results.
+		// .locks and any other non-record directory drop out here: get rejects
+		// unsafe ids outright, and anything else has no readable meta.json.
 		flow, ok := b.get(entry.Name())
 		if !ok {
 			continue
@@ -72,9 +80,13 @@ func (b *fileBackend) list() ([]storedFlow, error) {
 	return stored, nil
 }
 
-// save writes the record without taking the flow lock, and without touching
-// depends_on: normalization is domain logic and stays above the seam. It must
-// not copy record.Phases.
+// save writes the record without taking the flow lock. It must not: fileSession
+// routes every in-section save through here while acquireFlowLock's flock is
+// already held, and that flock is not re-entrant, so taking it again would
+// block until it timed out.
+//
+// It also leaves depends_on alone. Normalization is domain logic and stays
+// above the seam, in Store.saveSession.
 func (b *fileBackend) save(record FlowRecord) error {
 	dir, err := artifacts.EnsureRecordDir(b.root, "flows", record.FlowID)
 	if err != nil {
@@ -113,18 +125,19 @@ func (b *fileBackend) delete(flowID string) error {
 	return nil
 }
 
-func (b *fileBackend) update(flowID string, mutate func(tx flowTx) error) error {
+func (b *fileBackend) update(flowID string, mutate func(sess flowSession) (FlowRecord, error)) (FlowRecord, error) {
 	if err := validateFlowID(flowID); err != nil {
-		return err
+		return FlowRecord{}, err
 	}
 	release, err := b.acquireFlowLock(flowID)
 	if err != nil {
-		return err
+		return FlowRecord{}, err
 	}
 	defer release()
-	// Returned verbatim: the flock has no rollback, so every tx.save is already
-	// durable, and callers match on the error's identity and text.
-	return mutate(fileTx{backend: b, flowID: flowID})
+	// Invoked exactly once, and its record and error both returned verbatim:
+	// the flock has no rollback, so every save is already durable, and callers
+	// match on the error's identity and text.
+	return mutate(fileSession{backend: b, flowID: flowID})
 }
 
 func (b *fileBackend) allocateID(title string, now time.Time) (string, error) {
@@ -161,19 +174,19 @@ func (b *fileBackend) flowDir(flowID string) string {
 	return artifacts.RecordDir(b.root, "flows", flowID)
 }
 
-// fileTx is the in-lock handle. It holds no state beyond the target flow, so
-// every operation reads or writes through the backend directly.
-type fileTx struct {
+// fileSession is the in-lock handle. It holds no state beyond the target flow,
+// so every operation reads or writes through the backend directly.
+type fileSession struct {
 	backend *fileBackend
 	flowID  string
 }
 
-func (t fileTx) get() (storedFlow, bool) {
-	return t.backend.get(t.flowID)
+func (s fileSession) get() (storedFlow, bool) {
+	return s.backend.get(s.flowID)
 }
 
-func (t fileTx) exists() (bool, error) {
-	if _, err := os.Stat(t.backend.flowDir(t.flowID)); err == nil {
+func (s fileSession) exists() (bool, error) {
+	if _, err := os.Stat(s.backend.flowDir(s.flowID)); err == nil {
 		return true, nil
 	} else if !os.IsNotExist(err) {
 		return false, err
@@ -181,8 +194,8 @@ func (t fileTx) exists() (bool, error) {
 	return false, nil
 }
 
-func (t fileTx) save(record FlowRecord) error {
-	return t.backend.save(record)
+func (s fileSession) save(record FlowRecord) error {
+	return s.backend.save(record)
 }
 
 func marshalFlowRecord(record FlowRecord) ([]byte, error) {

--- a/flowstore/backend_file.go
+++ b/flowstore/backend_file.go
@@ -1,0 +1,315 @@
+package flowstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/approachcontrol/approach/internal/artifacts"
+)
+
+// fileBackend stores one Flow record per directory under <root>/flows, with a
+// flock-guarded critical section per flow under <root>/flows/.locks.
+type fileBackend struct {
+	root        string
+	lockTimeout time.Duration
+}
+
+func newFileBackend(root string, lockTimeout time.Duration) (*fileBackend, error) {
+	if err := artifacts.EnsureCollection(root, "flows"); err != nil {
+		return nil, fmt.Errorf("create flow store: %w", err)
+	}
+	return &fileBackend{root: root, lockTimeout: lockTimeout}, nil
+}
+
+func (b *fileBackend) get(flowID string) (storedFlow, bool) {
+	if err := validateFlowID(flowID); err != nil {
+		return storedFlow{}, false
+	}
+	data, err := os.ReadFile(filepath.Join(b.flowDir(flowID), "meta.json"))
+	if err != nil {
+		return storedFlow{}, false
+	}
+	presence := rawDependsOnPresence(data)
+	headlessPresent := rawFieldPresent(data, "headless")
+	var record FlowRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		return storedFlow{}, false
+	}
+	if record.FlowID != flowID || record.SchemaVersion != schemaVersion {
+		return storedFlow{}, false
+	}
+	return storedFlow{record: record, dependsOnPresence: presence, headlessPresent: headlessPresent}, true
+}
+
+// list preserves os.ReadDir order. Store.List sorts stably on UpdatedAt, so
+// records with equal timestamps keep storage order; reordering here would
+// reorder ties.
+func (b *fileBackend) list() ([]storedFlow, error) {
+	root := filepath.Join(b.root, "flows")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list flows: %w", err)
+	}
+	var stored []storedFlow
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		// get's validateFlowID is what keeps .locks and other unsafe-ID
+		// directories out of the results.
+		flow, ok := b.get(entry.Name())
+		if !ok {
+			continue
+		}
+		stored = append(stored, flow)
+	}
+	return stored, nil
+}
+
+// save writes the record without taking the flow lock, and without touching
+// depends_on: normalization is domain logic and stays above the seam. It must
+// not copy record.Phases.
+func (b *fileBackend) save(record FlowRecord) error {
+	dir, err := artifacts.EnsureRecordDir(b.root, "flows", record.FlowID)
+	if err != nil {
+		return fmt.Errorf("secure flow directory: %w", err)
+	}
+	data, err := marshalFlowRecord(record)
+	if err != nil {
+		return fmt.Errorf("encode flow metadata: %w", err)
+	}
+	if err := artifacts.WriteFileAtomic(filepath.Join(dir, "meta.json"), data); err != nil {
+		return fmt.Errorf("write flow metadata: %w", err)
+	}
+	return nil
+}
+
+// delete removes the record directory but deliberately leaves the flow's lock
+// file behind, so a concurrent holder of the critical section keeps its lock.
+func (b *fileBackend) delete(flowID string) error {
+	if err := validateFlowID(flowID); err != nil {
+		return err
+	}
+	release, err := b.acquireFlowLock(flowID)
+	if err != nil {
+		return err
+	}
+	defer release()
+	dir := b.flowDir(flowID)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return flowNotFoundError(flowID)
+	} else if err != nil {
+		return fmt.Errorf("stat flow %q: %w", flowID, err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("delete flow %q: %w", flowID, err)
+	}
+	return nil
+}
+
+func (b *fileBackend) update(flowID string, mutate func(tx flowTx) error) error {
+	if err := validateFlowID(flowID); err != nil {
+		return err
+	}
+	release, err := b.acquireFlowLock(flowID)
+	if err != nil {
+		return err
+	}
+	defer release()
+	// Returned verbatim: the flock has no rollback, so every tx.save is already
+	// durable, and callers match on the error's identity and text.
+	return mutate(fileTx{backend: b, flowID: flowID})
+}
+
+func (b *fileBackend) allocateID(title string, now time.Time) (string, error) {
+	return artifacts.AllocateTimestampedID(artifacts.IDOptions{
+		Root:         b.root,
+		Collection:   "flows",
+		Title:        title,
+		FallbackSlug: "flow",
+		Kind:         "flow",
+		Now:          now,
+	})
+}
+
+// acquireFlowLock is NOT re-entrant: artifacts.AcquireFileLock opens a fresh fd
+// per call and POSIX flock is per open-file-description, so a second acquire
+// from the same process blocks until it times out. Nothing reachable from
+// inside update may take it again.
+func (b *fileBackend) acquireFlowLock(flowID string) (func(), error) {
+	if err := validateFlowID(flowID); err != nil {
+		return nil, err
+	}
+	lockDir := filepath.Join(b.root, "flows", ".locks")
+	if err := os.MkdirAll(lockDir, artifacts.DirPerm); err != nil {
+		return nil, fmt.Errorf("create flow lock directory: %w", err)
+	}
+	if err := os.Chmod(lockDir, artifacts.DirPerm); err != nil {
+		return nil, fmt.Errorf("secure flow lock directory: %w", err)
+	}
+	lockPath := filepath.Join(lockDir, flowID+".lock")
+	return artifacts.AcquireFileLock(lockPath, fmt.Sprintf("flow lock %q", flowID), b.lockTimeout)
+}
+
+func (b *fileBackend) flowDir(flowID string) string {
+	return artifacts.RecordDir(b.root, "flows", flowID)
+}
+
+// fileTx is the in-lock handle. It holds no state beyond the target flow, so
+// every operation reads or writes through the backend directly.
+type fileTx struct {
+	backend *fileBackend
+	flowID  string
+}
+
+func (t fileTx) get() (storedFlow, bool) {
+	return t.backend.get(t.flowID)
+}
+
+func (t fileTx) exists() (bool, error) {
+	if _, err := os.Stat(t.backend.flowDir(t.flowID)); err == nil {
+		return true, nil
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	return false, nil
+}
+
+func (t fileTx) save(record FlowRecord) error {
+	return t.backend.save(record)
+}
+
+func marshalFlowRecord(record FlowRecord) ([]byte, error) {
+	if len(record.preserveMissingDependsOn) == 0 {
+		return json.MarshalIndent(record, "", "  ")
+	}
+	phases := make([]flowPhaseForWrite, 0, len(record.Phases))
+	for _, phase := range record.Phases {
+		phases = append(phases, flowPhaseForWriteFrom(phase, record.preserveMissingDependsOn[artifacts.NormalizePhaseID(phase.PhaseID)]))
+	}
+	return json.MarshalIndent(flowRecordForWrite{
+		SchemaVersion: record.SchemaVersion,
+		FlowID:        record.FlowID,
+		Title:         record.Title,
+		Instructions:  record.Instructions,
+		Status:        record.Status,
+		RepoPath:      record.RepoPath,
+		WorktreePath:  record.WorktreePath,
+		Branch:        record.Branch,
+		BaseRef:       record.BaseRef,
+		Commit:        record.Commit,
+		PresetName:    record.PresetName,
+		PlanID:        record.PlanID,
+		PlanPath:      record.PlanPath,
+		Issue:         record.Issue,
+		PR:            record.PR,
+		Merge:         record.Merge,
+		AutoMode:      record.AutoMode,
+		Headless:      record.Headless,
+		Phases:        phases,
+		CreatedAt:     record.CreatedAt,
+		UpdatedAt:     record.UpdatedAt,
+	}, "", "  ")
+}
+
+type flowRecordForWrite struct {
+	SchemaVersion int                 `json:"schema_version"`
+	FlowID        string              `json:"flow_id"`
+	Title         string              `json:"title"`
+	Instructions  string              `json:"instructions"`
+	Status        string              `json:"status"`
+	RepoPath      string              `json:"repo_path"`
+	WorktreePath  string              `json:"worktree_path,omitempty"`
+	Branch        string              `json:"branch,omitempty"`
+	BaseRef       string              `json:"base_ref,omitempty"`
+	Commit        string              `json:"commit,omitempty"`
+	PresetName    string              `json:"preset_name,omitempty"`
+	PlanID        string              `json:"plan_id,omitempty"`
+	PlanPath      string              `json:"plan_path,omitempty"`
+	Issue         Issue               `json:"issue,omitempty"`
+	PR            PullRequest         `json:"pr,omitempty"`
+	Merge         Merge               `json:"merge,omitempty"`
+	AutoMode      bool                `json:"auto_mode,omitempty"`
+	Headless      bool                `json:"headless"`
+	Phases        []flowPhaseForWrite `json:"phases"`
+	CreatedAt     time.Time           `json:"created_at"`
+	UpdatedAt     time.Time           `json:"updated_at"`
+}
+
+type flowPhaseForWrite struct {
+	PhaseID       string    `json:"phase_id"`
+	ParentPhaseID string    `json:"parent_phase_id,omitempty"`
+	Title         string    `json:"title"`
+	Kind          string    `json:"kind"`
+	DependsOn     *[]string `json:"depends_on,omitempty"`
+	Status        string    `json:"status"`
+	Order         int       `json:"order"`
+	Outcome       string    `json:"outcome,omitempty"`
+	Notes         string    `json:"notes,omitempty"`
+	Summary       string    `json:"summary,omitempty"`
+	LaunchIDs     []string  `json:"launch_ids,omitempty"`
+	Sessions      []Session `json:"sessions,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+func flowPhaseForWriteFrom(phase FlowPhase, omitDependsOn bool) flowPhaseForWrite {
+	var dependsOn *[]string
+	if !omitDependsOn {
+		dependsOn = &phase.DependsOn
+	}
+	return flowPhaseForWrite{
+		PhaseID:       phase.PhaseID,
+		ParentPhaseID: phase.ParentPhaseID,
+		Title:         phase.Title,
+		Kind:          phase.Kind,
+		DependsOn:     dependsOn,
+		Status:        phase.Status,
+		Order:         phase.Order,
+		Outcome:       phase.Outcome,
+		Notes:         phase.Notes,
+		Summary:       phase.Summary,
+		LaunchIDs:     phase.LaunchIDs,
+		Sessions:      phase.Sessions,
+		CreatedAt:     phase.CreatedAt,
+		UpdatedAt:     phase.UpdatedAt,
+	}
+}
+
+// rawDependsOnPresence records, positionally, whether each persisted phase
+// object carried a depends_on key at all — the distinction between a legacy
+// record with no edges and an edge-aware record with empty edges.
+func rawDependsOnPresence(data []byte) []rawDependsOnState {
+	var raw struct {
+		Phases []map[string]json.RawMessage `json:"phases"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	presence := make([]rawDependsOnState, len(raw.Phases))
+	for i, phase := range raw.Phases {
+		_, ok := phase["depends_on"]
+		presence[i] = rawDependsOnState{
+			Present: ok,
+		}
+	}
+	return presence
+}
+
+// rawFieldPresent reports whether the persisted record carried a top-level key
+// at all, so the read path can tell a legacy record with no field from one that
+// stored the zero value.
+func rawFieldPresent(data []byte, field string) bool {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return false
+	}
+	_, ok := raw[field]
+	return ok
+}

--- a/flowstore/backend_seam_internal_test.go
+++ b/flowstore/backend_seam_internal_test.go
@@ -4,13 +4,14 @@ import (
 	"errors"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
 
 var (
 	_ backend         = (*fileBackend)(nil)
-	_ flowTx          = fileTx{}
+	_ flowSession     = fileSession{}
 	_ planPhaseSyncer = planstoreSyncer{}
 	_ planPhaseWriter = planstorePhaseWriter{}
 )
@@ -83,12 +84,21 @@ func TestInjectedPlanSyncerWriteFailureCompensates(t *testing.T) {
 	syncer := &fakePlanSyncer{writeErr: errors.New("plan write exploded")}
 	store, record, hookCalls := seamStoreWithHook(t, syncer)
 
-	_, err := store.SetPhase(PhaseUpdate{FlowID: record.FlowID, PhaseID: "plan", Status: PhaseCompleted})
+	got, err := store.SetPhase(PhaseUpdate{FlowID: record.FlowID, PhaseID: "plan", Status: PhaseCompleted})
 	if err == nil {
 		t.Fatal("SetPhase() error = nil, want sync failure")
 	}
 	if !strings.Contains(err.Error(), "sync linked plan phase: plan write exploded") {
 		t.Fatalf("SetPhase() error = %v, want sync linked plan phase wrapping", err)
+	}
+	// Half of the asymmetry pinned by clause 3 on backend.update: SetPhase
+	// discards the record on a sync failure even though the compensation was
+	// persisted. TestManualMergeSyncFailureReturnsCompensatedRecord pins the
+	// other half. Nothing else in the suite looks at this return value, so
+	// without this assertion the seam could start returning the record here and
+	// stay green.
+	if got.FlowID != "" {
+		t.Fatalf("SetPhase() record = %+v, want the zero record beside the error", got)
 	}
 	// The write path opens the plan store, fires the hook, and only then writes.
 	if *hookCalls != 1 {
@@ -119,59 +129,509 @@ func TestInjectedPlanSyncerOpenFailureCompensatesBeforeHook(t *testing.T) {
 	assertPhaseNeedsAttention(t, store, record.FlowID, "plan")
 }
 
-// TestBackendUpdateSavesRemainDurableAfterMutateError pins clause 1 of the
-// backend.update contract: a non-nil error from mutate is an outcome, not a
-// rollback signal. The needs_attention compensation in SetPhase and
-// MarkManualMerge depends on it, so any future backend must satisfy it too.
-func TestBackendUpdateSavesRemainDurableAfterMutateError(t *testing.T) {
-	store, record := newSeamTestFlow(t, &fakePlanSyncer{})
+// TestManualMergeSyncFailureReturnsCompensatedRecord pins the other half of the
+// clause 3 asymmetry: unlike SetPhase, MarkManualMerge hands back the
+// compensated record beside the sync error, with the PR and merge status rolled
+// back to what they were before the merge was recorded.
+func TestManualMergeSyncFailureReturnsCompensatedRecord(t *testing.T) {
+	syncer := &fakePlanSyncer{writeErr: errors.New("plan write exploded")}
+	store, record := newMergeReadySeamFlow(t, syncer)
 
-	sentinel := errors.New("mutate refused")
-	err := store.backend.update(record.FlowID, func(tx flowTx) error {
-		stored, ok := tx.get()
-		if !ok {
-			t.Fatalf("tx.get() = false, want the seeded record")
-		}
-		saved := stored.record
-		saved.Title = "Durable after error"
-		if err := tx.save(saved); err != nil {
-			t.Fatalf("tx.save() error = %v", err)
-		}
-		return sentinel
+	mergedAt := time.Date(2026, 5, 6, 9, 0, 0, 0, time.UTC)
+	got, err := store.MarkManualMerge(ManualMergeUpdate{
+		FlowID:   record.FlowID,
+		PRNumber: record.PR.Number,
+		PRURL:    record.PR.URL,
+		Commit:   "deadbeef",
+		MergedAt: mergedAt,
 	})
-	// Clause 2: the error is returned verbatim, never wrapped or replaced.
-	if !errors.Is(err, sentinel) || err.Error() != sentinel.Error() {
-		t.Fatalf("update() error = %v, want the mutate error verbatim", err)
+	if err == nil {
+		t.Fatal("MarkManualMerge() error = nil, want sync failure")
 	}
-	got, readErr := store.Read(record.FlowID)
-	if readErr != nil {
-		t.Fatalf("Read() error = %v", readErr)
+	if got.FlowID != record.FlowID {
+		t.Fatalf("MarkManualMerge() record = %+v, want the compensated record beside the error", got)
 	}
-	if got.Title != "Durable after error" {
-		t.Fatalf("title = %q, want the save to survive the mutate error", got.Title)
+	if got.PR.Status == MergeMerged {
+		t.Fatalf("PR status = %q, want the pre-merge status restored", got.PR.Status)
 	}
+	if got.Merge.Status != MergePending {
+		t.Fatalf("merge status = %q, want %q", got.Merge.Status, MergePending)
+	}
+	assertPhaseNeedsAttention(t, store, record.FlowID, "merge")
 }
 
+// TestBackendSaveDoesNotTakeTheFlowLock pins the invariant that keeps every
+// in-section write from deadlocking: Store.saveSession runs inside the closure
+// backend.update is holding the lock for, and routes through backend.save, so
+// save must never acquire that lock itself. The flock is not re-entrant, so a
+// second acquire would block until it timed out.
 func TestBackendSaveDoesNotTakeTheFlowLock(t *testing.T) {
 	store, record := newSeamTestFlow(t, &fakePlanSyncer{})
 
-	// Store.write is reachable from inside a held critical section (and from
-	// test seeding), so backend.save must never acquire the lock: the flock is
-	// not re-entrant and a second acquire would block until it timed out.
 	done := make(chan error, 1)
 	go func() {
-		done <- store.backend.update(record.FlowID, func(tx flowTx) error {
-			return store.write(record)
+		_, err := store.backend.update(record.FlowID, func(sess flowSession) (FlowRecord, error) {
+			stored, ok := sess.get()
+			if !ok {
+				return FlowRecord{}, errors.New("seeded record missing")
+			}
+			// The production path: saveSession -> sess.save -> backend.save,
+			// all while update holds the critical section.
+			return stored.record, store.saveSession(sess, stored.record)
 		})
+		done <- err
 	}()
 	select {
 	case err := <-done:
 		if err != nil {
-			t.Fatalf("write inside update error = %v", err)
+			t.Fatalf("save inside update error = %v", err)
 		}
 	case <-time.After(3 * time.Second):
-		t.Fatal("write inside update deadlocked on the flow lock")
+		t.Fatal("save inside update deadlocked on the flow lock")
 	}
+	if _, err := store.Read(record.FlowID); err != nil {
+		t.Fatalf("Read() after in-section save error = %v", err)
+	}
+}
+
+// TestFileBackendSatisfiesContract runs the shared seam contract against the
+// only implementation that exists today. When the SQLite backend lands it
+// should call testBackendContract with its own factory rather than
+// hand-verifying the clauses on backend.update again.
+func TestFileBackendSatisfiesContract(t *testing.T) {
+	testBackendContract(t, func(t *testing.T) backend {
+		t.Helper()
+		b, err := newFileBackend(t.TempDir(), time.Second)
+		if err != nil {
+			t.Fatalf("newFileBackend() error = %v", err)
+		}
+		return b
+	})
+}
+
+// testBackendContract asserts the clauses documented on the backend interface.
+// It is implementation-agnostic on purpose: it touches no file paths and makes
+// no assumption about encoding.
+func testBackendContract(t *testing.T, newBackend func(t *testing.T) backend) {
+	t.Helper()
+
+	// save goes through update because the seam exposes no lock-free write:
+	// flowSession.save is the only way in.
+	save := func(t *testing.T, b backend, record FlowRecord) {
+		t.Helper()
+		if _, err := b.update(record.FlowID, func(sess flowSession) (FlowRecord, error) {
+			return record, sess.save(record)
+		}); err != nil {
+			t.Fatalf("save(%q) error = %v", record.FlowID, err)
+		}
+	}
+
+	seed := func(t *testing.T, b backend, flowID string) FlowRecord {
+		t.Helper()
+		record := FlowRecord{
+			SchemaVersion: schemaVersion,
+			FlowID:        flowID,
+			Title:         "Contract",
+			Status:        StatusPending,
+			RepoPath:      "/tmp/repo",
+			Phases:        defaultPhases(time.Unix(0, 0).UTC(), time.Unix(0, 0).UTC()),
+			CreatedAt:     time.Unix(0, 0).UTC(),
+			UpdatedAt:     time.Unix(0, 0).UTC(),
+		}
+		save(t, b, record)
+		return record
+	}
+
+	t.Run("get reports every read failure as a miss", func(t *testing.T) {
+		b := newBackend(t)
+		if _, ok := b.get("absent-flow"); ok {
+			t.Fatal("get() on an absent flow = true, want a miss")
+		}
+		if _, ok := b.get("../escape"); ok {
+			t.Fatal("get() on an invalid id = true, want a miss")
+		}
+	})
+
+	// The schema-version filter is what makes a record written by a future
+	// version invisible instead of half-decoded. It lives below the seam and
+	// nothing above repeats it, so every backend owes it.
+	t.Run("get rejects a foreign schema version", func(t *testing.T) {
+		b := newBackend(t)
+		record := seed(t, b, "future-schema")
+		record.SchemaVersion = schemaVersion + 1
+		save(t, b, record)
+		if _, ok := b.get("future-schema"); ok {
+			t.Fatal("get() on a future schema version = true, want a miss")
+		}
+		flows, err := b.list()
+		if err != nil {
+			t.Fatalf("list() error = %v", err)
+		}
+		for _, flow := range flows {
+			if flow.record.FlowID == "future-schema" {
+				t.Fatal("list() returned a record with a foreign schema version")
+			}
+		}
+	})
+
+	t.Run("save then get round-trips", func(t *testing.T) {
+		b := newBackend(t)
+		want := seed(t, b, "round-trip")
+		got, ok := b.get("round-trip")
+		if !ok {
+			t.Fatal("get() = false, want the saved record")
+		}
+		if got.record.FlowID != want.FlowID || got.record.Title != want.Title {
+			t.Fatalf("get() record = %+v, want %+v", got.record, want)
+		}
+		if len(got.record.Phases) != len(want.Phases) {
+			t.Fatalf("get() phases = %d, want %d", len(got.record.Phases), len(want.Phases))
+		}
+		if got.legacyEncoding && len(got.dependsOnPresence) != len(got.record.Phases) {
+			t.Fatalf("legacy backend returned %d presence entries for %d phases; a short slice reads as depends_on absent",
+				len(got.dependsOnPresence), len(got.record.Phases))
+		}
+		// Whatever the encoding, hydrate must not be told depends_on is missing
+		// on a record that was written with edges.
+		hints := got.dependsOnHints()
+		if len(hints) != len(got.record.Phases) {
+			t.Fatalf("dependsOnHints() = %d entries, want %d", len(hints), len(got.record.Phases))
+		}
+		for i, hint := range hints {
+			if !hint.Present {
+				t.Fatalf("dependsOnHints()[%d].Present = false, want true for a record saved with edges", i)
+			}
+		}
+	})
+
+	t.Run("clause 1: mutate is invoked exactly once on success", func(t *testing.T) {
+		b := newBackend(t)
+		seed(t, b, "once")
+		calls := 0
+		if _, err := b.update("once", func(sess flowSession) (FlowRecord, error) {
+			calls++
+			return FlowRecord{}, nil
+		}); err != nil {
+			t.Fatalf("update() error = %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("mutate invocations = %d, want exactly 1", calls)
+		}
+	})
+
+	// A backend that retries would only ever retry a FAILING mutate, so the
+	// success case above cannot catch it. This is the case that matters: the
+	// Create closure rewrites depends_on through the caller's shared phase
+	// array, so a second pass takes a different validation branch.
+	t.Run("clause 1: a failing mutate is not retried", func(t *testing.T) {
+		b := newBackend(t)
+		seed(t, b, "no-retry")
+		sentinel := errors.New("mutate refused")
+		calls := 0
+		_, err := b.update("no-retry", func(sess flowSession) (FlowRecord, error) {
+			calls++
+			return FlowRecord{}, sentinel
+		})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("update() error = %v, want %v", err, sentinel)
+		}
+		if calls != 1 {
+			t.Fatalf("mutate invocations on failure = %d, want exactly 1 (no retry)", calls)
+		}
+	})
+
+	t.Run("session get observes saves made in the same session", func(t *testing.T) {
+		b := newBackend(t)
+		record := seed(t, b, "in-section")
+		if _, err := b.update("in-section", func(sess flowSession) (FlowRecord, error) {
+			// Every production closure opens with sess.get, so it must neither
+			// block on the section update is already holding nor return a stale
+			// snapshot.
+			before, ok := sess.get()
+			if !ok {
+				t.Fatal("sess.get() = false at the top of the section")
+			}
+			if before.record.Title != record.Title {
+				t.Fatalf("sess.get() title = %q, want %q", before.record.Title, record.Title)
+			}
+			next := record
+			next.Title = "Rewritten in section"
+			if err := sess.save(next); err != nil {
+				t.Fatalf("sess.save() error = %v", err)
+			}
+			after, ok := sess.get()
+			if !ok {
+				t.Fatal("sess.get() = false after an in-section save")
+			}
+			if after.record.Title != "Rewritten in section" {
+				t.Fatalf("sess.get() title = %q, want the in-section save to be visible", after.record.Title)
+			}
+			return after.record, nil
+		}); err != nil {
+			t.Fatalf("update() error = %v", err)
+		}
+	})
+
+	t.Run("clause 5: updates to one flow are mutually exclusive", func(t *testing.T) {
+		b := newBackend(t)
+		seed(t, b, "contended")
+		var mu sync.Mutex
+		inside, overlaps := 0, 0
+		var wg sync.WaitGroup
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, _ = b.update("contended", func(sess flowSession) (FlowRecord, error) {
+					mu.Lock()
+					inside++
+					if inside > 1 {
+						overlaps++
+					}
+					mu.Unlock()
+					// Wide enough that unsynchronized sections would overlap.
+					time.Sleep(20 * time.Millisecond)
+					mu.Lock()
+					inside--
+					mu.Unlock()
+					return FlowRecord{}, nil
+				})
+			}()
+		}
+		wg.Wait()
+		if overlaps != 0 {
+			t.Fatalf("observed %d overlapping critical sections, want 0", overlaps)
+		}
+	})
+
+	t.Run("clause 5: updates to different flows do not block each other", func(t *testing.T) {
+		b := newBackend(t)
+		seed(t, b, "alpha-flow")
+		seed(t, b, "beta-flow")
+		release := make(chan struct{})
+		holding := make(chan struct{})
+		done := make(chan error, 1)
+		go func() {
+			_, err := b.update("alpha-flow", func(sess flowSession) (FlowRecord, error) {
+				close(holding)
+				<-release
+				return FlowRecord{}, nil
+			})
+			done <- err
+		}()
+		<-holding
+		second := make(chan error, 1)
+		go func() {
+			_, err := b.update("beta-flow", func(sess flowSession) (FlowRecord, error) {
+				return FlowRecord{}, nil
+			})
+			second <- err
+		}()
+		select {
+		case err := <-second:
+			if err != nil {
+				t.Fatalf("update() on a different flow error = %v", err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatal("update() on a different flow blocked behind an unrelated flow's section")
+		}
+		close(release)
+		if err := <-done; err != nil {
+			t.Fatalf("update() error = %v", err)
+		}
+	})
+
+	t.Run("clause 2: saves survive a mutate error", func(t *testing.T) {
+		b := newBackend(t)
+		record := seed(t, b, "durable")
+		sentinel := errors.New("mutate refused")
+		_, err := b.update("durable", func(sess flowSession) (FlowRecord, error) {
+			saved := record
+			saved.Title = "Durable after error"
+			if err := sess.save(saved); err != nil {
+				return FlowRecord{}, err
+			}
+			return FlowRecord{}, sentinel
+		})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("update() error = %v, want %v", err, sentinel)
+		}
+		got, ok := b.get("durable")
+		if !ok {
+			t.Fatal("get() = false, want the record the failed mutate saved")
+		}
+		if got.record.Title != "Durable after error" {
+			t.Fatalf("title = %q, want the save to survive the mutate error", got.record.Title)
+		}
+	})
+
+	t.Run("clause 3: record and error come back verbatim", func(t *testing.T) {
+		b := newBackend(t)
+		seed(t, b, "verbatim")
+		sentinel := errors.New("verbatim sentinel")
+		want := FlowRecord{FlowID: "verbatim", Title: "Marker"}
+		got, err := b.update("verbatim", func(sess flowSession) (FlowRecord, error) {
+			return want, sentinel
+		})
+		if !errors.Is(err, sentinel) || err.Error() != sentinel.Error() {
+			t.Fatalf("update() error = %v, want %v unwrapped and unrewritten", err, sentinel)
+		}
+		if got.FlowID != want.FlowID || got.Title != want.Title {
+			t.Fatalf("update() record = %+v, want %+v returned beside the error", got, want)
+		}
+	})
+
+	t.Run("clause 4: save may be called zero or many times", func(t *testing.T) {
+		b := newBackend(t)
+		record := seed(t, b, "many")
+		if _, err := b.update("many", func(sess flowSession) (FlowRecord, error) {
+			return FlowRecord{}, nil
+		}); err != nil {
+			t.Fatalf("update() with zero saves error = %v", err)
+		}
+		if _, err := b.update("many", func(sess flowSession) (FlowRecord, error) {
+			for i, title := range []string{"first", "second", "third"} {
+				saved := record
+				saved.Title = title
+				if err := sess.save(saved); err != nil {
+					t.Fatalf("save %d error = %v", i, err)
+				}
+			}
+			return FlowRecord{}, nil
+		}); err != nil {
+			t.Fatalf("update() with three saves error = %v", err)
+		}
+		got, ok := b.get("many")
+		if !ok {
+			t.Fatal("get() = false, want the last saved record")
+		}
+		if got.record.Title != "third" {
+			t.Fatalf("title = %q, want the last save to win", got.record.Title)
+		}
+	})
+
+	t.Run("session exists reflects the record", func(t *testing.T) {
+		b := newBackend(t)
+		if _, err := b.update("later", func(sess flowSession) (FlowRecord, error) {
+			if exists, err := sess.exists(); err != nil {
+				t.Fatalf("exists() error = %v", err)
+			} else if exists {
+				t.Fatal("exists() = true before any save")
+			}
+			return FlowRecord{}, nil
+		}); err != nil {
+			t.Fatalf("update() error = %v", err)
+		}
+		seed(t, b, "later")
+		if _, err := b.update("later", func(sess flowSession) (FlowRecord, error) {
+			if exists, err := sess.exists(); err != nil {
+				t.Fatalf("exists() error = %v", err)
+			} else if !exists {
+				t.Fatal("exists() = false after a save")
+			}
+			return FlowRecord{}, nil
+		}); err != nil {
+			t.Fatalf("update() error = %v", err)
+		}
+	})
+
+	t.Run("delete reports a missing record as not found", func(t *testing.T) {
+		b := newBackend(t)
+		err := b.delete("absent-flow")
+		if !errors.Is(err, errFlowNotFound) {
+			t.Fatalf("delete() error = %v, want errFlowNotFound", err)
+		}
+		seed(t, b, "doomed")
+		if err := b.delete("doomed"); err != nil {
+			t.Fatalf("delete() error = %v", err)
+		}
+		if _, ok := b.get("doomed"); ok {
+			t.Fatal("get() = true after delete, want a miss")
+		}
+	})
+
+	t.Run("list returns every saved record", func(t *testing.T) {
+		b := newBackend(t)
+		if got, err := b.list(); err != nil {
+			t.Fatalf("list() error = %v", err)
+		} else if len(got) != 0 {
+			t.Fatalf("list() = %d records on an empty store, want 0", len(got))
+		}
+		seed(t, b, "alpha")
+		seed(t, b, "beta")
+		got, err := b.list()
+		if err != nil {
+			t.Fatalf("list() error = %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("list() = %d records, want 2", len(got))
+		}
+		seen := map[string]bool{}
+		for _, flow := range got {
+			seen[flow.record.FlowID] = true
+		}
+		if !seen["alpha"] || !seen["beta"] {
+			t.Fatalf("list() ids = %v, want alpha and beta", seen)
+		}
+	})
+
+	// Store.List sorts stably on UpdatedAt, so records with equal timestamps
+	// come back in whatever order list() produced. That makes list()'s order a
+	// contract, not an implementation detail: it must at least be stable across
+	// calls, or equal-timestamp ties would shuffle between reads.
+	t.Run("list order is stable across calls", func(t *testing.T) {
+		b := newBackend(t)
+		for _, id := range []string{"tie-a", "tie-b", "tie-c", "tie-d"} {
+			seed(t, b, id)
+		}
+		first, err := b.list()
+		if err != nil {
+			t.Fatalf("list() error = %v", err)
+		}
+		order := func(flows []storedFlow) []string {
+			ids := make([]string, 0, len(flows))
+			for _, flow := range flows {
+				ids = append(ids, flow.record.FlowID)
+			}
+			return ids
+		}
+		want := order(first)
+		for i := 0; i < 3; i++ {
+			again, err := b.list()
+			if err != nil {
+				t.Fatalf("list() error = %v", err)
+			}
+			got := order(again)
+			if len(got) != len(want) {
+				t.Fatalf("list() = %d records, want %d", len(got), len(want))
+			}
+			for j := range want {
+				if got[j] != want[j] {
+					t.Fatalf("list() order = %v, want %v (equal-UpdatedAt ties must not shuffle)", got, want)
+				}
+			}
+		}
+	})
+
+	t.Run("allocateID returns a usable distinct id", func(t *testing.T) {
+		b := newBackend(t)
+		now := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+		first, err := b.allocateID("Contract Flow", now)
+		if err != nil {
+			t.Fatalf("allocateID() error = %v", err)
+		}
+		if err := validateFlowID(first); err != nil {
+			t.Fatalf("allocateID() returned an id the store rejects: %v", err)
+		}
+		seed(t, b, first)
+		second, err := b.allocateID("Contract Flow", now)
+		if err != nil {
+			t.Fatalf("allocateID() error = %v", err)
+		}
+		if second == first {
+			t.Fatalf("allocateID() = %q twice, want a distinct id once the first is taken", second)
+		}
+	})
 }
 
 func seamStoreWithHook(t *testing.T, syncer *fakePlanSyncer) (*Store, FlowRecord, *int) {
@@ -185,6 +645,63 @@ func seamStoreWithHook(t *testing.T, syncer *fakePlanSyncer) (*Store, FlowRecord
 		calls++
 	}
 	return store, record, &calls
+}
+
+// newMergeReadySeamFlow drives a Flow all the way to a ready merge phase with a
+// verified PR and a linked plan, which is the only state from which
+// MarkManualMerge reaches the linked-plan sync.
+func newMergeReadySeamFlow(t *testing.T, syncer planPhaseSyncer) (*Store, FlowRecord) {
+	t.Helper()
+	root := t.TempDir()
+	store, err := NewStore(StoreOptions{Root: root, LockTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(FlowRecord{
+		Title:        "Merge seam",
+		Instructions: "Drive a Flow to the merge phase.",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := store.SetStartMetadata(StartMetadataUpdate{
+		FlowID:       record.FlowID,
+		Branch:       "feat/seam",
+		WorktreePath: filepath.Join(root, "wt"),
+		BaseRef:      "main",
+	}); err != nil {
+		t.Fatalf("SetStartMetadata() error = %v", err)
+	}
+	prURL := "https://github.com/o/r/pull/42"
+	if _, err := store.SetPR(PRUpdate{
+		FlowID: record.FlowID, Provider: "github", Number: 42,
+		URL: prURL, HeadBranch: "feat/seam", BaseBranch: "main", Status: "open",
+	}); err != nil {
+		t.Fatalf("SetPR() error = %v", err)
+	}
+	for _, step := range []struct{ id, outcome string }{
+		{"plan", ""},
+		{"plan-review", "approved"},
+		{"implementation", ""},
+		{"review-loop", "approved"},
+		{"pr-creation", ""},
+		{"autoreview", "approved"},
+	} {
+		if _, err := store.SetPhase(PhaseUpdate{
+			FlowID: record.FlowID, PhaseID: step.id, Status: PhaseCompleted, Outcome: step.outcome,
+		}); err != nil {
+			t.Fatalf("SetPhase(%s) error = %v", step.id, err)
+		}
+	}
+	// Linked last, and the syncer injected last, so only the merge phase's sync
+	// goes through the fake.
+	record, err = store.SetStartMetadata(StartMetadataUpdate{FlowID: record.FlowID, PlanID: "seam-plan"})
+	if err != nil {
+		t.Fatalf("SetStartMetadata() error = %v", err)
+	}
+	store.planSync = syncer
+	return store, record
 }
 
 func assertPhaseNeedsAttention(t *testing.T, store *Store, flowID, phaseID string) {

--- a/flowstore/backend_seam_internal_test.go
+++ b/flowstore/backend_seam_internal_test.go
@@ -1,0 +1,207 @@
+package flowstore
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	_ backend         = (*fileBackend)(nil)
+	_ flowTx          = fileTx{}
+	_ planPhaseSyncer = planstoreSyncer{}
+	_ planPhaseWriter = planstorePhaseWriter{}
+)
+
+// fakePlanSyncer replaces the planstore collaborator so the sync boundary can
+// be driven without a real plan artifact.
+type fakePlanSyncer struct {
+	openErr  error
+	writeErr error
+	opens    int
+	calls    []string
+}
+
+func (f *fakePlanSyncer) open() (planPhaseWriter, error) {
+	f.opens++
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return fakePlanWriter{parent: f}, nil
+}
+
+type fakePlanWriter struct{ parent *fakePlanSyncer }
+
+func (w fakePlanWriter) markPhaseCompleted(planID, phaseID string) error {
+	w.parent.calls = append(w.parent.calls, planID+"/"+phaseID)
+	return w.parent.writeErr
+}
+
+// newSeamTestFlow creates a Flow with a linked plan id but without a plan
+// artifact, so the injected syncer is the only thing the sync path touches.
+func newSeamTestFlow(t *testing.T, syncer planPhaseSyncer) (*Store, FlowRecord) {
+	t.Helper()
+	root := t.TempDir()
+	store, err := NewStore(StoreOptions{Root: root, LockTimeout: time.Second})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	store.planSync = syncer
+	record, err := store.Create(FlowRecord{
+		Title:        "Seam",
+		Instructions: "Exercise the storage seam.",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	record, err = store.SetStartMetadata(StartMetadataUpdate{FlowID: record.FlowID, PlanID: "seam-plan"})
+	if err != nil {
+		t.Fatalf("SetStartMetadata() error = %v", err)
+	}
+	return store, record
+}
+
+func TestInjectedPlanSyncerReceivesCompletedPhase(t *testing.T) {
+	syncer := &fakePlanSyncer{}
+	store, record, hookCalls := seamStoreWithHook(t, syncer)
+
+	if _, err := store.SetPhase(PhaseUpdate{FlowID: record.FlowID, PhaseID: "plan", Status: PhaseCompleted}); err != nil {
+		t.Fatalf("SetPhase() error = %v", err)
+	}
+	if got := syncer.calls; len(got) != 1 || got[0] != "seam-plan/plan" {
+		t.Fatalf("syncer calls = %v, want [seam-plan/plan]", got)
+	}
+	if *hookCalls != 1 {
+		t.Fatalf("beforeLinkedPlanPhaseSync calls = %d, want 1", *hookCalls)
+	}
+}
+
+func TestInjectedPlanSyncerWriteFailureCompensates(t *testing.T) {
+	syncer := &fakePlanSyncer{writeErr: errors.New("plan write exploded")}
+	store, record, hookCalls := seamStoreWithHook(t, syncer)
+
+	_, err := store.SetPhase(PhaseUpdate{FlowID: record.FlowID, PhaseID: "plan", Status: PhaseCompleted})
+	if err == nil {
+		t.Fatal("SetPhase() error = nil, want sync failure")
+	}
+	if !strings.Contains(err.Error(), "sync linked plan phase: plan write exploded") {
+		t.Fatalf("SetPhase() error = %v, want sync linked plan phase wrapping", err)
+	}
+	// The write path opens the plan store, fires the hook, and only then writes.
+	if *hookCalls != 1 {
+		t.Fatalf("beforeLinkedPlanPhaseSync calls = %d, want 1", *hookCalls)
+	}
+	assertPhaseNeedsAttention(t, store, record.FlowID, "plan")
+}
+
+func TestInjectedPlanSyncerOpenFailureCompensatesBeforeHook(t *testing.T) {
+	syncer := &fakePlanSyncer{openErr: errors.New("plan store unavailable")}
+	store, record, hookCalls := seamStoreWithHook(t, syncer)
+
+	_, err := store.SetPhase(PhaseUpdate{FlowID: record.FlowID, PhaseID: "plan", Status: PhaseCompleted})
+	if err == nil {
+		t.Fatal("SetPhase() error = nil, want open failure")
+	}
+	if !strings.Contains(err.Error(), "sync linked plan phase: plan store unavailable") {
+		t.Fatalf("SetPhase() error = %v, want sync linked plan phase wrapping", err)
+	}
+	if syncer.opens != 1 {
+		t.Fatalf("syncer opens = %d, want 1", syncer.opens)
+	}
+	// An open failure precedes the hook: the two-phase syncer interface exists
+	// precisely so the hook keeps firing between open and write.
+	if *hookCalls != 0 {
+		t.Fatalf("beforeLinkedPlanPhaseSync calls = %d, want 0 on open failure", *hookCalls)
+	}
+	assertPhaseNeedsAttention(t, store, record.FlowID, "plan")
+}
+
+// TestBackendUpdateSavesRemainDurableAfterMutateError pins clause 1 of the
+// backend.update contract: a non-nil error from mutate is an outcome, not a
+// rollback signal. The needs_attention compensation in SetPhase and
+// MarkManualMerge depends on it, so any future backend must satisfy it too.
+func TestBackendUpdateSavesRemainDurableAfterMutateError(t *testing.T) {
+	store, record := newSeamTestFlow(t, &fakePlanSyncer{})
+
+	sentinel := errors.New("mutate refused")
+	err := store.backend.update(record.FlowID, func(tx flowTx) error {
+		stored, ok := tx.get()
+		if !ok {
+			t.Fatalf("tx.get() = false, want the seeded record")
+		}
+		saved := stored.record
+		saved.Title = "Durable after error"
+		if err := tx.save(saved); err != nil {
+			t.Fatalf("tx.save() error = %v", err)
+		}
+		return sentinel
+	})
+	// Clause 2: the error is returned verbatim, never wrapped or replaced.
+	if !errors.Is(err, sentinel) || err.Error() != sentinel.Error() {
+		t.Fatalf("update() error = %v, want the mutate error verbatim", err)
+	}
+	got, readErr := store.Read(record.FlowID)
+	if readErr != nil {
+		t.Fatalf("Read() error = %v", readErr)
+	}
+	if got.Title != "Durable after error" {
+		t.Fatalf("title = %q, want the save to survive the mutate error", got.Title)
+	}
+}
+
+func TestBackendSaveDoesNotTakeTheFlowLock(t *testing.T) {
+	store, record := newSeamTestFlow(t, &fakePlanSyncer{})
+
+	// Store.write is reachable from inside a held critical section (and from
+	// test seeding), so backend.save must never acquire the lock: the flock is
+	// not re-entrant and a second acquire would block until it timed out.
+	done := make(chan error, 1)
+	go func() {
+		done <- store.backend.update(record.FlowID, func(tx flowTx) error {
+			return store.write(record)
+		})
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("write inside update error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("write inside update deadlocked on the flow lock")
+	}
+}
+
+func seamStoreWithHook(t *testing.T, syncer *fakePlanSyncer) (*Store, FlowRecord, *int) {
+	t.Helper()
+	store, record := newSeamTestFlow(t, syncer)
+	calls := 0
+	store.beforeLinkedPlanPhaseSync = func(planID, phaseID string) {
+		if planID != "seam-plan" || phaseID != "plan" {
+			t.Errorf("hook boundary = %q/%q, want seam-plan/plan", planID, phaseID)
+		}
+		calls++
+	}
+	return store, record, &calls
+}
+
+func assertPhaseNeedsAttention(t *testing.T, store *Store, flowID, phaseID string) {
+	t.Helper()
+	got, err := store.Read(flowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	index := phaseIndexByID(got.Phases, phaseID)
+	if index < 0 {
+		t.Fatalf("phase %q missing from %#v", phaseID, got.Phases)
+	}
+	phase := got.Phases[index]
+	if phase.Status != PhaseNeedsAttention {
+		t.Fatalf("phase %q status = %q, want needs_attention compensation persisted", phaseID, phase.Status)
+	}
+	if !strings.Contains(phase.Notes, "Linked plan phase sync failed") {
+		t.Fatalf("phase %q notes = %q, want the sync failure note", phaseID, phase.Notes)
+	}
+}

--- a/flowstore/plan_sync.go
+++ b/flowstore/plan_sync.go
@@ -1,0 +1,40 @@
+package flowstore
+
+import (
+	"github.com/approachcontrol/approach/planstore"
+)
+
+// planPhaseSyncer opens a writer for the plan store that mirrors completed Flow
+// phases into their linked plan. It is a two-phase interface on purpose: the
+// Store's beforeLinkedPlanPhaseSync test hook must fire *after* the plan store
+// is opened and *before* the plan write, so opening and writing cannot collapse
+// into a single call.
+type planPhaseSyncer interface {
+	// open is called once per sync attempt, not once per Store, so a plan store
+	// that fails to open surfaces as a sync failure (which trips the
+	// needs_attention compensation) rather than as a Store construction failure.
+	open() (planPhaseWriter, error)
+}
+
+// planPhaseWriter marks one linked plan phase completed.
+type planPhaseWriter interface {
+	markPhaseCompleted(planID, phaseID string) error
+}
+
+// planstoreSyncer is the production syncer: plans are files under the same
+// artifact root as flows.
+type planstoreSyncer struct{ root string }
+
+func (s planstoreSyncer) open() (planPhaseWriter, error) {
+	store, err := planstore.NewStore(planstore.StoreOptions{Root: s.root})
+	if err != nil {
+		return nil, err
+	}
+	return planstorePhaseWriter{store: store}, nil
+}
+
+type planstorePhaseWriter struct{ store *planstore.Store }
+
+func (w planstorePhaseWriter) markPhaseCompleted(planID, phaseID string) error {
+	return w.store.SetPhaseStatus(planID, phaseID, "completed")
+}

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -82,9 +82,11 @@ const (
 type Store struct {
 	backend  backend
 	planSync planPhaseSyncer
-	// root outlives the storage seam because linked plans are still files under
-	// the same artifact root: SetPlanLink resolves plan paths and reads plans
-	// directly through planstore.
+	// root outlives the storage seam because the plan side is only half behind
+	// it: SetPhase syncs through planSync (which captures root itself), but
+	// SetPlanLink still resolves plan paths and constructs a planstore.Store
+	// inline. Finishing that extraction is follow-up work, not part of the
+	// storage seam.
 	root                      string
 	now                       func() time.Time
 	beforeLinkedPlanPhaseSync func(planID, phaseID string)
@@ -415,18 +417,18 @@ func (s *Store) CreateWithOptions(record FlowRecord, opts CreateOptions) (FlowRe
 	} else if err := validateFlowID(record.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
-	var out FlowRecord
-	err := s.backend.update(record.FlowID, func(tx flowTx) error {
-		out = FlowRecord{}
-		if exists, err := tx.exists(); err != nil {
-			return fmt.Errorf("check flow id collision: %w", err)
+	return s.backend.update(record.FlowID, func(sess flowSession) (FlowRecord, error) {
+		if exists, err := sess.exists(); err != nil {
+			return FlowRecord{}, fmt.Errorf("check flow id collision: %w", err)
 		} else if exists {
-			return fmt.Errorf("flow %q already exists", record.FlowID)
+			return FlowRecord{}, fmt.Errorf("flow %q already exists", record.FlowID)
 		}
 
-		// Build from a fresh copy each time: mutate must stay re-runnable, so
-		// nothing here may depend on a previous pass having already seeded
-		// phases or normalized the graph.
+		// draft is a shallow copy: draft.Phases still aliases the caller's
+		// array, and backfillLinearDependsOnForCreate rewrites depends_on
+		// through it. That makes this closure single-use — a second pass would
+		// see the first pass's edges and take the authoritative-graph branch
+		// instead. Clause 1 on backend.update is what makes that safe.
 		draft := record
 		now := s.now()
 		draft.SchemaVersion = schemaVersion
@@ -438,7 +440,7 @@ func (s *Store) CreateWithOptions(record FlowRecord, opts CreateOptions) (FlowRe
 			draft.Headless = *opts.Headless
 		}
 		if opts.Preset != nil && len(draft.Phases) > 0 {
-			return fmt.Errorf("preset cannot be used with declared phases")
+			return FlowRecord{}, fmt.Errorf("preset cannot be used with declared phases")
 		}
 		if len(draft.Phases) == 0 {
 			preset := DefaultPreset()
@@ -447,37 +449,32 @@ func (s *Store) CreateWithOptions(record FlowRecord, opts CreateOptions) (FlowRe
 				draft.PresetName = strings.ToLower(strings.TrimSpace(preset.Name))
 			}
 			if err := validatePreset(preset); err != nil {
-				return err
+				return FlowRecord{}, err
 			}
 			draft.Phases = seedPhases(preset.Phases, draft.CreatedAt, draft.UpdatedAt)
 			draft = refreshPhaseReadiness(draft, now)
 		} else {
 			if err := validateDeclaredPhaseDependencies(draft.Phases); err != nil {
-				return err
+				return FlowRecord{}, err
 			}
 			authoritativeEdges := graphHasAuthoritativeEdges(draft.Phases)
 			draft.Phases = backfillLinearDependsOnForCreate(draft.Phases)
 			if err := validateUniqueMergePhaseKind(draft.Phases); err != nil {
-				return err
+				return FlowRecord{}, err
 			}
 			if authoritativeEdges {
 				if err := validatePhaseGraph(draft.Phases); err != nil {
-					return err
+					return FlowRecord{}, err
 				}
 			}
 		}
 		draft = normalizeRecord(draft, false)
 		draft.Status = DeriveStatus(draft)
-		if err := s.saveTx(tx, draft); err != nil {
-			return err
+		if err := s.saveSession(sess, draft); err != nil {
+			return FlowRecord{}, err
 		}
-		out = draft
-		return nil
+		return draft, nil
 	})
-	if err != nil {
-		return FlowRecord{}, err
-	}
-	return out, nil
 }
 
 // Read returns one flow record by ID.
@@ -498,30 +495,28 @@ func (s *Store) SetPhase(update PhaseUpdate) (FlowRecord, error) {
 	if err := validateFlowID(update.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
-	var out FlowRecord
-	err := s.backend.update(update.FlowID, func(tx flowTx) error {
-		out = FlowRecord{}
-		stored, ok := tx.get()
+	return s.backend.update(update.FlowID, func(sess flowSession) (FlowRecord, error) {
+		stored, ok := sess.get()
 		if !ok {
-			return flowNotFoundError(update.FlowID)
+			return FlowRecord{}, flowNotFoundError(update.FlowID)
 		}
 		record := s.hydrate(stored, true)
 		if err := validatePhaseGraphResolved(record); err != nil {
-			return err
+			return FlowRecord{}, err
 		}
 		// When a legacy record still holds duplicate rows for this logical phase,
 		// the first row wins: it is validated, updated, and kept, while the others
 		// are merged into it by collapseDuplicatePhaseRows below.
 		phaseIndex := phaseIndexByID(record.Phases, update.PhaseID)
 		if phaseIndex < 0 {
-			return fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
+			return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
 		}
 
 		now := s.now()
 		phase := record.Phases[phaseIndex]
 		originalStatus := phase.Status
 		if err := validatePhaseUpdate(phase, update); err != nil {
-			return err
+			return FlowRecord{}, err
 		}
 		phase.Status = update.Status
 		if clearsPhaseOutcome(update.Status) {
@@ -544,13 +539,12 @@ func (s *Store) SetPhase(update PhaseUpdate) (FlowRecord, error) {
 		record.UpdatedAt = now
 		record = refreshPhaseReadiness(record, now)
 		record.Status = DeriveStatus(record)
-		if err := s.saveTx(tx, record); err != nil {
-			return err
+		if err := s.saveSession(sess, record); err != nil {
+			return FlowRecord{}, err
 		}
 		if err := s.syncLinkedPlanPhase(record, phase); err != nil {
 			if originalStatus == PhaseCompleted {
-				out = record
-				return nil
+				return record, nil
 			}
 			// The compensating write below must survive this error: see the
 			// durability clause on backend.update.
@@ -561,20 +555,16 @@ func (s *Store) SetPhase(update PhaseUpdate) (FlowRecord, error) {
 			record.UpdatedAt = now
 			record = refreshPhaseReadiness(record, now)
 			record.Status = DeriveStatus(record)
-			if writeErr := s.saveTx(tx, record); writeErr != nil {
-				out = FlowRecord{}
-				return fmt.Errorf("%w; additionally failed to persist needs_attention state: %v", err, writeErr)
+			if writeErr := s.saveSession(sess, record); writeErr != nil {
+				return FlowRecord{}, fmt.Errorf("%w; additionally failed to persist needs_attention state: %v", err, writeErr)
 			}
-			out = FlowRecord{}
-			return err
+			// Deliberately a ZERO record beside the error, unlike
+			// MarkManualMerge, which returns the compensated record. Both are
+			// pinned by tests; see clause 3 on backend.update.
+			return FlowRecord{}, err
 		}
-		out = record
-		return nil
+		return record, nil
 	})
-	if err != nil {
-		return FlowRecord{}, err
-	}
-	return out, nil
 }
 
 // RestartPhase atomically restarts a blocked or needs-attention phase as running.
@@ -828,31 +818,28 @@ func (s *Store) MarkManualMerge(update ManualMergeUpdate) (FlowRecord, error) {
 	if err := validateFlowID(update.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
-	var out FlowRecord
-	updateErr := s.backend.update(update.FlowID, func(tx flowTx) error {
-		out = FlowRecord{}
-		stored, ok := tx.get()
+	return s.backend.update(update.FlowID, func(sess flowSession) (FlowRecord, error) {
+		stored, ok := sess.get()
 		if !ok {
-			return flowNotFoundError(update.FlowID)
+			return FlowRecord{}, flowNotFoundError(update.FlowID)
 		}
 		record := s.hydrate(stored, true)
 		if err := validatePhaseGraphResolved(record); err != nil {
-			return err
+			return FlowRecord{}, err
 		}
 		phaseIndex := mergePhaseIndex(record)
 		if phaseIndex < 0 {
-			return fmt.Errorf("phase %q not found in flow %q", "merge", update.FlowID)
+			return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", "merge", update.FlowID)
 		}
 		phase := record.Phases[phaseIndex]
 		merge, err := validateManualMergeUpdate(record, phase, update)
 		if err != nil {
-			return err
+			return FlowRecord{}, err
 		}
 		if record.PR.Status == MergeMerged &&
 			phase.Status == PhaseCompleted &&
 			mergeEqual(record.Merge, merge) {
-			out = record
-			return nil
+			return record, nil
 		}
 
 		now := s.now()
@@ -872,8 +859,8 @@ func (s *Store) MarkManualMerge(update ManualMergeUpdate) (FlowRecord, error) {
 		record.UpdatedAt = now
 		record = refreshPhaseReadiness(record, now)
 		record.Status = DeriveStatus(record)
-		if err := s.saveTx(tx, record); err != nil {
-			return err
+		if err := s.saveSession(sess, record); err != nil {
+			return FlowRecord{}, err
 		}
 		if err := s.syncLinkedPlanPhase(record, phase); err != nil {
 			// The compensating write below must survive this error: see the
@@ -887,22 +874,16 @@ func (s *Store) MarkManualMerge(update ManualMergeUpdate) (FlowRecord, error) {
 			record.UpdatedAt = now
 			record = refreshPhaseReadiness(record, now)
 			record.Status = DeriveStatus(record)
-			if writeErr := s.saveTx(tx, record); writeErr != nil {
-				out = FlowRecord{}
-				return fmt.Errorf("%w; additionally failed to persist needs_attention state: %v", err, writeErr)
+			if writeErr := s.saveSession(sess, record); writeErr != nil {
+				return FlowRecord{}, fmt.Errorf("%w; additionally failed to persist needs_attention state: %v", err, writeErr)
 			}
-			// Unlike SetPhase, this path returns the compensated record
-			// alongside the error.
-			out = record
-			return err
+			// Deliberately the COMPENSATED record beside the error, unlike
+			// SetPhase, which returns a zero record. Both are pinned by tests;
+			// see clause 3 on backend.update.
+			return record, err
 		}
-		out = record
-		return nil
+		return record, nil
 	})
-	if updateErr != nil {
-		return out, updateErr
-	}
-	return out, nil
 }
 
 // SetAutoMode enables or disables TUI-owned automatic phase launching for one Flow.
@@ -1348,35 +1329,28 @@ func (s *Store) updateFlowMetadataOnly(flowID string, mutate func(FlowRecord, ti
 }
 
 func (s *Store) updateFlowWithReadiness(flowID string, selfHealOnRead bool, mutate func(FlowRecord, time.Time) (FlowRecord, error)) (FlowRecord, error) {
-	var out FlowRecord
-	err := s.backend.update(flowID, func(tx flowTx) error {
-		out = FlowRecord{}
-		stored, ok := tx.get()
+	return s.backend.update(flowID, func(sess flowSession) (FlowRecord, error) {
+		stored, ok := sess.get()
 		if !ok {
-			return flowNotFoundError(flowID)
+			return FlowRecord{}, flowNotFoundError(flowID)
 		}
 		record := s.hydrate(stored, selfHealOnRead)
 		if selfHealOnRead {
 			if err := validatePhaseGraphResolved(record); err != nil {
-				return err
+				return FlowRecord{}, err
 			}
 		}
 		record, err := mutate(record, s.now())
 		if err != nil {
-			return err
+			return FlowRecord{}, err
 		}
 		record = normalizeRecordBase(record)
 		record.Status = DeriveStatus(record)
-		if err := s.saveTx(tx, record); err != nil {
-			return err
+		if err := s.saveSession(sess, record); err != nil {
+			return FlowRecord{}, err
 		}
-		out = record
-		return nil
+		return record, nil
 	})
-	if err != nil {
-		return FlowRecord{}, err
-	}
-	return out, nil
 }
 
 func validatePhaseGraphResolved(record FlowRecord) error {
@@ -1983,41 +1957,24 @@ func defaultPhases(createdAt, updatedAt time.Time) []FlowPhase {
 	return seedPhases(DefaultPreset().Phases, createdAt, updatedAt)
 }
 
-// write persists one record without taking the flow lock; callers must already
-// hold it, or must not need it. After the seam extraction it has no production
-// callers left: it survives because preset_test.go seeds hand-authored records
-// through it. Routing it through backend.update instead would deadlock, because
-// the flow lock is not re-entrant.
-func (s *Store) write(record FlowRecord) error {
-	if err := validateFlowID(record.FlowID); err != nil {
-		return err
-	}
-	// Deliberately in place: callers observe the normalized DependsOn slices on
-	// the record they passed in, and on every record the public API returns.
-	record.Phases = normalizeDependsOnValues(record.Phases)
-	return s.backend.save(record)
-}
-
-// saveTx mirrors write for saves made inside a critical section, so both paths
-// validate and normalize identically.
-func (s *Store) saveTx(tx flowTx, record FlowRecord) error {
+// saveSession validates and normalizes one record, then persists it through the
+// critical section the caller already holds. Normalization is deliberately in
+// place: callers observe the normalized DependsOn slices on the record they
+// passed in, and on every record the public API returns.
+func (s *Store) saveSession(sess flowSession, record FlowRecord) error {
 	if err := validateFlowID(record.FlowID); err != nil {
 		return err
 	}
 	record.Phases = normalizeDependsOnValues(record.Phases)
-	return tx.save(record)
+	return sess.save(record)
 }
 
 func (s *Store) readRecord(flowID string) (FlowRecord, bool) {
-	return s.readRecordWithReadiness(flowID, true)
-}
-
-func (s *Store) readRecordWithReadiness(flowID string, selfHealOnRead bool) (FlowRecord, bool) {
 	stored, ok := s.backend.get(flowID)
 	if !ok {
 		return FlowRecord{}, false
 	}
-	return s.hydrate(stored, selfHealOnRead), true
+	return s.hydrate(stored, true), true
 }
 
 // hydrate turns a decoded record plus its raw encoding hints into the domain
@@ -2025,8 +1982,10 @@ func (s *Store) readRecordWithReadiness(flowID string, selfHealOnRead bool) (Flo
 // normalization, readiness, and derived status.
 func (s *Store) hydrate(stored storedFlow, selfHealOnRead bool) FlowRecord {
 	record := stored.record
-	presence := stored.dependsOnPresence
-	if !stored.headlessPresent {
+	presence := stored.dependsOnHints()
+	// Legacy records predate per-flow headless and stored no field for it, so
+	// they read back as headless rather than as Go's zero value.
+	if stored.legacyEncoding && !stored.headlessPresent {
 		record.Headless = true
 	}
 	selfHeal := rawDependsOnPresentForTopLevel(record.Phases, presence)

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -6,11 +6,9 @@
 package flowstore
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"path/filepath"
 	"slices"
 	"sort"
@@ -82,9 +80,13 @@ const (
 
 // Store reads and writes flow records under an artifact root.
 type Store struct {
+	backend  backend
+	planSync planPhaseSyncer
+	// root outlives the storage seam because linked plans are still files under
+	// the same artifact root: SetPlanLink resolves plan paths and reads plans
+	// directly through planstore.
 	root                      string
 	now                       func() time.Time
-	lockTimeout               time.Duration
 	beforeLinkedPlanPhaseSync func(planID, phaseID string)
 	presets                   map[string]Preset
 }
@@ -342,22 +344,32 @@ func NewStore(opts StoreOptions) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := artifacts.EnsureCollection(root, "flows"); err != nil {
-		return nil, fmt.Errorf("create flow store: %w", err)
+	// Ordering is load-bearing: the backend's EnsureCollection failure must
+	// still surface before a bad preset does. Only the lockTimeout default is
+	// hoisted, because the backend needs it at construction.
+	lockTimeout := opts.LockTimeout
+	if lockTimeout <= 0 {
+		lockTimeout = defaultLockTimeout
+	}
+	store, err := newFileBackend(root, lockTimeout)
+	if err != nil {
+		return nil, err
 	}
 	now := opts.Now
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
 	}
-	lockTimeout := opts.LockTimeout
-	if lockTimeout <= 0 {
-		lockTimeout = defaultLockTimeout
-	}
 	presets, err := presetRegistry(opts.Presets)
 	if err != nil {
 		return nil, err
 	}
-	return &Store{root: root, now: now, lockTimeout: lockTimeout, presets: presets}, nil
+	return &Store{
+		backend:  store,
+		planSync: planstoreSyncer{root: root},
+		root:     root,
+		now:      now,
+		presets:  presets,
+	}, nil
 }
 
 // DefaultRoot returns the default artifact root, matching sessions and plans.
@@ -392,7 +404,10 @@ func (s *Store) CreateWithOptions(record FlowRecord, opts CreateOptions) (FlowRe
 		return FlowRecord{}, fmt.Errorf("flow repo path must be absolute: %s", record.RepoPath)
 	}
 	if record.FlowID == "" {
-		id, err := s.generateID(record.Title)
+		// Create reads the clock twice: once to allocate the timestamped ID and
+		// again below for the record's own timestamps. Both reads are counted by
+		// the existing tests, so neither may be collapsed into the other.
+		id, err := s.backend.allocateID(record.Title, s.now())
 		if err != nil {
 			return FlowRecord{}, err
 		}
@@ -400,61 +415,69 @@ func (s *Store) CreateWithOptions(record FlowRecord, opts CreateOptions) (FlowRe
 	} else if err := validateFlowID(record.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
-	release, err := s.acquireFlowLock(record.FlowID)
+	var out FlowRecord
+	err := s.backend.update(record.FlowID, func(tx flowTx) error {
+		out = FlowRecord{}
+		if exists, err := tx.exists(); err != nil {
+			return fmt.Errorf("check flow id collision: %w", err)
+		} else if exists {
+			return fmt.Errorf("flow %q already exists", record.FlowID)
+		}
+
+		// Build from a fresh copy each time: mutate must stay re-runnable, so
+		// nothing here may depend on a previous pass having already seeded
+		// phases or normalized the graph.
+		draft := record
+		now := s.now()
+		draft.SchemaVersion = schemaVersion
+		draft.CreatedAt = defaultTime(draft.CreatedAt, now)
+		draft.UpdatedAt = defaultTime(draft.UpdatedAt, now)
+		draft.AutoMode = true
+		draft.Headless = true
+		if opts.Headless != nil {
+			draft.Headless = *opts.Headless
+		}
+		if opts.Preset != nil && len(draft.Phases) > 0 {
+			return fmt.Errorf("preset cannot be used with declared phases")
+		}
+		if len(draft.Phases) == 0 {
+			preset := DefaultPreset()
+			if opts.Preset != nil {
+				preset = *opts.Preset
+				draft.PresetName = strings.ToLower(strings.TrimSpace(preset.Name))
+			}
+			if err := validatePreset(preset); err != nil {
+				return err
+			}
+			draft.Phases = seedPhases(preset.Phases, draft.CreatedAt, draft.UpdatedAt)
+			draft = refreshPhaseReadiness(draft, now)
+		} else {
+			if err := validateDeclaredPhaseDependencies(draft.Phases); err != nil {
+				return err
+			}
+			authoritativeEdges := graphHasAuthoritativeEdges(draft.Phases)
+			draft.Phases = backfillLinearDependsOnForCreate(draft.Phases)
+			if err := validateUniqueMergePhaseKind(draft.Phases); err != nil {
+				return err
+			}
+			if authoritativeEdges {
+				if err := validatePhaseGraph(draft.Phases); err != nil {
+					return err
+				}
+			}
+		}
+		draft = normalizeRecord(draft, false)
+		draft.Status = DeriveStatus(draft)
+		if err := s.saveTx(tx, draft); err != nil {
+			return err
+		}
+		out = draft
+		return nil
+	})
 	if err != nil {
 		return FlowRecord{}, err
 	}
-	defer release()
-	if _, err := os.Stat(s.flowDir(record.FlowID)); err == nil {
-		return FlowRecord{}, fmt.Errorf("flow %q already exists", record.FlowID)
-	} else if !os.IsNotExist(err) {
-		return FlowRecord{}, fmt.Errorf("check flow id collision: %w", err)
-	}
-
-	now := s.now()
-	record.SchemaVersion = schemaVersion
-	record.CreatedAt = defaultTime(record.CreatedAt, now)
-	record.UpdatedAt = defaultTime(record.UpdatedAt, now)
-	record.AutoMode = true
-	record.Headless = true
-	if opts.Headless != nil {
-		record.Headless = *opts.Headless
-	}
-	if opts.Preset != nil && len(record.Phases) > 0 {
-		return FlowRecord{}, fmt.Errorf("preset cannot be used with declared phases")
-	}
-	if len(record.Phases) == 0 {
-		preset := DefaultPreset()
-		if opts.Preset != nil {
-			preset = *opts.Preset
-			record.PresetName = strings.ToLower(strings.TrimSpace(preset.Name))
-		}
-		if err := validatePreset(preset); err != nil {
-			return FlowRecord{}, err
-		}
-		record.Phases = seedPhases(preset.Phases, record.CreatedAt, record.UpdatedAt)
-		record = refreshPhaseReadiness(record, now)
-	} else {
-		if err := validateDeclaredPhaseDependencies(record.Phases); err != nil {
-			return FlowRecord{}, err
-		}
-		authoritativeEdges := graphHasAuthoritativeEdges(record.Phases)
-		record.Phases = backfillLinearDependsOnForCreate(record.Phases)
-		if err := validateUniqueMergePhaseKind(record.Phases); err != nil {
-			return FlowRecord{}, err
-		}
-		if authoritativeEdges {
-			if err := validatePhaseGraph(record.Phases); err != nil {
-				return FlowRecord{}, err
-			}
-		}
-	}
-	record = normalizeRecord(record, false)
-	record.Status = DeriveStatus(record)
-	if err := s.write(record); err != nil {
-		return FlowRecord{}, err
-	}
-	return record, nil
+	return out, nil
 }
 
 // Read returns one flow record by ID.
@@ -475,73 +498,83 @@ func (s *Store) SetPhase(update PhaseUpdate) (FlowRecord, error) {
 	if err := validateFlowID(update.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
-	release, err := s.acquireFlowLock(update.FlowID)
-	if err != nil {
-		return FlowRecord{}, err
-	}
-	defer release()
-	record, ok := s.readRecord(update.FlowID)
-	if !ok {
-		return FlowRecord{}, flowNotFoundError(update.FlowID)
-	}
-	if err := validatePhaseGraphResolved(record); err != nil {
-		return FlowRecord{}, err
-	}
-	// When a legacy record still holds duplicate rows for this logical phase,
-	// the first row wins: it is validated, updated, and kept, while the others
-	// are merged into it by collapseDuplicatePhaseRows below.
-	phaseIndex := phaseIndexByID(record.Phases, update.PhaseID)
-	if phaseIndex < 0 {
-		return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
-	}
+	var out FlowRecord
+	err := s.backend.update(update.FlowID, func(tx flowTx) error {
+		out = FlowRecord{}
+		stored, ok := tx.get()
+		if !ok {
+			return flowNotFoundError(update.FlowID)
+		}
+		record := s.hydrate(stored, true)
+		if err := validatePhaseGraphResolved(record); err != nil {
+			return err
+		}
+		// When a legacy record still holds duplicate rows for this logical phase,
+		// the first row wins: it is validated, updated, and kept, while the others
+		// are merged into it by collapseDuplicatePhaseRows below.
+		phaseIndex := phaseIndexByID(record.Phases, update.PhaseID)
+		if phaseIndex < 0 {
+			return fmt.Errorf("phase %q not found in flow %q", update.PhaseID, update.FlowID)
+		}
 
-	now := s.now()
-	phase := record.Phases[phaseIndex]
-	originalStatus := phase.Status
-	if err := validatePhaseUpdate(phase, update); err != nil {
-		return FlowRecord{}, err
-	}
-	phase.Status = update.Status
-	if clearsPhaseOutcome(update.Status) {
-		phase.Outcome = ""
-	}
-	if outcome := strings.TrimSpace(update.Outcome); outcome != "" {
-		phase.Outcome = outcome
-	}
-	if update.Notes != "" {
-		phase.Notes = update.Notes
-	}
-	if update.Summary != "" {
-		phase.Summary = update.Summary
-	}
-	phase.PhaseID = update.PhaseID
-	phase.UpdatedAt = now
-	record.Phases[phaseIndex] = phase
-	record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
-	record = resetMergePendingForActiveMergePhase(record, phase)
-	record.UpdatedAt = now
-	record = refreshPhaseReadiness(record, now)
-	record.Status = DeriveStatus(record)
-	if err := s.write(record); err != nil {
-		return FlowRecord{}, err
-	}
-	if err := s.syncLinkedPlanPhase(record, phase); err != nil {
-		if originalStatus == PhaseCompleted {
-			return record, nil
+		now := s.now()
+		phase := record.Phases[phaseIndex]
+		originalStatus := phase.Status
+		if err := validatePhaseUpdate(phase, update); err != nil {
+			return err
 		}
-		failedPhase := markPhaseSyncNeedsAttention(phase, err, now)
-		if failedIndex := phaseIndexByID(record.Phases, failedPhase.PhaseID); failedIndex >= 0 {
-			record.Phases[failedIndex] = failedPhase
+		phase.Status = update.Status
+		if clearsPhaseOutcome(update.Status) {
+			phase.Outcome = ""
 		}
+		if outcome := strings.TrimSpace(update.Outcome); outcome != "" {
+			phase.Outcome = outcome
+		}
+		if update.Notes != "" {
+			phase.Notes = update.Notes
+		}
+		if update.Summary != "" {
+			phase.Summary = update.Summary
+		}
+		phase.PhaseID = update.PhaseID
+		phase.UpdatedAt = now
+		record.Phases[phaseIndex] = phase
+		record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
+		record = resetMergePendingForActiveMergePhase(record, phase)
 		record.UpdatedAt = now
 		record = refreshPhaseReadiness(record, now)
 		record.Status = DeriveStatus(record)
-		if writeErr := s.write(record); writeErr != nil {
-			return FlowRecord{}, fmt.Errorf("%w; additionally failed to persist needs_attention state: %v", err, writeErr)
+		if err := s.saveTx(tx, record); err != nil {
+			return err
 		}
+		if err := s.syncLinkedPlanPhase(record, phase); err != nil {
+			if originalStatus == PhaseCompleted {
+				out = record
+				return nil
+			}
+			// The compensating write below must survive this error: see the
+			// durability clause on backend.update.
+			failedPhase := markPhaseSyncNeedsAttention(phase, err, now)
+			if failedIndex := phaseIndexByID(record.Phases, failedPhase.PhaseID); failedIndex >= 0 {
+				record.Phases[failedIndex] = failedPhase
+			}
+			record.UpdatedAt = now
+			record = refreshPhaseReadiness(record, now)
+			record.Status = DeriveStatus(record)
+			if writeErr := s.saveTx(tx, record); writeErr != nil {
+				out = FlowRecord{}
+				return fmt.Errorf("%w; additionally failed to persist needs_attention state: %v", err, writeErr)
+			}
+			out = FlowRecord{}
+			return err
+		}
+		out = record
+		return nil
+	})
+	if err != nil {
 		return FlowRecord{}, err
 	}
-	return record, nil
+	return out, nil
 }
 
 // RestartPhase atomically restarts a blocked or needs-attention phase as running.
@@ -676,14 +709,14 @@ func (s *Store) syncLinkedPlanPhase(record FlowRecord, phase FlowPhase) error {
 	if planID == "" || phase.Status != PhaseCompleted {
 		return nil
 	}
-	planStore, err := planstore.NewStore(planstore.StoreOptions{Root: s.root})
+	writer, err := s.planSync.open()
 	if err != nil {
 		return fmt.Errorf("sync linked plan phase: %w", err)
 	}
 	if s.beforeLinkedPlanPhaseSync != nil {
 		s.beforeLinkedPlanPhaseSync(planID, phase.PhaseID)
 	}
-	if err := planStore.SetPhaseStatus(planID, phase.PhaseID, "completed"); err != nil {
+	if err := writer.markPhaseCompleted(planID, phase.PhaseID); err != nil {
 		return fmt.Errorf("sync linked plan phase: %w", err)
 	}
 	return nil
@@ -795,69 +828,81 @@ func (s *Store) MarkManualMerge(update ManualMergeUpdate) (FlowRecord, error) {
 	if err := validateFlowID(update.FlowID); err != nil {
 		return FlowRecord{}, err
 	}
-	release, err := s.acquireFlowLock(update.FlowID)
-	if err != nil {
-		return FlowRecord{}, err
-	}
-	defer release()
-	record, ok := s.readRecord(update.FlowID)
-	if !ok {
-		return FlowRecord{}, flowNotFoundError(update.FlowID)
-	}
-	if err := validatePhaseGraphResolved(record); err != nil {
-		return FlowRecord{}, err
-	}
-	phaseIndex := mergePhaseIndex(record)
-	if phaseIndex < 0 {
-		return FlowRecord{}, fmt.Errorf("phase %q not found in flow %q", "merge", update.FlowID)
-	}
-	phase := record.Phases[phaseIndex]
-	merge, err := validateManualMergeUpdate(record, phase, update)
-	if err != nil {
-		return FlowRecord{}, err
-	}
-	if record.PR.Status == MergeMerged &&
-		phase.Status == PhaseCompleted &&
-		mergeEqual(record.Merge, merge) {
-		return record, nil
-	}
-
-	now := s.now()
-	summary := strings.TrimSpace(update.Summary)
-	if summary == "" {
-		summary = fmt.Sprintf("Marked GitHub PR #%d as manually merged at %s.", record.PR.Number, merge.Commit)
-	}
-	previousPRStatus := record.PR.Status
-	phase.Status = PhaseCompleted
-	phase.Outcome = MergeMerged
-	phase.Summary = summary
-	phase.UpdatedAt = now
-	record.Phases[phaseIndex] = phase
-	record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
-	record.PR.Status = MergeMerged
-	record.Merge = merge
-	record.UpdatedAt = now
-	record = refreshPhaseReadiness(record, now)
-	record.Status = DeriveStatus(record)
-	if err := s.write(record); err != nil {
-		return FlowRecord{}, err
-	}
-	if err := s.syncLinkedPlanPhase(record, phase); err != nil {
-		failedPhase := markPhaseSyncNeedsAttention(phase, err, now)
-		if failedIndex := phaseIndexByID(record.Phases, failedPhase.PhaseID); failedIndex >= 0 {
-			record.Phases[failedIndex] = failedPhase
+	var out FlowRecord
+	updateErr := s.backend.update(update.FlowID, func(tx flowTx) error {
+		out = FlowRecord{}
+		stored, ok := tx.get()
+		if !ok {
+			return flowNotFoundError(update.FlowID)
 		}
-		record.PR.Status = previousPRStatus
-		record.Merge = Merge{Status: MergePending}
+		record := s.hydrate(stored, true)
+		if err := validatePhaseGraphResolved(record); err != nil {
+			return err
+		}
+		phaseIndex := mergePhaseIndex(record)
+		if phaseIndex < 0 {
+			return fmt.Errorf("phase %q not found in flow %q", "merge", update.FlowID)
+		}
+		phase := record.Phases[phaseIndex]
+		merge, err := validateManualMergeUpdate(record, phase, update)
+		if err != nil {
+			return err
+		}
+		if record.PR.Status == MergeMerged &&
+			phase.Status == PhaseCompleted &&
+			mergeEqual(record.Merge, merge) {
+			out = record
+			return nil
+		}
+
+		now := s.now()
+		summary := strings.TrimSpace(update.Summary)
+		if summary == "" {
+			summary = fmt.Sprintf("Marked GitHub PR #%d as manually merged at %s.", record.PR.Number, merge.Commit)
+		}
+		previousPRStatus := record.PR.Status
+		phase.Status = PhaseCompleted
+		phase.Outcome = MergeMerged
+		phase.Summary = summary
+		phase.UpdatedAt = now
+		record.Phases[phaseIndex] = phase
+		record.Phases = collapseDuplicatePhaseRows(record.Phases, phaseIndex)
+		record.PR.Status = MergeMerged
+		record.Merge = merge
 		record.UpdatedAt = now
 		record = refreshPhaseReadiness(record, now)
 		record.Status = DeriveStatus(record)
-		if writeErr := s.write(record); writeErr != nil {
-			return FlowRecord{}, fmt.Errorf("%w; additionally failed to persist needs_attention state: %v", err, writeErr)
+		if err := s.saveTx(tx, record); err != nil {
+			return err
 		}
-		return record, err
+		if err := s.syncLinkedPlanPhase(record, phase); err != nil {
+			// The compensating write below must survive this error: see the
+			// durability clause on backend.update.
+			failedPhase := markPhaseSyncNeedsAttention(phase, err, now)
+			if failedIndex := phaseIndexByID(record.Phases, failedPhase.PhaseID); failedIndex >= 0 {
+				record.Phases[failedIndex] = failedPhase
+			}
+			record.PR.Status = previousPRStatus
+			record.Merge = Merge{Status: MergePending}
+			record.UpdatedAt = now
+			record = refreshPhaseReadiness(record, now)
+			record.Status = DeriveStatus(record)
+			if writeErr := s.saveTx(tx, record); writeErr != nil {
+				out = FlowRecord{}
+				return fmt.Errorf("%w; additionally failed to persist needs_attention state: %v", err, writeErr)
+			}
+			// Unlike SetPhase, this path returns the compensated record
+			// alongside the error.
+			out = record
+			return err
+		}
+		out = record
+		return nil
+	})
+	if updateErr != nil {
+		return out, updateErr
 	}
-	return record, nil
+	return out, nil
 }
 
 // SetAutoMode enables or disables TUI-owned automatic phase launching for one Flow.
@@ -1291,21 +1336,7 @@ func (s *Store) Delete(flowID string) error {
 	if err := validateFlowID(flowID); err != nil {
 		return err
 	}
-	release, err := s.acquireFlowLock(flowID)
-	if err != nil {
-		return err
-	}
-	defer release()
-	dir := s.flowDir(flowID)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return flowNotFoundError(flowID)
-	} else if err != nil {
-		return fmt.Errorf("stat flow %q: %w", flowID, err)
-	}
-	if err := os.RemoveAll(dir); err != nil {
-		return fmt.Errorf("delete flow %q: %w", flowID, err)
-	}
-	return nil
+	return s.backend.delete(flowID)
 }
 
 func (s *Store) updateFlow(flowID string, mutate func(FlowRecord, time.Time) (FlowRecord, error)) (FlowRecord, error) {
@@ -1317,30 +1348,35 @@ func (s *Store) updateFlowMetadataOnly(flowID string, mutate func(FlowRecord, ti
 }
 
 func (s *Store) updateFlowWithReadiness(flowID string, selfHealOnRead bool, mutate func(FlowRecord, time.Time) (FlowRecord, error)) (FlowRecord, error) {
-	release, err := s.acquireFlowLock(flowID)
-	if err != nil {
-		return FlowRecord{}, err
-	}
-	defer release()
-	record, ok := s.readRecordWithReadiness(flowID, selfHealOnRead)
-	if !ok {
-		return FlowRecord{}, flowNotFoundError(flowID)
-	}
-	if selfHealOnRead {
-		if err := validatePhaseGraphResolved(record); err != nil {
-			return FlowRecord{}, err
+	var out FlowRecord
+	err := s.backend.update(flowID, func(tx flowTx) error {
+		out = FlowRecord{}
+		stored, ok := tx.get()
+		if !ok {
+			return flowNotFoundError(flowID)
 		}
-	}
-	record, err = mutate(record, s.now())
+		record := s.hydrate(stored, selfHealOnRead)
+		if selfHealOnRead {
+			if err := validatePhaseGraphResolved(record); err != nil {
+				return err
+			}
+		}
+		record, err := mutate(record, s.now())
+		if err != nil {
+			return err
+		}
+		record = normalizeRecordBase(record)
+		record.Status = DeriveStatus(record)
+		if err := s.saveTx(tx, record); err != nil {
+			return err
+		}
+		out = record
+		return nil
+	})
 	if err != nil {
 		return FlowRecord{}, err
 	}
-	record = normalizeRecordBase(record)
-	record.Status = DeriveStatus(record)
-	if err := s.write(record); err != nil {
-		return FlowRecord{}, err
-	}
-	return record, nil
+	return out, nil
 }
 
 func validatePhaseGraphResolved(record FlowRecord) error {
@@ -1363,40 +1399,16 @@ func appendUnique(values []string, value string) []string {
 	return append(values, value)
 }
 
-func (s *Store) acquireFlowLock(flowID string) (func(), error) {
-	if err := validateFlowID(flowID); err != nil {
-		return nil, err
-	}
-	lockDir := filepath.Join(s.root, "flows", ".locks")
-	if err := os.MkdirAll(lockDir, artifacts.DirPerm); err != nil {
-		return nil, fmt.Errorf("create flow lock directory: %w", err)
-	}
-	if err := os.Chmod(lockDir, artifacts.DirPerm); err != nil {
-		return nil, fmt.Errorf("secure flow lock directory: %w", err)
-	}
-	lockPath := filepath.Join(lockDir, flowID+".lock")
-	return artifacts.AcquireFileLock(lockPath, fmt.Sprintf("flow lock %q", flowID), s.lockTimeout)
-}
-
 // List returns records matching filter, sorted by UpdatedAt descending.
 func (s *Store) List(filter FlowFilter) ([]FlowRecord, error) {
-	root := filepath.Join(s.root, "flows")
-	entries, err := os.ReadDir(root)
+	stored, err := s.backend.list()
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("list flows: %w", err)
+		return nil, err
 	}
 	var records []FlowRecord
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		record, ok := s.readRecord(entry.Name())
-		if !ok {
-			continue
-		}
+	for _, flow := range stored {
+		// List reaches hydration through readRecord today, so it self-heals.
+		record := s.hydrate(flow, true)
 		if matchesFilter(record, filter) {
 			records = append(records, record)
 		}
@@ -1971,131 +1983,29 @@ func defaultPhases(createdAt, updatedAt time.Time) []FlowPhase {
 	return seedPhases(DefaultPreset().Phases, createdAt, updatedAt)
 }
 
-func (s *Store) generateID(title string) (string, error) {
-	return artifacts.AllocateTimestampedID(artifacts.IDOptions{
-		Root:         s.root,
-		Collection:   "flows",
-		Title:        title,
-		FallbackSlug: "flow",
-		Kind:         "flow",
-		Now:          s.now(),
-	})
-}
-
+// write persists one record without taking the flow lock; callers must already
+// hold it, or must not need it. After the seam extraction it has no production
+// callers left: it survives because preset_test.go seeds hand-authored records
+// through it. Routing it through backend.update instead would deadlock, because
+// the flow lock is not re-entrant.
 func (s *Store) write(record FlowRecord) error {
 	if err := validateFlowID(record.FlowID); err != nil {
 		return err
 	}
+	// Deliberately in place: callers observe the normalized DependsOn slices on
+	// the record they passed in, and on every record the public API returns.
 	record.Phases = normalizeDependsOnValues(record.Phases)
-	dir, err := artifacts.EnsureRecordDir(s.root, "flows", record.FlowID)
-	if err != nil {
-		return fmt.Errorf("secure flow directory: %w", err)
-	}
-	data, err := marshalFlowRecord(record)
-	if err != nil {
-		return fmt.Errorf("encode flow metadata: %w", err)
-	}
-	if err := artifacts.WriteFileAtomic(filepath.Join(dir, "meta.json"), data); err != nil {
-		return fmt.Errorf("write flow metadata: %w", err)
-	}
-	return nil
+	return s.backend.save(record)
 }
 
-func marshalFlowRecord(record FlowRecord) ([]byte, error) {
-	if len(record.preserveMissingDependsOn) == 0 {
-		return json.MarshalIndent(record, "", "  ")
+// saveTx mirrors write for saves made inside a critical section, so both paths
+// validate and normalize identically.
+func (s *Store) saveTx(tx flowTx, record FlowRecord) error {
+	if err := validateFlowID(record.FlowID); err != nil {
+		return err
 	}
-	phases := make([]flowPhaseForWrite, 0, len(record.Phases))
-	for _, phase := range record.Phases {
-		phases = append(phases, flowPhaseForWriteFrom(phase, record.preserveMissingDependsOn[artifacts.NormalizePhaseID(phase.PhaseID)]))
-	}
-	return json.MarshalIndent(flowRecordForWrite{
-		SchemaVersion: record.SchemaVersion,
-		FlowID:        record.FlowID,
-		Title:         record.Title,
-		Instructions:  record.Instructions,
-		Status:        record.Status,
-		RepoPath:      record.RepoPath,
-		WorktreePath:  record.WorktreePath,
-		Branch:        record.Branch,
-		BaseRef:       record.BaseRef,
-		Commit:        record.Commit,
-		PresetName:    record.PresetName,
-		PlanID:        record.PlanID,
-		PlanPath:      record.PlanPath,
-		Issue:         record.Issue,
-		PR:            record.PR,
-		Merge:         record.Merge,
-		AutoMode:      record.AutoMode,
-		Headless:      record.Headless,
-		Phases:        phases,
-		CreatedAt:     record.CreatedAt,
-		UpdatedAt:     record.UpdatedAt,
-	}, "", "  ")
-}
-
-type flowRecordForWrite struct {
-	SchemaVersion int                 `json:"schema_version"`
-	FlowID        string              `json:"flow_id"`
-	Title         string              `json:"title"`
-	Instructions  string              `json:"instructions"`
-	Status        string              `json:"status"`
-	RepoPath      string              `json:"repo_path"`
-	WorktreePath  string              `json:"worktree_path,omitempty"`
-	Branch        string              `json:"branch,omitempty"`
-	BaseRef       string              `json:"base_ref,omitempty"`
-	Commit        string              `json:"commit,omitempty"`
-	PresetName    string              `json:"preset_name,omitempty"`
-	PlanID        string              `json:"plan_id,omitempty"`
-	PlanPath      string              `json:"plan_path,omitempty"`
-	Issue         Issue               `json:"issue,omitempty"`
-	PR            PullRequest         `json:"pr,omitempty"`
-	Merge         Merge               `json:"merge,omitempty"`
-	AutoMode      bool                `json:"auto_mode,omitempty"`
-	Headless      bool                `json:"headless"`
-	Phases        []flowPhaseForWrite `json:"phases"`
-	CreatedAt     time.Time           `json:"created_at"`
-	UpdatedAt     time.Time           `json:"updated_at"`
-}
-
-type flowPhaseForWrite struct {
-	PhaseID       string    `json:"phase_id"`
-	ParentPhaseID string    `json:"parent_phase_id,omitempty"`
-	Title         string    `json:"title"`
-	Kind          string    `json:"kind"`
-	DependsOn     *[]string `json:"depends_on,omitempty"`
-	Status        string    `json:"status"`
-	Order         int       `json:"order"`
-	Outcome       string    `json:"outcome,omitempty"`
-	Notes         string    `json:"notes,omitempty"`
-	Summary       string    `json:"summary,omitempty"`
-	LaunchIDs     []string  `json:"launch_ids,omitempty"`
-	Sessions      []Session `json:"sessions,omitempty"`
-	CreatedAt     time.Time `json:"created_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
-}
-
-func flowPhaseForWriteFrom(phase FlowPhase, omitDependsOn bool) flowPhaseForWrite {
-	var dependsOn *[]string
-	if !omitDependsOn {
-		dependsOn = &phase.DependsOn
-	}
-	return flowPhaseForWrite{
-		PhaseID:       phase.PhaseID,
-		ParentPhaseID: phase.ParentPhaseID,
-		Title:         phase.Title,
-		Kind:          phase.Kind,
-		DependsOn:     dependsOn,
-		Status:        phase.Status,
-		Order:         phase.Order,
-		Outcome:       phase.Outcome,
-		Notes:         phase.Notes,
-		Summary:       phase.Summary,
-		LaunchIDs:     phase.LaunchIDs,
-		Sessions:      phase.Sessions,
-		CreatedAt:     phase.CreatedAt,
-		UpdatedAt:     phase.UpdatedAt,
-	}
+	record.Phases = normalizeDependsOnValues(record.Phases)
+	return tx.save(record)
 }
 
 func (s *Store) readRecord(flowID string) (FlowRecord, bool) {
@@ -2103,23 +2013,20 @@ func (s *Store) readRecord(flowID string) (FlowRecord, bool) {
 }
 
 func (s *Store) readRecordWithReadiness(flowID string, selfHealOnRead bool) (FlowRecord, bool) {
-	if err := validateFlowID(flowID); err != nil {
+	stored, ok := s.backend.get(flowID)
+	if !ok {
 		return FlowRecord{}, false
 	}
-	data, err := os.ReadFile(filepath.Join(s.flowDir(flowID), "meta.json"))
-	if err != nil {
-		return FlowRecord{}, false
-	}
-	presence := rawDependsOnPresence(data)
-	headlessPresent := rawFieldPresent(data, "headless")
-	var record FlowRecord
-	if err := json.Unmarshal(data, &record); err != nil {
-		return FlowRecord{}, false
-	}
-	if record.FlowID != flowID || record.SchemaVersion != schemaVersion {
-		return FlowRecord{}, false
-	}
-	if !headlessPresent {
+	return s.hydrate(stored, selfHealOnRead), true
+}
+
+// hydrate turns a decoded record plus its raw encoding hints into the domain
+// record the public API returns: legacy field defaults, graph recovery,
+// normalization, readiness, and derived status.
+func (s *Store) hydrate(stored storedFlow, selfHealOnRead bool) FlowRecord {
+	record := stored.record
+	presence := stored.dependsOnPresence
+	if !stored.headlessPresent {
 		record.Headless = true
 	}
 	selfHeal := rawDependsOnPresentForTopLevel(record.Phases, presence)
@@ -2145,7 +2052,7 @@ func (s *Store) readRecordWithReadiness(flowID string, selfHealOnRead bool) (Flo
 		}
 	}
 	record.Status = DeriveStatus(record)
-	return record, true
+	return record
 }
 
 func (s *Store) restoreMissingDependsOn(record FlowRecord, presence []rawDependsOnState) FlowRecord {
@@ -2217,32 +2124,6 @@ func applyPresetDependsOn(phases []FlowPhase, preset Preset) []FlowPhase {
 	return normalizeDependsOnValues(phases)
 }
 
-func rawDependsOnPresence(data []byte) []rawDependsOnState {
-	var raw struct {
-		Phases []map[string]json.RawMessage `json:"phases"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil
-	}
-	presence := make([]rawDependsOnState, len(raw.Phases))
-	for i, phase := range raw.Phases {
-		_, ok := phase["depends_on"]
-		presence[i] = rawDependsOnState{
-			Present: ok,
-		}
-	}
-	return presence
-}
-
-func rawFieldPresent(data []byte, field string) bool {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return false
-	}
-	_, ok := raw[field]
-	return ok
-}
-
 func rawDependsOnPresentForTopLevel(phases []FlowPhase, presence []rawDependsOnState) bool {
 	for i, phase := range phases {
 		if phase.ParentPhaseID == "" && i < len(presence) && presence[i].Present {
@@ -2284,10 +2165,6 @@ func missingTopLevelDependsOnByID(phases []FlowPhase, presence []rawDependsOnSta
 		return nil
 	}
 	return missing
-}
-
-func (s *Store) flowDir(flowID string) string {
-	return artifacts.RecordDir(s.root, "flows", flowID)
 }
 
 func flowNotFoundError(flowID string) error {

--- a/flowstore/testhelpers_internal_test.go
+++ b/flowstore/testhelpers_internal_test.go
@@ -1,0 +1,21 @@
+package flowstore
+
+// write persists one hand-authored record through the seam, skipping every
+// domain rule above it except flow-id validation and depends_on normalization.
+//
+// It is test-only on purpose. Production has no such path any more: after the
+// seam extraction every write goes through backend.update, and the tests that
+// need to plant a record in a shape the public API would never produce (legacy
+// preset graphs, phases with no depends_on at all) seed it here instead.
+//
+// It takes the critical section like any other write, so it must not be called
+// from inside one.
+func (s *Store) write(record FlowRecord) error {
+	if err := validateFlowID(record.FlowID); err != nil {
+		return err
+	}
+	_, err := s.backend.update(record.FlowID, func(sess flowSession) (FlowRecord, error) {
+		return record, s.saveSession(sess, record)
+	})
+	return err
+}


### PR DESCRIPTION
## Summary

Extracts an unexported storage backend inside `flowstore` and moves all file mechanics behind it, so a SQLite backend can be plugged in later without touching domain logic. This is a pure refactor: no public API change, no on-disk format change, no observable behavior change.

## What changed

**`flowstore/backend.go` — the seam.** Declares `get`/`list`/`delete`/`update` plus a `flowSession` handle, and documents the clauses that are load-bearing:

- `update`'s `mutate` is invoked **exactly once and must not be retried**. `CreateWithOptions` rewrites `depends_on` through the caller's shared phase array, so a second pass would take the authoritative-graph branch instead.
- Saves made by `mutate` are durable **even when the closure then returns an error** — `SetPhase` and `MarkManualMerge` persist `needs_attention` compensation and then propagate the sync failure. This forbids rollback-on-error, which is why the handle is `flowSession` and not `flowTx`: the old name promised atomicity the contract rules out.
- The closure's error is returned verbatim, so `errors.Is` and the substring assertions in `store_test.go` keep working.
- `mutate` returns `(FlowRecord, error)` and the backend returns both verbatim. The `SetPhase`/`MarkManualMerge` asymmetry is now visible at the return statements rather than buried in an `out` accumulator assigned across branches.
- `get` documents the two admissibility rules that live below the seam and are stated nowhere above it: a flow-id mismatch is a miss, and so is a foreign schema version — that filter is what keeps records written by a future version invisible rather than half-decoded. `list` documents that its order is load-bearing, since `Store.List` sorts stably and equal `UpdatedAt` ties inherit it.

**`flowstore/backend_file.go` — the moved mechanics.** Flock critical section, atomic `meta.json` writes, the `ReadDir` listing, record encoding, and timestamped ID allocation.

`save` did **not** stay on the backend interface. Its only production caller was `flowSession.save`, and exposing it on the seam meant exposing a lock-free write. `Store.write`, which has no production callers, moved to `testhelpers_internal_test.go` and now goes through `update` like everything else.

`storedFlow` gained `legacyEncoding` so its zero value is safe. A nil `dependsOnPresence` used to read as "`depends_on` absent everywhere" and drive every read into graph recovery; only a backend that stores the historical JSON documents sets the flag now, and `dependsOnHints` answers "present everywhere" for anyone else. The migration obligation and the positional length invariant are stated on the field.

**`flowstore/plan_sync.go`.** Turns the inline `planstore.NewStore` in `syncLinkedPlanPhase` into an injected collaborator. It stays a two-phase interface so the `beforeLinkedPlanPhaseSync` hook still fires between opening the plan store and writing to it, and so an open failure still surfaces as a sync failure rather than a `Store` construction failure.

**`flowstore/store.go`.** Keeps the domain logic. `depends_on` normalization stays above the seam and still mutates in place, because the shape of `DependsOn` on every record the public API returns is a side effect of that write path. `readRecordWithReadiness` collapsed into `readRecord`. `Store.root` survives only because `SetPlanLink` is not yet behind the plan seam (approach-80e.4).

## Verification

The existing `flowstore` suite is unmodified and green — that is the proof the extraction preserved behavior.

New internal tests pin the seam itself. `testBackendContract(t, factory)` is implementation-agnostic, so the SQLite backend can be dropped straight into it rather than re-verifying the clauses by hand. It covers clauses 1–5, session `get` visibility, schema-version admissibility, list-order stability, and delete.

The harness is mutation-checked: a backend that retries a failing `mutate`, one that takes no critical section, and one that drops the schema-version filter each fail it. `SetPhase`'s zero record and `MarkManualMerge`'s compensated record are both asserted now; nothing looked at those return values before.

Also covered: the injected syncer's success, write-failure, and open-failure paths, and that `save` does not deadlock when called from inside a held critical section.

Refs approach-80e.1
