### PR TITLE
Finish the SetPlanLink planstore seam

### DIFF
--- a/flowstore/backend_seam_internal_test.go
+++ b/flowstore/backend_seam_internal_test.go
@@ -14,11 +14,25 @@ import (
 )
 
 var (
-	_ backend         = (*sqliteBackend)(nil)
-	_ flowSession     = sqliteSession{}
-	_ planPhaseSyncer = planstoreSyncer{}
-	_ planPhaseWriter = planstorePhaseWriter{}
+	_ backend          = (*sqliteBackend)(nil)
+	_ flowSession      = sqliteSession{}
+	_ planLinkResolver = planstoreSyncer{}
+	_ planPhaseSyncer  = planstoreSyncer{}
+	_ planPhaseWriter  = planstorePhaseWriter{}
 )
+
+type fakePlanLinkResolver struct {
+	path  string
+	err   error
+	calls [][2]string
+}
+
+func (f *fakePlanLinkResolver) resolvePlanLink(planID, suppliedPath string) (string, error) {
+	f.calls = append(f.calls, [2]string{planID, suppliedPath})
+	return f.path, f.err
+}
+
+var _ planLinkResolver = (*fakePlanLinkResolver)(nil)
 
 // fakePlanSyncer replaces the planstore collaborator so the sync boundary can
 // be driven without a real plan artifact.
@@ -27,6 +41,190 @@ type fakePlanSyncer struct {
 	writeErr error
 	opens    int
 	calls    []string
+}
+
+func TestSetPlanLinkUsesInjectedResolverWithoutPlanArtifact(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewStore(StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	resolver := &fakePlanLinkResolver{path: filepath.Join(root, "plans", "seam-plan", "plan.md")}
+	store.planLink = resolver
+	record, err := store.Create(FlowRecord{
+		Title:        "Plan link seam",
+		Instructions: "Resolve a plan through the injected collaborator.",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	got, err := store.SetPlanLink(PlanLinkUpdate{
+		FlowID:   record.FlowID,
+		PlanID:   " seam-plan ",
+		PlanPath: " supplied plan path ",
+	})
+	if err != nil {
+		t.Fatalf("SetPlanLink() error = %v", err)
+	}
+	if got.PlanID != "seam-plan" || got.PlanPath != resolver.path {
+		t.Fatalf("linked plan = (%q, %q), want seam-plan and %q", got.PlanID, got.PlanPath, resolver.path)
+	}
+	if want := [][2]string{{"seam-plan", " supplied plan path "}}; !reflect.DeepEqual(resolver.calls, want) {
+		t.Fatalf("resolver calls = %#v, want %#v", resolver.calls, want)
+	}
+	persisted, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !reflect.DeepEqual(persisted, got) {
+		t.Fatalf("persisted record = %#v, want %#v", persisted, got)
+	}
+}
+
+func TestSetPlanLinkValidatesFlowAndPlanIDsBeforeResolver(t *testing.T) {
+	store, err := NewStore(StoreOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	resolver := &fakePlanLinkResolver{path: "/unused/plan.md"}
+	store.planLink = resolver
+
+	for _, tc := range []struct {
+		name   string
+		update PlanLinkUpdate
+		want   string
+	}{
+		{
+			name:   "invalid flow id",
+			update: PlanLinkUpdate{FlowID: "../bad", PlanID: "plan-1"},
+			want:   `invalid flow id "../bad"`,
+		},
+		{
+			name:   "blank plan id",
+			update: PlanLinkUpdate{FlowID: "missing-flow", PlanID: " \t\n "},
+			want:   "plan id is required",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := store.SetPlanLink(tc.update)
+			if err == nil || err.Error() != tc.want {
+				t.Fatalf("SetPlanLink() error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+	if len(resolver.calls) != 0 {
+		t.Fatalf("resolver calls = %#v, want none for pre-resolver validation failures", resolver.calls)
+	}
+}
+
+func TestSetPlanLinkReturnsResolverFailureWithoutMutatingFlow(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewStore(StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	record, err := store.Create(FlowRecord{
+		Title:        "Resolver failure",
+		Instructions: "Keep the complete Flow record unchanged.",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	wantErr := errors.New("plan resolver exploded")
+	resolver := &fakePlanLinkResolver{err: wantErr}
+	store.planLink = resolver
+
+	got, err := store.SetPlanLink(PlanLinkUpdate{FlowID: record.FlowID, PlanID: "plan-1"})
+	if err != wantErr {
+		t.Fatalf("SetPlanLink() error = %v, want exact resolver error %v", err, wantErr)
+	}
+	if !reflect.DeepEqual(got, FlowRecord{}) {
+		t.Fatalf("SetPlanLink() record = %#v, want zero record beside resolver error", got)
+	}
+	persisted, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !reflect.DeepEqual(persisted, record) {
+		t.Fatalf("record changed after resolver failure:\n got: %#v\nwant: %#v", persisted, record)
+	}
+}
+
+func TestSetPlanLinkResolvesBeforeReportingMissingFlow(t *testing.T) {
+	store, err := NewStore(StoreOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	resolver := &fakePlanLinkResolver{path: "/configured/plans/plan-1/plan.md"}
+	store.planLink = resolver
+
+	_, err = store.SetPlanLink(PlanLinkUpdate{FlowID: "missing-flow", PlanID: "plan-1"})
+	if !errors.Is(err, ErrFlowNotFound) {
+		t.Fatalf("SetPlanLink() error = %v, want ErrFlowNotFound", err)
+	}
+	if want := [][2]string{{"plan-1", ""}}; !reflect.DeepEqual(resolver.calls, want) {
+		t.Fatalf("resolver calls = %#v, want %#v before the missing-Flow result", resolver.calls, want)
+	}
+}
+
+func TestSetPlanLinkRevalidatesIdenticalLinkWithoutTimestampChurn(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 8, 13, 20, 0, 0, 0, time.UTC)
+	store, err := NewStore(StoreOptions{Root: root, Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	resolver := &fakePlanLinkResolver{path: filepath.Join(root, "plans", "plan-1", "plan.md")}
+	store.planLink = resolver
+	record, err := store.Create(FlowRecord{
+		Title:        "Repeat plan link",
+		Instructions: "Revalidate every attempt.",
+		RepoPath:     filepath.Join(root, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	now = now.Add(time.Minute)
+	linked, err := store.SetPlanLink(PlanLinkUpdate{FlowID: record.FlowID, PlanID: "plan-1"})
+	if err != nil {
+		t.Fatalf("first SetPlanLink() error = %v", err)
+	}
+
+	wantErr := errors.New("linked artifact disappeared")
+	resolver.err = wantErr
+	now = now.Add(time.Minute)
+	if _, err := store.SetPlanLink(PlanLinkUpdate{FlowID: record.FlowID, PlanID: "plan-1"}); err != wantErr {
+		t.Fatalf("failed relink error = %v, want exact resolver error %v", err, wantErr)
+	}
+	afterFailure, err := store.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() after failed relink error = %v", err)
+	}
+	if !reflect.DeepEqual(afterFailure, linked) {
+		t.Fatalf("record changed after failed relink:\n got: %#v\nwant: %#v", afterFailure, linked)
+	}
+
+	resolver.err = nil
+	now = now.Add(time.Minute)
+	relinked, err := store.SetPlanLink(PlanLinkUpdate{FlowID: record.FlowID, PlanID: "plan-1"})
+	if err != nil {
+		t.Fatalf("successful relink error = %v", err)
+	}
+	if !reflect.DeepEqual(relinked, linked) {
+		t.Fatalf("idempotent relink changed record:\n got: %#v\nwant: %#v", relinked, linked)
+	}
+	if len(resolver.calls) != 3 {
+		t.Fatalf("resolver calls = %#v, want one call for every link attempt", resolver.calls)
+	}
+}
+
+func TestStoreDoesNotRetainConfiguredRoot(t *testing.T) {
+	if _, ok := reflect.TypeOf(Store{}).FieldByName("root"); ok {
+		t.Fatal("Store still contains obsolete configured root field")
+	}
 }
 
 func (f *fakePlanSyncer) open() (planPhaseWriter, error) {

--- a/flowstore/plan_link_resolver_internal_test.go
+++ b/flowstore/plan_link_resolver_internal_test.go
@@ -1,0 +1,182 @@
+package flowstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/approachcontrol/approach/planstore"
+)
+
+func TestPlanstoreSyncerResolvePlanLinkCollapsesInvalidMetadataToNotFound(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		metadata []byte
+	}{
+		{name: "missing metadata"},
+		{name: "malformed metadata", metadata: []byte("{")},
+		{name: "mismatched metadata id", metadata: []byte(`{"plan_id":"some-other-plan"}`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if tc.metadata != nil {
+				writePlanLinkMetadataFixture(t, root, "plan-1", tc.metadata)
+			}
+
+			_, err := (planstoreSyncer{root: root, lockTimeout: time.Second}).resolvePlanLink("plan-1", "")
+			if err == nil || err.Error() != `plan "plan-1" not found` {
+				t.Fatalf("resolvePlanLink() error = %v, want exact not-found error", err)
+			}
+		})
+	}
+}
+
+func TestPlanstoreSyncerResolvePlanLinkValidatesBeforeOpeningStore(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "not-created")
+	resolver := planstoreSyncer{root: root, lockTimeout: time.Second}
+	for _, tc := range []struct {
+		name         string
+		planID       string
+		suppliedPath string
+		want         string
+	}{
+		{
+			name:         "plan id before supplied path",
+			planID:       "../bad",
+			suppliedPath: "relative/plan.md",
+			want:         `invalid plan id "../bad"`,
+		},
+		{
+			name:         "relative supplied path",
+			planID:       "plan-1",
+			suppliedPath: "relative/plan.md",
+			want:         "flow plan path must be absolute: relative/plan.md",
+		},
+		{
+			name:         "mismatched supplied path",
+			planID:       "plan-1",
+			suppliedPath: filepath.Join(t.TempDir(), "plans", "plan-1", "plan.md"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolver.resolvePlanLink(tc.planID, tc.suppliedPath)
+			want := tc.want
+			if want == "" {
+				want = fmt.Sprintf("flow plan path %q does not match plan %q path %q", filepath.Clean(tc.suppliedPath), tc.planID, filepath.Join(root, "plans", tc.planID, "plan.md"))
+			}
+			if err == nil || err.Error() != want {
+				t.Fatalf("resolvePlanLink() error = %v, want %q", err, want)
+			}
+			if _, err := os.Stat(root); !os.IsNotExist(err) {
+				t.Fatalf("resolver opened plan store before validation; root stat error = %v", err)
+			}
+		})
+	}
+}
+
+func TestPlanstoreSyncerResolvePlanLinkReportsMissingMarkdownBody(t *testing.T) {
+	root := t.TempDir()
+	metadata, err := json.Marshal(planstore.PlanRecord{
+		SchemaVersion: 1,
+		PlanID:        "plan-1",
+		Title:         "Missing Markdown",
+		Status:        "approved",
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	writePlanLinkMetadataFixture(t, root, "plan-1", metadata)
+
+	_, err = (planstoreSyncer{root: root, lockTimeout: time.Second}).resolvePlanLink("plan-1", "")
+	if err == nil || !strings.Contains(err.Error(), "read plan:") || !strings.Contains(err.Error(), filepath.Join("plans", "plan-1", "plan.md")) {
+		t.Fatalf("resolvePlanLink() error = %v, want wrapped missing plan.md read error", err)
+	}
+}
+
+func TestPlanstoreSyncerResolvePlanLinkPreservesConfiguredSymlinkRoot(t *testing.T) {
+	parent := t.TempDir()
+	realRoot := filepath.Join(parent, "real-root")
+	configuredRoot := filepath.Join(parent, "configured-root")
+	if err := os.Mkdir(realRoot, 0o700); err != nil {
+		t.Fatalf("Mkdir(real root) error = %v", err)
+	}
+	if err := os.Symlink(realRoot, configuredRoot); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+
+	flowStore, err := NewStore(StoreOptions{Root: configuredRoot})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = flowStore.Close() })
+	planStore, err := planstore.NewStore(planstore.StoreOptions{Root: configuredRoot})
+	if err != nil {
+		t.Fatalf("planstore.NewStore() error = %v", err)
+	}
+	if _, err := planStore.Save(planstore.PlanRecord{
+		PlanID:   "plan-1",
+		Title:    "Symlink-root plan",
+		Markdown: "Keep the configured-root spelling.",
+		Status:   "approved",
+	}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	record, err := flowStore.Create(FlowRecord{
+		Title:        "Symlink-root Flow",
+		Instructions: "Persist the configured plan path.",
+		RepoPath:     filepath.Join(parent, "repo"),
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	configuredPlanPath := filepath.Join(configuredRoot, "plans", "plan-1", "plan.md")
+	linked, err := flowStore.SetPlanLink(PlanLinkUpdate{
+		FlowID:   record.FlowID,
+		PlanID:   "plan-1",
+		PlanPath: configuredPlanPath,
+	})
+	if err != nil {
+		t.Fatalf("SetPlanLink(configured path) error = %v", err)
+	}
+	if linked.PlanPath != configuredPlanPath {
+		t.Fatalf("PlanPath = %q, want configured-root path %q", linked.PlanPath, configuredPlanPath)
+	}
+
+	canonicalPlanPath := filepath.Join(realRoot, "plans", "plan-1", "plan.md")
+	got, err := flowStore.SetPlanLink(PlanLinkUpdate{
+		FlowID:   record.FlowID,
+		PlanID:   "plan-1",
+		PlanPath: canonicalPlanPath,
+	})
+	wantErr := fmt.Sprintf("flow plan path %q does not match plan %q path %q", canonicalPlanPath, "plan-1", configuredPlanPath)
+	if err == nil || err.Error() != wantErr {
+		t.Fatalf("SetPlanLink(canonical path) error = %v, want %q", err, wantErr)
+	}
+	if !reflect.DeepEqual(got, FlowRecord{}) {
+		t.Fatalf("SetPlanLink(canonical path) record = %#v, want zero record", got)
+	}
+	persisted, err := flowStore.Read(record.FlowID)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if !reflect.DeepEqual(persisted, linked) {
+		t.Fatalf("mismatched path changed record:\n got: %#v\nwant: %#v", persisted, linked)
+	}
+}
+
+func writePlanLinkMetadataFixture(t *testing.T, root, planID string, metadata []byte) {
+	t.Helper()
+	dir := filepath.Join(root, "plans", planID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(%q) error = %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), metadata, 0o600); err != nil {
+		t.Fatalf("WriteFile(meta.json) error = %v", err)
+	}
+}

--- a/flowstore/plan_sync.go
+++ b/flowstore/plan_sync.go
@@ -1,10 +1,19 @@
 package flowstore
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/approachcontrol/approach/planstore"
 )
+
+// planLinkResolver validates a saved plan and returns the configured-root path
+// that a Flow should persist for it.
+type planLinkResolver interface {
+	resolvePlanLink(planID, suppliedPath string) (string, error)
+}
 
 // planPhaseSyncer opens a writer for the plan store that mirrors completed Flow
 // phases into their linked plan. It is a two-phase interface on purpose: the
@@ -40,6 +49,35 @@ type planPhaseWriter interface {
 type planstoreSyncer struct {
 	root        string
 	lockTimeout time.Duration
+}
+
+func (s planstoreSyncer) resolvePlanLink(planID, suppliedPath string) (string, error) {
+	planPath, err := planstore.MarkdownPath(s.root, planID)
+	if err != nil {
+		return "", err
+	}
+	if supplied := strings.TrimSpace(suppliedPath); supplied != "" {
+		if !filepath.IsAbs(supplied) {
+			return "", fmt.Errorf("flow plan path must be absolute: %s", supplied)
+		}
+		if filepath.Clean(supplied) != planPath {
+			return "", fmt.Errorf("flow plan path %q does not match plan %q path %q", filepath.Clean(supplied), planID, planPath)
+		}
+	}
+	store, err := planstore.NewStore(planstore.StoreOptions{
+		Root:        s.root,
+		LockTimeout: s.lockTimeout,
+	})
+	if err != nil {
+		return "", err
+	}
+	if !store.HasPlan(planID) {
+		return "", fmt.Errorf("plan %q not found", planID)
+	}
+	if _, err := store.ReadPlan(planID); err != nil {
+		return "", err
+	}
+	return planPath, nil
 }
 
 func (s planstoreSyncer) open() (planPhaseWriter, error) {

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/internal/artifacts"
-	"github.com/approachcontrol/approach/planstore"
 )
 
 const schemaVersion = 1
@@ -96,28 +95,14 @@ const (
 // Store reads and writes Flow rows in the artifact root's approach.db.
 type Store struct {
 	backend  backend
+	planLink planLinkResolver
 	planSync planPhaseSyncer
 	// canonicalRoot and lockTimeout back the short cross-process repair-launch
 	// reservation shared with CloseFlow. The advisory lock orders the final
 	// closed-state read and terminal start without persisting transient launch
 	// metadata that a crash could strand.
-	canonicalRoot string
-	lockTimeout   time.Duration
-	// root outlives the storage seam because the plan side is only half behind
-	// it: SetPhase syncs through planSync (which captures root itself), but
-	// SetPlanLink still resolves plan paths and constructs a planstore.Store
-	// inline. Finishing that extraction is follow-up work, not part of the
-	// storage seam.
-	//
-	// This is the CONFIGURED root, deliberately not the symlink-resolved one the
-	// SQLite bootstrap canonicalizes for the database, lease, and reserved child
-	// paths. Plan paths are user-facing strings: SetPlanLink derives one from
-	// this root and requires an exact match against any --plan-path the caller
-	// supplies, and it persists that string in the record. Resolving here would
-	// reject the paths launchers build from the configured root, and rewrite
-	// every stored plan_path, on any root with a symlink component — which the
-	// file backend accepted and this cutover keeps accepting.
-	root                      string
+	canonicalRoot             string
+	lockTimeout               time.Duration
 	now                       func() time.Time
 	beforeLinkedPlanPhaseSync func(planID, phaseID string)
 }
@@ -541,10 +526,11 @@ func NewStore(opts StoreOptions) (*Store, error) {
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
 	}
+	planAdapter := planstoreSyncer{root: root, lockTimeout: lockTimeout}
 	return &Store{
 		backend:       store,
-		planSync:      planstoreSyncer{root: root, lockTimeout: lockTimeout},
-		root:          root,
+		planLink:      planAdapter,
+		planSync:      planAdapter,
 		canonicalRoot: store.root,
 		lockTimeout:   lockTimeout,
 		now:           now,
@@ -1216,26 +1202,8 @@ func (s *Store) SetPlanLink(update PlanLinkUpdate) (FlowRecord, error) {
 	if planID == "" {
 		return FlowRecord{}, fmt.Errorf("plan id is required")
 	}
-	planPath, err := planstore.MarkdownPath(s.root, planID)
+	planPath, err := s.planLink.resolvePlanLink(planID, update.PlanPath)
 	if err != nil {
-		return FlowRecord{}, err
-	}
-	if supplied := strings.TrimSpace(update.PlanPath); supplied != "" {
-		if !filepath.IsAbs(supplied) {
-			return FlowRecord{}, fmt.Errorf("flow plan path must be absolute: %s", supplied)
-		}
-		if filepath.Clean(supplied) != planPath {
-			return FlowRecord{}, fmt.Errorf("flow plan path %q does not match plan %q path %q", filepath.Clean(supplied), planID, planPath)
-		}
-	}
-	planStore, err := planstore.NewStore(planstore.StoreOptions{Root: s.root})
-	if err != nil {
-		return FlowRecord{}, err
-	}
-	if !planStore.HasPlan(planID) {
-		return FlowRecord{}, fmt.Errorf("plan %q not found", planID)
-	}
-	if _, err := planStore.ReadPlan(planID); err != nil {
 		return FlowRecord{}, err
 	}
 	return s.updateFlowMetadataOnly(update.FlowID, func(record FlowRecord, now time.Time) (FlowRecord, error) {


### PR DESCRIPTION
## Summary

- inject plan lookup and path resolution into `flowstore.Store` instead of constructing a `planstore.Store` inside `SetPlanLink`
- preserve configured-root path semantics, validation ordering, persistence behavior, and idempotent revalidation through the collaborator seam
- remove the redundant `Store.root` field and add focused double-driven and boundary coverage for resolver failures and path edge cases

## Verification

- `make fmt-check`
- `make test`
- `make build`