### PR TITLE
Create the worktree for a worktree-less Flow phase launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,11 @@ launch an agent, or invoke `bd`; the Bead remains untouched.
 The result is the same parked Flow the Flows-pane `n` form creates, so `g` on
 its first phase launches the agent inside the Flow's isolated worktree. If the
 worktree cannot be created, the Flow record is still persisted with its
-launchable phases blocked and the error is shown in the status line.
+launchable phases blocked and the error is shown in the status line. A Flow that
+has no worktree at all — one created through `approach flow create` without
+`--worktree-path`, for example — gets one created on its first phase launch
+rather than running the agent in the repository root; when that creation is
+impossible the launch is refused with the reason.
 
 ## Agents, Plans, and Flows
 

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -397,6 +397,116 @@ func CreateFlowWorktree(repoPath, title, baseRef string) (FlowWorktreeCreateResu
 	return FlowWorktreeCreateResult{}, fmt.Errorf("could not allocate a unique flow worktree for %q after %d attempts", title, 999)
 }
 
+// ErrFlowBranchMissing reports that the branch a Flow record names does not
+// exist in its repository, so there is nothing to attach a worktree to. It is a
+// sentinel rather than a message because the caller's next move — allocate a
+// fresh flow/<slug> pair instead — depends on this case and no other.
+var ErrFlowBranchMissing = errors.New("branch does not exist")
+
+// AttachFlowWorktree gives an existing local branch a worktree at the
+// conventional sibling path. It is the counterpart to CreateFlowWorktree for a
+// Flow that already records the branch it means to run on: inventing a second
+// branch there would strand the recorded one.
+func AttachFlowWorktree(repoPath, branch string) (FlowWorktreeCreateResult, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return FlowWorktreeCreateResult{}, fmt.Errorf("branch cannot be empty")
+	}
+	if strings.HasPrefix(branch, "-") {
+		return FlowWorktreeCreateResult{}, fmt.Errorf("branch cannot start with -: %q", branch)
+	}
+	// A local branch, not any commit-ish: `git worktree add <path> v1.0.0`
+	// succeeds on a tag, a remote-tracking ref, or a raw SHA and leaves a
+	// detached HEAD, which would let an agent commit onto nothing while the
+	// record kept naming a branch that never moved.
+	if !localBranchExists(repoPath, branch) {
+		if refExists(repoPath, branch) {
+			return FlowWorktreeCreateResult{}, fmt.Errorf("%s is not a local branch", branch)
+		}
+		return FlowWorktreeCreateResult{}, fmt.Errorf("%s: %w", branch, ErrFlowBranchMissing)
+	}
+	// A branch that already has a worktree of its own is where the Flow belongs.
+	// Git will not check it out twice, so refusing here would leave the Flow
+	// permanently unlaunchable for the most ordinary reason a record names a
+	// branch. The main worktree is never adopted — running there is the
+	// isolation break this whole path exists to prevent — so it falls through to
+	// the loud refusal `git worktree add` produces on its own.
+	if existing := linkedWorktreeForBranch(repoPath, branch); existing != "" {
+		return FlowWorktreeCreateResult{WorktreePath: existing, Branch: branch}, nil
+	}
+	basePath := DefaultWorktreePath(repoPath, branch)
+	for i := 1; i < 1000; i++ {
+		worktreePath := basePath
+		if i > 1 {
+			worktreePath = fmt.Sprintf("%s-%d", basePath, i)
+		}
+		if _, err := os.Stat(worktreePath); err == nil {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(worktreePath), 0o755); err != nil {
+			return FlowWorktreeCreateResult{}, err
+		}
+		out, err := exec.Command("git", "-C", repoPath, "worktree", "add", worktreePath, branch).CombinedOutput()
+		if err == nil {
+			return FlowWorktreeCreateResult{WorktreePath: worktreePath, Branch: branch}, nil
+		}
+		msg := strings.TrimSpace(string(out))
+		// Only the path may move. A branch already checked out somewhere else
+		// fails loudly instead: adopting that worktree is how a Flow ends up
+		// running in the primary checkout, which is the whole bug being fixed.
+		if isFlowWorktreePathCollisionError(msg) {
+			continue
+		}
+		if msg == "" {
+			return FlowWorktreeCreateResult{}, err
+		}
+		return FlowWorktreeCreateResult{}, fmt.Errorf("%s: %w", msg, err)
+	}
+	return FlowWorktreeCreateResult{}, fmt.Errorf("could not allocate a worktree for branch %q after %d attempts", branch, 999)
+}
+
+func localBranchExists(repoPath, branch string) bool {
+	return exec.Command("git", "-C", repoPath, "show-ref", "--verify", "--quiet", "refs/heads/"+branch).Run() == nil
+}
+
+// linkedWorktreeForBranch returns the linked worktree that already has branch
+// checked out, or "" when there is none. Git lists the main worktree first, and
+// a match there answers "" precisely so the caller does not adopt the user's
+// primary checkout.
+func linkedWorktreeForBranch(repoPath, branch string) string {
+	out, err := exec.Command("git", "-C", repoPath, "worktree", "list", "--porcelain").Output()
+	if err != nil {
+		return ""
+	}
+	want := "branch refs/heads/" + branch
+	mainPath := ""
+	current := ""
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if path, ok := strings.CutPrefix(line, "worktree "); ok {
+			current = path
+			if mainPath == "" {
+				mainPath = path
+			}
+			continue
+		}
+		if line == want {
+			if current == "" || current == mainPath {
+				return ""
+			}
+			// git keeps listing a worktree whose directory the user deleted,
+			// marking it prunable. Adopting that path would persist a worktree
+			// that is not there; falling through instead reaches git's own
+			// already-used-by refusal, which is the one that says to prune.
+			if info, err := os.Stat(current); err != nil || !info.IsDir() {
+				return ""
+			}
+			return current
+		}
+	}
+	return ""
+}
+
 func flowBranchOrPathExists(repoPath, branch, worktreePath string) bool {
 	if refExists(repoPath, branch) {
 		return true
@@ -408,9 +518,19 @@ func flowBranchOrPathExists(repoPath, branch, worktreePath string) bool {
 }
 
 func isFlowWorktreeCollisionError(msg string) bool {
+	return isFlowWorktreePathCollisionError(msg) ||
+		strings.Contains(strings.ToLower(msg), "is already checked out")
+}
+
+// isFlowWorktreePathCollisionError separates the collisions a different path
+// resolves from the ones only a different branch would. For CreateFlowWorktree
+// that includes a directory the user deleted without pruning, since the branch
+// moves with the path; for AttachFlowWorktree the branch is fixed, so a stale
+// registration reappears at the next suffix as an already-used-by refusal that
+// only `git worktree prune` clears.
+func isFlowWorktreePathCollisionError(msg string) bool {
 	msg = strings.ToLower(msg)
 	return strings.Contains(msg, "already exists") ||
-		strings.Contains(msg, "is already checked out") ||
 		strings.Contains(msg, "missing but already registered")
 }
 

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -481,30 +481,43 @@ func linkedWorktreeForBranch(repoPath, branch string) string {
 	want := "branch refs/heads/" + branch
 	mainPath := ""
 	current := ""
+	// The match is not answered at the branch line: git emits `prunable` after
+	// it, so a candidate has to survive to the end of its own record before it
+	// can be adopted.
+	candidate := ""
 	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
 		if path, ok := strings.CutPrefix(line, "worktree "); ok {
+			if candidate != "" {
+				return candidate
+			}
 			current = path
 			if mainPath == "" {
 				mainPath = path
 			}
 			continue
 		}
+		if candidate != "" && (line == "prunable" || strings.HasPrefix(line, "prunable ")) {
+			// git keeps listing a worktree whose gitdir link is gone — a
+			// directory the user deleted, or one whose `.git` file alone went
+			// missing — and marks the registration prunable. Adopting either
+			// would hand an agent a directory that is not a worktree; dropping
+			// the candidate instead reaches git's own already-used-by refusal,
+			// which is the one that says to prune.
+			candidate = ""
+			continue
+		}
 		if line == want {
 			if current == "" || current == mainPath {
 				return ""
 			}
-			// git keeps listing a worktree whose directory the user deleted,
-			// marking it prunable. Adopting that path would persist a worktree
-			// that is not there; falling through instead reaches git's own
-			// already-used-by refusal, which is the one that says to prune.
 			if info, err := os.Stat(current); err != nil || !info.IsDir() {
 				return ""
 			}
-			return current
+			candidate = current
 		}
 	}
-	return ""
+	return candidate
 }
 
 func flowBranchOrPathExists(repoPath, branch, worktreePath string) bool {

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -951,6 +951,58 @@ func TestAttachFlowWorktree_DoesNotAdoptAPrunedAwayWorktree(t *testing.T) {
 	}
 }
 
+// The directory surviving is not proof the registration did: a worktree whose
+// `.git` link alone went missing still lists its branch, and git marks it
+// prunable on the line after. Adopting it would launch an agent into a
+// directory that is not a worktree at all.
+func TestAttachFlowWorktree_DoesNotAdoptAWorktreeWhoseGitLinkIsGone(t *testing.T) {
+	repoPath := setupRepo(t)
+	mustRun(t, repoPath, "git", "branch", "feature/login")
+	stale := filepath.Join(t.TempDir(), "stale-wt")
+	mustRun(t, repoPath, "git", "worktree", "add", stale, "feature/login")
+	if err := os.Remove(filepath.Join(stale, ".git")); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := actions.AttachFlowWorktree(repoPath, "feature/login")
+	if err == nil {
+		t.Fatalf("AttachFlowWorktree returned %q, want the prunable registration refused", result.WorktreePath)
+	}
+	if errors.Is(err, actions.ErrFlowBranchMissing) {
+		t.Fatalf("AttachFlowWorktree error = %v, want a refusal distinct from ErrFlowBranchMissing", err)
+	}
+	if result.WorktreePath != "" {
+		t.Fatalf("worktree path = %q, want nothing adopted", result.WorktreePath)
+	}
+}
+
+// A prunable registration must not cost the branch its healthy worktree either:
+// the scan drops that one candidate rather than giving up on the branch.
+func TestAttachFlowWorktree_AdoptsAHealthyWorktreeListedAfterAPrunableOne(t *testing.T) {
+	repoPath := setupRepo(t)
+	mustRun(t, repoPath, "git", "branch", "feature/login")
+	mustRun(t, repoPath, "git", "branch", "feature/other")
+	stale := filepath.Join(t.TempDir(), "stale-wt")
+	mustRun(t, repoPath, "git", "worktree", "add", stale, "feature/other")
+	if err := os.RemoveAll(stale); err != nil {
+		t.Fatal(err)
+	}
+	live := filepath.Join(t.TempDir(), "live-wt")
+	mustRun(t, repoPath, "git", "worktree", "add", live, "feature/login")
+
+	result, err := actions.AttachFlowWorktree(repoPath, "feature/login")
+	if err != nil {
+		t.Fatalf("AttachFlowWorktree returned error: %v", err)
+	}
+	wantLive, err := filepath.EvalSymlinks(live)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.WorktreePath != wantLive {
+		t.Fatalf("worktree path = %q, want the branch's live worktree %q", result.WorktreePath, wantLive)
+	}
+}
+
 // The main worktree is the one that is never adopted: running there is the
 // isolation break this whole path exists to prevent, so it refuses instead.
 func TestAttachFlowWorktree_NeverAdoptsTheMainWorktree(t *testing.T) {

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -844,6 +844,176 @@ func TestCreateFlowWorktree_IncrementsBranchAndPathTogetherOnCollision(t *testin
 	}
 }
 
+func TestAttachFlowWorktree_ChecksOutTheExistingBranch(t *testing.T) {
+	repoPath := setupRepo(t)
+	mustRun(t, repoPath, "git", "branch", "feature/login")
+
+	result, err := actions.AttachFlowWorktree(repoPath, "feature/login")
+	if err != nil {
+		t.Fatalf("AttachFlowWorktree returned error: %v", err)
+	}
+
+	expectedPath := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feature-login")
+	if result.WorktreePath != expectedPath {
+		t.Fatalf("worktree path = %q, want %q", result.WorktreePath, expectedPath)
+	}
+	if result.Branch != "feature/login" {
+		t.Fatalf("branch = %q, want feature/login", result.Branch)
+	}
+	if got := runOutput(t, result.WorktreePath, "git", "branch", "--show-current"); got != "feature/login" {
+		t.Fatalf("worktree branch = %q, want the recorded branch checked out", got)
+	}
+}
+
+// The sentinel is what lets a caller distinguish "this record names nothing" —
+// where allocating a fresh flow/<slug> is correct — from every other failure.
+func TestAttachFlowWorktree_ReportsMissingBranchAsSentinel(t *testing.T) {
+	repoPath := setupRepo(t)
+
+	_, err := actions.AttachFlowWorktree(repoPath, "never-existed")
+	if !errors.Is(err, actions.ErrFlowBranchMissing) {
+		t.Fatalf("AttachFlowWorktree error = %v, want ErrFlowBranchMissing", err)
+	}
+	if !strings.Contains(err.Error(), "never-existed") {
+		t.Fatalf("AttachFlowWorktree error = %v, want the branch named", err)
+	}
+}
+
+// A branch that is already checked out somewhere is a real failure, not the
+// sentinel: falling back to a fresh branch would strand the recorded one, and
+// adopting the worktree that holds it is how a Flow ends up in the primary
+// checkout.
+func TestAttachFlowWorktree_CheckedOutBranchIsNotTheMissingSentinel(t *testing.T) {
+	repoPath := setupRepo(t)
+	current := runOutput(t, repoPath, "git", "branch", "--show-current")
+
+	_, err := actions.AttachFlowWorktree(repoPath, current)
+	if err == nil {
+		t.Fatal("AttachFlowWorktree error = nil, want the already-checked-out failure")
+	}
+	if errors.Is(err, actions.ErrFlowBranchMissing) {
+		t.Fatalf("AttachFlowWorktree error = %v, want a failure distinct from ErrFlowBranchMissing", err)
+	}
+}
+
+// Git will not check a branch out twice, so a branch that already has a linked
+// worktree is adopted rather than refused: refusing would leave the Flow
+// permanently unlaunchable for the most ordinary reason a record names a branch.
+func TestAttachFlowWorktree_AdoptsAnExistingLinkedWorktree(t *testing.T) {
+	repoPath := setupRepo(t)
+	mustRun(t, repoPath, "git", "branch", "feature/login")
+	existing := filepath.Join(t.TempDir(), "already-here")
+	mustRun(t, repoPath, "git", "worktree", "add", existing, "feature/login")
+
+	result, err := actions.AttachFlowWorktree(repoPath, "feature/login")
+	if err != nil {
+		t.Fatalf("AttachFlowWorktree returned error: %v", err)
+	}
+	// git reports the symlink-free path, which on macOS differs from the one
+	// t.TempDir hands out.
+	wantExisting, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.WorktreePath != wantExisting {
+		t.Fatalf("worktree path = %q, want the branch's existing worktree %q", result.WorktreePath, wantExisting)
+	}
+	if result.Branch != "feature/login" {
+		t.Fatalf("branch = %q, want feature/login", result.Branch)
+	}
+	conventional := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feature-login")
+	if _, err := os.Stat(conventional); err == nil {
+		t.Fatalf("a second worktree was created at %q, want the existing one adopted", conventional)
+	}
+}
+
+// git keeps listing a worktree whose directory was deleted without a prune, so
+// adoption must not take one: persisting a path that is not there would poison
+// the record permanently, where git's own refusal says to prune.
+func TestAttachFlowWorktree_DoesNotAdoptAPrunedAwayWorktree(t *testing.T) {
+	repoPath := setupRepo(t)
+	mustRun(t, repoPath, "git", "branch", "feature/login")
+	stale := filepath.Join(t.TempDir(), "stale-wt")
+	mustRun(t, repoPath, "git", "worktree", "add", stale, "feature/login")
+	if err := os.RemoveAll(stale); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := actions.AttachFlowWorktree(repoPath, "feature/login")
+	if err == nil {
+		t.Fatalf("AttachFlowWorktree returned %q, want the stale registration refused", result.WorktreePath)
+	}
+	if errors.Is(err, actions.ErrFlowBranchMissing) {
+		t.Fatalf("AttachFlowWorktree error = %v, want a refusal distinct from ErrFlowBranchMissing", err)
+	}
+	if result.WorktreePath != "" {
+		t.Fatalf("worktree path = %q, want nothing adopted", result.WorktreePath)
+	}
+}
+
+// The main worktree is the one that is never adopted: running there is the
+// isolation break this whole path exists to prevent, so it refuses instead.
+func TestAttachFlowWorktree_NeverAdoptsTheMainWorktree(t *testing.T) {
+	repoPath := setupRepo(t)
+	current := runOutput(t, repoPath, "git", "branch", "--show-current")
+
+	result, err := actions.AttachFlowWorktree(repoPath, current)
+	if err == nil {
+		t.Fatalf("AttachFlowWorktree returned %q, want a refusal rather than the primary checkout", result.WorktreePath)
+	}
+	if result.WorktreePath == repoPath {
+		t.Fatal("AttachFlowWorktree adopted the repository root")
+	}
+}
+
+// `git worktree add <path> <tag>` succeeds and leaves a detached HEAD, so a
+// commit-ish that is not a local branch must be refused rather than attached: an
+// agent would otherwise commit onto nothing while the record kept naming a
+// branch that never moved. It is not the missing sentinel either — falling
+// through to a fresh flow/<slug> would silently discard what the user typed.
+func TestAttachFlowWorktree_RefusesARefThatIsNotALocalBranch(t *testing.T) {
+	repoPath := setupRepo(t)
+	mustRun(t, repoPath, "git", "tag", "v1.0.0")
+
+	_, err := actions.AttachFlowWorktree(repoPath, "v1.0.0")
+	if err == nil {
+		t.Fatal("AttachFlowWorktree error = nil, want a tag refused")
+	}
+	if errors.Is(err, actions.ErrFlowBranchMissing) {
+		t.Fatalf("AttachFlowWorktree error = %v, want a refusal distinct from ErrFlowBranchMissing", err)
+	}
+	if !strings.Contains(err.Error(), "not a local branch") {
+		t.Fatalf("AttachFlowWorktree error = %v, want the reason named", err)
+	}
+}
+
+// Only the path moves on a collision. A directory the user deleted without
+// pruning leaves git holding a registration that a fresh suffix steps past;
+// permanently blocking the phase over it would be a heavy price for a
+// recoverable state.
+func TestAttachFlowWorktree_MovesPastACollidingPath(t *testing.T) {
+	repoPath := setupRepo(t)
+	mustRun(t, repoPath, "git", "branch", "feature/login")
+	occupied := filepath.Join(filepath.Dir(repoPath), "repo-worktrees", "feature-login")
+	if err := os.MkdirAll(occupied, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := actions.AttachFlowWorktree(repoPath, "feature/login")
+	if err != nil {
+		t.Fatalf("AttachFlowWorktree returned error: %v", err)
+	}
+	if result.WorktreePath != occupied+"-2" {
+		t.Fatalf("worktree path = %q, want the next free suffix", result.WorktreePath)
+	}
+	if result.Branch != "feature/login" {
+		t.Fatalf("branch = %q, want the recorded branch regardless of the path suffix", result.Branch)
+	}
+	if got := runOutput(t, result.WorktreePath, "git", "branch", "--show-current"); got != "feature/login" {
+		t.Fatalf("worktree branch = %q, want the recorded branch checked out", got)
+	}
+}
+
 func TestCreatePullRequestWorktree_FromNumber(t *testing.T) {
 	localPath, upstreamPath, _ := setupRemoteRepo(t)
 	mustRun(t, upstreamPath, "git", "commit", "--allow-empty", "-m", "pr change")

--- a/agent-skills/approach-flow-create/SKILL.md
+++ b/agent-skills/approach-flow-create/SKILL.md
@@ -84,6 +84,15 @@ unclear, ask the user instead of creating a malformed Flow.
 Skip worktree creation only in two cases:
 
 - The user explicitly asks for a metadata-only Flow (set `APPROACH_FLOW_METADATA_ONLY=1`).
+  Such a Flow becomes worktree-backed on its first phase launch rather than
+  running the agent in the repository root. Approach creates a `flow/<slug>` pair
+  from the recorded base ref, or from the repository's current HEAD when no base
+  ref was recorded. Set `APPROACH_BRANCH` only for a local branch that already
+  exists and is not checked out in the repository itself: such a branch keeps its
+  name and gets a worktree, or the Flow adopts the linked worktree it already
+  has. A branch that does not exist yet is silently replaced by the
+  `flow/<slug>` name; a branch checked out in the repository's own working tree,
+  and a tag, remote-tracking ref, or raw commit, each refuse the launch outright.
 - The user provides an existing worktree to reuse (set `APPROACH_WORKTREE_PATH`).
   `APPROACH_BRANCH` and `APPROACH_COMMIT` are derived from that worktree when unset, and
   `APPROACH_BASE_REF` still defaults to the repository's default branch, so the reuse

--- a/docs/beads-view-spec.md
+++ b/docs/beads-view-spec.md
@@ -140,8 +140,9 @@ Approach-owned parked Flow — record, branch, and worktree — without invoking
   phase launch runs in the Flow's isolated worktree. On worktree or bootstrap
   failure the persisted record's launchable phases are blocked with the failure
   noted; existing Flow rendering then labels the worktree-less record
-  `missing-worktree` / `recover-worktree`, and phase launch falls back to the
-  repository root.
+  `missing-worktree` / `recover-worktree`. Phase launch never falls back to the
+  repository root: it creates the missing worktree first, and refuses with a
+  message when it cannot.
 - Config: `default_view` gains frozen numbers 10 (ready), 11 (blocked),
   12 (open), 13 (in-progress), 14 (closed), parallel to the git subviews'
   1–5. Numbers 1–9 keep their existing frozen meanings.

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -536,11 +536,48 @@ and discards the pending result.
 
 The result is the same parked Flow a successful `n` form submission produces,
 so `g` on its first phase launches the agent inside the Flow's isolated
-worktree. If worktree creation or the bootstrap hook fails, the persisted Flow
-record keeps its launchable phases blocked with the failure noted, the Flows
-pane renders the worktree-less record with the `missing-worktree` branch label
-and a `recover-worktree` phase state, and the error is reported in the status
-line.
+worktree. If worktree creation fails, the persisted Flow record keeps its
+launchable phases blocked with the failure noted, the Flows pane renders the
+worktree-less record with the `missing-worktree` branch label and a
+`recover-worktree` phase state, and the error is reported in the status line. A
+bootstrap-hook failure comes after the start metadata is persisted, so that
+record does have a worktree; only its launchable phases are blocked.
+
+A Flow that has no worktree at all — one created by `approach flow create`
+without `--worktree-path`, or left behind by a failure before the start metadata
+was written — never launches in the repository root. Pressing `g` creates the
+worktree first, announcing it in the status line, and only then starts the
+agent.
+
+A record that already names a local branch gets a worktree for that branch, so
+the name prompts render as the push target keeps meaning what it said. If that
+branch already has a linked worktree, the Flow adopts it rather than failing
+over a checkout git will not repeat — the bootstrap hook then runs against a
+directory that already exists, so a hook that scaffolds rather than installs
+sees a populated worktree. Only a record whose branch resolves to
+nothing — or that names none — is given a fresh `flow/<slug>` pair from the
+recorded base ref, or from the repository's current HEAD when no base ref was
+recorded.
+
+A manual launch is refused with the reason, and AutoMode blocks the phase with
+that reason in its notes rather than retrying every second, when:
+
+- the Flow records no repository of its own;
+- the recorded branch exists but is not a local branch — a tag, a
+  remote-tracking ref, or a raw commit — since checking one out would detach
+  HEAD under a record that keeps naming a branch;
+- the recorded branch is checked out in the repository's own working tree,
+  which is the launch this whole path exists to prevent;
+- `git worktree add` fails for any other reason, including a registration left
+  behind by a directory deleted without `git worktree prune`.
+
+Most of those refusals write nothing, but two happen after `git worktree add`
+has already run. A store that will not record the new worktree leaves a branch
+and directory on disk that no record names; the status line names the path. A
+bootstrap-hook failure comes after the start metadata is persisted, so the Flow
+does keep the worktree it just gained, and its status says so — note that a
+second `g` then takes the worktree as given and launches the agent into it even
+though the hook never completed.
 
 After the active subview settles, `enter` on its visible selected row
 asynchronously loads the raw human-readable output of
@@ -786,7 +823,7 @@ ordinary empty or pending work:
 
 | Label | Meaning |
 |-------|---------|
-| `recover-worktree` | Saved Flow with no branch/worktree metadata |
+| `recover-worktree` | Saved Flow with no branch/worktree metadata; a phase launch creates the missing worktree, and is refused with a message when it cannot |
 | `await-session` | Running phase with a recorded launch but no attached session yet |
 | `session-mismatch` | Attached session whose launch ID does not match the phase's launch attempts |
 | `ended-session` | Running phase whose latest attached session has ended |

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -551,18 +551,26 @@ agent.
 
 A record that already names a local branch gets a worktree for that branch, so
 the name prompts render as the push target keeps meaning what it said. If that
-branch already has a linked worktree, the Flow adopts it rather than failing
-over a checkout git will not repeat — the bootstrap hook then runs against a
-directory that already exists, so a hook that scaffolds rather than installs
-sees a populated worktree. Only a record whose branch resolves to
-nothing — or that names none — is given a fresh `flow/<slug>` pair from the
-recorded base ref, or from the repository's current HEAD when no base ref was
-recorded.
+branch already has a healthy linked worktree, the Flow adopts it rather than
+failing over a checkout git will not repeat — the bootstrap hook then runs
+against a directory that already exists, so a hook that scaffolds rather than
+installs sees a populated worktree. A registration git marks prunable is never
+adopted, whether the directory is gone or only its `.git` link is. Only a record
+whose branch resolves to nothing — or that names none — is given a fresh
+`flow/<slug>` pair from the recorded base ref, or from the repository's current
+HEAD when no base ref was recorded.
+
+Creating the worktree and recording it both happen under the Flow's launch
+reservation, so two Approach processes launching the same worktree-less Flow
+serialize: the second one adopts the worktree the first recorded instead of
+allocating a second pair beside it.
 
 A manual launch is refused with the reason, and AutoMode blocks the phase with
 that reason in its notes rather than retrying every second, when:
 
 - the Flow records no repository of its own;
+- the launch reservation cannot be taken, because the Flow was closed or
+  another process holds it past the lock timeout;
 - the recorded branch exists but is not a local branch — a tag, a
   remote-tracking ref, or a raw commit — since checking one out would detach
   HEAD under a record that keeps naming a branch;

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -560,17 +560,20 @@ whose branch resolves to nothing — or that names none — is given a fresh
 `flow/<slug>` pair from the recorded base ref, or from the repository's current
 HEAD when no base ref was recorded.
 
-Creating the worktree and recording it both happen under the Flow's launch
-reservation, so two Approach processes launching the same worktree-less Flow
-serialize: the second one adopts the worktree the first recorded instead of
-allocating a second pair beside it.
+Creating the worktree, recording it, and running the bootstrap hook all happen
+under the Flow's launch reservation, so two Approach processes launching the
+same worktree-less Flow serialize: the second one adopts the fully provisioned
+worktree the first recorded instead of allocating a second pair beside it. That
+reservation is held longer than its own lock timeout allows for, so a launch
+that arrives mid-provisioning is refused for now rather than for good — the
+status line says another launch is setting the worktree up, and AutoMode simply
+retries on its next poll. A Flow closed while the launch was reading is dropped
+without a status, the same as any other stale candidate.
 
 A manual launch is refused with the reason, and AutoMode blocks the phase with
 that reason in its notes rather than retrying every second, when:
 
 - the Flow records no repository of its own;
-- the launch reservation cannot be taken, because the Flow was closed or
-  another process holds it past the lock timeout;
 - the recorded branch exists but is not a local branch — a tag, a
   remote-tracking ref, or a raw commit — since checking one out would detach
   HEAD under a record that keeps naming a branch;

--- a/model/flow_launch_attempt.go
+++ b/model/flow_launch_attempt.go
@@ -183,8 +183,15 @@ func (m Model) suppressUnpersistedAutoFlowLaunchRetry(flowID string) Model {
 	}
 	switch attempt.State {
 	case flowLaunchStateReading:
-		// The read command is side-effect free, so its eventual event can be
-		// invalidated by releasing the attempt.
+		// The read command persists nothing about this launch, so its eventual
+		// event can be invalidated by releasing the attempt. It is no longer
+		// side-effect free: a stop edge landing inside the ensure window leaves
+		// the worktree it created and the start metadata it persisted behind.
+		// Once that write lands nothing needs cleaning up — the next launch
+		// takes EnsureWorktree's no-op passthrough and reuses both. Released
+		// before it lands, a launch started in the meantime reads the record as
+		// still worktree-less and ensures a second time; the store settles on
+		// whichever write is last and the extra pair is inert.
 		return m.releaseFlowLaunchAttempt(attempt.FlowID, attempt.Token)
 	case flowLaunchStatePreparing:
 		// Prepare may be blocked before or after its phase write. Keep ownership

--- a/model/flow_launch_attempt.go
+++ b/model/flow_launch_attempt.go
@@ -187,11 +187,11 @@ func (m Model) suppressUnpersistedAutoFlowLaunchRetry(flowID string) Model {
 		// event can be invalidated by releasing the attempt. It is no longer
 		// side-effect free: a stop edge landing inside the ensure window leaves
 		// the worktree it created and the start metadata it persisted behind.
-		// Once that write lands nothing needs cleaning up — the next launch
-		// takes EnsureWorktree's no-op passthrough and reuses both. Released
-		// before it lands, a launch started in the meantime reads the record as
-		// still worktree-less and ensures a second time; the store settles on
-		// whichever write is last and the extra pair is inert.
+		// Nothing needs cleaning up either way — the next launch takes
+		// EnsureWorktree's passthrough and reuses both. A launch started before
+		// the write lands does not allocate a second pair: EnsureWorktree holds
+		// the Flow's launch reservation across its creation and its write, and
+		// the record it re-reads under that fence already names the worktree.
 		return m.releaseFlowLaunchAttempt(attempt.FlowID, attempt.Token)
 	case flowLaunchStatePreparing:
 		// Prepare may be blocked before or after its phase write. Keep ownership

--- a/model/flow_launch_lifecycle.go
+++ b/model/flow_launch_lifecycle.go
@@ -46,6 +46,15 @@ const (
 	flowLaunchOutcomeRetry
 	flowLaunchOutcomeStale
 	flowLaunchOutcomeFailed
+	// flowLaunchOutcomeBlocked is a refusal AutoMode will not retry on its own:
+	// unlike failed, it does not re-arm the drain. Most of what it classifies
+	// cannot clear without the user, and re-arming those would repeat the
+	// refusal — and its filesystem work — on every 1 Hz poll. Two of them could
+	// clear on their own and are blocked anyway: a bootstrap-hook failure, since
+	// a Flow whose bootstrap did not run is not one to hand an agent
+	// unannounced, and a contended store write, since re-arming that one leaves
+	// an orphan worktree behind on every poll it loses.
+	flowLaunchOutcomeBlocked
 )
 
 // flowLaunchEventMsg carries one asynchronous hop back into Update. Token,
@@ -65,6 +74,11 @@ type flowLaunchEventMsg struct {
 	// was missing. It is attached to a successful embedded install's status; a
 	// failed install's own message wins instead.
 	FallbackNote string
+	// WorktreeNote is set only when the read stage created this Flow's worktree.
+	// Every route reports it: a new branch and directory appearing because the
+	// user pressed a key is the silent side effect this lifecycle step exists to
+	// remove, so it may not be dropped for the non-embedded agents.
+	WorktreeNote string
 	// Outcome is read-stage-only and autoPhase-only; every dispatch on it is
 	// gated on Stage for that reason.
 	Outcome flowLaunchOutcome
@@ -428,12 +442,24 @@ func (m Model) flowLaunchReadCmd(intent flowLaunchIntent, token string, settings
 			event.Err = err.Error()
 			return event
 		}
+		// Last, because it is the only step that touches the filesystem: every
+		// cheap refusal above, and the session check, must get to say no first.
+		prepared, err = launcher.EnsureLaunchWorktree(prepared)
+		if err != nil {
+			event.Err = err.Error()
+			return event
+		}
 		event.PhaseID = phase.PhaseID
-		event.Record = record
+		// The ensured record, not the pre-ensure one: prepare looks the phase up
+		// in it and builds the launch context from its branch and commit.
+		event.Record = prepared.Record
 		event.Headless = record.Headless
 		event.RepoPath = prepared.RepoPath
 		event.WorktreePath = prepared.WorktreePath
 		event.PlanPath = prepared.PlanPath
+		if prepared.CreatedWorktree {
+			event.WorktreeNote = createdFlowWorktreeNote(prepared.Record)
+		}
 		return event
 	}
 }
@@ -501,11 +527,27 @@ func autoFlowLaunchReadCmd(seams flowLaunchSeams, launcher FlowPhaseLauncher, in
 			event.Outcome = flowLaunchOutcomeRetry
 			return event
 		}
+		// Last, and behind the session check, so a phase a live session already
+		// owns never costs a `git worktree add`.
+		prepared, err = launcher.EnsureLaunchWorktree(prepared)
+		// The identity fields are set before the branch returns either way: the
+		// blocked handler writes against msg.PhaseID, and the intent still carries
+		// the spelling an earlier poll captured rather than the record's own.
 		event.PhaseID = phase.PhaseID
-		event.Record = record
+		event.Record = prepared.Record
+		if err != nil {
+			// Permanent, so it classifies blocked rather than failed. The write
+			// itself is the handler's, behind the attempt fence.
+			event.Outcome = flowLaunchOutcomeBlocked
+			event.Err = err.Error()
+			return event
+		}
 		event.RepoPath = prepared.RepoPath
 		event.WorktreePath = prepared.WorktreePath
 		event.PlanPath = prepared.PlanPath
+		if prepared.CreatedWorktree {
+			event.WorktreeNote = createdFlowWorktreeNote(prepared.Record)
+		}
 		return event
 	}
 }
@@ -595,9 +637,17 @@ func (m Model) handleFlowLaunchEvent(msg flowLaunchEventMsg) (Model, tea.Cmd) {
 			return m.handleAutoFlowLaunchRead(attempt, msg)
 		}
 		if msg.Err != "" {
-			// Nothing has been persisted at this point and no context exists,
-			// so the attempt simply goes away with a status.
-			return m.releaseFlowLaunchAttempt(attempt.FlowID, attempt.Token).setStatus(statusOther, msg.Err), nil
+			// No launch bookkeeping exists and no context does either, so the
+			// attempt simply goes away with a status. The ensure step is the one
+			// refusal that can still have persisted something — the worktree it
+			// created before the bootstrap hook failed — so the surface is
+			// refreshed rather than left rendering missing-worktree until the
+			// next periodic tick.
+			m = m.releaseFlowLaunchAttempt(attempt.FlowID, attempt.Token).setStatus(statusOther, msg.Err)
+			if msg.FlowID != "" && m.flowSurfaceVisible() {
+				return m.startFlowSurfaceFetch()
+			}
+			return m, nil
 		}
 		next, ok := m.transitionFlowLaunchAttempt(attempt.FlowID, attempt.Token, flowLaunchStateReading, flowLaunchStatePreparing)
 		if !ok {
@@ -631,6 +681,14 @@ func (m Model) handleFlowLaunchEvent(msg flowLaunchEventMsg) (Model, tea.Cmd) {
 // type has to survive the string-only Err hop. Every branch here is forbidden
 // from calling setStatus(statusOther, …): the poll runs at 1 Hz, so a sticky
 // status would be re-set every second over whatever the user is looking at.
+//
+// The blocked branch is the one exception, and only at one remove: the sticky
+// status comes from handleFlowLaunchFailurePersisted, a hop later. It cannot
+// repeat on the poll, because admission itself disarms the drain and this is
+// a branch that never arms it again — so only a fresh arm edge, such as
+// another phase completing, can bring the Flow back. Blocking the phase makes
+// it unlaunchable too, but that is the weaker guarantee of the two: it depends
+// on the write landing, and the disarm holds even when it does not.
 func (m Model) handleAutoFlowLaunchRead(attempt flowLaunchAttempt, msg flowLaunchEventMsg) (Model, tea.Cmd) {
 	switch msg.Outcome {
 	case flowLaunchOutcomeOK:
@@ -644,6 +702,8 @@ func (m Model) handleAutoFlowLaunchRead(attempt flowLaunchAttempt, msg flowLaunc
 		// transition it would otherwise overwrite will not.
 		m = m.releaseFlowLaunchAttempt(attempt.FlowID, attempt.Token).armAutoAdvanceDrain(attempt.FlowID)
 		return m.setAutoAdvanceLaunchStatus("Flow " + msg.FlowTitle + ": " + msg.Err)
+	case flowLaunchOutcomeBlocked:
+		return m.blockAutoFlowLaunchPhase(attempt, msg)
 	case flowLaunchOutcomeRetry:
 		// The blocker clears on its own, so re-arming is what makes the launch
 		// resume without waiting for another completion edge.
@@ -671,6 +731,52 @@ func (m Model) handleAutoFlowLaunchRead(attempt flowLaunchAttempt, msg flowLaunc
 		m, statusCmd = m.setAutoAdvanceLaunchStatus("Flow " + msg.FlowTitle + ": " + autoAdvancePhaseLabel(msg.PhaseID) + " queued")
 	}
 	return m, batchNonNil(statusCmd, prepareCmd)
+}
+
+// blockAutoFlowLaunchPhase records a permanent AutoMode refusal on the phase.
+// It reuses FlowStarter's blocked-phase precedent rather than
+// flowLaunchFailureUpdate, which would stamp needs_attention on every kind, and
+// it does not re-arm the drain: nothing about this refusal clears on its own.
+//
+// The synthesized launch context is load-bearing, not decoration.
+// handleFlowLaunchFailurePersisted releases the attempt by matching on the
+// context's Flow and launch IDs, and a zero context would leave the attempt in
+// failurePersisting forever — the Flow would never launch, auto-advance, or
+// repair again.
+func (m Model) blockAutoFlowLaunchPhase(attempt flowLaunchAttempt, msg flowLaunchEventMsg) (Model, tea.Cmd) {
+	phase, ok := flowPhaseByID(msg.Record, msg.PhaseID)
+	if !ok {
+		phase = flowstore.FlowPhase{PhaseID: msg.PhaseID}
+	}
+	next, advanced := m.transitionFlowLaunchAttempt(attempt.FlowID, attempt.Token, flowLaunchStateReading, flowLaunchStateFailurePersisting)
+	if !advanced {
+		return m, nil
+	}
+	update := blockedPhaseUpdate(attempt.FlowID, phase, "Auto-advance blocked: "+msg.Err)
+	ctx := actions.AgentLaunchContext{
+		FlowID:      attempt.FlowID,
+		LaunchID:    attempt.Token,
+		FlowPhaseID: msg.PhaseID,
+	}
+	return next, flowLaunchFailurePersistCmd(next.launchSeams.SetPhase, update, ctx, msg.Err)
+}
+
+// createdFlowWorktreeNote names the worktree a launch gave the Flow on the
+// user's behalf. "Set up" rather than "Created" because the seam may have
+// adopted a worktree the recorded branch already had, which the record it
+// returns cannot be told apart from a fresh one; the bootstrap hook ran either
+// way. The branch clause is omitted rather than left blank when the ensure seam
+// returned no branch.
+func createdFlowWorktreeNote(record flowstore.FlowRecord) string {
+	worktreePath := strings.TrimSpace(record.WorktreePath)
+	if worktreePath == "" {
+		return ""
+	}
+	note := "Set up worktree " + worktreePath
+	if branch := strings.TrimSpace(record.Branch); branch != "" {
+		note += " on branch " + branch
+	}
+	return note + " for this Flow"
 }
 
 func flowLaunchStageState(stage flowLaunchStage) (flowLaunchState, bool) {
@@ -726,10 +832,12 @@ func (m Model) installFlowLaunchEmbedded(attempt flowLaunchAttempt, msg flowLaun
 		m, fetchCmd = m.startFlowSurfaceFetch()
 	}
 	m = m.releaseFlowLaunchAttempt(attempt.FlowID, attempt.Token)
-	// Only a successful install reports the fallback. A failed one has already
-	// returned above with its own message, which is the more useful one.
-	if strings.TrimSpace(msg.FallbackNote) != "" {
-		m = m.setStatus(statusOther, msg.FallbackNote)
+	// Only a successful install reports these. A failed one has already returned
+	// above with its own message, which is the more useful one. The two compose
+	// rather than race for the slot: the worktree creation is the headline and
+	// the tmux fallback is the parenthetical.
+	if status := withFallbackNote(msg.WorktreeNote, msg.FallbackNote); strings.TrimSpace(status) != "" {
+		m = m.setStatus(statusOther, status)
 	}
 	return m, batchNonNil(prefillCmd, tickCmd, fetchCmd)
 }
@@ -762,7 +870,7 @@ func (m Model) handoffFlowLaunchTmux(attempt flowLaunchAttempt, msg flowLaunchEv
 		// matches any other state and the attempt would be stranded.
 		m = m.releaseFlowLaunchAttempt(attempt.FlowID, attempt.Token)
 	}
-	m, launchCmd := m.runAgentLaunchWithStatus(ctx, spec.Launch, msg.Release, tmuxLaunchStatus(spec))
+	m, launchCmd := m.runAgentLaunchWithStatus(ctx, spec.Launch, msg.Release, withFallbackNote(tmuxLaunchStatus(spec), msg.WorktreeNote))
 	var fetchCmd tea.Cmd
 	if ctx.FlowID != "" && m.flowSurfaceVisible() {
 		m, fetchCmd = m.startFlowSurfaceFetch()
@@ -790,7 +898,17 @@ func (m Model) handoffFlowLaunchExternal(attempt flowLaunchAttempt, msg flowLaun
 		// would strand it: no AgentResultMsg fence matches any other state.
 		m = m.releaseFlowLaunchAttempt(attempt.FlowID, attempt.Token)
 	}
-	m, launchCmd := m.runAgentLaunchWithReservation(ctx, launch, msg.Release)
+	// Composed onto the confirmation rather than replacing it: on the detached
+	// route an empty status is what lets AgentResultMsg fill in that same
+	// generic text, so passing the bare note would delete it. The interactive
+	// route sets whatever it is given before the TTY handover and otherwise
+	// announces nothing, which is why the empty default is preserved there too —
+	// only a created worktree is worth a line the route never had.
+	launchedStatus := ""
+	if strings.TrimSpace(msg.WorktreeNote) != "" {
+		launchedStatus = withFallbackNote(agentLaunchedStatus(ctx.Command), msg.WorktreeNote)
+	}
+	m, launchCmd := m.runAgentLaunchWithStatus(ctx, launch, msg.Release, launchedStatus)
 	var fetchCmd tea.Cmd
 	if ctx.FlowID != "" && m.flowSurfaceVisible() {
 		m, fetchCmd = m.startFlowSurfaceFetch()

--- a/model/flow_launch_lifecycle.go
+++ b/model/flow_launch_lifecycle.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -53,7 +54,10 @@ const (
 	// clear on their own and are blocked anyway: a bootstrap-hook failure, since
 	// a Flow whose bootstrap did not run is not one to hand an agent
 	// unannounced, and a contended store write, since re-arming that one leaves
-	// an orphan worktree behind on every poll it loses.
+	// an orphan worktree behind on every poll it loses. The line between those
+	// and the ensure step's contended reservation is what each one costs to
+	// repeat: the reservation is taken before anything is created, so a poll
+	// that loses it leaves nothing behind and retries instead.
 	flowLaunchOutcomeBlocked
 )
 
@@ -536,9 +540,22 @@ func autoFlowLaunchReadCmd(seams flowLaunchSeams, launcher FlowPhaseLauncher, in
 		event.PhaseID = phase.PhaseID
 		event.Record = prepared.Record
 		if err != nil {
-			// Permanent, so it classifies blocked rather than failed. The write
-			// itself is the handler's, behind the attempt fence.
+			// Permanent by default, so it classifies blocked rather than failed;
+			// the write itself is the handler's, behind the attempt fence. The
+			// two exceptions created nothing to orphan: a reservation another
+			// launch holds while it provisions this same Flow clears on its own
+			// and re-arms, and a Flow closed mid-read has no candidate left to
+			// block. Blocking either would answer a wait with a stop.
 			event.Outcome = flowLaunchOutcomeBlocked
+			var worktreeErr FlowPhaseLaunchWorktreeError
+			if errors.As(err, &worktreeErr) {
+				switch {
+				case worktreeErr.Stale:
+					event.Outcome = flowLaunchOutcomeStale
+				case worktreeErr.Transient:
+					event.Outcome = flowLaunchOutcomeRetry
+				}
+			}
 			event.Err = err.Error()
 			return event
 		}

--- a/model/flow_launch_lifecycle_internal_test.go
+++ b/model/flow_launch_lifecycle_internal_test.go
@@ -58,6 +58,12 @@ type manualLaunchHarness struct {
 	launchReservations int
 	launchReleases     int
 
+	// ensureRecords counts what the worktree-creation seam was asked to create,
+	// so "the git work never happened" is assertable rather than inferred.
+	ensureRecords []flowstore.FlowRecord
+	ensureErr     error
+	ensured       flowstore.FlowRecord
+
 	persistedRecord   flowstore.FlowRecord
 	persistedRecordOK bool
 }
@@ -126,6 +132,23 @@ func (h *manualLaunchHarness) options() Options {
 		},
 		ReadFlow: func(flowID string) (flowstore.FlowRecord, error) {
 			return h.persistedFlow(strings.TrimSpace(flowID))
+		},
+		// Overridden in every harness model: the default seam runs real git.
+		EnsureFlowWorktree: func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			h.ensureRecords = append(h.ensureRecords, record)
+			if h.ensureErr != nil {
+				// The two compose, because the real seam's bootstrap-hook
+				// failure does: it persists the worktree and then reports.
+				return h.ensured, h.ensureErr
+			}
+			if h.ensured.FlowID != "" {
+				return h.ensured, nil
+			}
+			ensured := record
+			ensured.WorktreePath = "/dev/alpha-worktrees/flow-one"
+			ensured.Branch = "flow/flow-one"
+			ensured.Commit = "abc123"
+			return ensured, nil
 		},
 		ReserveFlowLaunch: func(flowID string) (flowstore.FlowRecord, func(), error) {
 			if h.reserveLaunchErr != nil {
@@ -1221,6 +1244,18 @@ func TestAutoFlowLaunchDelayedEventsAreIgnored(t *testing.T) {
 				Token: "token-1", Kind: flowLaunchKindAutoPhase, From: flowLaunchStateReading,
 				FlowID: record.FlowID, Stage: flowLaunchStageRead,
 				Outcome: flowLaunchOutcomeRetry, FlowTitle: "Flow one",
+			},
+		},
+		{
+			// Blocked is the only read outcome that writes, so a superseded one
+			// could otherwise block a phase a newer attempt is launching.
+			name:  "blocked from a superseded attempt",
+			model: live,
+			event: flowLaunchEventMsg{
+				Token: "token-1", Kind: flowLaunchKindAutoPhase, From: flowLaunchStateReading,
+				FlowID: record.FlowID, PhaseID: record.Phases[0].PhaseID, Stage: flowLaunchStageRead,
+				Record: record, Outcome: flowLaunchOutcomeBlocked, FlowTitle: "Flow one",
+				Err: "Worktree creation failed: branch already checked out",
 			},
 		},
 		{

--- a/model/flow_launch_worktree_internal_test.go
+++ b/model/flow_launch_worktree_internal_test.go
@@ -325,6 +325,70 @@ func TestAutoFlowLaunchBlocksPlanReviewWithTheBlockedOutcome(t *testing.T) {
 	}
 }
 
+// The reservation is held across a bootstrap hook whose budget is 120 s by
+// default, against the store's 5 s lock timeout, so the launch that loses it is
+// usually waiting on another one provisioning this very Flow. Blocking the
+// phase for losing that wait would answer a wait with a stop — and nothing was
+// created, so there is no orphan to argue against coming back.
+func TestAutoFlowLaunchRetriesAContendedReservationInsteadOfBlocking(t *testing.T) {
+	record := autoWorktreelessFlowRecord()
+	h := newManualLaunchHarness(t, record)
+	h.ensureErr = fmt.Errorf("%w: %w", ErrFlowWorktreeUnreserved, errors.New("acquire launch/close reservation for flow \"flow-one\": timeout"))
+
+	m := h.autoDrain(h.model(), record)
+
+	if len(h.phaseUpdates) != 0 {
+		t.Fatalf("phase updates = %#v, want a contended reservation to write nothing", h.phaseUpdates)
+	}
+	if !h.drainArmed(m, record.FlowID) {
+		t.Fatal("a contended reservation must re-arm the drain so the launch resumes")
+	}
+	if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
+		t.Fatal("a retried launch must release its attempt")
+	}
+}
+
+// A Flow closed while this launch was reading has no candidate left: nothing to
+// retry and nothing to write about it.
+func TestAutoFlowLaunchTreatsAClosedFlowReservationAsStale(t *testing.T) {
+	record := autoWorktreelessFlowRecord()
+	h := newManualLaunchHarness(t, record)
+	h.ensureErr = fmt.Errorf("%w: %w", ErrFlowWorktreeUnreserved,
+		fmt.Errorf("cannot launch an agent for flow %q because it is closed: %w", record.FlowID, flowstore.ErrFlowClosed))
+
+	m := h.autoDrain(h.model(), record)
+
+	if len(h.phaseUpdates) != 0 {
+		t.Fatalf("phase updates = %#v, want a closed Flow to block nothing", h.phaseUpdates)
+	}
+	if h.drainArmed(m, record.FlowID) {
+		t.Fatal("a closed Flow must not re-arm the drain")
+	}
+	if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
+		t.Fatal("a stale launch must release its attempt")
+	}
+}
+
+// The manual route has a user to read the reason, so it reports the wait rather
+// than reporting it as a creation that failed.
+func TestManualFlowLaunchReportsAContendedReservationAsAWait(t *testing.T) {
+	record := worktreelessFlowRecord()
+	h := newManualLaunchHarness(t, record)
+	h.ensureErr = fmt.Errorf("%w: %w", ErrFlowWorktreeUnreserved, errors.New("lock timeout"))
+
+	m := h.launch(h.model())
+
+	if !strings.HasPrefix(m.status.Text, "Another launch is setting up this Flow's worktree: ") {
+		t.Fatalf("status = %q, want the wait named rather than a creation failure", m.status.Text)
+	}
+	if len(h.phaseUpdates) != 0 || len(h.launchUpdates) != 0 {
+		t.Fatalf("a refused manual launch persisted something: phases=%#v launches=%#v", h.phaseUpdates, h.launchUpdates)
+	}
+	if len(h.agentContexts) != 0 {
+		t.Fatal("a refused manual launch must not start an agent")
+	}
+}
+
 func TestAutoFlowLaunchSkipsEnsureWhenASessionOwnsThePhase(t *testing.T) {
 	record := autoWorktreelessFlowRecord()
 	record.Phases[0].LaunchIDs = []string{"launch-live"}

--- a/model/flow_launch_worktree_internal_test.go
+++ b/model/flow_launch_worktree_internal_test.go
@@ -1,0 +1,359 @@
+package model
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/sessions"
+)
+
+// worktreelessFlowRecord is manualLaunchFlowRecord without the worktree every
+// other launch test takes for granted — the routine product of
+// `approach flow create` with no --worktree-path.
+func worktreelessFlowRecord() flowstore.FlowRecord {
+	record := manualLaunchFlowRecord()
+	record.WorktreePath = ""
+	record.Branch = ""
+	record.Commit = ""
+	record.BaseRef = "main"
+	return record
+}
+
+func TestManualFlowLaunchCreatesTheMissingWorktreeAndUsesIt(t *testing.T) {
+	record := worktreelessFlowRecord()
+	h := newManualLaunchHarness(t, record)
+
+	m := h.launch(h.model())
+
+	if len(h.ensureRecords) != 1 || h.ensureRecords[0].FlowID != record.FlowID {
+		t.Fatalf("ensure calls = %#v, want exactly one for this Flow", h.ensureRecords)
+	}
+	if len(h.launchContexts) != 1 {
+		t.Fatalf("embedded launches = %d, want 1", len(h.launchContexts))
+	}
+	ctx := h.launchContexts[0]
+	if ctx.WorktreePath != "/dev/alpha-worktrees/flow-one" {
+		t.Fatalf("launch worktree = %q, want the created worktree and never the repo root", ctx.WorktreePath)
+	}
+	if ctx.Branch != "flow/flow-one" || ctx.Commit != "abc123" {
+		t.Fatalf("launch context = %#v, want the ensured branch and commit", ctx)
+	}
+	if !strings.Contains(m.status.Text, "Set up worktree /dev/alpha-worktrees/flow-one on branch flow/flow-one") {
+		t.Fatalf("status = %q, want the creation announced", m.status.Text)
+	}
+}
+
+func TestManualFlowLaunchLeavesAWorktreedFlowUntouched(t *testing.T) {
+	record := manualLaunchFlowRecord()
+	h := newManualLaunchHarness(t, record)
+
+	m := h.launch(h.model())
+
+	if len(h.ensureRecords) != 0 {
+		t.Fatalf("ensure calls = %#v, want none for a Flow that already has a worktree", h.ensureRecords)
+	}
+	if len(h.launchContexts) != 1 || h.launchContexts[0].WorktreePath != record.WorktreePath {
+		t.Fatalf("launch contexts = %#v, want the record's own worktree", h.launchContexts)
+	}
+	if strings.Contains(m.status.Text, "Set up worktree") {
+		t.Fatalf("status = %q, want no creation announcement", m.status.Text)
+	}
+}
+
+// A keypress that is refused must not mutate Flow state as a side effect.
+func TestManualFlowLaunchWorktreeFailureRefusesWithoutWriting(t *testing.T) {
+	record := worktreelessFlowRecord()
+	h := newManualLaunchHarness(t, record)
+	h.ensureErr = errors.New("branch already checked out")
+
+	m := h.launch(h.model())
+
+	if m.status.Text != "Worktree creation failed: branch already checked out" {
+		t.Fatalf("status = %q, want the wrapped creation failure", m.status.Text)
+	}
+	if len(h.phaseUpdates) != 0 || len(h.launchUpdates) != 0 {
+		t.Fatalf("a refused manual launch persisted something: phases=%#v launches=%#v", h.phaseUpdates, h.launchUpdates)
+	}
+	if len(h.launchContexts) != 0 || len(h.agentContexts) != 0 {
+		t.Fatal("a refused manual launch must not start an agent")
+	}
+	if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
+		t.Fatal("a refused manual launch must release its attempt")
+	}
+}
+
+// A bootstrap-hook failure persists the worktree before it reports, so the
+// refusal must not claim creation failed — the directory is there — and the
+// Flows pane must stop rendering the record as worktree-less.
+func TestManualFlowLaunchReportsAWorktreeCreatedBeforeTheRefusal(t *testing.T) {
+	record := worktreelessFlowRecord()
+	h := newManualLaunchHarness(t, record)
+	ensured := record
+	ensured.WorktreePath = "/dev/alpha-worktrees/flow-one"
+	ensured.Branch = "flow/flow-one"
+	h.ensured = ensured
+	h.ensureErr = errors.New("bootstrap hook failed: missing env file")
+
+	m := h.launch(h.model())
+
+	if m.status.Text != "Worktree created but the launch was refused: bootstrap hook failed: missing env file" {
+		t.Fatalf("status = %q, want the created-but-refused wording", m.status.Text)
+	}
+	if len(h.launchUpdates) != 0 || len(h.launchContexts) != 0 || len(h.agentContexts) != 0 {
+		t.Fatal("a refused manual launch must not start an agent or record a launch")
+	}
+	if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
+		t.Fatal("a refused manual launch must release its attempt")
+	}
+}
+
+// The store write is the one refusal where creation is precisely what did not
+// fail, so it gets its own headline and names the directory left behind.
+func TestManualFlowLaunchReportsAnUnrecordedWorktreeSeparately(t *testing.T) {
+	record := worktreelessFlowRecord()
+	h := newManualLaunchHarness(t, record)
+	h.ensureErr = fmt.Errorf("%w: /dev/alpha-worktrees/flow-one: %w", ErrFlowWorktreeUnrecorded, errors.New("flow store locked"))
+
+	m := h.launch(h.model())
+
+	want := "Worktree could not be recorded: worktree not recorded: " +
+		"/dev/alpha-worktrees/flow-one: flow store locked"
+	if m.status.Text != want {
+		t.Fatalf("status = %q, want %q", m.status.Text, want)
+	}
+	if len(h.phaseUpdates) != 0 || len(h.launchUpdates) != 0 {
+		t.Fatalf("a refused manual launch persisted something: phases=%#v launches=%#v", h.phaseUpdates, h.launchUpdates)
+	}
+}
+
+// The ensure step is the only filesystem work in preparation, so it runs last:
+// a phase a live session already owns must never cost a `git worktree add`.
+func TestManualFlowLaunchSkipsEnsureWhenASessionOwnsThePhase(t *testing.T) {
+	record := worktreelessFlowRecord()
+	record.Phases[0].LaunchIDs = []string{"launch-live"}
+	h := newManualLaunchHarness(t, record)
+	h.sessionRecords = []sessions.SessionRecord{{
+		SessionID: "session-live",
+		LaunchID:  "launch-live",
+		FlowID:    record.FlowID,
+		Status:    "running",
+	}}
+
+	m := h.launch(h.model())
+
+	if len(h.ensureRecords) != 0 {
+		t.Fatalf("ensure calls = %#v, want none when a live session already owns the phase", h.ensureRecords)
+	}
+	if m.status.Text != noLaunchableFlowPhaseStatus {
+		t.Fatalf("status = %q, want %q", m.status.Text, noLaunchableFlowPhaseStatus)
+	}
+}
+
+func TestManualFlowLaunchAnnouncesTheWorktreeOnEveryRoute(t *testing.T) {
+	const note = "Set up worktree /dev/alpha-worktrees/flow-one on branch flow/flow-one for this Flow"
+	for _, tt := range []struct {
+		name          string
+		agentCommand  string
+		launchBackend string
+		tmuxAvailable bool
+		want          string
+	}{
+		{
+			name:         "embedded",
+			agentCommand: "codex",
+			want:         note,
+		},
+		{
+			name:         "external",
+			agentCommand: "codex-app",
+			want:         "Launched codex-app in a terminal session (" + note + ")",
+		},
+		{
+			name:          "tmux",
+			agentCommand:  "codex",
+			launchBackend: "tmux",
+			tmuxAvailable: true,
+			want:          "Launched implementation-abcd1234 in tmux session approach-alpha-0001 — tmux attach -t 'approach-alpha-0001' (" + note + ")",
+		},
+		{
+			name:          "embedded with a tmux fallback",
+			agentCommand:  "codex",
+			launchBackend: "tmux",
+			want:          note + " (" + tmuxFallbackNote + ")",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			record := worktreelessFlowRecord()
+			h := newManualLaunchHarness(t, record)
+			h.agentCommand = tt.agentCommand
+			h.launchBackend = tt.launchBackend
+			h.tmuxAvailable = tt.tmuxAvailable
+
+			m := h.launch(h.model())
+
+			if m.status.Text != tt.want {
+				t.Fatalf("status = %q, want %q", m.status.Text, tt.want)
+			}
+		})
+	}
+}
+
+func autoWorktreelessFlowRecord() flowstore.FlowRecord {
+	record := worktreelessFlowRecord()
+	record.AutoMode = true
+	return record
+}
+
+func TestAutoFlowLaunchCreatesTheMissingWorktreeAndLaunches(t *testing.T) {
+	record := autoWorktreelessFlowRecord()
+	h := newManualLaunchHarness(t, record)
+
+	m := h.autoDrain(h.model(), record)
+
+	if len(h.ensureRecords) != 1 {
+		t.Fatalf("ensure calls = %#v, want exactly one", h.ensureRecords)
+	}
+	if len(h.launchContexts) != 1 || h.launchContexts[0].WorktreePath != "/dev/alpha-worktrees/flow-one" {
+		t.Fatalf("launch contexts = %#v, want the created worktree", h.launchContexts)
+	}
+	if h.drainArmed(m, record.FlowID) {
+		t.Fatal("a successful auto launch must leave the drain disarmed")
+	}
+}
+
+// AutoMode has nobody to read a status, so a permanent refusal blocks the phase
+// instead of retrying at 1 Hz forever.
+func TestAutoFlowLaunchBlocksThePhaseWhenTheWorktreeCannotBeCreated(t *testing.T) {
+	record := autoWorktreelessFlowRecord()
+	h := newManualLaunchHarness(t, record)
+	h.ensureErr = errors.New("branch already checked out")
+
+	m := h.autoDrain(h.model(), record)
+
+	if len(h.phaseUpdates) != 1 {
+		t.Fatalf("phase updates = %#v, want exactly one blocked write", h.phaseUpdates)
+	}
+	update := h.phaseUpdates[0]
+	if update.FlowID != record.FlowID ||
+		update.PhaseID != "implementation" ||
+		update.Status != flowstore.PhaseBlocked ||
+		update.Notes != "Auto-advance blocked: Worktree creation failed: branch already checked out" {
+		t.Fatalf("phase update = %#v", update)
+	}
+	if update.Outcome != "" {
+		t.Fatalf("phase update outcome = %q, want it scoped to plan review", update.Outcome)
+	}
+	if len(h.launchUpdates) != 0 {
+		t.Fatalf("a blocked launch persisted a launch ID: %#v", h.launchUpdates)
+	}
+	// Without the synthesized launch context this fence misses and the Flow is
+	// held in failurePersisting forever — no manual launch, no AutoMode, no repair.
+	if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
+		t.Fatal("the blocked write must release the attempt once it lands")
+	}
+	if h.drainArmed(m, record.FlowID) {
+		t.Fatal("a blocked phase must not re-arm the drain")
+	}
+	if m.status.Text != "Worktree creation failed: branch already checked out" {
+		t.Fatalf("status = %q, want the refusal reported once", m.status.Text)
+	}
+
+	// The blocked phase is what makes the refusal permanent: even an armed drain
+	// finds nothing to launch, so there is no second `git worktree add`.
+	blocked := record
+	blocked.Phases = []flowstore.FlowPhase{{
+		PhaseID: "implementation",
+		Title:   "Implementation",
+		Kind:    flowstore.KindImplementation,
+		Status:  flowstore.PhaseBlocked,
+		Order:   1,
+	}}
+	m = h.autoDrain(m, blocked)
+	if len(h.ensureRecords) != 1 {
+		t.Fatalf("ensure calls = %d, want the refusal to be permanent", len(h.ensureRecords))
+	}
+}
+
+func TestAutoFlowLaunchBlockedWriteTargetsTheResolvedPhaseID(t *testing.T) {
+	record := autoWorktreelessFlowRecord()
+	h := newManualLaunchHarness(t, record)
+	h.ensureErr = errors.New("branch already checked out")
+	m := h.model()
+
+	// The intent carries the spelling an earlier poll captured; the record's own
+	// spelling is what the store accepts.
+	next, cmd, admitted := m.requestFlowLaunch(flowLaunchIntent{
+		Kind:      flowLaunchKindAutoPhase,
+		FlowID:    record.FlowID,
+		PhaseID:   " Implementation ",
+		FlowTitle: record.Title,
+		Origin:    flowLaunchOriginAutoMode,
+	})
+	if !admitted {
+		t.Fatal("AutoMode should have been admitted")
+	}
+	m = h.drain(next, cmd, 0)
+
+	if len(h.phaseUpdates) != 1 || h.phaseUpdates[0].PhaseID != "implementation" {
+		t.Fatalf("phase updates = %#v, want the record's own phase spelling", h.phaseUpdates)
+	}
+	if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
+		t.Fatal("the blocked write must release the attempt")
+	}
+}
+
+func TestAutoFlowLaunchBlocksPlanReviewWithTheBlockedOutcome(t *testing.T) {
+	record := autoWorktreelessFlowRecord()
+	record.PlanID = "plan-1"
+	record.PlanPath = "/state/approach/plans/plan-1/plan.md"
+	record.Phases = []flowstore.FlowPhase{
+		{PhaseID: "plan-review", Title: "Plan review", Kind: flowstore.KindPlanReview, Status: flowstore.PhaseReady, Order: 1},
+	}
+	h := newManualLaunchHarness(t, record)
+	h.ensureErr = errors.New("branch already checked out")
+
+	h.autoDrain(h.model(), record)
+
+	if len(h.phaseUpdates) != 1 {
+		t.Fatalf("phase updates = %#v, want exactly one", h.phaseUpdates)
+	}
+	if h.phaseUpdates[0].Outcome != flowstore.OutcomeBlocked {
+		t.Fatalf("phase update = %#v, want the plan-review blocked outcome", h.phaseUpdates[0])
+	}
+}
+
+func TestAutoFlowLaunchSkipsEnsureWhenASessionOwnsThePhase(t *testing.T) {
+	record := autoWorktreelessFlowRecord()
+	record.Phases[0].LaunchIDs = []string{"launch-live"}
+	h := newManualLaunchHarness(t, record)
+	h.sessionRecords = []sessions.SessionRecord{{
+		SessionID: "session-live",
+		LaunchID:  "launch-live",
+		FlowID:    record.FlowID,
+		Status:    "running",
+	}}
+	m := h.model()
+
+	next, cmd := h.autoPoll(m, record)
+	if cmd == nil {
+		t.Fatal("AutoMode should have been admitted")
+	}
+	event, ok := runCommandWithoutWaiting(cmd)
+	if !ok {
+		t.Fatal("the read hop produced no message")
+	}
+	read, ok := event.(flowLaunchEventMsg)
+	if !ok {
+		t.Fatalf("read hop message = %T, want a launch event", event)
+	}
+	if read.Outcome != flowLaunchOutcomeRetry {
+		t.Fatalf("outcome = %v, want retry so the drain re-arms", read.Outcome)
+	}
+	if len(h.ensureRecords) != 0 {
+		t.Fatalf("ensure calls = %#v, want none behind the session check", h.ensureRecords)
+	}
+	_ = next
+}

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -36,6 +37,10 @@ type FlowPhaseLaunchPreparedRequest struct {
 	WorktreePath string
 	PlanPath     string
 	LaunchID     string
+	// CreatedWorktree records that EnsureLaunchWorktree created this Flow's
+	// worktree for this launch. Creating a branch and a directory because the
+	// user pressed a key is announced rather than silent.
+	CreatedWorktree bool
 }
 
 type FlowPhaseLaunchResult struct {
@@ -56,6 +61,31 @@ func (err FlowPhaseLaunchValidationError) Error() string {
 	return err.Message
 }
 
+// FlowPhaseLaunchWorktreeError is what EnsureLaunchWorktree refuses with. It is
+// its own type so callers classify by step rather than by error text; the
+// lifecycle's outcome enum exists for the same reason.
+type FlowPhaseLaunchWorktreeError struct {
+	Message string
+}
+
+func (err FlowPhaseLaunchWorktreeError) Error() string {
+	return err.Message
+}
+
+const (
+	flowPhaseLaunchNoRepoStatus     = "Flow has no worktree and no repository of its own"
+	flowPhaseLaunchNoWorktreeStatus = "Flow has no worktree and none can be created"
+	flowPhaseLaunchWorktreeFailed   = "Worktree creation failed: "
+	// flowPhaseLaunchWorktreeUnusable covers the failures that happen after the
+	// worktree exists and is persisted — the bootstrap hook is the one the
+	// ensure seam produces. Reporting those as a creation failure would send the
+	// user looking for a directory that is already there.
+	flowPhaseLaunchWorktreeUnusable = "Worktree created but the launch was refused: "
+	// flowPhaseLaunchWorktreeUnrecorded is the third case: the directory exists
+	// but no record names it, so neither of the other two headlines is true.
+	flowPhaseLaunchWorktreeUnrecorded = "Worktree could not be recorded: "
+)
+
 type FlowPhaseLauncher struct {
 	CurrentRepoPath      func() (string, bool)
 	PlanMarkdownPath     func(string) (string, error)
@@ -71,6 +101,10 @@ type FlowPhaseLauncher struct {
 	Backend string
 	// TmuxAvailable probes for tmux. Nil means "probe the real PATH".
 	TmuxAvailable func() bool
+	// EnsureWorktree creates and persists the Flow's worktree when the record
+	// has none, returning the updated record. Nil means "refuse worktree-less
+	// launches" — it never means "fall back to the repository root".
+	EnsureWorktree func(flowstore.FlowRecord) (flowstore.FlowRecord, error)
 }
 
 func (m Model) flowPhaseLauncher() FlowPhaseLauncher {
@@ -88,6 +122,7 @@ func (m Model) flowPhaseLauncher() FlowPhaseLauncher {
 		Model:                model,
 		ReasoningEffort:      reasoningEffort,
 		PromptTemplates:      m.flowPromptTemplates,
+		EnsureWorktree:       m.ensureFlowWorktree,
 	}
 }
 
@@ -101,11 +136,12 @@ func (l FlowPhaseLauncher) Preflight(req FlowPhaseLaunchRequest) (FlowPhaseLaunc
 	if repoPath == "" && l.CurrentRepoPath != nil {
 		repoPath, _ = l.CurrentRepoPath()
 	}
+	// A worktree-less Flow deliberately leaves this empty rather than falling
+	// back to repoPath: running the agent in the user's primary checkout is the
+	// silent isolation break this step exists to prevent. Resolution is deferred
+	// to EnsureLaunchWorktree, which is allowed to touch the filesystem.
 	worktreePath := req.Record.WorktreePath
-	if worktreePath == "" {
-		worktreePath = repoPath
-	}
-	if worktreePath == "" {
+	if worktreePath == "" && repoPath == "" {
 		return FlowPhaseLaunchPreparedRequest{}, FlowPhaseLaunchValidationError{Message: "Cannot determine launch path for this flow"}
 	}
 	planPath := req.Record.PlanPath
@@ -135,7 +171,63 @@ func (l FlowPhaseLauncher) Preflight(req FlowPhaseLaunchRequest) (FlowPhaseLaunc
 	}, nil
 }
 
+// EnsureLaunchWorktree resolves a prepared request whose WorktreePath is still
+// empty. It is the only part of launch preparation that mutates the filesystem,
+// so callers must run it last: after every cheap refusal Preflight makes and
+// after the session-occupancy check, or a launch that is about to be refused
+// leaves an orphan branch and directory behind.
+func (l FlowPhaseLauncher) EnsureLaunchWorktree(req FlowPhaseLaunchPreparedRequest) (FlowPhaseLaunchPreparedRequest, error) {
+	if req.WorktreePath != "" {
+		return req, nil
+	}
+	// Record.RepoPath, never req.RepoPath: the latter has already fallen back to
+	// CurrentRepoPath, and creating a worktree there would put the Flow in
+	// whatever repository the user happens to have selected.
+	if req.Record.RepoPath == "" {
+		return req, FlowPhaseLaunchWorktreeError{Message: flowPhaseLaunchNoRepoStatus}
+	}
+	if l.EnsureWorktree == nil {
+		return req, FlowPhaseLaunchWorktreeError{Message: flowPhaseLaunchNoWorktreeStatus}
+	}
+	updated, err := l.EnsureWorktree(req.Record)
+	// A seam that persisted a worktree and then failed — the bootstrap hook is
+	// that case — is carried forward even though the launch is still refused.
+	// Dropping it would leave the caller holding a record the store has already
+	// moved past, and would report a directory that exists as one that does not.
+	created := updated.WorktreePath != ""
+	if created {
+		// The updated record is carried, not just its path: Prepare builds the
+		// launch context from Record.Branch and Record.Commit and renders the
+		// phase prompt from the same record.
+		req.Record = updated
+		req.WorktreePath = updated.WorktreePath
+		req.CreatedWorktree = true
+	}
+	if err != nil {
+		switch {
+		case created:
+			return req, FlowPhaseLaunchWorktreeError{Message: flowPhaseLaunchWorktreeUnusable + err.Error()}
+		case errors.Is(err, ErrFlowWorktreeUnrecorded):
+			// The seam made a directory it could not persist, so it hands back
+			// the pre-ensure record and `created` is false. Creation is the one
+			// thing that did not fail, and the wrapped error names the path.
+			return req, FlowPhaseLaunchWorktreeError{Message: flowPhaseLaunchWorktreeUnrecorded + err.Error()}
+		}
+		return req, FlowPhaseLaunchWorktreeError{Message: flowPhaseLaunchWorktreeFailed + err.Error()}
+	}
+	if !created {
+		return req, FlowPhaseLaunchWorktreeError{Message: flowPhaseLaunchWorktreeFailed + "no worktree path was recorded"}
+	}
+	return req, nil
+}
+
 func (l FlowPhaseLauncher) Prepare(req FlowPhaseLaunchPreparedRequest) (FlowPhaseLaunchResult, error) {
+	// Structural rather than topological: an empty WorktreePath becomes an empty
+	// cmd.Dir, which makes the agent inherit Approach's own working directory.
+	// Refusing here means a caller that forgets to ensure cannot express the bug.
+	if req.WorktreePath == "" {
+		return FlowPhaseLaunchResult{}, FlowPhaseLaunchWorktreeError{Message: flowPhaseLaunchNoWorktreeStatus}
+	}
 	planBody := ""
 	if req.Record.PlanID != "" && flowPhasePromptNeedsPlanBody(req.Phase) {
 		body, err := l.readPlan(req.Record.PlanID)

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -66,6 +66,15 @@ func (err FlowPhaseLaunchValidationError) Error() string {
 // lifecycle's outcome enum exists for the same reason.
 type FlowPhaseLaunchWorktreeError struct {
 	Message string
+	// Transient marks the refusals that clear without the user. AutoMode must
+	// not block a phase on one of these: the reservation the ensure seam waits
+	// for is most often held by another launch provisioning this same Flow, and
+	// blocking the phase for losing that wait would turn a wait into a stop.
+	Transient bool
+	// Stale marks a refusal that outlived its candidate — the Flow was closed
+	// while this launch was reading. Nothing should retry it and nothing should
+	// be written about it.
+	Stale bool
 }
 
 func (err FlowPhaseLaunchWorktreeError) Error() string {
@@ -84,6 +93,10 @@ const (
 	// flowPhaseLaunchWorktreeUnrecorded is the third case: the directory exists
 	// but no record names it, so neither of the other two headlines is true.
 	flowPhaseLaunchWorktreeUnrecorded = "Worktree could not be recorded: "
+	// flowPhaseLaunchWorktreeBusy is the fourth, and the only one that created
+	// nothing: another launch holds this Flow's reservation. Naming the wait is
+	// what tells the user a second `g` is worth pressing.
+	flowPhaseLaunchWorktreeBusy = "Another launch is setting up this Flow's worktree: "
 )
 
 type FlowPhaseLauncher struct {
@@ -207,6 +220,16 @@ func (l FlowPhaseLauncher) EnsureLaunchWorktree(req FlowPhaseLaunchPreparedReque
 		switch {
 		case created:
 			return req, FlowPhaseLaunchWorktreeError{Message: flowPhaseLaunchWorktreeUnusable + err.Error()}
+		case errors.Is(err, ErrFlowWorktreeUnreserved):
+			// Nothing was created, so nothing is orphaned by coming back. A Flow
+			// closed out from under this read is the one unreserved case that
+			// will never clear, and it is stale rather than transient: its
+			// candidate is gone, so neither a retry nor a write applies.
+			return req, FlowPhaseLaunchWorktreeError{
+				Message:   flowPhaseLaunchWorktreeBusy + err.Error(),
+				Transient: !flowstore.IsFlowClosed(err),
+				Stale:     flowstore.IsFlowClosed(err),
+			}
 		case errors.Is(err, ErrFlowWorktreeUnrecorded):
 			// The seam made a directory it could not persist, so it hands back
 			// the pre-ensure record and `created` is false. Creation is the one

--- a/model/flow_phase_launch_worktree_test.go
+++ b/model/flow_phase_launch_worktree_test.go
@@ -1,0 +1,341 @@
+package model_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/model"
+)
+
+func worktreelessLaunchRecord() flowstore.FlowRecord {
+	phase := flowstore.FlowPhase{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady}
+	return flowstore.FlowRecord{
+		FlowID:   "flow-1",
+		Title:    "Flow one",
+		RepoPath: "/dev/alpha",
+		BaseRef:  "main",
+		Phases:   []flowstore.FlowPhase{phase},
+	}
+}
+
+// The bead's regression guard: a Flow with no worktree must never resolve to
+// the repository root, which is where the agent would otherwise run.
+func TestFlowPhaseLauncherPreflightDefersWorktreeForWorktreelessFlow(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	launcher := model.FlowPhaseLauncher{AgentCommand: "codex", NewLaunchID: func() string { return "launch-1" }}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	if prepared.WorktreePath != "" {
+		t.Fatalf("prepared worktree path = %q, want it deferred to EnsureLaunchWorktree", prepared.WorktreePath)
+	}
+	if prepared.RepoPath != "/dev/alpha" {
+		t.Fatalf("prepared repo path = %q, want /dev/alpha", prepared.RepoPath)
+	}
+	if prepared.CreatedWorktree {
+		t.Fatal("Preflight() must not report a created worktree; it is side-effect free")
+	}
+}
+
+func TestFlowPhaseLauncherPreflightRefusesWithoutWorktreeOrRepoPath(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	record.RepoPath = ""
+	launcher := model.FlowPhaseLauncher{AgentCommand: "codex"}
+
+	_, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err == nil || err.Error() != "Cannot determine launch path for this flow" {
+		t.Fatalf("Preflight() error = %v, want the undeterminable-launch-path refusal", err)
+	}
+}
+
+func TestFlowPhaseLauncherPreflightKeepsExistingWorktreePath(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	record.WorktreePath = "/dev/alpha-worktrees/flow-one"
+	launcher := model.FlowPhaseLauncher{AgentCommand: "codex", NewLaunchID: func() string { return "launch-1" }}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	if prepared.WorktreePath != record.WorktreePath || prepared.RepoPath != record.RepoPath {
+		t.Fatalf("prepared paths = repo %q worktree %q, want them unchanged", prepared.RepoPath, prepared.WorktreePath)
+	}
+}
+
+func TestFlowPhaseLauncherEnsureLaunchWorktreeSkipsSeamWhenWorktreeExists(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	record.WorktreePath = "/dev/alpha-worktrees/flow-one"
+	calls := 0
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand: "codex",
+		NewLaunchID:  func() string { return "launch-1" },
+		EnsureWorktree: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			calls++
+			return flowstore.FlowRecord{}, nil
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	ensured, err := launcher.EnsureLaunchWorktree(prepared)
+	if err != nil {
+		t.Fatalf("EnsureLaunchWorktree() error = %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("ensure seam calls = %d, want 0 for a Flow that already has a worktree", calls)
+	}
+	if ensured.WorktreePath != record.WorktreePath || ensured.CreatedWorktree {
+		t.Fatalf("ensured request = %#v, want it returned unchanged", ensured)
+	}
+}
+
+func TestFlowPhaseLauncherEnsureLaunchWorktreeCreatesAndCarriesTheUpdatedRecord(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	updated := record
+	updated.WorktreePath = "/dev/alpha-worktrees/flow-one"
+	updated.Branch = "flow/flow-one"
+	updated.Commit = "abc123"
+	var seen []flowstore.FlowRecord
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand: "codex",
+		NewLaunchID:  func() string { return "launch-1" },
+		EnsureWorktree: func(got flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			seen = append(seen, got)
+			return updated, nil
+		},
+		AddFlowPhaseLaunchID: func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return updated, nil
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	ensured, err := launcher.EnsureLaunchWorktree(prepared)
+	if err != nil {
+		t.Fatalf("EnsureLaunchWorktree() error = %v", err)
+	}
+	if len(seen) != 1 || seen[0].FlowID != "flow-1" {
+		t.Fatalf("ensure seam calls = %#v, want exactly one for flow-1", seen)
+	}
+	if ensured.WorktreePath != updated.WorktreePath {
+		t.Fatalf("ensured worktree path = %q, want %q", ensured.WorktreePath, updated.WorktreePath)
+	}
+	if ensured.Record.Branch != "flow/flow-one" || ensured.Record.Commit != "abc123" {
+		t.Fatalf("ensured record = %#v, want the branch and commit the ensure seam persisted", ensured.Record)
+	}
+	if !ensured.CreatedWorktree {
+		t.Fatal("ensured request must report that it created the worktree")
+	}
+
+	// The launch context is built from the carried record, not the pre-ensure one.
+	result, err := launcher.Prepare(ensured)
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	if result.Context.WorktreePath != updated.WorktreePath ||
+		result.Context.Branch != "flow/flow-one" ||
+		result.Context.Commit != "abc123" {
+		t.Fatalf("launch context = %#v, want the ensured worktree, branch, and commit", result.Context)
+	}
+}
+
+func TestFlowPhaseLauncherEnsureLaunchWorktreeRefusesWithoutSeam(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	launcher := model.FlowPhaseLauncher{AgentCommand: "codex", NewLaunchID: func() string { return "launch-1" }}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	ensured, err := launcher.EnsureLaunchWorktree(prepared)
+	if err == nil || err.Error() != "Flow has no worktree and none can be created" {
+		t.Fatalf("EnsureLaunchWorktree() error = %v, want the nil-seam refusal", err)
+	}
+	var worktreeErr model.FlowPhaseLaunchWorktreeError
+	if !errors.As(err, &worktreeErr) {
+		t.Fatalf("EnsureLaunchWorktree() error type = %T, want FlowPhaseLaunchWorktreeError", err)
+	}
+	if ensured.WorktreePath != "" {
+		t.Fatalf("refused request worktree path = %q, want it empty and never the repo path", ensured.WorktreePath)
+	}
+}
+
+// Preflight resolves RepoPath through CurrentRepoPath, so a Flow with no repo of
+// its own would otherwise get a worktree in whatever repo happens to be selected.
+func TestFlowPhaseLauncherEnsureLaunchWorktreeNeverCreatesInTheSelectedRepo(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	record.RepoPath = ""
+	calls := 0
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand:    "codex",
+		NewLaunchID:     func() string { return "launch-1" },
+		CurrentRepoPath: func() (string, bool) { return "/dev/unrelated", true },
+		EnsureWorktree: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			calls++
+			return flowstore.FlowRecord{}, nil
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	if prepared.RepoPath != "/dev/unrelated" {
+		t.Fatalf("prepared repo path = %q, want the selected repo", prepared.RepoPath)
+	}
+	if _, err := launcher.EnsureLaunchWorktree(prepared); err == nil ||
+		err.Error() != "Flow has no worktree and no repository of its own" {
+		t.Fatalf("EnsureLaunchWorktree() error = %v, want the repo-less refusal", err)
+	}
+	if calls != 0 {
+		t.Fatalf("ensure seam calls = %d, want 0 for a Flow with no repo of its own", calls)
+	}
+}
+
+func TestFlowPhaseLauncherEnsureLaunchWorktreeWrapsSeamFailure(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand: "codex",
+		NewLaunchID:  func() string { return "launch-1" },
+		EnsureWorktree: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{}, errors.New("branch already checked out")
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	_, err = launcher.EnsureLaunchWorktree(prepared)
+	if err == nil || err.Error() != "Worktree creation failed: branch already checked out" {
+		t.Fatalf("EnsureLaunchWorktree() error = %v, want the wrapped creation failure", err)
+	}
+}
+
+// The bootstrap hook fails after the worktree exists and is recorded. Calling
+// that a creation failure would send the user looking for a directory that is
+// already there, and dropping the returned record would leave the caller
+// holding one the store has moved past.
+func TestFlowPhaseLauncherEnsureLaunchWorktreeReportsAPersistedWorktreeAsCreated(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand: "codex",
+		NewLaunchID:  func() string { return "launch-1" },
+		EnsureWorktree: func(got flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			started := got
+			started.WorktreePath = "/dev/alpha-worktrees/flow-one"
+			started.Branch = "flow/one"
+			return started, errors.New("bootstrap hook failed: missing env file")
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	ensured, err := launcher.EnsureLaunchWorktree(prepared)
+	if err == nil ||
+		err.Error() != "Worktree created but the launch was refused: bootstrap hook failed: missing env file" {
+		t.Fatalf("EnsureLaunchWorktree() error = %v, want the created-but-refused wording", err)
+	}
+	if ensured.WorktreePath != "/dev/alpha-worktrees/flow-one" ||
+		ensured.Record.Branch != "flow/one" ||
+		!ensured.CreatedWorktree {
+		t.Fatalf("refused request = %#v, want the persisted worktree carried forward", ensured)
+	}
+}
+
+func TestFlowPhaseLauncherEnsureLaunchWorktreeRejectsWorktreelessEnsureResult(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand: "codex",
+		NewLaunchID:  func() string { return "launch-1" },
+		EnsureWorktree: func(got flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			// The stub NewFlowStarter installs for a missing SetStartMetadata
+			// returns exactly this: an ID and nothing else.
+			return flowstore.FlowRecord{FlowID: got.FlowID}, nil
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	ensured, err := launcher.EnsureLaunchWorktree(prepared)
+	if err == nil || !strings.Contains(err.Error(), "Worktree creation failed") {
+		t.Fatalf("EnsureLaunchWorktree() error = %v, want a loud failure for a worktree-less ensure result", err)
+	}
+	if ensured.WorktreePath != "" {
+		t.Fatalf("refused request worktree path = %q, want it empty", ensured.WorktreePath)
+	}
+}
+
+// A blank branch and commit in the ensured record reach the agent environment
+// blank rather than falling back to the pre-ensure record's values.
+func TestFlowPhaseLauncherEnsureLaunchWorktreeCarriesBlankBranchAndCommit(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	record.Branch = "stale-branch"
+	record.Commit = "stalecommit"
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand: "codex",
+		NewLaunchID:  func() string { return "launch-1" },
+		EnsureWorktree: func(got flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{
+				FlowID:       got.FlowID,
+				RepoPath:     got.RepoPath,
+				WorktreePath: "/dev/alpha-worktrees/flow-one",
+				Phases:       got.Phases,
+			}, nil
+		},
+		AddFlowPhaseLaunchID: func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{}, nil
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	ensured, err := launcher.EnsureLaunchWorktree(prepared)
+	if err != nil {
+		t.Fatalf("EnsureLaunchWorktree() error = %v", err)
+	}
+	result, err := launcher.Prepare(ensured)
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	if result.Context.Branch != "" || result.Context.Commit != "" {
+		t.Fatalf("launch context = %#v, want the ensured record's blank branch and commit", result.Context)
+	}
+}
+
+// The invariant is structural: even if a future caller forgets to ensure, an
+// empty worktree path can never reach cmd.Dir.
+func TestFlowPhaseLauncherPrepareRefusesEmptyWorktreePath(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand: "codex",
+		NewLaunchID:  func() string { return "launch-1" },
+		AddFlowPhaseLaunchID: func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			t.Fatal("Prepare() must refuse before it persists a launch ID")
+			return flowstore.FlowRecord{}, nil
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	if _, err := launcher.Prepare(prepared); err == nil ||
+		err.Error() != "Flow has no worktree and none can be created" {
+		t.Fatalf("Prepare() error = %v, want the missing-worktree refusal", err)
+	}
+}

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -304,6 +304,25 @@ func (s FlowStarter) EnsureWorktree(record flowstore.FlowRecord) (flowstore.Flow
 	if strings.TrimSpace(record.RepoPath) == "" {
 		return record, fmt.Errorf("flow has no repository of its own")
 	}
+	// Everything below creates a branch and a directory and then persists them,
+	// and the launch reservation is not taken until the spawn, several hops
+	// later. Without a fence here two readers of the same worktree-less Flow —
+	// two Approach processes, or one whose reading attempt was released mid
+	// ensure — each allocate a pair and race the metadata write, leaving the
+	// loser's agent in a worktree no record names. The reservation is the
+	// existing per-Flow lock and it answers with the authoritative record, so it
+	// closes the window and supplies the re-read in one step.
+	fresh, release, err := s.reserveLaunch(record.FlowID)
+	if err != nil {
+		return record, err
+	}
+	defer releaseFlowLaunchReservation(release)
+	// The store is authoritative under the lock: whoever went first has already
+	// recorded a worktree, and this launch belongs in that one rather than in a
+	// second pair of its own.
+	if strings.TrimSpace(fresh.WorktreePath) != "" {
+		return fresh, nil
+	}
 	worktree, err := s.ensureWorktreeFor(record)
 	if err != nil {
 		return record, err

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,12 @@ import (
 )
 
 const flowPlanPhaseID = "plan"
+
+// ErrFlowWorktreeUnrecorded reports that EnsureWorktree created a worktree the
+// store then refused to record. It is a sentinel because the launch status
+// depends on it: the directory exists, so "worktree creation failed" would be
+// the one claim that is not true.
+var ErrFlowWorktreeUnrecorded = errors.New("worktree not recorded")
 
 // FlowStartRequest contains the user operation inputs needed to create a Flow
 // and optionally prepare the initial plan-phase agent launch.
@@ -50,8 +57,12 @@ type FlowStartResult struct {
 // FlowStarterOptions groups the deeper orchestration adapters for starting a
 // Flow. Tests can replace these directly without widening Model.Options.
 type FlowStarterOptions struct {
-	CreateFlow           func(flowstore.FlowRecord, flowstore.CreateOptions) (flowstore.FlowRecord, error)
-	CreateWorktree       func(repoPath, title, baseRef string) (actions.FlowWorktreeCreateResult, error)
+	CreateFlow     func(flowstore.FlowRecord, flowstore.CreateOptions) (flowstore.FlowRecord, error)
+	CreateWorktree func(repoPath, title, baseRef string) (actions.FlowWorktreeCreateResult, error)
+	// AttachWorktree gives a branch the Flow already records a worktree of its
+	// own. It reports actions.ErrFlowBranchMissing when that branch does not
+	// exist, which is the only case CreateWorktree may answer instead.
+	AttachWorktree       func(repoPath, branch string) (actions.FlowWorktreeCreateResult, error)
 	SetStartMetadata     func(flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error)
 	SetPhase             func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
 	AddPhaseLaunchID     func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
@@ -68,6 +79,7 @@ type FlowStarterOptions struct {
 type FlowStarter struct {
 	createFlow           func(flowstore.FlowRecord, flowstore.CreateOptions) (flowstore.FlowRecord, error)
 	createWorktree       func(repoPath, title, baseRef string) (actions.FlowWorktreeCreateResult, error)
+	attachWorktree       func(repoPath, branch string) (actions.FlowWorktreeCreateResult, error)
 	setStartMetadata     func(flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error)
 	setPhase             func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
 	addPhaseLaunchID     func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error)
@@ -83,6 +95,7 @@ func NewFlowStarter(opts FlowStarterOptions) FlowStarter {
 	starter := FlowStarter{
 		createFlow:           opts.CreateFlow,
 		createWorktree:       opts.CreateWorktree,
+		attachWorktree:       opts.AttachWorktree,
 		setStartMetadata:     opts.SetStartMetadata,
 		setPhase:             opts.SetPhase,
 		addPhaseLaunchID:     opts.AddPhaseLaunchID,
@@ -100,6 +113,9 @@ func NewFlowStarter(opts FlowStarterOptions) FlowStarter {
 	}
 	if starter.createWorktree == nil {
 		starter.createWorktree = actions.CreateFlowWorktree
+	}
+	if starter.attachWorktree == nil {
+		starter.attachWorktree = actions.AttachFlowWorktree
 	}
 	if starter.setStartMetadata == nil {
 		starter.setStartMetadata = func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
@@ -269,6 +285,74 @@ func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) 
 	}
 
 	return result, nil
+}
+
+// EnsureWorktree gives a worktree-less Flow the worktree its launch contract
+// already implies, in the order PrepareFlow uses. It reports failures instead of
+// blocking phases: the caller owns that decision, behind its own fence.
+//
+// The record it returns is the persisted one, complete with phases, because the
+// launch lifecycle threads it forward and looks the launching phase up in it.
+// That also holds for the bootstrap failure below, which returns a record whose
+// worktree is real — the caller must not report that one as a creation failure.
+func (s FlowStarter) EnsureWorktree(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+	if strings.TrimSpace(record.WorktreePath) != "" {
+		return record, nil
+	}
+	// Guarded here as well as at the launch call site: `git -C ""` would run in
+	// Approach's own working directory and put the worktree wherever that is.
+	if strings.TrimSpace(record.RepoPath) == "" {
+		return record, fmt.Errorf("flow has no repository of its own")
+	}
+	worktree, err := s.ensureWorktreeFor(record)
+	if err != nil {
+		return record, err
+	}
+	commit := s.resolveCommit(worktree.WorktreePath)
+	// SetStartMetadata is additive and returns the fresh record, so it is safe on
+	// a Flow that already exists. Branch is written back rather than preserved
+	// because ensureWorktreeFor only allocates a new name when the recorded one
+	// resolves to nothing.
+	started, err := s.setStartMetadata(flowstore.StartMetadataUpdate{
+		FlowID:       record.FlowID,
+		WorktreePath: worktree.WorktreePath,
+		Branch:       worktree.Branch,
+		BaseRef:      record.BaseRef,
+		Commit:       commit,
+	})
+	if err != nil {
+		// The worktree exists and nothing records it, and the retry allocates a
+		// fresh name rather than adopting this one, so the path is named here:
+		// an unattributable directory is worse than a wordy status. The sentinel
+		// is what lets the launcher pick a headline that does not claim creation
+		// failed, which is the one thing that did not.
+		return record, fmt.Errorf("%w: %s: %w", ErrFlowWorktreeUnrecorded, worktree.WorktreePath, err)
+	}
+	if err := s.runBootstrap(record.RepoPath, worktree); err != nil {
+		// The worktree and its metadata survive a hook failure — the same
+		// trade-off PrepareFlow makes — so a retry takes the passthrough above.
+		return started, fmt.Errorf("bootstrap hook failed: %w", err)
+	}
+	return started, nil
+}
+
+// ensureWorktreeFor honors the branch a Flow already records instead of
+// replacing it. A recorded branch is a promise the rest of the app keeps —
+// prompts render it as the push target and `flow pr set --head` validates
+// against it — so allocating a second flow/<slug> beside it would leave the
+// record naming a branch no agent ever touches. Only a branch that resolves to
+// nothing is replaced, which is the case the store cannot tell apart on its own.
+func (s FlowStarter) ensureWorktreeFor(record flowstore.FlowRecord) (actions.FlowWorktreeCreateResult, error) {
+	if branch := strings.TrimSpace(record.Branch); branch != "" {
+		worktree, err := s.attachWorktree(record.RepoPath, branch)
+		if err == nil {
+			return worktree, nil
+		}
+		if !errors.Is(err, actions.ErrFlowBranchMissing) {
+			return actions.FlowWorktreeCreateResult{}, err
+		}
+	}
+	return s.createWorktree(record.RepoPath, record.Title, record.BaseRef)
 }
 
 // phaseAgentSettingsForRequest captures the request's agent selection for the

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -18,6 +18,12 @@ const flowPlanPhaseID = "plan"
 // the one claim that is not true.
 var ErrFlowWorktreeUnrecorded = errors.New("worktree not recorded")
 
+// ErrFlowWorktreeUnreserved reports that EnsureWorktree could not take the
+// Flow's launch reservation, so it created nothing at all. It is a sentinel
+// because it is the one ensure refusal that clears on its own: the usual cause
+// is another launch holding the reservation while it provisions this very Flow.
+var ErrFlowWorktreeUnreserved = errors.New("launch reservation unavailable")
+
 // FlowStartRequest contains the user operation inputs needed to create a Flow
 // and optionally prepare the initial plan-phase agent launch.
 type FlowStartRequest struct {
@@ -314,7 +320,13 @@ func (s FlowStarter) EnsureWorktree(record flowstore.FlowRecord) (flowstore.Flow
 	// closes the window and supplies the re-read in one step.
 	fresh, release, err := s.reserveLaunch(record.FlowID)
 	if err != nil {
-		return record, err
+		// Wrapped, not returned bare: the reservation is held across the
+		// bootstrap hook, whose budget is 120 s by default against the store's
+		// 5 s lock timeout, so a Flow another process is provisioning right now
+		// is the ordinary reason this fails. The sentinel is what stops the
+		// caller from reading that as a permanent refusal — nothing was created
+		// here, so there is nothing to clean up and every reason to come back.
+		return record, fmt.Errorf("%w: %w", ErrFlowWorktreeUnreserved, err)
 	}
 	defer releaseFlowLaunchReservation(release)
 	// The store is authoritative under the lock: whoever went first has already

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -301,6 +301,13 @@ func (s FlowStarter) PrepareFlow(req FlowStartRequest) (FlowStartResult, error) 
 // launch lifecycle threads it forward and looks the launching phase up in it.
 // That also holds for the bootstrap failure below, which returns a record whose
 // worktree is real — the caller must not report that one as a creation failure.
+// A recorded worktree path means the directory exists and the store names it.
+// It does not mean the bootstrap hook completed: the hook runs after
+// SetStartMetadata, so a Flow whose hook failed passes through here and launches
+// into the worktree it did get. That is the same contract PrepareFlow has had
+// since Flow creation gained a hook, and the TUI guide documents it for the
+// second `g`. Making path existence imply a finished bootstrap needs a
+// provisioning marker in the store, which is a change to Flow creation too.
 func (s FlowStarter) EnsureWorktree(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
 	if strings.TrimSpace(record.WorktreePath) != "" {
 		return record, nil

--- a/model/flow_start_ensure_worktree_test.go
+++ b/model/flow_start_ensure_worktree_test.go
@@ -129,6 +129,106 @@ func TestFlowStarterEnsureWorktreePassesThroughWhenWorktreeExists(t *testing.T) 
 	}
 }
 
+// The launch reservation is not taken until the spawn, several hops after this,
+// so the creation and the metadata write have to hold it themselves. Two
+// readers of the same worktree-less Flow would otherwise each allocate a pair
+// and race the write, leaving the loser's agent in a worktree no record names.
+func TestFlowStarterEnsureWorktreeHoldsTheLaunchReservationAcrossItsWrites(t *testing.T) {
+	var calls []string
+	record := ensureWorktreeFlowRecord()
+	persisted := record
+	persisted.WorktreePath = "/dev/alpha-worktrees/flow-add-flow-mode"
+	persisted.Branch = "flow/add-flow-mode"
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		ReserveLaunch: func(flowID string) (flowstore.FlowRecord, func(), error) {
+			if flowID != "flow-1" {
+				t.Fatalf("ReserveLaunch(%q)", flowID)
+			}
+			calls = append(calls, "reserve")
+			return record, func() { calls = append(calls, "release") }, nil
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			calls = append(calls, "create-worktree")
+			return actions.FlowWorktreeCreateResult{
+				WorktreePath: "/dev/alpha-worktrees/flow-add-flow-mode",
+				Branch:       "flow/add-flow-mode",
+			}, nil
+		},
+		SetStartMetadata: func(flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			calls = append(calls, "set-start")
+			return persisted, nil
+		},
+	})
+
+	if _, err := starter.EnsureWorktree(record); err != nil {
+		t.Fatalf("EnsureWorktree() error = %v", err)
+	}
+	if strings.Join(calls, ",") != "reserve,create-worktree,set-start,release" {
+		t.Fatalf("call order = %#v, want the reservation held across creation and the write", calls)
+	}
+}
+
+// The reservation answers with the authoritative record, which is what makes it
+// a fence rather than a lock: a launch that lost the race adopts the worktree
+// the winner recorded instead of allocating a second pair beside it.
+func TestFlowStarterEnsureWorktreeAdoptsAWorktreeRecordedWhileItWaited(t *testing.T) {
+	record := ensureWorktreeFlowRecord()
+	winner := record
+	winner.WorktreePath = "/dev/alpha-worktrees/flow-add-flow-mode"
+	winner.Branch = "flow/add-flow-mode"
+
+	released := false
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		ReserveLaunch: func(string) (flowstore.FlowRecord, func(), error) {
+			return winner, func() { released = true }, nil
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			t.Fatal("EnsureWorktree() must not create a second worktree beside the recorded one")
+			return actions.FlowWorktreeCreateResult{}, nil
+		},
+		SetStartMetadata: func(flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			t.Fatal("EnsureWorktree() must not overwrite the winner's start metadata")
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+
+	got, err := starter.EnsureWorktree(record)
+	if err != nil {
+		t.Fatalf("EnsureWorktree() error = %v", err)
+	}
+	if got.WorktreePath != winner.WorktreePath || got.Branch != winner.Branch {
+		t.Fatalf("ensured record = %#v, want the worktree recorded under the fence", got)
+	}
+	if !released {
+		t.Fatal("EnsureWorktree() kept the launch reservation after returning")
+	}
+}
+
+// A reservation that cannot be taken — a contended lock, or a Flow closed out
+// from under this launch — refuses before anything is created, so the refusal
+// costs no orphan worktree.
+func TestFlowStarterEnsureWorktreeRefusesWhenTheReservationFails(t *testing.T) {
+	record := ensureWorktreeFlowRecord()
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		ReserveLaunch: func(string) (flowstore.FlowRecord, func(), error) {
+			return flowstore.FlowRecord{}, nil, errors.New("flow is closed")
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			t.Fatal("EnsureWorktree() must not create a worktree it could not reserve")
+			return actions.FlowWorktreeCreateResult{}, nil
+		},
+	})
+
+	got, err := starter.EnsureWorktree(record)
+	if err == nil || !strings.Contains(err.Error(), "flow is closed") {
+		t.Fatalf("EnsureWorktree() error = %v, want the reservation failure", err)
+	}
+	if got.WorktreePath != "" {
+		t.Fatalf("ensured record = %#v, want the record returned unchanged", got)
+	}
+}
+
 // Blocking phases is the lifecycle's job, behind its attempt fence. EnsureWorktree
 // only reports.
 func TestFlowStarterEnsureWorktreeReportsFailuresWithoutBlockingPhases(t *testing.T) {

--- a/model/flow_start_ensure_worktree_test.go
+++ b/model/flow_start_ensure_worktree_test.go
@@ -1,0 +1,416 @@
+package model_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/model"
+)
+
+func ensureWorktreeFlowRecord() flowstore.FlowRecord {
+	return flowstore.FlowRecord{
+		FlowID:   "flow-1",
+		Title:    "Add Flow Mode",
+		RepoPath: "/dev/alpha",
+		BaseRef:  "main",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "plan", Title: "Plan", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady, Order: 1},
+		},
+	}
+}
+
+func TestFlowStarterEnsureWorktreeMirrorsPrepareFlowOrderAndArguments(t *testing.T) {
+	var calls []string
+	var createArgs []string
+	var startUpdate flowstore.StartMetadataUpdate
+	var bootstrapCtx actions.BootstrapContext
+	record := ensureWorktreeFlowRecord()
+	persisted := record
+	persisted.WorktreePath = "/dev/alpha-worktrees/flow-add-flow-mode"
+	persisted.Branch = "flow/add-flow-mode"
+	persisted.Commit = "abc123"
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateWorktree: func(repoPath, title, baseRef string) (actions.FlowWorktreeCreateResult, error) {
+			calls = append(calls, "create-worktree")
+			createArgs = []string{repoPath, title, baseRef}
+			return actions.FlowWorktreeCreateResult{
+				WorktreePath: "/dev/alpha-worktrees/flow-add-flow-mode",
+				Branch:       "flow/add-flow-mode",
+			}, nil
+		},
+		ResolveCommit: func(worktreePath string) string {
+			calls = append(calls, "resolve-commit")
+			if worktreePath != "/dev/alpha-worktrees/flow-add-flow-mode" {
+				t.Fatalf("ResolveCommit(%q)", worktreePath)
+			}
+			return "abc123"
+		},
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			calls = append(calls, "set-start")
+			startUpdate = update
+			return persisted, nil
+		},
+		BootstrapHookForRepo: func(repoPath string) (actions.BootstrapHook, bool) {
+			if repoPath != "/dev/alpha" {
+				t.Fatalf("BootstrapHookForRepo(%q)", repoPath)
+			}
+			return actions.BootstrapHook{Script: ".approach/bootstrap", TimeoutSeconds: 7}, true
+		},
+		RunBootstrapHook: func(ctx actions.BootstrapContext, _ actions.BootstrapHook) error {
+			calls = append(calls, "bootstrap")
+			bootstrapCtx = ctx
+			return nil
+		},
+		SetPhase: func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+			calls = append(calls, "set-phase")
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+
+	got, err := starter.EnsureWorktree(record)
+	if err != nil {
+		t.Fatalf("EnsureWorktree() error = %v", err)
+	}
+	if strings.Join(calls, ",") != "create-worktree,resolve-commit,set-start,bootstrap" {
+		t.Fatalf("call order = %#v", calls)
+	}
+	if strings.Join(createArgs, ",") != "/dev/alpha,Add Flow Mode,main" {
+		t.Fatalf("CreateWorktree args = %#v, want the record's repo path, title, and base ref", createArgs)
+	}
+	if startUpdate.FlowID != "flow-1" ||
+		startUpdate.WorktreePath != "/dev/alpha-worktrees/flow-add-flow-mode" ||
+		startUpdate.Branch != "flow/add-flow-mode" ||
+		startUpdate.BaseRef != "main" ||
+		startUpdate.Commit != "abc123" {
+		t.Fatalf("start metadata update = %#v", startUpdate)
+	}
+	if bootstrapCtx.RepoPath != "/dev/alpha" ||
+		bootstrapCtx.WorktreePath != "/dev/alpha-worktrees/flow-add-flow-mode" ||
+		bootstrapCtx.Ref != "flow/add-flow-mode" ||
+		bootstrapCtx.Kind != actions.WorktreeCreateFlow {
+		t.Fatalf("bootstrap context = %#v", bootstrapCtx)
+	}
+	// The read stage sets event.Record from this and the prepare stage looks the
+	// phase up in it, so a phase-less record would strand the launch.
+	if len(got.Phases) != 1 || got.Phases[0].PhaseID != "plan" {
+		t.Fatalf("ensured record phases = %#v, want the complete persisted record", got.Phases)
+	}
+	if got.WorktreePath != persisted.WorktreePath || got.Branch != persisted.Branch || got.Commit != persisted.Commit {
+		t.Fatalf("ensured record = %#v, want the persisted start metadata", got)
+	}
+}
+
+func TestFlowStarterEnsureWorktreePassesThroughWhenWorktreeExists(t *testing.T) {
+	record := ensureWorktreeFlowRecord()
+	record.WorktreePath = "/dev/alpha-worktrees/flow-add-flow-mode"
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			t.Fatal("EnsureWorktree() must not create a second worktree")
+			return actions.FlowWorktreeCreateResult{}, nil
+		},
+		SetStartMetadata: func(flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			t.Fatal("EnsureWorktree() must not rewrite start metadata for an existing worktree")
+			return flowstore.FlowRecord{}, nil
+		},
+	})
+
+	got, err := starter.EnsureWorktree(record)
+	if err != nil {
+		t.Fatalf("EnsureWorktree() error = %v", err)
+	}
+	if got.WorktreePath != record.WorktreePath {
+		t.Fatalf("ensured record = %#v, want the record returned unchanged", got)
+	}
+}
+
+// Blocking phases is the lifecycle's job, behind its attempt fence. EnsureWorktree
+// only reports.
+func TestFlowStarterEnsureWorktreeReportsFailuresWithoutBlockingPhases(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		options model.FlowStarterOptions
+		want    string
+	}{
+		{
+			name: "worktree creation",
+			options: model.FlowStarterOptions{
+				CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+					return actions.FlowWorktreeCreateResult{}, errors.New("branch already checked out")
+				},
+			},
+			want: "branch already checked out",
+		},
+		{
+			name: "start metadata",
+			options: model.FlowStarterOptions{
+				CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+					return actions.FlowWorktreeCreateResult{WorktreePath: "/dev/alpha-worktrees/flow-one", Branch: "flow/one"}, nil
+				},
+				SetStartMetadata: func(flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+					return flowstore.FlowRecord{}, errors.New("flow store locked")
+				},
+			},
+			// The path is named because nothing records it: the retry allocates
+			// flow-one-2 rather than adopting this directory, so a bare store
+			// error would leave it unattributable.
+			want: "worktree not recorded: /dev/alpha-worktrees/flow-one: flow store locked",
+		},
+		{
+			name: "bootstrap hook",
+			options: model.FlowStarterOptions{
+				CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+					return actions.FlowWorktreeCreateResult{WorktreePath: "/dev/alpha-worktrees/flow-one", Branch: "flow/one"}, nil
+				},
+				SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+					return flowstore.FlowRecord{FlowID: update.FlowID, WorktreePath: update.WorktreePath}, nil
+				},
+				BootstrapHookForRepo: func(string) (actions.BootstrapHook, bool) {
+					return actions.BootstrapHook{Script: ".approach/bootstrap"}, true
+				},
+				RunBootstrapHook: func(actions.BootstrapContext, actions.BootstrapHook) error {
+					return errors.New("missing env file")
+				},
+			},
+			want: "bootstrap hook failed: missing env file",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			phaseUpdates := 0
+			opts := tt.options
+			opts.SetPhase = func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
+				phaseUpdates++
+				return flowstore.FlowRecord{}, nil
+			}
+			starter := model.NewFlowStarter(opts)
+
+			_, err := starter.EnsureWorktree(ensureWorktreeFlowRecord())
+			if err == nil || err.Error() != tt.want {
+				t.Fatalf("EnsureWorktree() error = %v, want %q", err, tt.want)
+			}
+			if phaseUpdates != 0 {
+				t.Fatalf("phase updates = %d, want EnsureWorktree to leave blocking to the caller", phaseUpdates)
+			}
+		})
+	}
+}
+
+// CreateFlowWorktree derives the branch from the title, so a title-less record
+// surfaces its error rather than getting a synthesized slug.
+func TestFlowStarterEnsureWorktreeSurfacesMissingTitle(t *testing.T) {
+	record := ensureWorktreeFlowRecord()
+	record.Title = ""
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateWorktree: func(_, title, _ string) (actions.FlowWorktreeCreateResult, error) {
+			if title != "" {
+				t.Fatalf("CreateWorktree title = %q, want the record's empty title verbatim", title)
+			}
+			return actions.FlowWorktreeCreateResult{}, errors.New("flow title is required")
+		},
+	})
+
+	if _, err := starter.EnsureWorktree(record); err == nil || err.Error() != "flow title is required" {
+		t.Fatalf("EnsureWorktree() error = %v, want the create-worktree error surfaced", err)
+	}
+}
+
+// A --branch recorded by `approach flow create` without a --worktree-path is
+// still a promise: prompts render it as the push target and `flow pr set --head`
+// validates against it. Allocating flow/<slug> beside it would leave the record
+// naming a branch no agent ever touches.
+func TestFlowStarterEnsureWorktreeAttachesTheRecordedBranch(t *testing.T) {
+	record := ensureWorktreeFlowRecord()
+	record.Branch = "feature/login"
+	var attachArgs []string
+	var startUpdate flowstore.StartMetadataUpdate
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		AttachWorktree: func(repoPath, branch string) (actions.FlowWorktreeCreateResult, error) {
+			attachArgs = []string{repoPath, branch}
+			return actions.FlowWorktreeCreateResult{
+				WorktreePath: "/dev/alpha-worktrees/feature-login",
+				Branch:       "feature/login",
+			}, nil
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			t.Fatal("EnsureWorktree() must not allocate a second branch beside the recorded one")
+			return actions.FlowWorktreeCreateResult{}, nil
+		},
+		ResolveCommit: func(string) string { return "abc123" },
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			startUpdate = update
+			updated := record
+			updated.WorktreePath = update.WorktreePath
+			updated.Branch = update.Branch
+			updated.Commit = update.Commit
+			return updated, nil
+		},
+	})
+
+	got, err := starter.EnsureWorktree(record)
+	if err != nil {
+		t.Fatalf("EnsureWorktree() error = %v", err)
+	}
+	if strings.Join(attachArgs, ",") != "/dev/alpha,feature/login" {
+		t.Fatalf("AttachWorktree args = %#v, want the record's repo path and branch", attachArgs)
+	}
+	if startUpdate.Branch != "feature/login" || got.Branch != "feature/login" {
+		t.Fatalf("branch = update %q record %q, want the recorded branch preserved", startUpdate.Branch, got.Branch)
+	}
+	if got.WorktreePath != "/dev/alpha-worktrees/feature-login" {
+		t.Fatalf("worktree path = %q, want the attached worktree", got.WorktreePath)
+	}
+}
+
+// A recorded branch that resolves to nothing is the one case the store cannot
+// tell apart on its own, and the only one where a fresh flow/<slug> may replace
+// the recorded name.
+func TestFlowStarterEnsureWorktreeCreatesAFreshPairWhenTheRecordedBranchIsGone(t *testing.T) {
+	record := ensureWorktreeFlowRecord()
+	record.Branch = "deleted-long-ago"
+	var startUpdate flowstore.StartMetadataUpdate
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		AttachWorktree: func(_, branch string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{}, fmt.Errorf("%s: %w", branch, actions.ErrFlowBranchMissing)
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{
+				WorktreePath: "/dev/alpha-worktrees/flow-add-flow-mode",
+				Branch:       "flow/add-flow-mode",
+			}, nil
+		},
+		ResolveCommit: func(string) string { return "abc123" },
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			startUpdate = update
+			updated := record
+			updated.WorktreePath = update.WorktreePath
+			updated.Branch = update.Branch
+			return updated, nil
+		},
+	})
+
+	got, err := starter.EnsureWorktree(record)
+	if err != nil {
+		t.Fatalf("EnsureWorktree() error = %v", err)
+	}
+	if startUpdate.Branch != "flow/add-flow-mode" || got.Branch != "flow/add-flow-mode" {
+		t.Fatalf("branch = update %q record %q, want the created branch", startUpdate.Branch, got.Branch)
+	}
+}
+
+// A blank Branch is no branch at all, so the attach seam is never consulted for
+// one. Trimming here rather than inside the seam keeps `git worktree add` from
+// ever seeing a whitespace ref.
+func TestFlowStarterEnsureWorktreeIgnoresAWhitespaceOnlyBranch(t *testing.T) {
+	record := ensureWorktreeFlowRecord()
+	record.Branch = "   "
+	created := false
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		AttachWorktree: func(string, string) (actions.FlowWorktreeCreateResult, error) {
+			t.Fatal("EnsureWorktree() must not attach a whitespace-only branch")
+			return actions.FlowWorktreeCreateResult{}, nil
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			created = true
+			return actions.FlowWorktreeCreateResult{
+				WorktreePath: "/dev/alpha-worktrees/flow-add-flow-mode",
+				Branch:       "flow/add-flow-mode",
+			}, nil
+		},
+		ResolveCommit: func(string) string { return "abc123" },
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			updated := record
+			updated.WorktreePath = update.WorktreePath
+			updated.Branch = update.Branch
+			return updated, nil
+		},
+	})
+
+	if _, err := starter.EnsureWorktree(record); err != nil {
+		t.Fatalf("EnsureWorktree() error = %v", err)
+	}
+	if !created {
+		t.Fatal("EnsureWorktree() did not fall through to CreateWorktree for a blank branch")
+	}
+}
+
+// Only ErrFlowBranchMissing means "the recorded branch is not real". Any other
+// attach failure — the branch is checked out elsewhere, git is unhappy — must
+// surface rather than silently becoming a second branch.
+func TestFlowStarterEnsureWorktreeSurfacesNonMissingAttachFailures(t *testing.T) {
+	record := ensureWorktreeFlowRecord()
+	record.Branch = "feature/login"
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		AttachWorktree: func(string, string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{}, errors.New("branch is already checked out")
+		},
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			t.Fatal("EnsureWorktree() must not fall back to a fresh branch on an unrelated attach failure")
+			return actions.FlowWorktreeCreateResult{}, nil
+		},
+	})
+
+	if _, err := starter.EnsureWorktree(record); err == nil || err.Error() != "branch is already checked out" {
+		t.Fatalf("EnsureWorktree() error = %v, want the attach error surfaced", err)
+	}
+}
+
+// The launch call site guards this too, but `git -C ""` would run in Approach's
+// own working directory, so the seam refuses on its own account.
+func TestFlowStarterEnsureWorktreeRefusesARecordWithNoRepository(t *testing.T) {
+	record := ensureWorktreeFlowRecord()
+	record.RepoPath = ""
+
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			t.Fatal("EnsureWorktree() must not run git without a repository path")
+			return actions.FlowWorktreeCreateResult{}, nil
+		},
+	})
+
+	if _, err := starter.EnsureWorktree(record); err == nil || err.Error() != "flow has no repository of its own" {
+		t.Fatalf("EnsureWorktree() error = %v, want a refusal naming the missing repository", err)
+	}
+}
+
+// The bootstrap failure is the one that persists before it fails, so the record
+// it returns must carry the worktree the store now holds. Callers phrase their
+// refusal from exactly this.
+func TestFlowStarterEnsureWorktreeReturnsThePersistedRecordAfterABootstrapFailure(t *testing.T) {
+	starter := model.NewFlowStarter(model.FlowStarterOptions{
+		CreateWorktree: func(string, string, string) (actions.FlowWorktreeCreateResult, error) {
+			return actions.FlowWorktreeCreateResult{WorktreePath: "/dev/alpha-worktrees/flow-one", Branch: "flow/one"}, nil
+		},
+		ResolveCommit: func(string) string { return "abc123" },
+		SetStartMetadata: func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+			return flowstore.FlowRecord{
+				FlowID:       update.FlowID,
+				WorktreePath: update.WorktreePath,
+				Branch:       update.Branch,
+				Commit:       update.Commit,
+			}, nil
+		},
+		BootstrapHookForRepo: func(string) (actions.BootstrapHook, bool) {
+			return actions.BootstrapHook{Script: ".approach/bootstrap"}, true
+		},
+		RunBootstrapHook: func(actions.BootstrapContext, actions.BootstrapHook) error {
+			return errors.New("missing env file")
+		},
+	})
+
+	got, err := starter.EnsureWorktree(ensureWorktreeFlowRecord())
+	if err == nil {
+		t.Fatal("EnsureWorktree() error = nil, want the bootstrap failure reported")
+	}
+	if got.WorktreePath != "/dev/alpha-worktrees/flow-one" || got.Branch != "flow/one" {
+		t.Fatalf("record = %#v, want the persisted worktree carried alongside the error", got)
+	}
+}

--- a/model/model.go
+++ b/model/model.go
@@ -134,6 +134,7 @@ type Model struct {
 	countClosedBeads          func(string) (int, error)
 	createFlow                func(FlowStartRequest) (FlowStartResult, error)
 	startFlowPlan             func(FlowStartRequest) (FlowStartResult, error)
+	ensureFlowWorktree        func(flowstore.FlowRecord) (flowstore.FlowRecord, error)
 	setFlowPhase              func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
 	setFlowAutoMode           func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
 	setFlowHeadless           func(flowstore.HeadlessUpdate) (flowstore.FlowRecord, error)
@@ -257,6 +258,7 @@ type Options struct {
 	CountClosedBeads         func(repoPath string) (int, error)
 	CreateFlow               func(FlowStartRequest) (FlowStartResult, error)
 	StartFlowPlan            func(FlowStartRequest) (FlowStartResult, error)
+	EnsureFlowWorktree       func(flowstore.FlowRecord) (flowstore.FlowRecord, error)
 	ReadFlow                 func(flowID string) (flowstore.FlowRecord, error)
 	SetFlowPhase             func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error)
 	SetFlowAutoMode          func(flowstore.AutoModeUpdate) (flowstore.FlowRecord, error)
@@ -636,43 +638,55 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if runBootstrapHook == nil {
 		runBootstrapHook = actions.RunBootstrapHook
 	}
+	createFlow := func(record flowstore.FlowRecord, createOpts flowstore.CreateOptions) (flowstore.FlowRecord, error) {
+		store, err := newFlowStore()
+		if err != nil {
+			return flowstore.FlowRecord{}, err
+		}
+		createOpts.Preset = opts.FlowPreset
+		return store.CreateWithOptions(record, createOpts)
+	}
+	setFlowStartMetadata := func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
+		store, err := newFlowStore()
+		if err != nil {
+			return flowstore.FlowRecord{}, err
+		}
+		return store.SetStartMetadata(update)
+	}
+	// The starter is built unconditionally because the launch path needs its
+	// EnsureWorktree even when a test injects both CreateFlow and StartFlowPlan.
+	// Nothing here is called until one of its methods is, so the cost is a few
+	// closures. A test that launches a phase on a worktree-less Flow must set
+	// Options.EnsureFlowWorktree, or replace launch persistence and get the
+	// refusing contract instead: the default runs real git and a real hook.
+	starter := NewFlowStarter(FlowStarterOptions{
+		CreateFlow:           createFlow,
+		CreateWorktree:       actions.CreateFlowWorktree,
+		SetStartMetadata:     setFlowStartMetadata,
+		SetPhase:             setFlowPhase,
+		AddPhaseLaunchID:     addFlowPhaseLaunchID,
+		ReserveLaunch:        reserveFlowLaunch,
+		BootstrapHookForRepo: bootstrapHookForRepo,
+		RunBootstrapHook:     runBootstrapHook,
+		ResolveCommit:        actions.ResolveWorktreeCommit,
+		NewLaunchID:          newLaunchID,
+		FlowPromptTemplates:  opts.FlowPromptTemplates,
+	})
 	createFlowForRepo := opts.CreateFlow
+	if createFlowForRepo == nil {
+		createFlowForRepo = starter.PrepareFlow
+	}
 	startFlowPlan := opts.StartFlowPlan
-	if createFlowForRepo == nil || startFlowPlan == nil {
-		createFlow := func(record flowstore.FlowRecord, createOpts flowstore.CreateOptions) (flowstore.FlowRecord, error) {
-			store, err := newFlowStore()
-			if err != nil {
-				return flowstore.FlowRecord{}, err
-			}
-			createOpts.Preset = opts.FlowPreset
-			return store.CreateWithOptions(record, createOpts)
-		}
-		setFlowStartMetadata := func(update flowstore.StartMetadataUpdate) (flowstore.FlowRecord, error) {
-			store, err := newFlowStore()
-			if err != nil {
-				return flowstore.FlowRecord{}, err
-			}
-			return store.SetStartMetadata(update)
-		}
-		starter := NewFlowStarter(FlowStarterOptions{
-			CreateFlow:           createFlow,
-			CreateWorktree:       actions.CreateFlowWorktree,
-			SetStartMetadata:     setFlowStartMetadata,
-			SetPhase:             setFlowPhase,
-			AddPhaseLaunchID:     addFlowPhaseLaunchID,
-			ReserveLaunch:        reserveFlowLaunch,
-			BootstrapHookForRepo: bootstrapHookForRepo,
-			RunBootstrapHook:     runBootstrapHook,
-			ResolveCommit:        actions.ResolveWorktreeCommit,
-			NewLaunchID:          newLaunchID,
-			FlowPromptTemplates:  opts.FlowPromptTemplates,
-		})
-		if createFlowForRepo == nil {
-			createFlowForRepo = starter.PrepareFlow
-		}
-		if startFlowPlan == nil {
-			startFlowPlan = starter.StartPlan
-		}
+	if startFlowPlan == nil {
+		startFlowPlan = starter.StartPlan
+	}
+	ensureFlowWorktree := opts.EnsureFlowWorktree
+	if ensureFlowWorktree == nil && !customPhaseLaunchPersistence {
+		// Same storage boundary as reserveFlowLaunch above, and for a stronger
+		// reason: the default seam runs real git and a real bootstrap hook, then
+		// writes start metadata into the default store. Left nil, the launcher's
+		// documented contract takes over and refuses worktree-less launches.
+		ensureFlowWorktree = starter.EnsureWorktree
 	}
 	finalizeAgentSession := opts.FinalizeAgentSession
 	if finalizeAgentSession == nil {
@@ -720,11 +734,12 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 			listInProgressBeads,
 			listClosedBeads,
 		},
-		showBead:         showBead,
-		countClosedBeads: countClosedBeads,
-		createFlow:       createFlowForRepo,
-		startFlowPlan:    startFlowPlan,
-		setFlowPhase:     setFlowPhase,
+		showBead:           showBead,
+		countClosedBeads:   countClosedBeads,
+		createFlow:         createFlowForRepo,
+		startFlowPlan:      startFlowPlan,
+		ensureFlowWorktree: ensureFlowWorktree,
+		setFlowPhase:       setFlowPhase,
 		launchSeams: newFlowLaunchSeams(
 			readFlow,
 			listSessions,

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -127,10 +127,14 @@ func flowWithPhaseDetails() flowstore.FlowRecord {
 	return flowstore.FlowRecord{
 		FlowID:   "flow-1",
 		RepoPath: "/dev/alpha",
-		Title:    "Flow with phases",
-		Status:   flowstore.StatusInProgress,
-		Branch:   "flow/with-phases",
-		Headless: true,
+		// An in-progress Flow has a worktree. Leaving it out would send every
+		// launch in this file through the worktree-creation step, which is its
+		// own path with its own tests.
+		WorktreePath: "/dev/alpha-worktrees/flow-with-phases",
+		Title:        "Flow with phases",
+		Status:       flowstore.StatusInProgress,
+		Branch:       "flow/with-phases",
+		Headless:     true,
 		Phases: []flowstore.FlowPhase{
 			{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
 			{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: "approved"},

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -99,6 +99,22 @@ func newTestModel(repos []scanner.Repo, opts model.Options) model.Model {
 			return record, func() {}, nil
 		}
 	}
+	if opts.EnsureFlowWorktree == nil {
+		// The production default runs real git and a real bootstrap hook, so a
+		// test model that launches a phase on a worktree-less Flow would shell
+		// out to a repository that does not exist. This stands in for the
+		// worktree the launch now creates instead of falling back to the repo.
+		opts.EnsureFlowWorktree = func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			if record.WorktreePath != "" {
+				return record, nil
+			}
+			record.WorktreePath = record.RepoPath + "-worktrees/" + record.FlowID
+			if record.Branch == "" {
+				record.Branch = "flow/" + record.FlowID
+			}
+			return record, nil
+		}
+	}
 	return model.NewWithOptions(repos, opts)
 }
 


### PR DESCRIPTION
Launching a phase (`g`) on a Flow record with no worktree ran the coding agent in the user's primary checkout, on whatever branch happened to be checked out. Worktree-less records are routine — `approach flow create` accepts an omitted `--worktree-path`, and the Beads Ready `f` shortcut produces them — so the repo-root fallback in `FlowPhaseLauncher.Preflight` silently defeated worktree isolation for a supported case (bead approach-c35).

A phase launch on a worktree-less Flow now creates the worktree first, or is refused with a message that says what happened. It never runs in the repository root.

## Implementation

- **Preflight stays pure.** It leaves `WorktreePath` empty for a worktree-less record instead of substituting the repo path. A new, explicitly side-effecting `FlowPhaseLauncher.EnsureLaunchWorktree` resolves it via `FlowStarter.EnsureWorktree`, which runs `PrepareFlow`'s own sequence with the worktree step widened (attach-or-create → resolveCommit → setStartMetadata → bootstrap hook) and returns the persisted record.
- **Ensure runs last.** Both read stages call it after every cheap refusal and after the session-occupancy check, so a launch that is about to be refused never leaves an orphan branch, and a phase a live session already owns never costs a `git worktree add`.
- **Recorded branches are honored.** A record that already names a branch keeps it; `actions.AttachFlowWorktree` gives that branch a worktree of its own rather than stranding it behind a second `flow/<slug>`, since prompts render the recorded branch as the push target and `flow pr set --head` validates against it. Tags, remote-tracking refs, and raw commits are refused (they would detach HEAD under a record that goes on naming a branch). Only `actions.ErrFlowBranchMissing` falls through to `CreateFlowWorktree`.
- **Adoption is fenced.** A branch that already has a linked worktree is adopted (git will not check one out twice, and refusing would leave the Flow permanently unlaunchable), but the repository's own working tree is never adopted, and `linkedWorktreeForBranch` now reads each `git worktree list --porcelain` record to its end so a `prunable` registration left by a deleted directory is dropped — the user gets git's own prune message instead of a persisted path that is not there.
- **Ensure holds the launch reservation** across creation and the metadata write, and re-reads the authoritative record that reservation answers with, so two Approach processes reading the same worktree-less Flow cannot each allocate a branch/directory pair and race the write. The loser adopts the recorded worktree.
- **Contended reservations retry rather than block.** The reservation is held across the bootstrap hook (120s default budget) while the flow store's lock timeout is 5s, so a second instance auto-advancing the same Flow would time out reliably — and the read stage classified every ensure refusal as permanent, blocking the ready phase for good. Reservation failure now carries its own sentinel: it is the one refusal taken before anything is created, so repeating it costs no orphan worktree. AutoMode re-arms and picks the Flow up once the winner finishes; the manual route says another launch is setting the worktree up. A Flow closed mid-read classifies stale instead.
- **Refusal, never fallback**, when the record has no repository of its own, no ensure seam is wired, or the recorded branch cannot be given a worktree. `Prepare` refuses an empty worktree path outright, so a caller that forgets to ensure cannot hand `actions.LaunchAgent` an empty `cmd.Dir`. AutoMode classifies the new `flowLaunchOutcomeBlocked` and blocks the phase from the handler, behind the attempt fence, instead of retrying at 1 Hz forever.
- **Two refusals happen after `git worktree add` has run** and get their own headlines rather than the creation-failed one that would be untrue: a store that will not record the new worktree (`model.ErrFlowWorktreeUnrecorded`, whose message names the path left behind), and a bootstrap-hook failure, which comes after start metadata is persisted and so carries the ensured record forward.
- **The setup is announced** on all three launch routes — embedded, external, and tmux — composed with the existing tmux fallback note rather than racing it for the status slot. The external route goes through `runAgentLaunchWithStatus` so a bare note cannot delete the detached route's own confirmation.
- `ensureFlowWorktree` defaults only when launch persistence has not been replaced, matching `reserveFlowLaunch`: a caller that owns its storage boundary gets the launcher's refusing contract, not a seam that runs real git and a real hook against the default store.

## Docs

`README.md`, `docs/tui-guide.md`, `docs/beads-view-spec.md`, and the `approach-flow-create` skill record the new behavior, including which refusals leave something behind and which branches are refused outright. A note records the pre-existing invariant that a recorded worktree path does not imply a finished bootstrap (tracked as approach-6ia).

## Verification

`gofmt -l .` clean, `make test` and `make build` pass. New coverage: `model/flow_start_ensure_worktree_test.go`, `model/flow_phase_launch_worktree_test.go`, `model/flow_launch_worktree_internal_test.go`, plus `actions/actions_test.go` cases for branch attach, tag/remote-ref refusal, and prunable-registration rejection.

## Follow-ups

approach-dfo covers a recorded worktree path whose directory no longer exists — a different failure, out of scope here.
