### PR TITLE
Expand stale worktree lifecycle coverage

### DIFF
--- a/model/flow_launch_worktree_internal_test.go
+++ b/model/flow_launch_worktree_internal_test.go
@@ -63,36 +63,55 @@ func TestManualFlowLaunchLeavesAWorktreedFlowUntouched(t *testing.T) {
 	}
 }
 
-func TestManualFlowLaunchRefusesMissingRecordedWorktree(t *testing.T) {
-	record := manualLaunchFlowRecord()
-	record.WorktreePath = "/dev/alpha-worktrees/missing-flow"
-	h := newManualLaunchHarness(t, record)
-	h.inspectErr = errors.New("stat /dev/alpha-worktrees/missing-flow: no such file or directory")
+func TestManualFlowLaunchRefusesUnusableRecordedWorktree(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		worktreePath  string
+		inspectionErr error
+	}{
+		{
+			name:          "missing path",
+			worktreePath:  "/dev/alpha-worktrees/missing-flow",
+			inspectionErr: errors.New("stat /dev/alpha-worktrees/missing-flow: no such file or directory"),
+		},
+		{
+			name:          "not a directory",
+			worktreePath:  "/dev/alpha-worktrees/not-a-directory",
+			inspectionErr: errors.New("/dev/alpha-worktrees/not-a-directory is not a directory"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			record := manualLaunchFlowRecord()
+			record.WorktreePath = tt.worktreePath
+			h := newManualLaunchHarness(t, record)
+			h.inspectErr = tt.inspectionErr
 
-	m := h.launch(h.model())
+			m := h.launch(h.model())
 
-	want := `Recorded Flow worktree "/dev/alpha-worktrees/missing-flow" is unusable: stat /dev/alpha-worktrees/missing-flow: no such file or directory`
-	if m.status.Text != want {
-		t.Fatalf("status = %q, want %q", m.status.Text, want)
-	}
-	if len(h.inspectedPaths) != 1 || h.inspectedPaths[0] != record.WorktreePath {
-		t.Fatalf("inspected paths = %#v, want the recorded path once", h.inspectedPaths)
-	}
-	if len(h.ensureRecords) != 0 {
-		t.Fatalf("ensure calls = %#v, want none for a non-empty recorded path", h.ensureRecords)
-	}
-	if len(h.phaseUpdates) != 0 || len(h.launchUpdates) != 0 {
-		t.Fatalf("a refused manual launch persisted something: phases=%#v launches=%#v", h.phaseUpdates, h.launchUpdates)
-	}
-	if h.launchReservations != 0 {
-		t.Fatalf("launch reservations = %d, want 0 before prepare", h.launchReservations)
-	}
-	if len(h.agentContexts) != 0 || len(h.launchContexts) != 0 || len(h.tmuxContexts) != 0 {
-		t.Fatalf("a refused manual launch spawned something: agents=%#v terminals=%#v tmux=%#v",
-			h.agentContexts, h.launchContexts, h.tmuxContexts)
-	}
-	if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
-		t.Fatal("a refused manual launch must release its attempt")
+			want := fmt.Sprintf("Recorded Flow worktree %q is unusable: %v", tt.worktreePath, tt.inspectionErr)
+			if m.status.Text != want {
+				t.Fatalf("status = %q, want %q", m.status.Text, want)
+			}
+			if len(h.inspectedPaths) != 1 || h.inspectedPaths[0] != record.WorktreePath {
+				t.Fatalf("inspected paths = %#v, want the recorded path once", h.inspectedPaths)
+			}
+			if len(h.ensureRecords) != 0 {
+				t.Fatalf("ensure calls = %#v, want none for a non-empty recorded path", h.ensureRecords)
+			}
+			if len(h.phaseUpdates) != 0 || len(h.launchUpdates) != 0 {
+				t.Fatalf("a refused manual launch persisted something: phases=%#v launches=%#v", h.phaseUpdates, h.launchUpdates)
+			}
+			if h.launchReservations != 0 {
+				t.Fatalf("launch reservations = %d, want 0 before prepare", h.launchReservations)
+			}
+			if len(h.agentContexts) != 0 || len(h.launchContexts) != 0 || len(h.tmuxContexts) != 0 {
+				t.Fatalf("a refused manual launch spawned something: agents=%#v terminals=%#v tmux=%#v",
+					h.agentContexts, h.launchContexts, h.tmuxContexts)
+			}
+			if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
+				t.Fatal("a refused manual launch must release its attempt")
+			}
+		})
 	}
 }
 
@@ -253,8 +272,24 @@ func TestAutoFlowLaunchCreatesTheMissingWorktreeAndLaunches(t *testing.T) {
 	}
 }
 
-func TestAutoFlowLaunchBlocksMissingRecordedWorktree(t *testing.T) {
-	for _, tt := range []struct {
+func TestAutoFlowLaunchBlocksUnusableRecordedWorktree(t *testing.T) {
+	worktrees := []struct {
+		name          string
+		worktreePath  string
+		inspectionErr error
+	}{
+		{
+			name:          "missing path",
+			worktreePath:  "/dev/alpha-worktrees/missing-flow",
+			inspectionErr: errors.New("stat /dev/alpha-worktrees/missing-flow: no such file or directory"),
+		},
+		{
+			name:          "not a directory",
+			worktreePath:  "/dev/alpha-worktrees/not-a-directory",
+			inspectionErr: errors.New("/dev/alpha-worktrees/not-a-directory is not a directory"),
+		},
+	}
+	phases := []struct {
 		name        string
 		phase       flowstore.FlowPhase
 		planID      string
@@ -278,66 +313,70 @@ func TestAutoFlowLaunchBlocksMissingRecordedWorktree(t *testing.T) {
 			planPath:    "/state/approach/plans/plan-1/plan.md",
 			wantOutcome: flowstore.OutcomeBlocked,
 		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			record := autoLaunchFlowRecord()
-			record.WorktreePath = "/dev/alpha-worktrees/missing-flow"
-			record.PlanID = tt.planID
-			record.PlanPath = tt.planPath
-			record.Phases = []flowstore.FlowPhase{tt.phase}
-			h := newManualLaunchHarness(t, record)
-			h.inspectErr = errors.New("stat /dev/alpha-worktrees/missing-flow: no such file or directory")
+	}
 
-			m := h.autoDrain(h.model(), record)
+	for _, worktree := range worktrees {
+		for _, phase := range phases {
+			t.Run(worktree.name+"/"+phase.name, func(t *testing.T) {
+				record := autoLaunchFlowRecord()
+				record.WorktreePath = worktree.worktreePath
+				record.PlanID = phase.planID
+				record.PlanPath = phase.planPath
+				record.Phases = []flowstore.FlowPhase{phase.phase}
+				h := newManualLaunchHarness(t, record)
+				h.inspectErr = worktree.inspectionErr
 
-			reason := `Recorded Flow worktree "/dev/alpha-worktrees/missing-flow" is unusable: stat /dev/alpha-worktrees/missing-flow: no such file or directory`
-			if len(h.phaseUpdates) != 1 {
-				t.Fatalf("phase updates = %#v, want exactly one blocked write", h.phaseUpdates)
-			}
-			update := h.phaseUpdates[0]
-			if update.FlowID != record.FlowID ||
-				update.PhaseID != tt.phase.PhaseID ||
-				update.Status != flowstore.PhaseBlocked ||
-				update.Notes != "Auto-advance blocked: "+reason ||
-				update.Outcome != tt.wantOutcome {
-				t.Fatalf("phase update = %#v", update)
-			}
-			if len(h.inspectedPaths) != 1 || h.inspectedPaths[0] != record.WorktreePath {
-				t.Fatalf("inspected paths = %#v, want the recorded path once", h.inspectedPaths)
-			}
-			if len(h.ensureRecords) != 0 || len(h.launchUpdates) != 0 {
-				t.Fatalf("a blocked launch provisioned or persisted a launch ID: ensures=%#v launches=%#v",
-					h.ensureRecords, h.launchUpdates)
-			}
-			if h.launchReservations != 0 {
-				t.Fatalf("launch reservations = %d, want 0 before prepare", h.launchReservations)
-			}
-			if len(h.agentContexts) != 0 || len(h.launchContexts) != 0 || len(h.tmuxContexts) != 0 {
-				t.Fatalf("a blocked launch spawned something: agents=%#v terminals=%#v tmux=%#v",
-					h.agentContexts, h.launchContexts, h.tmuxContexts)
-			}
-			if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
-				t.Fatal("the blocked write must release the attempt once it lands")
-			}
-			if h.drainArmed(m, record.FlowID) {
-				t.Fatal("a blocked phase must not re-arm the drain")
-			}
-			if m.status.Text != reason {
-				t.Fatalf("status = %q, want %q", m.status.Text, reason)
-			}
+				m := h.autoDrain(h.model(), record)
 
-			blocked := record
-			blocked.Phases = append([]flowstore.FlowPhase(nil), record.Phases...)
-			blocked.Phases[0].Status = flowstore.PhaseBlocked
-			m = h.autoDrain(m, blocked)
-			if len(h.inspectedPaths) != 1 || h.launchReservations != 0 ||
-				len(h.phaseUpdates) != 1 || len(h.launchUpdates) != 0 ||
-				len(h.agentContexts) != 0 || len(h.launchContexts) != 0 || len(h.tmuxContexts) != 0 {
-				t.Fatalf("blocked phase retried work: inspections=%#v reservations=%d phases=%#v launches=%#v agents=%#v terminals=%#v tmux=%#v",
-					h.inspectedPaths, h.launchReservations, h.phaseUpdates, h.launchUpdates,
-					h.agentContexts, h.launchContexts, h.tmuxContexts)
-			}
-		})
+				reason := fmt.Sprintf("Recorded Flow worktree %q is unusable: %v", worktree.worktreePath, worktree.inspectionErr)
+				if len(h.phaseUpdates) != 1 {
+					t.Fatalf("phase updates = %#v, want exactly one blocked write", h.phaseUpdates)
+				}
+				update := h.phaseUpdates[0]
+				if update.FlowID != record.FlowID ||
+					update.PhaseID != phase.phase.PhaseID ||
+					update.Status != flowstore.PhaseBlocked ||
+					update.Notes != "Auto-advance blocked: "+reason ||
+					update.Outcome != phase.wantOutcome {
+					t.Fatalf("phase update = %#v", update)
+				}
+				if len(h.inspectedPaths) != 1 || h.inspectedPaths[0] != record.WorktreePath {
+					t.Fatalf("inspected paths = %#v, want the recorded path once", h.inspectedPaths)
+				}
+				if len(h.ensureRecords) != 0 || len(h.launchUpdates) != 0 {
+					t.Fatalf("a blocked launch provisioned or persisted a launch ID: ensures=%#v launches=%#v",
+						h.ensureRecords, h.launchUpdates)
+				}
+				if h.launchReservations != 0 {
+					t.Fatalf("launch reservations = %d, want 0 before prepare", h.launchReservations)
+				}
+				if len(h.agentContexts) != 0 || len(h.launchContexts) != 0 || len(h.tmuxContexts) != 0 {
+					t.Fatalf("a blocked launch spawned something: agents=%#v terminals=%#v tmux=%#v",
+						h.agentContexts, h.launchContexts, h.tmuxContexts)
+				}
+				if _, ok := m.flowLaunchAttempt(record.FlowID); ok {
+					t.Fatal("the blocked write must release the attempt once it lands")
+				}
+				if h.drainArmed(m, record.FlowID) {
+					t.Fatal("a blocked phase must not re-arm the drain")
+				}
+				if m.status.Text != reason {
+					t.Fatalf("status = %q, want %q", m.status.Text, reason)
+				}
+
+				blocked := record
+				blocked.Phases = append([]flowstore.FlowPhase(nil), record.Phases...)
+				blocked.Phases[0].Status = flowstore.PhaseBlocked
+				m = h.autoDrain(m, blocked)
+				if len(h.inspectedPaths) != 1 || h.launchReservations != 0 ||
+					len(h.phaseUpdates) != 1 || len(h.launchUpdates) != 0 ||
+					len(h.agentContexts) != 0 || len(h.launchContexts) != 0 || len(h.tmuxContexts) != 0 {
+					t.Fatalf("blocked phase retried work: inspections=%#v reservations=%d phases=%#v launches=%#v agents=%#v terminals=%#v tmux=%#v",
+						h.inspectedPaths, h.launchReservations, h.phaseUpdates, h.launchUpdates,
+						h.agentContexts, h.launchContexts, h.tmuxContexts)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- cover both missing paths and non-directory paths in manual Flow launch lifecycle tests
- exercise the same unusable-worktree matrix across implementation and plan AutoMode phases
- preserve assertions that refused launches do not reserve, persist, spawn, or retry work

## Verification

- `go test ./model -run 'Test(ManualFlowLaunchRefusesUnusableRecordedWorktree|AutoFlowLaunchBlocksUnusableRecordedWorktree)' -count=1`\n- `make fmt-check`\n- `make test`\n- `make build`