### PR TITLE
Gracefully list healthy Flows when rows are corrupt

### DIFF
--- a/cmd/approach/flow.go
+++ b/cmd/approach/flow.go
@@ -280,13 +280,22 @@ func runFlowList(args []string, deps runDeps) error {
 	}
 	defer func() { _ = store.Close() }()
 	records, err := store.List(flowstore.FlowFilter{RepoPath: *repoPath})
-	if err != nil {
+	_, partial := flowstore.AsPartialList(err)
+	if err != nil && !partial {
 		return err
 	}
 	if records == nil {
 		records = []flowstore.FlowRecord{}
 	}
-	return writeFlowJSON(deps.stdout, records)
+	if err := writeFlowJSON(deps.stdout, records); err != nil {
+		return err
+	}
+	if partial {
+		if _, writeErr := fmt.Fprintln(deps.stderr, err); writeErr != nil {
+			return fmt.Errorf("write partial flow list diagnostic: %w", writeErr)
+		}
+	}
+	return nil
 }
 
 func printFlowListHelp(w io.Writer) {
@@ -1408,6 +1417,8 @@ func writeFlowJSON(w io.Writer, value any) error {
 	if err != nil {
 		return fmt.Errorf("encode flow JSON: %w", err)
 	}
-	fmt.Fprintln(w, string(data))
+	if _, err := fmt.Fprintln(w, string(data)); err != nil {
+		return fmt.Errorf("write flow JSON: %w", err)
+	}
 	return nil
 }

--- a/cmd/approach/flow_test.go
+++ b/cmd/approach/flow_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -472,6 +473,88 @@ func TestRunFlowListJSONFiltersByRepo(t *testing.T) {
 	}
 }
 
+func TestRunFlowListJSONReportsPartialResultAndSucceeds(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	healthy := mustRunFlow(t, []string{"approach", "flow", "create", "--title", "Healthy", "--instructions", "healthy", "--repo-path", repoPath, "--json", "--state-root", root})
+	malformed := mustRunFlow(t, []string{"approach", "flow", "create", "--title", "Malformed", "--instructions", "bad", "--repo-path", repoPath, "--json", "--state-root", root})
+	future := mustRunFlow(t, []string{"approach", "flow", "create", "--title", "Future", "--instructions", "future", "--repo-path", repoPath, "--json", "--state-root", root})
+
+	db, err := sql.Open("sqlite", filepath.Join(root, "approach.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("UPDATE flows SET record = ? WHERE flow_id = ?", []byte("{"), malformed.FlowID); err != nil {
+		t.Fatal(err)
+	}
+	futureJSON := fmt.Sprintf(`{"schema_version":99,"flow_id":%q}`, future.FlowID)
+	if _, err := db.Exec("UPDATE flows SET record = ? WHERE flow_id = ?", []byte(futureJSON), future.FlowID); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = run([]string{"approach", "flow", "list", "--repo-path", repoPath, "--json", "--state-root", root},
+		noScanDeps(t, runDeps{stdout: &stdout, stderr: &stderr}))
+	if err != nil {
+		t.Fatalf("run returned partial-list error: %v", err)
+	}
+	var records []flowstore.FlowRecord
+	if err := json.Unmarshal(stdout.Bytes(), &records); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(records) != 1 || records[0].FlowID != healthy.FlowID {
+		t.Fatalf("stdout records = %#v, want only healthy Flow %q", records, healthy.FlowID)
+	}
+	wantStderr := fmt.Sprintf("skipped 2 unreadable Flows: %s: flow %q has unsupported schema version 99; %s: decode flow %q record: unexpected end of JSON input\n",
+		future.FlowID, future.FlowID, malformed.FlowID, malformed.FlowID)
+	if stderr.String() != wantStderr {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), wantStderr)
+	}
+}
+
+func TestRunFlowListFatalFailureEmitsNoJSON(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	mustRunFlow(t, []string{"approach", "flow", "create", "--title", "Healthy", "--instructions", "healthy", "--repo-path", repoPath, "--json", "--state-root", root})
+
+	db, err := sql.Open("sqlite", filepath.Join(root, "approach.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("PRAGMA user_version = 999"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	err = run([]string{"approach", "flow", "list", "--json", "--state-root", root},
+		noScanDeps(t, runDeps{stdout: &stdout, stderr: &bytes.Buffer{}}))
+	if err == nil || !strings.Contains(err.Error(), "newer version of approach") {
+		t.Fatalf("run error = %v, want fatal database-version error", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want no JSON beside fatal list failure", stdout.String())
+	}
+}
+
+func TestRunFlowListJSONWriterFailureRemainsFatal(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	mustRunFlow(t, []string{"approach", "flow", "create", "--title", "Healthy", "--instructions", "healthy", "--repo-path", repoPath, "--json", "--state-root", root})
+	wantErr := errors.New("stdout unavailable")
+
+	err := run([]string{"approach", "flow", "list", "--json", "--state-root", root},
+		noScanDeps(t, runDeps{stdout: failingWriter{err: wantErr}, stderr: &bytes.Buffer{}}))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("run error = %v, want JSON writer failure", err)
+	}
+}
+
 func TestRunFlowListRequiresJSON(t *testing.T) {
 	err := run([]string{"approach", "flow", "list", "--state-root", t.TempDir()},
 		noScanDeps(t, runDeps{stdout: &bytes.Buffer{}}))
@@ -482,6 +565,10 @@ func TestRunFlowListRequiresJSON(t *testing.T) {
 		t.Fatalf("expected --json requirement error, got %q", err)
 	}
 }
+
+type failingWriter struct{ err error }
+
+func (w failingWriter) Write([]byte) (int, error) { return 0, w.err }
 
 func TestRunFlowReadPrintsJSONRecord(t *testing.T) {
 	root := t.TempDir()

--- a/docs/config.md
+++ b/docs/config.md
@@ -522,8 +522,41 @@ Migration failure modes:
 > and the wrong move at any later point. The migration notice says so where it
 > offers it; nothing else in Approach will ever suggest it.
 
-The database carries `PRAGMA user_version`, so a database written by a newer
-Approach is reported as needing an upgrade rather than as corruption.
+The database and its records have separate compatibility gates:
+
+- `PRAGMA user_version` covers the database as a whole. A value newer than this
+  build supports prevents the store from opening and reports that Approach must
+  be upgraded. This is not corruption and is never downgraded to a partial
+  result.
+- Each JSON record carries its own `schema_version`. A malformed record or a
+  record written with a newer per-record version does not prevent healthy rows
+  from being listed. List operations skip only rows that SQLite scanned
+  successfully but Approach could not decode, preserve the normal
+  `updated_at DESC, flow_id ASC` order for healthy rows, and report every
+  skipped Flow ID. Query, scan, iteration, and close failures remain fatal.
+
+Point reads stay strict: `approach flow read --flow-id ID` returns the damaged
+row's decode or version error and never reports it as not found. By contrast,
+`approach flow list --json` writes the healthy subset as a valid JSON array to
+stdout, writes the skipped-row diagnostic to stderr, and exits successfully.
+`--repo-path` scopes both the returned rows and the diagnostic. If every
+matching row is unreadable, stdout is still `[]` and stderr carries the
+diagnostic. Any non-partial storage failure exits unsuccessfully instead.
+
+The Repository Flows and Active Flows panes show skipped rows as a persistent
+degraded-data warning, separate from the existing cached-data refresh warning;
+the banner remains visible even when no healthy rows remain. Repository and
+Active Flows own independent warnings. AutoMode never launches from a partial
+corpus and retains its last complete comparison snapshot until a clean list
+succeeds.
+
+Approach deliberately does not quarantine, delete, repair, or rewrite an
+unreadable authoritative row automatically. It also does not roll back the
+database or re-migrate from the frozen legacy `flows/` snapshot: either action
+could discard newer data or destroy a record that only a newer build can read.
+Inspect the stderr/server log diagnostic, upgrade first when a version is newer,
+and make any manual recovery decision against a preserved copy of
+`approach.db`.
 
 ```bash
 # Create a flow. --repo-path must be absolute, instructions are required, and

--- a/docs/graphql-api.md
+++ b/docs/graphql-api.md
@@ -318,9 +318,13 @@ that parses, the last two only to one that would really execute.
 
 ### Errors and logs
 
-Store and scan failures are logged server-side with full detail and surface to
-clients as the fixed message `internal error reading application state` — never
-a filesystem path or `os` error text.
+Store and scan failures are logged server-side with full detail. A non-partial
+Flow-store failure surfaces to clients as the fixed message
+`internal error reading application state` — never a filesystem path or `os`
+error text. A typed partial Flow-list result is different: the server logs the
+full skipped-row diagnostic, indexes the accompanying healthy records, and
+serves them normally. The GraphQL schema has no degradation field, and skipped
+row IDs or decoder causes never enter a response.
 
 One log line per request: method, path, status, duration. Never the
 `Authorization` or `X-Approach-Token` value, and never the query body. Request
@@ -339,10 +343,12 @@ Each request builds **one snapshot** — one `scanner.Scan` plus one
 therefore internally consistent, and every new request re-reads disk. There is
 no cross-request cache.
 
-**A failing scan degrades; a failing store errors.** A missing or mistyped scan
-root is the ordinary case, not an exceptional one, so a scan failure yields an
-empty scanned-repo set plus one logged warning: flow-derived repos still
-populate `repos`, and `flows` / `flow` are unaffected. A `flowstore.List`
+**A failing scan degrades; a non-partial failing store errors.** A missing or
+mistyped scan root is the ordinary case, not an exceptional one, so a scan
+failure yields an empty scanned-repo set plus one logged warning: flow-derived
+repos still populate `repos`, and `flows` / `flow` are unaffected. When
+`flowstore.List` returns healthy rows with its typed partial diagnostic, the
+snapshot logs the diagnostic and indexes those rows. Every other Flow-store
 failure is a real failure of the primary data source and surfaces as the
 sanitized GraphQL error above.
 

--- a/flowstore/backend.go
+++ b/flowstore/backend.go
@@ -29,7 +29,9 @@ type backend interface {
 	get(flowID string) (storedFlow, bool, error)
 
 	// list applies the filter and returns records ordered by updated_at DESC,
-	// flow_id ASC. Any malformed authoritative row fails the whole call.
+	// flow_id ASC. A decodeStoredFlow failure after a successful row scan omits
+	// only that row and returns the healthy rows with a *PartialListError. Query,
+	// scan, iteration, and close failures are fatal and return no usable rows.
 	list(filter FlowFilter) ([]storedFlow, error)
 
 	// delete removes the record, serialized against update by whatever mechanism

--- a/flowstore/backend_sqlite.go
+++ b/flowstore/backend_sqlite.go
@@ -56,8 +56,16 @@ type sqliteBackend struct {
 	db *sql.DB
 	// root is the canonical, symlink-resolved store root. Kept because it is the
 	// evidence that secureCanonicalRoot's resolution reached the backend.
-	root    string
-	beginTx func(context.Context) (sqliteTransaction, error)
+	root          string
+	beginTx       func(context.Context) (sqliteTransaction, error)
+	queryListRows func(string, ...any) (flowListRows, error)
+}
+
+type flowListRows interface {
+	Next() bool
+	Scan(...any) error
+	Err() error
+	Close() error
 }
 
 type sqliteTransaction interface {
@@ -147,6 +155,9 @@ func openSQLiteBackend(root string, lockTimeout time.Duration) (*sqliteBackend, 
 	backend := &sqliteBackend{db: db, root: root}
 	backend.beginTx = func(ctx context.Context) (sqliteTransaction, error) {
 		return db.BeginTx(ctx, nil)
+	}
+	backend.queryListRows = func(query string, args ...any) (flowListRows, error) {
+		return db.Query(query, args...)
 	}
 	return backend, nil
 }
@@ -379,11 +390,12 @@ func (b *sqliteBackend) list(filter FlowFilter) ([]storedFlow, error) {
 		args = append(args, filepath.Clean(filter.RepoPath))
 	}
 	query += " ORDER BY updated_at DESC, flow_id ASC"
-	rows, err := b.db.Query(query, args...)
+	rows, err := b.queryListRows(query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list flows: %w", err)
 	}
-	var flows []storedFlow
+	flows := make([]storedFlow, 0)
+	partial := &PartialListError{}
 	for rows.Next() {
 		var flowID, repoPath, status, updatedAt string
 		var record []byte
@@ -393,8 +405,8 @@ func (b *sqliteBackend) list(filter FlowFilter) ([]storedFlow, error) {
 		}
 		decoded, err := decodeStoredFlow(flowID, repoPath, status, updatedAt, record)
 		if err != nil {
-			_ = rows.Close()
-			return nil, err
+			partial.Entries = append(partial.Entries, PartialListEntry{FlowID: flowID, Cause: err})
+			continue
 		}
 		flows = append(flows, decoded)
 	}
@@ -404,6 +416,9 @@ func (b *sqliteBackend) list(filter FlowFilter) ([]storedFlow, error) {
 	}
 	if err := rows.Close(); err != nil {
 		return nil, fmt.Errorf("close flow list: %w", err)
+	}
+	if len(partial.Entries) > 0 {
+		return flows, partial
 	}
 	return flows, nil
 }

--- a/flowstore/partial_list_internal_test.go
+++ b/flowstore/partial_list_internal_test.go
@@ -1,0 +1,280 @@
+package flowstore
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSQLiteListReturnsHealthyRowsWithPartialDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewStore(StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	backend := store.backend.(*sqliteBackend)
+	repo := filepath.Join(root, "repo")
+	otherRepo := filepath.Join(root, "other")
+
+	insertListTestRecord(t, backend, listTestRecord("healthy-new", repo, 4))
+	insertListTestRecord(t, backend, listTestRecord("healthy-old", repo, 1))
+	insertListTestRaw(t, backend, "future", repo, StatusPending, listTestTime(5),
+		[]byte(`{"schema_version":99,"flow_id":"future"}`))
+	insertListTestRaw(t, backend, "malformed", repo, StatusPending, listTestTime(3), []byte("{"))
+	insertListTestRaw(t, backend, "excluded", otherRepo, StatusPending, listTestTime(6), []byte("{"))
+
+	records, err := store.List(FlowFilter{RepoPath: repo})
+	if got, want := flowIDs(records), []string{"healthy-new", "healthy-old"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("List() records = %v, want %v", got, want)
+	}
+	partial, ok := AsPartialList(err)
+	if !ok {
+		t.Fatalf("AsPartialList(%v) = false, want typed partial diagnostic", err)
+	}
+	if got, want := partialFlowIDs(partial), []string{"future", "malformed"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("partial flow IDs = %v, want %v", got, want)
+	}
+	if got, want := err.Error(), `skipped 2 unreadable Flows: future: flow "future" has unsupported schema version 99; malformed: decode flow "malformed" record: unexpected end of JSON input`; got != want {
+		t.Fatalf("List() error = %q, want %q", got, want)
+	}
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Fatalf("errors.As(%v, *json.SyntaxError) = false, want aggregate cause traversal", err)
+	}
+
+	if _, readErr := store.Read("malformed"); readErr == nil || IsNotFound(readErr) || !strings.Contains(readErr.Error(), "decode flow") {
+		t.Fatalf("Read(malformed) error = %v, want strict non-not-found corruption", readErr)
+	}
+}
+
+func TestSQLiteListAllCorruptReturnsNonNilEmptyPartialResult(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewStore(StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	backend := store.backend.(*sqliteBackend)
+	repo := filepath.Join(root, "repo")
+
+	insertListTestRaw(t, backend, "future", repo, StatusPending, listTestTime(2),
+		[]byte(`{"schema_version":99,"flow_id":"future"}`))
+	insertListTestRaw(t, backend, "malformed", repo, StatusPending, listTestTime(1), []byte("{"))
+
+	records, err := store.List(FlowFilter{RepoPath: repo})
+	if records == nil || len(records) != 0 {
+		t.Fatalf("List() records = %#v, want non-nil empty result", records)
+	}
+	partial, ok := AsPartialList(err)
+	if !ok {
+		t.Fatalf("AsPartialList(%v) = false, want typed partial diagnostic", err)
+	}
+	if got, want := partialFlowIDs(partial), []string{"future", "malformed"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("partial flow IDs = %v, want %v", got, want)
+	}
+}
+
+func TestSQLiteListFilterExcludesCorruptRowsFromDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewStore(StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	backend := store.backend.(*sqliteBackend)
+	includedRepo := filepath.Join(root, "included")
+	excludedRepo := filepath.Join(root, "excluded")
+
+	insertListTestRecord(t, backend, listTestRecord("healthy", includedRepo, 1))
+	insertListTestRaw(t, backend, "malformed", excludedRepo, StatusPending, listTestTime(2), []byte("{"))
+
+	records, err := store.List(FlowFilter{RepoPath: includedRepo})
+	if err != nil {
+		t.Fatalf("List() error = %v, want corrupt row outside filter ignored", err)
+	}
+	if got, want := flowIDs(records), []string{"healthy"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("List() records = %v, want %v", got, want)
+	}
+}
+
+func TestStoreListDiscardsRowsForFatalListFailures(t *testing.T) {
+	fatal := errors.New("injected fatal list failure")
+	for _, test := range []struct {
+		name string
+		rows *fakeFlowListRows
+		fail bool
+	}{
+		{name: "query", fail: true},
+		{name: "scan", rows: &fakeFlowListRows{rows: []fakeFlowListRow{
+			fakeListRowForRecord(t, listTestRecord("healthy", "/repo", 3)),
+			{flowID: "corrupt", repoPath: "/repo", status: StatusPending, updatedAt: listTestTimeString(t, 2), record: []byte("{")},
+			{scanErr: fatal},
+		}}},
+		{name: "iteration", rows: &fakeFlowListRows{
+			rows: []fakeFlowListRow{
+				fakeListRowForRecord(t, listTestRecord("healthy", "/repo", 3)),
+				{flowID: "corrupt", repoPath: "/repo", status: StatusPending, updatedAt: listTestTimeString(t, 2), record: []byte("{")},
+			},
+			iterateErr: fatal,
+		}},
+		{name: "close", rows: &fakeFlowListRows{
+			rows: []fakeFlowListRow{
+				fakeListRowForRecord(t, listTestRecord("healthy", "/repo", 3)),
+				{flowID: "corrupt", repoPath: "/repo", status: StatusPending, updatedAt: listTestTimeString(t, 2), record: []byte("{")},
+			},
+			closeErr: fatal,
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store, err := NewStore(StoreOptions{Root: t.TempDir()})
+			if err != nil {
+				t.Fatalf("NewStore() error = %v", err)
+			}
+			t.Cleanup(func() { _ = store.Close() })
+			backend := store.backend.(*sqliteBackend)
+			backend.queryListRows = func(string, ...any) (flowListRows, error) {
+				if test.fail {
+					return nil, fatal
+				}
+				return test.rows, nil
+			}
+
+			records, err := store.List(FlowFilter{})
+			if records != nil {
+				t.Fatalf("List() records = %#v, want nil beside fatal error", records)
+			}
+			if !errors.Is(err, fatal) {
+				t.Fatalf("List() error = %v, want injected fatal cause", err)
+			}
+			if _, partial := AsPartialList(err); partial {
+				t.Fatalf("List() error = %v, must not classify fatal iterator failure as partial", err)
+			}
+		})
+	}
+}
+
+func listTestRecord(flowID, repo string, second int) FlowRecord {
+	stamp := listTestTime(second)
+	return FlowRecord{
+		SchemaVersion: schemaVersion,
+		FlowID:        flowID,
+		Title:         flowID,
+		Instructions:  "test",
+		Status:        StatusPending,
+		RepoPath:      repo,
+		Phases:        []FlowPhase{},
+		CreatedAt:     stamp,
+		UpdatedAt:     stamp,
+	}
+}
+
+func listTestTime(second int) time.Time {
+	return time.Date(2026, 8, 14, 0, 0, second, 0, time.UTC)
+}
+
+func insertListTestRecord(t *testing.T, backend *sqliteBackend, record FlowRecord) {
+	t.Helper()
+	data, projection, err := encodeStoredFlow(record)
+	if err != nil {
+		t.Fatalf("encodeStoredFlow(%q) error = %v", record.FlowID, err)
+	}
+	insertListTestRaw(t, backend, projection.flowID, projection.repoPath, projection.status, record.UpdatedAt, data)
+}
+
+func insertListTestRaw(t *testing.T, backend *sqliteBackend, flowID, repo, status string, updatedAt time.Time, data []byte) {
+	t.Helper()
+	projectionTime, err := formatStorageTime(updatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.db.Exec(`
+INSERT INTO flows(flow_id, repo_path, status, updated_at, record) VALUES(?, ?, ?, ?, ?)`,
+		flowID, filepath.Clean(repo), status, projectionTime, data); err != nil {
+		t.Fatalf("insert flow %q: %v", flowID, err)
+	}
+}
+
+func flowIDs(records []FlowRecord) []string {
+	ids := make([]string, len(records))
+	for i := range records {
+		ids[i] = records[i].FlowID
+	}
+	return ids
+}
+
+func partialFlowIDs(partial *PartialListError) []string {
+	ids := make([]string, len(partial.Entries))
+	for i := range partial.Entries {
+		ids[i] = partial.Entries[i].FlowID
+	}
+	return ids
+}
+
+type fakeFlowListRow struct {
+	flowID    string
+	repoPath  string
+	status    string
+	updatedAt string
+	record    []byte
+	scanErr   error
+}
+
+type fakeFlowListRows struct {
+	rows       []fakeFlowListRow
+	next       int
+	iterateErr error
+	closeErr   error
+}
+
+func (r *fakeFlowListRows) Next() bool {
+	if r.next >= len(r.rows) {
+		return false
+	}
+	r.next++
+	return true
+}
+
+func (r *fakeFlowListRows) Scan(dest ...any) error {
+	row := r.rows[r.next-1]
+	if row.scanErr != nil {
+		return row.scanErr
+	}
+	*dest[0].(*string) = row.flowID
+	*dest[1].(*string) = row.repoPath
+	*dest[2].(*string) = row.status
+	*dest[3].(*string) = row.updatedAt
+	*dest[4].(*[]byte) = row.record
+	return nil
+}
+
+func (r *fakeFlowListRows) Err() error   { return r.iterateErr }
+func (r *fakeFlowListRows) Close() error { return r.closeErr }
+
+func fakeListRowForRecord(t *testing.T, record FlowRecord) fakeFlowListRow {
+	t.Helper()
+	data, projection, err := encodeStoredFlow(record)
+	if err != nil {
+		t.Fatalf("encodeStoredFlow(%q) error = %v", record.FlowID, err)
+	}
+	return fakeFlowListRow{
+		flowID:    projection.flowID,
+		repoPath:  projection.repoPath,
+		status:    projection.status,
+		updatedAt: projection.updatedAt,
+		record:    data,
+	}
+}
+
+func listTestTimeString(t *testing.T, second int) string {
+	t.Helper()
+	value, err := formatStorageTime(listTestTime(second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return value
+}

--- a/flowstore/partial_list_internal_test.go
+++ b/flowstore/partial_list_internal_test.go
@@ -3,12 +3,43 @@ package flowstore
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestAsPartialListRequiresStandaloneValidDiagnostic(t *testing.T) {
+	cause := errors.New("unreadable row")
+	partial := &PartialListError{Entries: []PartialListEntry{{FlowID: "bad", Cause: cause}}}
+
+	for _, err := range []error{partial, fmt.Errorf("list flows: %w", partial)} {
+		got, ok := AsPartialList(err)
+		if !ok || got != partial {
+			t.Fatalf("AsPartialList(%v) = (%#v, %t), want original partial diagnostic", err, got, ok)
+		}
+	}
+
+	fatal := errors.New("database unavailable")
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{name: "joined fatal", err: errors.Join(partial, fatal)},
+		{name: "wrapped joined fatal", err: fmt.Errorf("list flows: %w", errors.Join(partial, fatal))},
+		{name: "empty", err: &PartialListError{}},
+		{name: "missing flow ID", err: &PartialListError{Entries: []PartialListEntry{{Cause: cause}}}},
+		{name: "missing cause", err: &PartialListError{Entries: []PartialListEntry{{FlowID: "bad"}}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got, ok := AsPartialList(test.err); ok || got != nil {
+				t.Fatalf("AsPartialList(%v) = (%#v, %t), want fatal classification", test.err, got, ok)
+			}
+		})
+	}
+}
 
 func TestSQLiteListReturnsHealthyRowsWithPartialDiagnostic(t *testing.T) {
 	root := t.TempDir()

--- a/flowstore/partial_list_internal_test.go
+++ b/flowstore/partial_list_internal_test.go
@@ -14,11 +14,12 @@ import (
 func TestAsPartialListRequiresStandaloneValidDiagnostic(t *testing.T) {
 	cause := errors.New("unreadable row")
 	partial := &PartialListError{Entries: []PartialListEntry{{FlowID: "bad", Cause: cause}}}
+	blankID := &PartialListError{Entries: []PartialListEntry{{Cause: cause}}}
 
-	for _, err := range []error{partial, fmt.Errorf("list flows: %w", partial)} {
+	for _, err := range []error{partial, fmt.Errorf("list flows: %w", partial), blankID} {
 		got, ok := AsPartialList(err)
-		if !ok || got != partial {
-			t.Fatalf("AsPartialList(%v) = (%#v, %t), want original partial diagnostic", err, got, ok)
+		if !ok {
+			t.Fatalf("AsPartialList(%v) = (%#v, %t), want typed partial diagnostic", err, got, ok)
 		}
 	}
 
@@ -30,7 +31,6 @@ func TestAsPartialListRequiresStandaloneValidDiagnostic(t *testing.T) {
 		{name: "joined fatal", err: errors.Join(partial, fatal)},
 		{name: "wrapped joined fatal", err: fmt.Errorf("list flows: %w", errors.Join(partial, fatal))},
 		{name: "empty", err: &PartialListError{}},
-		{name: "missing flow ID", err: &PartialListError{Entries: []PartialListEntry{{Cause: cause}}}},
 		{name: "missing cause", err: &PartialListError{Entries: []PartialListEntry{{FlowID: "bad"}}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -38,6 +38,60 @@ func TestAsPartialListRequiresStandaloneValidDiagnostic(t *testing.T) {
 				t.Fatalf("AsPartialList(%v) = (%#v, %t), want fatal classification", test.err, got, ok)
 			}
 		})
+	}
+}
+
+func TestPartialListEntryDiagnosticFlowIDEscapesUnsafeValues(t *testing.T) {
+	for _, test := range []struct {
+		flowID string
+		want   string
+	}{
+		{flowID: "safe-id", want: "safe-id"},
+		{flowID: "", want: `""`},
+		{flowID: "   ", want: `"   "`},
+		{flowID: "bad\n\x1b]8;;https://example.invalid\a", want: `"bad\n\x1b]8;;https://example.invalid\a"`},
+	} {
+		entry := PartialListEntry{FlowID: test.flowID, Cause: errors.New("unreadable")}
+		if got := entry.DiagnosticFlowID(); got != test.want {
+			t.Errorf("DiagnosticFlowID(%q) = %q, want %q", test.flowID, got, test.want)
+		}
+	}
+}
+
+func TestSQLiteListRetainsHealthyRowsBesideBlankAndUnsafeCorruptIDs(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewStore(StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	backend := store.backend.(*sqliteBackend)
+	repo := filepath.Join(root, "repo")
+
+	insertListTestRecord(t, backend, listTestRecord("healthy", repo, 3))
+	insertListTestRaw(t, backend, "", repo, StatusPending, listTestTime(2), []byte("{"))
+	unsafeID := "bad\n\x1b]8;;https://example.invalid\a"
+	insertListTestRaw(t, backend, unsafeID, repo, StatusPending, listTestTime(1), []byte("{"))
+
+	records, err := store.List(FlowFilter{RepoPath: repo})
+	if got, want := flowIDs(records), []string{"healthy"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("List() records = %v, want %v", got, want)
+	}
+	partial, ok := AsPartialList(err)
+	if !ok {
+		t.Fatalf("AsPartialList(%v) = false, want typed partial diagnostic", err)
+	}
+	if got, want := partialFlowIDs(partial), []string{"", unsafeID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("partial flow IDs = %q, want %q", got, want)
+	}
+	diagnostic := err.Error()
+	if strings.ContainsAny(diagnostic, "\n\x1b\a") {
+		t.Fatalf("List() diagnostic contains terminal control bytes: %q", diagnostic)
+	}
+	for _, want := range []string{`"": decode flow "" record`, `"bad\n\x1b]8;;https://example.invalid\a"`} {
+		if !strings.Contains(diagnostic, want) {
+			t.Fatalf("List() diagnostic = %q, want escaped identifier %q", diagnostic, want)
+		}
 	}
 }
 

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -67,14 +67,33 @@ func (e *PartialListError) Unwrap() []error {
 	return causes
 }
 
-// AsPartialList classifies err as a partial Flow-list result without requiring
-// callers to match diagnostic text.
+// AsPartialList classifies a valid standalone partial Flow-list result without
+// requiring callers to match diagnostic text. Ordinary single-error wrapping
+// is accepted, but aggregate error trees are rejected so a joined fatal error
+// can never be downgraded merely because it also contains a partial diagnostic.
 func AsPartialList(err error) (*PartialListError, bool) {
-	var partial *PartialListError
-	if !errors.As(err, &partial) || partial == nil {
-		return nil, false
+	for err != nil {
+		if partial, ok := err.(*PartialListError); ok {
+			if partial == nil || len(partial.Entries) == 0 {
+				return nil, false
+			}
+			for _, entry := range partial.Entries {
+				if strings.TrimSpace(entry.FlowID) == "" || entry.Cause == nil {
+					return nil, false
+				}
+			}
+			return partial, true
+		}
+		if _, aggregate := err.(interface{ Unwrap() []error }); aggregate {
+			return nil, false
+		}
+		wrapped, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			return nil, false
+		}
+		err = wrapped.Unwrap()
 	}
-	return partial, true
+	return nil, false
 }
 
 // ErrAutoLaunchOutdated is the sentinel every outdated-auto-launch rejection

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -38,6 +38,21 @@ type PartialListEntry struct {
 	Cause  error
 }
 
+// DiagnosticFlowID renders the authoritative row ID without allowing corrupt
+// control bytes or an ambiguous blank value to reach terminal and log sinks.
+// FlowID itself remains unchanged so callers can inspect the exact stored key.
+func (e PartialListEntry) DiagnosticFlowID() string {
+	if strings.TrimSpace(e.FlowID) == "" {
+		return strconv.QuoteToASCII(e.FlowID)
+	}
+	for _, r := range e.FlowID {
+		if !strconv.IsPrint(r) {
+			return strconv.QuoteToASCII(e.FlowID)
+		}
+	}
+	return e.FlowID
+}
+
 // PartialListError reports rows omitted from an otherwise usable List result.
 // Entries retain the list query's deterministic SQL order.
 type PartialListError struct {
@@ -50,7 +65,7 @@ func (e *PartialListError) Error() string {
 	}
 	parts := make([]string, len(e.Entries))
 	for i, entry := range e.Entries {
-		parts[i] = fmt.Sprintf("%s: %v", entry.FlowID, entry.Cause)
+		parts[i] = fmt.Sprintf("%s: %v", entry.DiagnosticFlowID(), entry.Cause)
 	}
 	return fmt.Sprintf("skipped %d unreadable Flows: %s", len(e.Entries), strings.Join(parts, "; "))
 }
@@ -78,7 +93,7 @@ func AsPartialList(err error) (*PartialListError, bool) {
 				return nil, false
 			}
 			for _, entry := range partial.Entries {
-				if strings.TrimSpace(entry.FlowID) == "" || entry.Cause == nil {
+				if entry.Cause == nil {
 					return nil, false
 				}
 			}

--- a/flowstore/store.go
+++ b/flowstore/store.go
@@ -31,6 +31,52 @@ var ErrFlowNotFound = errors.New("flow not found")
 
 var errFlowNotFound = ErrFlowNotFound
 
+// PartialListEntry identifies one authoritative Flow row that could be scanned
+// but not decoded while listing. Cause retains the row-local corruption error.
+type PartialListEntry struct {
+	FlowID string
+	Cause  error
+}
+
+// PartialListError reports rows omitted from an otherwise usable List result.
+// Entries retain the list query's deterministic SQL order.
+type PartialListError struct {
+	Entries []PartialListEntry
+}
+
+func (e *PartialListError) Error() string {
+	if e == nil {
+		return ""
+	}
+	parts := make([]string, len(e.Entries))
+	for i, entry := range e.Entries {
+		parts[i] = fmt.Sprintf("%s: %v", entry.FlowID, entry.Cause)
+	}
+	return fmt.Sprintf("skipped %d unreadable Flows: %s", len(e.Entries), strings.Join(parts, "; "))
+}
+
+// Unwrap exposes every retained row-local cause to errors.Is and errors.As.
+func (e *PartialListError) Unwrap() []error {
+	if e == nil {
+		return nil
+	}
+	causes := make([]error, len(e.Entries))
+	for i, entry := range e.Entries {
+		causes[i] = entry.Cause
+	}
+	return causes
+}
+
+// AsPartialList classifies err as a partial Flow-list result without requiring
+// callers to match diagnostic text.
+func AsPartialList(err error) (*PartialListError, bool) {
+	var partial *PartialListError
+	if !errors.As(err, &partial) || partial == nil {
+		return nil, false
+	}
+	return partial, true
+}
+
 // ErrAutoLaunchOutdated is the sentinel every outdated-auto-launch rejection
 // wraps. It is exported so callers outside this package can build the rejection
 // their AutoMode handling has to survive.
@@ -2205,14 +2251,14 @@ func appendUnique(values []string, value string) []string {
 // List returns records matching filter, sorted by UpdatedAt descending.
 func (s *Store) List(filter FlowFilter) ([]FlowRecord, error) {
 	stored, err := s.backend.list(filter)
-	if err != nil {
+	if _, partial := AsPartialList(err); err != nil && !partial {
 		return nil, err
 	}
-	var records []FlowRecord
+	records := make([]FlowRecord, 0, len(stored))
 	for _, flow := range stored {
 		records = append(records, flow.record)
 	}
-	return records, nil
+	return records, err
 }
 
 func validatePhaseUpdate(current FlowPhase, update PhaseUpdate) error {

--- a/graphqlapi/source.go
+++ b/graphqlapi/source.go
@@ -26,8 +26,9 @@ import (
 type RepoSource func() ([]scanner.Repo, error)
 
 // FlowSource returns every persisted Flow record, in the store's order
-// (UpdatedAt descending). A failure is a real failure of the primary data
-// source and surfaces to clients as a sanitized GraphQL error.
+// (UpdatedAt descending). A typed partial-list error accompanies usable healthy
+// records and is logged server-side; every other failure surfaces to clients as
+// a sanitized GraphQL error.
 type FlowSource func() ([]flowstore.FlowRecord, error)
 
 // errStateUnavailable is the fixed message clients see when the primary data
@@ -108,9 +109,13 @@ func buildSnapshot(repos RepoSource, flows FlowSource, logf func(string, ...any)
 	}
 	records, err := flows()
 	if err != nil {
-		logf("reading flow records failed: %v", err)
-		snap.err = errStateUnavailable
-		return snap
+		if _, partial := flowstore.AsPartialList(err); partial {
+			logf("reading flow records partially degraded: %v", err)
+		} else {
+			logf("reading flow records failed: %v", err)
+			snap.err = errStateUnavailable
+			return snap
+		}
 	}
 	for _, record := range records {
 		// An externally written record with an empty repo_path would

--- a/graphqlapi/source_test.go
+++ b/graphqlapi/source_test.go
@@ -284,6 +284,37 @@ func TestBuildSnapshotFlowErrorIsSanitized(t *testing.T) {
 	}
 }
 
+func TestBuildSnapshotIndexesHealthyFlowsFromTypedPartialResultAndLogsDiagnostic(t *testing.T) {
+	partial := &flowstore.PartialListError{Entries: []flowstore.PartialListEntry{
+		{FlowID: "bad-json", Cause: errors.New("malformed JSON")},
+		{FlowID: "future", Cause: errors.New("unsupported schema version 99")},
+	}}
+	var logged []string
+	snap := buildSnapshot(
+		staticRepos(),
+		func() ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{{FlowID: "healthy", RepoPath: "/repos/alpha"}}, partial
+		},
+		func(format string, args ...any) {
+			logged = append(logged, fmt.Sprintf(format, args...))
+		},
+	)
+	if snap.err != nil {
+		t.Fatalf("snapshot err = %v, want typed partial result accepted", snap.err)
+	}
+	if got, want := flowIDs(snap.Flows()), []string{"healthy"}; !equalStrings(got, want) {
+		t.Fatalf("Flows() = %v, want %v", got, want)
+	}
+	if len(logged) != 1 {
+		t.Fatalf("logged = %#v, want one partial-list diagnostic", logged)
+	}
+	for _, want := range []string{"reading flow records partially degraded", "bad-json", "malformed JSON", "future", "unsupported schema version 99"} {
+		if !strings.Contains(logged[0], want) {
+			t.Fatalf("partial log missing %q: %q", want, logged[0])
+		}
+	}
+}
+
 func TestBuildSnapshotEmptySources(t *testing.T) {
 	snap := buildSnapshot(staticRepos(), staticFlows(), nil)
 	if len(snap.Repos()) != 0 || len(snap.Flows()) != 0 {

--- a/model/flow_advance_tick.go
+++ b/model/flow_advance_tick.go
@@ -21,9 +21,10 @@ type autoAdvanceTickMsg struct{}
 // listFlows failure arrives as Err instead of a FetchErrorMsg so the loop
 // always reschedules and never stomps display status.
 type AutoAdvanceResultMsg struct {
-	Flows   []flowstore.FlowRecord
-	Err     string
-	Request uint64
+	Flows       []flowstore.FlowRecord
+	Degradation *flowstore.PartialListError
+	Err         string
+	Request     uint64
 }
 
 func autoAdvanceTickCmd() tea.Cmd {
@@ -35,6 +36,9 @@ func autoAdvanceTickCmd() tea.Cmd {
 func (m Model) fetchAutoAdvanceFlows(request uint64) tea.Cmd {
 	return func() tea.Msg {
 		records, err := m.listFlows(flowstore.FlowFilter{})
+		if partial, ok := flowstore.AsPartialList(err); ok {
+			return AutoAdvanceResultMsg{Flows: records, Degradation: partial, Request: request}
+		}
 		if err != nil {
 			return AutoAdvanceResultMsg{Err: err.Error(), Request: request}
 		}
@@ -63,7 +67,7 @@ func (m Model) handleAutoAdvanceResult(msg AutoAdvanceResultMsg) (Model, tea.Cmd
 	if msg.Request == 0 || msg.Request != m.autoAdvanceInFlight {
 		return m.finishAutoAdvanceFetch(msg.Request)
 	}
-	if msg.Err != "" {
+	if msg.Err != "" || msg.Degradation != nil {
 		return m.finishAutoAdvanceFetch(msg.Request)
 	}
 

--- a/model/flow_partial_list_internal_test.go
+++ b/model/flow_partial_list_internal_test.go
@@ -1,0 +1,233 @@
+package model
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/scanner"
+	"github.com/approachcontrol/approach/ui"
+)
+
+func TestFlowFetchCarriesTypedPartialResultInsteadOfFatalError(t *testing.T) {
+	healthy := flowForRefreshTest("healthy")
+	partial := testPartialList("corrupt")
+	m := NewWithOptions(flowRefreshTestRepos(), Options{
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{healthy}, partial
+		},
+	})
+
+	msg := flowResultFromCommand(t, m.Init())
+	if len(msg.Flows) != 1 || msg.Flows[0].FlowID != healthy.FlowID {
+		t.Fatalf("FlowResultMsg.Flows = %#v, want healthy Flow", msg.Flows)
+	}
+	if msg.Degradation != partial {
+		t.Fatalf("FlowResultMsg.Degradation = %#v, want typed diagnostic %#v", msg.Degradation, partial)
+	}
+}
+
+func TestRepositoryFlowDegradationFollowsAcceptedResultFreshness(t *testing.T) {
+	m := New([]scanner.Repo{{Path: "/repo/a"}, {Path: "/repo/b"}})
+	m.width, m.height = 160, 26
+	request := m.currentListRequest(ui.ModeFlows)
+	partial := testPartialList("id1", "id2", "id3", "id4")
+
+	m, _ = updateFlowRefreshTest(m, FlowResultMsg{
+		RepoPath: "/repo/a", Flows: []flowstore.FlowRecord{{FlowID: "healthy", RepoPath: "/repo/a"}},
+		Degradation: partial, ListRequest: request,
+	})
+	if got, want := m.flowDegradationWarning(ui.ModeFlows), "Skipped 4 unreadable Flows (id1, id2, id3, …); run approach flow list --json"; got != want {
+		t.Fatalf("repository degradation warning = %q, want %q", got, want)
+	}
+	if got := m.currentListError(ui.ModeFlows); got != "" {
+		t.Fatalf("partial result reused fatal list error = %q", got)
+	}
+
+	m, freshRequest := m.nextListFetchRequest(ui.ModeFlows)
+	if got := m.flowDegradationWarning(ui.ModeFlows); got == "" {
+		t.Fatal("starting same-repository request cleared degradation warning")
+	}
+	m, _ = updateFlowRefreshTest(m, FlowResultMsg{RepoPath: "/repo/a", ListRequest: request})
+	if got := m.flowDegradationWarning(ui.ModeFlows); got == "" {
+		t.Fatal("stale clean result cleared degradation warning")
+	}
+	m, _ = updateFlowRefreshTest(m, FlowResultMsg{RepoPath: "/repo/a", ListRequest: freshRequest})
+	if got := m.flowDegradationWarning(ui.ModeFlows); got != "" {
+		t.Fatalf("current clean result left degradation warning %q", got)
+	}
+}
+
+func TestFlowDegradationWarningsAreIndependentAcrossRepositoryAndActiveSurfaces(t *testing.T) {
+	m := New([]scanner.Repo{{Path: "/repo/a"}, {Path: "/repo/b"}})
+	repoRequest := m.currentListRequest(ui.ModeFlows)
+	m, _ = updateFlowRefreshTest(m, FlowResultMsg{
+		RepoPath: "/repo/a", Degradation: testPartialList("repo-bad"), ListRequest: repoRequest,
+	})
+
+	m = modelWithModeForTest(m, ui.ModeActiveFlows)
+	m, activeRequest := m.nextListFetchRequest(ui.ModeActiveFlows)
+	m, _ = updateFlowRefreshTest(m, ActiveFlowResultMsg{
+		Degradation: testPartialList("global-bad"), ListRequest: activeRequest,
+	})
+	if got := m.flowDegradationWarning(ui.ModeFlows); got == "" {
+		t.Fatal("repository warning missing before repository switch")
+	}
+	if got := m.flowDegradationWarning(ui.ModeActiveFlows); got == "" {
+		t.Fatal("Active Flows warning missing before repository switch")
+	}
+
+	next, _ := m.moveRepoSelection(1)
+	m = next.(Model)
+	if got := m.flowDegradationWarning(ui.ModeFlows); got != "" {
+		t.Fatalf("repository switch retained old repository warning %q", got)
+	}
+	if got := m.flowDegradationWarning(ui.ModeActiveFlows); got == "" {
+		t.Fatal("repository switch cleared global Active Flows warning")
+	}
+
+	m, _ = updateFlowRefreshTest(m, FlowResultMsg{
+		RepoPath: "/repo/a", Degradation: testPartialList("old-a"), ListRequest: repoRequest,
+	})
+	if got := m.flowDegradationWarning(ui.ModeFlows); got != "" {
+		t.Fatalf("old repository result reinstalled warning %q", got)
+	}
+
+	m, freshActiveRequest := m.nextListFetchRequest(ui.ModeActiveFlows)
+	m, _ = updateFlowRefreshTest(m, ActiveFlowResultMsg{ListRequest: activeRequest})
+	if got := m.flowDegradationWarning(ui.ModeActiveFlows); got == "" {
+		t.Fatal("stale clean Active Flows result cleared degradation warning")
+	}
+	m, _ = updateFlowRefreshTest(m, ActiveFlowResultMsg{ListRequest: freshActiveRequest})
+	if got := m.flowDegradationWarning(ui.ModeActiveFlows); got != "" {
+		t.Fatalf("current clean Active Flows result left warning %q", got)
+	}
+}
+
+func TestFlowDegradationWarningCoexistsWithFatalCachedRefreshWarning(t *testing.T) {
+	m := New([]scanner.Repo{{Path: "/repo/a"}})
+	request := m.currentListRequest(ui.ModeFlows)
+	m, _ = updateFlowRefreshTest(m, FlowResultMsg{
+		RepoPath: "/repo/a", Flows: []flowstore.FlowRecord{{FlowID: "healthy", RepoPath: "/repo/a"}},
+		Degradation: testPartialList("bad"), ListRequest: request,
+	})
+	m, _ = updateFlowRefreshTest(m, FetchErrorMsg{
+		RepoPath: "/repo/a", Pane: "flows", Err: "failed to load flows: database unavailable",
+		Kind: FetchList, Mode: ui.ModeFlows, ListRequest: request,
+	})
+	if got := m.flowDegradationWarning(ui.ModeFlows); got == "" {
+		t.Fatal("fatal refresh cleared prior degradation warning")
+	}
+	if got := m.currentListError(ui.ModeFlows); got == "" {
+		t.Fatal("fatal refresh did not retain cached-refresh warning state")
+	}
+	if got := m.paneFlowDegradationWarningRows(ui.ModeFlows) + m.paneCachedWarningRows(ui.ModeFlows); got != 2 {
+		t.Fatalf("warning rows = %d, want two independent rows", got)
+	}
+}
+
+func TestFlowDegradationWarningReflowsSelectionAndScrollGeometry(t *testing.T) {
+	m := New([]scanner.Repo{{Path: "/repo/a"}})
+	m = modelWithModeForTest(m, ui.ModeFlows)
+	m.width, m.height = 160, 26
+	m.activePane, m.contentPane = ui.PaneBottom, ui.PaneBottom
+	records := make([]flowstore.FlowRecord, 20)
+	for i := range records {
+		records[i] = flowstore.FlowRecord{FlowID: string(rune('a' + i)), RepoPath: "/repo/a"}
+	}
+	m.flows = m.flows.SetItems(records)
+	cleanRows := m.paneContentHeight(ui.ModeFlows)
+	m.flows = m.flows.Move(len(records)-1, cleanRows, m.contentWidth())
+
+	m = m.setFlowDegradation(ui.ModeFlows, "/repo/a", testPartialList("bad"))
+	if got := m.paneContentHeight(ui.ModeFlows); got != cleanRows-1 {
+		t.Fatalf("degraded pane rows = %d, want %d", got, cleanRows-1)
+	}
+	if got, want := m.flows.Scroll(), len(records)-(cleanRows-1); got != want {
+		t.Fatalf("degraded pane scroll = %d, want %d", got, want)
+	}
+
+	m = m.setCurrentListError(ui.ModeFlows, "refresh failed")
+	if got := m.paneContentHeight(ui.ModeFlows); got != cleanRows-2 {
+		t.Fatalf("two-warning pane rows = %d, want %d", got, cleanRows-2)
+	}
+	m = m.setFlowDegradation(ui.ModeFlows, "/repo/a", nil)
+	if got := m.paneContentHeight(ui.ModeFlows); got != cleanRows-1 {
+		t.Fatalf("cached-only pane rows = %d, want %d", got, cleanRows-1)
+	}
+}
+
+func TestAutoAdvancePartialPollRetainsCompleteSnapshotAndDoesNotLaunch(t *testing.T) {
+	baseline := autoAdvanceTestFlow("flow-1", "/repo/a", true, map[string]string{
+		"plan": flowstore.PhaseRunning,
+	})
+	incomplete := autoAdvanceTestFlow("flow-1", "/repo/a", true, map[string]string{
+		"plan":           flowstore.PhaseCompleted,
+		"plan-review":    flowstore.PhaseCompleted,
+		"implementation": flowstore.PhaseReady,
+	})
+	partial := testPartialList("missing-flow")
+	var launches int
+	m := NewWithOptions([]scanner.Repo{{Path: "/repo/a"}}, Options{
+		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{incomplete}, partial
+		},
+		AddFlowPhaseLaunchID: func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
+			launches++
+			return incomplete, nil
+		},
+	})
+	m.autoAdvanceSnapshot = cloneFlowRecords([]flowstore.FlowRecord{baseline})
+
+	fetched, ok := m.fetchAutoAdvanceFlows(1)().(AutoAdvanceResultMsg)
+	if !ok || fetched.Degradation != partial {
+		t.Fatalf("auto poll result = %#v, want typed partial diagnostic", fetched)
+	}
+	m.autoAdvanceInFlight = 1
+	before := cloneFlowRecords(m.autoAdvanceSnapshot)
+	beforeStatus := m.status
+	m, _ = updateFlowRefreshTest(m, fetched)
+	if !reflect.DeepEqual(m.autoAdvanceSnapshot, before) {
+		t.Fatalf("partial poll changed baseline:\n got: %#v\nwant: %#v", m.autoAdvanceSnapshot, before)
+	}
+	if launches != 0 {
+		t.Fatalf("partial poll launched %d phases, want none", launches)
+	}
+	if !reflect.DeepEqual(m.status, beforeStatus) {
+		t.Fatalf("partial poll changed status from %#v to %#v", beforeStatus, m.status)
+	}
+}
+
+func TestPartialDisplayResultsDoNotSeedAutoAdvanceSnapshot(t *testing.T) {
+	baseline := autoAdvanceTestFlow("baseline", "/repo/a", true, map[string]string{"plan": flowstore.PhaseRunning})
+	partialFlow := autoAdvanceTestFlow("partial", "/repo/a", true, map[string]string{"plan": flowstore.PhaseCompleted})
+	m := New([]scanner.Repo{{Path: "/repo/a"}})
+	m.autoAdvanceSnapshot = cloneFlowRecords([]flowstore.FlowRecord{baseline})
+	want := cloneFlowRecords(m.autoAdvanceSnapshot)
+
+	m, _ = updateFlowRefreshTest(m, FlowResultMsg{
+		RepoPath: "/repo/a", Flows: []flowstore.FlowRecord{partialFlow},
+		Degradation: testPartialList("repo-bad"), ListRequest: m.currentListRequest(ui.ModeFlows),
+	})
+	if !reflect.DeepEqual(m.autoAdvanceSnapshot, want) {
+		t.Fatalf("partial repository result changed baseline:\n got: %#v\nwant: %#v", m.autoAdvanceSnapshot, want)
+	}
+
+	m = modelWithModeForTest(m, ui.ModeActiveFlows)
+	m, request := m.nextListFetchRequest(ui.ModeActiveFlows)
+	m, _ = updateFlowRefreshTest(m, ActiveFlowResultMsg{
+		Flows: []flowstore.FlowRecord{partialFlow}, Degradation: testPartialList("global-bad"), ListRequest: request,
+	})
+	if !reflect.DeepEqual(m.autoAdvanceSnapshot, want) {
+		t.Fatalf("partial Active Flows result changed baseline:\n got: %#v\nwant: %#v", m.autoAdvanceSnapshot, want)
+	}
+}
+
+func testPartialList(ids ...string) *flowstore.PartialListError {
+	partial := &flowstore.PartialListError{Entries: make([]flowstore.PartialListEntry, len(ids))}
+	for i, id := range ids {
+		partial.Entries[i] = flowstore.PartialListEntry{FlowID: id, Cause: errors.New("unreadable " + id)}
+	}
+	return partial
+}

--- a/model/flow_partial_list_internal_test.go
+++ b/model/flow_partial_list_internal_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/approachcontrol/approach/flowstore"
@@ -56,6 +57,18 @@ func TestRepositoryFlowDegradationFollowsAcceptedResultFreshness(t *testing.T) {
 	m, _ = updateFlowRefreshTest(m, FlowResultMsg{RepoPath: "/repo/a", ListRequest: freshRequest})
 	if got := m.flowDegradationWarning(ui.ModeFlows); got != "" {
 		t.Fatalf("current clean result left degradation warning %q", got)
+	}
+}
+
+func TestFlowDegradationWarningEscapesUnsafeFlowIDs(t *testing.T) {
+	m := New([]scanner.Repo{{Path: "/repo/a"}})
+	m = m.setFlowDegradation(ui.ModeFlows, "/repo/a", testPartialList("", "   ", "bad\n\x1b]8;;https://example.invalid\a"))
+	warning := m.flowDegradationWarning(ui.ModeFlows)
+	if strings.ContainsAny(warning, "\n\x1b\a") {
+		t.Fatalf("degradation warning contains terminal control bytes: %q", warning)
+	}
+	if want := `Skipped 3 unreadable Flows ("", "   ", "bad\n\x1b]8;;https://example.invalid\a"); run approach flow list --json`; warning != want {
+		t.Fatalf("degradation warning = %q, want %q", warning, want)
 	}
 }
 

--- a/model/mode_fetch.go
+++ b/model/mode_fetch.go
@@ -125,6 +125,9 @@ func listFetchDescriptorForMode(mode ui.Mode) (listFetchDescriptor, bool) {
 			errorPrefix: "failed to load flows",
 			load: func(m Model, repoPath string, request uint64) (tea.Msg, error) {
 				records, err := m.listFlows(flowstore.FlowFilter{RepoPath: repoPath})
+				if partial, ok := flowstore.AsPartialList(err); ok {
+					return FlowResultMsg{RepoPath: repoPath, Flows: records, Degradation: partial, ListRequest: request}, nil
+				}
 				if err != nil {
 					return nil, err
 				}
@@ -277,6 +280,9 @@ func (m Model) fetchMode(mode ui.Mode, request uint64) tea.Cmd {
 func (m Model) fetchActiveFlows(request uint64) tea.Cmd {
 	return func() tea.Msg {
 		records, err := m.listFlows(flowstore.FlowFilter{})
+		if partial, ok := flowstore.AsPartialList(err); ok {
+			return ActiveFlowResultMsg{Flows: records, Degradation: partial, ListRequest: request}
+		}
 		if err != nil {
 			return FetchErrorMsg{
 				Pane:        "active-flows",

--- a/model/model.go
+++ b/model/model.go
@@ -55,6 +55,11 @@ type beadExpansionSnapshot struct {
 	projection ui.BeadExpansion
 }
 
+type flowDegradationState struct {
+	repoPath   string
+	diagnostic *flowstore.PartialListError
+}
+
 // Model is the bubbletea application model.
 type Model struct {
 	repos                     pane.Pane[scanner.Repo]
@@ -113,6 +118,7 @@ type Model struct {
 	pendingRepoSelection      string
 	listRequests              [listRequestSlots]uint64
 	listErrors                [listRequestSlots]string
+	flowDegradations          [listRequestSlots]flowDegradationState
 	activePane                ui.Pane
 	repoPaneCollapsed         bool
 	activeFlowSurface         bool
@@ -1293,6 +1299,8 @@ func (m Model) View() string {
 		Flows:                        flows,
 		FlowSelected:                 flowSelected,
 		FlowScroll:                   flowScroll,
+		FlowDegradationWarning:       m.flowDegradationWarning(ui.ModeFlows),
+		ActiveFlowDegradationWarning: m.flowDegradationWarning(ui.ModeActiveFlows),
 		BeadsOpen:                    beadsActive,
 		BeadsOpenSelected:            beadsSelected,
 		BeadsOpenScroll:              beadsScroll,

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -146,6 +146,67 @@ func (m Model) setCurrentListError(mode ui.Mode, detail string) Model {
 	return m
 }
 
+func (m Model) flowDegradation(mode ui.Mode) *flowstore.PartialListError {
+	if mode != ui.ModeFlows && mode != ui.ModeActiveFlows {
+		return nil
+	}
+	state := m.flowDegradations[int(mode)]
+	if state.diagnostic == nil || len(state.diagnostic.Entries) == 0 {
+		return nil
+	}
+	if mode == ui.ModeFlows {
+		repoPath, ok := m.currentRepoPath()
+		if !ok || !sameRepoPath(repoPath, state.repoPath) {
+			return nil
+		}
+	}
+	return state.diagnostic
+}
+
+func (m Model) flowDegradationWarning(mode ui.Mode) string {
+	diagnostic := m.flowDegradation(mode)
+	if diagnostic == nil {
+		return ""
+	}
+	limit := min(3, len(diagnostic.Entries))
+	ids := make([]string, 0, limit+1)
+	for _, entry := range diagnostic.Entries[:limit] {
+		ids = append(ids, entry.FlowID)
+	}
+	if len(diagnostic.Entries) > limit {
+		ids = append(ids, "…")
+	}
+	return fmt.Sprintf("Skipped %d unreadable Flows (%s); run approach flow list --json",
+		len(diagnostic.Entries), strings.Join(ids, ", "))
+}
+
+func (m Model) setFlowDegradation(mode ui.Mode, repoPath string, diagnostic *flowstore.PartialListError) Model {
+	if mode != ui.ModeFlows && mode != ui.ModeActiveFlows {
+		return m
+	}
+	beforeRows := m.paneFlowDegradationWarningRows(mode)
+	state := flowDegradationState{}
+	if diagnostic != nil && len(diagnostic.Entries) > 0 {
+		copied := &flowstore.PartialListError{Entries: append([]flowstore.PartialListEntry(nil), diagnostic.Entries...)}
+		state = flowDegradationState{diagnostic: copied}
+		if mode == ui.ModeFlows {
+			state.repoPath = repoPath
+		}
+	}
+	m.flowDegradations[int(mode)] = state
+	if m.paneFlowDegradationWarningRows(mode) != beforeRows {
+		m = m.reflowMode(mode)
+	}
+	return m
+}
+
+func (m Model) paneFlowDegradationWarningRows(mode ui.Mode) int {
+	if m.flowDegradationWarning(mode) == "" {
+		return 0
+	}
+	return 1
+}
+
 func (m Model) reflowMode(mode ui.Mode) Model {
 	switch mode {
 	case ui.ModeActiveFlows:

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -171,7 +171,7 @@ func (m Model) flowDegradationWarning(mode ui.Mode) string {
 	limit := min(3, len(diagnostic.Entries))
 	ids := make([]string, 0, limit+1)
 	for _, entry := range diagnostic.Entries[:limit] {
-		ids = append(ids, entry.FlowID)
+		ids = append(ids, entry.DiagnosticFlowID())
 	}
 	if len(diagnostic.Entries) > limit {
 		ids = append(ids, "…")

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -3457,6 +3457,7 @@ func (m Model) resetRightPaneCursors() Model {
 
 func (m Model) resetStoredPaneCursors() Model {
 	m = m.invalidateStoredListRequests()
+	m = m.setFlowDegradation(ui.ModeFlows, "", nil)
 	// Covers the rescan-driven repo changes in handleRepoRefreshResult, which
 	// never route through handleRepoSelectionChanged.
 	m = m.invalidateReadyBeadFlowCreateRequest()
@@ -3555,6 +3556,7 @@ func (m Model) paneContentHeight(mode ui.Mode) int {
 		rows -= ui.TableHeaderRows
 	}
 	rows -= m.paneCachedWarningRows(mode)
+	rows -= m.paneFlowDegradationWarningRows(mode)
 	// The positive floor predates the warning row and also covers hidden
 	// background panes, which are allocated no rows at all. Viewports this
 	// small cannot show a cached row either way, so the floor stays.

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -279,11 +279,13 @@ type PlanResultMsg struct {
 type FlowResultMsg struct {
 	RepoPath    string
 	Flows       []flowstore.FlowRecord
+	Degradation *flowstore.PartialListError
 	ListRequest uint64
 }
 
 type ActiveFlowResultMsg struct {
 	Flows       []flowstore.FlowRecord
+	Degradation *flowstore.PartialListError
 	ListRequest uint64
 }
 
@@ -1552,9 +1554,12 @@ func (m Model) handleFlowResult(msg FlowResultMsg) (Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
+	m = m.setFlowDegradation(ui.ModeFlows, msg.RepoPath, msg.Degradation)
 	flows := preferNewerCachedFlowRecords(msg.Flows, msg.ListRequest, m.latestFlowMutations)
 	m = m.pruneAcknowledgedFlowMutations()
-	m = m.seedAutoAdvanceSnapshot(flows)
+	if msg.Degradation == nil {
+		m = m.seedAutoAdvanceSnapshot(flows)
+	}
 	selectedFlowID := ""
 	if record, ok := m.flows.Selected(); ok {
 		selectedFlowID = record.FlowID
@@ -1582,9 +1587,12 @@ func (m Model) handleActiveFlowResult(msg ActiveFlowResultMsg) (Model, tea.Cmd) 
 	if !ok {
 		return m, nil
 	}
+	m = m.setFlowDegradation(ui.ModeActiveFlows, "", msg.Degradation)
 	flows := preferNewerCachedFlowRecords(msg.Flows, msg.ListRequest, m.latestFlowMutations)
 	m = m.pruneAcknowledgedFlowMutations()
-	m = m.seedAutoAdvanceSnapshot(flows)
+	if msg.Degradation == nil {
+		m = m.seedAutoAdvanceSnapshot(flows)
+	}
 	m.activeFlowRecords = append([]flowstore.FlowRecord(nil), flows...)
 	m = m.syncActiveFlowsFromCache()
 	m = m.clampSelectionsAfterFilter()

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -422,6 +422,8 @@ type RenderParams struct {
 	Flows                        []flowstore.FlowRecord
 	FlowSelected                 int
 	FlowScroll                   int
+	FlowDegradationWarning       string
+	ActiveFlowDegradationWarning string
 	BeadsOpen                    []beadsquery.Bead
 	BeadsOpenSelected            int
 	BeadsOpenScroll              int
@@ -986,8 +988,12 @@ func renderStackedModePane(p RenderParams, mode Mode, width, outerRows int, focu
 	hasRows := stackedModePaneHasRows(p, mode, takeover)
 	_, sourceCount := paneItemFilterState(p, mode)
 	showCachedWarning := ShowsCachedListWarning(paneListError(p, mode), hasRows, sourceCount)
+	degradationWarning := paneFlowDegradationWarning(p, mode)
 	bodyRows := listRows
 	if showCachedWarning && bodyRows > 0 {
+		bodyRows--
+	}
+	if degradationWarning != "" && bodyRows > 0 {
 		bodyRows--
 	}
 	switch {
@@ -1028,9 +1034,16 @@ func renderStackedModePane(p RenderParams, mode Mode, width, outerRows int, focu
 	default:
 		body = renderPlaceholderPane(width, bodyRows, paneEmptyMessage(p, mode, repoPath))
 	}
+	var warnings []string
+	if degradationWarning != "" {
+		warnings = append(warnings, truncateToWidth(aheadBehindStyle.Render(" "+degradationWarning), width))
+	}
 	if showCachedWarning {
 		warning := " Could not refresh " + modeDataLabel(mode) + "; showing cached data"
-		body = append([]string{truncateToWidth(dirtyRedStyle.Render(warning), width)}, body...)
+		warnings = append(warnings, truncateToWidth(dirtyRedStyle.Render(warning), width))
+	}
+	if len(warnings) > 0 {
+		body = append(warnings, body...)
 	}
 
 	lines := append(headerLines, body...)
@@ -1154,6 +1167,17 @@ func paneListError(p RenderParams, mode Mode) string {
 		return p.TopListError
 	case paneOK && pane == PaneBottom:
 		return p.BottomListError
+	default:
+		return ""
+	}
+}
+
+func paneFlowDegradationWarning(p RenderParams, mode Mode) string {
+	switch mode {
+	case ModeFlows:
+		return p.FlowDegradationWarning
+	case ModeActiveFlows:
+		return p.ActiveFlowDegradationWarning
 	default:
 		return ""
 	}

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -1146,6 +1146,58 @@ func TestStatusBar_FlowsModeShowsManualMergeOnlyForEligibleFlowRow(t *testing.T)
 	}
 }
 
+func TestRender_FlowDegradationWarningReservesRowWithNoHealthyFlows(t *testing.T) {
+	warning := "Skipped 4 unreadable Flows (id1, id2, id3, …); run approach flow list --json"
+	view := Render(RenderParams{
+		Width:                  180,
+		Height:                 26,
+		Repos:                  []scanner.Repo{{Path: "/repo", DisplayName: "repo"}},
+		Selected:               0,
+		Mode:                   ModeFlows,
+		TopMode:                ModeWorktrees,
+		BottomMode:             ModeFlows,
+		ContentPane:            PaneBottom,
+		ActivePane:             PaneBottom,
+		FlowDegradationWarning: warning,
+		RightEmptyMessage:      "No flows",
+	})
+	plain := ansi.Strip(view)
+	for _, want := range []string{warning, "No flows"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("degraded empty Flow pane missing %q:\n%s", want, plain)
+		}
+	}
+	if !strings.Contains(view, aheadBehindStyle.Render(" "+warning)) {
+		t.Fatalf("degradation warning did not use warning style:\n%q", view)
+	}
+}
+
+func TestRender_FlowDegradationAndCachedRefreshWarningsAreDistinct(t *testing.T) {
+	degraded := "Skipped 1 unreadable Flows (bad); run approach flow list --json"
+	view := Render(RenderParams{
+		Width:                  180,
+		Height:                 26,
+		Repos:                  []scanner.Repo{{Path: "/repo", DisplayName: "repo"}},
+		Selected:               0,
+		Mode:                   ModeFlows,
+		TopMode:                ModeWorktrees,
+		BottomMode:             ModeFlows,
+		ContentPane:            PaneBottom,
+		ActivePane:             PaneBottom,
+		Flows:                  []flowstore.FlowRecord{{FlowID: "healthy", Title: "Healthy"}},
+		FlowSelected:           0,
+		BottomListError:        "database unavailable",
+		FlowDegradationWarning: degraded,
+	})
+	if !strings.Contains(view, aheadBehindStyle.Render(" "+degraded)) {
+		t.Fatalf("view missing styled degradation warning:\n%q", view)
+	}
+	cached := " Could not refresh flows; showing cached data"
+	if !strings.Contains(view, dirtyRedStyle.Render(cached)) {
+		t.Fatalf("view missing distinct styled cached warning:\n%q", view)
+	}
+}
+
 func TestRender_FlowsModeCompactSelectedFlowPrioritizesFlowActions(t *testing.T) {
 	view := Render(RenderParams{
 		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},


### PR DESCRIPTION
## Summary

- return healthy Flow records alongside a typed partial-list diagnostic when individual SQLite rows cannot be decoded
- keep point reads and non-row-local storage failures strict
- surface partial results safely in the CLI, Repository and Active Flows panes, and GraphQL snapshots
- prevent AutoMode from acting on incomplete Flow corpora
- document the partial-list contract and operator guidance without adding destructive repair behavior

## Implementation

- add deterministic skipped-row diagnostics with typed classification and wrapped causes
- preserve fatal query, scan, iteration, and close error boundaries
- track independent, freshness-safe degradation warnings for Repository and Active Flows
- harden classification so joined or malformed errors cannot be downgraded
- sanitize corrupt Flow identifiers before terminal and log diagnostics

## Verification

- `git diff --check origin/main...HEAD`
- `make fmt-check`
- `make test`
- `make build`
