### PR TITLE
Surface Bead link and epic progression in GraphQL and web viewer

### DIFF
--- a/cmd/approach/serve.go
+++ b/cmd/approach/serve.go
@@ -85,7 +85,11 @@ func runServeContext(ctx context.Context, args []string, deps runDeps) error {
 	handler, err := graphqlapi.NewServer(graphqlapi.ServerOptions{
 		Repos: func() ([]scanner.Repo, error) { return deps.scan(scanOptions) },
 		Flows: func() ([]flowstore.FlowRecord, error) { return store.List(flowstore.FlowFilter{}) },
-		Token: token,
+		// Read-only by construction: the store's read API is the only epic
+		// progression seam the API gets, so serving can observe progression
+		// state but never enable, disable, or halt it.
+		EpicProgressions: store.ReadEpicProgression,
+		Token:            token,
 		// The Logger seam keeps request logging off stdout, where the
 		// resolved address is printed for scripts to read.
 		Logger: deps.stderr,

--- a/cmd/approach/serve_live_test.go
+++ b/cmd/approach/serve_live_test.go
@@ -108,6 +108,77 @@ func TestServeReflectsLiveStoreMutations(t *testing.T) {
 	}
 }
 
+// TestServeSurfacesBeadLinkAndEpicProgression proves the progression read seam
+// is wired to the same store `serve` lists Flows from. The GraphQL package
+// tests the projection against a fake source; only this one shows a row written
+// through flowstore reaching a client.
+func TestServeSurfacesBeadLinkAndEpicProgression(t *testing.T) {
+	root := t.TempDir()
+	repoPath := t.TempDir()
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	linked, err := store.Create(flowstore.FlowRecord{
+		Title:        "Linked to an epic child",
+		Instructions: "Work the child Bead",
+		RepoPath:     repoPath,
+		Bead:         flowstore.BeadLink{ID: "approach-y7g.7", EpicID: "approach-y7g"},
+	})
+	if err != nil {
+		t.Fatalf("Create(linked) error = %v", err)
+	}
+	unlinked, err := store.Create(flowstore.FlowRecord{
+		Title:        "No Bead at all",
+		Instructions: "Nothing to track",
+		RepoPath:     repoPath,
+	})
+	if err != nil {
+		t.Fatalf("Create(unlinked) error = %v", err)
+	}
+	if _, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{
+		Key:     flowstore.EpicProgressionKey{RepoPath: repoPath, EpicID: "approach-y7g"},
+		Enabled: true,
+	}); err != nil {
+		t.Fatalf("SetEpicProgression() error = %v", err)
+	}
+
+	harness := startServe(t, []string{"approach", "serve", "--addr", "127.0.0.1:0", "--state-root", root},
+		serveDeps(t, t.TempDir(), nil))
+	query := func(flowID string) map[string]any {
+		t.Helper()
+		status, payload := harness.query(t,
+			`{ flow(id: "`+flowID+`") { bead { id epicId } epicProgression { enabled done halt { childBeadId } } } }`)
+		if status != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (%v)", status, payload)
+		}
+		return flowFromPayload(t, payload)
+	}
+
+	flow := query(linked.FlowID)
+	bead, ok := flow["bead"].(map[string]any)
+	if !ok {
+		t.Fatalf("bead = %#v, want the persisted link", flow["bead"])
+	}
+	if bead["id"] != "approach-y7g.7" || bead["epicId"] != "approach-y7g" {
+		t.Errorf("bead = %#v, want the child and epic ids written at creation", bead)
+	}
+	progression, ok := flow["epicProgression"].(map[string]any)
+	if !ok {
+		t.Fatalf("epicProgression = %#v, want the row written through the store", flow["epicProgression"])
+	}
+	if progression["enabled"] != true || progression["done"] != false || progression["halt"] != nil {
+		t.Errorf("epicProgression = %#v, want enabled, not done, not halted", progression)
+	}
+
+	// A Flow with no Bead reads back as linked to nothing, with no progression
+	// invented for it.
+	bare := query(unlinked.FlowID)
+	if bare["bead"] != nil || bare["epicProgression"] != nil {
+		t.Errorf("unlinked flow = %#v, want null bead and epicProgression", bare)
+	}
+}
+
 // TestServePassesPresetsToStore proves cfg.Flow.Presets reaches the store.
 // Presets are consulted during migrate-on-open to restore depends_on edges
 // missing from legacy records, so a store built without them reports

--- a/docs/graphql-api.md
+++ b/docs/graphql-api.md
@@ -567,6 +567,10 @@ nothing else.
   does not select `epicProgression` are unaffected. This is deliberately weaker
   than the Flow-list failure, which fails the request: progression is an
   optional projection and must not be a single point of failure for the API.
+  Because that error repeats per Flow and per aliased selection, the
+  response-size limit charges each of those entries — including the response
+  keys its `path` names — so an unreadable row cannot amplify past the cap. A
+  snapshot with nothing unreadable in it is charged nothing.
 
 ```graphql
 {

--- a/docs/graphql-api.md
+++ b/docs/graphql-api.md
@@ -338,10 +338,15 @@ push terminal escapes into a foreground stderr.
 
 ## Live state and consistency
 
-Each request builds **one snapshot** — one `scanner.Scan` plus one
-`flowstore.List` — and resolves the whole query from it. A single response is
-therefore internally consistent, and every new request re-reads disk. There is
-no cross-request cache.
+Each request builds **one snapshot** — one `scanner.Scan`, one `flowstore.List`,
+and one `ReadEpicProgression` per distinct epic those Flows name — and resolves
+the whole query from it. A single response is therefore internally consistent,
+and every new request re-reads disk. There is no cross-request cache.
+
+All three reads happen before execution and none of them depends on the query:
+the response-size limiter has to bound what the snapshot *could* serialize, not
+what this query selected. The progression reads are indexed point lookups on the
+already-open store, so the `scanner.Scan` filesystem walk dominates.
 
 **A failing scan degrades; a non-partial failing store errors.** A missing or
 mistyped scan root is the ordinary case, not an exceptional one, so a scan
@@ -352,9 +357,9 @@ snapshot logs the diagnostic and indexes those rows. Every other Flow-store
 failure is a real failure of the primary data source and surfaces as the
 sanitized GraphQL error above.
 
-**The scan cannot be cancelled.** `scanner.Scan` and `flowstore.List` take no
-`context.Context` and walk the filesystem synchronously, so the request timeout
-cannot interrupt them. The design is explicit about this:
+**The scan cannot be cancelled.** `scanner.Scan`, `flowstore.List`, and
+`ReadEpicProgression` take no `context.Context` and read synchronously, so the
+request timeout cannot interrupt them. The design is explicit about this:
 
 1. The handler takes an in-flight semaphore slot *before* launching snapshot
    construction; if none is free it returns 503 immediately.
@@ -534,9 +539,12 @@ nothing else.
 - `BeadLink.id` and `BeadLink.epicId` are the persisted link text, **verbatim**.
   A child-only link resolves a non-null `bead` with `epicId: null`.
 - Progression is looked up by canonical `(normalized repo path, trimmed epic
-  id)` — the same key `ReadEpicProgression` canonicalizes — so a padded or
+  id)`, compatible with what `ReadEpicProgression` canonicalizes, so a padded or
   differently spelled epic id still resolves the right row while `bead.epicId`
   keeps reading back exactly as stored.
+- `epicProgression` is null whenever `bead` is. An epic id with no child Bead id
+  is a shape the store forbids, so only an externally written record holds one;
+  the two fields never disagree about whether a Flow is linked.
 - A **missing row is `null`, not a disabled epic.** Nothing is synthesized:
   "nobody enabled progression for this epic" and "somebody turned it off" are
   different claims, and only the second one has a row.
@@ -547,9 +555,18 @@ nothing else.
   free-text message.
 - One request reads **one row per distinct canonical key**. Sibling Flows under
   the same epic share a single read, found or missing, and a Flow that links no
-  epic causes none. A row that cannot be read fails the request the same way an
-  unreadable Flow list does: the fixed `internal error reading application
-  state` message to the client, the key and the cause in the server log only.
+  epic causes none. The reads are eager and do not depend on the query — the
+  response-size limiter has to know the widest halt message before executing —
+  so a request costs one indexed point lookup per distinct epic your Flows
+  name, whether or not it selects `epicProgression`.
+- A row that cannot be read — a malformed record is likelier here than I/O —
+  is **scoped to the epic that failed**. `Flow.epicProgression` resolves null
+  for the Flows naming that epic and reports the fixed `internal error reading
+  application state` message in the `errors` array; the key and the cause go to
+  the server log only. Every other field, every other Flow, and any query that
+  does not select `epicProgression` are unaffected. This is deliberately weaker
+  than the Flow-list failure, which fails the request: progression is an
+  optional projection and must not be a single point of failure for the API.
 
 ```graphql
 {

--- a/docs/graphql-api.md
+++ b/docs/graphql-api.md
@@ -420,6 +420,8 @@ type Flow {
   presetName: String
   planId: String
   autoMode: Boolean!
+  bead: BeadLink
+  epicProgression: EpicProgression
   issue: Issue
   pullRequest: PullRequest
   merge: Merge
@@ -427,6 +429,23 @@ type Flow {
   currentPhase: Phase
   createdAt: DateTime!
   updatedAt: DateTime!
+}
+
+type BeadLink {
+  id: ID!
+  epicId: ID
+}
+
+type EpicProgression {
+  enabled: Boolean!
+  done: Boolean!
+  halt: EpicProgressionHalt
+}
+
+type EpicProgressionHalt {
+  childBeadId: ID!
+  status: String!
+  message: String!
 }
 
 type Phase {
@@ -495,9 +514,55 @@ sitting on", not "the phase actively executing"** — `blocked` and
 | `Merge.mergedAt` | the merge has not landed |
 | `Flow.currentPhase` | no phase is actionable |
 | `Issue.number`, `PullRequest.number` | the number is unset (`0` is not emitted) |
+| `Flow.bead` | the Flow links no Bead |
+| `BeadLink.epicId` | the link records a child Bead but no epic |
+| `Flow.epicProgression` | the Flow links no epic, **or** that epic has no progression row |
+| `EpicProgression.halt` | progression has not halted |
 
 `Phase.dependsOn` is `[String!]!` and is **never** null: a phase with no edges
 serializes as `[]`.
+
+### Bead linkage and epic progression
+
+`Flow.bead` is the Beads issue the Flow tracks, and `Flow.epicProgression` is
+the durable auto-progression state of that Bead's epic (`docs/flow-phases.md`
+covers what progression does). Both are read-only projections of what the store
+already holds — **the API never reads Beads itself and never writes progression
+state**; the server is wired to `flowstore.Store.ReadEpicProgression` and to
+nothing else.
+
+- `BeadLink.id` and `BeadLink.epicId` are the persisted link text, **verbatim**.
+  A child-only link resolves a non-null `bead` with `epicId: null`.
+- Progression is looked up by canonical `(normalized repo path, trimmed epic
+  id)` — the same key `ReadEpicProgression` canonicalizes — so a padded or
+  differently spelled epic id still resolves the right row while `bead.epicId`
+  keeps reading back exactly as stored.
+- A **missing row is `null`, not a disabled epic.** Nothing is synthesized:
+  "nobody enabled progression for this epic" and "somebody turned it off" are
+  different claims, and only the second one has a row.
+- `done` is the persisted completion flag. It is never derived from
+  `enabled: false` — a manually disabled epic is not finished.
+- `halt` carries the child Bead, the child Flow status that stopped
+  progression (`blocked`, `needs_attention`, `closed`, or `abandoned`), and a
+  free-text message.
+- One request reads **one row per distinct canonical key**. Sibling Flows under
+  the same epic share a single read, found or missing, and a Flow that links no
+  epic causes none. A row that cannot be read fails the request the same way an
+  unreadable Flow list does: the fixed `internal error reading application
+  state` message to the client, the key and the cause in the server log only.
+
+```graphql
+{
+  flow(id: "20260814T210915Z-surface-bead-link") {
+    bead { id epicId }
+    epicProgression {
+      enabled
+      done
+      halt { childBeadId status message }
+    }
+  }
+}
+```
 
 ### Statuses are strings, not enums
 

--- a/graphqlapi/limits.go
+++ b/graphqlapi/limits.go
@@ -358,6 +358,16 @@ type resultBounds struct {
 	// progressionErrorBytes is errorEntryOverheadBytes when this snapshot holds
 	// an unreadable progression row, and zero otherwise — a healthy snapshot
 	// emits no per-field errors, so it is charged for none.
+	//
+	// One flag for the whole snapshot, not a count of the Flows that name the
+	// failed key: an unreadable row then charges every Flow.epicProgression
+	// occurrence, including Flows whose own row read fine. That is deliberate
+	// over-counting, of a piece with the pessimistic fallbacks above.
+	// Distinguishing them means a second cardinality threaded through the cost
+	// walk beside flows/flowsPerRepo, and the walk multiplies by list bounds,
+	// not by per-field counts — a bound that is subtly wrong reopens the hole,
+	// where one that is merely generous costs a 400 on an unusually wide
+	// document against a store that already has a row needing repair.
 	progressionErrorBytes int64
 }
 

--- a/graphqlapi/limits.go
+++ b/graphqlapi/limits.go
@@ -51,6 +51,18 @@ const (
 	// plus the braces around an object one. It is charged per resolved
 	// occurrence, where fieldNameOverheadBytes is charged per response key.
 	elementOverheadBytes = 3
+	// errorEntryOverheadBytes covers one `errors` entry for a field whose
+	// failure is scoped to the field rather than the request: the sanitized
+	// message, the locations array, the braces and separators, and the numeric
+	// list indices along its path. The path's response *keys* are not in here —
+	// an alias makes those as wide as the client cares to type, so they are
+	// charged from the document in documentKeyBytes.
+	//
+	// The response body is not only `data`. Flow.epicProgression fails per Flow,
+	// so one unreadable progression row yields one entry per Flow naming that
+	// epic and per aliased selection of it — unbounded amplification of a
+	// snapshot the data budget alone measures as small.
+	errorEntryOverheadBytes = 512
 	// typenameField resolves per object instance rather than against the
 	// schema, so it is exempt from the depth limit but not the cost limit.
 	typenameField = "__typename"
@@ -343,6 +355,21 @@ type resultBounds struct {
 	phasesPerFlow     int
 	dependsOnPerPhase int
 	values            fieldValueBytes
+	// progressionErrorBytes is errorEntryOverheadBytes when this snapshot holds
+	// an unreadable progression row, and zero otherwise — a healthy snapshot
+	// emits no per-field errors, so it is charged for none.
+	progressionErrorBytes int64
+}
+
+// errorBytes maps a field to the fixed part of the `errors` entry one resolved
+// occurrence of it can add. It is zero for every field that cannot fail on its
+// own: those either succeed or fail the whole request, which produces one entry
+// for the response rather than one per occurrence.
+func (b resultBounds) errorBytes(parentType, field string) int64 {
+	if parentType == "Flow" && field == "epicProgression" {
+		return b.progressionErrorBytes
+	}
+	return 0
 }
 
 // listSize maps a *schema* list field to its cardinality bound; a schema field
@@ -432,6 +459,7 @@ func inspectCost(schema *graphql.Schema, document *ast.Document, bounds resultBo
 	walker := &costWalker{
 		schema:    schema,
 		bounds:    bounds,
+		keyBytes:  documentKeyBytes(document),
 		fragments: make(map[string]*ast.FragmentDefinition),
 		memo:      make(map[string]costMeasure),
 		budget:    maxWalkBudget,
@@ -458,11 +486,63 @@ func inspectCost(schema *graphql.Schema, document *ast.Document, bounds resultBo
 }
 
 type costWalker struct {
-	schema    *graphql.Schema
-	bounds    resultBounds
+	schema *graphql.Schema
+	bounds resultBounds
+	// keyBytes bounds the response keys along any one error path. It is a
+	// property of the document, not of where the walk currently is, so it does
+	// not disturb the per-fragment memoization below.
+	keyBytes  int64
 	fragments map[string]*ast.FragmentDefinition
 	memo      map[string]costMeasure
 	budget    int
+}
+
+// documentKeyBytes is the total width of every response key in the document.
+//
+// It bounds the keys `errors[].path` can name for any one failure: a path is a
+// chain of nested fields, each contributed by a distinct field node — a node
+// can only repeat on a single path through a fragment cycle, which
+// rejectFragmentCycles has already refused — so no path names more keys than
+// the document contains. Charging the enclosing field's own key is not enough:
+// `{ <55 KiB alias>: flows { epicProgression { enabled } } }` writes that alias
+// once in `data` and once per failing Flow in `errors`.
+//
+// Iterative rather than recursive: this walks raw definitions, including
+// fragments no operation spreads, so its nesting is not the nesting
+// measureDocument bounded.
+func documentKeyBytes(document *ast.Document) int64 {
+	var total int64
+	var pending []*ast.SelectionSet
+	push := func(set *ast.SelectionSet) {
+		if set != nil {
+			pending = append(pending, set)
+		}
+	}
+	for _, definition := range document.Definitions {
+		switch node := definition.(type) {
+		case *ast.OperationDefinition:
+			push(node.SelectionSet)
+		case *ast.FragmentDefinition:
+			push(node.SelectionSet)
+		}
+	}
+	for len(pending) > 0 {
+		set := pending[len(pending)-1]
+		pending = pending[:len(pending)-1]
+		for _, selection := range set.Selections {
+			switch node := selection.(type) {
+			case *ast.Field:
+				total += int64(len(responseKey(node)))
+				push(node.SelectionSet)
+			case *ast.InlineFragment:
+				push(node.SelectionSet)
+			}
+		}
+		if total > maxResponseBytes {
+			return maxResponseBytes + 1
+		}
+	}
+	return total
 }
 
 // costOfSelectionSet sums the cost of every selection against parent, the
@@ -526,6 +606,11 @@ func (w *costWalker) costOfSelection(selection ast.Selection, parent *graphql.Ob
 		// response, and 999 aliases of `flows { id }` across 800 repos really
 		// do run Repo.flows 799 200 times, both assessed at nearly nothing.
 		perParent := costMeasure{values: 1, bytes: int64(fieldNameOverheadBytes + len(responseKey(node)))}
+		// Charged alongside the response key, and for the same reason: one
+		// resolved occurrence of a field that fails on its own writes one
+		// `errors` entry, whatever its subtree would have held. It is zero
+		// unless this snapshot actually holds a row that cannot be read.
+		perParent.bytes = saturate(perParent.bytes+w.errorEntryBytes(node, parent), maxResponseBytes)
 		return perParent.plus(w.elementCost(node, parent, shape).plus(subtree).scaledBy(shape.multiplier)), nil
 	case *ast.InlineFragment:
 		// The schema has no interfaces or unions, so an inline fragment's type
@@ -566,6 +651,22 @@ func (w *costWalker) elementCost(node *ast.Field, parent *graphql.Object, shape 
 	}
 	cost.bytes += w.bounds.valueBytes(parent.Name(), node.Name.Value)
 	return cost
+}
+
+// errorEntryBytes is what one resolved occurrence of this field can add to the
+// response's `errors` array: the fixed entry overhead plus an upper bound on
+// the response keys its path names. Fields that cannot fail on their own carry
+// nothing, and neither does any field in a snapshot with nothing unreadable in
+// it.
+func (w *costWalker) errorEntryBytes(node *ast.Field, parent *graphql.Object) int64 {
+	if parent == nil || node.Name == nil {
+		return 0
+	}
+	overhead := w.bounds.errorBytes(parent.Name(), node.Name.Value)
+	if overhead == 0 {
+		return 0
+	}
+	return saturate(overhead+w.keyBytes, maxResponseBytes)
 }
 
 // selectsBeneathALeaf reports whether the document selects fields under a

--- a/graphqlapi/limits_test.go
+++ b/graphqlapi/limits_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/language/parser"
+
+	"github.com/approachcontrol/approach/flowstore"
 )
 
 func nestedQuery(depth int) string {
@@ -235,7 +237,7 @@ func costOf(t *testing.T, query string, bounds resultBounds) error {
 	t.Helper()
 	if bounds.values == nil {
 		repos, flows := testSources()
-		bounds.values = buildSnapshot(repos, flows, nil).bounds().values
+		bounds.values = buildSnapshot(repos, flows, nil, nil).bounds().values
 	}
 	schema, err := newSchema()
 	if err != nil {
@@ -439,6 +441,44 @@ func TestInspectCostIgnoresUnknownFields(t *testing.T) {
 	bounds := resultBounds{repos: 1000, flows: 1000, flowsPerRepo: 1000}
 	if err := costOf(t, `{ nope { alsoNope { stillNope } } }`, bounds); err != nil {
 		t.Fatalf("inspectCost(unknown fields) error = %v, want nil", err)
+	}
+}
+
+// TestInspectCostChargesBeadAndProgressionWidths keeps the Bead link and the
+// progression projection inside the byte budget. They add no list field — so no
+// cardinality bound moves — but their scalars serialize like any other leaf, and
+// the halt message is unbounded agent-supplied text.
+func TestInspectCostChargesBeadAndProgressionWidths(t *testing.T) {
+	repos, flows, progressions, logf := fullyPopulatedSources()
+	values := buildSnapshot(repos, flows, progressions, logf).bounds().values
+	for field, want := range map[string]int64{
+		"BeadLink.id":                     int64(jsonStringBytes("approach-y7g.9")),
+		"BeadLink.epicId":                 int64(jsonStringBytes("approach-y7g")),
+		"EpicProgression.enabled":         boolValueBytes,
+		"EpicProgression.done":            boolValueBytes,
+		"EpicProgressionHalt.childBeadId": int64(jsonStringBytes("approach-y7g.9")),
+		"EpicProgressionHalt.status":      int64(jsonStringBytes(flowstore.StatusBlocked)),
+		"EpicProgressionHalt.message":     int64(jsonStringBytes("the child Flow is blocked on review")),
+	} {
+		got, measured := values[field]
+		if !measured {
+			t.Errorf("%s has no measured width; it would take the %d-byte drift fallback", field, fallbackValueBytes)
+			continue
+		}
+		if got != want {
+			t.Errorf("valueBytes(%s) = %d, want %d", field, got, want)
+		}
+	}
+
+	// A halt message wide enough to matter is still charged per Flow that
+	// resolves it, so the response budget rejects the query rather than
+	// building the body.
+	bounds := resultBounds{
+		repos: 1, flows: 1000, flowsPerRepo: 1000, phasesPerFlow: 1, dependsOnPerPhase: 1,
+		values: fieldValueBytes{"EpicProgressionHalt.message": maxResponseBytes},
+	}
+	if err := costOf(t, `{ flows { epicProgression { halt { message } } } }`, bounds); !errors.Is(err, errResponseTooLarge) {
+		t.Errorf("inspectCost(wide halt message) error = %v, want errResponseTooLarge", err)
 	}
 }
 

--- a/graphqlapi/limits_test.go
+++ b/graphqlapi/limits_test.go
@@ -523,6 +523,77 @@ func TestInspectCostMeasuresProgressionWidthsWithNoRows(t *testing.T) {
 	}
 }
 
+// TestInspectCostChargesProgressionErrorEntries closes the amplification path
+// that is not in `data` at all. An unreadable progression row is scoped to the
+// field, so it writes one `errors` entry per Flow naming that epic and per
+// aliased selection of it — and encoding/json buffers errors and data together.
+// Measuring only the data tree let one bad row build a body several times over
+// the cap while every scalar in it measured small.
+func TestInspectCostChargesProgressionErrorEntries(t *testing.T) {
+	const flowCount = 2000
+	records := make([]flowstore.FlowRecord, 0, flowCount)
+	for i := range flowCount {
+		records = append(records, beadFlow(
+			fmt.Sprintf("flow-%d", i), "/repos/alpha",
+			fmt.Sprintf("approach-y7g.%d", i), "approach-y7g",
+		))
+	}
+	unreadable := &countingProgressions{failKeys: map[flowstore.EpicProgressionKey]error{
+		epicKey("/repos/alpha", "approach-y7g"): errors.New("malformed epic progression row"),
+	}}
+	snap := buildSnapshot(staticRepos(), staticFlows(records...), unreadable.source(), nil)
+	bounds := snap.bounds()
+	bounds.flows = flowCount
+	if bounds.progressionErrorBytes == 0 {
+		t.Fatal("an unreadable row is charged nothing; every error entry it writes is off the budget")
+	}
+
+	// The response key of a failing field is written twice: once in `data`, and
+	// once in that Flow's `errors[].path`. Charging only the first left the
+	// alias free for all 2000 entries.
+	alias := strings.Repeat("k", 32<<10)
+	query := fmt.Sprintf(`{ %s: flows { epicProgression { enabled } } }`, alias)
+	if err := costOf(t, query, bounds); !errors.Is(err, errResponseTooLarge) {
+		t.Errorf("inspectCost(wide alias over unreadable rows) error = %v, want errResponseTooLarge", err)
+	}
+
+	// The charge is conditional on this snapshot, not on the schema: a store
+	// with nothing unreadable in it emits no entries and must pay for none.
+	healthy := buildSnapshot(staticRepos(), staticFlows(records...), (&countingProgressions{}).source(), nil).bounds()
+	healthy.flows = flowCount
+	if healthy.progressionErrorBytes != 0 {
+		t.Errorf("progressionErrorBytes = %d with every row readable, want 0", healthy.progressionErrorBytes)
+	}
+	if err := costOf(t, query, healthy); err != nil {
+		t.Errorf("inspectCost(wide alias over readable rows) error = %v, want nil", err)
+	}
+}
+
+// TestDocumentKeyBytesBoundsAnyErrorPath pins what makes the charge above an
+// upper bound: an error path names nested fields, and each one is a distinct
+// node in the document text.
+func TestDocumentKeyBytesBoundsAnyErrorPath(t *testing.T) {
+	document := parseQuery(`{ alpha: repos { beta: flows { gamma: epicProgression { enabled } } } }`)
+	if document == nil {
+		t.Fatal("parseQuery() did not parse")
+	}
+	// The deepest path is alpha/beta/gamma/enabled; the total also covers the
+	// keys off that path, which is what makes it a bound rather than a guess.
+	if got, want := documentKeyBytes(document), int64(len("alpha")+len("beta")+len("gamma")+len("enabled")); got != want {
+		t.Errorf("documentKeyBytes() = %d, want %d", got, want)
+	}
+
+	// Fragments are counted from their definitions, so a spread path is charged
+	// even though the walk never expands it here.
+	spread := parseQuery(`{ ...Outer } fragment Outer on Query { wide: flows { epicProgression { done } } }`)
+	if spread == nil {
+		t.Fatal("parseQuery(fragment) did not parse")
+	}
+	if got, want := documentKeyBytes(spread), int64(len("wide")+len("epicProgression")+len("done")); got != want {
+		t.Errorf("documentKeyBytes(fragment) = %d, want %d", got, want)
+	}
+}
+
 // TestResultBoundsCoverEveryField is the drift guard for resultBounds. A new
 // list field with no cardinality bound, or a new scalar field with no measured
 // width, silently falls back to a guess — exactly what this design removed.

--- a/graphqlapi/limits_test.go
+++ b/graphqlapi/limits_test.go
@@ -482,6 +482,47 @@ func TestInspectCostChargesBeadAndProgressionWidths(t *testing.T) {
 	}
 }
 
+// TestInspectCostMeasuresProgressionWidthsWithNoRows is the regression guard for
+// the default state of every store: Flows link epics, and nothing has ever
+// enabled progression, so there is no row to measure a width from.
+//
+// EpicProgression is a non-list object, so an unmeasured scalar of it is charged
+// the pessimistic fallback once per Flow. Measuring only found rows put the
+// fallback on all five fields and rejected an ordinary flows query — over a
+// response that is null for every Flow. TestResultBoundsCoverEveryField cannot
+// catch this: its fixture always has a halted row.
+func TestInspectCostMeasuresProgressionWidthsWithNoRows(t *testing.T) {
+	const flowCount = 500
+	records := make([]flowstore.FlowRecord, 0, flowCount)
+	for i := range flowCount {
+		records = append(records, beadFlow(
+			fmt.Sprintf("flow-%d", i), "/repos/alpha",
+			fmt.Sprintf("approach-y7g.%d", i), "approach-y7g",
+		))
+	}
+	// An epic link on every Flow and not one progression row anywhere.
+	empty := &countingProgressions{}
+	snap := buildSnapshot(staticRepos(), staticFlows(records...), empty.source(), nil)
+	if len(empty.calls) != 1 {
+		t.Fatalf("progression reads = %v, want exactly the one shared key", progressionKeys(empty.calls))
+	}
+
+	bounds := snap.bounds()
+	for _, field := range []string{
+		"EpicProgression.enabled", "EpicProgression.done",
+		"EpicProgressionHalt.childBeadId", "EpicProgressionHalt.status", "EpicProgressionHalt.message",
+	} {
+		if _, measured := bounds.values[field]; !measured {
+			t.Errorf("%s has no measured width with no rows; it would take the %d-byte drift fallback per Flow",
+				field, fallbackValueBytes)
+		}
+	}
+	query := `{ flows { epicProgression { enabled done halt { childBeadId status message } } } }`
+	if err := costOf(t, query, bounds); err != nil {
+		t.Errorf("inspectCost(%s) error = %v, want none: every field resolves null", query, err)
+	}
+}
+
 // TestResultBoundsCoverEveryField is the drift guard for resultBounds. A new
 // list field with no cardinality bound, or a new scalar field with no measured
 // width, silently falls back to a guess — exactly what this design removed.

--- a/graphqlapi/schema.go
+++ b/graphqlapi/schema.go
@@ -95,6 +95,79 @@ func newSchema() (graphql.Schema, error) {
 		},
 	})
 
+	beadLinkType := graphql.NewObject(graphql.ObjectConfig{
+		Name: "BeadLink",
+		Description: "The Beads issue a Flow tracks. Both ids are the persisted link text, " +
+			"verbatim; the API never reads Beads itself.",
+		Fields: graphql.Fields{
+			"id": &graphql.Field{
+				Type:        graphql.NewNonNull(graphql.ID),
+				Description: "Child Bead id. A linked Flow always has one — the link is what makes bead non-null.",
+				Resolve:     valueResolver(func(link flowstore.BeadLink) (any, error) { return link.ID, nil }),
+			},
+			"epicId": &graphql.Field{
+				Type:        graphql.ID,
+				Description: "Parent epic Bead id; null when the link records only a child Bead.",
+				Resolve:     valueResolver(func(link flowstore.BeadLink) (any, error) { return nullableString(link.EpicID), nil }),
+			},
+		},
+	})
+
+	epicProgressionHaltType := graphql.NewObject(graphql.ObjectConfig{
+		Name:        "EpicProgressionHalt",
+		Description: "The durable reason auto-progression stopped for an epic.",
+		Fields: graphql.Fields{
+			"childBeadId": &graphql.Field{
+				Type:        graphql.NewNonNull(graphql.ID),
+				Description: "The child Bead whose Flow stopped progression.",
+				Resolve:     valueResolver(func(halt flowstore.EpicProgressionHalt) (any, error) { return halt.ChildBeadID, nil }),
+			},
+			"status": &graphql.Field{
+				Type:        graphql.NewNonNull(graphql.String),
+				Description: "The child Flow status that halted progression: blocked, needs_attention, closed, or abandoned.",
+				Resolve:     valueResolver(func(halt flowstore.EpicProgressionHalt) (any, error) { return halt.Status, nil }),
+			},
+			"message": &graphql.Field{
+				Type:        graphql.NewNonNull(graphql.String),
+				Description: "Human-readable halt reason. Free text; the store only requires it to be non-empty.",
+				Resolve:     valueResolver(func(halt flowstore.EpicProgressionHalt) (any, error) { return halt.Message, nil }),
+			},
+		},
+	})
+
+	epicProgressionType := graphql.NewObject(graphql.ObjectConfig{
+		Name: "EpicProgression",
+		Description: "Durable auto-progression state for the epic a Flow's Bead link names. " +
+			"Read-only: nothing in this schema enables, disables, or halts it.",
+		Fields: graphql.Fields{
+			"enabled": &graphql.Field{
+				Type:        graphql.NewNonNull(graphql.Boolean),
+				Description: "Whether progression is currently active for this epic.",
+				Resolve: valueResolver(func(record flowstore.EpicProgression) (any, error) {
+					return record.Enabled, nil
+				}),
+			},
+			"done": &graphql.Field{
+				Type: graphql.NewNonNull(graphql.Boolean),
+				Description: "The persisted completion flag. It is never inferred from enabled: a manually " +
+					"disabled epic is not done.",
+				Resolve: valueResolver(func(record flowstore.EpicProgression) (any, error) {
+					return record.Done, nil
+				}),
+			},
+			"halt": &graphql.Field{
+				Type:        epicProgressionHaltType,
+				Description: "Why progression stopped; null when it stopped for no recorded reason or never stopped.",
+				Resolve: valueResolver(func(record flowstore.EpicProgression) (any, error) {
+					if record.Halt == nil {
+						return nil, nil
+					}
+					return *record.Halt, nil
+				}),
+			},
+		},
+	})
+
 	phaseType := graphql.NewObject(graphql.ObjectConfig{
 		Name:        "Phase",
 		Description: "One phase in a Flow's phase graph.",
@@ -286,6 +359,37 @@ func newSchema() (graphql.Schema, error) {
 					Type:    graphql.NewNonNull(graphql.Boolean),
 					Resolve: flowResolver(func(flow *Flow) (any, error) { return flow.Record.AutoMode, nil }),
 				},
+				"bead": &graphql.Field{
+					Type:        beadLinkType,
+					Description: "The Flow's persisted Beads linkage; null when no Bead is linked.",
+					Resolve: flowResolver(func(flow *Flow) (any, error) {
+						if flow.Record.Bead.ID == "" {
+							return nil, nil
+						}
+						return flow.Record.Bead, nil
+					}),
+				},
+				"epicProgression": &graphql.Field{
+					Type: epicProgressionType,
+					Description: "Auto-progression state for the epic this Flow's Bead link names. Null when the " +
+						"Flow links no epic and when no progression row exists for it — an absent row is not a " +
+						"disabled epic, and neither is synthesized into one.",
+					Resolve: func(p graphql.ResolveParams) (any, error) {
+						flow, ok := p.Source.(*Flow)
+						if !ok {
+							return nil, errStateUnavailable
+						}
+						snap, err := snapshotFrom(p.Context)
+						if err != nil {
+							return nil, err
+						}
+						record, ok := snap.EpicProgression(flow)
+						if !ok {
+							return nil, nil
+						}
+						return record, nil
+					},
+				},
 				"issue": &graphql.Field{
 					Type: issueType,
 					Resolve: flowResolver(func(flow *Flow) (any, error) {
@@ -463,6 +567,19 @@ func stringField[T any](description string, get func(T) string) *graphql.Field {
 			}
 			return nullableString(get(source)), nil
 		},
+	}
+}
+
+// valueResolver adapts an object type whose source is a value-typed flowstore
+// struct rather than a snapshot pointer, the way stringField already does for
+// nullable strings.
+func valueResolver[T any](get func(T) (any, error)) graphql.FieldResolveFn {
+	return func(p graphql.ResolveParams) (any, error) {
+		source, ok := p.Source.(T)
+		if !ok {
+			return nil, errStateUnavailable
+		}
+		return get(source)
 	}
 }
 

--- a/graphqlapi/schema.go
+++ b/graphqlapi/schema.go
@@ -383,7 +383,13 @@ func newSchema() (graphql.Schema, error) {
 						if err != nil {
 							return nil, err
 						}
-						record, ok := snap.EpicProgression(flow)
+						record, ok, err := snap.EpicProgression(flow)
+						if err != nil {
+							// Scoped to this field on this Flow: an unreadable
+							// progression row nulls it and reports an error
+							// entry, and leaves the rest of the response intact.
+							return nil, err
+						}
 						if !ok {
 							return nil, nil
 						}
@@ -571,8 +577,9 @@ func stringField[T any](description string, get func(T) string) *graphql.Field {
 }
 
 // valueResolver adapts an object type whose source is a value-typed flowstore
-// struct rather than a snapshot pointer, the way stringField already does for
-// nullable strings.
+// struct rather than a snapshot pointer. It reports errStateUnavailable on a
+// source-type mismatch, the way repoResolver and flowResolver do — not the
+// nil, nil that stringField returns.
 func valueResolver[T any](get func(T) (any, error)) graphql.FieldResolveFn {
 	return func(p graphql.ResolveParams) (any, error) {
 		source, ok := p.Source.(T)

--- a/graphqlapi/schema_test.go
+++ b/graphqlapi/schema_test.go
@@ -111,6 +111,7 @@ func fixtureSnapshot() *snapshot {
 			},
 		),
 		nil,
+		nil,
 	)
 }
 
@@ -249,7 +250,10 @@ func TestSchemaCurrentPhase(t *testing.T) {
 				RepoPath: "/repos/alpha",
 				Merge:    flowstore.Merge{Status: flowstore.MergePending},
 				Phases:   testCase.phases,
-			}), nil)
+			}),
+				nil,
+				nil,
+			)
 			result := executeQuery(t, snap, `{ flow(id: "f1") { currentPhase { id status } } }`)
 			data := mustSucceed(t, result)
 			flow := data["flow"].(map[string]any)
@@ -293,7 +297,10 @@ func TestSchemaNullabilityMatrix(t *testing.T) {
 			Merge:    flowstore.Merge{Status: flowstore.MergePending, Commit: "cafe"},
 			Phases:   []flowstore.FlowPhase{{PhaseID: "plan", Status: flowstore.PhaseCompleted}},
 		},
-	), nil)
+	),
+		nil,
+		nil,
+	)
 
 	result := executeQuery(t, snap, `{
 		empty: flow(id: "empty") {
@@ -330,6 +337,191 @@ func TestSchemaNullabilityMatrix(t *testing.T) {
 	if strings.Contains(jsonOf(t, data), "0001-01-01") {
 		t.Errorf("response serialized a zero time: %s", jsonOf(t, data))
 	}
+}
+
+// beadSnapshot pairs the four link shapes with the four progression states the
+// store can persist, so one query can prove every projection at once.
+func beadSnapshot(progressions *countingProgressions) *snapshot {
+	return buildSnapshot(
+		staticRepos(),
+		staticFlows(
+			flowstore.FlowRecord{FlowID: "unlinked", RepoPath: "/repos/alpha"},
+			beadFlow("child-only", "/repos/alpha", "approach-y7g.7", ""),
+			beadFlow("enabled", "/repos/enabled", "approach-e.1", "approach-e"),
+			beadFlow("disabled", "/repos/disabled", "approach-d.1", "approach-d"),
+			beadFlow("halted", "/repos/halted", "approach-h.1", "approach-h"),
+			beadFlow("done", "/repos/done", "approach-done.1", "approach-done"),
+			// A padded epic id: the key is canonicalized for the read, the link
+			// is emitted exactly as persisted.
+			beadFlow("missing-row", "/repos/missing", "approach-m.1", "  approach-m  "),
+		),
+		progressions.source(),
+		nil,
+	)
+}
+
+func beadProgressions() *countingProgressions {
+	created := fixtureTime(0)
+	row := func(repoPath, epicID string, enabled, done bool, halt *flowstore.EpicProgressionHalt) flowstore.EpicProgression {
+		return flowstore.EpicProgression{
+			SchemaVersion: 1, RepoPath: repoPath, EpicID: epicID,
+			Enabled: enabled, Done: done, Halt: halt,
+			CreatedAt: created, UpdatedAt: created,
+		}
+	}
+	return &countingProgressions{rows: map[flowstore.EpicProgressionKey]flowstore.EpicProgression{
+		epicKey("/repos/enabled", "approach-e"):  row("/repos/enabled", "approach-e", true, false, nil),
+		epicKey("/repos/disabled", "approach-d"): row("/repos/disabled", "approach-d", false, false, nil),
+		epicKey("/repos/done", "approach-done"):  row("/repos/done", "approach-done", false, true, nil),
+		epicKey("/repos/halted", "approach-h"): row("/repos/halted", "approach-h", false, false, &flowstore.EpicProgressionHalt{
+			ChildBeadID: "approach-h.4", Status: flowstore.StatusNeedsAttention, Message: "child Flow needs attention",
+		}),
+	}}
+}
+
+func TestSchemaBeadLinkIsVerbatimAndNullOnlyWhenUnlinked(t *testing.T) {
+	result := executeQuery(t, beadSnapshot(beadProgressions()), `{
+		unlinked: flow(id: "unlinked") { bead { id epicId } }
+		childOnly: flow(id: "child-only") { bead { id epicId } }
+		linked: flow(id: "missing-row") { bead { id epicId } }
+	}`)
+	data := mustSucceed(t, result)
+	for name, want := range map[string]string{
+		"unlinked":  `{"bead":null}`,
+		"childOnly": `{"bead":{"epicId":null,"id":"approach-y7g.7"}}`,
+		// Padded exactly as persisted: the trim happens on the progression key,
+		// not on the link the client reads back.
+		"linked": `{"bead":{"epicId":"  approach-m  ","id":"approach-m.1"}}`,
+	} {
+		if got := jsonOf(t, data[name]); got != want {
+			t.Errorf("%s = %s, want %s", name, got, want)
+		}
+	}
+}
+
+func TestSchemaEpicProgressionProjectsEveryDurableState(t *testing.T) {
+	progressions := beadProgressions()
+	result := executeQuery(t, beadSnapshot(progressions), `{
+		unlinked: flow(id: "unlinked") { epicProgression { enabled done halt { childBeadId } } }
+		childOnly: flow(id: "child-only") { epicProgression { enabled done halt { childBeadId } } }
+		missingRow: flow(id: "missing-row") { epicProgression { enabled done halt { childBeadId } } }
+		enabled: flow(id: "enabled") { epicProgression { enabled done halt { childBeadId status message } } }
+		disabled: flow(id: "disabled") { epicProgression { enabled done halt { childBeadId status message } } }
+		done: flow(id: "done") { epicProgression { enabled done halt { childBeadId status message } } }
+		halted: flow(id: "halted") { epicProgression { enabled done halt { childBeadId status message } } }
+	}`)
+	data := mustSucceed(t, result)
+	for name, want := range map[string]string{
+		// No epic link and no row are both "nothing to say", never a fabricated
+		// record: a disabled projection here would invent an epic.
+		"unlinked":   `{"epicProgression":null}`,
+		"childOnly":  `{"epicProgression":null}`,
+		"missingRow": `{"epicProgression":null}`,
+		"enabled":    `{"epicProgression":{"done":false,"enabled":true,"halt":null}}`,
+		// Manually disabled is not done: only the explicit durable flag is.
+		"disabled": `{"epicProgression":{"done":false,"enabled":false,"halt":null}}`,
+		"done":     `{"epicProgression":{"done":true,"enabled":false,"halt":null}}`,
+		"halted": `{"epicProgression":{"done":false,"enabled":false,` +
+			`"halt":{"childBeadId":"approach-h.4","message":"child Flow needs attention","status":"needs_attention"}}}`,
+	} {
+		if got := jsonOf(t, data[name]); got != want {
+			t.Errorf("%s = %s, want %s", name, got, want)
+		}
+	}
+	// One read per canonical key, none for the two Flows with no epic link, and
+	// the padded epic id was trimmed before the read.
+	want := []string{
+		"/repos/enabled|approach-e", "/repos/disabled|approach-d",
+		"/repos/halted|approach-h", "/repos/done|approach-done",
+		"/repos/missing|approach-m",
+	}
+	if got := progressionKeys(progressions.calls); !equalStrings(got, want) {
+		t.Errorf("progression reads = %v, want %v", got, want)
+	}
+}
+
+func TestSchemaSanitizesEpicProgressionSourceFailure(t *testing.T) {
+	secretPath := "/tmp/approach-secret-root/flows.db"
+	progressions := &countingProgressions{err: errors.New("read epic progression: open " + secretPath + ": permission denied")}
+	snap := buildSnapshot(
+		staticRepos(),
+		staticFlows(beadFlow("a1", "/repos/alpha", "approach-y7g.1", "approach-y7g")),
+		progressions.source(),
+		nil,
+	)
+	result := executeQuery(t, snap, `{ flows { id bead { id } epicProgression { enabled } } }`)
+	if len(result.Errors) == 0 {
+		t.Fatalf("errors = none, want a sanitized failure")
+	}
+	encoded := jsonOf(t, result)
+	if !strings.Contains(encoded, errStateUnavailable.Error()) {
+		t.Errorf("response = %s, want it to contain %q", encoded, errStateUnavailable.Error())
+	}
+	for _, leak := range []string{secretPath, "permission denied", "approach-secret-root"} {
+		if strings.Contains(encoded, leak) {
+			t.Errorf("response leaked %q: %s", leak, encoded)
+		}
+	}
+}
+
+// TestSchemaBeadAndProgressionSDL pins the public contract these fields were
+// specified as: an unexpectedly nullable id or a widened halt tuple is a
+// breaking change for every client, and introspection is where clients read it.
+func TestSchemaBeadAndProgressionSDL(t *testing.T) {
+	result := executeQuery(t, fixtureSnapshot(), `{
+		mutationType: __schema { mutationType { name } subscriptionType { name } }
+		flow: __type(name: "Flow") { fields { name type { kind name ofType { kind name } } } }
+		bead: __type(name: "BeadLink") { fields { name type { kind name ofType { kind name } } } }
+		progression: __type(name: "EpicProgression") { fields { name type { kind name ofType { kind name } } } }
+		halt: __type(name: "EpicProgressionHalt") { fields { name type { kind name ofType { kind name } } } }
+	}`)
+	data := mustSucceed(t, result)
+
+	roots := data["mutationType"].(map[string]any)
+	if roots["mutationType"] != nil || roots["subscriptionType"] != nil {
+		t.Fatalf("roots = %#v, want no mutation or subscription type", roots)
+	}
+
+	for _, testCase := range []struct {
+		typeName string
+		field    string
+		want     string
+	}{
+		{"flow", "bead", `{"kind":"OBJECT","name":"BeadLink","ofType":null}`},
+		{"flow", "epicProgression", `{"kind":"OBJECT","name":"EpicProgression","ofType":null}`},
+		{"bead", "id", `{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"ID"}}`},
+		{"bead", "epicId", `{"kind":"SCALAR","name":"ID","ofType":null}`},
+		{"progression", "enabled", `{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Boolean"}}`},
+		{"progression", "done", `{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"Boolean"}}`},
+		{"progression", "halt", `{"kind":"OBJECT","name":"EpicProgressionHalt","ofType":null}`},
+		{"halt", "childBeadId", `{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"ID"}}`},
+		{"halt", "status", `{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String"}}`},
+		{"halt", "message", `{"kind":"NON_NULL","name":null,"ofType":{"kind":"SCALAR","name":"String"}}`},
+	} {
+		got, ok := introspectedFieldType(t, data, testCase.typeName, testCase.field)
+		if !ok {
+			t.Errorf("%s has no field %q", testCase.typeName, testCase.field)
+			continue
+		}
+		if got != testCase.want {
+			t.Errorf("%s.%s type = %s, want %s", testCase.typeName, testCase.field, got, testCase.want)
+		}
+	}
+}
+
+func introspectedFieldType(t *testing.T, data map[string]any, alias, field string) (string, bool) {
+	t.Helper()
+	typeInfo, ok := data[alias].(map[string]any)
+	if !ok {
+		t.Fatalf("%s = %#v, want an introspected type", alias, data[alias])
+	}
+	for _, entry := range typeInfo["fields"].([]any) {
+		fieldInfo := entry.(map[string]any)
+		if fieldInfo["name"] == field {
+			return jsonOf(t, fieldInfo["type"]), true
+		}
+	}
+	return "", false
 }
 
 func TestSchemaDateTimeIsRFC3339(t *testing.T) {
@@ -404,6 +596,7 @@ func TestSchemaSanitizesFlowSourceFailure(t *testing.T) {
 		func() ([]flowstore.FlowRecord, error) {
 			return nil, errors.New("list flows: open " + secretPath + ": permission denied")
 		},
+		nil,
 		nil,
 	)
 	result := executeQuery(t, snap, `{ flows { id } repos { id } }`)

--- a/graphqlapi/schema_test.go
+++ b/graphqlapi/schema_test.go
@@ -462,6 +462,53 @@ func TestSchemaSanitizesEpicProgressionSourceFailure(t *testing.T) {
 			t.Errorf("response leaked %q: %s", leak, encoded)
 		}
 	}
+
+	// The failure nulls the one field that could not be read and nothing else.
+	// epicProgression is an optional projection; a client that never selects it
+	// must not be able to tell that a row was unreadable.
+	flows, ok := result.Data.(map[string]any)["flows"].([]any)
+	if !ok || len(flows) != 1 {
+		t.Fatalf("flows = %#v, want the Flow to resolve despite the failed row", result.Data)
+	}
+	flow := flows[0].(map[string]any)
+	if flow["id"] != "a1" {
+		t.Errorf("flows[0].id = %v, want a1", flow["id"])
+	}
+	if bead, _ := flow["bead"].(map[string]any); bead == nil || bead["id"] != "approach-y7g.1" {
+		t.Errorf("flows[0].bead = %#v, want the link to resolve", flow["bead"])
+	}
+	if flow["epicProgression"] != nil {
+		t.Errorf("flows[0].epicProgression = %#v, want null", flow["epicProgression"])
+	}
+
+	if unrelated := executeQuery(t, snap, `{ repos { id } flows { id } }`); len(unrelated.Errors) != 0 {
+		t.Errorf("errors = %v, want none: an unreadable progression row must not fail a query that never selects it", unrelated.Errors)
+	}
+}
+
+// TestSchemaNilEpicProgressionSourceResolvesNull holds ServerOptions to its
+// promise that the seam is optional: with no source wired, a Flow that links a
+// real epic still resolves its Bead link and simply reports no progression. The
+// alternative — an error, or a synthesized disabled row — would make an
+// unconfigured server look like a store with progression turned off.
+func TestSchemaNilEpicProgressionSourceResolvesNull(t *testing.T) {
+	snap := buildSnapshot(
+		staticRepos(),
+		staticFlows(beadFlow("a1", "/repos/alpha", "approach-y7g.1", "approach-y7g")),
+		nil,
+		nil,
+	)
+	result := executeQuery(t, snap, `{ flows { id bead { id epicId } epicProgression { enabled done } } }`)
+	data := mustSucceed(t, result)
+
+	flow := data["flows"].([]any)[0].(map[string]any)
+	bead, _ := flow["bead"].(map[string]any)
+	if bead == nil || bead["id"] != "approach-y7g.1" || bead["epicId"] != "approach-y7g" {
+		t.Errorf("bead = %#v, want the link to resolve without a progression source", flow["bead"])
+	}
+	if flow["epicProgression"] != nil {
+		t.Errorf("epicProgression = %#v, want null with no source wired", flow["epicProgression"])
+	}
 }
 
 // TestSchemaBeadAndProgressionSDL pins the public contract these fields were

--- a/graphqlapi/schema_test.go
+++ b/graphqlapi/schema_test.go
@@ -481,6 +481,19 @@ func TestSchemaSanitizesEpicProgressionSourceFailure(t *testing.T) {
 		t.Errorf("flows[0].epicProgression = %#v, want null", flow["epicProgression"])
 	}
 
+	// The path is load-bearing, not incidental. The web client tells a field it
+	// can serve without from a failure that nulled a whole entity by reading the
+	// last element of this path; without one it has to treat every partial as
+	// fatal, and `{"data":{"flow":null}}` from a failed snapshot is otherwise
+	// indistinguishable from an unknown id.
+	path := result.Errors[0].Path
+	if len(path) == 0 {
+		t.Fatalf("error path = empty, want it to name the field that failed")
+	}
+	if got := path[len(path)-1]; got != "epicProgression" {
+		t.Errorf("error path = %#v, want it to terminate at epicProgression", path)
+	}
+
 	if unrelated := executeQuery(t, snap, `{ repos { id } flows { id } }`); len(unrelated.Errors) != 0 {
 		t.Errorf("errors = %v, want none: an unreadable progression row must not fail a query that never selects it", unrelated.Errors)
 	}

--- a/graphqlapi/server.go
+++ b/graphqlapi/server.go
@@ -34,9 +34,12 @@ const (
 
 // ServerOptions configures the GraphQL HTTP handler.
 type ServerOptions struct {
-	// Repos and Flows are the read seams for one snapshot per request.
-	Repos RepoSource
-	Flows FlowSource
+	// Repos, Flows, and EpicProgressions are the read seams for one snapshot
+	// per request. EpicProgressions may be nil: the snapshot then reads no
+	// progression rows and Flow.epicProgression resolves null everywhere.
+	Repos            RepoSource
+	Flows            FlowSource
+	EpicProgressions EpicProgressionSource
 
 	// Token, when non-empty, is required on every /graphql request as either
 	// `Authorization: Bearer <token>` or `X-Approach-Token`.
@@ -73,6 +76,7 @@ type server struct {
 	schema         graphql.Schema
 	repos          RepoSource
 	flows          FlowSource
+	progressions   EpicProgressionSource
 	token          string
 	logger         io.Writer
 	requestTimeout time.Duration
@@ -102,6 +106,7 @@ func NewServer(opts ServerOptions) (http.Handler, error) {
 		schema:         schema,
 		repos:          opts.Repos,
 		flows:          opts.Flows,
+		progressions:   opts.EpicProgressions,
 		token:          opts.Token,
 		logger:         logger,
 		requestTimeout: timeout,
@@ -289,7 +294,7 @@ func (s *server) acquireSnapshot(ctx context.Context) (*snapshot, func(), snapsh
 	// Buffered, so the builder never blocks on a handler that has given up and
 	// exactly one of the two receives below consumes the result.
 	built := make(chan *snapshot, 1)
-	go func() { built <- buildSnapshot(s.repos, s.flows, s.logf) }()
+	go func() { built <- buildSnapshot(s.repos, s.flows, s.progressions, s.logf) }()
 
 	timer := time.NewTimer(s.requestTimeout)
 	defer timer.Stop()

--- a/graphqlapi/source.go
+++ b/graphqlapi/source.go
@@ -59,16 +59,20 @@ type Flow struct {
 }
 
 // epicProgressionProjection is one request's single read of one canonical key:
-// either the row that was there, or the fact that there was none. Holding both
-// in the snapshot is what keeps sibling Flows sharing an epic — found or
-// missing — from re-reading the store per resolver.
+// the row that was there, the fact that there was none, or the fact that it
+// could not be read. Holding all three in the snapshot is what keeps sibling
+// Flows sharing an epic — found, missing, or unreadable — from re-reading the
+// store per resolver, and what keeps an unreadable row scoped to the Flows that
+// name it.
 type epicProgressionProjection struct {
 	record flowstore.EpicProgression
 	found  bool
+	err    error
 }
 
-// snapshot is the immutable read model for exactly one request: one scan plus
-// one store list, indexed for pure map and slice reads by every resolver.
+// snapshot is the immutable read model for exactly one request: one scan, one
+// store list, and one progression read per distinct epic those Flows name,
+// indexed for pure map and slice reads by every resolver.
 type snapshot struct {
 	repos        []*Repo
 	repoByPath   map[string]*Repo
@@ -167,12 +171,18 @@ func buildSnapshot(repos RepoSource, flows FlowSource, progressions EpicProgress
 }
 
 // loadEpicProgressions reads one row per distinct canonical key referenced by a
-// loaded Flow, so the resolvers below do no I/O at all.
+// loaded Flow, so the resolvers below do no I/O at all. It is eager and does
+// not consult the query: bounds below has to know the widest halt message this
+// snapshot can serialize *before* execution, so a lazily loaded row would be
+// charged the pessimistic fallback instead.
 //
-// The key is built exactly the way flowstore.ReadEpicProgression canonicalizes
+// The key is compatible with how flowstore.ReadEpicProgression canonicalizes
 // one — the snapshot's normalized absolute repo path plus the trimmed epic id —
 // so two Flows that name the same epic through different spellings collapse to
-// a single read, and a Flow with no epic link causes none.
+// a single read, and a Flow with no epic link causes none. It is not identical:
+// normalizePath resolves a relative path against the serving process's working
+// directory, where ReadEpicProgression rejects one outright. Only an externally
+// written record can hold a relative repo path, and it resolves null either way.
 func (s *snapshot) loadEpicProgressions(read EpicProgressionSource, logf func(string, ...any)) {
 	for _, flow := range s.flows {
 		key, ok := epicProgressionKey(flow)
@@ -184,22 +194,38 @@ func (s *snapshot) loadEpicProgressions(read EpicProgressionSource, logf func(st
 		}
 		record, found, err := read(key)
 		if err != nil {
+			// Recorded against the key rather than the whole snapshot. A
+			// malformed row is the likeliest failure here, and progression is a
+			// secondary projection: failing `{ repos { id } }` — a query that
+			// never mentions Beads — over one bad row would make an optional
+			// field a single point of failure for the entire API. Only the
+			// Flows naming this epic see an error.
+			//
 			// The key names a real path on this machine and the cause may name
-			// the store file, so both stay server-side; clients get the same
+			// the store file, so both stay server-side; those Flows get the same
 			// fixed message a failed flow list produces.
 			logf("reading epic progression %q/%q failed: %v", key.RepoPath, key.EpicID, err)
-			s.err = errStateUnavailable
-			return
+			s.progressions[key] = epicProgressionProjection{err: errStateUnavailable}
+			continue
 		}
 		s.progressions[key] = epicProgressionProjection{record: record, found: found}
 	}
 }
 
 // epicProgressionKey is the canonical lookup key for a Flow's linked epic, and
-// false for a Flow that links none. It deliberately does not consult the child
-// Bead id: progression is keyed by epic, and a child-only link has no epic to
-// read state for.
+// false for a Flow that links none. It deliberately does not key on the child
+// Bead id — progression is keyed by epic, and a child-only link has no epic to
+// read state for — but it does require one: flowstore.validateBeadLink forbids
+// an epic without a child, so a record holding one is externally written, and
+// Flow.bead resolves null for it. Reading progression there would surface an
+// epic through a Flow whose linkage the schema reports as absent.
 func epicProgressionKey(flow *Flow) (flowstore.EpicProgressionKey, bool) {
+	// Tested exactly the way Flow.bead resolves and the way
+	// flowstore.validateBeadLink states the invariant, so the two fields cannot
+	// disagree about whether a Flow is linked at all.
+	if flow.Record.Bead.ID == "" {
+		return flowstore.EpicProgressionKey{}, false
+	}
 	epicID := strings.TrimSpace(flow.Record.Bead.EpicID)
 	if epicID == "" {
 		return flowstore.EpicProgressionKey{}, false
@@ -241,8 +267,17 @@ func (s *snapshot) bounds() resultBounds {
 			limits.values.observePhase(phase)
 		}
 	}
+	// Registered unconditionally, before any real row. EpicProgression is a
+	// non-list object, so an unregistered scalar of it is charged the
+	// pessimistic fallback once per Flow — and a store that has never used epic
+	// progression has no rows to register it from. Seeding only from found rows
+	// would 400 an ordinary flows query whose progression fields all resolve
+	// null, which is the default state of every store.
+	limits.values.observeEpicProgression(flowstore.EpicProgression{})
 	// Measured over the projections rather than the Flows: many Flows resolve
 	// Flow.epicProgression from one row, and only a found row serializes.
+	// fieldValueBytes keeps a per-field maximum and the multiplier comes from
+	// list cardinality, so the widest row bounds every Flow that shares it.
 	for _, projection := range s.progressions {
 		if !projection.found {
 			continue
@@ -332,22 +367,23 @@ func (f fieldValueBytes) observeFlow(flow *Flow) {
 	f.observeText("BeadLink.epicId", record.Bead.EpicID)
 }
 
+// observeEpicProgression registers one progression row's widths. bounds calls
+// it with a zero record before any real one, so every field below is registered
+// even where no row exists.
 func (f fieldValueBytes) observeEpicProgression(record flowstore.EpicProgression) {
 	f.observe("EpicProgression.enabled", boolValueBytes)
 	f.observe("EpicProgression.done", boolValueBytes)
-	// Seeded outside the halt branch: a snapshot where nothing is halted still
-	// has to register these fields, or they would look like schema drift and
-	// take the pessimistic fallback. The message is unbounded agent-supplied
-	// text, so it is measured at its encoded width like any other free text.
-	f.observeText("EpicProgressionHalt.childBeadId", "")
-	f.observeText("EpicProgressionHalt.status", "")
-	f.observeText("EpicProgressionHalt.message", "")
-	if record.Halt == nil {
-		return
+	// Measured outside the halt branch, so an unhalted row still registers the
+	// halt fields rather than leaving them looking like schema drift. The
+	// message is unbounded agent-supplied text, so it is measured at its
+	// encoded width like any other free text.
+	halt := record.Halt
+	if halt == nil {
+		halt = &flowstore.EpicProgressionHalt{}
 	}
-	f.observeText("EpicProgressionHalt.childBeadId", record.Halt.ChildBeadID)
-	f.observeText("EpicProgressionHalt.status", record.Halt.Status)
-	f.observeText("EpicProgressionHalt.message", record.Halt.Message)
+	f.observeText("EpicProgressionHalt.childBeadId", halt.ChildBeadID)
+	f.observeText("EpicProgressionHalt.status", halt.Status)
+	f.observeText("EpicProgressionHalt.message", halt.Message)
 }
 
 func (f fieldValueBytes) observePhase(phase flowstore.FlowPhase) {
@@ -456,16 +492,26 @@ func (s *snapshot) Flow(id string) (*Flow, bool) {
 // epic. It reports false both for a Flow that links no epic and for a link
 // whose row is absent: neither case fabricates an epic or a progression record,
 // and "no row" is not the same claim as "disabled".
-func (s *snapshot) EpicProgression(flow *Flow) (flowstore.EpicProgression, bool) {
+//
+// A row that could not be read is the third case, and it returns the error
+// rather than false — reporting an unreadable row as an absent one would make
+// up exactly the answer this projection is careful never to invent.
+func (s *snapshot) EpicProgression(flow *Flow) (flowstore.EpicProgression, bool, error) {
 	key, ok := epicProgressionKey(flow)
 	if !ok {
-		return flowstore.EpicProgression{}, false
+		return flowstore.EpicProgression{}, false, nil
 	}
 	projection, loaded := s.progressions[key]
-	if !loaded || !projection.found {
-		return flowstore.EpicProgression{}, false
+	if !loaded {
+		return flowstore.EpicProgression{}, false, nil
 	}
-	return projection.record, true
+	if projection.err != nil {
+		return flowstore.EpicProgression{}, false, projection.err
+	}
+	if !projection.found {
+		return flowstore.EpicProgression{}, false, nil
+	}
+	return projection.record, true, nil
 }
 
 // FlowsForRepo serves both flows(repoId:) and Repo.flows from the same index,

--- a/graphqlapi/source.go
+++ b/graphqlapi/source.go
@@ -31,6 +31,12 @@ type RepoSource func() ([]scanner.Repo, error)
 // a sanitized GraphQL error.
 type FlowSource func() ([]flowstore.FlowRecord, error)
 
+// EpicProgressionSource reads one persisted epic auto-progression row by its
+// canonical key, distinguishing a missing row (found=false) from an unreadable
+// one (a non-nil error). It is a read seam onto flowstore only: the API never
+// enables, disables, or halts progression, and it never reaches Beads itself.
+type EpicProgressionSource func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error)
+
 // errStateUnavailable is the fixed message clients see when the primary data
 // source fails. Underlying paths and os error text are logged server-side and
 // never reach a response body.
@@ -52,28 +58,39 @@ type Flow struct {
 	RepoPath string
 }
 
+// epicProgressionProjection is one request's single read of one canonical key:
+// either the row that was there, or the fact that there was none. Holding both
+// in the snapshot is what keeps sibling Flows sharing an epic — found or
+// missing — from re-reading the store per resolver.
+type epicProgressionProjection struct {
+	record flowstore.EpicProgression
+	found  bool
+}
+
 // snapshot is the immutable read model for exactly one request: one scan plus
 // one store list, indexed for pure map and slice reads by every resolver.
 type snapshot struct {
-	repos       []*Repo
-	repoByPath  map[string]*Repo
-	flows       []*Flow
-	flowByID    map[string]*Flow
-	flowsByRepo map[string][]*Flow
-	err         error
+	repos        []*Repo
+	repoByPath   map[string]*Repo
+	flows        []*Flow
+	flowByID     map[string]*Flow
+	flowsByRepo  map[string][]*Flow
+	progressions map[flowstore.EpicProgressionKey]epicProgressionProjection
+	err          error
 }
 
-// buildSnapshot reads both sources once and indexes the result. logf receives
+// buildSnapshot reads every source once and indexes the result. logf receives
 // the unsanitized failure detail; it is never nil-checked by callers below, so
 // buildSnapshot substitutes a no-op.
-func buildSnapshot(repos RepoSource, flows FlowSource, logf func(string, ...any)) *snapshot {
+func buildSnapshot(repos RepoSource, flows FlowSource, progressions EpicProgressionSource, logf func(string, ...any)) *snapshot {
 	if logf == nil {
 		logf = func(string, ...any) {}
 	}
 	snap := &snapshot{
-		repoByPath:  make(map[string]*Repo),
-		flowByID:    make(map[string]*Flow),
-		flowsByRepo: make(map[string][]*Flow),
+		repoByPath:   make(map[string]*Repo),
+		flowByID:     make(map[string]*Flow),
+		flowsByRepo:  make(map[string][]*Flow),
+		progressions: make(map[flowstore.EpicProgressionKey]epicProgressionProjection),
 	}
 
 	var scanned []scanner.Repo
@@ -143,7 +160,51 @@ func buildSnapshot(repos RepoSource, flows FlowSource, logf func(string, ...any)
 		snap.flowsByRepo[path] = append(snap.flowsByRepo[path], flow)
 	}
 	sortRepos(snap.repos)
+	if progressions != nil {
+		snap.loadEpicProgressions(progressions, logf)
+	}
 	return snap
+}
+
+// loadEpicProgressions reads one row per distinct canonical key referenced by a
+// loaded Flow, so the resolvers below do no I/O at all.
+//
+// The key is built exactly the way flowstore.ReadEpicProgression canonicalizes
+// one — the snapshot's normalized absolute repo path plus the trimmed epic id —
+// so two Flows that name the same epic through different spellings collapse to
+// a single read, and a Flow with no epic link causes none.
+func (s *snapshot) loadEpicProgressions(read EpicProgressionSource, logf func(string, ...any)) {
+	for _, flow := range s.flows {
+		key, ok := epicProgressionKey(flow)
+		if !ok {
+			continue
+		}
+		if _, loaded := s.progressions[key]; loaded {
+			continue
+		}
+		record, found, err := read(key)
+		if err != nil {
+			// The key names a real path on this machine and the cause may name
+			// the store file, so both stay server-side; clients get the same
+			// fixed message a failed flow list produces.
+			logf("reading epic progression %q/%q failed: %v", key.RepoPath, key.EpicID, err)
+			s.err = errStateUnavailable
+			return
+		}
+		s.progressions[key] = epicProgressionProjection{record: record, found: found}
+	}
+}
+
+// epicProgressionKey is the canonical lookup key for a Flow's linked epic, and
+// false for a Flow that links none. It deliberately does not consult the child
+// Bead id: progression is keyed by epic, and a child-only link has no epic to
+// read state for.
+func epicProgressionKey(flow *Flow) (flowstore.EpicProgressionKey, bool) {
+	epicID := strings.TrimSpace(flow.Record.Bead.EpicID)
+	if epicID == "" {
+		return flowstore.EpicProgressionKey{}, false
+	}
+	return flowstore.EpicProgressionKey{RepoPath: flow.RepoPath, EpicID: epicID}, true
 }
 
 func (s *snapshot) addRepo(repo *Repo) {
@@ -179,6 +240,14 @@ func (s *snapshot) bounds() resultBounds {
 			limits.dependsOnPerPhase = maxInt(limits.dependsOnPerPhase, len(phase.DependsOn))
 			limits.values.observePhase(phase)
 		}
+	}
+	// Measured over the projections rather than the Flows: many Flows resolve
+	// Flow.epicProgression from one row, and only a found row serializes.
+	for _, projection := range s.progressions {
+		if !projection.found {
+			continue
+		}
+		limits.values.observeEpicProgression(projection.record)
 	}
 	return limits
 }
@@ -257,6 +326,28 @@ func (f fieldValueBytes) observeFlow(flow *Flow) {
 	f.observeText("Merge.status", record.Merge.Status)
 	f.observeText("Merge.commit", record.Merge.Commit)
 	f.observe("Merge.mergedAt", dateTimeValueBytes)
+
+	// The persisted link text, which is what BeadLink resolves verbatim.
+	f.observeText("BeadLink.id", record.Bead.ID)
+	f.observeText("BeadLink.epicId", record.Bead.EpicID)
+}
+
+func (f fieldValueBytes) observeEpicProgression(record flowstore.EpicProgression) {
+	f.observe("EpicProgression.enabled", boolValueBytes)
+	f.observe("EpicProgression.done", boolValueBytes)
+	// Seeded outside the halt branch: a snapshot where nothing is halted still
+	// has to register these fields, or they would look like schema drift and
+	// take the pessimistic fallback. The message is unbounded agent-supplied
+	// text, so it is measured at its encoded width like any other free text.
+	f.observeText("EpicProgressionHalt.childBeadId", "")
+	f.observeText("EpicProgressionHalt.status", "")
+	f.observeText("EpicProgressionHalt.message", "")
+	if record.Halt == nil {
+		return
+	}
+	f.observeText("EpicProgressionHalt.childBeadId", record.Halt.ChildBeadID)
+	f.observeText("EpicProgressionHalt.status", record.Halt.Status)
+	f.observeText("EpicProgressionHalt.message", record.Halt.Message)
 }
 
 func (f fieldValueBytes) observePhase(phase flowstore.FlowPhase) {
@@ -359,6 +450,22 @@ func (s *snapshot) Flows() []*Flow { return s.flows }
 func (s *snapshot) Flow(id string) (*Flow, bool) {
 	flow, ok := s.flowByID[strings.TrimSpace(id)]
 	return flow, ok
+}
+
+// EpicProgression returns the persisted progression row for the Flow's linked
+// epic. It reports false both for a Flow that links no epic and for a link
+// whose row is absent: neither case fabricates an epic or a progression record,
+// and "no row" is not the same claim as "disabled".
+func (s *snapshot) EpicProgression(flow *Flow) (flowstore.EpicProgression, bool) {
+	key, ok := epicProgressionKey(flow)
+	if !ok {
+		return flowstore.EpicProgression{}, false
+	}
+	projection, loaded := s.progressions[key]
+	if !loaded || !projection.found {
+		return flowstore.EpicProgression{}, false
+	}
+	return projection.record, true
 }
 
 // FlowsForRepo serves both flows(repoId:) and Repo.flows from the same index,

--- a/graphqlapi/source.go
+++ b/graphqlapi/source.go
@@ -279,6 +279,17 @@ func (s *snapshot) bounds() resultBounds {
 	// fieldValueBytes keeps a per-field maximum and the multiplier comes from
 	// list cardinality, so the widest row bounds every Flow that shares it.
 	for _, projection := range s.progressions {
+		if projection.err != nil {
+			// An unreadable row is charged as bytes, not as a value: it puts an
+			// `errors` entry on the wire for every Flow naming that epic and
+			// every aliased selection of the field, and encoding/json buffers
+			// the whole body — errors included — before any of it is written.
+			// Left uncharged, one bad row is an amplifier that turns a response
+			// the data budget measures as small into one several times over the
+			// cap.
+			limits.progressionErrorBytes = errorEntryOverheadBytes
+			continue
+		}
 		if !projection.found {
 			continue
 		}

--- a/graphqlapi/source_test.go
+++ b/graphqlapi/source_test.go
@@ -26,15 +26,21 @@ func staticFlows(records ...flowstore.FlowRecord) FlowSource {
 // asked for. The read set is the assertion: progression rows are read once per
 // distinct canonical key per request, so a Flow that links no epic must cause no
 // read at all and siblings sharing an epic must cause exactly one.
+// failKeys fails only the keys it names, so a test can assert that one
+// unreadable row leaves every other key readable.
 type countingProgressions struct {
-	rows  map[flowstore.EpicProgressionKey]flowstore.EpicProgression
-	err   error
-	calls []flowstore.EpicProgressionKey
+	rows     map[flowstore.EpicProgressionKey]flowstore.EpicProgression
+	failKeys map[flowstore.EpicProgressionKey]error
+	err      error
+	calls    []flowstore.EpicProgressionKey
 }
 
 func (c *countingProgressions) source() EpicProgressionSource {
 	return func(key flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 		c.calls = append(c.calls, key)
+		if err, fails := c.failKeys[key]; fails {
+			return flowstore.EpicProgression{}, false, err
+		}
 		if c.err != nil {
 			return flowstore.EpicProgression{}, false, c.err
 		}
@@ -79,9 +85,39 @@ func TestBuildSnapshotReadsNoEpicProgressionWithoutAnEpicLink(t *testing.T) {
 		t.Fatalf("progression reads = %v, want none", progressionKeys(progressions.calls))
 	}
 	for _, flow := range snap.Flows() {
-		if _, ok := snap.EpicProgression(flow); ok {
-			t.Errorf("flow %q resolved a progression with no epic link", flow.Record.FlowID)
+		record, ok, err := snap.EpicProgression(flow)
+		if err != nil {
+			t.Errorf("flow %q progression err = %v, want none", flow.Record.FlowID, err)
 		}
+		if ok {
+			t.Errorf("flow %q resolved progression %+v with no epic link", flow.Record.FlowID, record)
+		}
+	}
+}
+
+// An epic id with no child Bead id is a shape flowstore.validateBeadLink
+// forbids, so only an externally written record holds one. Flow.bead resolves
+// null for it, and reading progression anyway would surface an epic through a
+// Flow the schema reports as unlinked.
+func TestBuildSnapshotReadsNoEpicProgressionForAnEpicWithoutAChildBead(t *testing.T) {
+	progressions := &countingProgressions{rows: map[flowstore.EpicProgressionKey]flowstore.EpicProgression{
+		epicKey("/repos/alpha", "approach-y7g"): {RepoPath: "/repos/alpha", EpicID: "approach-y7g", Enabled: true},
+	}}
+	snap := buildSnapshot(
+		staticRepos(),
+		staticFlows(beadFlow("epic-only", "/repos/alpha", "", "approach-y7g")),
+		progressions.source(),
+		nil,
+	)
+	if len(progressions.calls) != 0 {
+		t.Fatalf("progression reads = %v, want none", progressionKeys(progressions.calls))
+	}
+	flow, ok := snap.Flow("epic-only")
+	if !ok {
+		t.Fatal(`Flow("epic-only") not found`)
+	}
+	if record, ok, _ := snap.EpicProgression(flow); ok {
+		t.Errorf("progression = %+v, want none for a Flow whose bead resolves null", record)
 	}
 }
 
@@ -118,7 +154,10 @@ func TestBuildSnapshotReadsOneEpicProgressionPerCanonicalKey(t *testing.T) {
 		if !ok {
 			t.Fatalf("Flow(%q) not found", flowID)
 		}
-		record, ok := snap.EpicProgression(flow)
+		record, ok, err := snap.EpicProgression(flow)
+		if err != nil {
+			t.Fatalf("flow %q progression err = %v, want none", flowID, err)
+		}
 		if !ok {
 			t.Fatalf("flow %q has no progression, want the shared row", flowID)
 		}
@@ -131,29 +170,78 @@ func TestBuildSnapshotReadsOneEpicProgressionPerCanonicalKey(t *testing.T) {
 		if !ok {
 			t.Fatalf("Flow(%q) not found", flowID)
 		}
-		if record, ok := snap.EpicProgression(flow); ok {
+		record, ok, err := snap.EpicProgression(flow)
+		if err != nil {
+			t.Fatalf("flow %q progression err = %v, want none", flowID, err)
+		}
+		if ok {
 			t.Errorf("flow %q progression = %+v, want none (no row exists)", flowID, record)
 		}
 	}
 }
 
-func TestBuildSnapshotEpicProgressionFailureIsSanitized(t *testing.T) {
+// A progression read failure is sanitized like any other source failure, and it
+// is scoped to the key that failed. Progression is a secondary projection: one
+// malformed row must not take down the Flows that do not name that epic, let
+// alone a query that never mentions Beads.
+func TestBuildSnapshotEpicProgressionFailureIsSanitizedAndScopedToItsKey(t *testing.T) {
 	var logged []string
-	progressions := &countingProgressions{err: errors.New("read epic progression: open /tmp/secret-root/flows.db: permission denied")}
+	progressions := &countingProgressions{
+		rows: map[flowstore.EpicProgressionKey]flowstore.EpicProgression{
+			epicKey("/repos/beta", "approach-zzz"): {RepoPath: "/repos/beta", EpicID: "approach-zzz", Enabled: true},
+		},
+		failKeys: map[flowstore.EpicProgressionKey]error{
+			epicKey("/repos/alpha", "approach-y7g"): errors.New("read epic progression: open /tmp/secret-root/flows.db: permission denied"),
+		},
+	}
 	snap := buildSnapshot(
 		staticRepos(),
-		staticFlows(beadFlow("a1", "/repos/alpha", "approach-y7g.1", "approach-y7g")),
+		staticFlows(
+			beadFlow("a1", "/repos/alpha", "approach-y7g.1", "approach-y7g"),
+			beadFlow("b1", "/repos/beta", "approach-zzz.1", "approach-zzz"),
+			flowstore.FlowRecord{FlowID: "unlinked", RepoPath: "/repos/gamma"},
+		),
 		progressions.source(),
 		func(format string, args ...any) {
 			logged = append(logged, fmt.Sprintf(format, args...))
 		},
 	)
-	if !errors.Is(snap.err, errStateUnavailable) {
-		t.Fatalf("snapshot err = %v, want errStateUnavailable", snap.err)
+	if snap.err != nil {
+		t.Fatalf("snapshot err = %v, want none: one unreadable row must not fail the whole request", snap.err)
 	}
-	if strings.Contains(snap.err.Error(), "secret-root") || strings.Contains(snap.err.Error(), "permission denied") {
-		t.Fatalf("snapshot err leaked detail: %v", snap.err)
+
+	failed, ok := snap.Flow("a1")
+	if !ok {
+		t.Fatal(`Flow("a1") not found`)
 	}
+	_, found, err := snap.EpicProgression(failed)
+	if !errors.Is(err, errStateUnavailable) {
+		t.Fatalf("flow a1 progression err = %v, want errStateUnavailable", err)
+	}
+	if found {
+		t.Error("flow a1 reported a found progression despite an unreadable row")
+	}
+	if strings.Contains(err.Error(), "secret-root") || strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("progression err leaked detail: %v", err)
+	}
+
+	// The sibling key and an unlinked Flow are untouched by the failure.
+	healthy, ok := snap.Flow("b1")
+	if !ok {
+		t.Fatal(`Flow("b1") not found`)
+	}
+	record, found, err := snap.EpicProgression(healthy)
+	if err != nil || !found || !record.Enabled {
+		t.Errorf("flow b1 progression = (%+v, %v, %v), want the enabled row and no error", record, found, err)
+	}
+	unlinked, ok := snap.Flow("unlinked")
+	if !ok {
+		t.Fatal(`Flow("unlinked") not found`)
+	}
+	if _, found, err := snap.EpicProgression(unlinked); found || err != nil {
+		t.Errorf("unlinked flow progression = (%v, %v), want none and no error", found, err)
+	}
+
 	if len(logged) != 1 {
 		t.Fatalf("logged = %#v, want one epic-progression failure", logged)
 	}

--- a/graphqlapi/source_test.go
+++ b/graphqlapi/source_test.go
@@ -22,6 +22,148 @@ func staticFlows(records ...flowstore.FlowRecord) FlowSource {
 	return func() ([]flowstore.FlowRecord, error) { return records, nil }
 }
 
+// countingProgressions is an EpicProgressionSource that records every key it is
+// asked for. The read set is the assertion: progression rows are read once per
+// distinct canonical key per request, so a Flow that links no epic must cause no
+// read at all and siblings sharing an epic must cause exactly one.
+type countingProgressions struct {
+	rows  map[flowstore.EpicProgressionKey]flowstore.EpicProgression
+	err   error
+	calls []flowstore.EpicProgressionKey
+}
+
+func (c *countingProgressions) source() EpicProgressionSource {
+	return func(key flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
+		c.calls = append(c.calls, key)
+		if c.err != nil {
+			return flowstore.EpicProgression{}, false, c.err
+		}
+		record, found := c.rows[key]
+		return record, found, nil
+	}
+}
+
+func epicKey(repoPath, epicID string) flowstore.EpicProgressionKey {
+	return flowstore.EpicProgressionKey{RepoPath: repoPath, EpicID: epicID}
+}
+
+func progressionKeys(keys []flowstore.EpicProgressionKey) []string {
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, key.RepoPath+"|"+key.EpicID)
+	}
+	return out
+}
+
+func beadFlow(flowID, repoPath, beadID, epicID string) flowstore.FlowRecord {
+	return flowstore.FlowRecord{
+		FlowID:   flowID,
+		RepoPath: repoPath,
+		Bead:     flowstore.BeadLink{ID: beadID, EpicID: epicID},
+	}
+}
+
+func TestBuildSnapshotReadsNoEpicProgressionWithoutAnEpicLink(t *testing.T) {
+	progressions := &countingProgressions{}
+	snap := buildSnapshot(
+		staticRepos(),
+		staticFlows(
+			flowstore.FlowRecord{FlowID: "unlinked", RepoPath: "/repos/alpha"},
+			beadFlow("child-only", "/repos/alpha", "approach-y7g.7", ""),
+			beadFlow("blank-epic", "/repos/alpha", "approach-y7g.8", "   "),
+		),
+		progressions.source(),
+		nil,
+	)
+	if len(progressions.calls) != 0 {
+		t.Fatalf("progression reads = %v, want none", progressionKeys(progressions.calls))
+	}
+	for _, flow := range snap.Flows() {
+		if _, ok := snap.EpicProgression(flow); ok {
+			t.Errorf("flow %q resolved a progression with no epic link", flow.Record.FlowID)
+		}
+	}
+}
+
+func TestBuildSnapshotReadsOneEpicProgressionPerCanonicalKey(t *testing.T) {
+	found := flowstore.EpicProgression{RepoPath: "/repos/alpha", EpicID: "approach-y7g", Enabled: true}
+	progressions := &countingProgressions{rows: map[flowstore.EpicProgressionKey]flowstore.EpicProgression{
+		epicKey("/repos/alpha", "approach-y7g"): found,
+	}}
+	snap := buildSnapshot(
+		staticRepos(),
+		staticFlows(
+			// Equivalent raw repo paths and whitespace-variant epic ids collapse
+			// onto one canonical key, so these four cause one read of a found row.
+			beadFlow("a1", "/repos/alpha", "approach-y7g.1", "approach-y7g"),
+			beadFlow("a2", "/repos/alpha/", "approach-y7g.2", "  approach-y7g  "),
+			beadFlow("a3", "/repos/beta/../alpha", "approach-y7g.3", "approach-y7g"),
+			// A second distinct key whose row is absent, shared by two siblings:
+			// a missing row is read once and remembered as missing.
+			beadFlow("b1", "/repos/beta", "approach-zzz.1", "approach-zzz"),
+			beadFlow("b2", "/repos/beta", "approach-zzz.2", "approach-zzz"),
+			// Same epic id, different repo: genuinely distinct, so a third read.
+			beadFlow("c1", "/repos/gamma", "approach-y7g.4", "approach-y7g"),
+		),
+		progressions.source(),
+		nil,
+	)
+	want := []string{"/repos/alpha|approach-y7g", "/repos/beta|approach-zzz", "/repos/gamma|approach-y7g"}
+	if got := progressionKeys(progressions.calls); !equalStrings(got, want) {
+		t.Fatalf("progression reads = %v, want %v", got, want)
+	}
+
+	for _, flowID := range []string{"a1", "a2", "a3"} {
+		flow, ok := snap.Flow(flowID)
+		if !ok {
+			t.Fatalf("Flow(%q) not found", flowID)
+		}
+		record, ok := snap.EpicProgression(flow)
+		if !ok {
+			t.Fatalf("flow %q has no progression, want the shared row", flowID)
+		}
+		if record != found {
+			t.Errorf("flow %q progression = %+v, want %+v", flowID, record, found)
+		}
+	}
+	for _, flowID := range []string{"b1", "b2", "c1"} {
+		flow, ok := snap.Flow(flowID)
+		if !ok {
+			t.Fatalf("Flow(%q) not found", flowID)
+		}
+		if record, ok := snap.EpicProgression(flow); ok {
+			t.Errorf("flow %q progression = %+v, want none (no row exists)", flowID, record)
+		}
+	}
+}
+
+func TestBuildSnapshotEpicProgressionFailureIsSanitized(t *testing.T) {
+	var logged []string
+	progressions := &countingProgressions{err: errors.New("read epic progression: open /tmp/secret-root/flows.db: permission denied")}
+	snap := buildSnapshot(
+		staticRepos(),
+		staticFlows(beadFlow("a1", "/repos/alpha", "approach-y7g.1", "approach-y7g")),
+		progressions.source(),
+		func(format string, args ...any) {
+			logged = append(logged, fmt.Sprintf(format, args...))
+		},
+	)
+	if !errors.Is(snap.err, errStateUnavailable) {
+		t.Fatalf("snapshot err = %v, want errStateUnavailable", snap.err)
+	}
+	if strings.Contains(snap.err.Error(), "secret-root") || strings.Contains(snap.err.Error(), "permission denied") {
+		t.Fatalf("snapshot err leaked detail: %v", snap.err)
+	}
+	if len(logged) != 1 {
+		t.Fatalf("logged = %#v, want one epic-progression failure", logged)
+	}
+	for _, want := range []string{"/repos/alpha", "approach-y7g", "permission denied"} {
+		if !strings.Contains(logged[0], want) {
+			t.Errorf("log %q is missing %q; the unsanitized key and cause belong server-side", logged[0], want)
+		}
+	}
+}
+
 func repoPaths(repos []*Repo) []string {
 	out := make([]string, 0, len(repos))
 	for _, repo := range repos {
@@ -59,6 +201,7 @@ func TestBuildSnapshotKeepsStoreFlowOrder(t *testing.T) {
 			flowstore.FlowRecord{FlowID: "oldest", RepoPath: "/repos/alpha"},
 		),
 		nil,
+		nil,
 	)
 	if got, want := flowIDs(snap.Flows()), []string{"newest", "middle", "oldest"}; !equalStrings(got, want) {
 		t.Fatalf("Flows() = %v, want %v", got, want)
@@ -80,6 +223,7 @@ func TestBuildSnapshotGroupsFlowsByRepo(t *testing.T) {
 			flowstore.FlowRecord{FlowID: "a2", RepoPath: "/repos/alpha"},
 		),
 		nil,
+		nil,
 	)
 	if got, want := flowIDs(snap.FlowsForRepo("/repos/alpha")), []string{"a1", "a2"}; !equalStrings(got, want) {
 		t.Fatalf("FlowsForRepo(alpha) = %v, want %v", got, want)
@@ -96,6 +240,7 @@ func TestBuildSnapshotSynthesizesRepoOutsideScanRoot(t *testing.T) {
 	snap := buildSnapshot(
 		staticRepos(scanner.Repo{Path: "/repos/alpha", DisplayName: "alpha", IsBare: true}),
 		staticFlows(flowstore.FlowRecord{FlowID: "f1", RepoPath: "/elsewhere/outsider"}),
+		nil,
 		nil,
 	)
 	repo, ok := snap.Repo("/elsewhere/outsider")
@@ -129,6 +274,7 @@ func TestBuildSnapshotNormalizesFlowRepoPathOntoScannedRepo(t *testing.T) {
 			flowstore.FlowRecord{FlowID: "dotdot", RepoPath: "/repos/beta/../alpha"},
 		),
 		nil,
+		nil,
 	)
 	if got, want := len(snap.Repos()), 1; got != want {
 		t.Fatalf("len(Repos()) = %d (%v), want %d", got, repoPaths(snap.Repos()), want)
@@ -147,6 +293,7 @@ func TestSnapshotRepoResolvesUnnormalizedArgument(t *testing.T) {
 	snap := buildSnapshot(
 		staticRepos(scanner.Repo{Path: "/repos/alpha", DisplayName: "alpha"}),
 		staticFlows(),
+		nil,
 		nil,
 	)
 	for _, id := range []string{"/repos/alpha/", "/repos/alpha/.", "  /repos/alpha  ", "/repos/beta/../alpha"} {
@@ -168,6 +315,7 @@ func TestSnapshotRepoResolvesRelativeArgumentAgainstWorkingDirectory(t *testing.
 		staticRepos(scanner.Repo{Path: filepath.Join(wd, "here"), DisplayName: "here"}),
 		staticFlows(),
 		nil,
+		nil,
 	)
 	if _, ok := snap.Repo("here"); !ok {
 		t.Fatalf("Repo(%q) not found, want the scanned repo", "here")
@@ -181,6 +329,7 @@ func TestBuildSnapshotUnionOrderingIsDeterministic(t *testing.T) {
 			flowstore.FlowRecord{FlowID: "f2", RepoPath: "/other/zeta/child"},
 			flowstore.FlowRecord{FlowID: "f1", RepoPath: "/other/alpha/child"},
 		),
+		nil,
 		nil,
 	)
 	// "child" sorts before "parent/child"; the two synthesized "child"
@@ -200,6 +349,7 @@ func TestBuildSnapshotSortsCaseInsensitively(t *testing.T) {
 		),
 		staticFlows(),
 		nil,
+		nil,
 	)
 	want := []string{"/repos/alpha", "/repos/Bravo", "/repos/Zulu"}
 	if got := repoPaths(snap.Repos()); !equalStrings(got, want) {
@@ -218,6 +368,7 @@ func TestBuildSnapshotSkipsRecordWithEmptyRepoPath(t *testing.T) {
 			flowstore.FlowRecord{FlowID: "phantom", RepoPath: ""},
 			flowstore.FlowRecord{FlowID: "blank", RepoPath: "   "},
 		),
+		nil,
 		nil,
 	)
 	if got := len(snap.Repos()); got != 0 {
@@ -241,10 +392,11 @@ func TestBuildSnapshotDegradesOnScanError(t *testing.T) {
 			return nil, errors.New("open /nope/dev: no such file or directory")
 		},
 		staticFlows(flowstore.FlowRecord{FlowID: "f1", RepoPath: "/repos/alpha"}),
+		nil,
 		func(format string, args ...any) {
 			logged = append(logged, format)
-		},
-	)
+		})
+
 	if snap.err != nil {
 		t.Fatalf("snapshot err = %v, want nil (scan failures degrade)", snap.err)
 	}
@@ -269,10 +421,11 @@ func TestBuildSnapshotFlowErrorIsSanitized(t *testing.T) {
 		func() ([]flowstore.FlowRecord, error) {
 			return nil, errors.New("list flows: open /tmp/secret-root/flows: permission denied")
 		},
+		nil,
 		func(format string, args ...any) {
 			logged = append(logged, format)
-		},
-	)
+		})
+
 	if !errors.Is(snap.err, errStateUnavailable) {
 		t.Fatalf("snapshot err = %v, want errStateUnavailable", snap.err)
 	}
@@ -295,10 +448,11 @@ func TestBuildSnapshotIndexesHealthyFlowsFromTypedPartialResultAndLogsDiagnostic
 		func() ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{{FlowID: "healthy", RepoPath: "/repos/alpha"}}, partial
 		},
+		nil,
 		func(format string, args ...any) {
 			logged = append(logged, fmt.Sprintf(format, args...))
-		},
-	)
+		})
+
 	if snap.err != nil {
 		t.Fatalf("snapshot err = %v, want typed partial result accepted", snap.err)
 	}
@@ -316,7 +470,7 @@ func TestBuildSnapshotIndexesHealthyFlowsFromTypedPartialResultAndLogsDiagnostic
 }
 
 func TestBuildSnapshotEmptySources(t *testing.T) {
-	snap := buildSnapshot(staticRepos(), staticFlows(), nil)
+	snap := buildSnapshot(staticRepos(), staticFlows(), nil, nil)
 	if len(snap.Repos()) != 0 || len(snap.Flows()) != 0 {
 		t.Fatalf("empty sources produced repos=%v flows=%v", repoPaths(snap.Repos()), flowIDs(snap.Flows()))
 	}
@@ -327,7 +481,7 @@ func TestBuildSnapshotEmptySources(t *testing.T) {
 		t.Fatalf("Flow(nope) resolved against an empty snapshot")
 	}
 
-	nilSources := buildSnapshot(nil, nil, nil)
+	nilSources := buildSnapshot(nil, nil, nil, nil)
 	if len(nilSources.Repos()) != 0 || len(nilSources.Flows()) != 0 || nilSources.err != nil {
 		t.Fatalf("nil sources produced repos=%v flows=%v err=%v",
 			repoPaths(nilSources.Repos()), flowIDs(nilSources.Flows()), nilSources.err)
@@ -341,6 +495,7 @@ func TestBuildSnapshotDeduplicatesScannedPaths(t *testing.T) {
 			scanner.Repo{Path: "/repos/alpha/", DisplayName: "alpha-dup"},
 		),
 		staticFlows(),
+		nil,
 		nil,
 	)
 	if got, want := len(snap.Repos()), 1; got != want {
@@ -360,6 +515,7 @@ func TestBuildSnapshotFlowLookupPrefersFirstRecordForDuplicateID(t *testing.T) {
 			flowstore.FlowRecord{FlowID: "dupe", RepoPath: "/repos/beta", UpdatedAt: now.Add(-time.Hour)},
 		),
 		nil,
+		nil,
 	)
 	flow, ok := snap.Flow("dupe")
 	if !ok {
@@ -373,15 +529,27 @@ func TestBuildSnapshotFlowLookupPrefersFirstRecordForDuplicateID(t *testing.T) {
 // fullyPopulatedSources fills every optional field on every type, so the
 // drift guard sees a width for each one and byte-budget tests have realistic
 // free text to measure.
-func fullyPopulatedSources() (RepoSource, FlowSource, func(string, ...any)) {
+func fullyPopulatedSources() (RepoSource, FlowSource, EpicProgressionSource, func(string, ...any)) {
 	created := fixtureTime(0)
 	merged := fixtureTime(time.Hour)
+	// Halted, so the halt tuple's widths are measured too. A row that is merely
+	// enabled would leave three scalar fields unobserved, which is exactly the
+	// drift the bounds guard exists to catch.
+	halted := flowstore.EpicProgression{
+		SchemaVersion: 1, RepoPath: "/repos/alpha", EpicID: "approach-y7g",
+		Halt: &flowstore.EpicProgressionHalt{
+			ChildBeadID: "approach-y7g.9", Status: flowstore.StatusBlocked,
+			Message: "the child Flow is blocked on review",
+		},
+		CreatedAt: created, UpdatedAt: created,
+	}
 	return staticRepos(scanner.Repo{Path: "/repos/alpha", DisplayName: "alpha", IsBare: true}),
 		staticFlows(flowstore.FlowRecord{
 			FlowID: "flow-alpha-1", Title: "Alpha one", Instructions: "do the thing",
 			Status: flowstore.StatusInProgress, RepoPath: "/repos/alpha",
 			WorktreePath: "/repos/alpha-worktrees/one", Branch: "flow/one", BaseRef: "main",
 			Commit: "abc123", PresetName: "default", PlanID: "plan-1", AutoMode: true,
+			Bead:  flowstore.BeadLink{ID: "approach-y7g.9", EpicID: "approach-y7g"},
 			Issue: flowstore.Issue{Provider: "github", Number: 7, URL: "https://example.test/i/7"},
 			PR: flowstore.PullRequest{
 				Provider: "github", Number: 9, URL: "https://example.test/p/9",
@@ -402,6 +570,9 @@ func fullyPopulatedSources() (RepoSource, FlowSource, func(string, ...any)) {
 			},
 			CreatedAt: created, UpdatedAt: created,
 		}),
+		(&countingProgressions{rows: map[flowstore.EpicProgressionKey]flowstore.EpicProgression{
+			epicKey("/repos/alpha", "approach-y7g"): halted,
+		}}).source(),
 		nil
 }
 
@@ -425,7 +596,7 @@ func TestSnapshotBounds(t *testing.T) {
 		{FlowID: "a3", Title: "a3", RepoPath: "/repos/alpha", CreatedAt: created, UpdatedAt: created},
 		{FlowID: "b1", Title: "b1", RepoPath: "/repos/beta", CreatedAt: created, UpdatedAt: created},
 	}
-	bounds := buildSnapshot(repos, staticFlows(records...), nil).bounds()
+	bounds := buildSnapshot(repos, staticFlows(records...), nil, nil).bounds()
 
 	for name, got := range map[string][2]int{
 		"repos":             {bounds.repos, 2},
@@ -524,7 +695,7 @@ func TestSnapshotBoundsCountPhasesAsResolved(t *testing.T) {
 	bounds := buildSnapshot(nil, staticFlows(flowstore.FlowRecord{
 		FlowID: "f1", Title: "f1", RepoPath: "/repos/alpha", Phases: phases,
 		CreatedAt: created, UpdatedAt: created,
-	}), nil).bounds()
+	}), nil, nil).bounds()
 	if bounds.phasesPerFlow < resolved {
 		t.Fatalf("bounds.phasesPerFlow = %d, want >= %d (the number Flow.phases actually resolves)",
 			bounds.phasesPerFlow, resolved)

--- a/web/src/app/flows/[id]/page.tsx
+++ b/web/src/app/flows/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
 import { EmptyPanel, ErrorPanel } from '@/components/error-panel'
+import { FlowTracking } from '@/components/flow-tracking'
 import { Badge, OutcomeBadge, StatusBadge } from '@/components/status-badge'
 import { getFlow, type FlowDetail, type Phase } from '@/lib/approach-api'
 import { formatCommit, formatTimestamp } from '@/lib/format'
@@ -47,7 +48,7 @@ export default async function FlowPage({ params }: { params: Promise<{ id: strin
       </div>
 
       <FlowFacts flow={detail} />
-      <FlowLinks flow={detail} />
+      <FlowTracking flow={detail} />
 
       <h2 className="section-heading">Phases ({detail.phases.length})</h2>
       {detail.phases.length === 0 ? (
@@ -99,87 +100,6 @@ function FlowFacts({ flow }: { flow: FlowDetail }) {
       <dt>Updated</dt>
       <dd>{formatTimestamp(flow.updatedAt)}</dd>
     </dl>
-  )
-}
-
-function FlowLinks({ flow }: { flow: FlowDetail }) {
-  const { issue, pullRequest, merge } = flow
-  if (!issue && !pullRequest && !merge) {
-    return null
-  }
-
-  return (
-    <>
-      <h2 className="section-heading">Tracking</h2>
-      <dl className="facts">
-        {issue ? (
-          <>
-            <dt>Issue</dt>
-            <dd>
-              <Ref
-                provider={issue.provider}
-                number={issue.number}
-                url={issue.url}
-                fallback="issue"
-              />
-            </dd>
-          </>
-        ) : null}
-
-        {pullRequest ? (
-          <>
-            <dt>Pull request</dt>
-            <dd>
-              <Ref
-                provider={pullRequest.provider}
-                number={pullRequest.number}
-                url={pullRequest.url}
-                fallback="pull request"
-              />
-              {pullRequest.headBranch || pullRequest.baseBranch ? (
-                <span> · {pullRequest.headBranch ?? '?'} → {pullRequest.baseBranch ?? '?'}</span>
-              ) : null}
-              {pullRequest.status ? (
-                <span> · <StatusBadge status={pullRequest.status} /></span>
-              ) : null}
-            </dd>
-          </>
-        ) : null}
-
-        {merge ? (
-          <>
-            <dt>Merge</dt>
-            <dd>
-              <StatusBadge status={merge.status ?? 'pending'} />
-              {merge.commit ? <span> · {formatCommit(merge.commit)}</span> : null}
-              {merge.mergedAt ? <span> · {formatTimestamp(merge.mergedAt)}</span> : null}
-            </dd>
-          </>
-        ) : null}
-      </dl>
-    </>
-  )
-}
-
-function Ref({
-  provider,
-  number,
-  url,
-  fallback,
-}: {
-  provider: string | null
-  number: number | null
-  url: string | null
-  fallback: string
-}) {
-  const label = number !== null ? `${provider ?? fallback} #${number}` : (provider ?? fallback)
-  if (!url) {
-    return <>{label}</>
-  }
-  return (
-    <a href={url} rel="noreferrer noopener" target="_blank">
-      {label}
-    </a>
   )
 }
 

--- a/web/src/components/flow-tracking.test.tsx
+++ b/web/src/components/flow-tracking.test.tsx
@@ -7,7 +7,7 @@ import { FlowTracking } from './flow-tracking'
 
 /**
  * These assert rendered markup rather than element props: the point of the
- * section is what a reader can see, and the four progression states are only
+ * section is what a reader can see, and the progression states are only
  * distinguishable in the output.
  */
 function render(flow: Partial<FlowDetail>): string {
@@ -50,15 +50,28 @@ describe('FlowTracking', () => {
     expect(render({})).toBe('')
   })
 
-  it('renders for a child-only Bead link, with no epic and no progression claim', () => {
+  it('renders for a child-only Bead link, with no epic and no progression row at all', () => {
     const markup = render({ bead: { id: 'approach-y7g.7', epicId: null } })
 
     expect(markup).toContain('Tracking')
     expect(markup).toContain('approach-y7g.7')
     expect(markup).not.toContain('epic')
-    // No epic means nothing is known about progression — not "disabled".
+    // No epic means there is nothing to report, so the row is omitted rather
+    // than filled in — and certainly not reported as "disabled".
+    expect(markup).not.toContain('Progression')
     expect(markup).not.toContain('not configured')
     expect(markup).not.toContain('disabled')
+  })
+
+  // The API trims before looking a row up, so it would never find one for this
+  // link. Rendering an empty epic and a progression verdict would claim more
+  // than the server was ever asked.
+  it('treats a whitespace-only epic id as no epic, the way the API does', () => {
+    const markup = render({ bead: { id: 'approach-y7g.7', epicId: '   ' } })
+
+    expect(markup).toContain('approach-y7g.7')
+    expect(markup).not.toContain('epic')
+    expect(markup).not.toContain('Progression')
   })
 
   it('keeps the child and epic ids when the epic has no progression row', () => {
@@ -67,8 +80,8 @@ describe('FlowTracking', () => {
       epicProgression: null,
     })
 
-    expect(markup).toContain('approach-y7g.7')
-    expect(markup).toContain('approach-y7g<')
+    expect(markup).toContain('<code>approach-y7g.7</code>')
+    expect(markup).toContain('<code>approach-y7g</code>')
     // A missing row is "nobody turned this on", which is not the same as off.
     expect(markup).toContain('not configured')
     expect(markup).not.toContain('disabled')
@@ -119,6 +132,24 @@ describe('FlowTracking', () => {
     expect(markup).toContain('approach-y7g.4')
     expect(markup).toContain('blocked')
     expect(markup).toContain('the child Flow is blocked on review')
+  })
+
+  it('renders the halt status as a badge, not as a raw underscored value', () => {
+    const markup = render({
+      bead: { id: 'approach-y7g.7', epicId: 'approach-y7g' },
+      epicProgression: progression({
+        halt: {
+          childBeadId: 'approach-y7g.4',
+          status: 'needs_attention',
+          message: 'child Flow needs attention',
+        },
+      }),
+    })
+
+    // The same treatment every other status on the page gets: a toned badge
+    // with the underscore spelled out.
+    expect(markup).toContain('<span class="badge badge--warn">needs attention</span>')
+    expect(markup).not.toContain('>needs_attention<')
   })
 
   it('reports only the explicit done flag, never an inference from enabled', () => {

--- a/web/src/components/flow-tracking.test.tsx
+++ b/web/src/components/flow-tracking.test.tsx
@@ -1,0 +1,165 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import type { EpicProgression, FlowDetail } from '@/lib/approach-api'
+
+import { FlowTracking } from './flow-tracking'
+
+/**
+ * These assert rendered markup rather than element props: the point of the
+ * section is what a reader can see, and the four progression states are only
+ * distinguishable in the output.
+ */
+function render(flow: Partial<FlowDetail>): string {
+  return renderToStaticMarkup(<FlowTracking flow={flowDetail(flow)} />)
+}
+
+function flowDetail(overrides: Partial<FlowDetail>): FlowDetail {
+  return {
+    id: 'flow-1',
+    title: 'A Flow',
+    status: 'in_progress',
+    repoPath: '/repos/alpha',
+    repo: { id: '/repos/alpha', displayName: 'alpha' },
+    worktreePath: null,
+    branch: null,
+    baseRef: null,
+    commit: null,
+    presetName: null,
+    planId: null,
+    autoMode: false,
+    bead: null,
+    epicProgression: null,
+    issue: null,
+    pullRequest: null,
+    merge: null,
+    phases: [],
+    currentPhase: null,
+    createdAt: '2026-08-11T12:00:00Z',
+    updatedAt: '2026-08-11T12:00:00Z',
+    ...overrides,
+  }
+}
+
+function progression(overrides: Partial<EpicProgression>): EpicProgression {
+  return { enabled: false, done: false, halt: null, ...overrides }
+}
+
+describe('FlowTracking', () => {
+  it('renders nothing for a Flow with no linkage at all', () => {
+    expect(render({})).toBe('')
+  })
+
+  it('renders for a child-only Bead link, with no epic and no progression claim', () => {
+    const markup = render({ bead: { id: 'approach-y7g.7', epicId: null } })
+
+    expect(markup).toContain('Tracking')
+    expect(markup).toContain('approach-y7g.7')
+    expect(markup).not.toContain('epic')
+    // No epic means nothing is known about progression — not "disabled".
+    expect(markup).not.toContain('not configured')
+    expect(markup).not.toContain('disabled')
+  })
+
+  it('keeps the child and epic ids when the epic has no progression row', () => {
+    const markup = render({
+      bead: { id: 'approach-y7g.7', epicId: 'approach-y7g' },
+      epicProgression: null,
+    })
+
+    expect(markup).toContain('approach-y7g.7')
+    expect(markup).toContain('approach-y7g<')
+    // A missing row is "nobody turned this on", which is not the same as off.
+    expect(markup).toContain('not configured')
+    expect(markup).not.toContain('disabled')
+  })
+
+  it('distinguishes enabled, disabled, done, and halted', () => {
+    const bead = { id: 'approach-y7g.7', epicId: 'approach-y7g' }
+    const labels = {
+      enabled: render({ bead, epicProgression: progression({ enabled: true }) }),
+      disabled: render({ bead, epicProgression: progression({}) }),
+      done: render({ bead, epicProgression: progression({ done: true }) }),
+      halted: render({
+        bead,
+        epicProgression: progression({
+          halt: {
+            childBeadId: 'approach-y7g.4',
+            status: 'needs_attention',
+            message: 'child Flow needs attention',
+          },
+        }),
+      }),
+    }
+
+    expect(labels.enabled).toContain('enabled')
+    expect(labels.disabled).toContain('disabled')
+    expect(labels.done).toContain('done')
+    expect(labels.halted).toContain('halted')
+    // Distinct, not merely present: "done" must not read as "enabled", and a
+    // halted epic must not be reported as simply disabled.
+    expect(labels.done).not.toContain('enabled')
+    expect(labels.halted).not.toContain('>disabled<')
+    expect(labels.disabled).not.toContain('>done<')
+    expect(new Set(Object.values(labels)).size).toBe(4)
+  })
+
+  it('names the child, status, and message that halted progression', () => {
+    const markup = render({
+      bead: { id: 'approach-y7g.7', epicId: 'approach-y7g' },
+      epicProgression: progression({
+        halt: {
+          childBeadId: 'approach-y7g.4',
+          status: 'blocked',
+          message: 'the child Flow is blocked on review',
+        },
+      }),
+    })
+
+    expect(markup).toContain('approach-y7g.4')
+    expect(markup).toContain('blocked')
+    expect(markup).toContain('the child Flow is blocked on review')
+  })
+
+  it('reports only the explicit done flag, never an inference from enabled', () => {
+    // Disabled with no halt is an epic somebody turned off; calling it done
+    // would claim the epic's children all finished.
+    expect(render({
+      bead: { id: 'approach-y7g.7', epicId: 'approach-y7g' },
+      epicProgression: progression({}),
+    })).not.toContain('done')
+  })
+
+  it('keeps issue, pull request, and merge rows alongside Bead data', () => {
+    const markup = render({
+      bead: { id: 'approach-y7g.7', epicId: 'approach-y7g' },
+      epicProgression: progression({ enabled: true }),
+      issue: { provider: 'github', number: 12, url: 'https://example.test/issues/12' },
+      pullRequest: {
+        provider: 'github',
+        number: 34,
+        url: 'https://example.test/pull/34',
+        headBranch: 'flow/api',
+        baseBranch: 'main',
+        status: 'open',
+      },
+      merge: { status: 'merged', commit: 'deadbeefcafe', mergedAt: '2026-08-11T14:00:00Z' },
+    })
+
+    expect(markup).toContain('github #12')
+    expect(markup).toContain('github #34')
+    expect(markup).toContain('flow/api')
+    expect(markup).toContain('merged')
+    expect(markup).toContain('approach-y7g.7')
+    expect(markup).toContain('enabled')
+  })
+
+  it('still renders for issue, pull request, or merge data with no Bead link', () => {
+    const markup = render({
+      issue: { provider: 'github', number: 12, url: null },
+    })
+
+    expect(markup).toContain('github #12')
+    expect(markup).not.toContain('Bead')
+  })
+})

--- a/web/src/components/flow-tracking.test.tsx
+++ b/web/src/components/flow-tracking.test.tsx
@@ -30,6 +30,7 @@ function flowDetail(overrides: Partial<FlowDetail>): FlowDetail {
     autoMode: false,
     bead: null,
     epicProgression: null,
+    epicProgressionUnavailable: false,
     issue: null,
     pullRequest: null,
     merge: null,
@@ -85,6 +86,21 @@ describe('FlowTracking', () => {
     // A missing row is "nobody turned this on", which is not the same as off.
     expect(markup).toContain('not configured')
     expect(markup).not.toContain('disabled')
+  })
+
+  // The API nulls epicProgression for an unreadable row and reports the failure
+  // out of band, so this state arrives as the same null a missing row does.
+  // Rendering it as "not configured" would claim nobody enabled progression for
+  // an epic nothing managed to look at.
+  it('separates a row that could not be read from an epic with no row', () => {
+    const bead = { id: 'approach-y7g.7', epicId: 'approach-y7g' }
+    const markup = render({ bead, epicProgression: null, epicProgressionUnavailable: true })
+
+    expect(markup).toContain('<code>approach-y7g</code>')
+    expect(markup).toContain('unavailable')
+    expect(markup).not.toContain('not configured')
+    expect(markup).not.toContain('disabled')
+    expect(markup).not.toContain('enabled')
   })
 
   it('distinguishes enabled, disabled, done, and halted', () => {

--- a/web/src/components/flow-tracking.tsx
+++ b/web/src/components/flow-tracking.tsx
@@ -43,7 +43,10 @@ export function FlowTracking({ flow }: { flow: FlowDetail }) {
               <>
                 <dt>Progression</dt>
                 <dd>
-                  <Progression progression={flow.epicProgression} />
+                  <Progression
+                    progression={flow.epicProgression}
+                    unavailable={flow.epicProgressionUnavailable}
+                  />
                 </dd>
               </>
             ) : null}
@@ -107,8 +110,21 @@ export function FlowTracking({ flow }: { flow: FlowDetail }) {
  * - `not configured` when the epic has no row at all. That is not `disabled`:
  *   nobody has turned progression on for that epic, which is a different claim
  *   from having turned it off.
+ * - `unavailable` when the API could not read the row. It nulls the field in
+ *   that case, so this is the one state that cannot be read off `progression`
+ *   at all — and reporting it as `not configured` would be the one invented
+ *   answer in a projection built to avoid inventing any.
  */
-function Progression({ progression }: { progression: EpicProgression | null }) {
+function Progression({
+  progression,
+  unavailable,
+}: {
+  progression: EpicProgression | null
+  unavailable: boolean
+}) {
+  if (unavailable) {
+    return <Badge tone="warn">unavailable</Badge>
+  }
   if (!progression) {
     return <Badge>not configured</Badge>
   }

--- a/web/src/components/flow-tracking.tsx
+++ b/web/src/components/flow-tracking.tsx
@@ -1,0 +1,142 @@
+import type { FlowDetail } from '@/lib/approach-api'
+import { formatCommit, formatTimestamp } from '@/lib/format'
+
+import { Badge, StatusBadge } from './status-badge'
+
+/**
+ * The Tracking section of the Flow detail page: the issue, pull request, and
+ * merge an agent reported, plus the Bead the Flow is linked to and the durable
+ * auto-progression state of that Bead's epic.
+ *
+ * It is a pure function of one `FlowDetail`, so every state below is assertable
+ * from rendered output rather than from a running page.
+ */
+export function FlowTracking({ flow }: { flow: FlowDetail }) {
+  const { issue, pullRequest, merge, bead } = flow
+  // A Bead link is enough on its own: a Flow created from an epic child usually
+  // has no issue, PR, or merge yet, and hiding the section would hide the only
+  // linkage it has.
+  if (!issue && !pullRequest && !merge && !bead) {
+    return null
+  }
+
+  return (
+    <>
+      <h2 className="section-heading">Tracking</h2>
+      <dl className="facts">
+        {bead ? (
+          <>
+            <dt>Bead</dt>
+            <dd>
+              <code>{bead.id}</code>
+              {bead.epicId ? <span> · epic <code>{bead.epicId}</code></span> : null}
+            </dd>
+
+            <dt>Progression</dt>
+            <dd>
+              <Progression flow={flow} />
+            </dd>
+          </>
+        ) : null}
+
+        {issue ? (
+          <>
+            <dt>Issue</dt>
+            <dd>
+              <Ref provider={issue.provider} number={issue.number} url={issue.url} fallback="issue" />
+            </dd>
+          </>
+        ) : null}
+
+        {pullRequest ? (
+          <>
+            <dt>Pull request</dt>
+            <dd>
+              <Ref
+                provider={pullRequest.provider}
+                number={pullRequest.number}
+                url={pullRequest.url}
+                fallback="pull request"
+              />
+              {pullRequest.headBranch || pullRequest.baseBranch ? (
+                <span> · {pullRequest.headBranch ?? '?'} → {pullRequest.baseBranch ?? '?'}</span>
+              ) : null}
+              {pullRequest.status ? (
+                <span> · <StatusBadge status={pullRequest.status} /></span>
+              ) : null}
+            </dd>
+          </>
+        ) : null}
+
+        {merge ? (
+          <>
+            <dt>Merge</dt>
+            <dd>
+              <StatusBadge status={merge.status ?? 'pending'} />
+              {merge.commit ? <span> · {formatCommit(merge.commit)}</span> : null}
+              {merge.mergedAt ? <span> · {formatTimestamp(merge.mergedAt)}</span> : null}
+            </dd>
+          </>
+        ) : null}
+      </dl>
+    </>
+  )
+}
+
+/**
+ * Four distinct states, read from the API rather than inferred:
+ *
+ * - `halted` whenever a halt reason is present, with the child, status, and
+ *   message that stopped it;
+ * - `done` only when the API says so — a manually disabled epic is not done,
+ *   and deriving one from the other would report finished work that never ran;
+ * - `enabled` / `disabled` otherwise.
+ *
+ * An epic link with no progression row is `not configured`, not `disabled`:
+ * nobody has turned progression on for that epic, which is a different claim
+ * from having turned it off.
+ */
+function Progression({ flow }: { flow: FlowDetail }) {
+  const progression = flow.epicProgression
+  if (!flow.bead?.epicId) {
+    return <>—</>
+  }
+  if (!progression) {
+    return <Badge>not configured</Badge>
+  }
+  if (progression.halt) {
+    const { childBeadId, status, message } = progression.halt
+    return (
+      <>
+        <Badge tone="danger">halted</Badge>
+        <span> · <code>{childBeadId}</code> {status} · {message}</span>
+      </>
+    )
+  }
+  if (progression.done) {
+    return <Badge tone="good">done</Badge>
+  }
+  return progression.enabled ? <Badge tone="active">enabled</Badge> : <Badge>disabled</Badge>
+}
+
+function Ref({
+  provider,
+  number,
+  url,
+  fallback,
+}: {
+  provider: string | null
+  number: number | null
+  url: string | null
+  fallback: string
+}) {
+  const label = number !== null ? `${provider ?? fallback} #${number}` : (provider ?? fallback)
+  if (!url) {
+    return <>{label}</>
+  }
+  return (
+    <a href={url} rel="noreferrer noopener" target="_blank">
+      {label}
+    </a>
+  )
+}

--- a/web/src/components/flow-tracking.tsx
+++ b/web/src/components/flow-tracking.tsx
@@ -1,4 +1,4 @@
-import type { FlowDetail } from '@/lib/approach-api'
+import type { EpicProgression, FlowDetail } from '@/lib/approach-api'
 import { formatCommit, formatTimestamp } from '@/lib/format'
 
 import { Badge, StatusBadge } from './status-badge'
@@ -13,6 +13,11 @@ import { Badge, StatusBadge } from './status-badge'
  */
 export function FlowTracking({ flow }: { flow: FlowDetail }) {
   const { issue, pullRequest, merge, bead } = flow
+  // Trimmed the way the API trims before looking a progression row up, so a
+  // whitespace-only epic id — reachable only through an externally written
+  // record — reads as the no-epic link it resolves as, rather than rendering an
+  // empty `epic` and asking for progression the server never looked for.
+  const epicId = bead?.epicId?.trim()
   // A Bead link is enough on its own: a Flow created from an epic child usually
   // has no issue, PR, or merge yet, and hiding the section would hide the only
   // linkage it has.
@@ -29,13 +34,19 @@ export function FlowTracking({ flow }: { flow: FlowDetail }) {
             <dt>Bead</dt>
             <dd>
               <code>{bead.id}</code>
-              {bead.epicId ? <span> · epic <code>{bead.epicId}</code></span> : null}
+              {epicId ? <span> · epic <code>{epicId}</code></span> : null}
             </dd>
 
-            <dt>Progression</dt>
-            <dd>
-              <Progression flow={flow} />
-            </dd>
+            {/* Omitted entirely for a child-only link: there is no epic, so
+                there is no progression to report either way. */}
+            {epicId ? (
+              <>
+                <dt>Progression</dt>
+                <dd>
+                  <Progression progression={flow.epicProgression} />
+                </dd>
+              </>
+            ) : null}
           </>
         ) : null}
 
@@ -84,23 +95,20 @@ export function FlowTracking({ flow }: { flow: FlowDetail }) {
 }
 
 /**
- * Four distinct states, read from the API rather than inferred:
+ * The caller has already established that the Flow links an epic, so this
+ * renders one of four row states plus the no-row case, each read from the API
+ * rather than inferred:
  *
  * - `halted` whenever a halt reason is present, with the child, status, and
  *   message that stopped it;
  * - `done` only when the API says so — a manually disabled epic is not done,
  *   and deriving one from the other would report finished work that never ran;
- * - `enabled` / `disabled` otherwise.
- *
- * An epic link with no progression row is `not configured`, not `disabled`:
- * nobody has turned progression on for that epic, which is a different claim
- * from having turned it off.
+ * - `enabled` / `disabled` otherwise;
+ * - `not configured` when the epic has no row at all. That is not `disabled`:
+ *   nobody has turned progression on for that epic, which is a different claim
+ *   from having turned it off.
  */
-function Progression({ flow }: { flow: FlowDetail }) {
-  const progression = flow.epicProgression
-  if (!flow.bead?.epicId) {
-    return <>—</>
-  }
+function Progression({ progression }: { progression: EpicProgression | null }) {
   if (!progression) {
     return <Badge>not configured</Badge>
   }
@@ -109,7 +117,9 @@ function Progression({ flow }: { flow: FlowDetail }) {
     return (
       <>
         <Badge tone="danger">halted</Badge>
-        <span> · <code>{childBeadId}</code> {status} · {message}</span>
+        {/* The halt status is a Flow status like any other on this page, so it
+            reads through StatusBadge rather than as raw `needs_attention`. */}
+        <span> · <code>{childBeadId}</code> <StatusBadge status={status} /> · {message}</span>
       </>
     )
   }

--- a/web/src/lib/approach-api.test.ts
+++ b/web/src/lib/approach-api.test.ts
@@ -163,6 +163,29 @@ describe('approach api client', () => {
       await expect(getRepos()).rejects.toMatchObject({ kind: 'graphql' })
     })
 
+    // The API scopes some failures to one field: an unreadable epic progression
+    // row nulls `Flow.epicProgression` for the Flows naming that epic and leaves
+    // the rest of the response intact. Discarding the data would turn a missing
+    // optional field into a blank error page for the whole Flow.
+    it('keeps a partial response that carries data alongside errors', async () => {
+      const errors = [{ message: 'internal error reading application state' }]
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          data: { flow: { id: 'f1', bead: { id: 'approach-y7g.7', epicId: 'approach-y7g' }, epicProgression: null } },
+          errors,
+        }),
+      )
+      const logged = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const flow = await getFlow('f1')
+
+      expect(flow?.id).toBe('f1')
+      expect(flow?.epicProgression).toBeNull()
+      // Not silent: the reader sees the Flow, the operator sees the cause.
+      expect(logged).toHaveBeenCalledWith('approach-api partial response:', JSON.stringify(errors))
+      logged.mockRestore()
+    })
+
     it('maps a network failure to an unreachable error', async () => {
       fetchMock.mockRejectedValue(new TypeError('fetch failed'))
 

--- a/web/src/lib/approach-api.test.ts
+++ b/web/src/lib/approach-api.test.ts
@@ -167,8 +167,13 @@ describe('approach api client', () => {
     // row nulls `Flow.epicProgression` for the Flows naming that epic and leaves
     // the rest of the response intact. Discarding the data would turn a missing
     // optional field into a blank error page for the whole Flow.
-    it('keeps a partial response that carries data alongside errors', async () => {
-      const errors = [{ message: 'internal error reading application state' }]
+    it('keeps a partial response whose errors all name a tolerated field', async () => {
+      const errors = [
+        {
+          message: 'internal error reading application state',
+          path: ['flow', 'epicProgression'],
+        },
+      ]
       fetchMock.mockResolvedValue(
         jsonResponse({
           data: { flow: { id: 'f1', bead: { id: 'approach-y7g.7', epicId: 'approach-y7g' }, epicProgression: null } },
@@ -184,6 +189,47 @@ describe('approach api client', () => {
       // Not silent: the reader sees the Flow, the operator sees the cause.
       expect(logged).toHaveBeenCalledWith('approach-api partial response:', JSON.stringify(errors))
       logged.mockRestore()
+    })
+
+    // The regression the whitelist exists for. A failed snapshot errors the
+    // `flow` root, and GraphQL nulls a failed field up to its nearest nullable
+    // parent — so the body is byte-identical to an unknown id apart from the
+    // errors array. Tolerating any response that carries `data` rendered "flow
+    // not found" for a store the server could not read at all.
+    it('rejects an errored null root rather than reporting it as a missing flow', async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          data: { flow: null },
+          errors: [{ message: 'internal error reading application state', path: ['flow'] }],
+        }),
+      )
+
+      await expect(getFlow('f1')).rejects.toMatchObject({ kind: 'graphql' })
+    })
+
+    it('rejects an error with no path, which is a request-level failure', async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          data: { repos: [] },
+          errors: [{ message: 'internal error reading application state' }],
+        }),
+      )
+
+      await expect(getRepos()).rejects.toMatchObject({ kind: 'graphql' })
+    })
+
+    it('rejects a response whose errors are only partly tolerated', async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({
+          data: { flow: { id: 'f1', epicProgression: null } },
+          errors: [
+            { message: 'internal error reading application state', path: ['flow', 'epicProgression'] },
+            { message: 'internal error reading application state', path: ['flow', 'phases'] },
+          ],
+        }),
+      )
+
+      await expect(getFlow('f1')).rejects.toMatchObject({ kind: 'graphql' })
     })
 
     it('maps a network failure to an unreachable error', async () => {

--- a/web/src/lib/approach-api.test.ts
+++ b/web/src/lib/approach-api.test.ts
@@ -186,9 +186,20 @@ describe('approach api client', () => {
 
       expect(flow?.id).toBe('f1')
       expect(flow?.epicProgression).toBeNull()
+      // The null is the same one a missing row produces, so the failure has to
+      // survive as its own flag or the viewer reports "not configured".
+      expect(flow?.epicProgressionUnavailable).toBe(true)
       // Not silent: the reader sees the Flow, the operator sees the cause.
       expect(logged).toHaveBeenCalledWith('approach-api partial response:', JSON.stringify(errors))
       logged.mockRestore()
+    })
+
+    it('leaves the progression flag clear when nothing failed', async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse({ data: { flow: { id: 'f1', bead: null, epicProgression: null } } }),
+      )
+
+      expect((await getFlow('f1'))?.epicProgressionUnavailable).toBe(false)
     })
 
     // The regression the whitelist exists for. A failed snapshot errors the

--- a/web/src/lib/approach-api.test.ts
+++ b/web/src/lib/approach-api.test.ts
@@ -218,6 +218,19 @@ describe('approach api client', () => {
       await expect(getFlow('f1')).rejects.toMatchObject({ kind: 'graphql' })
     })
 
+    // The response body is a cast, not a parsed shape. A TypeError raised while
+    // reading it would escape the ApproachApiError path into the generic error
+    // boundary — the outcome the non-object-body check exists to prevent.
+    it.each([
+      ['a non-list errors field', { data: { flow: null }, errors: {} }],
+      ['a null entry in the errors list', { data: { flow: null }, errors: [null] }],
+      ['a scalar entry in the errors list', { data: { flow: null }, errors: ['boom'] }],
+    ])('rejects %s without throwing past fail()', async (_name, body) => {
+      fetchMock.mockResolvedValue(jsonResponse(body))
+
+      await expect(getFlow('f1')).rejects.toBeInstanceOf(ApproachApiError)
+    })
+
     it('rejects an error with no path, which is a request-level failure', async () => {
       fetchMock.mockResolvedValue(
         jsonResponse({

--- a/web/src/lib/approach-api.ts
+++ b/web/src/lib/approach-api.ts
@@ -124,9 +124,44 @@ function authHeaders(): Record<string, string> {
   return token ? { authorization: `Bearer ${token}` } : {}
 }
 
+interface GraphQLError {
+  message?: string
+  path?: (string | number)[]
+}
+
 interface GraphQLResponse<T> {
   data?: T | null
-  errors?: { message?: string }[]
+  errors?: GraphQLError[]
+}
+
+/**
+ * The only fields whose failure this client serves around. The API resolves
+ * each of them from its own source — `Flow.epicProgression` reads one
+ * progression row per epic — and scopes a failed read to that field, so the
+ * rest of the response is still the answer the reader asked for.
+ *
+ * Everything else stays fatal. This is a whitelist rather than "any response
+ * carrying data" because GraphQL nulls a failed field up to its nearest
+ * nullable parent: a failed snapshot nulls the whole `flow` root and still
+ * sends `{"data":{"flow":null}}`, which is byte-identical to an unknown id.
+ * Accepting that would render "flow not found" for an unreachable store.
+ */
+const PARTIAL_FIELDS = new Set(['epicProgression'])
+
+/**
+ * Reports whether one error entry names a field this client can serve without.
+ * Matched on the path's last element — the response key of the field that
+ * actually failed — so an error that propagated up to a parent, and therefore
+ * nulled more than the field itself, is not matched and stays fatal. An entry
+ * with no path (a request-level failure) is never partial.
+ */
+function isPartialFieldError(error: GraphQLError): boolean {
+  const path = error.path
+  if (!Array.isArray(path) || path.length === 0) {
+    return false
+  }
+  const failed = path[path.length - 1]
+  return typeof failed === 'string' && PARTIAL_FIELDS.has(failed)
 }
 
 async function query<T>(document: string, variables?: Record<string, unknown>): Promise<T> {
@@ -188,25 +223,30 @@ async function query<T>(document: string, variables?: Record<string, unknown>): 
       `status ${response.status}: ${JSON.stringify(body.errors ?? null)}`,
     )
   }
-  // A GraphQL response can carry both. The API resolves some optional fields
-  // from their own sources — `Flow.epicProgression` reads a progression row per
-  // epic — and one unreadable row nulls that field and adds an error entry while
-  // every other field, and every other Flow, resolves normally. Discarding a
-  // populated `data` here would turn that into a blank error page for the whole
-  // Flow, which is worse than the missing field it is reporting.
+  // A GraphQL response can carry both, and one field failing is not the same
+  // event as the query failing. `Flow.epicProgression` reads a progression row
+  // per epic, and one unreadable row nulls that field and adds an error entry
+  // while every other field, and every other Flow, resolves normally. Failing
+  // the whole load there would turn a missing Tracking row into a blank error
+  // page for the entire Flow.
   //
-  // Nothing is lost silently: the errors are logged server-side, and a field the
-  // schema declares non-null cannot survive as a hole — GraphQL propagates its
-  // error up until it reaches a nullable parent, so a broken required field
-  // still arrives here as a null `data` or a null entity the caller rejects.
+  // Only the fields named above buy that tolerance. Any other error is still
+  // fatal, whatever `data` holds, because a failed field nulls its way up to
+  // the nearest nullable parent — a failed snapshot arrives as
+  // `{"data":{"flow":null},"errors":[...]}`, which without this check reads as
+  // an unknown id and renders a 404 instead of the error panel.
+  const errors = body.errors ?? []
+  const fatal = errors.filter((error) => !isPartialFieldError(error))
+  if (fatal.length > 0) {
+    fail('graphql', JSON.stringify(fatal))
+  }
   if (body.data == null) {
-    if (body.errors?.length) {
-      fail('graphql', JSON.stringify(body.errors))
-    }
+    // Every error was partial, so the data envelope cannot be null: a nullable
+    // field's error stops at that field. Reaching here means a malformed body.
     fail('http', 'response carried neither data nor errors')
   }
-  if (body.errors?.length) {
-    console.error('approach-api partial response:', JSON.stringify(body.errors))
+  if (errors.length > 0) {
+    console.error('approach-api partial response:', JSON.stringify(errors))
   }
   return body.data
 }

--- a/web/src/lib/approach-api.ts
+++ b/web/src/lib/approach-api.ts
@@ -188,11 +188,25 @@ async function query<T>(document: string, variables?: Record<string, unknown>): 
       `status ${response.status}: ${JSON.stringify(body.errors ?? null)}`,
     )
   }
-  if (body.errors?.length) {
-    fail('graphql', JSON.stringify(body.errors))
-  }
+  // A GraphQL response can carry both. The API resolves some optional fields
+  // from their own sources — `Flow.epicProgression` reads a progression row per
+  // epic — and one unreadable row nulls that field and adds an error entry while
+  // every other field, and every other Flow, resolves normally. Discarding a
+  // populated `data` here would turn that into a blank error page for the whole
+  // Flow, which is worse than the missing field it is reporting.
+  //
+  // Nothing is lost silently: the errors are logged server-side, and a field the
+  // schema declares non-null cannot survive as a hole — GraphQL propagates its
+  // error up until it reaches a nullable parent, so a broken required field
+  // still arrives here as a null `data` or a null entity the caller rejects.
   if (body.data == null) {
+    if (body.errors?.length) {
+      fail('graphql', JSON.stringify(body.errors))
+    }
     fail('http', 'response carried neither data nor errors')
+  }
+  if (body.errors?.length) {
+    console.error('approach-api partial response:', JSON.stringify(body.errors))
   }
   return body.data
 }

--- a/web/src/lib/approach-api.ts
+++ b/web/src/lib/approach-api.ts
@@ -156,15 +156,29 @@ const PARTIAL_FIELDS = new Set(['epicProgression'])
  * with no path (a request-level failure) is never partial.
  */
 function isPartialFieldError(error: GraphQLError): boolean {
-  const path = error.path
-  if (!Array.isArray(path) || path.length === 0) {
-    return false
-  }
-  const failed = path[path.length - 1]
-  return typeof failed === 'string' && PARTIAL_FIELDS.has(failed)
+  return PARTIAL_FIELDS.has(failedField(error) ?? '')
 }
 
-async function query<T>(document: string, variables?: Record<string, unknown>): Promise<T> {
+/** The response key of the field an error entry names, if it names one. */
+function failedField(error: GraphQLError): string | undefined {
+  const path = error.path
+  if (!Array.isArray(path) || path.length === 0) {
+    return undefined
+  }
+  const failed = path[path.length - 1]
+  return typeof failed === 'string' ? failed : undefined
+}
+
+/** A successful read: the selected data, plus whichever fields failed anyway. */
+interface QueryResult<T> {
+  data: T
+  partial: GraphQLError[]
+}
+
+async function query<T>(
+  document: string,
+  variables?: Record<string, unknown>,
+): Promise<QueryResult<T>> {
   const url = endpoint()
 
   let response: Response
@@ -248,7 +262,10 @@ async function query<T>(document: string, variables?: Record<string, unknown>): 
   if (errors.length > 0) {
     console.error('approach-api partial response:', JSON.stringify(errors))
   }
-  return body.data
+  // The tolerated errors come back with the data: a field this client serves
+  // without still has to be *reported* as missing rather than rendered as an
+  // ordinary null, and only the response knows which fields those were.
+  return { data: body.data, partial: errors }
 }
 
 export interface FlowRef {
@@ -359,6 +376,17 @@ export interface FlowDetail {
   // Null both when the Flow links no epic and when that epic has no persisted
   // progression row; the two are distinguished by `bead.epicId`.
   epicProgression: EpicProgression | null
+  /**
+   * Client-derived, not a schema field: the API could not read this Flow's
+   * progression row and said so in `errors`.
+   *
+   * It nulls `epicProgression` when that happens, which is the same null a
+   * Flow whose epic has no row at all gets. The API keeps the two apart on
+   * purpose, so the viewer has to as well — otherwise an unreadable row reads
+   * back as "nobody has configured progression for this epic", which is a
+   * claim nothing checked.
+   */
+  epicProgressionUnavailable: boolean
   issue: Issue | null
   pullRequest: PullRequest | null
   merge: Merge | null
@@ -471,16 +499,26 @@ function describe(value: unknown): string {
 }
 
 export async function getRepos(): Promise<RepoSummary[]> {
-  const data = await query<{ repos: RepoSummary[] }>(REPOS_QUERY)
+  const { data } = await query<{ repos: RepoSummary[] }>(REPOS_QUERY)
   return requireList<RepoSummary>(data.repos, 'repos')
 }
 
 export async function getRepo(id: string): Promise<RepoDetail | null> {
-  const data = await query<{ repo: RepoDetail | null }>(REPO_QUERY, { id })
+  const { data } = await query<{ repo: RepoDetail | null }>(REPO_QUERY, { id })
   return requireNodeOrNull<RepoDetail>(data.repo, 'repo')
 }
 
 export async function getFlow(id: string): Promise<FlowDetail | null> {
-  const data = await query<{ flow: FlowDetail | null }>(FLOW_QUERY, { id })
-  return requireNodeOrNull<FlowDetail>(data.flow, 'flow')
+  const { data, partial } = await query<{ flow: FlowDetail | null }>(FLOW_QUERY, { id })
+  const flow = requireNodeOrNull<FlowDetail>(data.flow, 'flow')
+  if (flow === null) {
+    return null
+  }
+  // Set from the response rather than read off the Flow: the API reports an
+  // unreadable progression row out of band, and the field it nulls is the same
+  // null a missing row produces.
+  return {
+    ...flow,
+    epicProgressionUnavailable: partial.some((error) => failedField(error) === 'epicProgression'),
+  }
 }

--- a/web/src/lib/approach-api.ts
+++ b/web/src/lib/approach-api.ts
@@ -271,6 +271,23 @@ export interface Merge {
   mergedAt: string | null
 }
 
+export interface BeadLink {
+  id: string
+  epicId: string | null
+}
+
+export interface EpicProgressionHalt {
+  childBeadId: string
+  status: string
+  message: string
+}
+
+export interface EpicProgression {
+  enabled: boolean
+  done: boolean
+  halt: EpicProgressionHalt | null
+}
+
 export interface FlowDetail {
   id: string
   title: string
@@ -284,6 +301,10 @@ export interface FlowDetail {
   presetName: string | null
   planId: string | null
   autoMode: boolean
+  bead: BeadLink | null
+  // Null both when the Flow links no epic and when that epic has no persisted
+  // progression row; the two are distinguished by `bead.epicId`.
+  epicProgression: EpicProgression | null
   issue: Issue | null
   pullRequest: PullRequest | null
   merge: Merge | null
@@ -334,6 +355,8 @@ const FLOW_QUERY = `query Flow($id: ID!) {
     presetName
     planId
     autoMode
+    bead { id epicId }
+    epicProgression { enabled done halt { childBeadId status message } }
     issue { provider number url }
     pullRequest { provider number url headBranch baseBranch status }
     merge { status commit mergedAt }

--- a/web/src/lib/approach-api.ts
+++ b/web/src/lib/approach-api.ts
@@ -159,6 +159,31 @@ function isPartialFieldError(error: GraphQLError): boolean {
   return PARTIAL_FIELDS.has(failedField(error) ?? '')
 }
 
+/**
+ * Reads the errors envelope as the list of objects everything below assumes it
+ * is. `body` is a TypeScript cast, not a parsed shape — a stale tunnel or a
+ * misconfigured endpoint can answer 200 with any JSON at all — and a TypeError
+ * raised while filtering it would escape `fail()`, and therefore `load()`'s
+ * ApproachApiError handling, into the generic Next.js boundary. That is the
+ * one outcome this module exists to prevent, which is why a non-object body is
+ * already checked above.
+ *
+ * A malformed entry inside a well-formed array is kept rather than dropped: it
+ * names no field, so the whitelist below treats it as fatal, which is the
+ * conservative reading of an error nobody can attribute.
+ */
+function errorEntries(value: unknown): GraphQLError[] {
+  if (value === undefined || value === null) {
+    return []
+  }
+  if (!Array.isArray(value)) {
+    fail('http', `response carried ${describe(value)} where an errors list was expected`)
+  }
+  return value.map((entry) =>
+    typeof entry === 'object' && entry !== null ? (entry as GraphQLError) : {},
+  )
+}
+
 /** The response key of the field an error entry names, if it names one. */
 function failedField(error: GraphQLError): string | undefined {
   const path = error.path
@@ -249,7 +274,7 @@ async function query<T>(
   // the nearest nullable parent — a failed snapshot arrives as
   // `{"data":{"flow":null},"errors":[...]}`, which without this check reads as
   // an unknown id and renders a 404 instead of the error panel.
-  const errors = body.errors ?? []
+  const errors = errorEntries(body.errors)
   const fatal = errors.filter((error) => !isPartialFieldError(error))
   if (fatal.length > 0) {
     fail('graphql', JSON.stringify(fatal))

--- a/web/vitest.config.mts
+++ b/web/vitest.config.mts
@@ -6,6 +6,11 @@ export default defineConfig({
   resolve: {
     alias: {
       'server-only': fileURLToPath(new URL('./src/test/server-only-stub.ts', import.meta.url)),
+      // The same `@/*` path mapping tsconfig gives the app. Without it a
+      // component that imports the way the pages do is untestable, and the
+      // alternative — relative imports in components only — is a rule nobody
+      // would remember.
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
   test: {


### PR DESCRIPTION
Exposes each Flow's persisted Beads linkage and its epic's durable auto-progression state through the read-only GraphQL API, and renders both on the Flow detail page of the web viewer.

## User-visible change

The Flow detail page gains a Tracking section showing the child Bead id, the epic id, and the epic's auto-progression state. Progression is distinguished across five outcomes — not configured, enabled, disabled, done, and halted (with its child, status, and message) — plus an `unavailable` badge when the row exists but could not be read. GraphQL clients get the same data via two new nullable fields, `Flow.bead` and `Flow.epicProgression`.

## Implementation

**Schema and source.** `Flow.bead` (`BeadLink`) and `Flow.epicProgression` (`EpicProgression`, with an `EpicProgressionHalt` tuple) are new. Link ids are the persisted text verbatim. Progression reads go through a new `EpicProgressionSource` seam wired to `flowstore.Store.ReadEpicProgression`, so the API gains no write authority and still never touches Beads directly.

**Read amplification.** One progression row is read per distinct canonical (repo path, epic id) key per request: siblings under one epic share a read, found or missing, and a Flow with no epic link causes none. A missing row resolves null rather than a synthesized disabled epic; `done` is only the explicit persisted flag. `epicProgressionKey` requires a child Bead id, so `Flow.bead` and `Flow.epicProgression` cannot disagree about whether a Flow is linked.

**Failure scoping.** An unreadable progression row is recorded against the key that produced it rather than failing the whole request — `Flow.epicProgression` reports the sanitized error for the Flows naming that epic, and every other field, every other Flow, and every query that does not select it are unaffected. A malformed record is the likeliest failure here and progression is a secondary projection, so one bad row should not make an optional field a single point of failure for the API.

**Response-byte budget.** The width walk accounts the seven new scalars, including the unbounded halt message. `bounds` now seeds the five `EpicProgression` widths from a zero record before measuring any real one — a store that has never used epic progression has no rows, so previously all five took the 8 KiB drift fallback, charged once per Flow, and roughly 409 epic-linked Flows were enough to reject an ordinary query whose progression fields all resolve null. Field-scoped `errors` entries are now charged against the byte budget too (fixed overhead plus an upper bound on the response keys the path names, so an alias cannot inflate the term for free), since `encoding/json` buffers errors and data together and one unreadable row could otherwise build a body several times over the 16 MiB cap while every scalar in it measured small. A snapshot with nothing unreadable is charged nothing.

**Web client.** `query` returns partial data with its tolerated errors instead of discarding a populated payload whenever any error is present. Errors are tolerated only when every entry's path terminates at a field the client can serve without; anything else is fatal, so a failed snapshot that nulls the `flow` root still renders the error panel rather than "flow not found". `getFlow` derives `epicProgressionUnavailable` from those errors so an unreadable row renders as unavailable rather than the invented "not configured". The `errors` envelope is read defensively before filtering, since a stale tunnel answering 200 with a non-list envelope previously raised a `TypeError` that escaped the `ApproachApiError` handling into the generic Next.js boundary.

**Presentation.** The Flow detail Tracking section is extracted into a pure component. The halt status renders through `StatusBadge` rather than as raw `needs_attention`, and the Progression row is omitted for a child-only link.

## Docs

`docs/graphql-api.md` documents the new fields, their nullability, the one-read-per-key rule, and the per-request disk-work accounting that previously omitted the progression reads.

## Verification

`go test ./...` (`make test`), `make fmt-check`, `make build`; web `lint`, `typecheck`, `test`, and `build`. New coverage in `graphqlapi/{schema,source,limits}_test.go`, `cmd/approach/serve_live_test.go`, `web/src/components/flow-tracking.test.tsx`, and `web/src/lib/approach-api.test.ts`.

## Follow-up

`approach-b9b` filed to bound the per-request read count.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b650f828289213165c417441c001170d592ab039. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->