### PR TITLE
Reject Flow launches with stale worktrees

### DIFF
--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -637,11 +637,12 @@ agent.
 
 A Flow that records a non-empty worktree path takes a different route: Approach
 inspects that exact path before persisting a phase launch ID or preparing an
-agent process. If the path is missing or is not a directory, a manual launch is
-refused with the recorded path and inspection reason, while AutoMode blocks the
-candidate phase with the same reason in its notes. Approach does not clear the
-path, prune Git metadata, recreate the worktree, or fall back to the repository
-root; those cases can require different recovery choices.
+agent process. If the path is missing or is not a directory, a `g` phase launch
+or `r` phase resume is refused with the recorded path and inspection reason,
+while AutoMode blocks the candidate phase with the same reason in its notes.
+Approach does not clear the path, prune Git metadata, recreate the worktree, or
+fall back to the repository root; those cases can require different recovery
+choices.
 
 A record that already names a local branch gets a worktree for that branch, so
 the name prompts render as the push target keeps meaning what it said. If that

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -635,6 +635,14 @@ was written — never launches in the repository root. Pressing `g` creates the
 worktree first, announcing it in the status line, and only then starts the
 agent.
 
+A Flow that records a non-empty worktree path takes a different route: Approach
+inspects that exact path before persisting a phase launch ID or preparing an
+agent process. If the path is missing or is not a directory, a manual launch is
+refused with the recorded path and inspection reason, while AutoMode blocks the
+candidate phase with the same reason in its notes. Approach does not clear the
+path, prune Git metadata, recreate the worktree, or fall back to the repository
+root; those cases can require different recovery choices.
+
 A record that already names a local branch gets a worktree for that branch, so
 the name prompts render as the push target keeps meaning what it said. If that
 branch already has a healthy linked worktree, the Flow adopts it rather than
@@ -665,16 +673,15 @@ that reason in its notes rather than retrying every second, when:
   HEAD under a record that keeps naming a branch;
 - the recorded branch is checked out in the repository's own working tree,
   which is the launch this whole path exists to prevent;
-- `git worktree add` fails for any other reason, including a registration left
-  behind by a directory deleted without `git worktree prune`.
+- `git worktree add` fails for any other reason.
 
 Most of those refusals write nothing, but two happen after `git worktree add`
 has already run. A store that will not record the new worktree leaves a branch
 and directory on disk that no record names; the status line names the path. A
 bootstrap-hook failure comes after the start metadata is persisted, so the Flow
 does keep the worktree it just gained, and its status says so — note that a
-second `g` then takes the worktree as given and launches the agent into it even
-though the hook never completed.
+second `g` validates the recorded directory and launches the agent into it when
+it remains usable, even though the hook never completed.
 
 After the active subview settles, `enter` on its visible selected row
 asynchronously loads the raw human-readable output of

--- a/model/export_test.go
+++ b/model/export_test.go
@@ -68,6 +68,11 @@ func ClearFlowEmbeddedTerminalsForTest(m Model) Model {
 	return m
 }
 
+func WithFlowWorktreeInspectionForTest(m Model, inspect func(string) error) Model {
+	m.launchSeams.InspectWorktreeDirectory = inspect
+	return m
+}
+
 func AutoAdvanceResultForTest(m Model, flows []flowstore.FlowRecord) (Model, tea.Cmd) {
 	m.autoAdvanceInFlight = 1
 	return m.handleAutoAdvanceResult(AutoAdvanceResultMsg{Flows: flows, Request: 1})

--- a/model/flow_advance_tick_test.go
+++ b/model/flow_advance_tick_test.go
@@ -51,7 +51,9 @@ func newAutoAdvanceTestModel(repos []scanner.Repo, opts Options) Model {
 	if opts.ReadFlow == nil {
 		opts.ReadFlow = autoAdvanceTestReadFlow
 	}
-	return NewWithOptions(repos, opts)
+	m := NewWithOptions(repos, opts)
+	m.launchSeams.InspectWorktreeDirectory = func(string) error { return nil }
+	return m
 }
 
 func autoAdvancePrepareForRequest(m Model, previous, current []flowstore.FlowRecord, request uint64) (Model, tea.Cmd, []string) {

--- a/model/flow_launch_generic_agent_internal_test.go
+++ b/model/flow_launch_generic_agent_internal_test.go
@@ -152,6 +152,7 @@ func TestGenericWorktreeAgentPressTimeRefusalsUseGenericContract(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			record := genericFlowAgentRecord(t)
 			h := newManualLaunchHarness(t, record)
+			h.inspectFunc = inspectWorktreeDirectory
 			m := h.model()
 			if tc.command == "__empty__" {
 				m.agentCommand = ""
@@ -225,6 +226,7 @@ func TestGenericWorktreeAgentSKeyUsesBothFlowSurfaces(t *testing.T) {
 		t.Run(map[bool]string{false: "flows", true: "active flows"}[active], func(t *testing.T) {
 			record := genericFlowAgentRecord(t)
 			h := newManualLaunchHarness(t, record)
+			h.inspectFunc = inspectWorktreeDirectory
 			m := h.model()
 			m.activePane = m.contentPane
 			if active {
@@ -536,6 +538,7 @@ func TestGenericWorktreeAgentProtectedRevalidationRejectsFreshOccupancyAndPaths(
 		t.Run(tc.name, func(t *testing.T) {
 			record := genericFlowAgentRecord(t)
 			h := newManualLaunchHarness(t, record)
+			h.inspectFunc = inspectWorktreeDirectory
 			m := h.model()
 			next, readCmd := m.handleStartSelectedFlowWorktreeAgent()
 			m = next.(Model)

--- a/model/flow_launch_lifecycle_internal_test.go
+++ b/model/flow_launch_lifecycle_internal_test.go
@@ -91,9 +91,12 @@ type manualLaunchHarness struct {
 
 	// ensureRecords counts what the worktree-creation seam was asked to create,
 	// so "the git work never happened" is assertable rather than inferred.
-	ensureRecords []flowstore.FlowRecord
-	ensureErr     error
-	ensured       flowstore.FlowRecord
+	ensureRecords  []flowstore.FlowRecord
+	ensureErr      error
+	ensured        flowstore.FlowRecord
+	inspectedPaths []string
+	inspectErr     error
+	inspectFunc    func(string) error
 
 	persistedRecord   flowstore.FlowRecord
 	persistedRecordOK bool
@@ -294,6 +297,13 @@ func (h *manualLaunchHarness) model() Model {
 func (h *manualLaunchHarness) modelWith(repos []scanner.Repo, opts Options) Model {
 	h.t.Helper()
 	m := NewWithOptions(repos, opts)
+	m.launchSeams.InspectWorktreeDirectory = func(path string) error {
+		h.inspectedPaths = append(h.inspectedPaths, path)
+		if h.inspectFunc != nil {
+			return h.inspectFunc(path)
+		}
+		return h.inspectErr
+	}
 	m.contentPane = ui.PaneBottom
 	m.bottomMode = ui.ModeFlows
 	m.flows = m.flows.SetItems([]flowstore.FlowRecord{h.record})

--- a/model/flow_launch_resume.go
+++ b/model/flow_launch_resume.go
@@ -228,6 +228,10 @@ func phaseResumeFlowLaunchReadCmd(seams flowLaunchSeams, intent flowLaunchIntent
 			event.Err = flowPhaseResumeNoWorktreeStatus
 			return event
 		}
+		if err := seams.inspectWorktreeDirectory(record.WorktreePath); err != nil {
+			event.Err = recordedFlowWorktreeUnusableError(record.WorktreePath, err).Error()
+			return event
+		}
 		repoPath := record.RepoPath
 		if repoPath == "" {
 			repoPath = intent.FallbackRepoPath

--- a/model/flow_launch_resume_internal_test.go
+++ b/model/flow_launch_resume_internal_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -518,6 +519,53 @@ func TestPhaseResumeReadStageRefusals(t *testing.T) {
 				t.Fatalf("a refused resume opened a terminal: %#v", h.launchContexts)
 			}
 			if _, ok := m.flowLaunchAttempt("flow-1"); ok {
+				t.Fatal("a refused resume must release the Flow")
+			}
+		})
+	}
+}
+
+func TestPhaseResumeRefusesUnusableRecordedWorktree(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		worktreePath  string
+		inspectionErr error
+	}{
+		{
+			name:          "missing path",
+			worktreePath:  "/dev/alpha-worktrees/missing-flow",
+			inspectionErr: errors.New("stat /dev/alpha-worktrees/missing-flow: no such file or directory"),
+		},
+		{
+			name:          "not a directory",
+			worktreePath:  "/dev/alpha-worktrees/not-a-directory",
+			inspectionErr: errors.New("/dev/alpha-worktrees/not-a-directory is not a directory"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			record := resumeLaunchFlowRecord()
+			record.WorktreePath = tt.worktreePath
+			h := newManualLaunchHarness(t, record)
+			h.inspectErr = tt.inspectionErr
+
+			m := h.resume(h.resumeModel())
+
+			want := fmt.Sprintf("Recorded Flow worktree %q is unusable: %v", tt.worktreePath, tt.inspectionErr)
+			if got := m.status.Text; got != want {
+				t.Fatalf("status = %q, want %q", got, want)
+			}
+			if len(h.inspectedPaths) != 1 || h.inspectedPaths[0] != tt.worktreePath {
+				t.Fatalf("inspected paths = %#v, want the recorded path once", h.inspectedPaths)
+			}
+			if h.launchReservations != 0 || len(h.launchUpdates) != 0 {
+				t.Fatalf("a refused resume persisted something: reservations=%d launches=%#v",
+					h.launchReservations, h.launchUpdates)
+			}
+			if len(h.launchContexts) != 0 || len(h.agentContexts) != 0 || len(h.tmuxContexts) != 0 {
+				t.Fatalf("a refused resume spawned something: embedded=%#v agents=%#v tmux=%#v",
+					h.launchContexts, h.agentContexts, h.tmuxContexts)
+			}
+			if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
 				t.Fatal("a refused resume must release the Flow")
 			}
 		})

--- a/model/flow_launch_worktree_internal_test.go
+++ b/model/flow_launch_worktree_internal_test.go
@@ -63,6 +63,39 @@ func TestManualFlowLaunchLeavesAWorktreedFlowUntouched(t *testing.T) {
 	}
 }
 
+func TestManualFlowLaunchRefusesMissingRecordedWorktree(t *testing.T) {
+	record := manualLaunchFlowRecord()
+	record.WorktreePath = "/dev/alpha-worktrees/missing-flow"
+	h := newManualLaunchHarness(t, record)
+	h.inspectErr = errors.New("stat /dev/alpha-worktrees/missing-flow: no such file or directory")
+
+	m := h.launch(h.model())
+
+	want := `Recorded Flow worktree "/dev/alpha-worktrees/missing-flow" is unusable: stat /dev/alpha-worktrees/missing-flow: no such file or directory`
+	if m.status.Text != want {
+		t.Fatalf("status = %q, want %q", m.status.Text, want)
+	}
+	if len(h.inspectedPaths) != 1 || h.inspectedPaths[0] != record.WorktreePath {
+		t.Fatalf("inspected paths = %#v, want the recorded path once", h.inspectedPaths)
+	}
+	if len(h.ensureRecords) != 0 {
+		t.Fatalf("ensure calls = %#v, want none for a non-empty recorded path", h.ensureRecords)
+	}
+	if len(h.phaseUpdates) != 0 || len(h.launchUpdates) != 0 {
+		t.Fatalf("a refused manual launch persisted something: phases=%#v launches=%#v", h.phaseUpdates, h.launchUpdates)
+	}
+	if h.launchReservations != 0 {
+		t.Fatalf("launch reservations = %d, want 0 before prepare", h.launchReservations)
+	}
+	if len(h.agentContexts) != 0 || len(h.launchContexts) != 0 || len(h.tmuxContexts) != 0 {
+		t.Fatalf("a refused manual launch spawned something: agents=%#v terminals=%#v tmux=%#v",
+			h.agentContexts, h.launchContexts, h.tmuxContexts)
+	}
+	if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
+		t.Fatal("a refused manual launch must release its attempt")
+	}
+}
+
 // A keypress that is refused must not mutate Flow state as a side effect.
 func TestManualFlowLaunchWorktreeFailureRefusesWithoutWriting(t *testing.T) {
 	record := worktreelessFlowRecord()
@@ -217,6 +250,94 @@ func TestAutoFlowLaunchCreatesTheMissingWorktreeAndLaunches(t *testing.T) {
 	}
 	if h.drainArmed(m, record.FlowID) {
 		t.Fatal("a successful auto launch must leave the drain disarmed")
+	}
+}
+
+func TestAutoFlowLaunchBlocksMissingRecordedWorktree(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		phase       flowstore.FlowPhase
+		planID      string
+		planPath    string
+		wantOutcome string
+	}{
+		{
+			name: "implementation",
+			phase: flowstore.FlowPhase{
+				PhaseID: "implementation", Title: "Implementation", Kind: flowstore.KindImplementation,
+				Status: flowstore.PhaseReady, Order: 1,
+			},
+		},
+		{
+			name: "plan review",
+			phase: flowstore.FlowPhase{
+				PhaseID: "plan-review", Title: "Plan review", Kind: flowstore.KindPlanReview,
+				Status: flowstore.PhaseReady, Order: 1,
+			},
+			planID:      "plan-1",
+			planPath:    "/state/approach/plans/plan-1/plan.md",
+			wantOutcome: flowstore.OutcomeBlocked,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			record := autoLaunchFlowRecord()
+			record.WorktreePath = "/dev/alpha-worktrees/missing-flow"
+			record.PlanID = tt.planID
+			record.PlanPath = tt.planPath
+			record.Phases = []flowstore.FlowPhase{tt.phase}
+			h := newManualLaunchHarness(t, record)
+			h.inspectErr = errors.New("stat /dev/alpha-worktrees/missing-flow: no such file or directory")
+
+			m := h.autoDrain(h.model(), record)
+
+			reason := `Recorded Flow worktree "/dev/alpha-worktrees/missing-flow" is unusable: stat /dev/alpha-worktrees/missing-flow: no such file or directory`
+			if len(h.phaseUpdates) != 1 {
+				t.Fatalf("phase updates = %#v, want exactly one blocked write", h.phaseUpdates)
+			}
+			update := h.phaseUpdates[0]
+			if update.FlowID != record.FlowID ||
+				update.PhaseID != tt.phase.PhaseID ||
+				update.Status != flowstore.PhaseBlocked ||
+				update.Notes != "Auto-advance blocked: "+reason ||
+				update.Outcome != tt.wantOutcome {
+				t.Fatalf("phase update = %#v", update)
+			}
+			if len(h.inspectedPaths) != 1 || h.inspectedPaths[0] != record.WorktreePath {
+				t.Fatalf("inspected paths = %#v, want the recorded path once", h.inspectedPaths)
+			}
+			if len(h.ensureRecords) != 0 || len(h.launchUpdates) != 0 {
+				t.Fatalf("a blocked launch provisioned or persisted a launch ID: ensures=%#v launches=%#v",
+					h.ensureRecords, h.launchUpdates)
+			}
+			if h.launchReservations != 0 {
+				t.Fatalf("launch reservations = %d, want 0 before prepare", h.launchReservations)
+			}
+			if len(h.agentContexts) != 0 || len(h.launchContexts) != 0 || len(h.tmuxContexts) != 0 {
+				t.Fatalf("a blocked launch spawned something: agents=%#v terminals=%#v tmux=%#v",
+					h.agentContexts, h.launchContexts, h.tmuxContexts)
+			}
+			if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
+				t.Fatal("the blocked write must release the attempt once it lands")
+			}
+			if h.drainArmed(m, record.FlowID) {
+				t.Fatal("a blocked phase must not re-arm the drain")
+			}
+			if m.status.Text != reason {
+				t.Fatalf("status = %q, want %q", m.status.Text, reason)
+			}
+
+			blocked := record
+			blocked.Phases = append([]flowstore.FlowPhase(nil), record.Phases...)
+			blocked.Phases[0].Status = flowstore.PhaseBlocked
+			m = h.autoDrain(m, blocked)
+			if len(h.inspectedPaths) != 1 || h.launchReservations != 0 ||
+				len(h.phaseUpdates) != 1 || len(h.launchUpdates) != 0 ||
+				len(h.agentContexts) != 0 || len(h.launchContexts) != 0 || len(h.tmuxContexts) != 0 {
+				t.Fatalf("blocked phase retried work: inspections=%#v reservations=%d phases=%#v launches=%#v agents=%#v terminals=%#v tmux=%#v",
+					h.inspectedPaths, h.launchReservations, h.phaseUpdates, h.launchUpdates,
+					h.agentContexts, h.launchContexts, h.tmuxContexts)
+			}
+		})
 	}
 }
 

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -121,25 +121,29 @@ type FlowPhaseLauncher struct {
 	// has none, returning the updated record. Nil means "refuse worktree-less
 	// launches" — it never means "fall back to the repository root".
 	EnsureWorktree func(flowstore.FlowRecord) (flowstore.FlowRecord, error)
+	// InspectWorktreeDirectory validates a non-empty recorded worktree path.
+	// Nil means "use the real filesystem inspector", never "skip validation".
+	InspectWorktreeDirectory func(string) error
 }
 
 func (m Model) flowPhaseLauncher() FlowPhaseLauncher {
 	command, model, reasoningEffort := m.flowLaunchAgentSettings()
 	return FlowPhaseLauncher{
-		Backend:              m.launchBackend,
-		TmuxAvailable:        m.tmuxAvailable,
-		CurrentRepoPath:      m.currentRepoPath,
-		PlanMarkdownPath:     m.planMarkdownPath,
-		ReadPlan:             m.readPlan,
-		AddFlowPhaseLaunchID: m.addFlowPhaseLaunchID,
-		NewLaunchID:          newLaunchID,
-		SessionStateRoot:     m.sessionStateRoot,
-		AgentPreferences:     m.agentPreferences(),
-		AgentCommand:         command,
-		Model:                model,
-		ReasoningEffort:      reasoningEffort,
-		PromptTemplates:      m.flowPromptTemplates,
-		EnsureWorktree:       m.ensureFlowWorktree,
+		Backend:                  m.launchBackend,
+		TmuxAvailable:            m.tmuxAvailable,
+		CurrentRepoPath:          m.currentRepoPath,
+		PlanMarkdownPath:         m.planMarkdownPath,
+		ReadPlan:                 m.readPlan,
+		AddFlowPhaseLaunchID:     m.addFlowPhaseLaunchID,
+		NewLaunchID:              newLaunchID,
+		SessionStateRoot:         m.sessionStateRoot,
+		AgentPreferences:         m.agentPreferences(),
+		AgentCommand:             command,
+		Model:                    model,
+		ReasoningEffort:          reasoningEffort,
+		PromptTemplates:          m.flowPromptTemplates,
+		EnsureWorktree:           m.ensureFlowWorktree,
+		InspectWorktreeDirectory: m.launchSeams.inspectWorktreeDirectory,
 	}
 }
 
@@ -196,13 +200,18 @@ func (l FlowPhaseLauncher) Preflight(req FlowPhaseLaunchRequest) (FlowPhaseLaunc
 	}, nil
 }
 
-// EnsureLaunchWorktree resolves a prepared request whose WorktreePath is still
-// empty. It is the only part of launch preparation that mutates the filesystem,
-// so callers must run it last: after every cheap refusal Preflight makes and
-// after the session-occupancy check, or a launch that is about to be refused
-// leaves an orphan branch and directory behind.
+// EnsureLaunchWorktree validates a prepared request's recorded worktree, or
+// provisions one when the record has no path. It is the only filesystem-aware
+// part of launch preparation, so callers must run it last: after every cheap
+// refusal Preflight makes and after the session-occupancy check, or a launch
+// that is about to be refused may inspect unnecessarily or leave an orphan
+// branch and directory behind.
 func (l FlowPhaseLauncher) EnsureLaunchWorktree(req FlowPhaseLaunchPreparedRequest) (FlowPhaseLaunchPreparedRequest, error) {
 	if req.WorktreePath != "" {
+		if err := l.inspectWorktreeDirectory(req.WorktreePath); err != nil {
+			return req, FlowPhaseLaunchWorktreeError{Message: fmt.Sprintf(
+				"Recorded Flow worktree %q is unusable: %v", req.WorktreePath, err)}
+		}
 		return req, nil
 	}
 	// Record.RepoPath, never req.RepoPath: the latter has already fallen back to
@@ -254,6 +263,13 @@ func (l FlowPhaseLauncher) EnsureLaunchWorktree(req FlowPhaseLaunchPreparedReque
 		return req, FlowPhaseLaunchWorktreeError{Message: flowPhaseLaunchWorktreeFailed + "no worktree path was recorded"}
 	}
 	return req, nil
+}
+
+func (l FlowPhaseLauncher) inspectWorktreeDirectory(path string) error {
+	if l.InspectWorktreeDirectory != nil {
+		return l.InspectWorktreeDirectory(path)
+	}
+	return inspectWorktreeDirectory(path)
 }
 
 func (l FlowPhaseLauncher) Prepare(req FlowPhaseLaunchPreparedRequest) (FlowPhaseLaunchResult, error) {

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -209,8 +209,7 @@ func (l FlowPhaseLauncher) Preflight(req FlowPhaseLaunchRequest) (FlowPhaseLaunc
 func (l FlowPhaseLauncher) EnsureLaunchWorktree(req FlowPhaseLaunchPreparedRequest) (FlowPhaseLaunchPreparedRequest, error) {
 	if req.WorktreePath != "" {
 		if err := l.inspectWorktreeDirectory(req.WorktreePath); err != nil {
-			return req, FlowPhaseLaunchWorktreeError{Message: fmt.Sprintf(
-				"Recorded Flow worktree %q is unusable: %v", req.WorktreePath, err)}
+			return req, recordedFlowWorktreeUnusableError(req.WorktreePath, err)
 		}
 		return req, nil
 	}
@@ -263,6 +262,11 @@ func (l FlowPhaseLauncher) EnsureLaunchWorktree(req FlowPhaseLaunchPreparedReque
 		return req, FlowPhaseLaunchWorktreeError{Message: flowPhaseLaunchWorktreeFailed + "no worktree path was recorded"}
 	}
 	return req, nil
+}
+
+func recordedFlowWorktreeUnusableError(path string, err error) FlowPhaseLaunchWorktreeError {
+	return FlowPhaseLaunchWorktreeError{Message: fmt.Sprintf(
+		"Recorded Flow worktree %q is unusable: %v", path, err)}
 }
 
 func (l FlowPhaseLauncher) inspectWorktreeDirectory(path string) error {

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -261,6 +261,12 @@ func (l FlowPhaseLauncher) EnsureLaunchWorktree(req FlowPhaseLaunchPreparedReque
 	if !created {
 		return req, FlowPhaseLaunchWorktreeError{Message: flowPhaseLaunchWorktreeFailed + "no worktree path was recorded"}
 	}
+	// EnsureWorktree may return a path another process recorded while this
+	// launch was waiting for the reservation. Validate every successfully
+	// ensured path before Prepare can persist a launch ID against it.
+	if err := l.inspectWorktreeDirectory(req.WorktreePath); err != nil {
+		return req, recordedFlowWorktreeUnusableError(req.WorktreePath, err)
+	}
 	return req, nil
 }
 

--- a/model/flow_phase_launch_worktree_test.go
+++ b/model/flow_phase_launch_worktree_test.go
@@ -66,15 +66,20 @@ func TestFlowPhaseLauncherPreflightKeepsExistingWorktreePath(t *testing.T) {
 	}
 }
 
-func TestFlowPhaseLauncherEnsureLaunchWorktreeSkipsSeamWhenWorktreeExists(t *testing.T) {
+func TestFlowPhaseLauncherEnsureLaunchWorktreeInspectsExistingWorktreePath(t *testing.T) {
 	record := worktreelessLaunchRecord()
 	record.WorktreePath = "/dev/alpha-worktrees/flow-one"
-	calls := 0
+	ensureCalls := 0
+	var inspectedPaths []string
 	launcher := model.FlowPhaseLauncher{
 		AgentCommand: "codex",
 		NewLaunchID:  func() string { return "launch-1" },
+		InspectWorktreeDirectory: func(path string) error {
+			inspectedPaths = append(inspectedPaths, path)
+			return nil
+		},
 		EnsureWorktree: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
-			calls++
+			ensureCalls++
 			return flowstore.FlowRecord{}, nil
 		},
 	}
@@ -87,11 +92,125 @@ func TestFlowPhaseLauncherEnsureLaunchWorktreeSkipsSeamWhenWorktreeExists(t *tes
 	if err != nil {
 		t.Fatalf("EnsureLaunchWorktree() error = %v", err)
 	}
-	if calls != 0 {
-		t.Fatalf("ensure seam calls = %d, want 0 for a Flow that already has a worktree", calls)
+	if len(inspectedPaths) != 1 || inspectedPaths[0] != record.WorktreePath {
+		t.Fatalf("inspected paths = %#v, want the recorded path", inspectedPaths)
+	}
+	if ensureCalls != 0 {
+		t.Fatalf("ensure seam calls = %d, want 0 for a Flow that already has a worktree", ensureCalls)
 	}
 	if ensured.WorktreePath != record.WorktreePath || ensured.CreatedWorktree {
 		t.Fatalf("ensured request = %#v, want it returned unchanged", ensured)
+	}
+}
+
+func TestFlowPhaseLauncherEnsureLaunchWorktreeUsesRealInspectorWhenNil(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	record.WorktreePath = t.TempDir()
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand: "codex",
+		NewLaunchID:  func() string { return "launch-1" },
+		EnsureWorktree: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			t.Fatal("a non-empty recorded path must not be provisioned")
+			return flowstore.FlowRecord{}, nil
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	ensured, err := launcher.EnsureLaunchWorktree(prepared)
+	if err != nil {
+		t.Fatalf("EnsureLaunchWorktree() error = %v", err)
+	}
+	if ensured.WorktreePath != record.WorktreePath || ensured.CreatedWorktree {
+		t.Fatalf("ensured request = %#v, want the real directory returned unchanged", ensured)
+	}
+}
+
+func TestFlowPhaseLauncherEnsureLaunchWorktreeRefusesNonDirectoryRecordedPath(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	record.WorktreePath = "/dev/alpha-worktrees/not-a-directory"
+	inspectionErr := errors.New("/dev/alpha-worktrees/not-a-directory is not a directory")
+	var inspectedPaths []string
+	ensureCalls := 0
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand: "codex",
+		NewLaunchID:  func() string { return "launch-1" },
+		InspectWorktreeDirectory: func(path string) error {
+			inspectedPaths = append(inspectedPaths, path)
+			return inspectionErr
+		},
+		EnsureWorktree: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			ensureCalls++
+			return flowstore.FlowRecord{}, nil
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	_, err = launcher.EnsureLaunchWorktree(prepared)
+	want := `Recorded Flow worktree "/dev/alpha-worktrees/not-a-directory" is unusable: /dev/alpha-worktrees/not-a-directory is not a directory`
+	if err == nil || err.Error() != want {
+		t.Fatalf("EnsureLaunchWorktree() error = %v, want %q", err, want)
+	}
+	var worktreeErr model.FlowPhaseLaunchWorktreeError
+	if !errors.As(err, &worktreeErr) {
+		t.Fatalf("EnsureLaunchWorktree() error type = %T, want FlowPhaseLaunchWorktreeError", err)
+	}
+	if worktreeErr.Transient || worktreeErr.Stale {
+		t.Fatalf("worktree error classification = transient %v stale %v, want permanent", worktreeErr.Transient, worktreeErr.Stale)
+	}
+	if len(inspectedPaths) != 1 || inspectedPaths[0] != record.WorktreePath {
+		t.Fatalf("inspected paths = %#v, want the recorded path", inspectedPaths)
+	}
+	if ensureCalls != 0 {
+		t.Fatalf("ensure seam calls = %d, want 0 for a non-empty recorded path", ensureCalls)
+	}
+}
+
+func TestFlowPhaseLauncherEnsureLaunchWorktreeRefusesMissingRecordedPath(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	record.WorktreePath = "/dev/alpha-worktrees/missing-flow"
+	inspectionErr := errors.New("stat /dev/alpha-worktrees/missing-flow: no such file or directory")
+	var inspectedPaths []string
+	ensureCalls := 0
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand: "codex",
+		NewLaunchID:  func() string { return "launch-1" },
+		InspectWorktreeDirectory: func(path string) error {
+			inspectedPaths = append(inspectedPaths, path)
+			return inspectionErr
+		},
+		EnsureWorktree: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			ensureCalls++
+			return flowstore.FlowRecord{}, nil
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	_, err = launcher.EnsureLaunchWorktree(prepared)
+	want := `Recorded Flow worktree "/dev/alpha-worktrees/missing-flow" is unusable: stat /dev/alpha-worktrees/missing-flow: no such file or directory`
+	if err == nil || err.Error() != want {
+		t.Fatalf("EnsureLaunchWorktree() error = %v, want %q", err, want)
+	}
+	var worktreeErr model.FlowPhaseLaunchWorktreeError
+	if !errors.As(err, &worktreeErr) {
+		t.Fatalf("EnsureLaunchWorktree() error type = %T, want FlowPhaseLaunchWorktreeError", err)
+	}
+	if worktreeErr.Transient || worktreeErr.Stale {
+		t.Fatalf("worktree error classification = transient %v stale %v, want permanent", worktreeErr.Transient, worktreeErr.Stale)
+	}
+	if len(inspectedPaths) != 1 || inspectedPaths[0] != record.WorktreePath {
+		t.Fatalf("inspected paths = %#v, want the recorded path", inspectedPaths)
+	}
+	if ensureCalls != 0 {
+		t.Fatalf("ensure seam calls = %d, want 0 for a non-empty recorded path", ensureCalls)
 	}
 }
 

--- a/model/flow_phase_launch_worktree_test.go
+++ b/model/flow_phase_launch_worktree_test.go
@@ -224,6 +224,9 @@ func TestFlowPhaseLauncherEnsureLaunchWorktreeCreatesAndCarriesTheUpdatedRecord(
 	launcher := model.FlowPhaseLauncher{
 		AgentCommand: "codex",
 		NewLaunchID:  func() string { return "launch-1" },
+		InspectWorktreeDirectory: func(string) error {
+			return nil
+		},
 		EnsureWorktree: func(got flowstore.FlowRecord) (flowstore.FlowRecord, error) {
 			seen = append(seen, got)
 			return updated, nil
@@ -263,6 +266,48 @@ func TestFlowPhaseLauncherEnsureLaunchWorktreeCreatesAndCarriesTheUpdatedRecord(
 		result.Context.Branch != "flow/flow-one" ||
 		result.Context.Commit != "abc123" {
 		t.Fatalf("launch context = %#v, want the ensured worktree, branch, and commit", result.Context)
+	}
+}
+
+func TestFlowPhaseLauncherEnsureLaunchWorktreeRefusesUnusableEnsuredPath(t *testing.T) {
+	record := worktreelessLaunchRecord()
+	updated := record
+	updated.WorktreePath = "/dev/alpha-worktrees/disappeared"
+	inspectionErr := errors.New("stat /dev/alpha-worktrees/disappeared: no such file or directory")
+	var inspectedPaths []string
+	launcher := model.FlowPhaseLauncher{
+		AgentCommand: "codex",
+		NewLaunchID:  func() string { return "launch-1" },
+		EnsureWorktree: func(flowstore.FlowRecord) (flowstore.FlowRecord, error) {
+			return updated, nil
+		},
+		InspectWorktreeDirectory: func(path string) error {
+			inspectedPaths = append(inspectedPaths, path)
+			return inspectionErr
+		},
+	}
+
+	prepared, err := launcher.Preflight(model.FlowPhaseLaunchRequest{Record: record, Phase: record.Phases[0]})
+	if err != nil {
+		t.Fatalf("Preflight() error = %v", err)
+	}
+	ensured, err := launcher.EnsureLaunchWorktree(prepared)
+	want := `Recorded Flow worktree "/dev/alpha-worktrees/disappeared" is unusable: stat /dev/alpha-worktrees/disappeared: no such file or directory`
+	if err == nil || err.Error() != want {
+		t.Fatalf("EnsureLaunchWorktree() error = %v, want %q", err, want)
+	}
+	var worktreeErr model.FlowPhaseLaunchWorktreeError
+	if !errors.As(err, &worktreeErr) {
+		t.Fatalf("EnsureLaunchWorktree() error type = %T, want FlowPhaseLaunchWorktreeError", err)
+	}
+	if worktreeErr.Transient || worktreeErr.Stale {
+		t.Fatalf("worktree error classification = transient %v stale %v, want permanent", worktreeErr.Transient, worktreeErr.Stale)
+	}
+	if len(inspectedPaths) != 1 || inspectedPaths[0] != updated.WorktreePath {
+		t.Fatalf("inspected paths = %#v, want the ensured path", inspectedPaths)
+	}
+	if ensured.WorktreePath != updated.WorktreePath || ensured.Record.WorktreePath != updated.WorktreePath || !ensured.CreatedWorktree {
+		t.Fatalf("refused request = %#v, want the persisted ensured worktree carried forward", ensured)
 	}
 }
 
@@ -406,6 +451,9 @@ func TestFlowPhaseLauncherEnsureLaunchWorktreeCarriesBlankBranchAndCommit(t *tes
 	launcher := model.FlowPhaseLauncher{
 		AgentCommand: "codex",
 		NewLaunchID:  func() string { return "launch-1" },
+		InspectWorktreeDirectory: func(string) error {
+			return nil
+		},
 		EnsureWorktree: func(got flowstore.FlowRecord) (flowstore.FlowRecord, error) {
 			return flowstore.FlowRecord{
 				FlowID:       got.FlowID,

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -405,13 +405,13 @@ func (f callbackPreparationFinalizer) Finalize(callback func() error) (flowstore
 // launch lifecycle threads it forward and looks the launching phase up in it.
 // That also holds for the bootstrap failure below, which returns a record whose
 // worktree is real — the caller must not report that one as a creation failure.
-// A recorded worktree path means the directory exists and the store names it.
-// It does not mean the bootstrap hook completed: the hook runs after
-// SetStartMetadata, so a Flow whose hook failed passes through here and launches
-// into the worktree it did get. That is the same contract PrepareFlow has had
-// since Flow creation gained a hook, and the TUI guide documents it for the
-// second `g`. Making path existence imply a finished bootstrap needs a
-// provisioning marker in the store, which is a change to Flow creation too.
+// The launch lifecycle validates a non-empty recorded path before it reaches
+// this method, so the passthrough below assumes the directory still exists. It
+// does not mean the bootstrap hook completed: the hook runs after
+// SetStartMetadata, so a Flow whose hook failed keeps the worktree it did get
+// and a later launch may use it after directory inspection. Making path
+// existence imply a finished bootstrap needs a provisioning marker in the
+// store, which is a change to Flow creation too.
 func (s FlowStarter) EnsureWorktree(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
 	if strings.TrimSpace(record.WorktreePath) != "" {
 		return record, nil

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -27,6 +27,7 @@ import (
 
 func flowsInRightPane(t *testing.T, m model.Model, records []flowstore.FlowRecord) model.Model {
 	t.Helper()
+	m = model.WithFlowWorktreeInspectionForTest(m, func(string) error { return nil })
 	m, _ = update(m, tea.WindowSizeMsg{Width: 140, Height: 24})
 	m = inRightPane(m)
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyTab})
@@ -172,6 +173,7 @@ func flowStartRequestHeadless(req model.FlowStartRequest) bool {
 
 func enterActiveFlowsWithRecords(t *testing.T, m model.Model, records []flowstore.FlowRecord) model.Model {
 	t.Helper()
+	m = model.WithFlowWorktreeInspectionForTest(m, func(string) error { return nil })
 	if m.ActivePane() == ui.PaneRepos {
 		m = inRightPane(m)
 	}

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -115,7 +115,8 @@ func newTestModel(repos []scanner.Repo, opts model.Options) model.Model {
 			return record, nil
 		}
 	}
-	return model.NewWithOptions(repos, opts)
+	m := model.NewWithOptions(repos, opts)
+	return model.WithFlowWorktreeInspectionForTest(m, func(string) error { return nil })
 }
 
 // update sends a message and returns the concrete Model.


### PR DESCRIPTION
## Summary

- refuse Flow phase launches when the recorded worktree path is missing or is not a directory
- apply the same validation to tracked phase resumes and to worktrees returned by launch-time ensure logic
- keep refusals ahead of reservation, launch-ID persistence, and process preparation, with AutoMode treating permanent refusals as blocked
- document the stale-worktree behavior and add regression coverage for each launch path

## Verification

- `make fmt-check`
- `make test`
- `make build`