### PR TITLE
chore: save Cloud Agent env (.cursor/environment.json + AGENTS.md notes)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Approach",
+  "install": "go mod download && if [ -f web/package-lock.json ]; then npm --prefix web ci; fi"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,38 @@ Branch first — never commit or push directly to main. Everything else (TDD, qu
 
 If this file conflicts with a linked doc, trust the linked doc and remove the duplicate here.
 
+## Cursor Cloud specific instructions
+
+Startup runs the update script (`go mod download`; `npm ci` in `web/` when its
+lockfile is present), so Go modules and `web/node_modules` are already fetched.
+Two independent products live here; standard commands are already documented —
+use them rather than duplicating:
+
+- Go TUI (`approach`, repo root): build/test/fmt/run commands are in
+  `docs/agent-operations.md` and the `Makefile`.
+- Next.js web viewer (`web/`): lint/typecheck/test/build/dev commands are in
+  `web/README.md`. It is a separate deployable with its own CI job.
+
+Non-obvious caveats worth knowing:
+
+- `make test` is slow (roughly 6–7 min): `actions` and `gitquery` spin up real
+  temporary git repositories. When iterating, run one package (e.g.
+  `go test ./scanner`) instead of the full gate.
+- `bd` (beads) is not installed in this environment. The TUI degrades gracefully
+  to a calm `beads not configured` state, and the Beads task-tracking commands in
+  the blocks below will not run — don't block on them for env work.
+- The TUI is a full-screen Bubble Tea app that needs a real TTY. Run it under
+  tmux with an explicit size (e.g. `tmux new-session -x 200 -y 50 ... './bin/approach'`)
+  and inspect it with `tmux capture-pane`; it will not render in a plain
+  non-TTY shell.
+- To exercise the web viewer end-to-end: start `approach serve` (see
+  `docs/graphql-api.md`) against scratch `--state-root`/`--scan-root` dirs (never
+  the default artifact root), point `web/.env.local`'s `APPROACH_GRAPHQL_URL` at
+  it, then `npm run dev` in `web/`. `scripts/generate-test-repos.sh` creates demo
+  repos, and `approach flow create ... --state-root <dir>` seeds a Flow to view.
+- `npm run dev`/`next build` regenerate `web/AGENTS.md`, `web/CLAUDE.md`, and
+  touch `web/next-env.d.ts`. These are Next.js artifacts — do not commit them.
+
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:970c3bf2 -->
 ## Beads Issue Tracker
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Saves the Cloud Agent development environment for this repository and records durable, non-obvious startup/run notes for future agents. No product code changed.

- `.cursor/environment.json` — repo-managed environment config with the dependency-install step. This is the version-controlled source of truth and follows branches/PRs.
- `AGENTS.md` — added a `## Cursor Cloud specific instructions` section (two-product layout, slow `make test`, `bd` not installed, TUI needs a TTY under tmux, how to wire the web viewer to `approach serve`, Next.js-generated files not to commit).

Next.js-generated artifacts (`web/AGENTS.md`, `web/CLAUDE.md`, `web/next-env.d.ts`) were intentionally left uncommitted.

## Environment install step

```
go mod download && if [ -f web/package-lock.json ]; then npm --prefix web ci; fi
```

Validated with a prebuilt environment build that **SUCCEEDED**; the build logs show both `go mod download` and `npm ci` running with exit code 0.

## Products verified

| Product | Location | Lint / fmt | Test | Build | Run |
| --- | --- | --- | --- | --- | --- |
| Go TUI (`approach`) | repo root | `make fmt-check` ✅ | `make test` ✅ (all 20 packages) | `make build` ✅ | `./bin/approach` (TUI) / `approach serve` (GraphQL API) ✅ |
| Next.js web viewer | `web/` | `npm run lint` ✅ | `npm test` ✅ (71) / `npm run typecheck` ✅ | `npm run build` ✅ | `npm run dev` ✅ |

## End-to-end verification

Generated demo repos with `scripts/generate-test-repos.sh`, created a Flow via `approach flow create`, served it with `approach serve`, and viewed it end-to-end through the web viewer (repositories list → repository detail → Flow detail with all 7 phases). The same Flow also renders in the TUI Flows pane.

[approach_web_viewer_end_to_end.mp4](https://cursor.com/agents/bc-430c4543-f637-4ba0-9d14-aadd3aa886f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapproach_web_viewer_end_to_end.mp4)

[Flow detail in web viewer](https://cursor.com/agents/bc-430c4543-f637-4ba0-9d14-aadd3aa886f5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_flow_detail.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-430c4543-f637-4ba0-9d14-aadd3aa886f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-430c4543-f637-4ba0-9d14-aadd3aa886f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

