### PR TITLE
Polish the prompt-template picker and editor

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -276,9 +276,10 @@ value immediately, creating the config file if needed.
 | `claude_reasoning_effort` | string | Optional Claude Code reasoning effort for new launches. Supported values: `default`, `low`, `medium`, `high`, `xhigh`, `max`. Empty or `default` omits the Claude override and keeps provider defaults. |
 | `plan_prompt` | string | Optional template for the editable instructions opened by `i` in the plans pane. Supports `{title}`, `{plan_id}`, `{plan_path}`, `{repo_path}`, and `{worktree_path}`. When a saved-plan phase row is selected, it also supports `{phase_id}`, `{phase_title}`, and `{phase_status}`. Unknown placeholders remain literal. Blank or omitted uses the built-in prompt. |
 
-Press `f2` in normal TUI views to open the prompt-template editor. The editor
-can save a custom `[agent].plan_prompt`, reset it to the built-in default, or
-preview the built-in prompt.
+Press `f2` in normal TUI views to open the prompt-template picker. From it you
+can edit `[agent].plan_prompt` (`enter`, then `ctrl+s` to save — `enter` inserts
+a newline), reset it to the built-in default (`r`, then confirm), or preview the
+built-in prompt (`v`). See `docs/tui-guide.md` for the full key map.
 
 In the flows pane, `M` opens a provider-specific model picker and persists the
 corresponding key for the selected CLI agent. `E` opens the reasoning-effort
@@ -303,8 +304,9 @@ configured phase templates unless the template already ends with that exact
 standalone instruction. The `autofix` key is not a phase prompt and never
 receives that suffix.
 
-The `f2` prompt-template editor also manages these Flow prompt keys. Saving a
-blank template resets that key by removing the config override.
+The `f2` prompt-template picker also manages these Flow prompt keys. Saving a
+blank or whitespace-only template with `ctrl+s` resets that key by removing the
+config override, the same as a confirmed `r` from the picker.
 
 | Key | Type | Description |
 |-----|------|-------------|

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -31,9 +31,10 @@ focus. Focus still moves through both stored panes and swaps which one is
 visible. Active Flows and PR Babysitter are separate takeovers that always span
 the combined content height and restore both stored panes exactly when closed.
 
-Press `f2` from normal TUI views to open the prompt-template editor for the
+Press `f2` from normal TUI views to open the prompt-template picker for the
 `[agent].plan_prompt` and `[flow_prompts]` templates; embedded terminal input
-focus passes F2 through to the embedded agent.
+focus passes F2 through to the embedded agent. See
+[Prompt Templates](#prompt-templates) for the picker and editor workflow.
 
 Empty panes explain why they are empty: no data for the selected repo, no
 fuzzy filter matches, or a load failure with details in the status bar. Beads
@@ -69,7 +70,7 @@ title, and assignee; repo filtering remains available from the left pane.
 | `enter` | Collapse the repos pane and focus the top content pane |
 | `tab` | Focus the top content pane without collapsing the repos pane |
 | `T` | Attach an external terminal to the selected repo's Approach tmux session (tmux mode only) |
-| `f2` | Edit prompt templates |
+| `f2` | Open the prompt-template picker |
 | `q`/`esc` | Quit |
 
 **Content panes**
@@ -121,8 +122,57 @@ title, and assignee; repo filtering remains available from the left pane.
 | `ctrl+t` | Hide or show the shared embedded terminal dock (outside search and terminal input); when input is focused, use `ctrl+] t` |
 | `tab` | Cycle focus forward through repos, top, bottom, and an eligible terminal; collapsed repos are skipped |
 | `bksp` | Cycle focus in reverse (outside search or embedded-terminal input focus) |
-| `f2` | Edit prompt templates |
+| `f2` | Open the prompt-template picker |
 | `q`/`esc` | Close a prompt/dialog or quit |
+
+## Prompt Templates
+
+`f2` opens the prompt-template picker: a fixed 42-column panel listing every
+`[agent].plan_prompt` and `[flow_prompts]` template with its `default` or
+`custom` state, plus one reserved row at the bottom for feedback. The feedback
+row reports what just happened (saved, discarded, reset, or the error that
+stopped it) and clears on the next keystroke, so key hints stay in the status
+bar.
+
+| Key | Action |
+|-----|--------|
+| `up`/`down` | Move the selection |
+| `enter` | Open the selected template in the editor |
+| `r` | Reset the selected template to its built-in default, after a `y`/`n` confirmation |
+| `v` | Preview the built-in template with its placeholders literal |
+| `esc` | Close the picker |
+
+`r` on a template that is already the built-in default is a no-op with an
+informational note. Cancelling the confirmation returns to the same selection
+with the custom value untouched, and closing a preview returns there too.
+
+**The editor.** The editor is a fixed 72x21 panel: a title, the
+`section.key` identity with its `default`/`custom` and `modified` state, a
+separately framed 12-line text viewport, a two-row feedback block, and a hint
+row. It stays that size no matter how long the template, the draft, or the
+error is, and clamps cleanly — shedding the second note row, then the hint row,
+then the identity row — on terminals too small for the full panel.
+
+| Key | Action |
+|-----|--------|
+| `ctrl+s` | Save the template exactly as typed |
+| `enter` / `alt+enter` | Insert a newline |
+| `esc` | Cancel without persisting anything |
+| `home`/`end`, `ctrl+a`/`ctrl+e` | Move to the start or end of the current line |
+| `arrows`, `bksp`, `del` | Move and edit |
+| `ctrl+u` | Clear the buffer |
+
+Text is stored raw: blank lines, leading and trailing whitespace, repeated
+spaces, and Unicode are preserved verbatim. Long templates scroll inside the
+viewport, which keeps the cursor visible and shows overflow arrows and a
+logical `line L/N` indicator on its frame rather than resizing the modal.
+
+Saving a blank or whitespace-only template still means reset-to-default; while
+the buffer is blank over a custom template the note block says so. Cancelling
+returns to the picker and distinguishes a clean cancel from discarded unsaved
+changes. A failed write keeps the draft and cursor in the editor with the error
+in the note block, so the save can be retried with `ctrl+s` or abandoned with
+`esc`; it is never reported as success.
 
 ## View Switching and the Header
 

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -151,7 +151,8 @@ with the custom value untouched, and closing a preview returns there too.
 separately framed 12-line text viewport, a two-row feedback block, and a hint
 row. It stays that size no matter how long the template, the draft, or the
 error is, and clamps cleanly — shedding the second note row, then the hint row,
-then the identity row — on terminals too small for the full panel.
+then the identity row, then the remaining note, then the viewport frame, then
+the viewport to the cursor line — on terminals too small for the full panel.
 
 | Key | Action |
 |-----|--------|

--- a/model/modal/editor_test.go
+++ b/model/modal/editor_test.go
@@ -507,6 +507,23 @@ func TestDiffCancelIgnoresCancelHook(t *testing.T) {
 	}
 }
 
+func TestFormCancelIgnoresCancelHook(t *testing.T) {
+	fired := false
+	m := modal.OpenForm(modal.FormSpec{Title: "Create", Fields: []modal.FormField{{ID: "a", Label: "A"}}}).
+		WithCancel(func(modal.View) tea.Cmd {
+			fired = true
+			return func() tea.Msg { return sentinelMsg("cancelled") }
+		})
+
+	_, out, cmd := m.Update(keyOf("esc"))
+	if out != modal.Cancelled {
+		t.Fatalf("outcome = %v, want Cancelled", out)
+	}
+	if cmd != nil || fired {
+		t.Fatal("form overlays should not use the cancel hook")
+	}
+}
+
 func TestSetSelectNoteCarriesFeedbackWithoutDisturbingSelection(t *testing.T) {
 	items := []modal.SelectItem{{Label: "a", Value: "a"}, {Label: "b", Value: "b"}}
 	layout := modal.Layout{Width: 42, Height: 13, Placement: modal.PlacementCenter}

--- a/model/modal/editor_test.go
+++ b/model/modal/editor_test.go
@@ -1,0 +1,588 @@
+package modal_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/approachcontrol/approach/model/modal"
+)
+
+func newEditor(initial string, spec modal.EditorSpec, submit func(string) tea.Cmd) modal.Modal {
+	return modal.OpenRawMultiLineInput("Edit Plan launch", "prompt template", initial, nil, submit).AsEditor(spec)
+}
+
+func TestAsEditorSnapshotsSpecInView(t *testing.T) {
+	view := newEditor("alpha\nbeta", modal.EditorSpec{
+		Title:    "Plan launch",
+		Identity: "agent.plan_prompt   custom",
+		Original: "alpha\nbeta",
+		Cursor:   3,
+		Note:     "Saved",
+		NoteKind: modal.NoteSuccess,
+	}, nil).View()
+
+	if view.Kind != modal.Input {
+		t.Fatalf("kind = %v, want Input", view.Kind)
+	}
+	if !view.Editor.Enabled {
+		t.Fatal("expected Editor.Enabled")
+	}
+	if view.Editor.Title != "Plan launch" {
+		t.Fatalf("title = %q", view.Editor.Title)
+	}
+	if view.Editor.Identity != "agent.plan_prompt   custom" {
+		t.Fatalf("identity = %q", view.Editor.Identity)
+	}
+	if view.Editor.Note != "Saved" || view.Editor.NoteKind != modal.NoteSuccess {
+		t.Fatalf("note = %q/%v", view.Editor.Note, view.Editor.NoteKind)
+	}
+	if view.InputCursor != 3 {
+		t.Fatalf("cursor = %d, want 3", view.InputCursor)
+	}
+	if view.Editor.Dirty {
+		t.Fatal("fresh editor should be clean")
+	}
+}
+
+func TestAsEditorClampsSpecCursor(t *testing.T) {
+	view := newEditor("abc", modal.EditorSpec{Original: "abc", Cursor: 99}, nil).View()
+	if view.InputCursor != 3 {
+		t.Fatalf("cursor = %d, want clamped to 3", view.InputCursor)
+	}
+
+	view = newEditor("abc", modal.EditorSpec{Original: "abc", Cursor: -4}, nil).View()
+	if view.InputCursor != 0 {
+		t.Fatalf("cursor = %d, want clamped to 0", view.InputCursor)
+	}
+}
+
+func TestAsEditorOriginalIsIndependentOfInitialValue(t *testing.T) {
+	// The reconstructed-after-failure editor opens with a draft that differs
+	// from the persisted original and must report itself dirty immediately.
+	view := newEditor("draft", modal.EditorSpec{Original: "persisted"}, nil).View()
+
+	if !view.Editor.Dirty {
+		t.Fatal("expected editor reopened with a differing draft to be dirty at open")
+	}
+}
+
+func TestEditorEnterInsertsNewlineAndNeverSubmits(t *testing.T) {
+	submitted := false
+	m := newEditor("ab", modal.EditorSpec{Original: "ab", Cursor: 1}, func(string) tea.Cmd {
+		submitted = true
+		return nil
+	})
+
+	next, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if out != modal.Consumed {
+		t.Fatalf("outcome = %v, want Consumed", out)
+	}
+	if cmd != nil {
+		t.Fatal("enter should not produce a submit command in the editor")
+	}
+	if submitted {
+		t.Fatal("enter must not submit in the editor")
+	}
+	view := next.View()
+	if view.Input != "a\nb" {
+		t.Fatalf("input = %q, want newline inserted at the cursor", view.Input)
+	}
+	if view.InputCursor != 2 {
+		t.Fatalf("cursor = %d, want 2", view.InputCursor)
+	}
+	if !view.Editor.Dirty {
+		t.Fatal("expected editor dirty after mutation")
+	}
+}
+
+func TestEditorCtrlSSubmitsRawValue(t *testing.T) {
+	var submitted string
+	m := newEditor("  raw\n\nvalue  \n", modal.EditorSpec{Original: "  raw\n\nvalue  \n"}, func(input string) tea.Cmd {
+		submitted = input
+		return nil
+	})
+
+	next, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+
+	if out != modal.Accepted {
+		t.Fatalf("outcome = %v, want Accepted", out)
+	}
+	if next.IsOpen() {
+		t.Fatal("expected modal closed after accept")
+	}
+	if cmd == nil {
+		t.Fatal("expected deferred submit command")
+	}
+	cmd()
+	if submitted != "  raw\n\nvalue  \n" {
+		t.Fatalf("submitted = %q, want raw value preserved", submitted)
+	}
+}
+
+func TestEditorCtrlSValidationFailureKeepsModalOpen(t *testing.T) {
+	m := modal.OpenRawMultiLineInput("Edit Plan launch", "prompt template", "bad", func(string) error {
+		return errors.New("nope")
+	}, func(string) tea.Cmd { return nil }).AsEditor(modal.EditorSpec{Original: "bad"})
+
+	next, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+
+	if out != modal.Consumed {
+		t.Fatalf("outcome = %v, want Consumed", out)
+	}
+	if cmd != nil {
+		t.Fatal("expected no submit command on validation failure")
+	}
+	if got := next.View().InputErr; got != "nope" {
+		t.Fatalf("input error = %q, want %q", got, "nope")
+	}
+	if !next.IsOpen() {
+		t.Fatal("expected modal to stay open on validation failure")
+	}
+}
+
+func TestEditorHomeAndEndAreLineAware(t *testing.T) {
+	const value = "alpha\nbeta\ngamma"
+	for _, key := range []tea.KeyType{tea.KeyHome, tea.KeyCtrlA} {
+		m := newEditor(value, modal.EditorSpec{Original: value, Cursor: 8}, nil) // inside "beta"
+		next, _, _ := m.Update(tea.KeyMsg{Type: key})
+		if got := next.View().InputCursor; got != 6 {
+			t.Fatalf("%v cursor = %d, want line start 6", key, got)
+		}
+	}
+	for _, key := range []tea.KeyType{tea.KeyEnd, tea.KeyCtrlE} {
+		m := newEditor(value, modal.EditorSpec{Original: value, Cursor: 8}, nil)
+		next, _, _ := m.Update(tea.KeyMsg{Type: key})
+		if got := next.View().InputCursor; got != 10 {
+			t.Fatalf("%v cursor = %d, want line end 10", key, got)
+		}
+	}
+}
+
+func TestEditorAltEnterStillInsertsNewline(t *testing.T) {
+	m := newEditor("ab", modal.EditorSpec{Original: "ab", Cursor: 2}, nil)
+	next, out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'\n'}, Alt: true})
+	if out != modal.Consumed {
+		t.Fatalf("outcome = %v, want Consumed", out)
+	}
+	if got := next.View().Input; got != "ab\n" {
+		t.Fatalf("input = %q, want alt+enter newline", got)
+	}
+}
+
+func TestEditorEditingKeysAndUnicodeRemainRuneCorrect(t *testing.T) {
+	const value = "héllo wörld"
+	m := newEditor(value, modal.EditorSpec{Original: value, Cursor: 11}, nil)
+
+	next, _, _ := m.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if got := next.View().InputCursor; got != 10 {
+		t.Fatalf("left cursor = %d, want 10", got)
+	}
+
+	next, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if got := next.View().Input; got != "héllo wörl" {
+		t.Fatalf("backspace input = %q", got)
+	}
+
+	next, _, _ = newEditor(value, modal.EditorSpec{Original: value, Cursor: 1}, nil).Update(tea.KeyMsg{Type: tea.KeyDelete})
+	if got := next.View().Input; got != "hllo wörld" {
+		t.Fatalf("delete input = %q", got)
+	}
+
+	next, _, _ = newEditor(value, modal.EditorSpec{Original: value, Cursor: 5}, nil).
+		Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("日本\nテキスト")})
+	if got := next.View().Input; got != "héllo日本\nテキスト wörld" {
+		t.Fatalf("paste input = %q", got)
+	}
+	if got := next.View().InputCursor; got != 12 {
+		t.Fatalf("paste cursor = %d, want 12", got)
+	}
+}
+
+func TestEditorCtrlUClearsBufferAndRaisesEmptyWarning(t *testing.T) {
+	m := newEditor("custom", modal.EditorSpec{Original: "custom", Note: "boom", NoteKind: modal.NoteError}, nil)
+
+	next, _, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+
+	view := next.View()
+	if view.Input != "" {
+		t.Fatalf("input = %q, want cleared", view.Input)
+	}
+	if !view.Editor.EmptyWarning {
+		t.Fatal("expected empty-buffer warning after ctrl+u")
+	}
+	if !view.Editor.Dirty {
+		t.Fatal("expected dirty after ctrl+u")
+	}
+}
+
+func TestEditorEmptyWarningTracksBufferAndOriginal(t *testing.T) {
+	cases := []struct {
+		name     string
+		initial  string
+		original string
+		want     bool
+	}{
+		{"blank buffer over custom original", "", "custom", true},
+		{"whitespace buffer over custom original", "  \n\t ", "custom", true},
+		{"blank buffer over default original", "", "", false},
+		{"non-empty buffer", "x", "custom", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			view := newEditor(tc.initial, modal.EditorSpec{Original: tc.original}, nil).View()
+			if view.Editor.EmptyWarning != tc.want {
+				t.Fatalf("EmptyWarning = %v, want %v", view.Editor.EmptyWarning, tc.want)
+			}
+		})
+	}
+}
+
+func TestEditorDirtyTracksValueAgainstOriginal(t *testing.T) {
+	m := newEditor("abc", modal.EditorSpec{Original: "abc", Cursor: 3}, nil)
+	if m.View().Editor.Dirty {
+		t.Fatal("expected clean at open")
+	}
+
+	m, _, _ = m.Update(keyRunes("d"))
+	if !m.View().Editor.Dirty {
+		t.Fatal("expected dirty after typing")
+	}
+
+	m, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if m.View().Editor.Dirty {
+		t.Fatal("expected clean again once the value matches the original")
+	}
+}
+
+func TestNonEditorInputIsNeverDirtyOrWarning(t *testing.T) {
+	view := modal.OpenRawMultiLineInput("Template", "prompt template", "content", nil, nil).View()
+	if view.Editor.Enabled || view.Editor.Dirty || view.Editor.EmptyWarning {
+		t.Fatalf("non-editor input leaked editor state: %#v", view.Editor)
+	}
+
+	empty := modal.OpenSingleLineInput("New branch", "branch name", "", nil, nil).View()
+	if empty.Editor.Dirty || empty.Editor.EmptyWarning {
+		t.Fatalf("non-editor empty input leaked editor state: %#v", empty.Editor)
+	}
+}
+
+func TestEditorNoteIsClearedByOrdinaryTypingButWarningSurvives(t *testing.T) {
+	m := newEditor("", modal.EditorSpec{Original: "custom", Note: "permission denied", NoteKind: modal.NoteError}, nil)
+	if got := m.View().Editor.Note; got != "permission denied" {
+		t.Fatalf("note = %q, want stored", got)
+	}
+	if !m.View().Editor.EmptyWarning {
+		t.Fatal("expected empty warning while buffer is blank")
+	}
+
+	next, _, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	if got := next.View().Editor.Note; got != "" {
+		t.Fatalf("note after space = %q, want cleared", got)
+	}
+	if !next.View().Editor.EmptyWarning {
+		t.Fatal("whitespace-only buffer should keep the derived empty warning")
+	}
+
+	next, _, _ = m.Update(keyRunes("x"))
+	if got := next.View().Editor.Note; got != "" {
+		t.Fatalf("note after rune = %q, want cleared", got)
+	}
+	if next.View().Editor.EmptyWarning {
+		t.Fatal("non-empty buffer should not warn")
+	}
+}
+
+func TestPlainRawMultiLineInputStillSubmitsOnEnter(t *testing.T) {
+	var submitted string
+	m := modal.OpenRawMultiLineInput("Template", "prompt template", " raw ", nil, func(input string) tea.Cmd {
+		submitted = input
+		return nil
+	})
+
+	_, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if out != modal.Accepted {
+		t.Fatalf("outcome = %v, want Accepted", out)
+	}
+	if cmd == nil {
+		t.Fatal("expected submit command")
+	}
+	cmd()
+	if submitted != " raw " {
+		t.Fatalf("submitted = %q", submitted)
+	}
+}
+
+func TestNonEditorInputIgnoresCtrlSAndKeepsBufferHomeEnd(t *testing.T) {
+	m := modal.OpenRawMultiLineInput("Template", "prompt template", "alpha\nbeta", nil, func(string) tea.Cmd {
+		return func() tea.Msg { return sentinelMsg("submitted") }
+	})
+
+	next, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	if out != modal.Consumed {
+		t.Fatalf("ctrl+s outcome = %v, want Consumed", out)
+	}
+	if cmd != nil {
+		t.Fatal("ctrl+s should not submit a non-editor input")
+	}
+	if got := next.View().Input; got != "alpha\nbeta" {
+		t.Fatalf("ctrl+s mutated the buffer: %q", got)
+	}
+
+	next, _, _ = m.Update(tea.KeyMsg{Type: tea.KeyHome})
+	if got := next.View().InputCursor; got != 0 {
+		t.Fatalf("non-editor home cursor = %d, want buffer start 0", got)
+	}
+}
+
+func TestWithCancelReceivesPreCancelViewForEachKind(t *testing.T) {
+	t.Run("dirty editor cancel", func(t *testing.T) {
+		var got modal.View
+		m := newEditor("abc", modal.EditorSpec{Title: "Plan launch", Original: "abc", Cursor: 3}, nil).
+			WithCancel(func(view modal.View) tea.Cmd {
+				got = view
+				return func() tea.Msg { return sentinelMsg("cancelled") }
+			})
+		m, _, _ = m.Update(keyRunes("d"))
+
+		next, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+		if out != modal.Cancelled {
+			t.Fatalf("outcome = %v, want Cancelled", out)
+		}
+		if next.IsOpen() {
+			t.Fatal("expected modal closed")
+		}
+		if cmd == nil {
+			t.Fatal("expected cancel command")
+		}
+		if got.Kind != modal.None {
+			t.Fatal("cancel hook should be deferred, not run during Update")
+		}
+		if msg := cmd(); msg != sentinelMsg("cancelled") {
+			t.Fatalf("cancel msg = %#v", msg)
+		}
+		if !got.Editor.Dirty {
+			t.Fatal("cancel hook should observe the dirty editor")
+		}
+		if got.Editor.Title != "Plan launch" {
+			t.Fatalf("cancel hook title = %q", got.Editor.Title)
+		}
+		if got.Input != "abcd" {
+			t.Fatalf("cancel hook input = %q, want the live draft", got.Input)
+		}
+	})
+
+	t.Run("clean editor cancel", func(t *testing.T) {
+		var got modal.View
+		m := newEditor("abc", modal.EditorSpec{Original: "abc"}, nil).
+			WithCancel(func(view modal.View) tea.Cmd {
+				got = view
+				return nil
+			})
+		_, out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+		if out != modal.Cancelled {
+			t.Fatalf("outcome = %v, want Cancelled", out)
+		}
+		if cmd == nil {
+			t.Fatal("expected cancel command")
+		}
+		cmd()
+		if !got.Editor.Enabled {
+			t.Fatal("cancel hook should observe the editor view")
+		}
+		if got.Editor.Dirty {
+			t.Fatal("clean cancel should report a clean editor")
+		}
+	})
+
+	t.Run("confirm", func(t *testing.T) {
+		for _, key := range []string{"n", "q", "esc"} {
+			fired := 0
+			m := modal.OpenConfirm("Reset?", nil).WithCancel(func(modal.View) tea.Cmd {
+				fired++
+				return func() tea.Msg { return sentinelMsg("cancelled") }
+			})
+			_, out, cmd := m.Update(keyOf(key))
+			if out != modal.Cancelled {
+				t.Fatalf("%s outcome = %v, want Cancelled", key, out)
+			}
+			if cmd == nil || fired != 0 {
+				t.Fatalf("%s: expected a deferred cancel command", key)
+			}
+			cmd()
+			if fired != 1 {
+				t.Fatalf("%s: cancel hook fired %d times", key, fired)
+			}
+		}
+	})
+
+	t.Run("select", func(t *testing.T) {
+		for _, key := range []string{"esc", "ctrl+c"} {
+			var got modal.View
+			m := modal.OpenSelect("Prompt templates", []modal.SelectItem{{Label: "a", Value: "a"}}, 0, nil).
+				WithCancel(func(view modal.View) tea.Cmd {
+					got = view
+					return nil
+				})
+			_, out, cmd := m.Update(keyOf(key))
+			if out != modal.Cancelled {
+				t.Fatalf("%s outcome = %v, want Cancelled", key, out)
+			}
+			if cmd == nil {
+				t.Fatalf("%s: expected cancel command", key)
+			}
+			cmd()
+			if got.Kind != modal.Select {
+				t.Fatalf("%s: cancel hook saw kind %v", key, got.Kind)
+			}
+		}
+	})
+
+	t.Run("text", func(t *testing.T) {
+		for _, key := range []string{"q", "esc"} {
+			var got modal.View
+			m := modal.OpenText("preview body").WithCancel(func(view modal.View) tea.Cmd {
+				got = view
+				return nil
+			})
+			_, out, cmd := m.Update(keyOf(key))
+			if out != modal.Cancelled {
+				t.Fatalf("%s outcome = %v, want Cancelled", key, out)
+			}
+			if cmd == nil {
+				t.Fatalf("%s: expected cancel command", key)
+			}
+			cmd()
+			if got.Text != "preview body" {
+				t.Fatalf("%s: cancel hook text = %q", key, got.Text)
+			}
+		}
+	})
+}
+
+func TestCancelWithoutHookReturnsNilCommandForEveryKind(t *testing.T) {
+	cases := []struct {
+		name  string
+		modal modal.Modal
+		key   string
+	}{
+		{"confirm", modal.OpenConfirm("Delete?", nil), "esc"},
+		{"input", modal.OpenSingleLineInput("New branch", "branch name", "", nil, nil), "esc"},
+		{"multiline input", modal.OpenMultiLineInput("Launch instructions", "instructions", "", nil, nil), "ctrl+c"},
+		{"editor", newEditor("a", modal.EditorSpec{Original: "a"}, nil), "esc"},
+		{"select", modal.OpenSelect("Choose", []modal.SelectItem{{Value: "a"}}, 0, nil), "esc"},
+		{"text", modal.OpenText("body"), "q"},
+		{"diff", modal.OpenDiff(modal.DiffStash, "body"), "esc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, out, cmd := tc.modal.Update(keyOf(tc.key))
+			if out != modal.Cancelled {
+				t.Fatalf("outcome = %v, want Cancelled", out)
+			}
+			if cmd != nil {
+				t.Fatal("expected nil cmd when no cancel hook is set")
+			}
+		})
+	}
+}
+
+func TestDiffCancelIgnoresCancelHook(t *testing.T) {
+	fired := false
+	m := modal.OpenDiff(modal.DiffStash, "body").WithCancel(func(modal.View) tea.Cmd {
+		fired = true
+		return func() tea.Msg { return sentinelMsg("cancelled") }
+	})
+
+	_, out, cmd := m.Update(keyOf("esc"))
+	if out != modal.Cancelled {
+		t.Fatalf("outcome = %v, want Cancelled", out)
+	}
+	if cmd != nil || fired {
+		t.Fatal("diff overlays should not use the cancel hook")
+	}
+}
+
+func TestSetSelectNoteCarriesFeedbackWithoutDisturbingSelection(t *testing.T) {
+	items := []modal.SelectItem{{Label: "a", Value: "a"}, {Label: "b", Value: "b"}}
+	layout := modal.Layout{Width: 42, Height: 13, Placement: modal.PlacementCenter}
+	m := modal.OpenSelectWithLayout("Prompt templates", items, 1, layout, nil).
+		SetSelectNote("Saved Plan launch", modal.NoteSuccess)
+
+	view := m.View()
+	if view.SelectNote != "Saved Plan launch" || view.SelectNoteKind != modal.NoteSuccess {
+		t.Fatalf("select note = %q/%v", view.SelectNote, view.SelectNoteKind)
+	}
+	if view.SelectIndex != 1 {
+		t.Fatalf("select index = %d, want 1 preserved", view.SelectIndex)
+	}
+	if view.SelectLayout != layout {
+		t.Fatalf("layout = %#v, want %#v", view.SelectLayout, layout)
+	}
+	if len(view.SelectItems) != 2 {
+		t.Fatalf("items = %#v", view.SelectItems)
+	}
+
+	if got := m.SetSelectNote("", modal.NoteNeutral).View().SelectNote; got != "" {
+		t.Fatalf("cleared note = %q", got)
+	}
+}
+
+func TestSetSelectNoteIsInertForNonSelectModals(t *testing.T) {
+	view := modal.OpenSingleLineInput("New branch", "branch name", "", nil, nil).
+		SetSelectNote("nope", modal.NoteError).
+		View()
+	if view.SelectNote != "" {
+		t.Fatalf("select note leaked onto an input modal: %q", view.SelectNote)
+	}
+}
+
+func TestSelectNoteIsClearedByConsumedKeys(t *testing.T) {
+	items := []modal.SelectItem{{Label: "a", Value: "a"}, {Label: "b", Value: "b"}}
+	for _, key := range []string{"down", "up", "j", "k", "x"} {
+		m := modal.OpenSelect("Prompt templates", items, 0, nil).
+			SetSelectNote("Saved", modal.NoteSuccess)
+		next, out, _ := m.Update(keyOf(key))
+		if out != modal.Consumed {
+			t.Fatalf("%s outcome = %v, want Consumed", key, out)
+		}
+		if got := next.View().SelectNote; got != "" {
+			t.Fatalf("%s left the note in place: %q", key, got)
+		}
+	}
+}
+
+func TestNonEditorViewsAreUnchangedByTheEditorFields(t *testing.T) {
+	confirm := modal.OpenConfirm("Delete?", nil).View()
+	if confirm.Editor.Enabled || confirm.SelectNote != "" {
+		t.Fatalf("confirm view leaked editor state: %#v", confirm)
+	}
+	form := modal.OpenForm(modal.FormSpec{Title: "Create", Fields: []modal.FormField{{ID: "a", Label: "A"}}}).View()
+	if form.Editor.Enabled || form.SelectNote != "" {
+		t.Fatalf("form view leaked editor state: %#v", form)
+	}
+	if strings.TrimSpace(form.Form.Title) != "Create" {
+		t.Fatalf("form title = %q", form.Form.Title)
+	}
+}
+
+func keyOf(key string) tea.KeyMsg {
+	switch key {
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "ctrl+c":
+		return tea.KeyMsg{Type: tea.KeyCtrlC}
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	default:
+		return keyRunes(key)
+	}
+}

--- a/model/modal/editor_test.go
+++ b/model/modal/editor_test.go
@@ -164,7 +164,7 @@ func TestEditorHomeAndEndAreLineAware(t *testing.T) {
 
 func TestEditorAltEnterStillInsertsNewline(t *testing.T) {
 	m := newEditor("ab", modal.EditorSpec{Original: "ab", Cursor: 2}, nil)
-	next, out, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'\n'}, Alt: true})
+	next, out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter, Alt: true})
 	if out != modal.Consumed {
 		t.Fatalf("outcome = %v, want Consumed", out)
 	}

--- a/model/modal/modal.go
+++ b/model/modal/modal.go
@@ -85,6 +85,8 @@ type EditorSpec struct {
 	// deliberately independent of the modal's initial value so an editor
 	// reconstructed after a failed save opens already dirty.
 	Original string
+	// Cursor is the rune offset to restore. Zero is buffer start, not "keep
+	// the Open* end cursor"; callers that want the end must pass it.
 	Cursor   int
 	Note     string
 	NoteKind NoteKind

--- a/model/modal/modal.go
+++ b/model/modal/modal.go
@@ -64,6 +64,43 @@ const (
 	InputMultiLine
 )
 
+// NoteKind classifies the severity of a modal feedback note. It is the
+// canonical enum; the ui package declares a parallel type because it imports
+// no modal.
+type NoteKind int
+
+const (
+	NoteNeutral NoteKind = iota
+	NoteSuccess
+	NoteWarning
+	NoteError
+)
+
+// EditorSpec opts an Input modal into the richer prompt-editor behavior. Every
+// field is inert for callers that never call AsEditor.
+type EditorSpec struct {
+	Title    string
+	Identity string
+	// Original is the persisted value the draft is compared against. It is
+	// deliberately independent of the modal's initial value so an editor
+	// reconstructed after a failed save opens already dirty.
+	Original string
+	Cursor   int
+	Note     string
+	NoteKind NoteKind
+}
+
+// EditorView is the read-only projection of prompt-editor state.
+type EditorView struct {
+	Enabled      bool
+	Title        string
+	Identity     string
+	Note         string
+	NoteKind     NoteKind
+	Dirty        bool
+	EmptyWarning bool
+}
+
 type FormFieldKind int
 
 const (
@@ -110,56 +147,68 @@ type FormView struct {
 // Modal is the single in-process state machine for transient modal UI. Its
 // zero value is closed.
 type Modal struct {
-	kind         Kind
-	prompt       string
-	placeholder  string
-	force        bool
-	action       func() tea.Cmd
-	input        string
-	inputMode    InputMode
-	inputRaw     bool
-	inputHeight  int
-	inputCursor  int
-	inputColumn  int
-	inputErr     string
-	validate     func(string) error
-	submit       func(string) tea.Cmd
-	selectItems  []SelectItem
-	selectIndex  int
-	selectLayout Layout
-	formPurpose  string
-	formTitle    string
-	formFields   []FormField
-	formFocus    int
-	formErr      string
-	formValidate func(FormValues) error
-	formSubmit   func(FormValues) tea.Cmd
-	diffKind     DiffKind
-	diff         string
-	text         string
-	scroll       int
-	request      uint64
+	kind           Kind
+	prompt         string
+	placeholder    string
+	force          bool
+	action         func() tea.Cmd
+	input          string
+	inputMode      InputMode
+	inputRaw       bool
+	inputHeight    int
+	inputCursor    int
+	inputColumn    int
+	inputErr       string
+	inputOriginal  string
+	editor         bool
+	editorTitle    string
+	editorIdentity string
+	editorNote     string
+	editorNoteKind NoteKind
+	validate       func(string) error
+	submit         func(string) tea.Cmd
+	cancel         func(View) tea.Cmd
+	selectItems    []SelectItem
+	selectIndex    int
+	selectLayout   Layout
+	selectNote     string
+	selectNoteKind NoteKind
+	formPurpose    string
+	formTitle      string
+	formFields     []FormField
+	formFocus      int
+	formErr        string
+	formValidate   func(FormValues) error
+	formSubmit     func(FormValues) tea.Cmd
+	diffKind       DiffKind
+	diff           string
+	text           string
+	scroll         int
+	request        uint64
 }
 
 type View struct {
-	Kind         Kind
-	Prompt       string
-	Placeholder  string
-	Force        bool
-	Input        string
-	InputMode    InputMode
-	InputHeight  int
-	InputCursor  int
-	InputErr     string
-	SelectItems  []SelectItem
-	SelectIndex  int
-	SelectLayout Layout
-	Form         FormView
-	DiffKind     DiffKind
-	Diff         string
-	Text         string
-	Scroll       int
-	Request      uint64
+	Kind           Kind
+	Prompt         string
+	Placeholder    string
+	Force          bool
+	Input          string
+	InputMode      InputMode
+	InputHeight    int
+	InputCursor    int
+	InputErr       string
+	Editor         EditorView
+	SelectItems    []SelectItem
+	SelectIndex    int
+	SelectLayout   Layout
+	SelectNote     string
+	SelectNoteKind NoteKind
+	Form           FormView
+	DiffKind       DiffKind
+	Diff           string
+	Text           string
+	Scroll         int
+	Request        uint64
 }
 
 func OpenConfirm(prompt string, action func() tea.Cmd) Modal {
@@ -205,6 +254,43 @@ func OpenMultiLineInput(prompt, placeholder, initial string, validate func(strin
 func OpenRawMultiLineInput(prompt, placeholder, initial string, validate func(string) error, submit func(string) tea.Cmd) Modal {
 	m := OpenMultiLineInput(prompt, placeholder, initial, validate, submit)
 	m.inputRaw = true
+	return m
+}
+
+// AsEditor opts an Input modal into prompt-editor behavior: enter inserts a
+// newline, ctrl+s submits, home/end are line-aware, and the view exposes
+// title, identity, dirty state, and a feedback note.
+func (m Modal) AsEditor(spec EditorSpec) Modal {
+	if m.kind != Input {
+		return m
+	}
+	m.editor = true
+	m.editorTitle = spec.Title
+	m.editorIdentity = spec.Identity
+	m.editorNote = spec.Note
+	m.editorNoteKind = spec.NoteKind
+	m.inputOriginal = spec.Original
+	m.inputCursor = clampInputCursor(m.input, spec.Cursor)
+	m.inputColumn = -1
+	return m
+}
+
+// WithCancel registers a hook invoked when the modal is cancelled. It receives
+// the view captured immediately before the modal is zeroed, so it can observe
+// runtime state such as editor dirtiness.
+func (m Modal) WithCancel(cancel func(View) tea.Cmd) Modal {
+	m.cancel = cancel
+	return m
+}
+
+// SetSelectNote sets (or, with an empty note, clears) the reserved feedback
+// row on a select modal without disturbing its selection or layout.
+func (m Modal) SetSelectNote(note string, kind NoteKind) Modal {
+	if m.kind != Select {
+		return m
+	}
+	m.selectNote = note
+	m.selectNoteKind = kind
 	return m
 }
 
@@ -305,18 +391,21 @@ func (m Modal) IsOpen() bool {
 
 func (m Modal) View() View {
 	return View{
-		Kind:         m.kind,
-		Prompt:       m.prompt,
-		Placeholder:  m.placeholder,
-		Force:        m.force,
-		Input:        m.input,
-		InputMode:    m.inputMode,
-		InputHeight:  m.inputHeight,
-		InputCursor:  clampInputCursor(m.input, m.inputCursor),
-		InputErr:     m.inputErr,
-		SelectItems:  append([]SelectItem(nil), m.selectItems...),
-		SelectIndex:  m.selectIndex,
-		SelectLayout: m.selectLayout,
+		Kind:           m.kind,
+		Prompt:         m.prompt,
+		Placeholder:    m.placeholder,
+		Force:          m.force,
+		Input:          m.input,
+		InputMode:      m.inputMode,
+		InputHeight:    m.inputHeight,
+		InputCursor:    clampInputCursor(m.input, m.inputCursor),
+		InputErr:       m.inputErr,
+		Editor:         m.editorView(),
+		SelectItems:    append([]SelectItem(nil), m.selectItems...),
+		SelectIndex:    m.selectIndex,
+		SelectLayout:   m.selectLayout,
+		SelectNote:     m.selectNote,
+		SelectNoteKind: m.selectNoteKind,
 		Form: FormView{
 			Purpose:    m.formPurpose,
 			Title:      m.formTitle,
@@ -329,6 +418,24 @@ func (m Modal) View() View {
 		Text:     m.text,
 		Scroll:   m.scroll,
 		Request:  m.request,
+	}
+}
+
+// editorView derives the editor projection. Dirty and EmptyWarning are
+// computed only for editors so a plain Input never reports state it does not
+// track.
+func (m Modal) editorView() EditorView {
+	if !m.editor {
+		return EditorView{}
+	}
+	return EditorView{
+		Enabled:      true,
+		Title:        m.editorTitle,
+		Identity:     m.editorIdentity,
+		Note:         m.editorNote,
+		NoteKind:     m.editorNoteKind,
+		Dirty:        m.input != m.inputOriginal,
+		EmptyWarning: strings.TrimSpace(m.input) == "" && m.inputOriginal != "",
 	}
 }
 
@@ -402,7 +509,7 @@ func (m Modal) updateConfirm(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 		}
 		return Modal{}, Accepted, cmd
 	case "n", "q", "esc":
-		return Modal{}, Cancelled, nil
+		return Modal{}, Cancelled, deferCancel(m.cancel, m.View())
 	default:
 		return m, Consumed, nil
 	}
@@ -415,36 +522,33 @@ func (m Modal) updateInput(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 		if m.inputMode == InputMultiLine {
 			m.input, m.inputCursor = insertRunes(m.input, m.inputCursor, []rune{'\n'})
 			m.inputColumn = -1
-			m.inputErr = ""
+			m.clearInputFeedback()
 		}
 		return m, Consumed, nil
 	case "enter":
-		input := m.input
-		if !m.inputRaw {
-			input = strings.TrimSpace(input)
+		if m.editor {
+			m.input, m.inputCursor = insertRunes(m.input, m.inputCursor, []rune{'\n'})
+			m.inputColumn = -1
+			m.clearInputFeedback()
+			return m, Consumed, nil
 		}
-		if m.validate != nil {
-			if err := m.validate(input); err != nil {
-				m.inputErr = err.Error()
-				return m, Consumed, nil
-			}
+		return m.submitInput()
+	case "ctrl+s":
+		if !m.editor {
+			return m, Consumed, nil
 		}
-		cmd := deferSubmit(m.submit, input)
-		if cmd == nil {
-			return Modal{}, Accepted, nil
-		}
-		return Modal{}, Accepted, cmd
+		return m.submitInput()
 	case "esc", "ctrl+c":
-		return Modal{}, Cancelled, nil
+		return Modal{}, Cancelled, deferCancel(m.cancel, m.View())
 	case "backspace", "ctrl+h":
 		m.input, m.inputCursor = deleteRuneBefore(m.input, m.inputCursor)
 		m.inputColumn = -1
-		m.inputErr = ""
+		m.clearInputFeedback()
 		return m, Consumed, nil
 	case "delete":
 		m.input, m.inputCursor = deleteRuneAt(m.input, m.inputCursor)
 		m.inputColumn = -1
-		m.inputErr = ""
+		m.clearInputFeedback()
 		return m, Consumed, nil
 	case "left":
 		if m.inputCursor > 0 {
@@ -469,34 +573,88 @@ func (m Modal) updateInput(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 		}
 		return m, Consumed, nil
 	case "home", "ctrl+a":
-		m.inputCursor = 0
+		if m.editor {
+			m.inputCursor = editorLineStart(m.input, m.inputCursor)
+		} else {
+			m.inputCursor = 0
+		}
 		m.inputColumn = -1
 		return m, Consumed, nil
 	case "end", "ctrl+e":
-		m.inputCursor = inputLength(m.input)
+		if m.editor {
+			m.inputCursor = editorLineEnd(m.input, m.inputCursor)
+		} else {
+			m.inputCursor = inputLength(m.input)
+		}
 		m.inputColumn = -1
 		return m, Consumed, nil
 	case "ctrl+u":
 		m.input = ""
 		m.inputCursor = 0
 		m.inputColumn = -1
-		m.inputErr = ""
+		m.clearInputFeedback()
 		return m, Consumed, nil
 	default:
 		if msg.Type == tea.KeySpace {
 			m.input, m.inputCursor = insertRunes(m.input, m.inputCursor, []rune{' '})
 			m.inputColumn = -1
-			m.inputErr = ""
+			m.clearInputFeedback()
 			return m, Consumed, nil
 		}
 		if msg.Type == tea.KeyRunes {
 			m.input, m.inputCursor = insertRunes(m.input, m.inputCursor, msg.Runes)
 			m.inputColumn = -1
-			m.inputErr = ""
+			m.clearInputFeedback()
 			return m, Consumed, nil
 		}
 		return m, Consumed, nil
 	}
+}
+
+// submitInput runs the shared validate-then-submit sequence for both the
+// generic enter binding and the editor's ctrl+s binding.
+func (m Modal) submitInput() (Modal, Outcome, tea.Cmd) {
+	input := m.input
+	if !m.inputRaw {
+		input = strings.TrimSpace(input)
+	}
+	if m.validate != nil {
+		if err := m.validate(input); err != nil {
+			m.inputErr = err.Error()
+			return m, Consumed, nil
+		}
+	}
+	cmd := deferSubmit(m.submit, input)
+	if cmd == nil {
+		return Modal{}, Accepted, nil
+	}
+	return Modal{}, Accepted, cmd
+}
+
+// clearInputFeedback drops the validation error and any stored editor note on
+// every buffer mutation, so a stale persistence error never sits under a
+// retry the user is already typing. The empty-buffer warning is derived rather
+// than stored precisely so it survives here.
+func (m *Modal) clearInputFeedback() {
+	m.inputErr = ""
+	m.editorNote = ""
+	m.editorNoteKind = NoteNeutral
+}
+
+func editorLineStart(input string, cursor int) int {
+	runes := []rune(input)
+	cursor = clampInputCursor(input, cursor)
+	starts := lineStarts(runes)
+	line, _ := lineColumn(runes, starts, cursor)
+	return starts[line]
+}
+
+func editorLineEnd(input string, cursor int) int {
+	runes := []rune(input)
+	cursor = clampInputCursor(input, cursor)
+	starts := lineStarts(runes)
+	line, _ := lineColumn(runes, starts, cursor)
+	return starts[line] + lineLength(runes, starts, line)
 }
 
 func inputLength(input string) int {
@@ -637,16 +795,26 @@ func (m Modal) updateSelect(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 		}
 		return Modal{}, Accepted, cmd
 	case "esc", "ctrl+c":
-		return Modal{}, Cancelled, nil
+		return Modal{}, Cancelled, deferCancel(m.cancel, m.View())
 	case "down", "j":
 		m.selectIndex = nextSelectIndex(m.selectIndex, len(m.selectItems))
+		m.clearSelectNote()
 		return m, Consumed, nil
 	case "up", "k":
 		m.selectIndex = previousSelectIndex(m.selectIndex, len(m.selectItems))
+		m.clearSelectNote()
 		return m, Consumed, nil
 	default:
+		m.clearSelectNote()
 		return m, Consumed, nil
 	}
+}
+
+// clearSelectNote makes picker feedback transient: the first key the select
+// consumes after a save, cancel, or reset clears it.
+func (m *Modal) clearSelectNote() {
+	m.selectNote = ""
+	m.selectNoteKind = NoteNeutral
 }
 
 func (m Modal) updateForm(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
@@ -835,6 +1003,21 @@ func deferAction(action func() tea.Cmd) tea.Cmd {
 	}
 }
 
+// deferCancel returns nil when no hook is registered, so every modal that does
+// not opt in keeps returning a nil command on cancel.
+func deferCancel(cancel func(View) tea.Cmd, view View) tea.Cmd {
+	if cancel == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		cmd := cancel(view)
+		if cmd == nil {
+			return nil
+		}
+		return cmd()
+	}
+}
+
 func deferSubmit(submit func(string) tea.Cmd, input string) tea.Cmd {
 	if submit == nil {
 		return nil
@@ -883,7 +1066,7 @@ func (m Modal) updateDiff(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 func (m Modal) updateText(msg tea.KeyMsg) (Modal, Outcome, tea.Cmd) {
 	switch msg.String() {
 	case "q", "esc":
-		return Modal{}, Cancelled, nil
+		return Modal{}, Cancelled, deferCancel(m.cancel, m.View())
 	case "up", "k":
 		if m.scroll > 0 {
 			m.scroll--

--- a/model/model.go
+++ b/model/model.go
@@ -1444,6 +1444,7 @@ func (m Model) View() string {
 		InputMode:                      uiInputMode(modalView.InputMode),
 		InputHeight:                    modalView.InputHeight,
 		InputCursor:                    modalView.InputCursor,
+		Editor:                         uiEditorParams(modalView.Editor),
 		WorktreeInputPrompt:            modalView.Prompt,
 		WorktreeInputPlaceholder:       modalView.Placeholder,
 		WorktreeInput:                  modalView.Input,
@@ -1453,6 +1454,8 @@ func (m Model) View() string {
 		SelectSelected:                 modalView.SelectIndex,
 		SelectWidth:                    modalView.SelectLayout.Width,
 		SelectHeight:                   modalView.SelectLayout.Height,
+		SelectNote:                     modalView.SelectNote,
+		SelectNoteKind:                 uiNoteKind(modalView.SelectNoteKind),
 		SelectPlacement:                uiSelectPlacement(modalView.SelectLayout.Placement),
 		Form:                           uiFormView(modalView.Form),
 		BranchScroll:                   branchScroll,
@@ -1797,6 +1800,33 @@ func uiInputMode(mode modal.InputMode) ui.InputMode {
 		return ui.InputMultiLine
 	}
 	return ui.InputSingleLine
+}
+
+// uiEditorParams and uiNoteKind are the single conversion point between the
+// canonical modal enums and ui's parallel declarations.
+func uiEditorParams(editor modal.EditorView) ui.EditorParams {
+	return ui.EditorParams{
+		Enabled:      editor.Enabled,
+		Title:        editor.Title,
+		Identity:     editor.Identity,
+		Note:         editor.Note,
+		NoteKind:     uiNoteKind(editor.NoteKind),
+		Dirty:        editor.Dirty,
+		EmptyWarning: editor.EmptyWarning,
+	}
+}
+
+func uiNoteKind(kind modal.NoteKind) ui.NoteKind {
+	switch kind {
+	case modal.NoteSuccess:
+		return ui.NoteSuccess
+	case modal.NoteWarning:
+		return ui.NoteWarning
+	case modal.NoteError:
+		return ui.NoteError
+	default:
+		return ui.NoteNeutral
+	}
 }
 
 func uiSelectPlacement(placement modal.Placement) ui.SelectPlacement {
@@ -2207,6 +2237,8 @@ func (m Model) Update(msg tea.Msg) (next tea.Model, cmd tea.Cmd) {
 		return m.handleFlowPhaseAgentSettingsSetFailed(msg), nil
 	case promptTemplateEditRequestedMsg:
 		return m.handlePromptTemplateEditRequested(msg), nil
+	case promptTemplatePickerReturnMsg:
+		return m.handlePromptTemplatePickerReturn(msg), nil
 	case PromptTemplateSavedMsg:
 		return m.handlePromptTemplateSaved(msg), nil
 	case PromptTemplateSaveFailedMsg:

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -4021,6 +4021,35 @@ func TestModel_PromptTemplateEditorOriginResetFailureReconstructsTheEditor(t *te
 	}
 }
 
+func TestModel_PromptTemplateEditorOriginResetFailureKeepsTheCursor(t *testing.T) {
+	m := newTestModel(testRepos(), model.Options{
+		PlanPromptTemplate:  "custom plan",
+		ResetPromptTemplate: func(string, string) error { return errors.New("read-only config") },
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, cmd())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlU})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("   ")})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyHome})
+	if got := m.InputCursor(); got != 0 {
+		t.Fatalf("cursor before submit = %d, want 0", got)
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd == nil {
+		t.Fatal("expected a reset command from a whitespace-only save")
+	}
+	m, _ = update(m, cmd())
+
+	// A failed write keeps the draft and cursor, so a retry resumes where the
+	// user left off instead of jumping to the end of the buffer.
+	if got := m.InputCursor(); got != 0 {
+		t.Fatalf("cursor after a failed editor-origin reset = %d, want the pre-submit 0", got)
+	}
+}
+
 func TestModel_PromptTemplateSaveRetryAfterFailureSucceeds(t *testing.T) {
 	attempts := 0
 	var savedValue string

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/creack/pty"
 
@@ -3562,7 +3563,8 @@ func TestModel_PromptTemplateEditSavesRawValueAndReopensPicker(t *testing.T) {
 		t.Fatalf("editor initial input = %q, want raw template", got)
 	}
 
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	// enter now inserts a newline in the editor; ctrl+s is the save key.
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyCtrlS})
 	if cmd == nil {
 		t.Fatal("expected save prompt template command")
 	}
@@ -3574,12 +3576,142 @@ func TestModel_PromptTemplateEditSavesRawValueAndReopensPicker(t *testing.T) {
 	if m.Overlay() != ui.OverlaySelect {
 		t.Fatalf("overlay = %v, want picker reopened", m.Overlay())
 	}
-	if !strings.Contains(m.View(), "Plan launch") || !strings.Contains(m.View(), "custom") {
-		t.Fatalf("expected refreshed picker with custom status:\n%s", m.View())
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Plan launch") || !strings.Contains(view, "custom") {
+		t.Fatalf("expected refreshed picker with custom status:\n%s", view)
+	}
+	if !strings.Contains(view, "Saved Plan launch") {
+		t.Fatalf("expected the picker to report which template was saved:\n%s", view)
 	}
 }
 
-func TestModel_PromptTemplateEditUsesTallEditor(t *testing.T) {
+func TestModel_PromptTemplateEditorEnterInsertsNewlineInsteadOfSaving(t *testing.T) {
+	saves := 0
+	m := newTestModel(testRepos(), model.Options{
+		PlanPromptTemplate: "one",
+		SavePromptTemplate: func(string, string, string) error {
+			saves++
+			return nil
+		},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, cmd())
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("editor enter returned cmd %T, want nil", cmd)
+	}
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("two")})
+	if got := m.WorktreeInput(); got != "one\ntwo" {
+		t.Fatalf("editor buffer = %q, want a newline inserted by enter", got)
+	}
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("overlay = %v, want the editor still open", m.Overlay())
+	}
+	if saves != 0 {
+		t.Fatalf("enter saved %d times, want 0", saves)
+	}
+}
+
+func TestModel_PromptTemplateEditorCancelReturnsToPickerWithFeedback(t *testing.T) {
+	cases := []struct {
+		name     string
+		mutate   func(model.Model) model.Model
+		wantNote string
+	}{
+		{"clean cancel", func(m model.Model) model.Model { return m }, "No changes to Plan launch"},
+		{"dirty cancel", func(m model.Model) model.Model {
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+			return m
+		}, "Discarded changes to Plan launch"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			saves := 0
+			m := newTestModel(testRepos(), model.Options{
+				PlanPromptTemplate: "custom plan",
+				SavePromptTemplate: func(string, string, string) error {
+					saves++
+					return nil
+				},
+			})
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+			m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+			m, _ = update(m, cmd())
+			m = tc.mutate(m)
+
+			m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEsc})
+			if cmd == nil {
+				t.Fatal("expected a picker return command from cancel")
+			}
+			m, _ = update(m, cmd())
+
+			if m.Overlay() != ui.OverlaySelect {
+				t.Fatalf("overlay = %v, want the picker reopened", m.Overlay())
+			}
+			view := ansi.Strip(m.View())
+			if !strings.Contains(view, tc.wantNote) {
+				t.Fatalf("expected %q in the picker note:\n%s", tc.wantNote, view)
+			}
+			if !strings.Contains(view, "> Plan launch") {
+				t.Fatalf("expected the same picker selection retained:\n%s", view)
+			}
+			if saves != 0 {
+				t.Fatalf("cancel persisted the draft %d times, want 0", saves)
+			}
+			if !strings.Contains(view, "Plan launch      custom") {
+				t.Fatalf("cancel must leave the custom template in place:\n%s", view)
+			}
+
+			// The note is transient: the next picker keystroke clears it.
+			m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+			if strings.Contains(ansi.Strip(m.View()), tc.wantNote) {
+				t.Fatalf("picker note survived a navigation keystroke:\n%s", m.View())
+			}
+		})
+	}
+}
+
+func TestModel_PromptTemplateBlankSaveResetsAndReportsThatOutcome(t *testing.T) {
+	resets := 0
+	m := newTestModel(testRepos(), model.Options{
+		PlanPromptTemplate: "custom plan",
+		ResetPromptTemplate: func(string, string) error {
+			resets++
+			return nil
+		},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, cmd())
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlU})
+	if !strings.Contains(ansi.Strip(m.View()), "empty: saving restores the built-in default") {
+		t.Fatalf("expected the empty-buffer warning while the buffer is blank:\n%s", m.View())
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd == nil {
+		t.Fatal("expected a reset command from a blank save")
+	}
+	m, _ = update(m, cmd())
+
+	if resets != 1 {
+		t.Fatalf("resets = %d, want 1", resets)
+	}
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Plan launch reset to default") {
+		t.Fatalf("expected the editor-origin reset wording:\n%s", view)
+	}
+	if !strings.Contains(view, "Plan launch      default") {
+		t.Fatalf("expected the template reset to its built-in default:\n%s", view)
+	}
+}
+
+func TestModel_PromptTemplateEditUsesFixedEditorViewport(t *testing.T) {
 	template := strings.Join([]string{
 		"line 01",
 		"line 02",
@@ -3608,9 +3740,44 @@ func TestModel_PromptTemplateEditUsesTallEditor(t *testing.T) {
 	view := ansi.Strip(m.View())
 	for _, want := range []string{"line 01", "line 12█"} {
 		if !strings.Contains(view, want) {
-			t.Fatalf("prompt template editor should show %q with tall editor:\n%s", want, view)
+			t.Fatalf("prompt template editor should show %q in its fixed viewport:\n%s", want, view)
 		}
 	}
+
+	// The panel's outer bounds are the same for a 12-line template and a
+	// single-line one.
+	tallBounds := promptEditorPanelBounds(t, view)
+
+	short := newTestModel(testRepos(), model.Options{PlanPromptTemplate: "one line"})
+	short, _ = update(short, tea.WindowSizeMsg{Width: 100, Height: 24})
+	short, _ = update(short, tea.KeyMsg{Type: tea.KeyF2})
+	short, cmd = update(short, tea.KeyMsg{Type: tea.KeyEnter})
+	short, _ = update(short, cmd())
+	if shortBounds := promptEditorPanelBounds(t, ansi.Strip(short.View())); shortBounds != tallBounds {
+		t.Fatalf("editor panel = %v for a short template, want the fixed %v", shortBounds, tallBounds)
+	}
+}
+
+// promptEditorPanelBounds reports the rendered editor panel's outer width and
+// row count.
+func promptEditorPanelBounds(t *testing.T, strippedView string) [2]int {
+	t.Helper()
+	rows, width := 0, 0
+	for _, line := range strings.Split(strippedView, "\n") {
+		trimmed := strings.TrimRight(line, " ")
+		idx := strings.IndexAny(trimmed, "┌│└")
+		if idx < 0 {
+			continue
+		}
+		rows++
+		if w := lipgloss.Width(trimmed[idx:]); w > width {
+			width = w
+		}
+	}
+	if rows == 0 {
+		t.Fatalf("no editor panel found in:\n%s", strippedView)
+	}
+	return [2]int{width, rows}
 }
 
 func TestModel_PromptTemplateSaveFailurePreservesCurrentLaunchPrompt(t *testing.T) {
@@ -3629,21 +3796,29 @@ func TestModel_PromptTemplateSaveFailurePreservesCurrentLaunchPrompt(t *testing.
 	m, _ = update(m, cmd())
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlU})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("new {title}")})
-	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyCtrlS})
 	if cmd == nil {
 		t.Fatal("expected save prompt template command")
 	}
 	m, _ = update(m, cmd())
 
-	view := m.View()
+	// Failure preserves the draft in a reconstructed editor rather than
+	// dropping the user back into the picker.
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("overlay = %v, want the editor retained after a failed save", m.Overlay())
+	}
+	if got := m.WorktreeInput(); got != "new {title}" {
+		t.Fatalf("editor draft after failure = %q, want the unsaved draft", got)
+	}
+	view := ansi.Strip(m.View())
 	if !strings.Contains(view, "read-only config") {
-		t.Fatalf("expected save failure status in view:\n%s", view)
+		t.Fatalf("expected the persistence error inside the editor:\n%s", view)
 	}
-	if !strings.Contains(view, "Plan launch      custom") {
-		t.Fatalf("expected failed save to keep old custom picker status:\n%s", view)
+	if !strings.Contains(view, "agent.plan_prompt  custom") {
+		t.Fatalf("failed save should still describe the persisted template as custom:\n%s", view)
 	}
-	if strings.Contains(view, "Plan launch      default") {
-		t.Fatalf("failed save should not mark existing custom template as default:\n%s", view)
+	if !strings.Contains(view, "modified") {
+		t.Fatalf("expected the reconstructed editor to open dirty:\n%s", view)
 	}
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyEsc})
 	m = inRightPane(m)
@@ -3684,7 +3859,23 @@ func TestModel_PromptTemplateResetClearsCustomValueAndReopensPicker(t *testing.T
 
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+
+	// Reset is protected from an accidental single keypress.
 	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd != nil {
+		t.Fatalf("r returned cmd %T, want a confirmation instead", cmd)
+	}
+	if m.Overlay() != ui.OverlayConfirm {
+		t.Fatalf("overlay = %v, want a reset confirmation", m.Overlay())
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "Reset Flow plan to its built-in default?") {
+		t.Fatalf("expected the reset confirmation prompt:\n%s", m.View())
+	}
+	if resetSection != "" || resetKey != "" {
+		t.Fatal("opening the confirmation must not reset anything")
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if cmd == nil {
 		t.Fatal("expected reset prompt template command")
 	}
@@ -3696,12 +3887,204 @@ func TestModel_PromptTemplateResetClearsCustomValueAndReopensPicker(t *testing.T
 	if m.Overlay() != ui.OverlaySelect {
 		t.Fatalf("overlay = %v, want picker reopened", m.Overlay())
 	}
-	view := m.View()
+	view := ansi.Strip(m.View())
 	if strings.Contains(view, "Flow plan        custom") {
 		t.Fatalf("expected Flow plan reset to default:\n%s", view)
 	}
 	if !strings.Contains(view, "Flow plan") || !strings.Contains(view, "default") {
 		t.Fatalf("expected refreshed picker with default status:\n%s", view)
+	}
+	if !strings.Contains(view, "Restored Flow plan to default") {
+		t.Fatalf("expected the picker to report which template was restored:\n%s", view)
+	}
+	if !strings.Contains(view, "> Flow plan") {
+		t.Fatalf("expected the same picker selection retained:\n%s", view)
+	}
+}
+
+func TestModel_PromptTemplateResetCancellationLeavesTheCustomValueIntact(t *testing.T) {
+	resets := 0
+	m := newTestModel(testRepos(), model.Options{
+		FlowPromptTemplates: model.FlowPromptTemplates{Plan: "custom flow plan"},
+		ResetPromptTemplate: func(string, string) error {
+			resets++
+			return nil
+		},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatal("expected a picker return command from a cancelled reset")
+	}
+	m, _ = update(m, cmd())
+
+	if resets != 0 {
+		t.Fatalf("cancelled reset ran %d times, want 0", resets)
+	}
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Flow plan        custom") {
+		t.Fatalf("cancelled reset must leave the custom value intact:\n%s", view)
+	}
+	if !strings.Contains(view, "Flow plan unchanged") {
+		t.Fatalf("expected the cancelled-reset note:\n%s", view)
+	}
+	if !strings.Contains(view, "> Flow plan") {
+		t.Fatalf("expected the same picker selection retained:\n%s", view)
+	}
+}
+
+func TestModel_PromptTemplateResetOnDefaultTemplateIsANoOpNote(t *testing.T) {
+	resets := 0
+	m := newTestModel(testRepos(), model.Options{
+		ResetPromptTemplate: func(string, string) error {
+			resets++
+			return nil
+		},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+
+	if cmd != nil {
+		t.Fatalf("r on a default template returned cmd %T, want nil", cmd)
+	}
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("overlay = %v, want the picker retained", m.Overlay())
+	}
+	if resets != 0 {
+		t.Fatalf("reset ran %d times on an already-default template, want 0", resets)
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "Plan launch is already default") {
+		t.Fatalf("expected the informational note:\n%s", m.View())
+	}
+}
+
+func TestModel_PromptTemplateResetFailureKeepsPickerSelectionAndShowsTheError(t *testing.T) {
+	m := newTestModel(testRepos(), model.Options{
+		FlowPromptTemplates: model.FlowPromptTemplates{Plan: "custom flow plan"},
+		ResetPromptTemplate: func(string, string) error { return errors.New("read-only config") },
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("expected reset prompt template command")
+	}
+	m, _ = update(m, cmd())
+
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("overlay = %v, want the picker", m.Overlay())
+	}
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "read-only config") {
+		t.Fatalf("expected the reset error in the picker note row:\n%s", view)
+	}
+	if !strings.Contains(view, "> Flow plan") {
+		t.Fatalf("expected the same picker selection retained:\n%s", view)
+	}
+	if !strings.Contains(view, "Flow plan        custom") {
+		t.Fatalf("failed reset must not present itself as success:\n%s", view)
+	}
+}
+
+func TestModel_PromptTemplateEditorOriginResetFailureReconstructsTheEditor(t *testing.T) {
+	m := newTestModel(testRepos(), model.Options{
+		PlanPromptTemplate:  "custom plan",
+		ResetPromptTemplate: func(string, string) error { return errors.New("read-only config") },
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, cmd())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyCtrlU})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeySpace})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd == nil {
+		t.Fatal("expected a reset command from a whitespace-only save")
+	}
+	m, _ = update(m, cmd())
+
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("overlay = %v, want the editor reconstructed", m.Overlay())
+	}
+	if got := m.WorktreeInput(); got != " " {
+		t.Fatalf("editor draft after a failed editor-origin reset = %q, want the whitespace draft", got)
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "read-only config") {
+		t.Fatalf("expected the reset error inside the editor:\n%s", m.View())
+	}
+}
+
+func TestModel_PromptTemplateSaveRetryAfterFailureSucceeds(t *testing.T) {
+	attempts := 0
+	var savedValue string
+	m := newTestModel(testRepos(), model.Options{
+		PlanPromptTemplate: "old",
+		SavePromptTemplate: func(_, _, value string) error {
+			attempts++
+			if attempts == 1 {
+				return errors.New("read-only config")
+			}
+			savedValue = value
+			return nil
+		},
+	})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m, _ = update(m, cmd())
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("er")})
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyCtrlS})
+	m, _ = update(m, cmd())
+
+	if m.Overlay() != ui.OverlayWorktreeInput {
+		t.Fatalf("overlay = %v, want the editor retained for retry", m.Overlay())
+	}
+
+	m, cmd = update(m, tea.KeyMsg{Type: tea.KeyCtrlS})
+	if cmd == nil {
+		t.Fatal("expected a retry save command")
+	}
+	m, _ = update(m, cmd())
+
+	if savedValue != "older" {
+		t.Fatalf("retried save value = %q, want %q", savedValue, "older")
+	}
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("overlay = %v, want the picker after a successful retry", m.Overlay())
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "Saved Plan launch") {
+		t.Fatalf("expected the success note after a retry:\n%s", m.View())
+	}
+}
+
+func TestModel_PromptTemplatePreviewReturnsToPickerSelection(t *testing.T) {
+	m := newTestModel(testRepos(), model.Options{})
+
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyF2})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+	if m.Overlay() != ui.OverlayPlanText {
+		t.Fatalf("overlay = %v, want the preview", m.Overlay())
+	}
+
+	m, cmd := update(m, tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatal("expected a picker return command when the preview closes")
+	}
+	m, _ = update(m, cmd())
+
+	if m.Overlay() != ui.OverlaySelect {
+		t.Fatalf("overlay = %v, want the picker reopened", m.Overlay())
+	}
+	if !strings.Contains(ansi.Strip(m.View()), "> Flow plan") {
+		t.Fatalf("expected the preview to return to the same selection:\n%s", m.View())
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -211,17 +211,22 @@ func isPromptTemplateEditor(view modal.View) bool {
 	return view.Kind == modal.Input && view.Editor.Enabled
 }
 
-// tagPromptTemplateCursor stamps the pre-submit cursor onto a failed save. The
+// tagPromptTemplateCursor stamps the pre-submit cursor onto a failed write. The
 // submit closure cannot supply it: it receives only the string, and by the
-// time it runs the modal has already been zeroed.
+// time it runs the modal has already been zeroed. Both failure messages are
+// tagged because a whitespace-only submit fails as a reset, not a save.
 func tagPromptTemplateCursor(cmd tea.Cmd, cursor int) tea.Cmd {
 	return func() tea.Msg {
-		msg := cmd()
-		if failed, ok := msg.(PromptTemplateSaveFailedMsg); ok {
+		switch failed := cmd().(type) {
+		case PromptTemplateSaveFailedMsg:
 			failed.Cursor = cursor
 			return failed
+		case PromptTemplateResetFailedMsg:
+			failed.Cursor = cursor
+			return failed
+		default:
+			return failed
 		}
-		return msg
 	}
 }
 

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -42,6 +42,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			var request uint64
 			m, request = m.nextRepoCreateRequest()
 			cmd = tagRepoCreateRequest(cmd, request)
+		} else if outcome == modal.Accepted && cmd != nil && isPromptTemplateEditor(view) {
+			cmd = tagPromptTemplateCursor(cmd, view.InputCursor)
 		} else if outcome == modal.Accepted && cmd != nil && isFlowCreateForm(view) {
 			if m.activeFlowCreate != 0 {
 				return m.setStatus(statusOther, flowCreateInProgressStatus), nil
@@ -203,6 +205,24 @@ func isWorktreeCreateInput(view modal.View) bool {
 		return false
 	}
 	return view.Placeholder == ui.WorktreeInputPlaceholder || view.Placeholder == ui.PRWorktreeInputPlaceholder
+}
+
+func isPromptTemplateEditor(view modal.View) bool {
+	return view.Kind == modal.Input && view.Editor.Enabled
+}
+
+// tagPromptTemplateCursor stamps the pre-submit cursor onto a failed save. The
+// submit closure cannot supply it: it receives only the string, and by the
+// time it runs the modal has already been zeroed.
+func tagPromptTemplateCursor(cmd tea.Cmd, cursor int) tea.Cmd {
+	return func() tea.Msg {
+		msg := cmd()
+		if failed, ok := msg.(PromptTemplateSaveFailedMsg); ok {
+			failed.Cursor = cursor
+			return failed
+		}
+		return msg
+	}
 }
 
 func isRepoCreateForm(view modal.View) bool {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -139,6 +139,24 @@ type promptTemplateEditRequestedMsg struct {
 	Value string
 }
 
+// promptTemplatePickerReturnMsg reopens the prompt-template picker at a target
+// with optional feedback. A tea.Cmd cannot reopen a modal on its own, so every
+// return path — editor cancel, cancelled reset confirm, closed preview —
+// produces this message.
+type promptTemplatePickerReturnMsg struct {
+	Target promptTemplateTarget
+	Note   promptNote
+}
+
+// PromptTemplateResetOrigin distinguishes the two ways a reset can start, so
+// failure can restore the surface the user was actually on.
+type PromptTemplateResetOrigin int
+
+const (
+	ResetFromPicker PromptTemplateResetOrigin = iota
+	ResetFromEditor
+)
+
 type PromptTemplateSavedMsg struct {
 	Section string
 	Key     string
@@ -149,17 +167,21 @@ type PromptTemplateSaveFailedMsg struct {
 	Section string
 	Key     string
 	Value   string
+	Cursor  int
 	Err     string
 }
 
 type PromptTemplateResetMsg struct {
 	Section string
 	Key     string
+	Origin  PromptTemplateResetOrigin
 }
 
 type PromptTemplateResetFailedMsg struct {
 	Section string
 	Key     string
+	Origin  PromptTemplateResetOrigin
+	Draft   string
 	Err     string
 }
 

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -182,6 +182,7 @@ type PromptTemplateResetFailedMsg struct {
 	Key     string
 	Origin  PromptTemplateResetOrigin
 	Draft   string
+	Cursor  int
 	Err     string
 }
 

--- a/model/prompt_templates.go
+++ b/model/prompt_templates.go
@@ -268,7 +268,10 @@ func (m Model) handlePromptTemplateResetFailed(msg PromptTemplateResetFailedMsg)
 	}
 	note := promptNote{Text: errText, Kind: modal.NoteError}
 	if msg.Origin == ResetFromEditor {
-		return m.openPromptTemplateEditor(target, msg.Draft, m.promptTemplateValue(target), len([]rune(msg.Draft)), note)
+		// Cursor is the pre-submit position stamped on the way out; a
+		// picker-origin reset never reaches this branch, so an untagged zero
+		// value cannot strand a cursor here.
+		return m.openPromptTemplateEditor(target, msg.Draft, m.promptTemplateValue(target), msg.Cursor, note)
 	}
 	return m.openPromptTemplatePicker(promptTemplateTargetIndex(target), note)
 }

--- a/model/prompt_templates.go
+++ b/model/prompt_templates.go
@@ -12,12 +12,17 @@ import (
 	"github.com/approachcontrol/approach/ui"
 )
 
-const promptTemplateEditorVisibleLines = 16
-
 type promptTemplateTarget struct {
 	Section string
 	Key     string
 	Title   string
+}
+
+// promptNote is one piece of modal feedback: text plus severity. Its zero
+// value renders no note at all.
+type promptNote struct {
+	Text string
+	Kind modal.NoteKind
 }
 
 var promptTemplateTargets = []promptTemplateTarget{
@@ -34,19 +39,25 @@ var promptTemplateTargets = []promptTemplateTarget{
 }
 
 func (m Model) handlePromptTemplates() (tea.Model, tea.Cmd) {
-	return m.openPromptTemplatePicker(0), nil
+	return m.openPromptTemplatePicker(0, promptNote{}), nil
 }
 
-func (m Model) openPromptTemplatePicker(selected int) Model {
+// openPromptTemplatePicker rebuilds the picker from scratch, which is why the
+// note is a parameter rather than something applied at each call site.
+func (m Model) openPromptTemplatePicker(selected int, note promptNote) Model {
 	m.modal = modal.OpenSelectWithLayout(
 		ui.PromptTemplateSelectPrompt,
 		m.promptTemplateSelectItems(),
 		selected,
-		modal.Layout{Width: 42, Height: len(promptTemplateTargets) + 3, Placement: modal.PlacementCenter},
+		modal.Layout{
+			Width:     ui.PromptPickerWidth,
+			Height:    len(promptTemplateTargets) + 3 + ui.PromptPickerNoteRows,
+			Placement: modal.PlacementCenter,
+		},
 		func(value string) tea.Cmd {
 			return func() tea.Msg { return promptTemplateEditRequestedMsg{Value: value} }
 		},
-	)
+	).SetSelectNote(note.Text, note.Kind)
 	return m
 }
 
@@ -61,17 +72,47 @@ func (m Model) handlePromptTemplateModalKey(msg tea.KeyMsg) (Model, tea.Cmd, boo
 		if !ok {
 			return m, nil, true
 		}
-		return m, m.resetPromptTemplateCommand(target), true
+		index := promptTemplateTargetIndex(target)
+		if strings.TrimSpace(m.promptTemplateValue(target)) == "" {
+			return m.openPromptTemplatePicker(index, promptNote{
+				Text: target.Title + " is already default",
+				Kind: modal.NoteNeutral,
+			}), nil, true
+		}
+		reset := m
+		m.modal = modal.OpenConfirm(
+			"Reset "+target.Title+" to its built-in default?",
+			func() tea.Cmd { return reset.resetPromptTemplateCommand(target, ResetFromPicker, "") },
+		).WithCancel(func(modal.View) tea.Cmd {
+			return promptTemplatePickerReturn(target, promptNote{
+				Text: target.Title + " unchanged",
+				Kind: modal.NoteNeutral,
+			})
+		})
+		return m, nil, true
 	case "v":
 		target, ok := selectedPromptTemplateTarget(view)
 		if !ok {
 			return m, nil, true
 		}
-		m.modal = modal.OpenText(m.builtInPromptTemplatePreview(target))
+		m.modal = modal.OpenText(m.builtInPromptTemplatePreview(target)).
+			WithCancel(func(modal.View) tea.Cmd {
+				return promptTemplatePickerReturn(target, promptNote{})
+			})
 		return m, nil, true
 	default:
 		return m, nil, false
 	}
+}
+
+func promptTemplatePickerReturn(target promptTemplateTarget, note promptNote) tea.Cmd {
+	return func() tea.Msg {
+		return promptTemplatePickerReturnMsg{Target: target, Note: note}
+	}
+}
+
+func (m Model) handlePromptTemplatePickerReturn(msg promptTemplatePickerReturnMsg) Model {
+	return m.openPromptTemplatePicker(promptTemplateTargetIndex(msg.Target), msg.Note)
 }
 
 func selectedPromptTemplateTarget(view modal.View) (promptTemplateTarget, bool) {
@@ -86,19 +127,60 @@ func (m Model) handlePromptTemplateEditRequested(msg promptTemplateEditRequested
 	if !ok {
 		return m.setStatus(statusOther, "Prompt template is unavailable")
 	}
+	value := m.promptTemplateValue(target)
+	return m.openPromptTemplateEditor(target, value, value, len([]rune(value)), promptNote{})
+}
+
+// openPromptTemplateEditor builds the editor for a target. draft is what the
+// user sees and original is the persisted value it is compared against; they
+// differ only when an editor is reconstructed after a failed write, which is
+// exactly when it must open already dirty.
+func (m Model) openPromptTemplateEditor(target promptTemplateTarget, draft, original string, cursor int, note promptNote) Model {
+	submitModel := m
 	m.modal = modal.OpenRawMultiLineInput(
 		"Edit "+target.Title,
 		"prompt template",
-		m.promptTemplateValue(target),
+		draft,
 		nil,
 		func(input string) tea.Cmd {
+			// A blank or whitespace-only save keeps its existing meaning:
+			// reset to the built-in default.
 			if strings.TrimSpace(input) == "" {
-				return m.resetPromptTemplateCommand(target)
+				return submitModel.resetPromptTemplateCommand(target, ResetFromEditor, input)
 			}
-			return m.savePromptTemplateCommand(target, input)
+			return submitModel.savePromptTemplateCommand(target, input)
 		},
-	).WithInputHeight(promptTemplateEditorVisibleLines)
+	).AsEditor(modal.EditorSpec{
+		Title:    target.Title,
+		Identity: promptTemplateIdentity(target, original),
+		Original: original,
+		Cursor:   cursor,
+		Note:     note.Text,
+		NoteKind: note.Kind,
+	}).WithCancel(func(view modal.View) tea.Cmd {
+		if view.Editor.Dirty {
+			return promptTemplatePickerReturn(target, promptNote{
+				Text: "Discarded changes to " + target.Title,
+				Kind: modal.NoteWarning,
+			})
+		}
+		return promptTemplatePickerReturn(target, promptNote{
+			Text: "No changes to " + target.Title,
+			Kind: modal.NoteNeutral,
+		})
+	})
 	return m
+}
+
+func promptTemplateIdentity(target promptTemplateTarget, value string) string {
+	return promptTemplateTargetValue(target) + "  " + promptTemplateState(value)
+}
+
+func promptTemplateState(value string) string {
+	if strings.TrimSpace(value) != "" {
+		return "custom"
+	}
+	return "default"
 }
 
 func (m Model) savePromptTemplateCommand(target promptTemplateTarget, value string) tea.Cmd {
@@ -110,12 +192,18 @@ func (m Model) savePromptTemplateCommand(target promptTemplateTarget, value stri
 	}
 }
 
-func (m Model) resetPromptTemplateCommand(target promptTemplateTarget) tea.Cmd {
+func (m Model) resetPromptTemplateCommand(target promptTemplateTarget, origin PromptTemplateResetOrigin, draft string) tea.Cmd {
 	return func() tea.Msg {
 		if err := m.resetPromptTemplate(target.Section, target.Key); err != nil {
-			return PromptTemplateResetFailedMsg{Section: target.Section, Key: target.Key, Err: err.Error()}
+			return PromptTemplateResetFailedMsg{
+				Section: target.Section,
+				Key:     target.Key,
+				Origin:  origin,
+				Draft:   draft,
+				Err:     err.Error(),
+			}
 		}
-		return PromptTemplateResetMsg{Section: target.Section, Key: target.Key}
+		return PromptTemplateResetMsg{Section: target.Section, Key: target.Key, Origin: origin}
 	}
 }
 
@@ -126,19 +214,30 @@ func (m Model) handlePromptTemplateSaved(msg PromptTemplateSavedMsg) Model {
 	}
 	m = m.withPromptTemplateValue(target, msg.Value)
 	m = m.clearStatus(statusOther)
-	return m.openPromptTemplatePicker(promptTemplateTargetIndex(target))
+	return m.openPromptTemplatePicker(promptTemplateTargetIndex(target), promptNote{
+		Text: "Saved " + target.Title,
+		Kind: modal.NoteSuccess,
+	})
 }
 
+// handlePromptTemplateSaveFailed reconstructs the editor with the user's draft
+// and cursor so the write can be retried with ctrl+s or abandoned with esc. It
+// never reports failed persistence as success.
 func (m Model) handlePromptTemplateSaveFailed(msg PromptTemplateSaveFailedMsg) Model {
-	target, ok := promptTemplateTargetBySectionKey(msg.Section, msg.Key)
-	if ok {
-		m = m.openPromptTemplatePicker(promptTemplateTargetIndex(target))
-	}
 	errText := msg.Err
 	if errText == "" {
 		errText = "Unable to persist prompt template"
 	}
-	return m.setStatus(statusOther, errText)
+	target, ok := promptTemplateTargetBySectionKey(msg.Section, msg.Key)
+	if !ok {
+		return m.setStatus(statusOther, errText)
+	}
+	// Failure never mutates the in-memory value, so the original re-derived
+	// here still differs from the draft and the editor opens dirty.
+	return m.openPromptTemplateEditor(target, msg.Value, m.promptTemplateValue(target), msg.Cursor, promptNote{
+		Text: errText,
+		Kind: modal.NoteError,
+	})
 }
 
 func (m Model) handlePromptTemplateReset(msg PromptTemplateResetMsg) Model {
@@ -148,7 +247,14 @@ func (m Model) handlePromptTemplateReset(msg PromptTemplateResetMsg) Model {
 	}
 	m = m.withPromptTemplateValue(target, "")
 	m = m.clearStatus(statusOther)
-	return m.openPromptTemplatePicker(promptTemplateTargetIndex(target))
+	note := "Restored " + target.Title + " to default"
+	if msg.Origin == ResetFromEditor {
+		note = target.Title + " reset to default"
+	}
+	return m.openPromptTemplatePicker(promptTemplateTargetIndex(target), promptNote{
+		Text: note,
+		Kind: modal.NoteSuccess,
+	})
 }
 
 func (m Model) handlePromptTemplateResetFailed(msg PromptTemplateResetFailedMsg) Model {
@@ -156,18 +262,22 @@ func (m Model) handlePromptTemplateResetFailed(msg PromptTemplateResetFailedMsg)
 	if errText == "" {
 		errText = "Unable to reset prompt template"
 	}
-	return m.setStatus(statusOther, errText)
+	target, ok := promptTemplateTargetBySectionKey(msg.Section, msg.Key)
+	if !ok {
+		return m.setStatus(statusOther, errText)
+	}
+	note := promptNote{Text: errText, Kind: modal.NoteError}
+	if msg.Origin == ResetFromEditor {
+		return m.openPromptTemplateEditor(target, msg.Draft, m.promptTemplateValue(target), len([]rune(msg.Draft)), note)
+	}
+	return m.openPromptTemplatePicker(promptTemplateTargetIndex(target), note)
 }
 
 func (m Model) promptTemplateSelectItems() []modal.SelectItem {
 	items := make([]modal.SelectItem, 0, len(promptTemplateTargets))
 	for _, target := range promptTemplateTargets {
-		status := "default"
-		if strings.TrimSpace(m.promptTemplateValue(target)) != "" {
-			status = "custom"
-		}
 		items = append(items, modal.SelectItem{
-			Label: fmt.Sprintf("%-16s %s", target.Title, status),
+			Label: fmt.Sprintf("%-16s %s", target.Title, promptTemplateState(m.promptTemplateValue(target))),
 			Value: promptTemplateTargetValue(target),
 		})
 	}

--- a/ui/prompt_editor.go
+++ b/ui/prompt_editor.go
@@ -1,0 +1,428 @@
+package ui
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// The prompt-template editor's ideal geometry. Unlike the picker's constants
+// these stay unexported: the model builds no editor layout, so nothing outside
+// ui reads them.
+const (
+	promptEditorWidth         = 72
+	promptEditorViewportLines = 12
+	promptEditorHeight        = 21
+	promptEditorMinWidth      = 32
+	promptEditorMinTextWidth  = 8
+)
+
+const (
+	promptEditorEmptyHint    = "using the built-in default — type to override"
+	promptEditorEmptyWarning = "empty: saving restores the built-in default"
+)
+
+// Hint copy, widest first. The renderer picks the widest variant that fits the
+// panel's content column so all three keys survive a clamped panel.
+var promptEditorHints = []string{
+	"ctrl+s: save   enter: newline   esc: cancel",
+	"ctrl+s save esc cancel enter nl",
+	"^s save ^[ cancel",
+}
+
+// Status-bar copy, used when the panel is too short to carry its own hint row.
+// Dropping the hint row is a height decision and truncation is a width
+// decision, so the two cannot share one string.
+const (
+	promptEditorStatusCompact  = "  ctrl+s save  esc cancel  enter nl"
+	promptEditorStatusFallback = "  ^s save ^[ cancel"
+)
+
+// promptEditorLayout is the fully resolved panel shape. The renderer emits
+// exactly what it describes, so nothing in the panel is content-dependent.
+type promptEditorLayout struct {
+	width         int
+	height        int
+	viewportLines int
+	noteRows      int
+	frame         bool
+	hasIdentity   bool
+	hasHint       bool
+}
+
+// fixedRows counts every row the panel spends outside the text viewport.
+func (l promptEditorLayout) fixedRows() int {
+	rows := 2 + 1 + l.noteRows // outer border, title, note block
+	if l.hasIdentity {
+		rows++
+	}
+	if l.hasHint {
+		rows++
+	}
+	if l.frame {
+		rows += 2
+	}
+	return rows
+}
+
+// contentWidth is the column count between the outer border's padding.
+func (l promptEditorLayout) contentWidth() int {
+	return max(1, l.width-4)
+}
+
+// textWidth is the column count available to the template itself.
+func (l promptEditorLayout) textWidth() int {
+	if l.frame {
+		return max(1, l.contentWidth()-2)
+	}
+	return l.contentWidth()
+}
+
+// normalizePromptEditorLayout resolves width first — it can drop the viewport
+// frame, which also changes the height budget — then walks the height ladder,
+// shedding one optional row at a time until the panel fits. The cursor line is
+// the last thing standing.
+func normalizePromptEditorLayout(terminalWidth, bodyHeight int) promptEditorLayout {
+	layout := promptEditorLayout{
+		viewportLines: promptEditorViewportLines,
+		noteRows:      2,
+		frame:         true,
+		hasIdentity:   true,
+		hasHint:       true,
+	}
+
+	width := terminalWidth - 4
+	if width > promptEditorWidth {
+		width = promptEditorWidth
+	}
+	if width < promptEditorMinWidth {
+		width = terminalWidth
+	}
+	if width < 1 {
+		width = 1
+	}
+	layout.width = width
+	if width-4-2 < promptEditorMinTextWidth {
+		layout.frame = false
+	}
+
+	// Step 1 is continuous: the viewport takes whatever the fixed rows leave.
+	viewport := bodyHeight - layout.fixedRows()
+	if viewport > promptEditorViewportLines {
+		viewport = promptEditorViewportLines
+	}
+	if viewport < 3 {
+		viewport = 3
+	}
+	layout.viewportLines = viewport
+
+	fits := func() bool { return layout.fixedRows()+layout.viewportLines <= bodyHeight }
+	if !fits() && layout.noteRows == 2 {
+		layout.noteRows = 1 // step 2: shrink the note block before dropping hints
+	}
+	if !fits() && layout.hasHint {
+		layout.hasHint = false // step 3: the status bar carries the keys instead
+	}
+	if !fits() && layout.hasIdentity {
+		layout.hasIdentity = false // step 4
+	}
+	if !fits() && layout.noteRows == 1 {
+		layout.noteRows = 0 // step 5
+	}
+	if !fits() && layout.frame {
+		layout.frame = false // step 6
+	}
+	if !fits() {
+		layout.viewportLines = 1 // step 7: the cursor line
+	}
+
+	layout.height = layout.fixedRows() + layout.viewportLines
+	return layout
+}
+
+// renderPromptEditorDialog draws the editor into a fixed-height buffer,
+// clipping rather than drawing out of bounds on a terminal too short to hold
+// even the floor panel.
+func renderPromptEditorDialog(p RenderParams, width, height int) []string {
+	lines := make([]string, height)
+	if width <= 0 || height <= 0 {
+		return lines
+	}
+	layout := normalizePromptEditorLayout(width, height)
+	panel := promptEditorPanel(p, layout)
+	top := (height - len(panel)) / 2
+	if top < 0 {
+		top = 0
+	}
+	for i, line := range panel {
+		row := top + i
+		if row >= len(lines) {
+			break
+		}
+		lines[row] = centeredLine(line, width)
+	}
+	return lines
+}
+
+func promptEditorPanel(p RenderParams, layout promptEditorLayout) []string {
+	width := layout.width
+	contentWidth := layout.contentWidth()
+	textWidth := layout.textWidth()
+
+	body, cursorLine := promptEditorBodyLines(p.InputValue, p.InputCursor, textWidth)
+	window, first, more := promptEditorViewportWindow(body, layout.viewportLines, cursorLine)
+
+	lines := make([]string, 0, layout.height)
+	lines = append(lines, selectPanelBorderLine("┌", "─", "┐", width))
+
+	title := strings.TrimSpace(p.Editor.Title)
+	if title == "" {
+		title = "prompt template"
+	}
+	lines = append(lines, promptEditorContentLine(
+		activeModeStyle.Render(truncateToWidth("Edit "+title, contentWidth)), width))
+
+	if layout.hasIdentity {
+		lines = append(lines, promptEditorContentLine(
+			statusStyle.Render(truncateToWidth(promptEditorIdentityText(p.Editor), contentWidth)), width))
+	}
+
+	if layout.frame {
+		up := ""
+		if first > 0 {
+			up = "▲"
+		}
+		lines = append(lines, promptEditorContentLine(
+			promptEditorFrameLine("┌", "┐", contentWidth, up, ""), width))
+	}
+	border := lipgloss.NewStyle().Foreground(clearDarkTheme.activeBorder)
+	for i := 0; i < layout.viewportLines; i++ {
+		content := ""
+		if i < len(window) {
+			content = window[i]
+		}
+		if layout.frame {
+			content = border.Render("│") + fitSessionColumn(content, textWidth) + border.Render("│")
+		}
+		lines = append(lines, promptEditorContentLine(content, width))
+	}
+	if layout.frame {
+		down := ""
+		if more {
+			down = "▼"
+		}
+		lines = append(lines, promptEditorContentLine(
+			promptEditorFrameLine("└", "┘", contentWidth, down,
+				promptEditorPositionLabel(p.InputValue, p.InputCursor)), width))
+	}
+
+	for _, note := range promptEditorNoteRows(p, layout.noteRows, contentWidth) {
+		lines = append(lines, promptEditorContentLine(note, width))
+	}
+
+	if layout.hasHint {
+		lines = append(lines, promptEditorContentLine(
+			statusStyle.Render(promptEditorHintText(contentWidth)), width))
+	}
+
+	lines = append(lines, selectPanelBorderLine("└", "─", "┘", width))
+	return lines
+}
+
+func promptEditorIdentityText(editor EditorParams) string {
+	identity := strings.TrimSpace(editor.Identity)
+	if editor.Dirty {
+		if identity == "" {
+			return "modified"
+		}
+		return identity + "  modified"
+	}
+	return identity
+}
+
+// promptEditorPositionLabel counts logical (newline-separated) lines, not
+// width-dependent wrapped lines, so the indicator does not change with the
+// terminal width. The re-slice through []rune is load-bearing: InputCursor is
+// a rune index.
+func promptEditorPositionLabel(value string, cursor int) string {
+	runes := []rune(value)
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor > len(runes) {
+		cursor = len(runes)
+	}
+	line := strings.Count(string(runes[:cursor]), "\n") + 1
+	total := strings.Count(value, "\n") + 1
+	return "line " + strconv.Itoa(line) + "/" + strconv.Itoa(total)
+}
+
+// promptEditorBodyLines is the editor's analogue of inputDialogBodyLines: it
+// wraps the value with the cursor glyph in place and reports the wrapped line
+// holding the cursor. It deliberately does not prefix line 0 with a prompt
+// label — the title has its own row, so column 0 of every rendered line is the
+// template's own first column.
+func promptEditorBodyLines(value string, cursor, contentWidth int) ([]string, int) {
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+	if value == "" {
+		// Eight of the nine targets open empty, so the built-in-default
+		// affordance is the common path, not an edge case. The hint is not
+		// part of the value.
+		line := activeModeStyle.Render("█")
+		if contentWidth > 1 {
+			line += placeholderStyle.Render(truncateToWidth(" "+promptEditorEmptyHint, contentWidth-1))
+		}
+		return []string{line}, 0
+	}
+	logical := strings.Split(insertCursorGlyph(value, cursor), "\n")
+	lines := make([]string, 0, len(logical))
+	for _, line := range logical {
+		lines = append(lines, wrapEditableInputLine(line, contentWidth)...)
+	}
+	if len(lines) == 0 {
+		return []string{activeModeStyle.Render("█")}, 0
+	}
+	return lines, lineIndexContainingCursor(lines)
+}
+
+// promptEditorViewportWindow returns at most rows real content lines with the
+// cursor line guaranteed in-window. Unlike compactInputDialogLines it never
+// overwrites a boundary line with an overflow marker — that would destroy a
+// real line of the user's template, and at two rows it can hide the cursor
+// itself. Overflow lives in the viewport frame instead.
+func promptEditorViewportWindow(lines []string, rows, cursorLine int) ([]string, int, bool) {
+	if rows <= 0 {
+		return nil, 0, len(lines) > 0
+	}
+	if len(lines) <= rows {
+		return lines, 0, false
+	}
+	if cursorLine < 0 {
+		cursorLine = 0
+	}
+	if cursorLine >= len(lines) {
+		cursorLine = len(lines) - 1
+	}
+	start := cursorLine - rows/2
+	if start < 0 {
+		start = 0
+	}
+	if maxStart := len(lines) - rows; start > maxStart {
+		start = maxStart
+	}
+	return lines[start : start+rows], start, start+rows < len(lines)
+}
+
+// promptEditorNoteRows fills exactly rows rows, blank when there is nothing to
+// say. Precedence, highest first: validation error, stored note, derived
+// empty-buffer warning. A message longer than the block is truncated with an
+// ellipsis rather than allowed to grow the panel.
+func promptEditorNoteRows(p RenderParams, rows, width int) []string {
+	if rows <= 0 {
+		return nil
+	}
+	out := make([]string, rows)
+	text := ""
+	kind := NoteNeutral
+	switch {
+	case p.InputError != "":
+		text, kind = p.InputError, NoteError
+	case p.Editor.Note != "":
+		text, kind = p.Editor.Note, p.Editor.NoteKind
+	case p.Editor.EmptyWarning:
+		text, kind = promptEditorEmptyWarning, NoteWarning
+	}
+	if text == "" {
+		return out
+	}
+	wrapped := wrapPlainText(terminalSafeSingleLine(text), width)
+	style := noteStyle(kind)
+	for i := 0; i < rows && i < len(wrapped); i++ {
+		line := wrapped[i]
+		if i == rows-1 && len(wrapped) > rows {
+			line = truncateWithEllipsis(line+" "+strings.Join(wrapped[rows:], " "), width)
+		}
+		out[i] = style.Render(line)
+	}
+	return out
+}
+
+func promptEditorHintText(contentWidth int) string {
+	for _, hint := range promptEditorHints {
+		if lipgloss.Width(hint) <= contentWidth {
+			return hint
+		}
+	}
+	return truncateToWidth(promptEditorHints[len(promptEditorHints)-1], contentWidth)
+}
+
+// promptEditorStatusText names the save key explicitly at every width the
+// terminal can still show it.
+func promptEditorStatusText(width int) string {
+	if width >= lipgloss.Width(promptEditorStatusCompact) {
+		return promptEditorStatusCompact
+	}
+	return promptEditorStatusFallback
+}
+
+func promptEditorContentLine(content string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	border := lipgloss.NewStyle().Foreground(clearDarkTheme.activeBorder)
+	if width == 1 {
+		return truncateToWidth(border.Render("│"), width)
+	}
+	if width < 4 {
+		return border.Render("│") + fitSessionColumn(content, width-2) + border.Render("│")
+	}
+	return border.Render("│") + " " + fitSessionColumn(content, width-4) + " " + border.Render("│")
+}
+
+// promptEditorFrameLine draws the viewport's own border, carrying the overflow
+// arrow and the logical-line indicator so neither ever replaces content.
+func promptEditorFrameLine(left, right string, width int, marker, label string) string {
+	border := lipgloss.NewStyle().Foreground(clearDarkTheme.activeBorder)
+	if width <= 2 {
+		return border.Render(truncateToWidth(strings.Repeat("─", max(0, width)), width))
+	}
+	inner := []rune(strings.Repeat("─", width-2))
+	if marker != "" {
+		copy(inner, []rune(marker))
+	}
+	if label != "" {
+		if labelRunes := []rune(label); len(labelRunes)+2 <= len(inner) {
+			copy(inner[len(inner)-len(labelRunes)-1:], labelRunes)
+		}
+	}
+	return border.Render(left + string(inner) + right)
+}
+
+func noteStyle(kind NoteKind) lipgloss.Style {
+	switch kind {
+	case NoteSuccess:
+		return cleanStyle
+	case NoteWarning:
+		return aheadBehindStyle
+	case NoteError:
+		return dirtyRedStyle
+	default:
+		return statusStyle
+	}
+}
+
+func truncateWithEllipsis(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= width {
+		return s
+	}
+	if width == 1 {
+		return "…"
+	}
+	return truncateToWidth(s, width-1) + "…"
+}

--- a/ui/prompt_editor_test.go
+++ b/ui/prompt_editor_test.go
@@ -1,0 +1,532 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/approachcontrol/approach/scanner"
+)
+
+func editorParams(width, height int, value string, cursor int) RenderParams {
+	return RenderParams{
+		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:       width,
+		Height:      height,
+		Mode:        ModePlans,
+		Overlay:     OverlayInput,
+		InputPrompt: "Edit Plan launch",
+		InputValue:  value,
+		InputCursor: cursor,
+		InputMode:   InputMultiLine,
+		Editor: EditorParams{
+			Enabled:  true,
+			Title:    "Plan launch",
+			Identity: "agent.plan_prompt  custom",
+		},
+	}
+}
+
+// panelBounds reports the rendered editor panel's outer width and row count by
+// finding the bordered block in the stripped view.
+func panelBounds(t *testing.T, view string) (int, int) {
+	t.Helper()
+	rows := 0
+	width := 0
+	for _, line := range strings.Split(ansi.Strip(view), "\n") {
+		trimmed := strings.TrimRight(line, " ")
+		idx := strings.IndexAny(trimmed, "┌│└")
+		if idx < 0 {
+			continue
+		}
+		rows++
+		if w := lipgloss.Width(trimmed[idx:]); w > width {
+			width = w
+		}
+	}
+	return width, rows
+}
+
+// overlaySelectPanelRows locates the composited select panel of the given
+// outer width and returns its row count.
+func overlaySelectPanelRows(t *testing.T, view string, width int) int {
+	t.Helper()
+	top := "┌" + strings.Repeat("─", width-2) + "┐"
+	bottom := "└" + strings.Repeat("─", width-2) + "┘"
+	lines := strings.Split(ansi.Strip(view), "\n")
+	first, last := -1, -1
+	for i, line := range lines {
+		if first < 0 && strings.Contains(line, top) {
+			first = i
+		}
+		if strings.Contains(line, bottom) {
+			last = i
+		}
+	}
+	if first < 0 || last < first {
+		t.Fatalf("no %d-wide select panel found in:\n%s", width, view)
+	}
+	return last - first + 1
+}
+
+func TestNormalizePromptEditorLayoutWalksTheClampLadder(t *testing.T) {
+	cases := []struct {
+		name         string
+		width, body  int
+		wantWidth    int
+		wantHeight   int
+		wantViewport int
+		wantNoteRows int
+		wantFrame    bool
+		wantIdentity bool
+		wantHint     bool
+	}{
+		{"80x24 ideal", 80, 23, promptEditorWidth, promptEditorHeight, 12, 2, true, true, true},
+		{"80x20 continuous viewport", 80, 19, promptEditorWidth, 19, 10, 2, true, true, true},
+		{"40x12 shrinks the note block first", 40, 11, 36, 11, 3, 1, true, true, true},
+		{"20x6 degenerate floor", 20, 5, 20, 4, 1, 0, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizePromptEditorLayout(tc.width, tc.body)
+			if got.width != tc.wantWidth || got.height != tc.wantHeight {
+				t.Fatalf("layout = %dx%d, want %dx%d", got.width, got.height, tc.wantWidth, tc.wantHeight)
+			}
+			if got.viewportLines != tc.wantViewport {
+				t.Fatalf("viewport = %d, want %d", got.viewportLines, tc.wantViewport)
+			}
+			if got.noteRows != tc.wantNoteRows {
+				t.Fatalf("note rows = %d, want %d", got.noteRows, tc.wantNoteRows)
+			}
+			if got.frame != tc.wantFrame || got.hasIdentity != tc.wantIdentity || got.hasHint != tc.wantHint {
+				t.Fatalf("frame/identity/hint = %v/%v/%v, want %v/%v/%v",
+					got.frame, got.hasIdentity, got.hasHint, tc.wantFrame, tc.wantIdentity, tc.wantHint)
+			}
+			if got.height > tc.body {
+				t.Fatalf("layout height %d exceeds body height %d", got.height, tc.body)
+			}
+		})
+	}
+}
+
+func TestNormalizePromptEditorLayoutNeverGoesBelowTheFloor(t *testing.T) {
+	for body := 0; body <= 24; body++ {
+		for _, width := range []int{4, 10, 20, 34, 40, 80, 200} {
+			layout := normalizePromptEditorLayout(width, body)
+			if layout.height < 4 {
+				t.Fatalf("%dx%d height = %d, want at least the 4-row floor", width, body, layout.height)
+			}
+			if layout.viewportLines < 1 {
+				t.Fatalf("%dx%d viewport = %d, want at least the cursor line", width, body, layout.viewportLines)
+			}
+			if layout.width < 1 || layout.width > max(1, width) {
+				t.Fatalf("%dx%d width = %d, want within the terminal", width, body, layout.width)
+			}
+			if layout.height > body && layout.height != 4 {
+				t.Fatalf("%dx%d height %d exceeds body without being the floor", width, body, layout.height)
+			}
+		}
+	}
+}
+
+func TestNormalizePromptEditorLayoutDropsFrameForNarrowText(t *testing.T) {
+	layout := normalizePromptEditorLayout(12, 23)
+	if layout.frame {
+		t.Fatalf("expected the viewport frame dropped to recover columns at width 12: %#v", layout)
+	}
+	if layout.textWidth() < 1 {
+		t.Fatalf("text width = %d, want at least 1", layout.textWidth())
+	}
+}
+
+func TestRender_PromptEditorGeometryIsFixedRegardlessOfContent(t *testing.T) {
+	long := make([]string, 400)
+	for i := range long {
+		long[i] = "line"
+	}
+	cases := []struct {
+		name   string
+		mutate func(RenderParams) RenderParams
+	}{
+		{"empty template", func(p RenderParams) RenderParams { return p }},
+		{"three lines", func(p RenderParams) RenderParams {
+			p.InputValue = "a\nb\nc"
+			p.InputCursor = 5
+			return p
+		}},
+		{"400 lines", func(p RenderParams) RenderParams {
+			p.InputValue = strings.Join(long, "\n")
+			p.InputCursor = len([]rune(p.InputValue))
+			return p
+		}},
+		{"single 400-column line", func(p RenderParams) RenderParams {
+			p.InputValue = strings.Repeat("x", 400)
+			p.InputCursor = 400
+			return p
+		}},
+		{"validation error", func(p RenderParams) RenderParams {
+			p.InputError = "template must not contain a null byte"
+			return p
+		}},
+		{"feedback note", func(p RenderParams) RenderParams {
+			p.Editor.Note = "open /etc/approach/config.toml: permission denied"
+			p.Editor.NoteKind = NoteError
+			return p
+		}},
+		{"dirty", func(p RenderParams) RenderParams {
+			p.Editor.Dirty = true
+			return p
+		}},
+	}
+
+	var wantWidth, wantRows int
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			view := Render(tc.mutate(editorParams(80, 24, "", 0)))
+			width, rows := panelBounds(t, view)
+			if i == 0 {
+				wantWidth, wantRows = width, rows
+				if wantWidth != promptEditorWidth || wantRows != promptEditorHeight {
+					t.Fatalf("panel = %dx%d, want %dx%d", wantWidth, wantRows, promptEditorWidth, promptEditorHeight)
+				}
+				return
+			}
+			if width != wantWidth || rows != wantRows {
+				t.Fatalf("panel = %dx%d, want fixed %dx%d", width, rows, wantWidth, wantRows)
+			}
+		})
+	}
+}
+
+func TestRender_PromptEditorShowsTitleIdentityStateAndHints(t *testing.T) {
+	p := editorParams(80, 24, "custom body", 11)
+	p.Editor.Dirty = true
+	view := ansi.Strip(Render(p))
+
+	for _, want := range []string{
+		"Edit Plan launch",
+		"agent.plan_prompt",
+		"custom",
+		"modified",
+		"ctrl+s",
+		"enter",
+		"esc",
+		"line 1/1",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected editor to show %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestRender_PromptEditorEmptyTemplateShowsBuiltInDefaultAffordance(t *testing.T) {
+	view := ansi.Strip(Render(editorParams(80, 24, "", 0)))
+	if !strings.Contains(view, promptEditorEmptyHint) {
+		t.Fatalf("expected the built-in-default placeholder:\n%s", view)
+	}
+	if !strings.Contains(view, "█") {
+		t.Fatalf("expected a cursor in the empty viewport:\n%s", view)
+	}
+}
+
+func TestRender_PromptEditorClampsWithoutDrawingOutOfBounds(t *testing.T) {
+	value := strings.Repeat("some template line\n", 40)
+	for _, size := range []struct{ w, h int }{{80, 24}, {80, 20}, {40, 12}, {20, 6}, {18, 5}, {12, 4}} {
+		t.Run(strings.Join([]string{"size", itoaTest(size.w), itoaTest(size.h)}, "-"), func(t *testing.T) {
+			p := editorParams(size.w, size.h, value, len([]rune(value))/2)
+			view := Render(p)
+			lines := strings.Split(view, "\n")
+			if len(lines) > size.h {
+				t.Fatalf("rendered %d lines, want at most %d", len(lines), size.h)
+			}
+			for i, line := range lines {
+				if w := lipgloss.Width(line); w > size.w {
+					t.Fatalf("line %d width %d exceeds terminal width %d", i, w, size.w)
+				}
+			}
+			if !strings.Contains(ansi.Strip(view), "█") {
+				t.Fatalf("cursor must stay visible at %dx%d:\n%s", size.w, size.h, view)
+			}
+		})
+	}
+}
+
+func TestRender_PromptEditorHintKeysSurviveClamping(t *testing.T) {
+	value := "template"
+	view := ansi.Strip(Render(editorParams(40, 12, value, 8)))
+	for _, want := range []string{"ctrl+s", "esc", "enter"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expected %q in the 40x12 hint row:\n%s", want, view)
+		}
+	}
+
+	// At widths that still fit it, the status bar names all three keys.
+	if got := promptEditorStatusText(80); !strings.Contains(got, "ctrl+s") ||
+		!strings.Contains(got, "esc") || !strings.Contains(got, "enter") {
+		t.Fatalf("wide status text = %q", got)
+	}
+	if got := promptEditorStatusText(35); got != promptEditorStatusCompact {
+		t.Fatalf("status text at width 35 = %q, want the compact form", got)
+	}
+	// Below that the compact form no longer fits; the fallback still names the
+	// save and cancel keys inside 20 columns.
+	got := promptEditorStatusText(20)
+	if got != promptEditorStatusFallback {
+		t.Fatalf("status text at width 20 = %q, want the fallback", got)
+	}
+	if lipgloss.Width(got) > 20 {
+		t.Fatalf("fallback status text is %d columns, want at most 20", lipgloss.Width(got))
+	}
+}
+
+func TestPromptEditorViewportWindowFollowsTheCursor(t *testing.T) {
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = "line"
+	}
+	lines[0] = "first"
+	lines[29] = "last"
+
+	window, first, more := promptEditorViewportWindow(lines, 12, 29)
+	if len(window) != 12 {
+		t.Fatalf("window = %d rows, want 12", len(window))
+	}
+	if window[len(window)-1] != "last" {
+		t.Fatal("expected the last line in view when the cursor is on it")
+	}
+	if first == 0 || more {
+		t.Fatalf("first = %d, more = %v, want a scrolled window at the end", first, more)
+	}
+
+	window, first, more = promptEditorViewportWindow(lines, 12, 0)
+	if first != 0 || !more || window[0] != "first" {
+		t.Fatalf("expected the top window: first=%d more=%v", first, more)
+	}
+
+	for cursor := 0; cursor < len(lines); cursor++ {
+		window, first, _ := promptEditorViewportWindow(lines, 5, cursor)
+		if cursor < first || cursor >= first+len(window) {
+			t.Fatalf("cursor %d fell outside window [%d,%d)", cursor, first, first+len(window))
+		}
+	}
+}
+
+func TestPromptEditorViewportWindowNeverReplacesContentWithAMarker(t *testing.T) {
+	lines := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
+	for _, rows := range []int{1, 2, 3, 4, 5, 6} {
+		for cursor := range lines {
+			window, first, _ := promptEditorViewportWindow(lines, rows, cursor)
+			for i, line := range window {
+				if line == shortcutOverflowMarker {
+					t.Fatalf("rows=%d cursor=%d: window row %d was replaced by an overflow marker", rows, cursor, i)
+				}
+				if line != lines[first+i] {
+					t.Fatalf("rows=%d cursor=%d: window row %d = %q, want %q", rows, cursor, i, line, lines[first+i])
+				}
+			}
+		}
+	}
+}
+
+func TestRender_PromptEditorShowsOverflowArrowsAndLogicalPosition(t *testing.T) {
+	// Non-ASCII on purpose: InputCursor is a rune index, so a byte-slice
+	// regression in the position label fails loudly here.
+	lines := make([]string, 40)
+	for i := range lines {
+		lines[i] = "テンプレート"
+	}
+	value := strings.Join(lines, "\n")
+	cursorLine := 20
+	cursor := len([]rune(strings.Join(lines[:cursorLine], "\n"))) + 1
+
+	view := ansi.Strip(Render(editorParams(80, 24, value, cursor)))
+	if !strings.Contains(view, "line 21/40") {
+		t.Fatalf("expected logical position line 21/40:\n%s", view)
+	}
+	if !strings.Contains(view, "▲") || !strings.Contains(view, "▼") {
+		t.Fatalf("expected overflow arrows on both frame edges:\n%s", view)
+	}
+}
+
+func TestPromptEditorBodyLinesPreserveRawWhitespace(t *testing.T) {
+	value := "    indented\n\n  two  interior   spaces  \nlast"
+	lines, cursorLine := promptEditorBodyLines(value, 0, 60)
+
+	if cursorLine != 0 {
+		t.Fatalf("cursor line = %d, want 0", cursorLine)
+	}
+	if got := lines[0]; got != "█    indented" {
+		t.Fatalf("line 0 = %q, want no label prefix and preserved leading spaces", got)
+	}
+	if got := lines[1]; got != "" {
+		t.Fatalf("interior blank line = %q, want preserved", got)
+	}
+	if got := lines[2]; got != "  two  interior   spaces  " {
+		t.Fatalf("line 2 = %q, want repeated spaces preserved verbatim", got)
+	}
+	if got := lines[3]; got != "last" {
+		t.Fatalf("line 3 = %q", got)
+	}
+}
+
+func TestPromptEditorNoteBlockPrecedenceAndTruncation(t *testing.T) {
+	base := editorParams(80, 24, "body", 4)
+	base.InputError = "validation failed"
+	base.Editor.Note = "persistence failed"
+	base.Editor.EmptyWarning = true
+
+	rows := promptEditorNoteRows(base, 2, 60)
+	if len(rows) != 2 {
+		t.Fatalf("note rows = %d, want 2", len(rows))
+	}
+	if !strings.Contains(ansi.Strip(rows[0]), "validation failed") {
+		t.Fatalf("expected the validation error to win: %q", rows[0])
+	}
+
+	base.InputError = ""
+	rows = promptEditorNoteRows(base, 2, 60)
+	if !strings.Contains(ansi.Strip(rows[0]), "persistence failed") {
+		t.Fatalf("expected the stored note next: %q", rows[0])
+	}
+
+	base.Editor.Note = ""
+	rows = promptEditorNoteRows(base, 2, 60)
+	if !strings.Contains(ansi.Strip(rows[0]), promptEditorEmptyWarning) {
+		t.Fatalf("expected the derived empty warning last: %q", rows[0])
+	}
+
+	base.Editor.EmptyWarning = false
+	rows = promptEditorNoteRows(base, 2, 60)
+	for i, row := range rows {
+		if row != "" {
+			t.Fatalf("row %d = %q, want a present-but-blank note block", i, row)
+		}
+	}
+}
+
+func TestPromptEditorLongErrorIsTruncatedInsideTheFixedNoteBlock(t *testing.T) {
+	p := editorParams(80, 24, "body", 4)
+	p.Editor.Note = "open /Users/someone/very/long/path/to/.config/approach/config.toml: " +
+		"permission denied while writing the agent section for this prompt template"
+	p.Editor.NoteKind = NoteError
+
+	rows := promptEditorNoteRows(p, 2, 66)
+	if len(rows) != 2 {
+		t.Fatalf("note rows = %d, want exactly 2", len(rows))
+	}
+	// The leading, specific part of the error — the path — survives; a
+	// pathological tail is elided rather than allowed to grow the panel.
+	if !strings.Contains(ansi.Strip(rows[0])+ansi.Strip(rows[1]), "config.toml") {
+		t.Fatalf("expected the leading, specific part of the error to survive:\n%q\n%q", rows[0], rows[1])
+	}
+	if !strings.HasSuffix(ansi.Strip(rows[1]), "…") {
+		t.Fatalf("expected the overflowing last row truncated with an ellipsis: %q", rows[1])
+	}
+	for i, row := range rows {
+		if w := lipgloss.Width(ansi.Strip(row)); w > 66 {
+			t.Fatalf("note row %d is %d columns, want at most 66", i, w)
+		}
+	}
+}
+
+func TestRender_PromptTemplatePickerReservesANoteRow(t *testing.T) {
+	items := make([]SelectItem, 9)
+	for i := range items {
+		items[i] = SelectItem{Label: "Template", Value: "t"}
+	}
+	base := RenderParams{
+		Repos:           []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:           80,
+		Height:          24,
+		Mode:            ModePlans,
+		Overlay:         OverlaySelect,
+		SelectPrompt:    PromptTemplateSelectPrompt,
+		SelectItems:     items,
+		SelectWidth:     PromptPickerWidth,
+		SelectHeight:    len(items) + 3 + PromptPickerNoteRows,
+		SelectPlacement: SelectPlacementCenter,
+	}
+
+	wantRows := len(items) + 3 + PromptPickerNoteRows
+	plainRows := overlaySelectPanelRows(t, Render(base), PromptPickerWidth)
+	if plainRows != wantRows {
+		t.Fatalf("picker panel rows = %d, want %d", plainRows, wantRows)
+	}
+
+	noted := base
+	noted.SelectNote = "Saved Plan launch"
+	noted.SelectNoteKind = NoteSuccess
+	notedView := Render(noted)
+	if notedRows := overlaySelectPanelRows(t, notedView, PromptPickerWidth); notedRows != plainRows {
+		t.Fatalf("note changed the picker geometry: %d rows vs %d", notedRows, plainRows)
+	}
+	if !strings.Contains(ansi.Strip(notedView), "Saved Plan launch") {
+		t.Fatalf("expected the picker note rendered:\n%s", notedView)
+	}
+	// Every item stays visible even with the note row reserved.
+	if strings.Count(ansi.Strip(notedView), "Template") < len(items) {
+		t.Fatalf("note row displaced picker items:\n%s", notedView)
+	}
+
+	errored := base
+	errored.SelectNote = "read-only config"
+	errored.SelectNoteKind = NoteError
+	if !strings.Contains(ansi.Strip(Render(errored)), "read-only config") {
+		t.Fatal("expected the picker note row to carry errors too")
+	}
+}
+
+func TestRender_SelectPanelWithoutANoteKeepsItsAutoGeometry(t *testing.T) {
+	items := []SelectItem{{Label: "codex", Value: "codex"}, {Label: "claude", Value: "claude"}}
+	view := Render(RenderParams{
+		Repos:        []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:        80,
+		Height:       24,
+		Mode:         ModeWorktrees,
+		Overlay:      OverlaySelect,
+		SelectPrompt: "Choose agent",
+		SelectItems:  items,
+	})
+	if rows := overlaySelectPanelRows(t, view, autoSelectPanelWidth("Choose agent", items)); rows != 2+1+len(items) {
+		t.Fatalf("auto select panel rows = %d, want %d", rows, 2+1+len(items))
+	}
+}
+
+func TestRender_PromptEditorStatusBarReplacesTheGenericMultilineHints(t *testing.T) {
+	view := ansi.Strip(Render(editorParams(80, 24, "body", 4)))
+	if strings.Contains(view, "alt+enter: newline") {
+		t.Fatalf("editor should not show the generic multiline hints:\n%s", view)
+	}
+	if !strings.Contains(view, "ctrl+s save") {
+		t.Fatalf("expected the editor status hints:\n%s", view)
+	}
+
+	generic := ansi.Strip(Render(RenderParams{
+		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:       80,
+		Height:      24,
+		Mode:        ModePlans,
+		Overlay:     OverlayInput,
+		InputPrompt: "Launch instructions",
+		InputValue:  "body",
+		InputCursor: 4,
+		InputMode:   InputMultiLine,
+	}))
+	if !strings.Contains(generic, "alt+enter: newline") {
+		t.Fatalf("generic multiline input lost its hints:\n%s", generic)
+	}
+}
+
+func itoaTest(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	out := ""
+	for n > 0 {
+		out = string(rune('0'+n%10)) + out
+		n /= 10
+	}
+	return out
+}

--- a/ui/prompt_editor_test.go
+++ b/ui/prompt_editor_test.go
@@ -478,6 +478,27 @@ func TestRender_PromptTemplatePickerReservesANoteRow(t *testing.T) {
 	}
 }
 
+func TestRenderSelectPanelDropsNoteBeforeStealingItemRows(t *testing.T) {
+	items := []SelectItem{{Label: "alpha", Value: "a"}, {Label: "bravo", Value: "b"}}
+	width, height := selectPanelDimensions("Prompt templates", items, 20, 6, 20, 5)
+	if height != 5 {
+		t.Fatalf("clamped height = %d, want 5", height)
+	}
+
+	lines := renderSelectPanel(selectPanelSpec{
+		prompt:   "Prompt templates",
+		items:    items,
+		note:     "Saved",
+		noteKind: NoteSuccess,
+		width:    width,
+		height:   height,
+	})
+	got := ansi.Strip(strings.Join(lines, "\n"))
+	if !strings.Contains(got, "alpha") || !strings.Contains(got, "bravo") {
+		t.Fatalf("clamped note stole an item row:\n%s", got)
+	}
+}
+
 func TestRender_SelectPanelWithoutANoteKeepsItsAutoGeometry(t *testing.T) {
 	items := []SelectItem{{Label: "codex", Value: "codex"}, {Label: "claude", Value: "claude"}}
 	view := Render(RenderParams{

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -54,6 +54,37 @@ const (
 	SelectPlacementBottomCenter
 )
 
+// NoteKind classifies the severity of a modal feedback note. It mirrors
+// modal.NoteKind, which ui cannot import; the model converts between them.
+type NoteKind int
+
+const (
+	NoteNeutral NoteKind = iota
+	NoteSuccess
+	NoteWarning
+	NoteError
+)
+
+// EditorParams carries the prompt-template editor's presentation state. Its
+// zero value keeps every other input modal on the generic renderer.
+type EditorParams struct {
+	Enabled      bool
+	Title        string
+	Identity     string
+	Note         string
+	NoteKind     NoteKind
+	Dirty        bool
+	EmptyWarning bool
+}
+
+// PromptPickerWidth and PromptPickerNoteRows are the prompt-template picker's
+// fixed geometry. They are exported because the model owns the target list and
+// therefore computes the panel height; ui cannot see len(promptTemplateTargets).
+const (
+	PromptPickerWidth    = 42
+	PromptPickerNoteRows = 1
+)
+
 const BranchPrompt = "New branch"
 const FlowTitlePrompt = "New flow title"
 const FlowInstructionsPrompt = "New flow instructions"
@@ -389,6 +420,7 @@ type RenderParams struct {
 	InputMode                      InputMode
 	InputHeight                    int
 	InputCursor                    int
+	Editor                         EditorParams
 	WorktreeInputPrompt            string
 	WorktreeInputPlaceholder       string
 	WorktreeInput                  string
@@ -398,6 +430,8 @@ type RenderParams struct {
 	SelectSelected                 int
 	SelectWidth                    int
 	SelectHeight                   int
+	SelectNote                     string
+	SelectNoteKind                 NoteKind
 	SelectPlacement                SelectPlacement
 	Form                           FormView
 	BranchScroll                   int
@@ -730,6 +764,7 @@ func renderApplication(p RenderParams) string {
 		PRBabysitter:                 prBabysitter,
 		Overlay:                      p.Overlay,
 		InputMode:                    inputRenderParamsFrom(p).mode,
+		PromptEditor:                 p.Editor.Enabled,
 		FormHasMultiline:             formHasMultilineField(p.Form),
 		WorktreeInputPrompt:          p.WorktreeInputPrompt,
 		ActivePane:                   p.ActivePane,
@@ -1556,6 +1591,7 @@ type statusBarParams struct {
 	PRBabysitter                 bool
 	Overlay                      OverlayState
 	InputMode                    InputMode
+	PromptEditor                 bool
 	FormHasMultiline             bool
 	WorktreeInputPrompt          string
 	SelectPrompt                 string
@@ -1711,6 +1747,9 @@ func renderStatusBarWithState(sp statusBarParams) string {
 	case overlay == OverlayConfirm:
 		return statusStyle.Width(width).Render("  y: confirm  n/esc: cancel")
 	case overlay == OverlayInput:
+		if sp.PromptEditor {
+			return renderStatusText(width, promptEditorStatusText(width))
+		}
 		if sp.InputMode == InputMultiLine {
 			return renderStatusText(width, "  enter: submit  alt+enter: newline  esc: cancel  bksp/del: edit")
 		}
@@ -4257,7 +4296,15 @@ func renderSelectOverlay(p RenderParams) string {
 	if panelWidth <= 0 || panelHeight <= 0 {
 		return joinBodyAndStatus(body, statusBar)
 	}
-	panel := renderSelectPanel(p.SelectPrompt, p.SelectItems, p.SelectSelected, panelWidth, panelHeight)
+	panel := renderSelectPanel(selectPanelSpec{
+		prompt:   p.SelectPrompt,
+		items:    p.SelectItems,
+		selected: p.SelectSelected,
+		note:     p.SelectNote,
+		noteKind: p.SelectNoteKind,
+		width:    panelWidth,
+		height:   panelHeight,
+	})
 	x, y := selectPanelPosition(p.Width, bodyHeight, panelWidth, panelHeight, p.SelectPlacement)
 	body = compositePanel(body, panel, x, y, p.Width)
 	return joinBodyAndStatus(body, statusBar)
@@ -4380,7 +4427,21 @@ func selectPanelPosition(terminalWidth, bodyHeight, panelWidth, panelHeight int,
 	return x, y
 }
 
-func renderSelectPanel(prompt string, items []SelectItem, selected, width, height int) []string {
+// selectPanelSpec groups the shared select renderer's inputs so the reserved
+// note row can be added without a seventh positional argument.
+type selectPanelSpec struct {
+	prompt   string
+	items    []SelectItem
+	selected int
+	note     string
+	noteKind NoteKind
+	width    int
+	height   int
+}
+
+func renderSelectPanel(spec selectPanelSpec) []string {
+	prompt, items, selected := spec.prompt, spec.items, spec.selected
+	width, height := spec.width, spec.height
 	if width <= 0 || height <= 0 {
 		return nil
 	}
@@ -4390,12 +4451,18 @@ func renderSelectPanel(prompt string, items []SelectItem, selected, width, heigh
 	if selected < 0 || selected >= len(items) {
 		selected = 0
 	}
+	// The note reserves a row only when there is one to show and the panel is
+	// tall enough that it would not displace the bottom border.
+	noteRows := 0
+	if spec.note != "" && height > 3 {
+		noteRows = 1
+	}
 	lines := make([]string, 0, height)
 	lines = append(lines, selectPanelBorderLine("┌", "─", "┐", width))
 	if height > 1 {
 		lines = append(lines, selectPanelContentLine(activeModeStyle.Render(prompt), width))
 	}
-	itemRows := height - 3
+	itemRows := height - 3 - noteRows
 	if itemRows < 0 {
 		itemRows = 0
 	}
@@ -4412,6 +4479,14 @@ func renderSelectPanel(prompt string, items []SelectItem, selected, width, heigh
 			line = selectedStyle.Render("> " + label)
 		}
 		lines = append(lines, selectPanelContentLine(line, width))
+	}
+	if noteRows == 1 {
+		noteWidth := width - 4
+		if noteWidth < 1 {
+			noteWidth = 1
+		}
+		note := noteStyle(spec.noteKind).Render(truncateWithEllipsis(spec.note, noteWidth))
+		lines = append(lines, selectPanelContentLine(note, width))
 	}
 	if height > 2 {
 		lines = append(lines, selectPanelBorderLine("└", "─", "┘", width))
@@ -4533,6 +4608,7 @@ func renderOverlay(p RenderParams) string {
 		Mode:                   p.Mode,
 		Overlay:                p.Overlay,
 		InputMode:              inputParams.mode,
+		PromptEditor:           p.Editor.Enabled,
 		FormHasMultiline:       formHasMultilineField(p.Form),
 		WorktreeInputPrompt:    inputParams.prompt,
 		SelectPrompt:           p.SelectPrompt,
@@ -4556,7 +4632,12 @@ func renderOverlay(p RenderParams) string {
 		return strings.Join(lines, "\n") + "\n" + statusBar
 	}
 	if p.Overlay == OverlayInput {
-		lines := renderInputDialog(inputParams, p.Width, contentHeight)
+		var lines []string
+		if p.Editor.Enabled {
+			lines = renderPromptEditorDialog(p, p.Width, contentHeight)
+		} else {
+			lines = renderInputDialog(inputParams, p.Width, contentHeight)
+		}
 		return strings.Join(lines, "\n") + "\n" + statusBar
 	}
 	if p.Overlay == OverlayForm {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -4451,20 +4451,22 @@ func renderSelectPanel(spec selectPanelSpec) []string {
 	if selected < 0 || selected >= len(items) {
 		selected = 0
 	}
-	// The note reserves a row only when there is one to show and the panel is
-	// tall enough that it would not displace the bottom border.
+	// A note takes a row only when the panel already has a spare item slot.
+	// Designed picker height includes that spare; a clamped panel does not, so
+	// the note is dropped instead of hiding an item that would otherwise fit.
+	itemRows := height - 3
+	if itemRows < 0 {
+		itemRows = 0
+	}
 	noteRows := 0
-	if spec.note != "" && height > 3 {
+	if spec.note != "" && height > 3 && itemRows > len(items) {
 		noteRows = 1
+		itemRows--
 	}
 	lines := make([]string, 0, height)
 	lines = append(lines, selectPanelBorderLine("┌", "─", "┐", width))
 	if height > 1 {
 		lines = append(lines, selectPanelContentLine(activeModeStyle.Render(prompt), width))
-	}
-	itemRows := height - 3 - noteRows
-	if itemRows < 0 {
-		itemRows = 0
 	}
 	start := selectItemViewportStart(len(items), selected, itemRows)
 	for i := 0; i < itemRows; i++ {


### PR DESCRIPTION
## Summary

The `f2` prompt-template workflow read as two generic utility dialogs. This gives the picker and the editor deliberate fixed geometry, natural multiline editing, explicit state, and honest in-modal feedback — without changing raw template semantics, built-in previews, placeholder interpolation, or the config format.

User-visible changes:

- **Editor geometry is fixed** at 72x21 instead of growing and shrinking with content: title, identity and `default`/`custom`/`modified` state, a framed 12-line viewport, a two-row note block, and a hint row.
- **Multiline editing is natural**: `enter` inserts a newline, `ctrl+s` saves the raw value, and `home`/`end` are line-aware.
- **Feedback is in the modal, not the status bar.** Save, reset, cancel, and write failures report into reserved rows, so the key hints stay visible and nothing flashes a 3s toast over them.
- **A failed write no longer drops your work.** The editor is reconstructed with the draft, the cursor, and the error, so `ctrl+s` retries and `esc` abandons.
- **Reset now confirms**, and carries an origin so a failed reset restores the surface you were on — the picker with its selection, or the editor with its blank draft.

## Implementation

- `Modal` gains an **opt-in editor spec (`AsEditor`)** rather than a new `Kind` or prompt-string sniffing, so confirmation, single-line, launch-instruction multiline, select, and form modals are untouched: every new field is inert at its zero value.
- `Original` is a required spec field independent of the initial value, so `Dirty` is exact and an editor rebuilt after a failed write opens already dirty.
- `WithCancel` receives the view captured *before* the modal is zeroed — the only way a cancel can distinguish a clean exit from discarded changes. `deferCancel` returns `nil` when no hook is set, so every existing cancel path still yields a nil command.
- **The renderer owns the geometry.** `normalizePromptEditorLayout` picks width first (it can drop the viewport frame, changing the height budget), then walks a continuous-then-discrete ladder down to a 4-row floor, clipping rather than drawing out of bounds. The picker is a fixed 42 columns with one reserved feedback row.
- The editor gets **its own windowing helper** instead of `compactInputDialogLines`, which overwrites its boundary lines with an overflow marker — that destroys real template text and at two rows can hide the cursor itself. Overflow arrows and a logical-line `L/N` indicator live on the viewport frame instead, counted over runes because `InputCursor` is a rune index.
- The cursor is tagged in `handleKey` from the pre-`Update` view, since the submit closure only ever receives the string. A whitespace-only submit takes the *reset* path rather than the save path, so `Cursor` is carried on `PromptTemplateResetFailedMsg` too and both failure messages are tagged in the same place — otherwise a failed reset would rebuild the editor with the cursor derived as `len(draft)`, jumping to the end of the buffer on every failed retry. Picker-origin resets never reach the editor branch, so their untagged zero cursor is inert.

## Verification

- `make fmt-check`, `make test`, `make build`.
- Re-ran `go build ./...`, `gofmt`, and `go test ./model/... ./ui/...` after rebasing onto current `main` (which landed the f2-editable autofix prompt and the CI flake hardening in the same packages) — all green.
- tmux smoke pass against a scratch `--state-root` and config home at 80x24, 80x20, 40x12, and 20x6, exercising save, both cancels, reset with confirm and with cancel, preview, scrolling, and a forced read-only-config failure and retry.
