### PR TITLE
Map the Flow launch variant matrix and propose a typed launch role

### DIFF
--- a/docs/adr/0002-flow-launch-context-deep-module.md
+++ b/docs/adr/0002-flow-launch-context-deep-module.md
@@ -1,0 +1,309 @@
+# ADR 0002: Flow launch context as a deep module
+
+Status: **proposed — pending user approval** (2026-08-18)
+
+`approach-hyl.1` is a HITL bead. This Flow ran headless in auto mode, so the
+bead's "approved by the user" criterion cannot be satisfied from inside it.
+Every decision below is a *proposal* with its evidence; the final section lists the open
+questions as explicit decision requests. Approval happens out of band.
+
+## Context
+
+`actions.AgentLaunchContext` (`actions/actions.go:1055`) is a 30-field struct
+that any caller can compose by hand. Ten of its fields are Flow role markers
+whose legal combinations are implicit. The evidence base is
+`docs/flow-launch-variant-matrix.md`: eight launch kinds
+(`model/flow_launch_intent.go:14`), seven construction sites, 17 reachable
+variants, and 19 consumers.
+
+Three facts from the matrix drive this design.
+
+1. **Construction is not the only place role fields are set.**
+   `FlowLaunchTracked` is stamped at `model/flow_launch_lifecycle.go:1105`;
+   `Embedded` is forced true in four places and false in five. An interface that
+   owns only construction does not own the values consumers read (matrix §3).
+2. **Three consumers already hand-write a full role predicate and disagree.**
+   `actions.resumeSessionIDForContext` (`actions/actions.go:1450`, 12 negated
+   fields), `actions.validateTrackedRepoTmuxRole` (`actions/tmux_mode.go:454`,
+   10 fields), and the autofix arm of `flowEmbeddedTerminalIdentity`
+   (`model/embedded_terminal.go:746`, 9 fields) each assert "this context is
+   role X" with a different field set (matrix F2).
+3. **The lifecycle asks a question the context cannot answer.** Both
+   `model/flow_launch_lifecycle.go:1104` and `:958` enumerate the same four
+   kinds by hand, because `attempt.Kind` is available there and the context
+   carries no equivalent (matrix F6).
+
+## Decision
+
+### D1 — a closed `flowLaunchRole` enum of six roles
+
+The 17 variants map to six roles. Each role is a distinct *policy class*: at
+least one consumer changes what it does, not merely how it renders.
+
+| Role | Variants | Distinguished by |
+| --- | --- | --- |
+| `RoleTrackedPhase` | V1–V6 (manual, auto, create) | tracked + phase, no resume session |
+| `RolePhaseResume` | V7–V10 | tracked + phase + `ResumeSessionID` |
+| `RoleRepair` | V11–V12 | `FlowRepair` |
+| `RoleAutofix` | V13–V15 | `FlowAutofix` |
+| `RoleWorktreeAgent` | V16 | `FlowAgent` |
+| `RoleSavedSessionResume` | V17 | `FlowSavedSessionResume` |
+
+Collapses, each argued from the matrix:
+
+- **manual + auto collapse.** No consumer changes policy class on
+  `FlowAutoLaunch`; the three that read it — dock visibility
+  (`model/embedded_terminal.go:458`), focus
+  (`model/model_keys.go:3010`), and `validateTrackedRepoTmuxRole`
+  (`actions/tmux_mode.go:458`) — change *presentation* or assert a
+  reachability invariant. `FlowAutoLaunch` therefore becomes payload, not role.
+- **create collapses into `RoleTrackedPhase`.** No predicate anywhere
+  distinguishes it. Its two apparent differences are payload
+  (`PlanPhaseID`/`Title`/`Status`, read only by the env export at
+  `actions/actions.go:1424`) and a pipeline artifact (its tracked stamp arriving
+  at install time, matrix F4), which D3 removes.
+- **resume does not collapse into `RoleTrackedPhase`.** `ResumeSessionID`
+  suppresses prefill (`actions/actions.go:1352`), changes the `launchKind`
+  label (`model/flow_launch_pin.go:132`), and `FlowPhaseTerminal` — which only
+  resume sets — flips `flowLaunchFailureUpdate` from "regress the phase" to
+  "leave it alone" (`model/model_keys.go:3158`). That is a policy class.
+- **autofix does not collapse into `RoleWorktreeAgent`.** They differ in three
+  consumers: detach policy (`model/embedded_terminal.go:989` — agent never
+  detaches, autofix does), route eligibility (autofix reaches tmux, V15; the
+  worktree agent has no tmux call site), and slot stamping
+  (`model/embedded_terminal.go:488` stamps `FlowAgent` but not `FlowAutofix`).
+
+### D2 — one builder, with role-specific payloads
+
+```go
+// package actions
+type FlowLaunchRole int
+
+type TrackedPhaseTarget struct {
+    PhaseID, PhaseKind string
+    Auto               bool
+    PlanPhase          *PlanPhaseTarget // create only
+}
+type PhaseResumeTarget struct {
+    PhaseID, PhaseKind string
+    SessionID          string // required, non-blank
+    PhaseTerminal      bool
+}
+type AutofixTarget struct{ PRNumber int }
+type SavedSessionResumeTarget struct{ SessionID string }
+// RoleRepair and RoleWorktreeAgent carry no payload beyond the Flow ID.
+```
+
+```go
+// package model
+func newFlowLaunchContext(target flowLaunchTarget, settings flowLaunchAgentSettingsSnapshot,
+    route flowLaunchRouting) (actions.AgentLaunchContext, flowLaunchRoute, error)
+```
+
+`target` is a sum over the payload structs above, so only the autofix payload
+carries a PR number and only the two resume payloads carry a session ID: the
+invalid combinations the matrix prunes become unrepresentable rather than
+merely unreached.
+
+### D3 — the builder owns the route, writing `Embedded` and `FlowLaunchTracked` exactly once
+
+Open question (a) from the plan, decided: **builder-computed with the route as
+an input**, not a post-construction transition function.
+
+The evidence is that every tmux-capable kind already computes the route
+immediately next to its literal and then rewrites `Embedded`
+(`model/flow_phase_launch.go:402–406`, `model/flow_launch_resume.go:299`+`:388`,
+`model/flow_launch_autofix.go:395–399`). Folding `tmuxLaunchRouteFor` into the
+builder and returning `(ctx, route)` removes all three rewrites and makes
+`Embedded` a derived value — `route == embedded` — rather than a mutable flag.
+`FlowLaunchTracked` is set at construction for `RoleTrackedPhase` and
+`RolePhaseResume`, which makes the install-time stamp at
+`model/flow_launch_lifecycle.go:1105` redundant for every kind including create
+(matrix F4).
+
+A post-construction transition function was rejected because it keeps two
+writers for one field and preserves the very ordering hazard the matrix
+documents: `Headless` must be resolved *before* the route is decided
+(`model/flow_phase_launch.go:396–402`), and only a builder that owns both can
+enforce that ordering by construction.
+
+The remaining forced writes stay, reclassified as assertions rather than
+mutations: `model/flow_launch_lifecycle.go:1097`,
+`model/embedded_terminal.go:479`, `model/embedded_terminal.go:200`,
+`actions/actions.go:1248`, `actions/tmux_mode.go:313`, `model/tmux_mode.go:132`.
+Each becomes a check that the context already agrees with the transport it
+reached, failing loudly if not.
+
+### D4 — the classifier is partial; a Flow-marked context that fails to classify is an error
+
+Open question (b), decided:
+
+```go
+// package actions
+func FlowLaunchRoleOf(ctx AgentLaunchContext) (FlowLaunchRole, bool)
+func ValidateFlowLaunchRole(ctx AgentLaunchContext) error
+```
+
+`FlowLaunchRoleOf` returns `false` for the five non-Flow launch contexts the
+matrix lists (plan implementation, non-Flow session resume,
+open-agent-in-worktree, slice-epic, session-release finalizer). Those are
+legitimate and must keep working, so totality is not available.
+
+`ValidateFlowLaunchRole` is the seam check: if
+`flowLaunchContextRequiresLifecycle` (`model/tmux_mode.go:329`) is true but
+`FlowLaunchRoleOf` returns `false`, the context carries Flow markers in a
+combination no role admits — an invariant violation, and an error. That
+preserves today's behaviour at the one place that already errors
+(`actions/actions.go:1467`) while extending it to the two predicates that
+currently fail silently or by exclusion.
+
+The defining test is the round trip:
+`FlowLaunchRoleOf(newFlowLaunchContext(target, …)) == target.Role()` for all
+six roles across all 17 variants.
+
+### D5 — the role type lives in `actions`, the builder in `model`
+
+Open question (c), decided against the plan's working sketch, on a hard
+constraint: **`model` imports `actions`, so `actions` cannot import `model`.**
+Three of the consumers that need the role — `resumeSessionIDForContext`,
+`validateTrackedRepoTmuxRole`, and the tracked-lease branch
+(`actions/tmux_mode.go:332`) — are in `actions`. A role defined in `model` is
+unreachable from them, and mirroring the enum in both packages reintroduces the
+two-definitions-of-one-concept problem this ADR exists to remove.
+
+So: `FlowLaunchRole`, the payload structs, `FlowLaunchRoleOf` and
+`ValidateFlowLaunchRole` go in a new `actions/flow_launch_role.go`;
+`newFlowLaunchContext` goes in a new `model/flow_launch_context.go`, because it
+needs prompts, records, settings snapshots and the routing probe, none of which
+`actions` has. `flowLaunchKind` stays in `model` unchanged: it is the
+*submission* intent, and it legitimately outlives the launch (the lifecycle
+keys attempts and fences on it).
+
+### D6 — post-migration form of every consumer
+
+| Consumer | After |
+| --- | --- |
+| `flowEmbeddedTerminalIdentity` | `switch FlowLaunchRoleOf(ctx)`; the 9-field autofix arm collapses to one case + `AutofixTarget.PRNumber` |
+| `flowEmbeddedTerminalDetachPolicy` | `switch` on role: `RoleWorktreeAgent`, `RoleSavedSessionResume` → never |
+| slot stamping | stamps the role, not four booleans |
+| dock visibility, `updateFlowTerminalFocusAfterLaunch` | unchanged — they read `FlowAutoLaunch`/`Headless`, which stay payload |
+| `reserveFlowSpawn` | `role == RoleTrackedPhase \|\| role == RolePhaseResume` |
+| `flowLaunchFailureUpdate` | `RoleTrackedPhase`, or `RolePhaseResume` with `!PhaseTerminal`; all other roles refuse |
+| `tmuxRouteEligible` | folded into the builder (D3); survives as the eligibility rule it already is |
+| `flowLaunchContextRequiresLifecycle` | `_, ok := FlowLaunchRoleOf(ctx); return ok` |
+| `ShouldPrefillEmbeddedPrompt` | four hand-written arms → `role != RolePhaseResume && role != RoleSavedSessionResume`, plus the existing transport conditions |
+| `resumeSessionIDForContext` | `ValidateFlowLaunchRole` + `role == RoleSavedSessionResume` |
+| `validateTrackedRepoTmuxRole` | `ValidateFlowLaunchRole` + role ∈ {`RoleTrackedPhase`, `RolePhaseResume`}; the dead `FlowAutoLaunch` clause (matrix F1) becomes the explicit invariant `Auto ⇒ Headless ⇒ embedded`, checked in the builder |
+| tracked lease branch, window namers | unchanged — they read `LaunchID`/`FlowPhaseKind`, which stay payload |
+| `launchKind` | `switch` on role; **fixes F3** by separating `RolePhaseResume` from `RoleSavedSessionResume` |
+| `registerLaunchControl`, `reconcileInteractiveLaunchExitCmd` | role-owning check instead of `FlowLaunchTracked` + non-empty phase ID |
+| lifecycle kind enumerations (`:1103`, `:958`) | `role.MutatesPhase()` — removes both hand-written four-kind lists (F6) |
+
+## Enforcement
+
+Chosen: **(2) a boundary test as the enforceable seam now, plus (3) a runtime
+invariant check as the safety net. (1) unexported-field discipline is deferred
+out of this epic.**
+
+**The boundary test's exact scope.** An AST walk, in the style of the existing
+`model/flow_launch_boundary_test.go`, over `model/` and `actions/`
+non-`_test.go` files, failing on any composite literal of
+`actions.AgentLaunchContext` that sets *any* of the ten Flow marker fields
+(`FlowID`, `FlowPhaseID`, `FlowPhaseKind`, `FlowLaunchTracked`,
+`FlowAutoLaunch`, `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`,
+`FlowAutofix`, `FlowPhaseTerminal`) outside `model/flow_launch_context.go`. The
+scope is chosen from the matrix: it permits the five non-Flow literals and the
+two probe-only literals (`model/flow_launch_resume.go:299`,
+`model/tmux_mode.go:392`), which set no marker, and it catches exactly the seven
+Flow builders.
+
+**The runtime net.** `ValidateFlowLaunchRole` at the two transport entry points
+(`actions.AgentLaunchWithOptions`, `repoTmuxAgentLaunchWithExecutable`) rejects
+any context that requires the lifecycle but classifies to no role.
+
+Rejection reasons for the alternatives:
+
+- **(1) unexported fields.** The matrix shows five non-Flow launch literals that
+  legitimately compose `AgentLaunchContext` directly. Making the Flow fields
+  unexported forces a constructor for those paths too, which is a strictly
+  larger change than this epic scopes, and it cannot be done incrementally —
+  the field either is exported or is not. Deferred, not dismissed: it is the
+  only mechanism that makes hand-assembly *impossible* rather than *detected*,
+  and it becomes cheap once D2's builder is the only Flow-marking writer.
+- **(3) runtime check alone.** It fires only on paths that execute. The matrix
+  has variants that a test suite reaches rarely (V10, V15) and one predicate
+  whose failure mode is already dead code (F1). A check that only speaks when
+  exercised would not have caught F1 at all.
+- **(2) alone.** A boundary test constrains the repository, not the package's
+  API; a future caller in a new package, or a test helper promoted to
+  production, escapes it. Hence (3) as the net.
+
+**Migration order for downstream slices**, with reasons:
+
+1. `approach-hyl.2` — tracer bullet. Use `RoleRepair`: one marker field, one
+   route, no route decision, no phase writes, and its refresh step
+   (`model/flow_repair.go:182`) exercises the "field set after the literal"
+   problem in its simplest form.
+2. `approach-hyl.11` — classifier. Pure addition plus the deletion of the three
+   hand-written predicates (F2). Lands before any consumer moves, so each later
+   slice deletes rather than rewrites.
+3. `approach-hyl.10` — model consumers. The largest surface, but every change is
+   mechanical once the classifier exists.
+4. `approach-hyl.8` — `createPhase` last. It is the only kind whose tracked
+   stamp moves from install to construction (F4, D3), so it is the only slice
+   that changes lifecycle behaviour rather than just its expression.
+
+## Grill dossier
+
+For each collapse, "what breaks if these two become the same value?"
+
+- **manual ≡ auto.** Nothing in policy; `FlowAutoLaunch` survives as payload. But
+  the invariant `Auto ⇒ Headless` (F1) is currently enforced by two unrelated
+  code paths. If the role collapses them and the builder does *not* assert that
+  invariant, an interactive auto launch becomes representable and reaches
+  `validateTrackedRepoTmuxRole`'s rejection. **The builder must assert it.**
+- **manual ≡ create.** Breaks nothing observable *provided* `PlanPhase*` stays
+  in the payload; those three fields reach providers as env
+  (`actions/actions.go:1424`) and a Flow agent that lost them would see an empty
+  `APPROACH_PLAN_PHASE_ID`.
+- **resume ≡ tracked phase.** Breaks three things: prefill would fire on a
+  resume, `launchKind` would mislabel it, and a failed resume of a completed
+  phase would regress it to `needs_attention`.
+- **autofix ≡ worktree agent.** Breaks detach policy (the agent's terminal is
+  deliberately nondetachable), and would make the worktree agent tmux-eligible
+  with no call site to serve it.
+- **saved-session resume ≡ phase resume.** Breaks the only assertion in the
+  codebase that currently returns an error for a malformed role
+  (`actions/actions.go:1467`) and would let a phase-untracked session resume
+  claim a phase.
+
+For each field the role does *not* carry, "which consumer proves it is payload?"
+
+| Field | Proof it is payload |
+| --- | --- |
+| `FlowAutoLaunch` | dock visibility (`model/embedded_terminal.go:458`) and focus (`model/model_keys.go:3010`) read it *within* a single role |
+| `Headless` | read by `UsesStreamJSONOutput` and focus across five of six roles |
+| `FlowPhaseTerminal` | read only inside `RolePhaseResume`, by `flowLaunchFailureUpdate` |
+| `FlowAutofixPRNumber` | read only inside `RoleAutofix`, by `flowEmbeddedTerminalIdentity` |
+| `ResumeSessionID` | distinguishes `RolePhaseResume` from `RoleTrackedPhase` — **role-determining**, hence in the payload *and* in the classifier |
+| `PlanPhase*` | export-only (`actions/actions.go:1424`); no predicate reads it |
+| `WorkingDir` | set by four roles and unset by three (matrix F5) — payload, but its emptiness is currently load-bearing for manual/auto/create/repair |
+
+## Open questions requiring approval
+
+1. **D5 reverses the bead's working sketch.** The bead proposes the role in
+   `model/flow_launch_context.go`; the import direction forbids it. Confirm the
+   role type moving to `actions`.
+2. **F1 is a latent bug, not just a design smell.** Should `approach-hyl` fix it
+   (assert `Auto ⇒ Headless` in the builder) or file it separately?
+3. **F3 (`launchKind` conflating the two resume roles) changes `launch.json`
+   output.** Confirm that is acceptable, or the label must be preserved.
+4. **D3 makes `newFlowLaunchContext` take the routing probe**, which means the
+   builder does I/O-adjacent work (`actions.TmuxAvailable`). Confirm, or keep
+   routing outside and accept a two-step `(build, route)` with a documented
+   ordering contract.
+5. **D1's six roles vs. seven** — splitting `RoleTrackedPhase` into
+   manual/auto/create would make the enum mirror `flowLaunchKind` exactly, at
+   the cost of three roles no consumer distinguishes. Confirm the collapse.
+6. **Enforcement scope**: the boundary test as specified covers `model/` and
+   `actions/` only. Confirm no other package should be in scope.

--- a/docs/adr/0002-flow-launch-context-deep-module.md
+++ b/docs/adr/0002-flow-launch-context-deep-module.md
@@ -144,18 +144,31 @@ func FlowLaunchRoleOf(ctx AgentLaunchContext) (FlowLaunchRole, bool)
 func ValidateFlowLaunchRole(ctx AgentLaunchContext) error
 ```
 
-`FlowLaunchRoleOf` returns `false` for the five non-Flow launch contexts the
+`FlowLaunchRoleOf` returns `false` for the four non-Flow launch contexts the
 matrix lists (plan implementation, non-Flow session resume,
-open-agent-in-worktree, slice-epic, session-release finalizer). Those are
-legitimate and must keep working, so totality is not available.
+open-agent-in-worktree, slice-epic), and for the two non-launch literals that
+carry Flow IDs without a role (`model/flow_session_release.go:407`,
+`model/flow_launch_lifecycle.go:1051`). Those are legitimate and must keep
+working, so totality is not available. The two Flow-ID-carrying ones are also
+why `ValidateFlowLaunchRole` belongs on the launch path rather than on every
+context: neither is ever routed or turned into a command.
 
-`ValidateFlowLaunchRole` is the seam check: if
-`flowLaunchContextRequiresLifecycle` (`model/tmux_mode.go:329`) is true but
-`FlowLaunchRoleOf` returns `false`, the context carries Flow markers in a
-combination no role admits — an invariant violation, and an error. That
-preserves today's behaviour at the one place that already errors
-(`actions/actions.go:1467`) while extending it to the two predicates that
-currently fail silently or by exclusion.
+`ValidateFlowLaunchRole` is the seam check: if the context carries any Flow
+marker but `FlowLaunchRoleOf` returns `false`, it carries them in a combination
+no role admits — an invariant violation, and an error. That preserves today's
+behaviour at the one place that already errors (`actions/actions.go:1467`)
+while extending it to the two predicates that currently fail silently or by
+exclusion.
+
+The marker-presence half must stay independent of classification. Today's
+`flowLaunchContextRequiresLifecycle` (`model/tmux_mode.go:329`) is exactly that
+predicate — a disjunction over the ten fields it already names — so it
+moves to `actions` as `HasFlowLaunchMarkers`, gaining one clause so that its
+field set matches the boundary test's eleven exactly (`FlowAutofixPRNumber != 0`
+is today the only Flow-specific value neither predicate covers), and becomes the
+check's left operand. Re-expressing it as `_, ok := FlowLaunchRoleOf(ctx)`
+would be circular: the two halves could never disagree, and the runtime net
+would accept every malformed hand-assembled context it exists to reject.
 
 The defining test is the round trip:
 `FlowLaunchRoleOf(newFlowLaunchContext(target, …)) == target.Role()` for all
@@ -172,7 +185,8 @@ unreachable from them, and mirroring the enum in both packages reintroduces the
 two-definitions-of-one-concept problem this ADR exists to remove.
 
 So: `FlowLaunchRole`, the payload structs, `FlowLaunchRoleOf` and
-`ValidateFlowLaunchRole` go in a new `actions/flow_launch_role.go`;
+`ValidateFlowLaunchRole` go in a new `actions/flow_launch_role.go`, alongside
+`HasFlowLaunchMarkers` relocated from `model/tmux_mode.go:329`;
 `newFlowLaunchContext` goes in a new `model/flow_launch_context.go`, because it
 needs prompts, records, settings snapshots and the routing probe, none of which
 `actions` has. `flowLaunchKind` stays in `model` unchanged: it is the
@@ -183,20 +197,21 @@ keys attempts and fences on it).
 
 | Consumer | After |
 | --- | --- |
-| `flowEmbeddedTerminalIdentity` | `switch FlowLaunchRoleOf(ctx)`; the 9-field autofix arm collapses to one case + `AutofixTarget.PRNumber` |
+| `flowEmbeddedTerminalIdentity` | `switch FlowLaunchRoleOf(ctx)`; the 9-field autofix arm collapses to one case reading `ctx.FlowAutofixPRNumber` — the classifier returns a role, not a payload, and `FlowAutofixPRNumber` stays on the context as `RoleAutofix`'s payload |
 | `flowEmbeddedTerminalDetachPolicy` | `switch` on role: `RoleWorktreeAgent`, `RoleSavedSessionResume` → never |
 | slot stamping | stamps the role, not four booleans |
 | dock visibility, `updateFlowTerminalFocusAfterLaunch` | unchanged — they read `FlowAutoLaunch`/`Headless`, which stay payload |
 | `reserveFlowSpawn` | `role == RoleTrackedPhase \|\| role == RolePhaseResume` |
 | `flowLaunchFailureUpdate` | `RoleTrackedPhase`, or `RolePhaseResume` with `!PhaseTerminal`; all other roles refuse |
 | `tmuxRouteEligible` | folded into the builder (D3); survives as the eligibility rule it already is |
-| `flowLaunchContextRequiresLifecycle` | `_, ok := FlowLaunchRoleOf(ctx); return ok` |
+| `flowLaunchContextRequiresLifecycle` | moves to `actions` as `HasFlowLaunchMarkers`, plus a `FlowAutofixPRNumber` clause — it must stay marker-based, not role-based (see D4) |
 | `ShouldPrefillEmbeddedPrompt` | four hand-written arms → `role != RolePhaseResume && role != RoleSavedSessionResume`, plus the existing transport conditions |
 | `resumeSessionIDForContext` | `ValidateFlowLaunchRole` + `role == RoleSavedSessionResume` |
 | `validateTrackedRepoTmuxRole` | `ValidateFlowLaunchRole` + role ∈ {`RoleTrackedPhase`, `RolePhaseResume`}; the dead `FlowAutoLaunch` clause (matrix F1) becomes the explicit invariant `Auto ⇒ Headless ⇒ embedded`, checked in the builder |
 | tracked lease branch, window namers | unchanged — they read `LaunchID`/`FlowPhaseKind`, which stay payload |
 | `launchKind` | `switch` on role; **fixes F3** by separating `RolePhaseResume` from `RoleSavedSessionResume` |
-| `registerLaunchControl`, `reconcileInteractiveLaunchExitCmd` | role-owning check instead of `FlowLaunchTracked` + non-empty phase ID |
+| `registerLaunchControl` | `_, ok := FlowLaunchRoleOf(ctx); ok && LaunchID != ""` — every Flow role registers, phase-less roles still as unowned |
+| `reconcileInteractiveLaunchExitCmd` | `role.MutatesPhase()` (i.e. `RoleTrackedPhase`/`RolePhaseResume`, V1–V10) instead of `FlowLaunchTracked` + non-empty phase ID |
 | lifecycle kind enumerations (`:1103`, `:958`) | `role.MutatesPhase()` — removes both hand-written four-kind lists (F6) |
 
 ## Enforcement
@@ -208,23 +223,40 @@ out of this epic.**
 **The boundary test's exact scope.** An AST walk, in the style of the existing
 `model/flow_launch_boundary_test.go`, over `model/` and `actions/`
 non-`_test.go` files, failing on any composite literal of
-`actions.AgentLaunchContext` that sets *any* of the ten Flow marker fields
+`actions.AgentLaunchContext` that sets *any* of the eleven Flow marker fields
 (`FlowID`, `FlowPhaseID`, `FlowPhaseKind`, `FlowLaunchTracked`,
 `FlowAutoLaunch`, `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`,
-`FlowAutofix`, `FlowPhaseTerminal`) outside `model/flow_launch_context.go`. The
-scope is chosen from the matrix: it permits the five non-Flow literals and the
-two probe-only literals (`model/flow_launch_resume.go:299`,
-`model/tmux_mode.go:392`), which set no marker, and it catches exactly the seven
+`FlowAutofix`, `FlowPhaseTerminal`, `FlowAutofixPRNumber`) outside
+`model/flow_launch_context.go`,
+with a file:line allowlist for the two non-launch literals below.
+
+The scope is chosen from the matrix. It needs no exemption for the four
+non-Flow literals or the two probe-only literals
+(`model/flow_launch_resume.go:299`, `model/tmux_mode.go:392`) — none of them
+sets a marker. It does need an explicit allowlist for the two literals that set
+`FlowID`/`FlowPhaseID` without being launches: the session-release finalizer
+(`model/flow_session_release.go:407`) and `blockAutoFlowLaunchPhase`
+(`model/flow_launch_lifecycle.go:1051`). Both address an existing launch record
+rather than constructing one, so routing them through a launch builder would be
+wrong; the allowlist is the honest encoding of that, and it is two entries the
+test names and pins. With those exempted, the rule catches exactly the seven
 Flow builders.
 
-**The runtime net.** `ValidateFlowLaunchRole` at the two transport entry points
-(`actions.AgentLaunchWithOptions`, `repoTmuxAgentLaunchWithExecutable`) rejects
-any context that requires the lifecycle but classifies to no role.
+**The runtime net.** `ValidateFlowLaunchRole` rejects any context that carries
+Flow markers (`HasFlowLaunchMarkers`) but classifies to no role. It belongs in
+`actions.agentCommandSpec`, the one function every transport funnels through —
+external terminal (`AgentLaunchWithOptions`), repo tmux
+(`repoTmuxAgentLaunchWithExecutable`), embedded tmux
+(`EmbeddedTmuxAgentCommand`), and embedded direct (`AgentCommand`) all reach it.
+Placing it at the two terminal entry points alone would leave the embedded path
+— which is the hardcoded route for four of the seven builders — unchecked, i.e.
+exactly the future-caller case the net exists for.
 
 Rejection reasons for the alternatives:
 
-- **(1) unexported fields.** The matrix shows five non-Flow launch literals that
-  legitimately compose `AgentLaunchContext` directly. Making the Flow fields
+- **(1) unexported fields.** The matrix shows four non-Flow launch literals, two
+  probes, and two non-launch Flow-ID literals that legitimately compose
+  `AgentLaunchContext` directly. Making the Flow fields
   unexported forces a constructor for those paths too, which is a strictly
   larger change than this epic scopes, and it cannot be done incrementally —
   the field either is exported or is not. Deferred, not dismissed: it is the

--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -1,0 +1,226 @@
+# Flow launch variant matrix
+
+Evidence base for `approach-hyl` (typed Flow launch intent). Every cell cites
+`file:line` against commit `e1dd62e`. This document describes the code as it is
+today; the proposed redesign is ADR 0002.
+
+Scope: the eight launch kinds in `model/flow_launch_intent.go:14`, crossed with
+route (embedded/tmux), headless, and phase-terminal resume, and every consumer
+of the Flow-scoped fields of `actions.AgentLaunchContext`
+(`actions/actions.go:1055`).
+
+## 1. Construction sites
+
+There are eight kinds but only seven Flow-scoped construction sites: manual and
+automatic phase launches share one builder and differ only by `req.AutoLaunch`.
+
+| Kind | Builder | Route decision |
+| --- | --- | --- |
+| `manualPhase` | `model/flow_phase_launch.go:371` | `model/flow_phase_launch.go:402` |
+| `autoPhase` | `model/flow_phase_launch.go:371` (same literal, `req.AutoLaunch` true) | `model/flow_phase_launch.go:402` |
+| `createPhase` | `model/flow_launch_create.go:808` (`createFlowLaunchContext`) | none — hardcoded embedded at `model/flow_launch_create.go:373` |
+| `phaseResume` | `model/flow_launch_resume.go:360` | `model/flow_launch_resume.go:299` (taken on the Model, before the closure) |
+| `repair` | `model/flow_launch_repair.go:420`, refreshed at `model/flow_repair.go:182` | none — hardcoded embedded at `model/flow_launch_repair.go:440` |
+| `autofix` | `model/flow_launch_autofix.go:366` | `model/flow_launch_autofix.go:395` |
+| `worktreeAgent` | `model/flow_launch_generic_agent.go:292` | none — hardcoded embedded at `model/flow_launch_generic_agent.go:299` |
+| `savedSessionResume` | `model/flow_launch_saved_session_resume.go:300` | none — hardcoded embedded at `model/flow_launch_saved_session_resume.go:226` |
+
+Five further `actions.AgentLaunchContext` literals exist outside the Flow
+lifecycle and set no Flow marker at all — the non-Flow session resume
+(`model/model_keys.go:2773`), plan implementation (`model/model_keys.go:2847`),
+open-agent-in-worktree (`model/model_keys.go:3308`), slice-epic
+(`model/ready_bead_slice.go:171`), and the session-release finalizer
+(`model/flow_session_release.go:407`, which carries Flow IDs but is not a
+launch). Two more are probe-only values used purely to ask a routing question:
+`model/flow_launch_resume.go:299` and `model/tmux_mode.go:392`. They matter to
+Phase 4: any enforcement mechanism must tolerate them.
+
+## 2. Reachable variants
+
+17 of the 64 cells in kind × route × headless × phase-terminal are reachable. Pruning rules, each with its gate:
+
+| Pruned | Why unreachable |
+| --- | --- |
+| any kind × tmux × headless | `tmuxRouteEligible` refuses `ctx.Headless` (`model/tmux_mode.go:64`). The route is decided *after* headless resolution (`model/flow_phase_launch.go:396–402`), so this holds for every kind. |
+| `autoPhase` × interactive | Both AutoMode read commands hardcode `Headless: true` (`model/flow_launch_lifecycle.go:665`, `:692`), and prepare's reservation override is skipped when `req.AutoLaunch` (`model/flow_phase_launch.go:396`). |
+| `autoPhase` × tmux | Follows from the previous two rows: auto ⇒ headless ⇒ embedded. |
+| `repair` × tmux | Refused twice: `tmuxRouteEligible` rejects `ctx.FlowRepair` (`model/tmux_mode.go:64`), and prepare has no tmux call site (`model/flow_launch_repair.go:440`). |
+| `createPhase` × tmux | No call site; route is hardcoded embedded (`model/flow_launch_create.go:373`). |
+| `worktreeAgent` × tmux | No call site (`model/flow_launch_generic_agent.go:299`). |
+| `savedSessionResume` × tmux | No call site (`model/flow_launch_saved_session_resume.go:226`). |
+| `phaseResume` × headless | `Headless` is never assigned by the resume builder (`model/flow_launch_resume.go:360–383`). |
+| `worktreeAgent` × headless | `Headless: false` is hardcoded (`model/flow_launch_generic_agent.go:296`). |
+| `savedSessionResume` × headless | `Headless` is never assigned (`model/flow_launch_saved_session_resume.go:300–314`). |
+| `FlowPhaseTerminal` = true for any kind but `phaseResume` | Only the resume builder assigns it (`model/flow_launch_resume.go:381`). |
+
+The reachable variants:
+
+| # | Kind | Route | Headless | PhaseTerminal |
+| --- | --- | --- | --- | --- |
+| V1 | manualPhase | embedded | false | false |
+| V2 | manualPhase | embedded | true | false |
+| V3 | manualPhase | tmux | false | false |
+| V4 | autoPhase | embedded | true | false |
+| V5 | createPhase | embedded | false | false |
+| V6 | createPhase | embedded | true | false |
+| V7 | phaseResume | embedded | false | false |
+| V8 | phaseResume | embedded | false | true |
+| V9 | phaseResume | tmux | false | false |
+| V10 | phaseResume | tmux | false | true |
+| V11 | repair | embedded | false | false |
+| V12 | repair | embedded | true | false |
+| V13 | autofix | embedded | false | false |
+| V14 | autofix | embedded | true | false |
+| V15 | autofix | tmux | false | false |
+| V16 | worktreeAgent | embedded | false | false |
+| V17 | savedSessionResume | embedded | false | false |
+
+## 3. Field values, with the pipeline point that sets them
+
+`C` = construction, `L` = lifecycle install (`installFlowLaunchEmbedded`),
+`T` = terminal open, `R` = tmux route, `X` = actions transport.
+
+### Marker fields
+
+| Field | V1–V3 manual | V4 auto | V5–V6 create | V7–V10 resume | V11–V12 repair | V13–V15 autofix | V16 agent | V17 saved |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `FlowID` | record `C:383` | same | `msg.FlowID` `C:813` | record `C:377` | `msg.FlowID` `C:430` | record `C:383` | record `C:297` | record `C:312` |
+| `FlowPhaseID` | phase `C:384` | same | phase `C:813` | `msg.PhaseID` `C:378` | **empty** (deliberate, `model/flow_launch_repair.go:436`) | empty | empty | empty |
+| `FlowPhaseKind` | `SemanticKind` `C:385` | same | `SemanticKind` `C:813` | `SemanticKind` `C:379` | empty | empty | empty | empty |
+| `FlowLaunchTracked` | true `C:392` | true `C:392` | **false at C; true at `L:1105`** | true `C:382` | false (never) | false | false | false |
+| `FlowAutoLaunch` | false `C:386` | true `C:386` | false | false | false | false | false | false |
+| `FlowRepair` | false | false | false | false | true `C:431` | false | false | false |
+| `FlowAgent` | false | false | false | false | false | false | true `C:297` | false |
+| `FlowSavedSessionResume` | false | false | false | false | false | false | false | true `C:313` |
+| `FlowAutofix` | false | false | false | false | false | true `C:387` | false | false |
+| `FlowAutofixPRNumber` | 0 | 0 | 0 | 0 | 0 | `record.PR.Number` `C:388` | 0 | 0 |
+| `FlowPhaseTerminal` | false | false | false | `PhaseStatusTerminal` `C:380` | false | false | false | false |
+
+### Transport fields
+
+| Field | V1–V3 manual | V4 auto | V5–V6 create | V7–V10 resume | V11–V12 repair | V13–V15 autofix | V16 agent | V17 saved |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `Embedded` | true `C:393`; false on tmux `R:406` | true `C:393` | **unset at C; true at `L:1097`, again `T:479`** | true `C:381`; false on tmux `R:388` | true `C:432` | true `C:389`; false on tmux `R:399` | true `C:297` | true `C:314` |
+| `Headless` | `req.Headless` `C:394`, replaced by the persisted reservation `C:398` | `req.Headless` (always true) `C:394` | `msg.Record.Headless` `C:814` | unset (false) | unset at C, then `record.Headless` at refresh (`model/flow_repair.go:199`) | `record`/`reserved.Headless` `C:390` | false `C:297` | unset (false) |
+| `Command` | `settings.Command` `C:372` | same | `settings.Command` `C:809` | `msg.ResumeCommand` `C:361` | `resolved.Command`, restricted to codex/claude/cursor (`model/flow_launch_repair.go:414`) | `settings.Command` `C:367` | `settings.Command` `C:293` | `string(refreshed.Provider)` `C:301` |
+| `ResumeSessionID` | "" | "" | "" | `msg.ProviderSessionID` `C:374` | "" | "" | "" | `refreshed.SessionID` `C:309` |
+| `InitialPrompt` | `flowPhasePrompt` `C:387` | same | `initialFlowLaunchPrompt` `C:815` | unset (deliberate; the resume carries no prompt) | set at refresh, `flowRepairPrompt` (`model/flow_repair.go:200`) | `autofixPrompt` `C:391` | "" `C:297` | "" |
+| `WorkingDir` | **unset** | unset | **unset** | `msg.Record.WorktreePath` `C:367` | **unset** | `record.WorktreePath` `C:375` | `record.WorktreePath` `C:294` | `refreshed.CWD` ‖ worktree `C:305` |
+| `PlanPhaseID` / `Title` / `Status` | unset | unset | `phase.PhaseID` / title / `PhaseRunning` `C:812` | unset | unset | unset | unset | unset |
+
+Every kind additionally passes through `applyLaunchStamp`
+(`model/flow_launch_pin.go:85`), which sets `Executable`, `BuildVersion`,
+`DBSchemaVersion`, `ControlEndpoint` and `ControlToken`, and through
+`registerLaunchControl` (`model/flow_launch_pin.go:102`).
+
+### The four fields that change value mid-flight
+
+1. `FlowLaunchTracked` is stamped at `model/flow_launch_lifecycle.go:1105` for
+   every kind except repair, autofix, worktreeAgent and savedSessionResume. For
+   manual, auto and resume that stamp is redundant — they already set it at
+   construction. **`createPhase` is the only kind for which it is load-bearing**,
+   and only on the embedded route, which is the only route it has.
+2. `Embedded` is forced true at `model/flow_launch_lifecycle.go:1097` and again
+   at `model/embedded_terminal.go:479`, and a third time inside the terminal
+   starter (`model/embedded_terminal.go:200`) and the embedded tmux command
+   (`actions/actions.go:1248`).
+3. `Embedded` is forced false on the tmux route in four places:
+   `model/flow_phase_launch.go:406`, `model/flow_launch_resume.go:388`,
+   `model/flow_launch_autofix.go:399`, `model/tmux_mode.go:132`, and once more
+   inside actions at `actions/tmux_mode.go:313`.
+4. `Headless` is resolved twice for manual launches — from the record at
+   `model/flow_launch_lifecycle.go:620` and again from the persisted reservation
+   at `model/flow_phase_launch.go:398` — and for repair only at refresh time
+   (`model/flow_repair.go:199`), i.e. *after* its literal.
+
+Consequence for the design: **an interface that only owns construction does not
+own the values these consumers read.** The builder must own the route decision,
+or the late mutations must become an explicit, narrow transition.
+
+## 4. Consumer map
+
+Each entry lists the fields read, the variants separated, and the variants
+deliberately treated alike.
+
+| Consumer | Fields read | Separates | Treats alike |
+| --- | --- | --- | --- |
+| `flowEmbeddedTerminalIdentity` (`model/embedded_terminal.go:736`) | `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`, `ResumeSessionID`, `FlowAutofix`, `FlowAutofixPRNumber`, `Embedded`, `Headless`, `FlowID`, `FlowPhaseID`, `FlowLaunchTracked`, `WorktreePath` | V11–12 (repair) ‖ V16 (agent) ‖ V17 (session id) ‖ V13–15 (autofix + PR) ‖ rest | V1–V10 all render as the phase ID |
+| `flowEmbeddedTerminalDetachPolicy` (`model/embedded_terminal.go:988`) | `FlowAgent`, `FlowSavedSessionResume` | V16, V17 (never detachable) ‖ rest | every tracked and untracked-repair/autofix variant |
+| slot stamping (`model/embedded_terminal.go:488`) | `RepoPath`, `WorktreePath`, `WorkingDir`, `FlowID`, `FlowPhaseID`, `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`, `LaunchID`, `Command`; forces `Embedded` true at `:479` | repair/agent/saved-resume slots | autofix is *not* stamped — it has no slot marker of its own |
+| dock visibility (`model/embedded_terminal.go:458`, `:467`) | `FlowAutoLaunch`, `Headless` | V4 (no dock, keeps the active slot) ‖ V2/V6/V12/V14 (headless) ‖ rest | manual vs create vs resume |
+| `updateFlowTerminalFocusAfterLaunch` (`model/model_keys.go:3003`) | `FlowAgent`, `FlowSavedSessionResume`, `FlowAutoLaunch`, `Headless` | V16/V17 (always focus input) ‖ V4 (no focus change) ‖ headless (focus list) ‖ rest | manual/create/resume/repair/autofix at equal headlessness |
+| `reserveFlowSpawn` (`model/model_keys.go:3145`) | `FlowID`, `FlowLaunchTracked`, `FlowRepair` | tracked non-repair (V1–V10) ‖ rest | all untracked kinds are no-ops |
+| `flowLaunchFailureUpdate` (`model/model_keys.go:3154`) | `FlowID`, `FlowPhaseID`, `ResumeSessionID`, `FlowLaunchTracked`, `FlowPhaseTerminal`, `FlowPhaseKind` | V8/V10 (terminal resume: refuse) ‖ V11–V17 (no phase: refuse) ‖ plan-review kind (blocked) ‖ rest | manual/auto/create/non-terminal resume |
+| `tmuxRouteEligible` (`model/tmux_mode.go:63`) | `Headless`, `FlowRepair`, `Command` | V3/V9/V10/V15 eligible ‖ rest | every embedded variant, for whichever of the two reasons |
+| `flowLaunchContextRequiresLifecycle` (`model/tmux_mode.go:329`) | all ten markers + `FlowID`/`FlowPhaseID`/`FlowPhaseKind` | Flow launches ‖ the five non-Flow literals | all 17 variants alike |
+| `actions.ShouldPrefillEmbeddedPrompt` (`actions/actions.go:1338`) | `Command`, `Embedded`, `Headless`, `ResumeSessionID`, `InitialPrompt`, `FlowID`, `FlowPhaseID`, `FlowLaunchTracked`, `FlowRepair`, `FlowAgent`, `FlowAutofix` | V1/V5 (prefill) ‖ V11/V13/V16 (untracked prefill arms) ‖ resume and headless and tmux (no prefill) | the three untracked arms are separate clauses with identical effect |
+| `actions.resumeSessionIDForContext` (`actions/actions.go:1450`) | `FlowSavedSessionResume` + 12 negated fields + `ResumeSessionID` | V17 ‖ everything else | asserts *one* variant; all others take the plain path |
+| `actions.validateTrackedRepoTmuxRole` (`actions/tmux_mode.go:454`) | `FlowLaunchTracked`, `FlowID`, `FlowPhaseID`, `FlowAutoLaunch`, `Headless`, `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`, `FlowAutofix`, `FlowAutofixPRNumber` | V3/V9/V10 accepted | manual and resume tmux launches are identical to it |
+| tracked lease branch (`actions/tmux_mode.go:332`) | `FlowLaunchTracked`, `SessionStateRoot`, `Executable`, `FlowID`, `FlowPhaseID`, `LaunchID` | V3/V9/V10 (leased window) ‖ V15 (plain window) | — |
+| `repoTmuxWindowName` / `repoTmuxLeasedWindowName` (`actions/tmux_mode.go:535`, `:549`) | `FlowPhaseKind`, `Command`, `LaunchID` | phase variants (kind-named) ‖ V15 (command-named) | manual vs resume |
+| `launchKind` (`model/flow_launch_pin.go:123`) | `FlowRepair`, `FlowAutofix`, `FlowAgent`, `FlowSavedSessionResume`, `ResumeSessionID` | repair ‖ autofix ‖ generic ‖ resume (V7–V10 **and** V17) ‖ phase | V1–V6 all report "phase" |
+| `registerLaunchControl` (`model/flow_launch_pin.go:102`) | `FlowID`, `LaunchID`, `FlowPhaseID` | phase-owning ‖ unowned (V11–V17) | — |
+| `reconcileInteractiveLaunchExitCmd` (`model/flow_launch_control.go:149`) | `FlowLaunchTracked`, `FlowID`, `FlowPhaseID`, `LaunchID` | V1–V10 ‖ rest | — |
+| `actions.UsesStreamJSONOutput` (`actions/actions.go:1333`) | `Command`, `Embedded`, `Headless` | V2/V4/V6/V12/V14 on claude/cursor | — |
+| provider env export (`actions/actions.go:1424`) | `PlanPhaseID`, `PlanPhaseTitle`, `PlanPhaseStatus` | V5/V6 only | every other variant exports empty strings |
+
+### Field coverage check
+
+Every field in the matrix has at least one named consumer:
+
+- `FlowID`, `FlowPhaseID`, `FlowLaunchTracked`, `FlowRepair`, `FlowAgent`,
+  `FlowSavedSessionResume`, `FlowAutofix`, `FlowAutoLaunch`, `Headless`,
+  `Embedded`, `ResumeSessionID`, `InitialPrompt`, `Command`, `LaunchID`:
+  multiple consumers each.
+- `FlowPhaseKind`: `flowLaunchFailureUpdate`, both tmux window namers,
+  `flowLaunchContextRequiresLifecycle`.
+- `FlowPhaseTerminal`: `flowLaunchFailureUpdate`, `resumeSessionIDForContext`,
+  `flowLaunchContextRequiresLifecycle`.
+- `FlowAutofixPRNumber`: `flowEmbeddedTerminalIdentity`,
+  `validateTrackedRepoTmuxRole`.
+- `WorkingDir`: slot stamping and `detachHandoffCWD`
+  (`model/embedded_terminal.go:995`), plus the agent cwd in actions.
+- `PlanPhaseID`/`PlanPhaseTitle`/`PlanPhaseStatus`: **export-only** — read
+  solely at `actions/actions.go:1424–1426` to populate provider env. No
+  predicate branches on them.
+
+## 5. Findings (candidate latent bugs and design constraints)
+
+**F1 — `validateTrackedRepoTmuxRole`'s `FlowAutoLaunch` rejection is currently
+dead, and only by an undocumented two-step coupling.** The predicate refuses any
+auto launch on the tracked tmux route (`actions/tmux_mode.go:458`). That refusal
+never fires today only because AutoMode hardcodes `Headless: true`
+(`model/flow_launch_lifecycle.go:665`, `:692`) and `tmuxRouteEligible` refuses
+headless (`model/tmux_mode.go:64`). Nothing states "auto ⇒ headless" as an
+invariant. Making auto launches interactive — a plausible future change — would
+turn every tmux-mode auto-advance into `invalid tracked Flow tmux launch role`.
+
+**F2 — the three hand-written role predicates disagree about which fields
+constitute a role.** `resumeSessionIDForContext` checks `FlowPhaseTerminal` and
+`InitialPrompt == ""`; `validateTrackedRepoTmuxRole` checks neither, but does
+check `FlowAutofixPRNumber != 0`; the autofix arm of
+`flowEmbeddedTerminalIdentity` (`model/embedded_terminal.go:746`) checks neither
+`FlowPhaseTerminal` nor `FlowAutoLaunch`. Three predicates, three different
+field sets, one concept.
+
+**F3 — `launchKind` classifies V17 and V7–V10 identically as `"resume"`**
+(`model/flow_launch_pin.go:132`), because it falls through on `ResumeSessionID`.
+A tracked phase resume and an untracked saved-session resume are different
+policy classes everywhere else in the matrix; `launch.json` cannot tell them
+apart.
+
+**F4 — `createPhase` is the only kind whose tracked-ness is established outside
+its builder**, and it is also the only kind that sets `PlanPhase*`. Both are
+consequences of it being the one kind whose builder runs before the Flow record
+exists.
+
+**F5 — `WorkingDir` is unset for manual, auto, create and repair launches**, so
+those four rely on the actions-side fallback chain while resume, autofix,
+worktree agent and saved-session resume set it explicitly. The role payload has
+to keep this distinction or change behaviour.
+
+**F6 — the lifecycle branches on `attempt.Kind`, not on the context.** Both the
+tracked stamp (`model/flow_launch_lifecycle.go:1104`) and the mutated-phase mark
+(`model/flow_launch_lifecycle.go:958`) enumerate the same four kinds by hand.
+The context cannot answer the question those branches ask, which is the clearest
+evidence that a role belongs *on* the context.

--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -25,15 +25,22 @@ automatic phase launches share one builder and differ only by `req.AutoLaunch`.
 | `worktreeAgent` | `model/flow_launch_generic_agent.go:292` | none — hardcoded embedded at `model/flow_launch_generic_agent.go:299` |
 | `savedSessionResume` | `model/flow_launch_saved_session_resume.go:300` | none — hardcoded embedded at `model/flow_launch_saved_session_resume.go:226` |
 
-Five further `actions.AgentLaunchContext` literals exist outside the Flow
+Four further `actions.AgentLaunchContext` literals exist outside the Flow
 lifecycle and set no Flow marker at all — the non-Flow session resume
 (`model/model_keys.go:2773`), plan implementation (`model/model_keys.go:2847`),
-open-agent-in-worktree (`model/model_keys.go:3308`), slice-epic
-(`model/ready_bead_slice.go:171`), and the session-release finalizer
-(`model/flow_session_release.go:407`, which carries Flow IDs but is not a
-launch). Two more are probe-only values used purely to ask a routing question:
-`model/flow_launch_resume.go:299` and `model/tmux_mode.go:392`. They matter to
-Phase 4: any enforcement mechanism must tolerate them.
+open-agent-in-worktree (`model/model_keys.go:3308`), and slice-epic
+(`model/ready_bead_slice.go:171`). Two more are probe-only values used purely to
+ask a routing question: `model/flow_launch_resume.go:299` and
+`model/tmux_mode.go:392`; they too set no marker.
+
+Two literals do set Flow marker fields without being launches at all. Both
+carry `FlowID` + `FlowPhaseID` purely to address an existing launch record: the
+session-release finalizer (`model/flow_session_release.go:407`) and the
+auto-advance failure persister in `blockAutoFlowLaunchPhase`
+(`model/flow_launch_lifecycle.go:1051`). Neither is routed, neither builds a
+command, and neither has a launch kind. They matter to Phase 4: any enforcement
+mechanism must tolerate all of the above, and must distinguish "sets a Flow
+marker" from "constructs a Flow launch".
 
 ## 2. Reachable variants
 
@@ -152,7 +159,7 @@ deliberately treated alike.
 | `reserveFlowSpawn` (`model/model_keys.go:3145`) | `FlowID`, `FlowLaunchTracked`, `FlowRepair` | tracked non-repair (V1–V10) ‖ rest | all untracked kinds are no-ops |
 | `flowLaunchFailureUpdate` (`model/model_keys.go:3154`) | `FlowID`, `FlowPhaseID`, `ResumeSessionID`, `FlowLaunchTracked`, `FlowPhaseTerminal`, `FlowPhaseKind` | V8/V10 (terminal resume: refuse) ‖ V11–V17 (no phase: refuse) ‖ plan-review kind (blocked) ‖ rest | manual/auto/create/non-terminal resume |
 | `tmuxRouteEligible` (`model/tmux_mode.go:63`) | `Headless`, `FlowRepair`, `Command` | V3/V9/V10/V15 eligible ‖ rest | every embedded variant, for whichever of the two reasons |
-| `flowLaunchContextRequiresLifecycle` (`model/tmux_mode.go:329`) | all ten markers + `FlowID`/`FlowPhaseID`/`FlowPhaseKind` | Flow launches ‖ the five non-Flow literals | all 17 variants alike |
+| `flowLaunchContextRequiresLifecycle` (`model/tmux_mode.go:329`) | all ten marker fields (`FlowID`, `FlowPhaseID`, `FlowPhaseKind`, plus the seven booleans; not `FlowAutofixPRNumber`) | Flow launches ‖ the four non-Flow literals and the two probes | all 17 variants alike; the two non-launch Flow-ID literals would also classify as Flow, but never reach it |
 | `actions.ShouldPrefillEmbeddedPrompt` (`actions/actions.go:1338`) | `Command`, `Embedded`, `Headless`, `ResumeSessionID`, `InitialPrompt`, `FlowID`, `FlowPhaseID`, `FlowLaunchTracked`, `FlowRepair`, `FlowAgent`, `FlowAutofix` | V1/V5 (prefill) ‖ V11/V13/V16 (untracked prefill arms) ‖ resume and headless and tmux (no prefill) | the three untracked arms are separate clauses with identical effect |
 | `actions.resumeSessionIDForContext` (`actions/actions.go:1450`) | `FlowSavedSessionResume` + 12 negated fields + `ResumeSessionID` | V17 ‖ everything else | asserts *one* variant; all others take the plain path |
 | `actions.validateTrackedRepoTmuxRole` (`actions/tmux_mode.go:454`) | `FlowLaunchTracked`, `FlowID`, `FlowPhaseID`, `FlowAutoLaunch`, `Headless`, `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`, `FlowAutofix`, `FlowAutofixPRNumber` | V3/V9/V10 accepted | manual and resume tmux launches are identical to it |


### PR DESCRIPTION
## Problem

`actions.AgentLaunchContext` is a 30-field struct that any caller can compose by hand. Ten of those fields are Flow role markers whose legal combinations exist only as convention, spread across seven construction sites in `model`. Nothing names the concept of "what kind of Flow launch is this," so three consumers each hand-write their own full role predicate — with 12, 10, and 9 negated fields respectively — and they disagree about which fields matter. The lifecycle, meanwhile, enumerates launch kinds by hand in two places because the context cannot answer the question it is asking.

Before proposing an interface for this, the shape of the problem needed to be established from the code rather than from memory. This is that groundwork plus the resulting design.

## Solution

Two documents, no code changes.

**`docs/flow-launch-variant-matrix.md`** — the evidence base. Every claim cites `file:line` against commit `e1dd62e`:

- the eight launch kinds and their seven construction sites (manual and auto phase launches share a builder, differing only by `req.AutoLaunch`);
- 17 of the 64 cells in kind × route × headless × phase-terminal are reachable, with each pruning rule tied to the specific gate that enforces it (e.g. `tmuxRouteEligible` refusing `ctx.Headless`, so no kind reaches tmux headless);
- the 19 consumers, and where role fields get written *after* construction — which is why an interface owning only construction would not own the values consumers read;
- the four non-Flow launch contexts and two non-launch literals that carry Flow IDs without a role, both of which any enforcement mechanism has to tolerate.

**`docs/adr/0002-flow-launch-context-deep-module.md`** — the proposed design, arguing each decision from the matrix:

- **D1** a closed six-role enum, with each collapse justified by whether a consumer changes *policy* or merely presentation (manual+auto collapse; create collapses; resume and autofix do not, and the ADR names the consumers that prove it);
- **D2** one builder over a sum of role-specific payload structs, making the pruned combinations unrepresentable instead of merely unreached;
- **D3** the builder owns the route, writing `Embedded` and `FlowLaunchTracked` exactly once — a post-construction transition function was considered and rejected, because it preserves the two-writer ordering hazard the matrix documents;
- **D4** a deliberately *partial* classifier plus a separate marker-presence predicate, kept independent so the runtime check cannot be trivially satisfied by its own classifier;
- **D5** the role type in `actions` and the builder in `model`, forced by the existing import direction;
- **D6** the post-migration form of every consumer, and the phased migration.

The ADR is marked **proposed — pending user approval**. `approach-hyl.1` is a HITL bead and this Flow ran headless in auto mode, so its approval criterion cannot be met from inside the Flow; the open questions are listed as explicit decision requests at the end.

## Verification

Documentation only — no code changed, so no build or test surface is affected. The matrix's citations were taken directly from the tree at `e1dd62e`, and a review pass over the ADR corrected three design defects (commit 2 of this branch), the substantive one being D5: the original sketch placed the role type in `model`, which the `model` → `actions` import direction makes unreachable from the three `actions` consumers that need it.
