### PR TITLE
Label autofix terminals with PR numbers

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -887,6 +887,9 @@ type AgentLaunchContext struct {
 	// FlowAutofix marks the distinct prompted, PR-gated untracked agent started
 	// by U. It shares prompt delivery mechanics with FlowAgent but not policy.
 	FlowAutofix bool
+	// FlowAutofixPRNumber is display-only typed metadata for the PR-gated
+	// FlowAutofix role. It is not exported to providers.
+	FlowAutofixPRNumber int
 	// FlowPhaseTerminal records that the persisted phase kept a terminal
 	// status (completed, skipped) when the launch was recorded, so launch
 	// failures must not regress the phase to needs_attention.

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -823,7 +823,11 @@ On a Flow row or an expanded phase row:
   the agent in the repository root. The launch goes through the same lifecycle as
   `g`, so occupancy, the persisted `h` headless preference, tmux mode, and the
   current agent/model/effort all apply, and interactive embedded launches prefill
-  the dock for you to send.
+  the dock for you to send. Their dock tab/chip uses the display identity
+  `autofix pr <num>` without `#`, so PR 116 renders, for example,
+  `1 codex autofix pr 116 running`; the agent prompt remains exactly
+  `autofix pr #116`. Headless launches are unchanged and retain the existing
+  Flow identity rather than using the interactive autofix label.
 
   It is deliberately **phase-untracked**: it writes no phase state, marks no
   phase running, and attaches its session to no phase history, so an autofix run

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -704,6 +704,18 @@ func flowEmbeddedTerminalIdentity(ctx actions.AgentLaunchContext) string {
 	if ctx.FlowSavedSessionResume {
 		return "session " + shortSessionID(ctx.ResumeSessionID)
 	}
+	if ctx.FlowAutofix &&
+		ctx.FlowAutofixPRNumber > 0 &&
+		ctx.Embedded &&
+		!ctx.Headless &&
+		strings.TrimSpace(ctx.FlowID) != "" &&
+		ctx.FlowPhaseID == "" &&
+		!ctx.FlowLaunchTracked &&
+		!ctx.FlowRepair &&
+		!ctx.FlowAgent &&
+		!ctx.FlowSavedSessionResume {
+		return fmt.Sprintf("autofix pr %d", ctx.FlowAutofixPRNumber)
+	}
 	for _, value := range []string{
 		ctx.FlowPhaseID,
 		ctx.FlowID,

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -204,6 +204,89 @@ func (t internalFakeEmbeddedTerminal) State() string {
 	return t.state
 }
 
+func TestFlowEmbeddedTerminalIdentityAutofix(t *testing.T) {
+	valid := actions.AgentLaunchContext{
+		FlowID:                 "flow-1",
+		WorktreePath:           "/dev/alpha/worktrees/flow-1",
+		FlowAutofix:            true,
+		FlowAutofixPRNumber:    116,
+		Embedded:               true,
+		InitialPrompt:          "autofix pr #116",
+		FlowLaunchTracked:      false,
+		FlowPhaseID:            "",
+		FlowRepair:             false,
+		FlowAgent:              false,
+		FlowSavedSessionResume: false,
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*actions.AgentLaunchContext)
+		want   string
+	}{
+		{name: "valid", want: "autofix pr 116"},
+		{name: "repair precedence", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowRepair = true
+		}, want: "repair"},
+		{name: "generic agent precedence", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowAgent = true
+		}, want: "agent"},
+		{name: "saved session precedence", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowSavedSessionResume = true
+			ctx.ResumeSessionID = "abcdefgh12345678"
+		}, want: "session abcdefgh"},
+		{name: "tracked phase precedence", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowPhaseID = "implementation"
+			ctx.FlowLaunchTracked = true
+		}, want: "implementation"},
+		{name: "untracked phase identity", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowPhaseID = "review-loop"
+		}, want: "review-loop"},
+		{name: "zero PR number", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowAutofixPRNumber = 0
+		}, want: "flow-1"},
+		{name: "negative PR number", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowAutofixPRNumber = -1
+		}, want: "flow-1"},
+		{name: "PR metadata without autofix role", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowAutofix = false
+		}, want: "flow-1"},
+		{name: "whitespace Flow ID", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowID = " \t "
+		}, want: "flow-1"},
+		{name: "whitespace phase ID", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowPhaseID = " \t "
+		}, want: "flow-1"},
+		{name: "not embedded", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.Embedded = false
+		}, want: "flow-1"},
+		{name: "headless", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.Headless = true
+		}, want: "flow-1"},
+		{name: "tracked without phase", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowLaunchTracked = true
+		}, want: "flow-1"},
+		{name: "malformed scope falls back to worktree", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowID = ""
+			ctx.WorktreePath = "/dev/alpha/worktrees/fallback"
+		}, want: "fallback"},
+		{name: "malformed scope falls back to flow", mutate: func(ctx *actions.AgentLaunchContext) {
+			ctx.FlowID = ""
+			ctx.WorktreePath = ""
+		}, want: "flow"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := valid
+			if tc.mutate != nil {
+				tc.mutate(&ctx)
+			}
+			if got := flowEmbeddedTerminalIdentity(ctx); got != tc.want {
+				t.Fatalf("flowEmbeddedTerminalIdentity(%#v) = %q, want %q", ctx, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEmbeddedTerminalNumbersAreGlobalAcrossScopes(t *testing.T) {
 	m := Model{
 		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {

--- a/model/flow_launch_autofix.go
+++ b/model/flow_launch_autofix.go
@@ -338,10 +338,11 @@ func (m Model) autofixFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flow
 			// No FlowPhaseID, no FlowLaunchTracked, no FlowRepair: this is the
 			// phase-untracked autofix agent. FlowAutofix is the explicit signal the
 			// prefill boundary reads rather than inferring it from those absences.
-			FlowAutofix:   true,
-			Embedded:      true,
-			Headless:      headless,
-			InitialPrompt: autofixPromptForPR(record.PR.Number),
+			FlowAutofix:         true,
+			FlowAutofixPRNumber: record.PR.Number,
+			Embedded:            true,
+			Headless:            headless,
+			InitialPrompt:       autofixPromptForPR(record.PR.Number),
 		}
 		event.Context = ctx
 		event.Route = flowLaunchRouteEmbedded

--- a/model/flow_launch_autofix_internal_test.go
+++ b/model/flow_launch_autofix_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
@@ -455,50 +456,91 @@ func liveFlowSession(flowID, launchID, sessionID string) sessions.SessionRecord 
 }
 
 func TestAutofixLaunchOpensOneUntrackedEmbeddedSlot(t *testing.T) {
-	record := autofixFlowRecord()
-	h := newManualLaunchHarness(t, record)
+	for _, tc := range []struct {
+		name     string
+		provider string
+	}{
+		{name: "codex", provider: agent.CommandCodex},
+		{name: "claude", provider: agent.CommandClaude},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			record := autofixFlowRecord()
+			h := newManualLaunchHarness(t, record)
+			opts := h.options()
+			opts.AgentCommand = tc.provider
+			m := h.modelWith([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, opts)
+			m.width = 160
+			m.height = 40
 
-	m := h.autofix(h.model())
+			m, prepareCmd := h.stageAutofixLaunch(m)
+			preparedMsg, ok := runCommandWithoutWaiting(prepareCmd)
+			if !ok {
+				t.Fatal("autofix prepare did not settle")
+			}
+			next, prefillCmd := m.Update(preparedMsg)
+			m = next.(Model)
+			if prefillCmd == nil {
+				t.Fatal("interactive autofix install returned no prefill command")
+			}
 
-	if len(h.launchContexts) != 1 {
-		t.Fatalf("embedded launches = %#v, want exactly one", h.launchContexts)
-	}
-	ctx := h.launchContexts[0]
-	if ctx.Command != agent.CommandCodex ||
-		ctx.FlowID != record.FlowID ||
-		ctx.RepoPath != record.RepoPath ||
-		ctx.WorktreePath != record.WorktreePath ||
-		ctx.WorkingDir != record.WorktreePath ||
-		ctx.Branch != record.Branch ||
-		ctx.Commit != record.Commit ||
-		ctx.InitialPrompt != "autofix pr #116" ||
-		!ctx.FlowAutofix || ctx.FlowAgent ||
-		!ctx.Embedded ||
-		ctx.Headless ||
-		ctx.FlowPhaseID != "" ||
-		ctx.FlowLaunchTracked ||
-		ctx.FlowRepair ||
-		ctx.ResumeSessionID != "" {
-		t.Fatalf("autofix launch context = %#v", ctx)
-	}
-	if len(h.launchUpdates) != 0 {
-		t.Fatalf("an untracked launch must write no phase launch ID: %#v", h.launchUpdates)
-	}
-	if len(h.phaseUpdates) != 0 {
-		t.Fatalf("an untracked launch must write no phase status: %#v", h.phaseUpdates)
-	}
-	if len(h.agentContexts) != 0 {
-		t.Fatalf("a CLI autofix must open an embedded terminal, not hand off: %#v", h.agentContexts)
-	}
-	if got := embeddedFlowSlots(m, record.FlowID); got != 1 {
-		t.Fatalf("embedded Flow slots = %d, want exactly one", got)
-	}
-	if h.launchReservations != 1 || h.launchReleases != 1 {
-		t.Fatalf("launch reservations = %d, releases = %d, want one held then released",
-			h.launchReservations, h.launchReleases)
-	}
-	if m.flowLaunchAttemptOccupied(record.FlowID) {
-		t.Fatal("the installed slot owns the Flow, so the attempt must be released")
+			if len(h.launchContexts) != 1 {
+				t.Fatalf("embedded launches = %#v, want exactly one", h.launchContexts)
+			}
+			ctx := h.launchContexts[0]
+			if ctx.Command != tc.provider ||
+				ctx.FlowID != record.FlowID ||
+				ctx.RepoPath != record.RepoPath ||
+				ctx.WorktreePath != record.WorktreePath ||
+				ctx.WorkingDir != record.WorktreePath ||
+				ctx.Branch != record.Branch ||
+				ctx.Commit != record.Commit ||
+				ctx.InitialPrompt != "autofix pr #116" ||
+				ctx.FlowAutofixPRNumber != 116 ||
+				!ctx.FlowAutofix || ctx.FlowAgent ||
+				!ctx.Embedded ||
+				ctx.Headless ||
+				ctx.FlowPhaseID != "" ||
+				ctx.FlowLaunchTracked ||
+				ctx.FlowRepair ||
+				ctx.ResumeSessionID != "" {
+				t.Fatalf("autofix launch context = %#v", ctx)
+			}
+			if len(h.launchUpdates) != 0 {
+				t.Fatalf("an untracked launch must write no phase launch ID: %#v", h.launchUpdates)
+			}
+			if len(h.phaseUpdates) != 0 {
+				t.Fatalf("an untracked launch must write no phase status: %#v", h.phaseUpdates)
+			}
+			if len(h.agentContexts) != 0 {
+				t.Fatalf("a CLI autofix must open an embedded terminal, not hand off: %#v", h.agentContexts)
+			}
+			if got := embeddedFlowSlots(m, record.FlowID); got != 1 {
+				t.Fatalf("embedded Flow slots = %d, want exactly one", got)
+			}
+			if len(m.embeddedTerminals) != 1 {
+				t.Fatalf("embedded terminals = %#v, want exactly one slot", m.embeddedTerminals)
+			}
+			slot := m.embeddedTerminals[0]
+			if slot.Number != 1 || slot.Provider != tc.provider || slot.Identity != "autofix pr 116" ||
+				slot.Terminal.State() != "running" || !slot.PrefillPending {
+				t.Fatalf("autofix terminal slot = %#v", slot)
+			}
+			wantLabel := "1 " + tc.provider + " autofix pr 116 running"
+			view := ansi.Strip(m.View())
+			if !strings.Contains(view, wantLabel) {
+				t.Fatalf("dock does not contain %q:\n%s", wantLabel, view)
+			}
+			if strings.Contains(view, "1 "+tc.provider+" "+record.FlowID+" running") {
+				t.Fatalf("dock retained the Flow ID identity:\n%s", view)
+			}
+			if h.launchReservations != 1 || h.launchReleases != 1 {
+				t.Fatalf("launch reservations = %d, releases = %d, want one held then released",
+					h.launchReservations, h.launchReleases)
+			}
+			if m.flowLaunchAttemptOccupied(record.FlowID) {
+				t.Fatal("the installed slot owns the Flow, so the attempt must be released")
+			}
+		})
 	}
 }
 
@@ -727,6 +769,43 @@ func TestAutofixPrepareResolvesHeadlessFromTheReservation(t *testing.T) {
 	}
 	if m.flowLaunchAttemptOccupied(record.FlowID) {
 		t.Fatal("the installed slot owns the Flow, so the attempt must be released")
+	}
+}
+
+func TestAutofixPrepareUsesReservedPRNumber(t *testing.T) {
+	record := autofixFlowRecord()
+	h := newManualLaunchHarness(t, record)
+	m := h.model()
+	m.width = 160
+	m.height = 40
+
+	m, prepareCmd := h.stageAutofixLaunch(m)
+	h.record.PR.Number = 204
+	h.record.PR.URL = "https://github.com/approachcontrol/approach/pull/204"
+	preparedMsg, ok := runCommandWithoutWaiting(prepareCmd)
+	if !ok {
+		t.Fatal("prepare did not settle")
+	}
+	next, prefillCmd := m.Update(preparedMsg)
+	m = next.(Model)
+	if prefillCmd == nil {
+		t.Fatal("interactive autofix install returned no prefill command")
+	}
+
+	if len(h.launchContexts) != 1 {
+		t.Fatalf("embedded launches = %#v, want exactly one", h.launchContexts)
+	}
+	ctx := h.launchContexts[0]
+	if ctx.FlowAutofixPRNumber != 204 || ctx.InitialPrompt != "autofix pr #204" {
+		t.Fatalf("reserved PR launch metadata = number %d prompt %q, want 204 and %q",
+			ctx.FlowAutofixPRNumber, ctx.InitialPrompt, "autofix pr #204")
+	}
+	if len(m.embeddedTerminals) != 1 || m.embeddedTerminals[0].Identity != "autofix pr 204" {
+		t.Fatalf("reserved PR terminal slot = %#v", m.embeddedTerminals)
+	}
+	wantLabel := "1 codex autofix pr 204 running"
+	if view := ansi.Strip(m.View()); !strings.Contains(view, wantLabel) {
+		t.Fatalf("dock does not contain %q:\n%s", wantLabel, view)
 	}
 }
 


### PR DESCRIPTION
## Summary

- label interactive Codex and Claude autofix terminals as provider autofix pr number running
- carry the PR number through the autofix launch context without changing the autofix prompt or other terminal identities
- document the terminal-label behavior and add regression coverage for launch context, identity precedence, fallbacks, and rendered dock labels

## Verification

- make fmt-check
- make test
- make build
- git diff --check origin/main...HEAD