### PR TITLE
Bump Go to 1.26.6 for the August security point release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/approachcontrol/approach
 
-go 1.26.1
+go 1.26.6
 
 // `web/node_modules` lives inside the module tree and some npm packages ship
 // Go files. Filtering them out of `go list ./...` *output* is too late: a Go


### PR DESCRIPTION
Go 1.26.6 landed on 2026-08-13 with toolchain and stdlib security fixes (module sumdb verification, `crypto/tls`, `net/http`, `encoding/xml`, and others). We were still pinned to 1.26.1, so CI and releases would keep building on the older patch.

This updates the `go` directive in `go.mod` to 1.26.6. Workflows already install Go from that file, so they pick up the new patch without further changes. No `toolchain` line was added, matching the existing pin style. `go mod tidy` under 1.26.6 left `go.sum` unchanged.

## Test plan
- [x] `GOTOOLCHAIN=go1.26.6 go version` reports `go1.26.6`
- [x] `make fmt-check`
- [x] `make build`
- [x] CI on this PR