### PR TITLE
Shrink the expanded terminal dock so the stored panes get the extra rows

### DIFF
--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -342,8 +342,8 @@ header. The current list remains usable above the dock; in particular, the
 saved-session table is never replaced by the terminal surface.
 
 Press `ctrl+t` from repo or list focus to store whether the dock is requested
-open or manually hidden. An expanded dock shrinks before either stored pane is
-sacrificed. If the viewport cannot fit both panes plus a framed terminal header
+open or manually hidden. An expanded dock asks for roughly three eighths of the
+viewport and shrinks before either stored pane is sacrificed. If the viewport cannot fit both panes plus a framed terminal header
 and one output row, the requested-open dock automatically becomes the collapsed
 chip. Growing the viewport restores it automatically while the request remains
 open. Pressing `ctrl+t` during automatic collapse changes that request to a

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -509,7 +509,7 @@ func TestFirstTerminalStartupUsesProspectiveRequestedState(t *testing.T) {
 	t.Run("interactive session requests expansion", func(t *testing.T) {
 		var started [2]int
 		next, opened, err := newModel(&started).openEmbeddedTerminal(actions.AgentLaunchContext{}, sessions.SessionRecord{Provider: sessions.ProviderCodex})
-		if err != nil || !opened || started[1] != 42 || !next.terminalDockVisible {
+		if err != nil || !opened || started[1] != 19 || !next.terminalDockVisible {
 			t.Fatalf("session startup: opened=%v err=%v size=%v requested=%v", opened, err, started, next.terminalDockVisible)
 		}
 	})
@@ -517,7 +517,7 @@ func TestFirstTerminalStartupUsesProspectiveRequestedState(t *testing.T) {
 	t.Run("interactive Flow requests expansion", func(t *testing.T) {
 		var started [2]int
 		next, opened, err, _ := newModel(&started).openFlowEmbeddedTerminal(actions.AgentLaunchContext{Command: "codex"})
-		if err != nil || !opened || started[1] != 42 || !next.terminalDockVisible {
+		if err != nil || !opened || started[1] != 19 || !next.terminalDockVisible {
 			t.Fatalf("interactive Flow startup: opened=%v err=%v size=%v requested=%v", opened, err, started, next.terminalDockVisible)
 		}
 	})

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -5495,13 +5495,13 @@ func TestModel_EmbeddedTerminalUsesFullAppWidth(t *testing.T) {
 func TestModel_EmbeddedTerminalUsesResponsiveRenderAndBackendRows(t *testing.T) {
 	m, fakeTerm, started := openEmbeddedSessionForSizingTest(t, 180, 65)
 	wantWidth := ui.EmbeddedTerminalPTYWidth(180)
-	if want := [2]int{wantWidth, 42}; started != want {
+	if want := [2]int{wantWidth, 19}; started != want {
 		t.Fatalf("height 65 start = %v, want %v", started, want)
 	}
 
 	fakeTerm.visibleCalls = nil
 	_ = m.View()
-	if want := [2]int{wantWidth, 42}; len(fakeTerm.visibleCalls) != 1 || fakeTerm.visibleCalls[0] != want {
+	if want := [2]int{wantWidth, 19}; len(fakeTerm.visibleCalls) != 1 || fakeTerm.visibleCalls[0] != want {
 		t.Fatalf("height 65 visible calls = %#v, want [%v]", fakeTerm.visibleCalls, want)
 	}
 
@@ -5510,7 +5510,7 @@ func TestModel_EmbeddedTerminalUsesResponsiveRenderAndBackendRows(t *testing.T) 
 		wantBackend int
 		wantRender  int
 	}{
-		{height: 64, wantBackend: 41, wantRender: 41},
+		{height: 64, wantBackend: 19, wantRender: 19},
 		{height: 24, wantBackend: 1, wantRender: 1},
 		{height: 23, wantBackend: 1},
 	} {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -350,8 +350,6 @@ const PlanContentOverhead = BranchContentOverhead + TableHeaderRows
 // render: right-pane chrome plus the flows table header.
 const FlowContentOverhead = BranchContentOverhead + TableHeaderRows
 
-const flowSplitMinPanelHeight = 4
-
 // TerminalChipRows is the list-space reserved by a collapsed dock chip.
 const TerminalChipRows = 1
 
@@ -580,21 +578,14 @@ func EmbeddedTerminalDockHeights(height int, state EmbeddedTerminalDockState) (l
 	if state != EmbeddedTerminalDockExpanded {
 		return height, 0
 	}
-	if height < flowSplitMinPanelHeight*2 {
-		listHeight = height / 2
-		if listHeight < 1 {
-			listHeight = 1
-		}
-		return listHeight, height - listHeight
-	}
-	listHeight = height / 4
-	if listHeight < flowSplitMinPanelHeight {
-		listHeight = flowSplitMinPanelHeight
-	}
-	terminalHeight = height - listHeight
+	terminalHeight = height * 3 / 8
 	if terminalHeight < 1 {
 		terminalHeight = 1
-		listHeight = height - terminalHeight
+	}
+	listHeight = height - terminalHeight
+	if listHeight < 1 {
+		listHeight = 1
+		terminalHeight = height - listHeight
 	}
 	return listHeight, terminalHeight
 }

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -104,8 +104,9 @@ func TestEmbeddedTerminalDockHeights(t *testing.T) {
 		wantTerminal int
 	}{
 		{name: "collapsed", height: 10, state: EmbeddedTerminalDockCollapsed, wantList: 10},
-		{name: "expanded", height: 10, state: EmbeddedTerminalDockExpanded, wantList: 4, wantTerminal: 6},
-		{name: "tiny expanded", height: 3, state: EmbeddedTerminalDockExpanded, wantList: 1, wantTerminal: 2},
+		{name: "expanded", height: 10, state: EmbeddedTerminalDockExpanded, wantList: 7, wantTerminal: 3},
+		{name: "tall expanded", height: 60, state: EmbeddedTerminalDockExpanded, wantList: 38, wantTerminal: 22},
+		{name: "tiny expanded", height: 3, state: EmbeddedTerminalDockExpanded, wantList: 2, wantTerminal: 1},
 		{name: "zero expanded", height: 0, state: EmbeddedTerminalDockExpanded},
 	}
 
@@ -133,8 +134,8 @@ func TestResolveEmbeddedTerminalDock(t *testing.T) {
 		wantBackend   int
 		wantShared    int
 	}{
-		{name: "preferred tall", height: 65, requested: true, wantState: EmbeddedTerminalDockExpanded, wantDock: 45, wantRenderPTY: 42, wantBackend: 42, wantShared: 19},
-		{name: "capped tall", height: 64, requested: true, wantState: EmbeddedTerminalDockExpanded, wantDock: 44, wantRenderPTY: 41, wantBackend: 41, wantShared: 19},
+		{name: "preferred tall", height: 65, requested: true, wantState: EmbeddedTerminalDockExpanded, wantDock: 22, wantRenderPTY: 19, wantBackend: 19, wantShared: 42},
+		{name: "capped tall", height: 64, requested: true, wantState: EmbeddedTerminalDockExpanded, wantDock: 22, wantRenderPTY: 19, wantBackend: 19, wantShared: 41},
 		{name: "minimum expanded", height: 24, requested: true, wantState: EmbeddedTerminalDockExpanded, wantDock: 4, wantRenderPTY: 1, wantBackend: 1, wantShared: 19},
 		{name: "auto collapsed", height: 23, requested: true, wantState: EmbeddedTerminalDockCollapsed, wantDock: 1, wantBackend: 1, wantShared: 21},
 		{name: "small collapsed", height: 7, requested: true, wantState: EmbeddedTerminalDockCollapsed, wantDock: 1, wantBackend: 1, wantShared: 5},


### PR DESCRIPTION
The embedded terminal took nearly the whole window when expanded. On a 65-row viewport the dock claimed 45 rows and the beads/flows panes were stuck at their 19-row floor, so growing the window only ever fed the terminal.

## Why it happened

`EmbeddedTerminalDockHeights` asked for three quarters of the split budget when expanded. That preferred height always exceeded the `viewportRows - statusRows - MinStackedPaneOuterRows` cap inside `ResolveEmbeddedTerminalDock`, which pinned `SharedOuterRows` at the 19-row minimum regardless of viewport height.

## The change

- Halve the preferred ratio to 3/8 of the split budget, so the dock stays below the cap and the freed rows fall through to `SharedOuterRows` automatically.
- Drop the now-unused `flowSplitMinPanelHeight` branches; the small-viewport cases are already covered by the 1-row clamps and the automatic chip-collapse path.
- Existing clamps, chip-collapse behavior, and row-conservation invariants in `ResolveEmbeddedTerminalDock` are untouched.

Resulting split at common heights:

| viewport | dock (before → after) | panes (before → after) |
| --- | --- | --- |
| 65 | 45 → 22 | 19 → 42 |
| 50 | 30 → 16 | 19 → 33 |
| ≤24 | unchanged | unchanged |

Viewports at or below 24 rows are unaffected because the cap already dominated the preferred height there.

## Verification

`go build ./...` and `go test ./ui/... ./model/...` pass. `ui/ui_test.go` gains a tall-viewport case and updates the expanded/tiny expectations; the `model` sizing tests now assert the smaller backend and render row counts. `docs/tui-guide.md` documents the new three-eighths behavior.