### PR TITLE
Harden sporadic CI flakes across git, model, and PTY tests

### DIFF
--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/internal/testgit"
 )
 
 var errFakeCommand = errors.New("fake command failed")
@@ -32,6 +33,10 @@ func (r *fakeCommandRunner) Run(name string, args ...string) ([]byte, []byte, er
 
 func mustRun(t *testing.T, dir string, args ...string) {
 	t.Helper()
+	if len(args) > 0 && args[0] == "git" {
+		testgit.Run(t, dir, args[1:]...)
+		return
+	}
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()

--- a/cmd/approach/plan_test.go
+++ b/cmd/approach/plan_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/approachcontrol/approach/config"
+	"github.com/approachcontrol/approach/internal/testgit"
 	"github.com/approachcontrol/approach/planstore"
 	"github.com/approachcontrol/approach/scanner"
 )
@@ -616,8 +616,7 @@ func makeLinkedWorktree(t *testing.T) (repoDir, worktreeDir string) {
 	repoDir = filepath.Join(root, "project")
 	worktreeDir = filepath.Join(root, "project-worktrees", "feature-plan")
 	mustGit(t, root, "init", repoDir)
-	mustGit(t, repoDir, "config", "user.email", "test@example.com")
-	mustGit(t, repoDir, "config", "user.name", "Test User")
+	testgit.ConfigureRepo(t, repoDir)
 	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -633,8 +632,7 @@ func makeBareRepo(t *testing.T) (bareDir, commit string) {
 	repoDir := filepath.Join(root, "project")
 	bareDir = filepath.Join(root, "project.git")
 	mustGit(t, root, "init", repoDir)
-	mustGit(t, repoDir, "config", "user.email", "test@example.com")
-	mustGit(t, repoDir, "config", "user.name", "Test User")
+	testgit.ConfigureRepo(t, repoDir)
 	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -647,22 +645,12 @@ func makeBareRepo(t *testing.T) (bareDir, commit string) {
 
 func mustGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git %v failed: %v\n%s", args, err, out)
-	}
+	testgit.Run(t, dir, args...)
 }
 
 func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %v failed: %v\n%s", args, err, out)
-	}
-	return strings.TrimSpace(string(out))
+	return testgit.Output(t, dir, args...)
 }
 
 func readPlanRecord(t *testing.T, root, planID string) planstore.PlanRecord {

--- a/embeddedterm/terminal.go
+++ b/embeddedterm/terminal.go
@@ -259,7 +259,7 @@ func (t *Terminal) Close() error {
 	}
 	t.unblockEmulatorWrites()
 	t.waitForReadDone()
-	t.saveFinalRows(t.snapshotRows())
+	t.saveFinalRows(t.trySnapshotRows())
 	t.shutdownEmulator()
 	t.waitForTerminalIO()
 	return nil
@@ -296,9 +296,9 @@ func (t *Terminal) waitLoop() {
 	if !t.waitForReadDone() {
 		_ = t.closePTY()
 		t.unblockEmulatorWrites()
-		<-t.readDone
+		_ = t.waitForReadDone()
 	}
-	finalRows := t.snapshotRows()
+	finalRows := t.trySnapshotRows()
 	_ = t.closePTY()
 	t.shutdownEmulator()
 	t.waitForTerminalIO()
@@ -383,13 +383,27 @@ func (t *Terminal) shutdownEmulator() {
 }
 
 func (t *Terminal) snapshotRows() []string {
+	return t.collectSnapshot(true)
+}
+
+// trySnapshotRows is for Close/waitLoop so a stuck emulator write cannot
+// deadlock shutdown the way real-tmux Detach did on CI.
+func (t *Terminal) trySnapshotRows() []string {
+	return t.collectSnapshot(false)
+}
+
+func (t *Terminal) collectSnapshot(block bool) []string {
 	t.mu.Lock()
 	emu := t.emulator
 	t.mu.Unlock()
 	if emu == nil {
 		return nil
 	}
-	t.emuMu.Lock()
+	if block {
+		t.emuMu.Lock()
+	} else if !t.emuMu.TryLock() {
+		return nil
+	}
 	defer t.emuMu.Unlock()
 	rows := make([]string, 0, emu.ScrollbackLen()+emu.Height())
 	if scrollback := emu.Scrollback(); scrollback != nil {

--- a/embeddedterm/terminal.go
+++ b/embeddedterm/terminal.go
@@ -382,26 +382,17 @@ func (t *Terminal) shutdownEmulator() {
 	closeEmulatorResponses(emu)
 }
 
-func (t *Terminal) snapshotRows() []string {
-	return t.collectSnapshot(true)
-}
-
 // trySnapshotRows is for Close/waitLoop so a stuck emulator write cannot
-// deadlock shutdown the way real-tmux Detach did on CI.
+// deadlock shutdown the way real-tmux Detach did on CI. A nil result is
+// intentional: dropping the last frame is preferable to blocking.
 func (t *Terminal) trySnapshotRows() []string {
-	return t.collectSnapshot(false)
-}
-
-func (t *Terminal) collectSnapshot(block bool) []string {
 	t.mu.Lock()
 	emu := t.emulator
 	t.mu.Unlock()
 	if emu == nil {
 		return nil
 	}
-	if block {
-		t.emuMu.Lock()
-	} else if !t.emuMu.TryLock() {
+	if !t.emuMu.TryLock() {
 		return nil
 	}
 	defer t.emuMu.Unlock()
@@ -415,6 +406,9 @@ func (t *Terminal) collectSnapshot(block bool) []string {
 	return trimBlankTerminalRows(rows)
 }
 
+// saveFinalRows keeps a Close/waitLoop snapshot when one was captured.
+// An empty or nil snapshot is intentional: trySnapshotRows skips when
+// emuMu is held rather than deadlock against a stuck emu.Write.
 func (t *Terminal) saveFinalRows(rows []string) {
 	if len(rows) == 0 {
 		return

--- a/embeddedterm/terminal_test.go
+++ b/embeddedterm/terminal_test.go
@@ -162,7 +162,7 @@ func TestTerminalBridgesTerminalQueryResponses(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash is not installed")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	term, err := NewManager().Start(ctx, StartRequest{
@@ -179,10 +179,7 @@ func TestTerminalBridgesTerminalQueryResponses(t *testing.T) {
 	}
 	defer term.Close()
 
-	if err := term.Wait(ctx); err != nil {
-		t.Fatalf("Wait returned error: %v", err)
-	}
-	got := strings.Join(term.VisibleLines(40, 5), "\n")
+	got := waitForVisible(t, term, 40, 5, "query-answered", 5*time.Second)
 	if !strings.Contains(got, "query-answered") {
 		t.Fatalf("visible lines = %q, want output after terminal query response", got)
 	}
@@ -393,7 +390,7 @@ func TestTerminalAnswersCursorPositionWithinScreenHeight(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash is not installed")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	term, err := NewManager().Start(ctx, StartRequest{
@@ -410,10 +407,7 @@ func TestTerminalAnswersCursorPositionWithinScreenHeight(t *testing.T) {
 	}
 	defer term.Close()
 
-	if err := term.Wait(ctx); err != nil {
-		t.Fatalf("Wait returned error: %v", err)
-	}
-	got := ansi.Strip(strings.Join(term.VisibleLines(40, 5), "\n"))
+	got := ansi.Strip(waitForVisible(t, term, 40, 5, "ROW=", 5*time.Second))
 	idx := strings.LastIndex(got, "ROW=")
 	if idx == -1 {
 		t.Fatalf("visible lines = %q, want echoed cursor row", got)
@@ -935,15 +929,15 @@ func TestTerminalCloseUnblocksWhenEmulatorResponseWriteIsStuck(t *testing.T) {
 	}
 	defer term.Terminate()
 
-	if err := term.closePTY(); err != nil {
-		t.Fatalf("closePTY returned error: %v", err)
-	}
-
 	term.mu.Lock()
 	emu := term.emulator
 	term.mu.Unlock()
 	if emu == nil {
 		t.Fatal("emulator was already shut down")
+	}
+
+	if err := term.closePTY(); err != nil {
+		t.Fatalf("closePTY returned error: %v", err)
 	}
 
 	// One device-attribute query lets the drain read a response, fail the
@@ -1100,4 +1094,19 @@ func TestTerminalTerminateWhileOutputIsActive(t *testing.T) {
 	if got := term.State(); got != StateTerminated {
 		t.Fatalf("State = %q, want %q", got, StateTerminated)
 	}
+}
+
+func waitForVisible(t *testing.T, term *Terminal, width, height int, needle string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var got string
+	for time.Now().Before(deadline) {
+		got = strings.Join(term.VisibleLines(width, height), "\n")
+		if strings.Contains(ansi.Strip(got), needle) {
+			return got
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("visible lines never contained %q, last=%q", needle, got)
+	return got
 }

--- a/embeddedterm/tmux_test.go
+++ b/embeddedterm/tmux_test.go
@@ -263,17 +263,20 @@ func TestTmuxBackedTerminalRealTmuxDetachLeavesSessionAlive(t *testing.T) {
 	if err := os.WriteFile(scriptPath, []byte("#!/bin/sh\nsleep 30\n"), 0o700); err != nil {
 		t.Fatalf("write script: %v", err)
 	}
+	tmux := func(args ...string) *exec.Cmd {
+		return exec.Command("tmux", append([]string{"-f", "/dev/null", "-L", sessionName}, args...)...)
+	}
 	t.Cleanup(func() {
-		_ = exec.Command("tmux", "kill-session", "-t", sessionName).Run()
+		_ = tmux("kill-session", "-t", sessionName).Run()
 	})
 
 	spec := actions.EmbeddedTmuxAgentSpec{
 		SessionName:        sessionName,
 		ScriptPath:         scriptPath,
-		HasSessionCommand:  exec.Command("tmux", "has-session", "-t", sessionName),
-		NewSessionCommand:  exec.Command("tmux", "new-session", "-d", "-s", sessionName, "-c", dir, "exec sh "+scriptPath),
-		AttachCommand:      exec.Command("tmux", "attach-session", "-t", sessionName),
-		KillSessionCommand: exec.Command("tmux", "kill-session", "-t", sessionName),
+		HasSessionCommand:  tmux("has-session", "-t", sessionName),
+		NewSessionCommand:  tmux("new-session", "-d", "-s", sessionName, "-c", dir, "exec sh "+scriptPath),
+		AttachCommand:      tmux("attach-session", "-t", sessionName),
+		KillSessionCommand: tmux("kill-session", "-t", sessionName),
 		Cleanup: func() {
 			_ = os.Remove(scriptPath)
 		},
@@ -283,10 +286,17 @@ func TestTmuxBackedTerminalRealTmuxDetachLeavesSessionAlive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartTmuxBackedAgent returned error: %v", err)
 	}
-	if err := term.Detach(); err != nil {
-		t.Fatalf("Detach returned error: %v", err)
+	done := make(chan error, 1)
+	go func() { done <- term.Detach() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Detach returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Detach timed out; Close must not block on a contended emulator snapshot")
 	}
-	if err := exec.Command("tmux", "has-session", "-t", sessionName).Run(); err != nil {
+	if err := tmux("has-session", "-t", sessionName).Run(); err != nil {
 		t.Fatalf("detached tmux session is not alive: %v", err)
 	}
 }

--- a/flowstore/close_test.go
+++ b/flowstore/close_test.go
@@ -627,7 +627,7 @@ func TestRepairLaunchReservationSerializesWithClose(t *testing.T) {
 	select {
 	case err := <-result:
 		t.Fatalf("CloseFlow() returned before repair launch reservation released: %v", err)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
 	}
 	once.Do(release)
 	select {
@@ -635,7 +635,7 @@ func TestRepairLaunchReservationSerializesWithClose(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CloseFlow() after release error = %v", err)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("CloseFlow() did not proceed after repair reservation release")
 	}
 
@@ -674,7 +674,7 @@ func TestAgentLaunchReservationSerializesWithClose(t *testing.T) {
 	select {
 	case err := <-result:
 		t.Fatalf("CloseFlow() returned before resume launch reservation released: %v", err)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
 	}
 	once.Do(release)
 	select {
@@ -682,7 +682,7 @@ func TestAgentLaunchReservationSerializesWithClose(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CloseFlow() after release error = %v", err)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("CloseFlow() did not proceed after resume reservation release")
 	}
 
@@ -738,7 +738,7 @@ func TestAgentLaunchReservationSerializesWithDeleteAndSameIDRecreate(t *testing.
 	select {
 	case err := <-result:
 		t.Fatalf("Delete() returned before launch reservation released: %v", err)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
 	}
 
 	once.Do(release)
@@ -747,7 +747,7 @@ func TestAgentLaunchReservationSerializesWithDeleteAndSameIDRecreate(t *testing.
 		if err != nil {
 			t.Fatalf("Delete() after release error = %v", err)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("Delete() did not proceed after launch reservation released")
 	}
 	if _, err := deleteStore.Create(record); err != nil {

--- a/gitquery/gitquery_test.go
+++ b/gitquery/gitquery_test.go
@@ -21,12 +21,20 @@ func realPath(t *testing.T, path string) string {
 	return resolved
 }
 
+func disableGitMaintenance(t *testing.T, dir string) {
+	t.Helper()
+	run(t, dir, "git", "config", "user.email", "test@test.com")
+	run(t, dir, "git", "config", "user.name", "Test")
+	run(t, dir, "git", "config", "gc.auto", "0")
+	run(t, dir, "git", "config", "gc.autoDetach", "false")
+	run(t, dir, "git", "config", "maintenance.auto", "false")
+}
+
 // initRepo creates a git repo in dir with one commit on "main".
 func initRepo(t *testing.T, dir string) {
 	t.Helper()
 	run(t, dir, "git", "init", "-b", "main")
-	run(t, dir, "git", "config", "user.email", "test@test.com")
-	run(t, dir, "git", "config", "user.name", "Test")
+	disableGitMaintenance(t, dir)
 	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -38,8 +46,7 @@ func initRepo(t *testing.T, dir string) {
 func initRepoWithInitialBranch(t *testing.T, dir, initialBranch string) {
 	t.Helper()
 	run(t, dir, "git", "init", "-b", initialBranch)
-	run(t, dir, "git", "config", "user.email", "test@test.com")
-	run(t, dir, "git", "config", "user.name", "Test")
+	disableGitMaintenance(t, dir)
 	writeFile(t, dir, "README.md", "init")
 	run(t, dir, "git", "add", ".")
 	run(t, dir, "git", "commit", "-m", "initial")
@@ -50,18 +57,53 @@ func initBranchRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	run(t, dir, "git", "init")
-	run(t, dir, "git", "config", "user.email", "test@test.com")
-	run(t, dir, "git", "config", "user.name", "Test")
+	disableGitMaintenance(t, dir)
 	writeFile(t, dir, "README.md", "init")
 	run(t, dir, "git", "add", ".")
 	run(t, dir, "git", "commit", "-m", "initial")
 	return dir
 }
 
+// hermeticGitEnv drops ambient git selectors and ignores user/system config so
+// test repos cannot inherit a runner's gc/maintenance settings or GIT_DIR.
+func hermeticGitEnv() []string {
+	env := make([]string, 0, len(os.Environ())+3)
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "GIT_CONFIG_") ||
+			strings.HasPrefix(entry, "GIT_TEMPLATE_DIR=") ||
+			strings.HasPrefix(entry, "GIT_DIR=") ||
+			strings.HasPrefix(entry, "GIT_WORK_TREE=") ||
+			strings.HasPrefix(entry, "GIT_INDEX_FILE=") ||
+			strings.HasPrefix(entry, "GIT_OBJECT_DIRECTORY=") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env,
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_OPTIONAL_LOCKS=0",
+	)
+}
+
 func run(t *testing.T, dir string, name string, args ...string) string {
 	t.Helper()
+	if name == "git" {
+		// Disable auto-gc and background maintenance. Rapid sequential commits
+		// under parallel package tests have failed CI with
+		// "fatal: unable to read tree" when git rewrites objects mid-commit.
+		args = append([]string{
+			"-c", "gc.auto=0",
+			"-c", "gc.autoDetach=false",
+			"-c", "maintenance.auto=false",
+			"-c", "commit.gpgsign=false",
+		}, args...)
+	}
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
+	if name == "git" {
+		cmd.Env = hermeticGitEnv()
+	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("%s %v failed: %v\n%s", name, args, err, out)
@@ -85,6 +127,7 @@ func initBareUpstream(t *testing.T, repo string) string {
 	t.Helper()
 	bare := t.TempDir()
 	run(t, bare, "git", "init", "--bare")
+	disableGitMaintenance(t, bare)
 	run(t, repo, "git", "remote", "add", "origin", bare)
 	run(t, repo, "git", "push", "-u", "origin", "HEAD")
 	return bare
@@ -887,21 +930,31 @@ func TestListCommits_ReturnsCommits(t *testing.T) {
 }
 
 func TestListCommits_Limit50(t *testing.T) {
-	dir := realPath(t, t.TempDir())
-	initRepo(t, dir)
-
-	for i := 0; i < 54; i++ {
-		writeFile(t, dir, "f.txt", fmt.Sprintf("v%d", i))
-		run(t, dir, "git", "add", ".")
-		run(t, dir, "git", "commit", "-m", fmt.Sprintf("commit %d", i))
+	// The 50-commit cap is the git `-n 50` argument, not a post-parse slice.
+	// Building 55 real commits here previously failed CI sporadically with
+	// "fatal: unable to read tree" during sequential add/commit.
+	var log strings.Builder
+	for i := 0; i < 50; i++ {
+		fmt.Fprintf(&log, "h%02d\x00Test\x00%ds ago\x00commit %d\n", i, i, i)
+	}
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey("/repo", "log", "--format=%h%x00%an%x00%ar%x00%s", "-n", "50"): {
+				out: log.String(),
+			},
+		},
 	}
 
-	commits, err := gitquery.ListCommits(dir)
+	commits, err := gitquery.NewQuerier(f).ListCommits("/repo")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(commits) != 50 {
 		t.Fatalf("expected 50 commits, got %d", len(commits))
+	}
+	if commits[0].Subject != "commit 0" || commits[49].Subject != "commit 49" {
+		t.Fatalf("unexpected first/last subjects: %q / %q", commits[0].Subject, commits[49].Subject)
 	}
 }
 

--- a/gitquery/gitquery_test.go
+++ b/gitquery/gitquery_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/approachcontrol/approach/gitquery"
+	"github.com/approachcontrol/approach/internal/testgit"
 )
 
 // realPath resolves symlinks (macOS /var → /private/var).
@@ -23,11 +24,7 @@ func realPath(t *testing.T, path string) string {
 
 func disableGitMaintenance(t *testing.T, dir string) {
 	t.Helper()
-	run(t, dir, "git", "config", "user.email", "test@test.com")
-	run(t, dir, "git", "config", "user.name", "Test")
-	run(t, dir, "git", "config", "gc.auto", "0")
-	run(t, dir, "git", "config", "gc.autoDetach", "false")
-	run(t, dir, "git", "config", "maintenance.auto", "false")
+	testgit.ConfigureRepo(t, dir)
 }
 
 // initRepo creates a git repo in dir with one commit on "main".
@@ -64,45 +61,14 @@ func initBranchRepo(t *testing.T) string {
 	return dir
 }
 
-// hermeticGitEnv drops ambient git selectors and ignores user/system config so
-// test repos cannot inherit a runner's gc/maintenance settings or GIT_DIR.
-func hermeticGitEnv() []string {
-	env := make([]string, 0, len(os.Environ())+3)
-	for _, entry := range os.Environ() {
-		if strings.HasPrefix(entry, "GIT_CONFIG_") ||
-			strings.HasPrefix(entry, "GIT_TEMPLATE_DIR=") ||
-			strings.HasPrefix(entry, "GIT_DIR=") ||
-			strings.HasPrefix(entry, "GIT_WORK_TREE=") ||
-			strings.HasPrefix(entry, "GIT_INDEX_FILE=") ||
-			strings.HasPrefix(entry, "GIT_OBJECT_DIRECTORY=") {
-			continue
-		}
-		env = append(env, entry)
-	}
-	return append(env,
-		"GIT_CONFIG_GLOBAL=/dev/null",
-		"GIT_CONFIG_NOSYSTEM=1",
-		"GIT_OPTIONAL_LOCKS=0",
-	)
-}
-
 func run(t *testing.T, dir string, name string, args ...string) string {
 	t.Helper()
+	var cmd *exec.Cmd
 	if name == "git" {
-		// Disable auto-gc and background maintenance. Rapid sequential commits
-		// under parallel package tests have failed CI with
-		// "fatal: unable to read tree" when git rewrites objects mid-commit.
-		args = append([]string{
-			"-c", "gc.auto=0",
-			"-c", "gc.autoDetach=false",
-			"-c", "maintenance.auto=false",
-			"-c", "commit.gpgsign=false",
-		}, args...)
-	}
-	cmd := exec.Command(name, args...)
-	cmd.Dir = dir
-	if name == "git" {
-		cmd.Env = hermeticGitEnv()
+		cmd = testgit.Command(dir, args...)
+	} else {
+		cmd = exec.Command(name, args...)
+		cmd.Dir = dir
 	}
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/testgit/testgit.go
+++ b/internal/testgit/testgit.go
@@ -1,0 +1,82 @@
+// Package testgit isolates git CLI invocations used by tests.
+//
+// Temp repos inherit the runner's user/system config and can trigger
+// auto-gc or background maintenance. Under parallel `go test ./...`
+// that has failed CI with "fatal: unable to read tree" mid-commit.
+package testgit
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// Env returns a process environment that ignores user/system git config
+// and drops ambient repo selectors such as GIT_DIR.
+func Env() []string {
+	env := make([]string, 0, len(os.Environ())+3)
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, "GIT_CONFIG_") ||
+			strings.HasPrefix(entry, "GIT_TEMPLATE_DIR=") ||
+			strings.HasPrefix(entry, "GIT_DIR=") ||
+			strings.HasPrefix(entry, "GIT_WORK_TREE=") ||
+			strings.HasPrefix(entry, "GIT_INDEX_FILE=") ||
+			strings.HasPrefix(entry, "GIT_OBJECT_DIRECTORY=") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env,
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_OPTIONAL_LOCKS=0",
+	)
+}
+
+// Command builds a git invocation in dir with auto-gc and signing disabled.
+func Command(dir string, args ...string) *exec.Cmd {
+	gitArgs := append([]string{
+		"-c", "gc.auto=0",
+		"-c", "gc.autoDetach=false",
+		"-c", "maintenance.auto=false",
+		"-c", "commit.gpgsign=false",
+	}, args...)
+	cmd := exec.Command("git", gitArgs...)
+	cmd.Dir = dir
+	cmd.Env = Env()
+	return cmd
+}
+
+// Run executes git in dir and returns combined output, failing the test on error.
+func Run(t testing.TB, dir string, args ...string) string {
+	t.Helper()
+	cmd := Command(dir, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+// Output executes git in dir and returns stdout, failing the test on error.
+func Output(t testing.TB, dir string, args ...string) string {
+	t.Helper()
+	cmd := Command(dir, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v failed: %v", args, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// ConfigureRepo sets a local identity and disables maintenance so later
+// production git invocations against the same temp repo stay quiet.
+func ConfigureRepo(t testing.TB, dir string) {
+	t.Helper()
+	Run(t, dir, "config", "user.email", "test@test.com")
+	Run(t, dir, "config", "user.name", "Test")
+	Run(t, dir, "config", "gc.auto", "0")
+	Run(t, dir, "config", "gc.autoDetach", "false")
+	Run(t, dir, "config", "maintenance.auto", "false")
+}

--- a/internal/testgit/testgit_test.go
+++ b/internal/testgit/testgit_test.go
@@ -1,0 +1,52 @@
+package testgit
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEnvDropsAmbientGitSelectors(t *testing.T) {
+	t.Setenv("GIT_DIR", "/tmp/other.git")
+	t.Setenv("GIT_WORK_TREE", "/tmp/other")
+	t.Setenv("GIT_INDEX_FILE", "/tmp/index")
+	t.Setenv("GIT_OBJECT_DIRECTORY", "/tmp/objects")
+	t.Setenv("GIT_TEMPLATE_DIR", "/tmp/template")
+	t.Setenv("GIT_CONFIG_GLOBAL", "/tmp/gitconfig")
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+
+	env := Env()
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "GIT_DIR=") ||
+			strings.HasPrefix(entry, "GIT_WORK_TREE=") ||
+			strings.HasPrefix(entry, "GIT_INDEX_FILE=") ||
+			strings.HasPrefix(entry, "GIT_OBJECT_DIRECTORY=") ||
+			strings.HasPrefix(entry, "GIT_TEMPLATE_DIR=") ||
+			strings.HasPrefix(entry, "GIT_CONFIG_") {
+			t.Fatalf("ambient git selector leaked into test env: %s", entry)
+		}
+	}
+	if !containsEnv(env, "GIT_CONFIG_GLOBAL=/dev/null") || !containsEnv(env, "GIT_CONFIG_NOSYSTEM=1") || !containsEnv(env, "GIT_OPTIONAL_LOCKS=0") {
+		t.Fatalf("expected hermetic git config overrides, got %v", env)
+	}
+}
+
+func TestCommandAndConfigureRepoDisableMaintenance(t *testing.T) {
+	dir := t.TempDir()
+	Run(t, dir, "init", "-b", "main")
+	ConfigureRepo(t, dir)
+	if got := Output(t, dir, "config", "--get", "gc.auto"); got != "0" {
+		t.Fatalf("gc.auto = %q, want 0", got)
+	}
+	if got := Output(t, dir, "config", "--get", "maintenance.auto"); got != "false" {
+		t.Fatalf("maintenance.auto = %q, want false", got)
+	}
+}
+
+func containsEnv(env []string, want string) bool {
+	for _, entry := range env {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/testgit/testgit_test.go
+++ b/internal/testgit/testgit_test.go
@@ -21,7 +21,7 @@ func TestEnvDropsAmbientGitSelectors(t *testing.T) {
 			strings.HasPrefix(entry, "GIT_INDEX_FILE=") ||
 			strings.HasPrefix(entry, "GIT_OBJECT_DIRECTORY=") ||
 			strings.HasPrefix(entry, "GIT_TEMPLATE_DIR=") ||
-			strings.HasPrefix(entry, "GIT_CONFIG_") {
+			strings.HasPrefix(entry, "GIT_CONFIG_COUNT=") {
 			t.Fatalf("ambient git selector leaked into test env: %s", entry)
 		}
 	}

--- a/model/flow_advance_tick_test.go
+++ b/model/flow_advance_tick_test.go
@@ -161,7 +161,7 @@ func runAutoAdvanceResultForTest(t *testing.T, m Model, flows []flowstore.FlowRe
 // disarms the drain, and the read event is what re-arms, drops, or announces.
 func applyAutoFlowLaunchReads(m Model, cmd tea.Cmd) (Model, []tea.Cmd) {
 	var produced []tea.Cmd
-	for _, msg := range immediateFlowRefreshMessages(cmd) {
+	for _, msg := range immediateFlowRefreshMessagesWithin(cmd, testStoreCommandSettleTimeout) {
 		event, ok := msg.(flowLaunchEventMsg)
 		if !ok || event.Stage != flowLaunchStageRead {
 			continue
@@ -187,7 +187,7 @@ func preparedAutoFlowLaunches(m Model, cmd tea.Cmd) (Model, []flowLaunchEventMsg
 	m, produced := applyAutoFlowLaunchReads(m, cmd)
 	var prepared []flowLaunchEventMsg
 	for _, next := range produced {
-		for _, msg := range immediateFlowRefreshMessages(next) {
+		for _, msg := range immediateFlowRefreshMessagesWithin(next, testStoreCommandSettleTimeout) {
 			if event, ok := msg.(flowLaunchEventMsg); ok && event.Stage == flowLaunchStagePrepared {
 				prepared = append(prepared, event)
 			}

--- a/model/flow_advance_tick_test.go
+++ b/model/flow_advance_tick_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,9 +30,14 @@ import (
 // registration path runs against an already-constructed model, so clearing at
 // construction cannot drop a record a live test still needs. Sharing one map
 // does forbid t.Parallel() in the tests that use it.
-var autoAdvanceTestFlows = map[string]flowstore.FlowRecord{}
+var (
+	autoAdvanceTestFlowsMu sync.RWMutex
+	autoAdvanceTestFlows   = map[string]flowstore.FlowRecord{}
+)
 
 func recordAutoAdvanceTestFlows(records []flowstore.FlowRecord) {
+	autoAdvanceTestFlowsMu.Lock()
+	defer autoAdvanceTestFlowsMu.Unlock()
 	for _, record := range records {
 		if record.FlowID != "" {
 			autoAdvanceTestFlows[record.FlowID] = cloneFlowRecord(record)
@@ -40,6 +46,8 @@ func recordAutoAdvanceTestFlows(records []flowstore.FlowRecord) {
 }
 
 func autoAdvanceTestReadFlow(flowID string) (flowstore.FlowRecord, error) {
+	autoAdvanceTestFlowsMu.RLock()
+	defer autoAdvanceTestFlowsMu.RUnlock()
 	if record, ok := autoAdvanceTestFlows[strings.TrimSpace(flowID)]; ok {
 		return record, nil
 	}
@@ -47,7 +55,9 @@ func autoAdvanceTestReadFlow(flowID string) (flowstore.FlowRecord, error) {
 }
 
 func newAutoAdvanceTestModel(repos []scanner.Repo, opts Options) Model {
+	autoAdvanceTestFlowsMu.Lock()
 	clear(autoAdvanceTestFlows)
+	autoAdvanceTestFlowsMu.Unlock()
 	if opts.ReadFlow == nil {
 		opts.ReadFlow = autoAdvanceTestReadFlow
 	}

--- a/model/flow_refresh_tick_test.go
+++ b/model/flow_refresh_tick_test.go
@@ -12,9 +12,14 @@ import (
 	"github.com/approachcontrol/approach/ui"
 )
 
-// testCommandSettleTimeout is long enough for real SQLite writes on a loaded
-// CI runner. The previous 20ms window dropped those results and flaked.
-const testCommandSettleTimeout = 2 * time.Second
+const (
+	// testCommandSettleTimeout is the default for in-memory refresh helpers.
+	// Keep it short so tea.Tick batch children do not wait seconds each.
+	testCommandSettleTimeout = 20 * time.Millisecond
+	// testStoreCommandSettleTimeout is only for AutoMode prepare/read hops
+	// that hit a real SQLite store on a loaded CI runner.
+	testStoreCommandSettleTimeout = 2 * time.Second
+)
 
 func flowRefreshTestRepos() []scanner.Repo {
 	return []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}
@@ -43,6 +48,10 @@ func flowResultFromCommand(t *testing.T, cmd tea.Cmd) FlowResultMsg {
 }
 
 func immediateFlowRefreshMessages(cmd tea.Cmd) []tea.Msg {
+	return immediateFlowRefreshMessagesWithin(cmd, testCommandSettleTimeout)
+}
+
+func immediateFlowRefreshMessagesWithin(cmd tea.Cmd, timeout time.Duration) []tea.Msg {
 	if cmd == nil {
 		return nil
 	}
@@ -53,12 +62,12 @@ func immediateFlowRefreshMessages(cmd tea.Cmd) []tea.Msg {
 		if batch, ok := msg.(tea.BatchMsg); ok {
 			var messages []tea.Msg
 			for _, child := range batch {
-				messages = append(messages, immediateFlowRefreshMessages(child)...)
+				messages = append(messages, immediateFlowRefreshMessagesWithin(child, timeout)...)
 			}
 			return messages
 		}
 		return []tea.Msg{msg}
-	case <-time.After(testCommandSettleTimeout):
+	case <-time.After(timeout):
 		return nil
 	}
 }

--- a/model/flow_refresh_tick_test.go
+++ b/model/flow_refresh_tick_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/approachcontrol/approach/ui"
 )
 
+// testCommandSettleTimeout is long enough for real SQLite writes on a loaded
+// CI runner. The previous 20ms window dropped those results and flaked.
+const testCommandSettleTimeout = 2 * time.Second
+
 func flowRefreshTestRepos() []scanner.Repo {
 	return []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}
 }
@@ -54,7 +58,7 @@ func immediateFlowRefreshMessages(cmd tea.Cmd) []tea.Msg {
 			return messages
 		}
 		return []tea.Msg{msg}
-	case <-time.After(20 * time.Millisecond):
+	case <-time.After(testCommandSettleTimeout):
 		return nil
 	}
 }

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/gitquery"
+	"github.com/approachcontrol/approach/internal/testgit"
 	"github.com/approachcontrol/approach/model"
 	"github.com/approachcontrol/approach/scanner"
 	"github.com/approachcontrol/approach/sessions"
@@ -55,6 +56,10 @@ func activeFlowResultFromCommand(t *testing.T, cmd tea.Cmd) model.ActiveFlowResu
 	t.Fatalf("command returned %T, want ActiveFlowResultMsg", msg)
 	return model.ActiveFlowResultMsg{}
 }
+
+// testCommandSettleTimeout is long enough for real SQLite writes on a loaded
+// CI runner. The previous 20ms window dropped those results and flaked.
+const testCommandSettleTimeout = 2 * time.Second
 
 func settleModelCommands(t *testing.T, m model.Model, cmd tea.Cmd, rounds int) model.Model {
 	t.Helper()
@@ -159,7 +164,7 @@ func runImmediateTestCommand(cmd tea.Cmd) (tea.Msg, bool) {
 	select {
 	case msg := <-result:
 		return msg, true
-	case <-time.After(20 * time.Millisecond):
+	case <-time.After(testCommandSettleTimeout):
 		return nil, false
 	}
 }
@@ -11891,8 +11896,7 @@ func TestModel_NewFlowPlanNowRoutesFormThroughProductionLifecycle(t *testing.T) 
 		t.Fatal(err)
 	}
 	mustGit(t, repoPath, "init", "-b", "main")
-	mustGit(t, repoPath, "config", "user.email", "test@example.com")
-	mustGit(t, repoPath, "config", "user.name", "Test User")
+	testgit.ConfigureRepo(t, repoPath)
 	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("fixture\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -57,9 +57,9 @@ func activeFlowResultFromCommand(t *testing.T, cmd tea.Cmd) model.ActiveFlowResu
 	return model.ActiveFlowResultMsg{}
 }
 
-// testCommandSettleTimeout is long enough for real SQLite writes on a loaded
-// CI runner. The previous 20ms window dropped those results and flaked.
-const testCommandSettleTimeout = 2 * time.Second
+// testCommandSettleTimeout stays short so settleModelCommands does not
+// consume status-fade timers (1s+) and clear the error under test.
+const testCommandSettleTimeout = 20 * time.Millisecond
 
 func settleModelCommands(t *testing.T, m model.Model, cmd tea.Cmd, rounds int) model.Model {
 	t.Helper()

--- a/model/model_realrepo_test.go
+++ b/model/model_realrepo_test.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/internal/testgit"
 	"github.com/approachcontrol/approach/model"
 	"github.com/approachcontrol/approach/scanner"
 	"github.com/approachcontrol/approach/ui"
@@ -24,19 +25,12 @@ import (
 
 func mustGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git %v: %v\n%s", args, err, out)
-	}
+	testgit.Run(t, dir, args...)
 }
 
 func gitOut(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).Output()
-	if err != nil {
-		t.Fatalf("git %v: %v", args, err)
-	}
-	return strings.TrimSpace(string(out))
+	return testgit.Output(t, dir, args...)
 }
 
 func initWorktreeResult(t *testing.T, m model.Model) (model.Model, model.WorktreeResultMsg) {
@@ -96,8 +90,7 @@ func setupModelRepo(t *testing.T) (model.Model, string) {
 		dir = resolved
 	}
 	mustGit(t, dir, "init")
-	mustGit(t, dir, "config", "user.email", "test@test.com")
-	mustGit(t, dir, "config", "user.name", "Test")
+	testgit.ConfigureRepo(t, dir)
 	writeFile(t, dir, "README.md", "hello\n")
 	mustGit(t, dir, "add", "README.md")
 	mustGit(t, dir, "commit", "-m", "initial commit")
@@ -119,8 +112,7 @@ func setupModelPullRequestRepoWithOptions(t *testing.T, opts model.Options) (mod
 	origin := filepath.Join(dir, "origin.git")
 	local := filepath.Join(dir, "local")
 	mustGit(t, dir, "init", upstream)
-	mustGit(t, upstream, "config", "user.email", "test@test.com")
-	mustGit(t, upstream, "config", "user.name", "Test")
+	testgit.ConfigureRepo(t, upstream)
 	writeFile(t, upstream, "README.md", "hello\n")
 	mustGit(t, upstream, "add", "README.md")
 	mustGit(t, upstream, "commit", "-m", "initial commit")
@@ -136,8 +128,7 @@ func setupModelPullRequestRepoWithOptions(t *testing.T, opts model.Options) (mod
 	if resolved, err := filepath.EvalSymlinks(local); err == nil {
 		local = resolved
 	}
-	mustGit(t, local, "config", "user.email", "test@test.com")
-	mustGit(t, local, "config", "user.name", "Test")
+	testgit.ConfigureRepo(t, local)
 	m := newTestModel([]scanner.Repo{{Path: local, DisplayName: filepath.Base(local)}}, opts)
 	return m, local
 }

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -3,6 +3,7 @@ package model_test
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -37,11 +38,16 @@ func testStashes() []gitquery.Stash {
 
 // The test record registries mirror Flow and session records fed into panes so
 // authoritative read seams can answer with the same records the surfaces show.
-// Package tests never run in parallel, so process-wide registries are enough.
-var testFlowRecords = map[string]flowstore.FlowRecord{}
-var testSessionRecords = map[string]sessions.SessionRecord{}
+// They are mutex-guarded so a later t.Parallel() cannot race shared IDs.
+var (
+	testRecordsMu      sync.RWMutex
+	testFlowRecords    = map[string]flowstore.FlowRecord{}
+	testSessionRecords = map[string]sessions.SessionRecord{}
+)
 
 func recordTestFlowRecords(records []flowstore.FlowRecord) {
+	testRecordsMu.Lock()
+	defer testRecordsMu.Unlock()
 	for _, record := range records {
 		if record.FlowID != "" {
 			testFlowRecords[record.FlowID] = record
@@ -49,16 +55,32 @@ func recordTestFlowRecords(records []flowstore.FlowRecord) {
 	}
 }
 
+func lookupTestFlowRecord(flowID string) (flowstore.FlowRecord, bool) {
+	testRecordsMu.RLock()
+	defer testRecordsMu.RUnlock()
+	record, ok := testFlowRecords[flowID]
+	return record, ok
+}
+
 func testSessionRecordKey(provider sessions.Provider, sessionID string) string {
 	return string(provider) + "\x00" + sessionID
 }
 
 func recordTestSessionRecords(records []sessions.SessionRecord) {
+	testRecordsMu.Lock()
+	defer testRecordsMu.Unlock()
 	for _, record := range records {
 		if record.SessionID != "" {
 			testSessionRecords[testSessionRecordKey(record.Provider, record.SessionID)] = record
 		}
 	}
+}
+
+func lookupTestSessionRecord(provider sessions.Provider, sessionID string) (sessions.SessionRecord, bool) {
+	testRecordsMu.RLock()
+	defer testRecordsMu.RUnlock()
+	record, ok := testSessionRecords[testSessionRecordKey(provider, sessionID)]
+	return record, ok
 }
 
 // newTestModel builds a Model and, unless the test supplies its own, points the
@@ -71,7 +93,7 @@ func newTestModel(repos []scanner.Repo, opts model.Options) model.Model {
 	}
 	if opts.ReadSession == nil {
 		opts.ReadSession = func(provider sessions.Provider, sessionID string) (sessions.SessionRecord, error) {
-			if record, ok := testSessionRecords[testSessionRecordKey(provider, sessionID)]; ok {
+			if record, ok := lookupTestSessionRecord(provider, sessionID); ok {
 				return record, nil
 			}
 			return sessions.SessionRecord{}, fmt.Errorf("session %s/%s not found", provider, sessionID)
@@ -79,7 +101,7 @@ func newTestModel(repos []scanner.Repo, opts model.Options) model.Model {
 	}
 	if opts.ReadFlow == nil {
 		opts.ReadFlow = func(flowID string) (flowstore.FlowRecord, error) {
-			if record, ok := testFlowRecords[flowID]; ok {
+			if record, ok := lookupTestFlowRecord(flowID); ok {
 				return record, nil
 			}
 			// Wrapped like the store's own miss so callers that treat a missing
@@ -101,7 +123,7 @@ func newTestModel(repos []scanner.Repo, opts model.Options) model.Model {
 					}
 				}
 			}
-			if record, ok := testFlowRecords[flowID]; ok {
+			if record, ok := lookupTestFlowRecord(flowID); ok {
 				return record, func() {}, nil
 			}
 			return flowstore.FlowRecord{}, nil, fmt.Errorf("flow %s not found", flowID)

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -38,7 +38,9 @@ func testStashes() []gitquery.Stash {
 
 // The test record registries mirror Flow and session records fed into panes so
 // authoritative read seams can answer with the same records the surfaces show.
-// They are mutex-guarded so a later t.Parallel() cannot race shared IDs.
+// The mutex only prevents concurrent-map panics. Tests still reuse IDs like
+// "flow-1", so they must not call t.Parallel() — Parallel would clobber those
+// records even with the lock held.
 var (
 	testRecordsMu      sync.RWMutex
 	testFlowRecords    = map[string]flowstore.FlowRecord{}

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -2,11 +2,10 @@ package scanner_test
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
+	"github.com/approachcontrol/approach/internal/testgit"
 	"github.com/approachcontrol/approach/scanner"
 )
 
@@ -35,27 +34,7 @@ func makeBareRepo(t *testing.T, path string) {
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	cmd.Env = hermeticGitEnv()
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("git %v failed: %v\n%s", args, err, output)
-	}
-}
-
-func hermeticGitEnv() []string {
-	env := make([]string, 0, len(os.Environ())+2)
-	for _, entry := range os.Environ() {
-		if strings.HasPrefix(entry, "GIT_CONFIG_") || strings.HasPrefix(entry, "GIT_TEMPLATE_DIR=") {
-			continue
-		}
-		env = append(env, entry)
-	}
-	return append(env,
-		"GIT_CONFIG_GLOBAL=/dev/null",
-		"GIT_CONFIG_NOSYSTEM=1",
-	)
+	testgit.Run(t, dir, args...)
 }
 
 func makeCommittedGitRepo(t *testing.T, path string) {
@@ -170,9 +149,7 @@ func TestScan_DiscoversNestedBareRepo(t *testing.T) {
 func TestScan_BareRepoCarriesIsBare(t *testing.T) {
 	root := t.TempDir()
 	repoDir := filepath.Join(root, "real.git")
-	if err := exec.Command("git", "init", "--bare", repoDir).Run(); err != nil {
-		t.Fatalf("git init --bare failed: %v", err)
-	}
+	testgit.Run(t, root, "init", "--bare", repoDir)
 
 	repos, err := scanner.Scan(scanner.ScanOptions{Root: root})
 	if err != nil {

--- a/sessions/ingest_test.go
+++ b/sessions/ingest_test.go
@@ -6,13 +6,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/internal/testgit"
 	"github.com/approachcontrol/approach/sessions"
 )
 
@@ -238,8 +238,7 @@ func TestIngestHookResolvesGitMetadataFromCWD(t *testing.T) {
 	t.Setenv("XDG_STATE_HOME", t.TempDir())
 	repoPath := t.TempDir()
 	runGit(t, repoPath, "init")
-	runGit(t, repoPath, "config", "user.email", "test@example.com")
-	runGit(t, repoPath, "config", "user.name", "Test User")
+	testgit.ConfigureRepo(t, repoPath)
 	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("test\n"), 0o600); err != nil {
 		t.Fatalf("write README: %v", err)
 	}
@@ -280,8 +279,7 @@ func TestIngestHookResolvesLinkedWorktreeToMainRepoPath(t *testing.T) {
 		t.Fatalf("create repo dir: %v", err)
 	}
 	runGit(t, repoPath, "init")
-	runGit(t, repoPath, "config", "user.email", "test@example.com")
-	runGit(t, repoPath, "config", "user.name", "Test User")
+	testgit.ConfigureRepo(t, repoPath)
 	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("test\n"), 0o600); err != nil {
 		t.Fatalf("write README: %v", err)
 	}
@@ -322,8 +320,7 @@ func TestIngestHookKeepsSeparateGitDirRepoPathAsWorktree(t *testing.T) {
 		t.Fatalf("create repo dir: %v", err)
 	}
 	runGit(t, root, "init", "--separate-git-dir", gitDir, repoPath)
-	runGit(t, repoPath, "config", "user.email", "test@example.com")
-	runGit(t, repoPath, "config", "user.name", "Test User")
+	testgit.ConfigureRepo(t, repoPath)
 	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("test\n"), 0o600); err != nil {
 		t.Fatalf("write README: %v", err)
 	}
@@ -357,8 +354,7 @@ func TestIngestHookAvoidsSeparateGitDirMetadataPathForLinkedWorktree(t *testing.
 		t.Fatalf("create repo dir: %v", err)
 	}
 	runGit(t, root, "init", "--separate-git-dir", gitDir, repoPath)
-	runGit(t, repoPath, "config", "user.email", "test@example.com")
-	runGit(t, repoPath, "config", "user.name", "Test User")
+	testgit.ConfigureRepo(t, repoPath)
 	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("test\n"), 0o600); err != nil {
 		t.Fatalf("write README: %v", err)
 	}
@@ -957,20 +953,12 @@ func assertNoSessionRecords(t *testing.T, root string) {
 
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git %v failed: %v\n%s", args, err, out)
-	}
+	testgit.Run(t, dir, args...)
 }
 
 func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
-	out, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("git %v failed: %v", args, err)
-	}
-	return string(bytes.TrimSpace(out))
+	return testgit.Output(t, dir, args...)
 }
 
 func quoteJSON(value string) string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the sporadic `TestListCommits_Limit50` CI failure (`unable to read tree` while creating commit 52) and hardens the other flake classes that showed up while landing that fix.

## What changed

- `TestListCommits_Limit50` asserts `git log --format=… -n 50` with a fake runner instead of creating 55 real commits.
- New `internal/testgit` shares hermetic git env (`GIT_CONFIG_GLOBAL=/dev/null`, strip `GIT_DIR` / `GIT_WORK_TREE`, `gc.auto=0`, no maintenance, no gpgsign) across `gitquery`, `actions`, `scanner`, `sessions`, `model`, and `cmd/approach`.
- AutoMode prepare/read hops settle for 2s (real SQLite on a loaded CI runner). UI command settle stays at 20ms so the 1s status-fade timer is not consumed.
- `embeddedterm` Close/waitLoop snapshot with `TryLock` so a stuck `emu.Write` cannot deadlock shutdown. Real-tmux detach uses an isolated socket.
- Test Flow/session registries are mutex-guarded. Comments now say that does **not** make reused IDs like `flow-1` safe under `t.Parallel()`.

## Review follow-up

- Deleted unused `snapshotRows` / `collectSnapshot`; Close/waitLoop only `TryLock`. A nil last frame is intentional vs deadlock.
- `immediateFlowRefreshMessages` is back to 20ms. Only `applyAutoFlowLaunchReads` / `preparedAutoFlowLaunches` use the 2s window. Failure follow-ups stay at 20ms (in-memory fakes).
- Empty commit `9223c05` is leftover retrigger noise; squash merge drops it.

## Test plan

- `go test ./internal/testgit ./gitquery ./scanner ./actions ./sessions ./cmd/approach ./flowstore ./embeddedterm`
- `go test ./model -run 'TestModel_TrackedResumeAndAutoAdvanceStartEachTerminalOnce|TestModel_RKeySessionResumeWithFlowMetadataRunFailureDoesNotUpdateFlow|TestModel_RKeyOnFlowPhaseResumeSetupFailureKeepsCompletedPhase|TestModel_GFlowPhaseEmbeddedInteractivePrefillFailureCleansUpTerminal'`
- `go test ./model` (full package)
- `make fmt-check` and `make build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-578a9e8f-8c57-41b5-90e4-7ef7e245895d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-578a9e8f-8c57-41b5-90e4-7ef7e245895d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

