### PR TITLE
Cut model test time from 230s to 11s by injecting timer cadences

### DIFF
--- a/model/flow_advance_tick.go
+++ b/model/flow_advance_tick.go
@@ -14,7 +14,19 @@ import (
 // The advance poll is a session-long 1 Hz loop that fetches the unscoped flow
 // set and drives AutoMode phase launches from its own snapshot, independent of
 // which view is displayed. It never touches display state.
-const autoAdvanceTickInterval = time.Second
+//
+// Options may override the cadence; tests drive the loop far faster so they
+// never wait on wall time.
+const defaultAutoAdvanceTickInterval = time.Second
+
+// autoAdvanceTickDelay is the cadence this Model polls at. A zero field means
+// "unset" — a directly constructed Model still ticks at the production rate.
+func (m Model) autoAdvanceTickDelay() time.Duration {
+	if m.autoAdvanceTickInterval > 0 {
+		return m.autoAdvanceTickInterval
+	}
+	return defaultAutoAdvanceTickInterval
+}
 
 type autoAdvanceTickMsg struct{}
 
@@ -28,8 +40,8 @@ type AutoAdvanceResultMsg struct {
 	Request     uint64
 }
 
-func autoAdvanceTickCmd() tea.Cmd {
-	return tea.Tick(autoAdvanceTickInterval, func(time.Time) tea.Msg {
+func (m Model) autoAdvanceTickCmd() tea.Cmd {
+	return tea.Tick(m.autoAdvanceTickDelay(), func(time.Time) tea.Msg {
 		return autoAdvanceTickMsg{}
 	})
 }
@@ -61,7 +73,7 @@ func (m Model) finishAutoAdvanceFetch(request uint64) (Model, tea.Cmd) {
 		return m, nil
 	}
 	m.autoAdvanceInFlight = 0
-	return m, autoAdvanceTickCmd()
+	return m, m.autoAdvanceTickCmd()
 }
 
 func (m Model) handleAutoAdvanceResult(msg AutoAdvanceResultMsg) (Model, tea.Cmd) {

--- a/model/flow_advance_tick_test.go
+++ b/model/flow_advance_tick_test.go
@@ -67,7 +67,7 @@ func newAutoAdvanceTestModel(repos []scanner.Repo, opts Options) Model {
 	if opts.ReadFlow == nil {
 		opts.ReadFlow = autoAdvanceTestReadFlow
 	}
-	m := NewWithOptions(repos, opts)
+	m := newModelForTest(repos, opts)
 	m.launchSeams.InspectWorktreeDirectory = func(string) error { return nil }
 	return m
 }
@@ -980,8 +980,19 @@ func hasAutoAdvanceTickMsg(t *testing.T, cmd tea.Cmd) bool {
 }
 
 func TestModel_AutoAdvanceTickIntervalIsOneSecond(t *testing.T) {
-	if autoAdvanceTickInterval != time.Second {
-		t.Fatalf("autoAdvanceTickInterval = %s, want %s", autoAdvanceTickInterval, time.Second)
+	if defaultAutoAdvanceTickInterval != time.Second {
+		t.Fatalf("defaultAutoAdvanceTickInterval = %s, want %s", defaultAutoAdvanceTickInterval, time.Second)
+	}
+	// Injection is a test seam, not a production default: a Model built without
+	// an explicit interval must still poll at 1 Hz.
+	if got := NewWithOptions(nil, Options{}).autoAdvanceTickDelay(); got != time.Second {
+		t.Fatalf("uninjected autoAdvanceTickDelay() = %s, want %s", got, time.Second)
+	}
+	if got := (Model{}).autoAdvanceTickDelay(); got != time.Second {
+		t.Fatalf("zero-value autoAdvanceTickDelay() = %s, want %s", got, time.Second)
+	}
+	if got := NewWithOptions(nil, Options{AutoAdvanceTickInterval: 5 * time.Millisecond}).autoAdvanceTickDelay(); got != 5*time.Millisecond {
+		t.Fatalf("injected autoAdvanceTickDelay() = %s, want %s", got, 5*time.Millisecond)
 	}
 }
 
@@ -997,7 +1008,7 @@ func TestModel_AutoAdvanceTickScheduledFromInitInFlowsMode(t *testing.T) {
 }
 
 func TestModel_AutoAdvanceTickScheduledFromInitWithoutRepos(t *testing.T) {
-	m := NewWithOptions(nil, Options{})
+	m := newModelForTest(nil, Options{})
 	if !hasAutoAdvanceTickMsg(t, m.Init()) {
 		t.Fatal("Init() with no flows fetch should still schedule the auto-advance tick")
 	}

--- a/model/flow_delete_internal_test.go
+++ b/model/flow_delete_internal_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestConfirmFlowDeleteAllowsStalePhaseSelectionOnly(t *testing.T) {
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{})
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{})
 	m.bottomMode = ui.ModeFlows
 	m.contentPane = ui.PaneBottom
 	m.activeFlowSurface = false

--- a/model/flow_launch_attempt_internal_test.go
+++ b/model/flow_launch_attempt_internal_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func attemptTestModel() Model {
-	return NewWithOptions([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{
+	return newModelForTest([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{
 		InspectFlowLease: func(string, string) (flowlease.LeaseState, error) {
 			return flowlease.Free, nil
 		},

--- a/model/flow_launch_boundary_test.go
+++ b/model/flow_launch_boundary_test.go
@@ -54,7 +54,7 @@ func TestGenericAgentLaunchRequestRejectsEveryFlowContextMarker(t *testing.T) {
 	}
 	for name, mark := range tests {
 		t.Run(name, func(t *testing.T) {
-			m := NewWithOptions(nil, Options{})
+			m := newModelForTest(nil, Options{})
 			ctx := actions.AgentLaunchContext{LaunchID: "launch-1"}
 			mark(&ctx)
 			released := 0

--- a/model/flow_launch_create_internal_test.go
+++ b/model/flow_launch_create_internal_test.go
@@ -108,7 +108,7 @@ func (f createLaunchPreparationFinalizer) Compensate(notes string) (flowstore.Fl
 }
 
 func TestBeadsReadyStartRoutesCreatePhaseBeforeSideEffects(t *testing.T) {
-	m := NewWithOptions(nil, Options{
+	m := newModelForTest(nil, Options{
 		AgentCommand: "codex",
 	})
 	cmd := m.requestReadyBeadFlowLaunch(
@@ -180,7 +180,7 @@ func TestCreateFlowLaunchCustomPhasePersistenceRereadsAuthoritativeReservationRe
 		t.Fatal("test Flow has no startup phases")
 	}
 
-	m := NewWithOptions(nil, Options{
+	m := newModelForTest(nil, Options{
 		FlowStore: store,
 		AddFlowPhaseLaunchID: func(update flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
 			return store.AddPhaseLaunchID(update)
@@ -238,7 +238,7 @@ func newCreateLaunchHarness(phases []flowstore.FlowPhase) *createLaunchHarness {
 
 func (h *createLaunchHarness) model(t *testing.T) Model {
 	t.Helper()
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{
 		AgentCommand: "codex", LaunchBackend: "tmux", TmuxLaunchAvailable: func() bool { return true },
 		StartEmbeddedTerminal: func(ctx actions.AgentLaunchContext, _, _ int) (EmbeddedTerminal, error) {
 			h.order = append(h.order, "terminal")

--- a/model/flow_launch_lifecycle_internal_test.go
+++ b/model/flow_launch_lifecycle_internal_test.go
@@ -292,7 +292,7 @@ func (h *manualLaunchHarness) model() Model {
 
 func (h *manualLaunchHarness) modelWith(repos []scanner.Repo, opts Options) Model {
 	h.t.Helper()
-	m := NewWithOptions(repos, opts)
+	m := newModelForTest(repos, opts)
 	m.launchSeams.EnsureWorktree = func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
 		h.ensureRecords = append(h.ensureRecords, record)
 		if h.ensureErr != nil {
@@ -373,6 +373,11 @@ func (h *manualLaunchHarness) drainMsg(m Model, msg tea.Msg, depth int) Model {
 	case embeddedTerminalTickMsg, flowRefreshTickMsg, autoAdvanceTickMsg:
 		// Periodic repaint and refresh ticks re-arm themselves forever and are
 		// not part of the launch chain.
+		return m
+	case StatusExpiredMsg, StatusFadeMsg:
+		// The transient-status fade and expiry timers only retire the message
+		// the launch already produced, so applying them here would clear the
+		// status these tests are about to assert on.
 		return m
 	}
 	next, cmd := m.Update(msg)
@@ -1533,7 +1538,7 @@ func TestManualFlowLaunchStatusPrecedence(t *testing.T) {
 			h := newManualLaunchHarness(t, tc.record)
 			opts := h.options()
 			opts.AgentCommand = tc.agentCommand
-			m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, opts)
+			m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, opts)
 			m.contentPane = ui.PaneBottom
 			m.bottomMode = ui.ModeFlows
 			m.flows = m.flows.SetItems([]flowstore.FlowRecord{tc.record})
@@ -2598,7 +2603,7 @@ func TestFlowLaunchPreflightMessagesSurfaceVerbatim(t *testing.T) {
 			if tc.planPath != nil {
 				opts.PlanMarkdownPath = tc.planPath
 			}
-			m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, opts)
+			m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, opts)
 			m.contentPane = ui.PaneBottom
 			m.bottomMode = ui.ModeFlows
 			m.flows = m.flows.SetItems([]flowstore.FlowRecord{tc.record})

--- a/model/flow_launch_saved_session_resume_internal_test.go
+++ b/model/flow_launch_saved_session_resume_internal_test.go
@@ -19,7 +19,7 @@ func savedSessionLifecycleModel(opts Options) Model {
 			return flowlease.Free, nil
 		}
 	}
-	return NewWithOptions([]scanner.Repo{{Path: "/repo", DisplayName: "repo"}}, opts)
+	return newModelForTest([]scanner.Repo{{Path: "/repo", DisplayName: "repo"}}, opts)
 }
 
 func TestSavedSessionResumeRefreshesCachedNonFlowAssociationBeforeRouting(t *testing.T) {

--- a/model/flow_partial_list_internal_test.go
+++ b/model/flow_partial_list_internal_test.go
@@ -14,7 +14,7 @@ import (
 func TestFlowFetchCarriesTypedPartialResultInsteadOfFatalError(t *testing.T) {
 	healthy := flowForRefreshTest("healthy")
 	partial := testPartialList("corrupt")
-	m := NewWithOptions(flowRefreshTestRepos(), Options{
+	m := newModelForTest(flowRefreshTestRepos(), Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{healthy}, partial
 		},
@@ -182,7 +182,7 @@ func TestAutoAdvancePartialPollRetainsCompleteSnapshotAndDoesNotLaunch(t *testin
 	})
 	partial := testPartialList("missing-flow")
 	var launches int
-	m := NewWithOptions([]scanner.Repo{{Path: "/repo/a"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/repo/a"}}, Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{incomplete}, partial
 		},

--- a/model/flow_phase_launch_internal_test.go
+++ b/model/flow_phase_launch_internal_test.go
@@ -36,7 +36,7 @@ func TestFlowPhaseLaunchCoordinatorSelectsFirstLaunchablePhase(t *testing.T) {
 			{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhaseReady, Order: 3},
 		},
 	}
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{
 		InspectFlowLease: func(string, string) (flowlease.LeaseState, error) { return flowlease.Free, nil },
 	})
 	m.flows = m.flows.SetItems([]flowstore.FlowRecord{record})
@@ -113,7 +113,7 @@ func TestPreviewFlowLaunchSkipsDuplicateReadyRow(t *testing.T) {
 			{PhaseID: "step-2", Title: "Step 2", DependsOn: []string{"step-1"}, Status: flowstore.PhaseReady, Order: 3},
 		},
 	}
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{
 		InspectFlowLease: func(string, string) (flowlease.LeaseState, error) { return flowlease.Free, nil },
 	})
 	m.flows = m.flows.SetItems([]flowstore.FlowRecord{record})

--- a/model/flow_preparation_reservation_internal_test.go
+++ b/model/flow_preparation_reservation_internal_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNewWithOptionsCustomLaunchPersistenceDoesNotAuthorizeDefaultPreparation(t *testing.T) {
 	repoPath := t.TempDir()
-	m := NewWithOptions(nil, Options{
+	m := newModelForTest(nil, Options{
 		SessionStateRoot: t.TempDir(),
 		AddFlowPhaseLaunchID: func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
 			t.Fatal("preparation reached custom launch persistence")
@@ -38,7 +38,7 @@ func TestNewWithOptionsFlowStoreAuthorizesProgressionRecoveryWithCustomLaunchPer
 	if err != nil {
 		t.Fatalf("CreatePreparation() error = %v", err)
 	}
-	m := NewWithOptions(nil, Options{
+	m := newModelForTest(nil, Options{
 		FlowStore: store,
 		AddFlowPhaseLaunchID: func(flowstore.PhaseLaunchUpdate) (flowstore.FlowRecord, error) {
 			return flowstore.FlowRecord{}, nil

--- a/model/flow_refresh_tick.go
+++ b/model/flow_refresh_tick.go
@@ -8,7 +8,19 @@ import (
 	"github.com/approachcontrol/approach/ui"
 )
 
-const flowRefreshTickInterval = time.Second
+// defaultFlowRefreshTickInterval is the production cadence. Options may
+// override it; tests drive the loop far faster so they never wait on wall time.
+const defaultFlowRefreshTickInterval = time.Second
+
+// flowRefreshTickDelay is the cadence this Model refreshes at. A zero field
+// means "unset" — a directly constructed Model still ticks at the production
+// rate.
+func (m Model) flowRefreshTickDelay() time.Duration {
+	if m.flowRefreshTickInterval > 0 {
+		return m.flowRefreshTickInterval
+	}
+	return defaultFlowRefreshTickInterval
+}
 
 type flowRefreshTickMsg struct {
 	Generation uint64
@@ -19,7 +31,7 @@ func (m Model) flowRefreshTickCmd() tea.Cmd {
 	if generation == 0 {
 		return nil
 	}
-	return tea.Tick(flowRefreshTickInterval, func(time.Time) tea.Msg {
+	return tea.Tick(m.flowRefreshTickDelay(), func(time.Time) tea.Msg {
 		return flowRefreshTickMsg{Generation: generation}
 	})
 }

--- a/model/flow_refresh_tick_test.go
+++ b/model/flow_refresh_tick_test.go
@@ -145,13 +145,24 @@ func assertFlowRefreshTickSuppressed(t *testing.T, m Model) Model {
 }
 
 func TestModel_FlowRefreshTickIntervalIsOneSecond(t *testing.T) {
-	if flowRefreshTickInterval != time.Second {
-		t.Fatalf("flowRefreshTickInterval = %s, want %s", flowRefreshTickInterval, time.Second)
+	if defaultFlowRefreshTickInterval != time.Second {
+		t.Fatalf("defaultFlowRefreshTickInterval = %s, want %s", defaultFlowRefreshTickInterval, time.Second)
+	}
+	// Injection is a test seam, not a production default: a Model built without
+	// an explicit interval must still refresh at 1 Hz.
+	if got := NewWithOptions(nil, Options{}).flowRefreshTickDelay(); got != time.Second {
+		t.Fatalf("uninjected flowRefreshTickDelay() = %s, want %s", got, time.Second)
+	}
+	if got := (Model{}).flowRefreshTickDelay(); got != time.Second {
+		t.Fatalf("zero-value flowRefreshTickDelay() = %s, want %s", got, time.Second)
+	}
+	if got := NewWithOptions(nil, Options{FlowRefreshTickInterval: 5 * time.Millisecond}).flowRefreshTickDelay(); got != 5*time.Millisecond {
+		t.Fatalf("injected flowRefreshTickDelay() = %s, want %s", got, 5*time.Millisecond)
 	}
 }
 
 func TestModel_FlowRefreshTickScheduledOnStartupInFlowsMode(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{
+	m := newModelForTest(flowRefreshTestRepos(), Options{
 		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{flowForRefreshTest("flow-1")}, nil
 		},
@@ -221,7 +232,7 @@ func TestModel_FlowRefreshTickScheduledWhenEnteringFlowsModePaths(t *testing.T) 
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := NewWithOptions(flowRefreshTestRepos(), Options{
+			m := newModelForTest(flowRefreshTestRepos(), Options{
 				ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 					return []flowstore.FlowRecord{flowForRefreshTest("flow-1")}, nil
 				},
@@ -264,7 +275,7 @@ func TestModel_FlowRefreshTickScheduledWhenEnteringFlowsModePaths(t *testing.T) 
 
 func TestModel_FlowRefreshTickFetchesAndSchedulesNextTick(t *testing.T) {
 	var calls int
-	m := NewWithOptions(flowRefreshTestRepos(), Options{
+	m := newModelForTest(flowRefreshTestRepos(), Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			calls++
 			return []flowstore.FlowRecord{flowForRefreshTest("flow-1")}, nil
@@ -307,7 +318,7 @@ func TestModel_ActiveFlowRefreshTickUsesGlobalFetchAndPreservesNormalFlowCache(t
 	bravoFlow := flowForRefreshTest("bravo-flow")
 	bravoFlow.RepoPath = "/dev/bravo"
 	var filters []flowstore.FlowFilter
-	m := NewWithOptions(repos, Options{
+	m := newModelForTest(repos, Options{
 		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			filters = append(filters, filter)
 			if filter.RepoPath != "" {
@@ -347,7 +358,7 @@ func TestModel_ActiveFlowRefreshTickUsesGlobalFetchAndPreservesNormalFlowCache(t
 }
 
 func TestModel_FlowRefreshTickDoesNotOverlapInFlightFetch(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{
+	m := newModelForTest(flowRefreshTestRepos(), Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{flowForRefreshTest("flow-1")}, nil
 		},
@@ -386,7 +397,7 @@ func TestModel_FlowRefreshTickDoesNotOverlapInFlightFetch(t *testing.T) {
 
 func TestModel_FlowRefreshTracksF5RefetchBeforePendingTick(t *testing.T) {
 	var scans int
-	m := NewWithOptions(flowRefreshTestRepos(), Options{
+	m := newModelForTest(flowRefreshTestRepos(), Options{
 		ScanRepos: func() ([]scanner.Repo, error) {
 			scans++
 			return flowRefreshTestRepos(), nil
@@ -429,7 +440,7 @@ func TestModel_FlowRefreshTracksRepoChangeRefetchBeforePendingTick(t *testing.T)
 		{Path: "/dev/alpha", DisplayName: "alpha"},
 		{Path: "/dev/bravo", DisplayName: "bravo"},
 	}
-	m := NewWithOptions(repos, Options{
+	m := newModelForTest(repos, Options{
 		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{flowForRefreshTest("flow-" + filter.RepoPath)}, nil
 		},
@@ -469,7 +480,7 @@ func TestModel_ActiveFlowRefreshRepoChangeKeepsInFlightGlobalFetch(t *testing.T)
 		{Path: "/dev/alpha", DisplayName: "alpha"},
 		{Path: "/dev/bravo", DisplayName: "bravo"},
 	}
-	m := NewWithOptions(repos, Options{
+	m := newModelForTest(repos, Options{
 		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{flowForRefreshTest("flow-" + filter.RepoPath)}, nil
 		},
@@ -512,7 +523,7 @@ func TestModel_ActiveFlowEntrySupersedesStaleInFlightFetch(t *testing.T) {
 		{Path: "/dev/alpha", DisplayName: "alpha"},
 		{Path: "/dev/bravo", DisplayName: "bravo"},
 	}
-	m := NewWithOptions(repos, Options{
+	m := newModelForTest(repos, Options{
 		ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{flowForRefreshTest("flow-" + filter.RepoPath)}, nil
 		},
@@ -553,7 +564,7 @@ func TestModel_ActiveFlowEntrySupersedesStaleInFlightFetch(t *testing.T) {
 }
 
 func TestModel_FlowRefreshTracksActionRefetchBeforePendingTick(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{
+	m := newModelForTest(flowRefreshTestRepos(), Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{flowForRefreshTest("flow-1")}, nil
 		},
@@ -596,7 +607,7 @@ func TestModel_FlowRefreshFastRefetchInvalidatesPendingTick(t *testing.T) {
 		{
 			name: "f5",
 			model: func() Model {
-				return NewWithOptions(flowRefreshTestRepos(), Options{
+				return newModelForTest(flowRefreshTestRepos(), Options{
 					ScanRepos: func() ([]scanner.Repo, error) {
 						return flowRefreshTestRepos(), nil
 					},
@@ -617,7 +628,7 @@ func TestModel_FlowRefreshFastRefetchInvalidatesPendingTick(t *testing.T) {
 					{Path: "/dev/alpha", DisplayName: "alpha"},
 					{Path: "/dev/bravo", DisplayName: "bravo"},
 				}
-				return NewWithOptions(repos, Options{
+				return newModelForTest(repos, Options{
 					ListFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 						return []flowstore.FlowRecord{flowForRefreshTest("flow-" + filter.RepoPath)}, nil
 					},
@@ -635,7 +646,7 @@ func TestModel_FlowRefreshFastRefetchInvalidatesPendingTick(t *testing.T) {
 		{
 			name: "action-refetch",
 			model: func() Model {
-				return NewWithOptions(flowRefreshTestRepos(), Options{
+				return newModelForTest(flowRefreshTestRepos(), Options{
 					ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 						return []flowstore.FlowRecord{flowForRefreshTest("flow-1")}, nil
 					},
@@ -694,7 +705,7 @@ func TestModel_FlowRefreshFastRefetchInvalidatesPendingTick(t *testing.T) {
 }
 
 func TestModel_FlowRefreshOldTrackedResultDoesNotScheduleAfterNewerRefetch(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{
+	m := newModelForTest(flowRefreshTestRepos(), Options{
 		ScanRepos: func() ([]scanner.Repo, error) {
 			return flowRefreshTestRepos(), nil
 		},
@@ -737,7 +748,7 @@ func TestModel_FlowRefreshOldTrackedResultDoesNotScheduleAfterNewerRefetch(t *te
 }
 
 func TestModel_ActiveFlowsExitCancelsRefreshOwnershipWithoutRefreshingHiddenStoredFlows(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{
+	m := newModelForTest(flowRefreshTestRepos(), Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{flowForRefreshTest("flow-1")}, nil
 		},
@@ -795,7 +806,7 @@ func TestModel_FlowCreationCompletionRefreshesVisibleBackgroundFlowsPane(t *test
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := NewWithOptions(flowRefreshTestRepos(), Options{
+			m := newModelForTest(flowRefreshTestRepos(), Options{
 				ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 					return []flowstore.FlowRecord{flowForRefreshTest("flow-new")}, nil
 				},
@@ -824,7 +835,7 @@ func TestModel_FlowCreationCompletionRefreshesVisibleBackgroundFlowsPane(t *test
 }
 
 func TestModel_HiddenStoredFlowsCompletionDoesNotScheduleTick(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{})
+	m := newModelForTest(flowRefreshTestRepos(), Options{})
 	m.height = 20
 	m.activePane = ui.PaneTop
 	m.contentPane = ui.PaneTop
@@ -845,7 +856,7 @@ func TestModel_HiddenStoredFlowsCompletionDoesNotScheduleTick(t *testing.T) {
 }
 
 func TestModel_FocusingDegradedStoredFlowsRestartsRefresh(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{
+	m := newModelForTest(flowRefreshTestRepos(), Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{flowForRefreshTest("flow-1")}, nil
 		},
@@ -915,7 +926,7 @@ func TestModel_NoRepoDoesNotStartStoredFlowsRefresh(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := tt.setup(NewWithOptions(nil, Options{}))
+			m := tt.setup(newModelForTest(nil, Options{}))
 			m.height = 20
 			beforeRequest := m.ListRequest(ui.ModeFlows)
 			beforeGeneration := m.flowRefreshTickGen
@@ -943,7 +954,7 @@ func TestModel_NoRepoDoesNotStartStoredFlowsRefresh(t *testing.T) {
 }
 
 func TestModel_FlowRefreshFetchErrorClearsInFlightAndSchedulesNextTick(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{
+	m := newModelForTest(flowRefreshTestRepos(), Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return nil, errors.New("boom")
 		},
@@ -964,7 +975,7 @@ func TestModel_FlowRefreshFetchErrorClearsInFlightAndSchedulesNextTick(t *testin
 }
 
 func TestModel_FlowRefreshTickIgnoresStaleGeneration(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{})
+	m := newModelForTest(flowRefreshTestRepos(), Options{})
 	before := m.ListRequest(ui.ModeFlows)
 
 	m, cmd := updateFlowRefreshTest(m, flowRefreshTickMsg{Generation: m.flowRefreshTickGen + 1})
@@ -977,7 +988,7 @@ func TestModel_FlowRefreshTickIgnoresStaleGeneration(t *testing.T) {
 }
 
 func TestModel_FlowRefreshTickIgnoresOldLoopAfterReenteringFlows(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{})
+	m := newModelForTest(flowRefreshTestRepos(), Options{})
 	m.bottomMode = ui.ModePlans
 	m.contentPane = ui.PaneBottom
 	m.activePane = ui.PaneBottom
@@ -1003,7 +1014,7 @@ func TestModel_FlowRefreshTickIgnoresOldLoopAfterReenteringFlows(t *testing.T) {
 
 func TestModel_FlowRefreshTickIgnoredOutsideFlowsMode(t *testing.T) {
 	var calls int
-	m := NewWithOptions(flowRefreshTestRepos(), Options{
+	m := newModelForTest(flowRefreshTestRepos(), Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			calls++
 			return nil, nil
@@ -1028,7 +1039,7 @@ func TestModel_FlowRefreshTickIgnoredOutsideFlowsMode(t *testing.T) {
 }
 
 func TestModel_FlowRefreshStaleResultStillIgnored(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{})
+	m := newModelForTest(flowRefreshTestRepos(), Options{})
 	startup := flowResultFromCommand(t, m.Init())
 	m, _ = updateFlowRefreshTest(m, startup)
 	staleRequest := m.ListRequest(ui.ModeFlows)
@@ -1058,7 +1069,7 @@ func TestModel_FlowRefreshStaleResultStillIgnored(t *testing.T) {
 
 func TestModel_FlowRefreshPreservesExpandedPhaseSelection(t *testing.T) {
 	implementation := flowstore.FlowPhase{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning}
-	m := NewWithOptions(flowRefreshTestRepos(), Options{})
+	m := newModelForTest(flowRefreshTestRepos(), Options{})
 	m, _ = updateFlowRefreshTest(m, FlowResultMsg{
 		RepoPath:    "/dev/alpha",
 		ListRequest: m.ListRequest(ui.ModeFlows),
@@ -1086,7 +1097,7 @@ func TestModel_FlowRefreshPreservesExpandedPhaseSelection(t *testing.T) {
 }
 
 func TestModel_FlowRefreshClearsExpansionWhenSelectedPhaseDisappears(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{})
+	m := newModelForTest(flowRefreshTestRepos(), Options{})
 	m, _ = updateFlowRefreshTest(m, FlowResultMsg{
 		RepoPath:    "/dev/alpha",
 		ListRequest: m.ListRequest(ui.ModeFlows),
@@ -1107,7 +1118,7 @@ func TestModel_FlowRefreshClearsExpansionWhenSelectedPhaseDisappears(t *testing.
 }
 
 func TestModel_FlowRefreshClearsExpansionWhenExpandedFlowDisappears(t *testing.T) {
-	m := NewWithOptions(flowRefreshTestRepos(), Options{})
+	m := newModelForTest(flowRefreshTestRepos(), Options{})
 	m, _ = updateFlowRefreshTest(m, FlowResultMsg{
 		RepoPath:    "/dev/alpha",
 		ListRequest: m.ListRequest(ui.ModeFlows),

--- a/model/flow_repair_internal_test.go
+++ b/model/flow_repair_internal_test.go
@@ -189,7 +189,7 @@ func TestFlowRepairObstructionClassifiesStalledAndHealthyFlows(t *testing.T) {
 func TestSelectedFlowRepairReadyUsesBothFlowSurfacesAndTerminalOccupancy(t *testing.T) {
 	record := repairClassificationRecord(flowstore.FlowPhase{PhaseID: "implementation", Status: flowstore.PhaseBlocked})
 	newModel := func(mode ui.Mode) Model {
-		m := modelWithModeForTest(NewWithOptions([]scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}}, Options{
+		m := modelWithModeForTest(newModelForTest([]scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}}, Options{
 			InspectFlowLease: func(string, string) (flowlease.LeaseState, error) { return flowlease.Free, nil },
 		}), mode)
 		m.activePane = 1

--- a/model/model.go
+++ b/model/model.go
@@ -154,6 +154,7 @@ type Model struct {
 	status                    statusError
 	statusSeq                 uint64
 	statusTimer               statusTimerFactory
+	statusSchedule            StatusTimings
 	pendingStatusCmds         []tea.Cmd
 	visibleRepoFetchSeq       uint64
 	visibleRepoFetch          visibleRepoFetchState
@@ -268,6 +269,10 @@ type Model struct {
 	launchSeams              flowLaunchSeams
 
 	embeddedTerminalTickGen uint64
+	// Tick cadences for the two 1 Hz poll loops. Zero means the production
+	// default; Options injects a faster value so tests never wait on wall time.
+	autoAdvanceTickInterval time.Duration
+	flowRefreshTickInterval time.Duration
 	flowRefreshTickGen      uint64
 	flowRefreshInFlight     uint64
 	flowRefreshInFlightMode ui.Mode
@@ -414,6 +419,14 @@ type Options struct {
 	// model construction stays free of filesystem work: a zero Pin means "no
 	// pin", which leaves agents on ambient PATH exactly as before.
 	LaunchPin controlplane.Pin
+	// AutoAdvanceTickInterval and FlowRefreshTickInterval override the two 1 Hz
+	// poll cadences. Zero leaves each at its production default; tests set a
+	// tiny value so driving a loop costs no real time.
+	AutoAdvanceTickInterval time.Duration
+	FlowRefreshTickInterval time.Duration
+	// StatusTimings overrides the transient-status fade and expiry schedule.
+	// Zero fields keep production timing.
+	StatusTimings StatusTimings
 	// LaunchPinNotice is context, never a gate: a degraded binary cache, or an
 	// `approach` on PATH that is a different build from the one launching
 	// agents. It is shown once at startup and changes nothing about routing.
@@ -942,43 +955,46 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	}
 	topMode, bottomMode, contentPane, activeFlowSurface := startupPaneState(ui.ModeBeadsReady)
 	m := Model{
-		repos:                 newRepoPane().SetItems(repos),
-		rows:                  newBranchPane(),
-		stashes:               newStashPane(),
-		worktrees:             newWorktreePane(),
-		worktreeSessions:      newSessionPane(),
-		commits:               newCommitPane(),
-		reflogs:               newReflogPane(),
-		sessions:              newSessionPane(),
-		plans:                 newPlanPane(),
-		flows:                 newFlowPane(),
-		activeFlows:           newFlowPane(),
-		prBabysitterFlows:     newPRBabysitterFlowPane(nil),
-		prBabysitterStatuses:  make(map[string]actions.PullRequestStatus),
-		beads:                 newBeadSubviews(),
-		terminalDockVisible:   true,
-		flowRefreshTickGen:    1,
-		topMode:               topMode,
-		bottomMode:            bottomMode,
-		contentPane:           contentPane,
-		activeFlowSurface:     activeFlowSurface,
-		takeover:              takeoverFromStartup(activeFlowSurface),
-		agentCommand:          agent.NormalizeStored(opts.AgentCommand),
-		codexModel:            agent.NormalizeModel(opts.CodexModel),
-		claudeModel:           agent.NormalizeModel(opts.ClaudeModel),
-		cursorModel:           agent.NormalizeModel(opts.CursorModel),
-		codexReasoningEffort:  agent.NormalizeReasoningEffort(opts.CodexReasoningEffort),
-		claudeReasoningEffort: agent.NormalizeReasoningEffort(opts.ClaudeReasoningEffort),
-		planPromptTemplate:    opts.PlanPromptTemplate,
-		flowPromptTemplates:   opts.FlowPromptTemplates,
-		repoCreateRoot:        opts.RepoCreateRoot,
-		scanRepos:             opts.ScanRepos,
-		createRepo:            createRepo,
-		fetchRepo:             fetchRepo,
-		listSessions:          listSessions,
-		readTranscript:        readTranscript,
-		listPlans:             listPlans,
-		listFlows:             listFlows,
+		repos:                   newRepoPane().SetItems(repos),
+		rows:                    newBranchPane(),
+		stashes:                 newStashPane(),
+		worktrees:               newWorktreePane(),
+		worktreeSessions:        newSessionPane(),
+		commits:                 newCommitPane(),
+		reflogs:                 newReflogPane(),
+		sessions:                newSessionPane(),
+		plans:                   newPlanPane(),
+		flows:                   newFlowPane(),
+		activeFlows:             newFlowPane(),
+		prBabysitterFlows:       newPRBabysitterFlowPane(nil),
+		prBabysitterStatuses:    make(map[string]actions.PullRequestStatus),
+		beads:                   newBeadSubviews(),
+		terminalDockVisible:     true,
+		flowRefreshTickGen:      1,
+		autoAdvanceTickInterval: opts.AutoAdvanceTickInterval,
+		flowRefreshTickInterval: opts.FlowRefreshTickInterval,
+		statusSchedule:          opts.StatusTimings,
+		topMode:                 topMode,
+		bottomMode:              bottomMode,
+		contentPane:             contentPane,
+		activeFlowSurface:       activeFlowSurface,
+		takeover:                takeoverFromStartup(activeFlowSurface),
+		agentCommand:            agent.NormalizeStored(opts.AgentCommand),
+		codexModel:              agent.NormalizeModel(opts.CodexModel),
+		claudeModel:             agent.NormalizeModel(opts.ClaudeModel),
+		cursorModel:             agent.NormalizeModel(opts.CursorModel),
+		codexReasoningEffort:    agent.NormalizeReasoningEffort(opts.CodexReasoningEffort),
+		claudeReasoningEffort:   agent.NormalizeReasoningEffort(opts.ClaudeReasoningEffort),
+		planPromptTemplate:      opts.PlanPromptTemplate,
+		flowPromptTemplates:     opts.FlowPromptTemplates,
+		repoCreateRoot:          opts.RepoCreateRoot,
+		scanRepos:               opts.ScanRepos,
+		createRepo:              createRepo,
+		fetchRepo:               fetchRepo,
+		listSessions:            listSessions,
+		readTranscript:          readTranscript,
+		listPlans:               listPlans,
+		listFlows:               listFlows,
 		listBeads: [beadSubviewCount]func(string) ([]beadsquery.Bead, error){
 			listReadyBeads,
 			listBlockedBeads,
@@ -1382,7 +1398,7 @@ func (m Model) withReasoningEffort(command, effort string) Model {
 func (m Model) RepoCreateRoot() string { return m.repoCreateRoot }
 
 func (m Model) Init() tea.Cmd {
-	return batchNonNil(m.fetchStoredModes(), autoAdvanceTickCmd())
+	return batchNonNil(m.fetchStoredModes(), m.autoAdvanceTickCmd())
 }
 
 func (m Model) View() string {

--- a/model/model_flow_store_reuse_test.go
+++ b/model/model_flow_store_reuse_test.go
@@ -64,7 +64,7 @@ func TestFlowStoreIsReusedAcrossFallbackMutations(t *testing.T) {
 
 	root := t.TempDir()
 	record := seedFlow(t, root)
-	m := NewWithOptions(nil, Options{SessionStateRoot: root})
+	m := newModelForTest(nil, Options{SessionStateRoot: root})
 
 	// The first write opens the Model's memoized store lazily; measure after it
 	// so the baseline already includes the shared store's own descriptors.
@@ -105,7 +105,7 @@ func TestFlowStoreIsSharedBetweenDistinctFallbackMutators(t *testing.T) {
 
 	root := t.TempDir()
 	record := seedFlow(t, root)
-	m := NewWithOptions(nil, Options{SessionStateRoot: root})
+	m := newModelForTest(nil, Options{SessionStateRoot: root})
 
 	// One mutator first, so the baseline already carries the shared store.
 	if _, err := m.setFlowAutoMode(flowstore.AutoModeUpdate{FlowID: record.FlowID, Enabled: true}); err != nil {
@@ -151,7 +151,7 @@ func TestInjectedFlowStoreIsUsedByFallbackMutators(t *testing.T) {
 	}
 	defer injected.Close()
 
-	m := NewWithOptions(nil, Options{SessionStateRoot: root, FlowStore: injected})
+	m := newModelForTest(nil, Options{SessionStateRoot: root, FlowStore: injected})
 	if _, err := m.setFlowAutoMode(flowstore.AutoModeUpdate{FlowID: record.FlowID, Enabled: false}); err != nil {
 		t.Fatalf("setFlowAutoMode() error = %v", err)
 	}

--- a/model/model_flow_test.go
+++ b/model/model_flow_test.go
@@ -57,8 +57,10 @@ func activeFlowResultFromCommand(t *testing.T, cmd tea.Cmd) model.ActiveFlowResu
 	return model.ActiveFlowResultMsg{}
 }
 
-// testCommandSettleTimeout stays short so settleModelCommands does not
-// consume status-fade timers (1s+) and clear the error under test.
+// testCommandSettleTimeout bounds how long a settle helper waits on any one
+// command. Status fade and expiry timers are excluded by type rather than by
+// outrunning them (see isStatusTimerMsg), so this no longer has to stay under
+// the status schedule to keep the error under test from being cleared.
 const testCommandSettleTimeout = 20 * time.Millisecond
 
 func settleModelCommands(t *testing.T, m model.Model, cmd tea.Cmd, rounds int) model.Model {
@@ -72,6 +74,9 @@ func settleModelCommands(t *testing.T, m model.Model, cmd tea.Cmd, rounds int) m
 			}
 			messages := immediateTestCommandMessages(current)
 			for _, msg := range messages {
+				if isStatusTimerMsg(msg) {
+					continue
+				}
 				var next tea.Cmd
 				m, next = update(m, msg)
 				if next != nil {
@@ -94,6 +99,9 @@ func settleModelCommandsWithin(t *testing.T, m model.Model, cmd tea.Cmd, rounds 
 		var nextPending []tea.Cmd
 		for _, current := range pending {
 			for _, msg := range testCommandMessagesWithin(current, timeout) {
+				if isStatusTimerMsg(msg) {
+					continue
+				}
 				var next tea.Cmd
 				m, next = update(m, msg)
 				if next != nil {
@@ -156,6 +164,17 @@ func immediateTestCommandMessages(cmd tea.Cmd) []tea.Msg {
 		messages = append(messages, immediateTestCommandMessages(child)...)
 	}
 	return messages
+}
+
+// isStatusTimerMsg reports whether a command produced nothing but a
+// transient-status fade or expiry. Those carry no launch work, and the helpers
+// below must not feed them back into Update as if they did.
+func isStatusTimerMsg(msg tea.Msg) bool {
+	switch msg.(type) {
+	case model.StatusExpiredMsg, model.StatusFadeMsg:
+		return true
+	}
+	return false
 }
 
 func runImmediateTestCommand(cmd tea.Cmd) (tea.Msg, bool) {
@@ -1565,7 +1584,7 @@ func advanceFlowLaunchRead(t *testing.T, m model.Model, cmd tea.Cmd) (model.Mode
 		return m, nil
 	}
 	msg, ok := runImmediateTestCommand(cmd)
-	if !ok {
+	if !ok || isStatusTimerMsg(msg) {
 		// A refused launch returns no asynchronous work, only the status timer.
 		return m, cmd
 	}
@@ -11917,13 +11936,16 @@ func TestModel_NewFlowPlanNowRoutesFormThroughProductionLifecycle(t *testing.T) 
 	var started actions.AgentLaunchContext
 	var startWidth, startHeight int
 	m := model.NewWithOptions([]scanner.Repo{{Path: repoPath, DisplayName: "repo"}}, model.Options{
-		AgentCommand:         "codex",
-		CodexModel:           "gpt-5.6-sol",
-		CodexReasoningEffort: "high",
-		SessionStateRoot:     sessionRoot,
-		FlowStore:            store,
-		LaunchBackend:        "tmux",
-		TmuxLaunchAvailable:  func() bool { return true },
+		AutoAdvanceTickInterval: testTickInterval,
+		FlowRefreshTickInterval: testTickInterval,
+		StatusTimings:           fastTickStatusTimings,
+		AgentCommand:            "codex",
+		CodexModel:              "gpt-5.6-sol",
+		CodexReasoningEffort:    "high",
+		SessionStateRoot:        sessionRoot,
+		FlowStore:               store,
+		LaunchBackend:           "tmux",
+		TmuxLaunchAvailable:     func() bool { return true },
 		LaunchAgent: func(actions.AgentLaunchContext) (actions.TerminalLaunchSpec, error) {
 			t.Fatal("Plan Now must stay embedded when tmux is configured")
 			return actions.TerminalLaunchSpec{}, nil
@@ -12303,11 +12325,14 @@ func fillNewFlowForm(t *testing.T, m model.Model, title, instructions, baseRef s
 func TestModel_NewFlowParkedCreateCapturesAgentSettings(t *testing.T) {
 	var createRequest model.FlowStartRequest
 	m := model.NewWithOptions(testRepos(), model.Options{
-		AgentCommand:          "claude",
-		ClaudeModel:           "claude-opus-5",
-		ClaudeReasoningEffort: "high",
-		CodexModel:            "gpt-5.5",
-		CodexReasoningEffort:  "medium",
+		AutoAdvanceTickInterval: testTickInterval,
+		FlowRefreshTickInterval: testTickInterval,
+		StatusTimings:           fastTickStatusTimings,
+		AgentCommand:            "claude",
+		ClaudeModel:             "claude-opus-5",
+		ClaudeReasoningEffort:   "high",
+		CodexModel:              "gpt-5.5",
+		CodexReasoningEffort:    "medium",
 		CreateFlow: func(req model.FlowStartRequest) (model.FlowStartResult, error) {
 			createRequest = req
 			return model.FlowStartResult{Flow: flowstore.FlowRecord{FlowID: "flow-parked", RepoPath: req.RepoPath, Title: req.Title}}, nil

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -155,7 +156,7 @@ func newTestModel(repos []scanner.Repo, opts model.Options) model.Model {
 			return record, func() {}, nil
 		}
 	}
-	modelValue := model.NewWithOptions(repos, opts)
+	modelValue := model.NewWithOptions(repos, fastTickOptions(opts))
 	modelValue = model.WithFlowLaunchEnsureWorktreeForTest(modelValue, func(record flowstore.FlowRecord) (flowstore.FlowRecord, error) {
 		if record.WorktreePath != "" {
 			return record, nil
@@ -2268,4 +2269,35 @@ func TestModel_RepoSwitchClearsReflogs(t *testing.T) {
 	if len(m.Reflogs()) != 0 {
 		t.Errorf("expected reflogs cleared on repo switch, got %d", len(m.Reflogs()))
 	}
+}
+
+// testTickInterval collapses the two 1 Hz poll loops for tests. The helpers
+// that drain a tea.Cmd tree run every command in it, including the loops' own
+// reschedule ticks, so at the production cadence each tick child in a batch
+// cost a real second of wall time.
+const testTickInterval = time.Millisecond
+
+// fastTickOptions injects the collapsed cadence unless the test set its own.
+func fastTickOptions(opts model.Options) model.Options {
+	if opts.AutoAdvanceTickInterval == 0 {
+		opts.AutoAdvanceTickInterval = testTickInterval
+	}
+	if opts.FlowRefreshTickInterval == 0 {
+		opts.FlowRefreshTickInterval = testTickInterval
+	}
+	if opts.StatusTimings == (model.StatusTimings{}) {
+		opts.StatusTimings = model.StatusTimings{
+			FadeStep1: testTickInterval,
+			FadeStep2: 2 * testTickInterval,
+			Lifetime:  3 * testTickInterval,
+		}
+	}
+	return opts
+}
+
+// fastTickStatusTimings collapses the transient-status schedule for tests.
+var fastTickStatusTimings = model.StatusTimings{
+	FadeStep1: testTickInterval,
+	FadeStep2: 2 * testTickInterval,
+	Lifetime:  3 * testTickInterval,
 }

--- a/model/pane_state_internal_test.go
+++ b/model/pane_state_internal_test.go
@@ -29,7 +29,7 @@ func TestFixedStackedPaneStartupState(t *testing.T) {
 }
 
 func TestInitFetchesBothStoredPanesWithoutActiveFlows(t *testing.T) {
-	m := NewWithOptions([]scanner.Repo{{Path: "/repo"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/repo"}}, Options{
 		ListReadyBeads: func(repoPath string) ([]beadsquery.Bead, error) {
 			return []beadsquery.Bead{{ID: "bd-1"}}, nil
 		},
@@ -78,7 +78,7 @@ func TestRepositorySwitchStartsBothStoredPaneRequests(t *testing.T) {
 func TestPaneLocalNumbersAndArrowNavigation(t *testing.T) {
 	readyCalls := 0
 	openCalls := 0
-	m := NewWithOptions([]scanner.Repo{{Path: "/repo"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/repo"}}, Options{
 		ListReadyBeads: func(string) ([]beadsquery.Bead, error) {
 			readyCalls++
 			return []beadsquery.Bead{{ID: "bd-ready"}}, nil
@@ -320,7 +320,7 @@ func TestDegradedPaneFocusSwapReflowsNewlyVisibleList(t *testing.T) {
 }
 
 func TestRefreshAndActiveFlowsUseIndependentRequestSlots(t *testing.T) {
-	m := NewWithOptions([]scanner.Repo{{Path: "/repo"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/repo"}}, Options{
 		ScanRepos: func() ([]scanner.Repo, error) { return []scanner.Repo{{Path: "/repo"}}, nil },
 	})
 	beadsBefore := m.currentListRequest(ui.ModeBeadsReady)

--- a/model/pr_babysitter_internal_test.go
+++ b/model/pr_babysitter_internal_test.go
@@ -32,7 +32,7 @@ func babysitterFlow(id, repo string, phaseStatus, mergeStatus string) flowstore.
 }
 
 func TestTakeoverTransitionMatrixPreservesOneOriginalSnapshot(t *testing.T) {
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{})
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, Options{})
 	m.topMode = ui.ModeBeadsReady
 	m.bottomMode = ui.ModePlans
 	m.activePane = ui.PaneRepos
@@ -67,7 +67,7 @@ func TestTakeoverTransitionMatrixPreservesOneOriginalSnapshot(t *testing.T) {
 }
 
 func TestActiveFlowsToPRBabysitterInvalidatesOldRefresh(t *testing.T) {
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{babysitterFlow("flow-1", "/dev/alpha", flowstore.PhaseReady, flowstore.MergePending)}, nil
 		},
@@ -103,7 +103,7 @@ func TestPRBabysitterRefreshFiltersOrdersAndReplacesPerRowFailures(t *testing.T)
 		babysitterFlow("flow-a", "/dev/alpha", flowstore.PhaseBlocked, flowstore.MergeBlocked),
 		{FlowID: "ineligible", RepoPath: "/dev/alpha"},
 	}
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha"}, {Path: "/dev/beta"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha"}, {Path: "/dev/beta"}}, Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) { return records, nil },
 		LookupPRStatus: func(_ context.Context, _ int, _ string) (actions.PullRequestStatus, error) {
 			return actions.PullRequestStatus{}, errors.New("lookup failed")
@@ -132,7 +132,7 @@ func TestPRBabysitterRefreshFiltersOrdersAndReplacesPerRowFailures(t *testing.T)
 
 func TestPRBabysitterTotalFailureRetainsCacheAndSkipsGitHub(t *testing.T) {
 	var lookups atomic.Int32
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return nil, errors.New("store unavailable")
 		},
@@ -160,7 +160,7 @@ func TestPRBabysitterTotalFailureRetainsCacheAndSkipsGitHub(t *testing.T) {
 func TestPRBabysitterAcceptsPartialListAndRejectsSupersededResult(t *testing.T) {
 	record := babysitterFlow("flow-1", "/dev/alpha", flowstore.PhaseReady, flowstore.MergePending)
 	partial := &flowstore.PartialListError{Entries: []flowstore.PartialListEntry{{FlowID: "broken", Cause: errors.New("bad JSON")}}}
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{record}, partial
 		},
@@ -189,7 +189,7 @@ func TestPRBabysitterAcceptsPartialListAndRejectsSupersededResult(t *testing.T) 
 func TestPRBabysitterPreservesSelectionByFlowIDAcrossAcceptedRefresh(t *testing.T) {
 	first := babysitterFlow("flow-1", "/dev/alpha", flowstore.PhaseReady, flowstore.MergePending)
 	second := babysitterFlow("flow-2", "/dev/beta", flowstore.PhaseReady, flowstore.MergePending)
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha"}, {Path: "/dev/beta"}}, Options{})
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha"}, {Path: "/dev/beta"}}, Options{})
 	m = m.setTakeover(takeoverPRBabysitter)
 	m.activePane = ui.PaneBottom
 	m.contentPane = ui.PaneBottom
@@ -213,7 +213,7 @@ func TestPRBabysitterFilterMatchesDisplayedDashboardFields(t *testing.T) {
 	first.Bead.ID = "bead-v8w7z6"
 	second := babysitterFlow("flow-2", "/dev/beta", flowstore.PhaseReady, flowstore.MergePending)
 	second.Bead.ID = "approach-other"
-	m := NewWithOptions([]scanner.Repo{
+	m := newModelForTest([]scanner.Repo{
 		{Path: "/dev/alpha", DisplayName: "repo-z9x8q7"},
 		{Path: "/dev/beta", DisplayName: "Other Repo"},
 	}, Options{})
@@ -273,7 +273,7 @@ func TestPRBabysitterRefreshCapsConcurrencyAndCancelsOnExit(t *testing.T) {
 			return actions.PullRequestStatus{Mergeability: actions.PRMergeable, Checks: actions.PRChecksPassing}, nil
 		}
 	}
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
 		ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) { return records, nil }, LookupPRStatus: lookup,
 	})
 	m = m.setTakeover(takeoverPRBabysitter)
@@ -334,7 +334,7 @@ func TestPRBabysitterForcedExitCancelsInFlightLookups(t *testing.T) {
 					return actions.PullRequestStatus{Mergeability: actions.PRMergeable, Checks: actions.PRChecksPassing}, nil
 				}
 			}
-			m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
+			m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
 				ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 					return []flowstore.FlowRecord{babysitterFlow("flow-1", "/dev/alpha", flowstore.PhaseReady, flowstore.MergePending)}, nil
 				},
@@ -364,7 +364,7 @@ func TestPRBabysitterForcedExitCancelsInFlightLookups(t *testing.T) {
 }
 
 func TestRepoChangeClearsHiddenPRBabysitterCache(t *testing.T) {
-	m := NewWithOptions([]scanner.Repo{
+	m := newModelForTest([]scanner.Repo{
 		{Path: "/dev/alpha", DisplayName: "alpha"},
 		{Path: "/dev/beta", DisplayName: "beta"},
 	}, Options{})
@@ -386,7 +386,7 @@ func TestRepoChangeClearsHiddenPRBabysitterCache(t *testing.T) {
 }
 
 func TestRepoChangeClearsHiddenPRBabysitterDegradation(t *testing.T) {
-	m := NewWithOptions([]scanner.Repo{
+	m := newModelForTest([]scanner.Repo{
 		{Path: "/dev/alpha", DisplayName: "alpha"},
 		{Path: "/dev/beta", DisplayName: "beta"},
 	}, Options{})
@@ -441,7 +441,7 @@ func TestPRBabysitterQuitCancelsInFlightLookups(t *testing.T) {
 					return actions.PullRequestStatus{Mergeability: actions.PRMergeable, Checks: actions.PRChecksPassing}, nil
 				}
 			}
-			m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
+			m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
 				ListFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 					return []flowstore.FlowRecord{babysitterFlow("flow-1", "/dev/alpha", flowstore.PhaseReady, flowstore.MergePending)}, nil
 				},
@@ -471,7 +471,7 @@ func TestPRBabysitterQuitCancelsInFlightLookups(t *testing.T) {
 }
 
 func TestPRBabysitterMutationRemovesIneligibleRowImmediately(t *testing.T) {
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha"}}, Options{})
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha"}}, Options{})
 	m = m.setTakeover(takeoverPRBabysitter)
 	record := babysitterFlow("flow-1", "/dev/alpha", flowstore.PhaseReady, flowstore.MergePending)
 	m.prBabysitterRecords = []flowstore.FlowRecord{record}
@@ -488,7 +488,7 @@ func TestPRBabysitterMutationRemovesIneligibleRowImmediately(t *testing.T) {
 func TestPRBabysitterReusesFlowActionsWithoutWideningBlockedMergeGates(t *testing.T) {
 	var opened []string
 	var copied string
-	m := NewWithOptions([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
+	m := newModelForTest([]scanner.Repo{{Path: "/dev/alpha"}}, Options{
 		OpenURL: func(target string) error {
 			opened = append(opened, target)
 			return nil

--- a/model/status.go
+++ b/model/status.go
@@ -9,7 +9,39 @@ import (
 	"github.com/approachcontrol/approach/ui"
 )
 
-const statusLifetime = 3 * time.Second
+// The transient-status schedule: two fade steps and then expiry. Options may
+// override it; tests collapse it so draining a command batch never waits on a
+// status timer.
+const (
+	defaultStatusFadeStep1 = time.Second
+	defaultStatusFadeStep2 = 2 * time.Second
+	defaultStatusLifetime  = 3 * time.Second
+)
+
+// StatusTimings overrides the transient-status fade and expiry schedule. A zero
+// field keeps that step at its production delay.
+type StatusTimings struct {
+	FadeStep1 time.Duration
+	FadeStep2 time.Duration
+	Lifetime  time.Duration
+}
+
+// statusTimings is this Model's schedule, with unset steps filled in from the
+// production defaults so a directly constructed Model behaves as before. Read
+// the schedule through here rather than off the field.
+func (m Model) statusTimings() StatusTimings {
+	timings := m.statusSchedule
+	if timings.FadeStep1 <= 0 {
+		timings.FadeStep1 = defaultStatusFadeStep1
+	}
+	if timings.FadeStep2 <= 0 {
+		timings.FadeStep2 = defaultStatusFadeStep2
+	}
+	if timings.Lifetime <= 0 {
+		timings.Lifetime = defaultStatusLifetime
+	}
+	return timings
+}
 
 type StatusExpiredMsg struct {
 	Seq uint64
@@ -72,10 +104,11 @@ func (m Model) setVisibleRepoFetchSummaryStatus(text string) Model {
 	m = m.setStatusNow(statusVisibleRepoFetchSummary, text)
 	seq := m.status.Seq
 	timer := m.currentStatusTimer()
+	timings := m.statusTimings()
 	return m.queueStatusCmds(
-		timer.Fade(seq, 1, time.Second),
-		timer.Fade(seq, 2, 2*time.Second),
-		timer.Expire(seq, statusLifetime),
+		timer.Fade(seq, 1, timings.FadeStep1),
+		timer.Fade(seq, 2, timings.FadeStep2),
+		timer.Expire(seq, timings.Lifetime),
 	)
 }
 
@@ -153,11 +186,11 @@ func (m Model) setRankedAutoAdvanceStatus(rank autoAdvanceStatusRank, text strin
 	}
 	m = m.setStatusNow(statusFlowAutoAdvance, text)
 	m.status.AutoRank = rank
-	return m, m.currentStatusTimer().Expire(m.status.Seq, statusLifetime)
+	return m, m.currentStatusTimer().Expire(m.status.Seq, m.statusTimings().Lifetime)
 }
 
 func (m Model) queueStatusExpiry(seq uint64) Model {
-	return m.queueStatusCmds(m.currentStatusTimer().Expire(seq, statusLifetime))
+	return m.queueStatusCmds(m.currentStatusTimer().Expire(seq, m.statusTimings().Lifetime))
 }
 
 func (m Model) queueStatusCmds(cmds ...tea.Cmd) Model {

--- a/model/status_test.go
+++ b/model/status_test.go
@@ -44,7 +44,7 @@ func TestStatusTransientExpiryUsesSequence(t *testing.T) {
 	if len(m.pendingStatusCmds) != 1 {
 		t.Fatalf("pending status commands = %d, want 1", len(m.pendingStatusCmds))
 	}
-	if len(events) != 1 || events[0].kind != "expire" || events[0].delay != statusLifetime {
+	if len(events) != 1 || events[0].kind != "expire" || events[0].delay != defaultStatusLifetime {
 		t.Fatalf("timer events = %#v, want one 3s expiry", events)
 	}
 
@@ -93,7 +93,7 @@ func TestVisibleRepoSummaryStatusSchedulesFadeAndExpiry(t *testing.T) {
 	want := []recordedStatusTimerEvent{
 		{kind: "fade", seq: m.status.Seq, step: 1, delay: time.Second},
 		{kind: "fade", seq: m.status.Seq, step: 2, delay: 2 * time.Second},
-		{kind: "expire", seq: m.status.Seq, delay: statusLifetime},
+		{kind: "expire", seq: m.status.Seq, delay: defaultStatusLifetime},
 	}
 	for i := range want {
 		if events[i] != want[i] {
@@ -236,5 +236,26 @@ func TestStatusCommandDrainsFromUpdate(t *testing.T) {
 	modelNext := next.(Model)
 	if modelNext.status.Text != "Opened PR #1" {
 		t.Fatalf("status = %#v, want Opened PR #1", modelNext.status)
+	}
+}
+
+func TestStatusTimingsDefaultToTheProductionSchedule(t *testing.T) {
+	want := StatusTimings{FadeStep1: time.Second, FadeStep2: 2 * time.Second, Lifetime: 3 * time.Second}
+	// Injection is a test seam, not a production default: a Model built without
+	// explicit timings must keep the 1s/2s/3s schedule.
+	if got := New(nil).statusTimings(); got != want {
+		t.Fatalf("uninjected statusTimings() = %#v, want %#v", got, want)
+	}
+	if got := (Model{}).statusTimings(); got != want {
+		t.Fatalf("zero-value statusTimings() = %#v, want %#v", got, want)
+	}
+	injected := StatusTimings{FadeStep1: time.Millisecond, FadeStep2: 2 * time.Millisecond, Lifetime: 3 * time.Millisecond}
+	if got := NewWithOptions(nil, Options{StatusTimings: injected}).statusTimings(); got != injected {
+		t.Fatalf("injected statusTimings() = %#v, want %#v", got, injected)
+	}
+	// A partially set schedule fills only its unset steps from production.
+	partial := NewWithOptions(nil, Options{StatusTimings: StatusTimings{Lifetime: time.Millisecond}}).statusTimings()
+	if partial != (StatusTimings{FadeStep1: time.Second, FadeStep2: 2 * time.Second, Lifetime: time.Millisecond}) {
+		t.Fatalf("partial statusTimings() = %#v", partial)
 	}
 }

--- a/model/tick_interval_export_test.go
+++ b/model/tick_interval_export_test.go
@@ -1,0 +1,38 @@
+package model
+
+import (
+	"time"
+
+	"github.com/approachcontrol/approach/scanner"
+)
+
+// testTickInterval collapses the two 1 Hz poll loops for tests. The test
+// helpers that drain a tea.Cmd tree run every command in it, including the
+// loops' own reschedule ticks, so at the production cadence each tick child in
+// a batch cost a real second of wall time.
+const testTickInterval = time.Millisecond
+
+// fastTickOptions injects the collapsed cadence unless the test set its own.
+func fastTickOptions(opts Options) Options {
+	if opts.AutoAdvanceTickInterval == 0 {
+		opts.AutoAdvanceTickInterval = testTickInterval
+	}
+	if opts.FlowRefreshTickInterval == 0 {
+		opts.FlowRefreshTickInterval = testTickInterval
+	}
+	if opts.StatusTimings == (StatusTimings{}) {
+		opts.StatusTimings = StatusTimings{
+			FadeStep1: testTickInterval,
+			FadeStep2: 2 * testTickInterval,
+			Lifetime:  3 * testTickInterval,
+		}
+	}
+	return opts
+}
+
+// newModelForTest is NewWithOptions with the poll loops collapsed. Tests build
+// Models through it rather than calling NewWithOptions directly so no test
+// waits on the production tick cadence.
+func newModelForTest(repos []scanner.Repo, opts Options) Model {
+	return NewWithOptions(repos, fastTickOptions(opts))
+}

--- a/model/tmux_mode_internal_test.go
+++ b/model/tmux_mode_internal_test.go
@@ -26,7 +26,7 @@ type tmuxResumeSpy struct {
 }
 
 func (s *tmuxResumeSpy) model(backend string, tmuxAvailable bool) Model {
-	return NewWithOptions(nil, Options{
+	return newModelForTest(nil, Options{
 		AgentCommand: "codex",
 		InspectFlowLease: func(string, string) (flowlease.LeaseState, error) {
 			return flowlease.Free, nil
@@ -708,7 +708,7 @@ func TestWorktreeSessionResumeRoutesToTmux(t *testing.T) {
 // through to a detached external launch whose own result message would
 // otherwise overwrite the fallback note with the generic launch text.
 func TestResumeFallbackNoteSurvivesTheExternalFallthrough(t *testing.T) {
-	m := NewWithOptions(nil, Options{
+	m := newModelForTest(nil, Options{
 		AgentCommand:        "codex",
 		LaunchBackend:       "tmux",
 		TmuxLaunchAvailable: func() bool { return false },


### PR DESCRIPTION
## The problem

`go test ./model` took **230 seconds**, and almost all of it was spent asleep rather than computing.

The test helpers drain a `tea.Cmd` tree by *running* every command in it — including the poll loops' own reschedule ticks, which are real `tea.Tick` timers. Batch children are drained sequentially, so a batch with three tick children cost three real seconds. The giveaway was the timing distribution: 75 of 1609 tests accounted for 173s of the total, and 58 of those landed within 60ms of a whole second. Real work does not produce times like `3.00`, `4.00`, `6.00`.

Three constants drove it:

- `autoAdvanceTickInterval` = 1s
- `flowRefreshTickInterval` = 1s
- `statusLifetime` = 3s, plus the 1s/2s fade steps — this turned out to be the larger half of the cost

## The fix

Make all three cadences injectable through `Options` instead of baking them into constants:

- `Options.AutoAdvanceTickInterval` and `Options.FlowRefreshTickInterval` for the two 1 Hz poll loops.
- `Options.StatusTimings` for the transient-status fade and expiry schedule.

Each resolves per field, so a zero value keeps the production default. A `Model` built without options — or a zero-value `Model{}` — behaves exactly as before. Tests build through `newModelForTest` / `newTestModel`, which collapse the cadences to milliseconds.

## Test helpers that were timing-dependent

Collapsing the schedule exposed two helpers deriving control flow from *how long a command took* rather than from the messages it produced:

- `advanceFlowLaunchRead` detected "refused launch" by letting the command time out.
- `settleModelCommands` carried a comment stating its 20ms timeout "stays short so it does not consume status-fade timers (1s+) and clear the error under test" — it depended on outrunning the status schedule.

Both now recognize status timers by message type, which is what `manualLaunchHarness.drainMsg` already did for tick messages. That helper's skip list gained `StatusExpiredMsg` / `StatusFadeMsg` alongside the tick types.

This does not weaken coverage: every test that asserts fade or expiry behavior injects `StatusExpiredMsg` / `StatusFadeMsg` directly and never routes through the filtered helpers.

## Guard tests

The two tests that asserted a constant equals `time.Second` now assert something more useful — that the production default survives on an uninjected model *and* on a zero-value `Model{}`, and that injection actually takes effect. A new `TestStatusTimingsDefaultToTheProductionSchedule` does the same for the status schedule, including that a partially set schedule fills only its unset steps.

## Verification

- `go test ./model` passes: **230s → 11s** (~21x), stable across repeated runs.
- `go test ./model -race` passes (15s).
- `make fmt-check` and `go vet ./...` clean.
- `make test`: one pre-existing unrelated failure, `flowstore TestEveryNonTestNewStoreCallSiteNamesARole`, which flags call sites inside stale `.claude/worktrees/` checkouts from June. This branch adds no `NewStore(` call sites.