### PR TITLE
Document Tailscale Funnel as the recommended Vercel tunnel

### DIFF
--- a/docs/graphql-api.md
+++ b/docs/graphql-api.md
@@ -518,7 +518,8 @@ A browser should not hold the token. The recommended shape is a **server-side
 route or proxy** in the consuming app that holds the token and reaches Approach
 over a tunnel. That works today with no CORS configuration, and the conditional
 `Host` rule above deliberately keeps it working — a tunnel sends
-`Host: <name>.trycloudflare.com`, which the allowlist would otherwise reject.
+`Host: <name>.trycloudflare.com` or `Host: <machine>.<tailnet>.ts.net`, which
+the allowlist would otherwise reject.
 
 `web/` is that consumer: a Next.js app, deployed on Vercel, whose GraphQL calls
 all run in React Server Components so the endpoint and token stay server-side.
@@ -526,3 +527,25 @@ It reaches this API over a tunnel and renders repositories, Flows, and phases.
 Setup, tunnel, and deploy steps are `web/README.md`.
 
 Direct browser access (CORS plus a remote bind) is a follow-up.
+
+### Tunnels and the token
+
+Any tunnel — Cloudflare, Tailscale Funnel, an nginx/Caddy reverse proxy —
+leaves the bind on `127.0.0.1` and reaches the network on the server's behalf.
+So the bind classification never demands a token, and it is easy to conclude
+none is needed. **Configure one anyway**: without it the handler enforces the
+`Host` allowlist, and the tunnel's `Host` is not `localhost` or a loopback IP
+literal, so every request 403s. The token is what turns that check off, and it
+is also the only access control on a URL that is now publicly reachable.
+
+Tailscale Funnel is the recommended shape for `web/`, and it differs from the
+others in one way that matters to this server's threat model. Funnel relays TLS
+with SNI passthrough to a certificate issued for the node, so TLS terminates on
+the machine running `approach serve`. A Cloudflare tunnel or a hosted proxy
+terminates TLS on someone else's hardware, which — given this server speaks
+plaintext with no TLS of its own — puts the bearer token and every Flow record
+in the clear there.
+
+Funnel is still *public* ingress: tailnet ACLs do not apply to it, unlike
+`tailscale serve`. Anyone with the `ts.net` hostname reaches `/graphql` gated
+only by the token, and `/healthz` gated by nothing.

--- a/web/README.md
+++ b/web/README.md
@@ -72,14 +72,18 @@ fetching the loopback API on their behalf. That would undo the exact protection
 else.
 
 To reach the dev server from another device, do not drop the flag, and do not
-reuse the `cloudflared` recipe from the section below: those are *public*
-tunnels. That is fine for the API, which checks a bearer token on every request,
-and not fine for this app, which checks nothing — the tunnel would simply publish
-your Flow state at a URL. Forward the port over a channel that authenticates:
+reuse the `cloudflared` or `tailscale funnel` recipes from the section below:
+those are *public* tunnels. That is fine for the API, which checks a bearer
+token on every request, and not fine for this app, which checks nothing — the
+tunnel would simply publish your Flow state at a URL. Use a channel that
+authenticates:
 
 ```bash
 # From the other device. The viewer stays bound to loopback on the host.
 ssh -N -L 3000:127.0.0.1:3000 you@host
+
+# Or, on the host: tailnet-only, gated by your ACLs. Note `serve`, not `funnel`.
+tailscale serve --bg 3000
 ```
 
 An authenticating proxy in front of the tunnel (Cloudflare Access, say) works
@@ -108,8 +112,71 @@ TLS-terminating tunnel in front of it and point `APPROACH_GRAPHQL_URL` at the
 tunnel. Do **not** simply bind `0.0.0.0` and forward a port: that puts the
 token and every Flow record on the wire in the clear.
 
-Set a token whenever the server is reachable off-loopback — `approach serve`
-requires one for any non-loopback bind.
+**Set a token for any tunnel, even though the bind stays loopback.** The
+familiar rule — `approach serve` refuses a non-loopback bind without one — is
+not what forces it here, because the server keeps listening on `127.0.0.1` and
+the tunnel is what reaches the network. The rule that bites is the other one:
+with no token configured the handler falls back to a `Host` allowlist, and a
+tunnel arrives with `Host: <tunnel-host>`, so every request 403s. Configure a
+token and the `Host` check is skipped by design
+(`docs/graphql-api.md`, "Auth posture").
+
+### Tailscale Funnel (recommended)
+
+Funnel publishes one port of a tailnet node at a stable
+`https://<machine>.<tailnet>.ts.net` URL. Vercel itself cannot join a tailnet —
+functions are ephemeral sandboxes with no persistent daemon and no way to hold
+node state across cold starts — so the connection has to be public ingress from
+your machine outward, which is what Funnel is. (`tailscale serve`, the
+tailnet-only sibling, does not help for the same reason.)
+
+Two one-time setup steps in the admin console, or Funnel refuses to start:
+enable **HTTPS Certificates** under DNS, and grant the node the `funnel`
+attribute in the ACL policy.
+
+```json
+"nodeAttrs": [
+  { "target": ["autogroup:member"], "attr": ["funnel"] }
+]
+```
+
+Then:
+
+```bash
+export APPROACH_API_TOKEN="$(openssl rand -hex 32)"
+approach serve --state-root ~/.local/state/approach/sessions/v1
+
+tailscale funnel --bg 8787     # https://<machine>.<tailnet>.ts.net → 127.0.0.1:8787
+tailscale funnel status
+```
+
+`APPROACH_GRAPHQL_URL` becomes
+`https://<machine>.<tailnet>.ts.net/graphql`.
+
+Why this over the cloudflared recipe below:
+
+- **The hostname is stable**, so it survives restarts. A quick tunnel's URL
+  changes every run, and each change means editing the Vercel env var and
+  redeploying.
+- **Tailscale cannot read the traffic.** Funnel relays TLS with SNI passthrough
+  and the certificate is issued to your node, so TLS terminates on the machine
+  running `approach serve`. A cloudflared tunnel terminates TLS at Cloudflare,
+  which puts the bearer token and every Flow record in the clear on their side.
+  With no TLS in `approach serve` itself, that difference is the whole
+  transport story.
+
+Two constraints:
+
+- **Funnel is public. Tailnet ACLs do not apply to it** — that is precisely
+  what separates it from `tailscale serve`. Anyone who knows the hostname
+  reaches `/graphql`, gated only by the token, and `/healthz`, gated by
+  nothing. Treat the token as the sole control, exactly as with a public
+  tunnel.
+- Funnel ingress is limited to ports 443, 8443, and 10000; the local port it
+  proxies to is unrestricted. And the node has to be awake — a sleeping laptop
+  is a 502.
+
+### Cloudflare tunnel
 
 ```bash
 export APPROACH_API_TOKEN="$(openssl rand -hex 32)"
@@ -118,9 +185,9 @@ approach serve --state-root ~/.local/state/approach/sessions/v1
 # Quick tunnel — ephemeral URL, fine for a demo.
 cloudflared tunnel --url http://127.0.0.1:8787
 
-# Named tunnel — stable hostname, recommended, because a quick tunnel's URL
-# changes every run and each change means editing the Vercel env var and
-# redeploying.
+# Named tunnel — prefer this over the quick tunnel above, because a quick
+# tunnel's URL changes every run and each change means editing the Vercel env
+# var and redeploying.
 cloudflared tunnel create approach
 cloudflared tunnel route dns approach approach.example.com
 cloudflared tunnel run --url http://127.0.0.1:8787 approach
@@ -129,6 +196,8 @@ cloudflared tunnel run --url http://127.0.0.1:8787 approach
 Self-hosting `approach serve` behind a reverse proxy (nginx/Caddy with a real
 certificate) works the same way: the app only needs a reachable HTTPS URL that
 proxies to the server, and the token.
+
+### Verify it
 
 Verify the tunnel independently of the app before blaming the app:
 


### PR DESCRIPTION
Adds a Tailscale Funnel path alongside the existing `cloudflared` recipe for reaching a machine-local `approach serve` from the Vercel-deployed viewer in `web/`, and recommends it. Documentation only — no Go or TypeScript changes.

## Why Funnel

- **The hostname is stable.** A cloudflared quick tunnel's URL changes every run, and each change means editing `APPROACH_GRAPHQL_URL` in Vercel and redeploying.
- **TLS terminates on your own machine.** Funnel relays TLS with SNI passthrough to a certificate issued for the node. A cloudflared tunnel or hosted proxy terminates TLS on someone else's hardware, which — given `approach serve` speaks plaintext with no TLS of its own — puts the bearer token and every Flow record in the clear there. For this server that difference is the whole transport story.

Vercel cannot join a tailnet: functions are ephemeral sandboxes holding no node state across cold starts. So the connection has to be public ingress from the serving machine outward, which is what Funnel is and what `tailscale serve` is not. The docs say this explicitly, because "put the function on the tailnet" is the first thing a reader will reach for.

## Corrected token guidance

The previous text justified the token by the non-loopback bind rule. That rule never fires behind a tunnel — the bind stays on `127.0.0.1` and the tunnel reaches the network on the server's behalf. The rule that actually bites is the `Host` allowlist, which 403s a tunnel's `Host` header whenever no token is configured. Same conclusion, reachable reasoning, and it now sits above both tunnel recipes rather than inside one.

## Also documented

- The two prerequisites that otherwise fail at `tailscale funnel` time: HTTPS certificates enabled for the tailnet, and the `funnel` node attribute in the ACL policy (with the `nodeAttrs` snippet).
- Funnel's 443/8443/10000 ingress restriction, and that a sleeping node is a 502.
- **Funnel is public — tailnet ACLs do not apply to it**, unlike `tailscale serve`. The token stays the only control on `/graphql`, and `/healthz` stays ungated.
- `tailscale funnel` now appears beside `cloudflared` in the local-dev warning against exposing the unauthenticated viewer through a public tunnel, with `tailscale serve --bg 3000` added to the authenticating alternatives next to the existing ssh port-forward.
- `docs/graphql-api.md` gains a "Tunnels and the token" subsection, and its `Host` example now shows the `ts.net` form alongside `trycloudflare.com`.

## Verification

Docs only; no code touched, so `make build`, `make test`, and `npm run build` are unaffected and were not run. The Funnel prerequisites, port restriction, and public-ingress semantics are documented behavior, not something this change can exercise in CI.

## Follow-up

Filed `approach-f5s` for the related gap this change does not close: the viewer has no authentication of its own, so protecting a deployed instance still depends on Vercel Deployment Protection — and on Hobby, Standard Protection covers every URL except the production domain. The issue records both candidate shapes (a shared passphrase exchanged for a signed session cookie, or GitHub OAuth with a login allowlist).