### PR TITLE
Close a merged child's Bead so epic auto-progression reaches the second child

### DIFF
--- a/actions/flow_launch_role.go
+++ b/actions/flow_launch_role.go
@@ -1,0 +1,49 @@
+package actions
+
+// FlowLaunchRole names the kind of Flow-scoped launch a context represents. It
+// is a closed enum: every Flow launch the TUI can start is exactly one of these
+// six, and the launch context's marker flags are the role's encoding rather
+// than six independent booleans a caller may combine freely.
+//
+// It lives in actions rather than model because actions is the package model
+// imports, not the other way round, and because the role's consumers — resume
+// identity, tmux role validation, the tracked-lease branch — already live here.
+type FlowLaunchRole int
+
+const (
+	// RoleTrackedPhase is a phase-attached launch that reserves the Flow lease
+	// and writes phase attempt history.
+	RoleTrackedPhase FlowLaunchRole = iota + 1
+	// RolePhaseResume resumes a phase's saved provider session.
+	RolePhaseResume
+	// RoleRepair is the untracked Flow-scoped repair session.
+	RoleRepair
+	// RoleAutofix is the prompted, PR-gated untracked agent.
+	RoleAutofix
+	// RoleWorktreeAgent is the generic untracked worktree agent started by s.
+	RoleWorktreeAgent
+	// RoleSavedSessionResume is a phase-untracked resume of a Flow's saved
+	// provider session.
+	RoleSavedSessionResume
+)
+
+// String names the role for diagnostics. An unknown value names itself rather
+// than masquerading as a real role.
+func (role FlowLaunchRole) String() string {
+	switch role {
+	case RoleTrackedPhase:
+		return "tracked phase"
+	case RolePhaseResume:
+		return "phase resume"
+	case RoleRepair:
+		return "repair"
+	case RoleAutofix:
+		return "autofix"
+	case RoleWorktreeAgent:
+		return "worktree agent"
+	case RoleSavedSessionResume:
+		return "saved session resume"
+	default:
+		return "unknown flow launch role"
+	}
+}

--- a/beadsmutate/beadsmutate.go
+++ b/beadsmutate/beadsmutate.go
@@ -53,16 +53,50 @@ func (m *Mutator) Claim(repoPath, beadID string) error {
 	return nil
 }
 
+// Close closes beadID in repoPath through bd close, recording reason when it is
+// non-blank. bd close is idempotent: closing an already-closed Bead succeeds, so
+// a retried caller does not have to probe status first.
+//
+// The reason precedes the -- separator deliberately. bd treats every argument
+// after -- as positional, so a trailing --reason is resolved as a second issue
+// ID and the call fails.
+func Close(repoPath, beadID, reason string) error {
+	return defaultMutator().Close(repoPath, beadID, reason)
+}
+
+// Close closes beadID in repoPath through bd close, recording reason when it is
+// non-blank.
+func (m *Mutator) Close(repoPath, beadID, reason string) error {
+	repoPath, beadID, err := canonicalMutationInput("closing bead", repoPath, beadID)
+	if err != nil {
+		return err
+	}
+	args := make([]string, 0, 4)
+	args = append(args, "close")
+	if reason = strings.TrimSpace(reason); reason != "" {
+		args = append(args, "--reason="+reason)
+	}
+	args = append(args, "--", beadID)
+	if _, err := m.runner.Run(repoPath, args...); err != nil {
+		return fmt.Errorf("closing bead %s: %w", beadID, err)
+	}
+	return nil
+}
+
 func canonicalClaimInput(repoPath, beadID string) (string, string, error) {
+	return canonicalMutationInput("claiming bead", repoPath, beadID)
+}
+
+func canonicalMutationInput(action, repoPath, beadID string) (string, string, error) {
 	if strings.TrimSpace(repoPath) == "" {
-		return "", "", fmt.Errorf("claiming bead: repository path is blank")
+		return "", "", fmt.Errorf("%s: repository path is blank", action)
 	}
 	if !filepath.IsAbs(repoPath) {
-		return "", "", fmt.Errorf("claiming bead: repository path must be absolute")
+		return "", "", fmt.Errorf("%s: repository path must be absolute", action)
 	}
 	beadID = strings.TrimSpace(beadID)
 	if beadID == "" {
-		return "", "", fmt.Errorf("claiming bead: bead ID is blank")
+		return "", "", fmt.Errorf("%s: bead ID is blank", action)
 	}
 	return filepath.Clean(repoPath), beadID, nil
 }

--- a/beadsmutate/beadsmutate_test.go
+++ b/beadsmutate/beadsmutate_test.go
@@ -102,3 +102,88 @@ func TestMutatorClaimWrapsRunnerFailureWithChildIdentity(t *testing.T) {
 		t.Fatalf("Claim() error = %q, want child identity", got)
 	}
 }
+
+func TestMutatorCloseCanonicalizesInputsAndUsesCloseCommand(t *testing.T) {
+	runner := &fakeRunner{}
+	err := beadsmutate.NewMutator(runner).Close("/selected/repo/../repo", "  child-42 \t", " merged as PR #7 ")
+	if err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if runner.calls != 1 || runner.dir != "/selected/repo" {
+		t.Fatalf("runner call = (%d, %q), want (1, %q)", runner.calls, runner.dir, "/selected/repo")
+	}
+	want := []string{"close", "--reason=merged as PR #7", "--", "child-42"}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("runner args = %#v, want %#v", runner.args, want)
+	}
+}
+
+// The reason precedes the -- separator: bd treats everything after -- as
+// positional, so a trailing --reason is parsed as a second issue ID.
+func TestMutatorCloseOmitsBlankReason(t *testing.T) {
+	runner := &fakeRunner{}
+	if err := beadsmutate.NewMutator(runner).Close("/repo", "bead-1", "   "); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if want := []string{"close", "--", "bead-1"}; !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("runner args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestMutatorCloseTreatsFlagShapedIDsAsPositional(t *testing.T) {
+	for _, beadID := range []string{"--help", "--db=/other/db"} {
+		t.Run(beadID, func(t *testing.T) {
+			runner := &fakeRunner{}
+			if err := beadsmutate.NewMutator(runner).Close("/repo", beadID, "why"); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+			if got := runner.args[len(runner.args)-2]; got != "--" {
+				t.Fatalf("args[%d] = %q, want %q", len(runner.args)-2, got, "--")
+			}
+		})
+	}
+}
+
+func TestMutatorCloseRejectsBlankInputs(t *testing.T) {
+	runner := &fakeRunner{}
+	for name, tc := range map[string]struct{ repo, bead string }{
+		"blank repo":    {"", "bead-1"},
+		"relative repo": {"repo", "bead-1"},
+		"blank bead":    {"/repo", "  "},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := beadsmutate.NewMutator(runner).Close(tc.repo, tc.bead, "why"); err == nil {
+				t.Fatal("Close() error = nil, want error")
+			}
+		})
+	}
+	if runner.calls != 0 {
+		t.Fatalf("runner calls = %d, want 0", runner.calls)
+	}
+}
+
+func TestMutatorCloseWrapsRunnerError(t *testing.T) {
+	sentinel := errors.New("boom")
+	runner := &fakeRunner{err: sentinel}
+	err := beadsmutate.NewMutator(runner).Close("/repo", "bead-1", "why")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Close() error = %v, want wrapped %v", err, sentinel)
+	}
+	if !strings.Contains(err.Error(), "bead-1") {
+		t.Fatalf("Close() error = %v, want it to name the bead", err)
+	}
+}
+
+func TestCloseUsesDefaultRunner(t *testing.T) {
+	runner := &fakeRunner{}
+	previous := beadsmutate.DefaultRunner
+	beadsmutate.DefaultRunner = runner
+	t.Cleanup(func() { beadsmutate.DefaultRunner = previous })
+
+	if err := beadsmutate.Close("/repo", "bead-default", "why"); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if want := []string{"close", "--reason=why", "--", "bead-default"}; !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("runner args = %#v, want %#v", runner.args, want)
+	}
+}

--- a/docs/adr/0002-flow-launch-context-deep-module.md
+++ b/docs/adr/0002-flow-launch-context-deep-module.md
@@ -339,3 +339,31 @@ For each field the role does *not* carry, "which consumer proves it is payload?"
    the cost of three roles no consumer distinguishes. Confirm the collapse.
 6. **Enforcement scope**: the boundary test as specified covers `model/` and
    `actions/` only. Confirm no other package should be in scope.
+
+## Implementation note — tracer bullet (`approach-hyl.2`)
+
+The first slice landed the seam and migrated one launch kind. Three things
+about it diverge from the text above and stay true until a later slice changes
+them:
+
+- **The tracer migrated `RoleWorktreeAgent`, not `RoleRepair`.** The migration
+  order above nominates repair; the worktree agent is the strictly simpler
+  tracer — one marker, one hardcoded route, no phase writes, no post-literal
+  field mutation — so it went first. Repair still owns its own slice, where
+  the post-literal refresh write at `model/flow_repair.go` gets handled.
+- **D5 was followed.** `FlowLaunchRole` lives in `actions/flow_launch_role.go`;
+  `newFlowLaunchContext` and the `flowLaunchTarget` sum live in
+  `model/flow_launch_context.go`. Open question 1 is therefore answered in the
+  code, not the ADR's status.
+- **The builder takes no routing probe yet (D3 deferred).** The worktree agent
+  has no tmux call site and no route to decide, so the builder returns
+  `flowLaunchRoute` without taking a probe. The routing input arrives with the
+  first tmux-capable kind. Open question 4 remains open.
+
+`TestEveryFlowLaunchRouteRefusesAnUnverifiedPin` now follows
+`newFlowLaunchContext` call sites as well as `applyLaunchStamp` ones, so a
+route that delegates construction still has to refuse an unverified pin before
+it reserves. The builder itself is exempt: it never reserves or writes, and the
+refusal has to happen earlier than it runs.
+
+The ADR's status stays `proposed`; the remaining open questions are unanswered.

--- a/docs/beads-view-spec.md
+++ b/docs/beads-view-spec.md
@@ -70,7 +70,7 @@ it claims a child before preparing that child's new Flow.
 22. As an Approach user, I want bead data fetched asynchronously on group entry and repo-cursor change, so that the UI never blocks on a `bd` subprocess.
 23. As an Approach user, I want stale-result protection on bead fetches, so that moving quickly across repos never shows one repo's beads under another repo's name.
 24. As an Approach user, I want `enter` on a bead to page its full detail (`bd show`) through the pager, so that I can read descriptions and dependencies without leaving the TUI.
-25. As an Approach user, I want Beads queries and manual Flow creation to remain read-only, so that only an explicit epic auto-progression claim mutates tracker state.
+25. As an Approach user, I want Beads queries and manual Flow creation to remain read-only, so that only epic auto-progression mutates tracker state: the claim it takes when enabling, and the `bd close` it records against a child whose Flow merged.
 26. As an Approach user, I want `default_view` numbers 10–14 pinning each beads subview, so that I can start the app directly in any of them, mirroring the git subview numbers.
 27. As an Approach user, I want the frozen `default_view` vocabulary (1–9) untouched, so that existing configs keep their meaning.
 28. As an Approach user, I want a manual way to refetch beads via the app's existing refresh affordance, so that I can pull in changes an agent made without bouncing the repo cursor.

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -411,13 +411,29 @@ Approach was down.
 Each live edge takes the shared, monotonically token-owned preparation
 admission. Before any Beads query or creation side effect, the worker re-reads
 the progression row; absent, disabled, done, or halted state cancels the edge, while
-an unreadable row leaves it armed for retry. With no successor already owned by
+an unreadable row leaves it armed for retry.
+
+When the observed source Flow carries a durable merge — `Merge.Status` is
+`merged`, not merely a derived or hand-edited `status` — the worker then closes
+that child's Bead through `bd close`, recording the Flow ID, PR number, and merge
+commit as the reason. This runs **before** the children and `bd ready` queries and
+is the one release for the claim taken at enablement: a still-claimed parent keeps
+its dependent siblings out of `bd ready`, so a close ordered after the query would
+select against a stale snapshot and the empty intersection would report the epic
+complete. `bd close` is idempotent, which is what makes it safe on this
+level-triggered edge; a close failure is retryable and stops the edge before the
+queries and before any exhaustion write, so a `bd` outage can never be mistaken
+for a finished epic. A child that reached `completed` without a recorded merge is
+deliberately left open — nothing landed on the base branch.
+
+With no successor already owned by
 that edge, it intersects a fresh direct-child query with fresh `bd ready` order,
 indexes the complete repository Flow corpus by exact canonical repository plus
 `{child ID, epic ID}`, skips every ready child that already has such a Flow, and
 selects the first unlinked child. Links for another repository or epic do not
 suppress the candidate. Selection is where the advance worker stops: it creates
-nothing, claims no Bead, and starts no phase.
+nothing, claims no Bead, and starts no phase. Closing the merged predecessor
+above is the worker's only tracker write.
 
 The selected child is then submitted to the create-phase launch lifecycle as one
 create-then-launch intent whose origin is epic progression. That single admitted

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -784,7 +784,10 @@ after it is created and started in one unattended step.
 Enabled epics advance from the same view-independent 1 Hz Flow poll. When the
 exact in-session baseline Flow is newly observed as `completed` or `merged`,
 Approach creates the next unlinked direct child in fresh `bd ready` order **and
-starts its first phase agent**, as one attempt; it does not claim the Bead. The
+starts its first phase agent**, as one attempt; it does not claim the Bead. It
+does close the merged predecessor's Bead first, when that Flow recorded a real
+merge, which is what releases the claim taken at enablement and lets the
+dependent siblings become ready in time for this same advance. The
 child is created headless with auto mode on, so its later phases drain by
 themselves and the whole chain runs without a key press. The status line reports
 retryable preparation/reconciliation errors, an owned successor that blocks later

--- a/model/epic_progression.go
+++ b/model/epic_progression.go
@@ -155,7 +155,7 @@ func (m Model) releaseFlowPreparation(kind flowPreparationKind, token uint64) Mo
 	return m
 }
 
-func (m Model) startEpicProgressionAdvance(epicKey string, baseline flowstore.FlowRecord) (Model, tea.Cmd) {
+func (m Model) startEpicProgressionAdvance(epicKey string, baseline, observed flowstore.FlowRecord) (Model, tea.Cmd) {
 	var ownerToken uint64
 	var admitted bool
 	m, ownerToken, admitted = m.acquireFlowPreparation(flowPreparationEpicAdvance)
@@ -168,7 +168,7 @@ func (m Model) startEpicProgressionAdvance(epicKey string, baseline flowstore.Fl
 		EpicKey: epicKey, SourceFlowID: baseline.FlowID,
 	}
 	m.activeEpicProgressionAdvance = request
-	return m, m.advanceEpicProgressionCmd(request, baseline)
+	return m, m.advanceEpicProgressionCmd(request, baseline, observed)
 }
 
 // advanceEpicProgressionCmd selects the next child and stops there. Everything
@@ -176,8 +176,9 @@ func (m Model) startEpicProgressionAdvance(epicKey string, baseline flowstore.Fl
 // successor reconciliation and its first phase — belongs to the create-phase
 // launch pipeline the selection is handed to, so the whole advance is one
 // admitted launch attempt rather than a preparation plus a later start.
-func (m Model) advanceEpicProgressionCmd(request epicProgressionAdvanceRequest, baseline flowstore.FlowRecord) tea.Cmd {
+func (m Model) advanceEpicProgressionCmd(request epicProgressionAdvanceRequest, baseline, observed flowstore.FlowRecord) tea.Cmd {
 	readProgression := m.readEpicProgression
+	closeBead := m.closeBead
 	listChildren := m.listChildrenBeads
 	listReady := m.listReadyBeads
 	listFlows := m.listFlows
@@ -199,6 +200,24 @@ func (m Model) advanceEpicProgressionCmd(request epicProgressionAdvanceRequest, 
 		}
 		if !found || !progression.Enabled || progression.Done || progression.Halt != nil {
 			return result(epicProgressionAdvanceInactive, fmt.Sprintf("Auto-progression for epic %s is no longer active", epicID))
+		}
+
+		// Closing the merged child's Bead must precede the readiness query, not
+		// follow it. Progression claims a child on enable but nothing else ever
+		// releases it, so a still-claimed parent keeps its dependent siblings out
+		// of `bd ready`; a close that lands afterwards selects against a stale
+		// snapshot and the empty intersection reports the epic complete.
+		//
+		// Only a recorded merge qualifies. A child that merely reached completed
+		// has nothing on the base branch, and closing its Bead would retire work
+		// that never landed.
+		if beadID, reason, ok := progressionMergedChildClose(observed); ok && closeBead != nil {
+			// bd close is idempotent, which is what makes this safe on a
+			// level-triggered edge: the success branch refires on every poll
+			// until an advance actually completes.
+			if err := closeBead(repoPath, beadID, reason); err != nil {
+				return result(epicProgressionAdvanceRetryable, fmt.Sprintf("Could not close Bead %s for merged Flow %s: %v", beadID, observed.FlowID, err))
+			}
 		}
 
 		var candidate epicProgressionOwnedSuccessor
@@ -306,6 +325,28 @@ func (m Model) advanceEpicProgressionCmd(request epicProgressionAdvanceRequest, 
 // startEpicProgressionHalt shares the single-flight preparation admission with
 // advance and the epic toggle, so a halt can never interleave with either. It
 // creates no Flow, queries no Beads, and takes no Flow reservation.
+// progressionMergedChildClose reports the Bead a merged child Flow retires, and
+// the reason recorded against it. It keys on the durable merge record rather
+// than on the derived status so that a hand-edited status cannot close a Bead
+// whose PR never landed.
+func progressionMergedChildClose(observed flowstore.FlowRecord) (string, string, bool) {
+	if observed.Merge.Status != flowstore.MergeMerged {
+		return "", "", false
+	}
+	beadID := strings.TrimSpace(observed.Bead.ID)
+	if beadID == "" {
+		return "", "", false
+	}
+	reason := fmt.Sprintf("Merged by Approach Flow %s", observed.FlowID)
+	if observed.PR.Number > 0 {
+		reason = fmt.Sprintf("Merged by Approach Flow %s (PR #%d)", observed.FlowID, observed.PR.Number)
+	}
+	if commit := strings.TrimSpace(observed.Merge.Commit); commit != "" {
+		reason += ": " + commit
+	}
+	return beadID, reason, true
+}
+
 func (m Model) startEpicProgressionHalt(epicKey string, baseline, observed flowstore.FlowRecord) (Model, tea.Cmd) {
 	var ownerToken uint64
 	var admitted bool

--- a/model/epic_progression_advance_internal_test.go
+++ b/model/epic_progression_advance_internal_test.go
@@ -650,3 +650,149 @@ func TestEpicProgressionBeadSlotRefusalConvergesAcrossPasses(t *testing.T) {
 		}
 	}
 }
+
+// progressionMergedFlow is the shape the advance edge must close a Bead for: a
+// child whose PR actually landed, not merely one whose phases all finished.
+func progressionMergedFlow(flowID, repoPath, childID, epicID string) flowstore.FlowRecord {
+	record := progressionAdvanceFlow(flowID, repoPath, childID, epicID, flowstore.StatusMerged)
+	record.PR = flowstore.PullRequest{Provider: "github", Number: 371, Status: flowstore.MergeMerged}
+	record.Merge = flowstore.Merge{Status: flowstore.MergeMerged, Commit: "abc123"}
+	return record
+}
+
+func TestEpicProgressionAdvanceClosesMergedChildBeadBeforeReadyQuery(t *testing.T) {
+	repo, epic := "/repo", "epic"
+	key := epicProgressionBaselineKey(repo, epic)
+	source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
+	merged := progressionMergedFlow("flow-a", repo, "epic.a", epic)
+
+	var order []string
+	var closedRepo, closedBead, closedReason string
+	// epic.b is ready only because closing epic.a unblocked it, which is the
+	// whole point: a close that lands after the query selects nothing.
+	ready := []beadsquery.Bead{}
+	m := Model{
+		autoAdvanceInFlight:      1,
+		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		agentCommand:             "codex",
+		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
+			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
+		},
+		closeBead: func(repoPath, beadID, reason string) error {
+			order = append(order, "close")
+			closedRepo, closedBead, closedReason = repoPath, beadID, reason
+			ready = []beadsquery.Bead{{ID: "epic.b", Title: "B"}}
+			return nil
+		},
+		listChildrenBeads: func(string, string) ([]beadsquery.Bead, error) {
+			order = append(order, "children")
+			return []beadsquery.Bead{{ID: "epic.a", Title: "A"}, {ID: "epic.b", Title: "B"}}, nil
+		},
+		listReadyBeads: func(string) ([]beadsquery.Bead, error) {
+			order = append(order, "ready")
+			return append([]beadsquery.Bead(nil), ready...), nil
+		},
+		listFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{merged}, nil
+		},
+	}
+
+	_, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{merged}, Request: 1})
+	result := epicProgressionAdvanceMessage(t, cmd)
+
+	if len(order) == 0 || order[0] != "close" {
+		t.Fatalf("call order = %v, want the Bead closed before any Beads query", order)
+	}
+	if closedRepo != repo || closedBead != "epic.a" {
+		t.Fatalf("closed (%q, %q), want (%q, %q)", closedRepo, closedBead, repo, "epic.a")
+	}
+	if !strings.Contains(closedReason, "flow-a") || !strings.Contains(closedReason, "371") {
+		t.Fatalf("close reason = %q, want it to name the Flow and the PR", closedReason)
+	}
+	if result.disposition != epicProgressionAdvanceSelected || result.owned.ChildID != "epic.b" {
+		t.Fatalf("advance result = %#v, want epic.b selected after the close unblocked it", result)
+	}
+}
+
+func TestEpicProgressionAdvanceDoesNotCloseUnmergedChildBead(t *testing.T) {
+	repo, epic := "/repo", "epic"
+	key := epicProgressionBaselineKey(repo, epic)
+	source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
+	// Completed without a recorded merge: the phases finished but nothing
+	// landed on the base branch, so the Bead is not this edge's to close.
+	completed := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusCompleted)
+
+	closes := 0
+	m := Model{
+		autoAdvanceInFlight:      1,
+		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		agentCommand:             "codex",
+		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
+			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
+		},
+		closeBead: func(string, string, string) error { closes++; return nil },
+		listChildrenBeads: func(string, string) ([]beadsquery.Bead, error) {
+			return []beadsquery.Bead{{ID: "epic.a"}, {ID: "epic.b"}}, nil
+		},
+		listReadyBeads: func(string) ([]beadsquery.Bead, error) {
+			return []beadsquery.Bead{{ID: "epic.b", Title: "B"}}, nil
+		},
+		listFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{completed}, nil
+		},
+	}
+
+	_, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{completed}, Request: 1})
+	result := epicProgressionAdvanceMessage(t, cmd)
+	if closes != 0 {
+		t.Fatalf("closeBead calls = %d, want 0 for a completed-but-unmerged child", closes)
+	}
+	if result.disposition != epicProgressionAdvanceSelected || result.owned.ChildID != "epic.b" {
+		t.Fatalf("advance result = %#v, want the advance to proceed unchanged", result)
+	}
+}
+
+// A close failure must not be swallowed into a false "no ready children", which
+// is exactly the shape that wrongly reports the epic complete.
+func TestEpicProgressionAdvanceCloseFailureIsRetryable(t *testing.T) {
+	repo, epic := "/repo", "epic"
+	key := epicProgressionBaselineKey(repo, epic)
+	source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
+	merged := progressionMergedFlow("flow-a", repo, "epic.a", epic)
+
+	queries := 0
+	setProgressionCalls := 0
+	m := Model{
+		autoAdvanceInFlight:      1,
+		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		agentCommand:             "codex",
+		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
+			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
+		},
+		closeBead: func(string, string, string) error { return errors.New("bd exploded") },
+		listChildrenBeads: func(string, string) ([]beadsquery.Bead, error) {
+			queries++
+			return nil, nil
+		},
+		listReadyBeads: func(string) ([]beadsquery.Bead, error) { queries++; return nil, nil },
+		listFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return []flowstore.FlowRecord{merged}, nil
+		},
+		setEpicProgression: func(flowstore.EpicProgressionUpdate) (flowstore.EpicProgression, error) {
+			setProgressionCalls++
+			return flowstore.EpicProgression{}, nil
+		},
+	}
+
+	_, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{merged}, Request: 1})
+	result := epicProgressionAdvanceMessage(t, cmd)
+	if result.disposition != epicProgressionAdvanceRetryable {
+		t.Fatalf("disposition = %v, want retryable", result.disposition)
+	}
+	if !strings.Contains(result.status, "epic.a") {
+		t.Fatalf("status = %q, want it to name the child Bead", result.status)
+	}
+	if queries != 0 || setProgressionCalls != 0 {
+		t.Fatalf("queries=%d setProgression=%d, want the edge to stop before both", queries, setProgressionCalls)
+	}
+}

--- a/model/flow_advance_tick.go
+++ b/model/flow_advance_tick.go
@@ -170,7 +170,7 @@ func (m Model) prepareEpicProgressionAdvance(current []flowstore.FlowRecord, req
 				continue
 			}
 			var cmd tea.Cmd
-			m, cmd = m.startEpicProgressionAdvance(key, baseline)
+			m, cmd = m.startEpicProgressionAdvance(key, baseline, observed)
 			if cmd != nil {
 				m.epicProgressionAdvanceCursor = key
 				return m, cmd

--- a/model/flow_launch_context.go
+++ b/model/flow_launch_context.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowstore"
+)
+
+// flowLaunchTarget is the payload half of a Flow launch: the role plus exactly
+// the inputs that role needs. It is a sum rather than one wide struct so a
+// role cannot be paired with another role's payload — the pairing is
+// unrepresentable, not merely unreached.
+type flowLaunchTarget interface {
+	role() actions.FlowLaunchRole
+}
+
+// worktreeAgentTarget is the generic untracked worktree agent started by s. It
+// carries the whole record rather than pre-split scalars so the mapping from
+// record fields onto context fields — including WorkingDir being the worktree,
+// not the repo — lives inside the builder instead of at the call site.
+type worktreeAgentTarget struct {
+	LaunchID string
+	Record   flowstore.FlowRecord
+	// PlanPath is the resolved markdown path for the Flow's linked plan. It is
+	// separate from the record because the prepare stage may have had to
+	// resolve it from PlanID, and that resolution is admission's job.
+	PlanPath string
+}
+
+func (worktreeAgentTarget) role() actions.FlowLaunchRole { return actions.RoleWorktreeAgent }
+
+// errIncompleteFlowLaunchTarget reports a payload that upstream admission
+// should already have guaranteed. The builder still checks: it is the one
+// place every Flow launch context is constructed, so it is the only place the
+// launch invariants can be enforced for all of them at once.
+var errIncompleteFlowLaunchTarget = errors.New("flow launch target is missing required fields")
+
+// newFlowLaunchContext builds the launch context and handoff route for target,
+// stamping the launching build and registering the launch with the controller
+// before returning. Callers submit a role payload and take back a finished
+// context; they no longer decide which markers a role sets or which route it
+// takes.
+func newFlowLaunchContext(
+	target flowLaunchTarget,
+	settings flowLaunchAgentSettingsSnapshot,
+) (actions.AgentLaunchContext, flowLaunchRoute, error) {
+	switch payload := target.(type) {
+	case worktreeAgentTarget:
+		return newWorktreeAgentLaunchContext(payload, settings)
+	default:
+		return actions.AgentLaunchContext{}, 0, errIncompleteFlowLaunchTarget
+	}
+}
+
+func newWorktreeAgentLaunchContext(
+	target worktreeAgentTarget,
+	settings flowLaunchAgentSettingsSnapshot,
+) (actions.AgentLaunchContext, flowLaunchRoute, error) {
+	record := target.Record
+	if strings.TrimSpace(target.LaunchID) == "" ||
+		strings.TrimSpace(record.FlowID) == "" ||
+		strings.TrimSpace(record.WorktreePath) == "" {
+		return actions.AgentLaunchContext{}, 0, errIncompleteFlowLaunchTarget
+	}
+	// The stamp is applied last, after every field is set: registration reads
+	// the finished context to name the launch, so stamping early would change
+	// the shape of what the controller records.
+	return applyLaunchStamp(actions.AgentLaunchContext{
+		Command: settings.Command, LaunchID: target.LaunchID,
+		RepoPath: record.RepoPath, WorktreePath: record.WorktreePath, WorkingDir: record.WorktreePath,
+		Branch: record.Branch, Commit: record.Commit, Model: settings.Model, ReasoningEffort: settings.ReasoningEffort,
+		SessionStateRoot: settings.SessionStateRoot, PlanID: record.PlanID, PlanPath: target.PlanPath,
+		FlowID: record.FlowID, FlowAgent: true, Embedded: true, Headless: false, InitialPrompt: "",
+	}, settings.stamp()), flowLaunchRouteEmbedded, nil
+}

--- a/model/flow_launch_context_internal_test.go
+++ b/model/flow_launch_context_internal_test.go
@@ -1,0 +1,155 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/internal/controlplane"
+)
+
+// launchContextVariantRecord is the fixture every variant row derives its
+// target from. It is deliberately a plain literal rather than the generic
+// agent's harness record: the builder is being pinned at its own interface,
+// so the row must not inherit whatever the prepare stage's fixture happens to
+// set.
+func launchContextVariantRecord() flowstore.FlowRecord {
+	return flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		Title:        "Flow one",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktree",
+		Branch:       "flow/one",
+		Commit:       "abc123",
+		PlanID:       "plan-1",
+		PlanPath:     "/state/plan.md",
+		Status:       flowstore.StatusInProgress,
+		UpdatedAt:    time.Now(),
+	}
+}
+
+func launchContextVariantSettings() flowLaunchAgentSettingsSnapshot {
+	return flowLaunchAgentSettingsSnapshot{
+		Command:          "codex",
+		Model:            "gpt-5",
+		ReasoningEffort:  "high",
+		SessionStateRoot: "/state",
+	}
+}
+
+// TestNewFlowLaunchContextPinsEachVariantsCanonicalContext compares the whole
+// returned struct, not a subset of fields, so a field added to any Flow role's
+// launch context has to be declared in this table before it can ship.
+func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
+	record := launchContextVariantRecord()
+	for _, variant := range []struct {
+		name   string
+		target flowLaunchTarget
+		want   actions.AgentLaunchContext
+		route  flowLaunchRoute
+	}{
+		{
+			name: "worktree agent",
+			target: worktreeAgentTarget{
+				LaunchID: "launch-1",
+				Record:   record,
+				PlanPath: record.PlanPath,
+			},
+			want: actions.AgentLaunchContext{
+				Command:          "codex",
+				LaunchID:         "launch-1",
+				RepoPath:         record.RepoPath,
+				WorktreePath:     record.WorktreePath,
+				WorkingDir:       record.WorktreePath,
+				Branch:           record.Branch,
+				Commit:           record.Commit,
+				SessionStateRoot: "/state",
+				PlanID:           record.PlanID,
+				PlanPath:         record.PlanPath,
+				FlowID:           record.FlowID,
+				FlowAgent:        true,
+				Embedded:         true,
+				Model:            "gpt-5",
+				ReasoningEffort:  "high",
+			},
+			route: flowLaunchRouteEmbedded,
+		},
+	} {
+		t.Run(variant.name, func(t *testing.T) {
+			ctx, route, err := newFlowLaunchContext(variant.target, launchContextVariantSettings())
+			if err != nil {
+				t.Fatalf("newFlowLaunchContext: %v", err)
+			}
+			if ctx != variant.want {
+				t.Fatalf("context = %#v, want %#v", ctx, variant.want)
+			}
+			if route != variant.route {
+				t.Fatalf("route = %v, want %v", route, variant.route)
+			}
+		})
+	}
+}
+
+func TestNewFlowLaunchContextStampsThePinnedBuild(t *testing.T) {
+	claims := stubRetainLaunchPin(t)
+	settings := launchContextVariantSettings()
+	settings.Pin = controlplane.Pin{
+		ExecutablePath: "/state/bin/approach-abc123",
+		Version:        "v0.10.3",
+		SchemaVersion:  6,
+		Digest:         "abc123def456",
+	}
+
+	ctx, _, err := newFlowLaunchContext(worktreeAgentTarget{
+		LaunchID: "launch-1",
+		Record:   launchContextVariantRecord(),
+	}, settings)
+	if err != nil {
+		t.Fatalf("newFlowLaunchContext: %v", err)
+	}
+	if ctx.Executable != settings.Pin.ExecutablePath || ctx.BuildVersion != "v0.10.3" || ctx.DBSchemaVersion != 6 {
+		t.Fatalf("builder did not stamp the pin: %#v", ctx)
+	}
+	if len(*claims) != 1 || (*claims)[0] != [3]string{"/state", "launch-1", "abc123def456"} {
+		t.Fatalf("pin claims = %v, want exactly one for this launch", *claims)
+	}
+}
+
+func TestNewFlowLaunchContextRejectsIncompletePayloads(t *testing.T) {
+	for _, missing := range []struct {
+		name   string
+		target worktreeAgentTarget
+	}{
+		{
+			name:   "launch id",
+			target: worktreeAgentTarget{Record: launchContextVariantRecord()},
+		},
+		{
+			name: "flow id",
+			target: func() worktreeAgentTarget {
+				record := launchContextVariantRecord()
+				record.FlowID = "  "
+				return worktreeAgentTarget{LaunchID: "launch-1", Record: record}
+			}(),
+		},
+		{
+			name: "worktree path",
+			target: func() worktreeAgentTarget {
+				record := launchContextVariantRecord()
+				record.WorktreePath = ""
+				return worktreeAgentTarget{LaunchID: "launch-1", Record: record}
+			}(),
+		},
+	} {
+		t.Run("missing "+missing.name, func(t *testing.T) {
+			ctx, route, err := newFlowLaunchContext(missing.target, launchContextVariantSettings())
+			if err == nil {
+				t.Fatalf("incomplete payload built a context: %#v", ctx)
+			}
+			if route != 0 {
+				t.Fatalf("failed build returned route %v", route)
+			}
+		})
+	}
+}

--- a/model/flow_launch_generic_agent.go
+++ b/model/flow_launch_generic_agent.go
@@ -6,7 +6,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
@@ -289,14 +288,15 @@ func (m Model) worktreeAgentFlowLaunchPrepareCmd(msg flowLaunchEventMsg, setting
 		event.RepoPath = record.RepoPath
 		event.WorktreePath = record.WorktreePath
 		event.PlanPath = planPath
-		event.Context = applyLaunchStamp(actions.AgentLaunchContext{
-			Command: settings.Command, LaunchID: msg.Token,
-			RepoPath: record.RepoPath, WorktreePath: record.WorktreePath, WorkingDir: record.WorktreePath,
-			Branch: record.Branch, Commit: record.Commit, Model: settings.Model, ReasoningEffort: settings.ReasoningEffort,
-			SessionStateRoot: settings.SessionStateRoot, PlanID: record.PlanID, PlanPath: planPath,
-			FlowID: record.FlowID, FlowAgent: true, Embedded: true, Headless: false, InitialPrompt: "",
-		}, settings.stamp())
-		event.Route = flowLaunchRouteEmbedded
+		ctx, route, err := newFlowLaunchContext(worktreeAgentTarget{
+			LaunchID: msg.Token, Record: record, PlanPath: planPath,
+		}, settings)
+		if err != nil {
+			event.Err = err.Error()
+			return event
+		}
+		event.Context = ctx
+		event.Route = route
 		return event
 	}
 }

--- a/model/flow_phase_launch_internal_test.go
+++ b/model/flow_phase_launch_internal_test.go
@@ -575,7 +575,11 @@ func TestRefuseUnverifiedLaunchPinIgnoresAnUnpinnedLaunch(t *testing.T) {
 // unverified one, including the non-Flow routes in model_keys.go. A new entry
 // here is a claim that needs a reason as specific as the ones in
 // nonLaunchingContextFiles.
-var unverifiedLaunchPinFiles = map[string]string{}
+var unverifiedLaunchPinFiles = map[string]string{
+	"flow_launch_context.go": "the shared launch-context builder constructs and stamps but never reserves " +
+		"or writes; the refusal has to happen at the route before it reserves, so the fence follows the " +
+		"newFlowLaunchContext call sites instead",
+}
 
 // preflight is not the only path that marks a phase running and bakes the
 // pinned path into a detached agent's argv: create, resume, saved-session
@@ -603,7 +607,10 @@ func TestEveryFlowLaunchRouteRefusesAnUnverifiedPin(t *testing.T) {
 			t.Fatalf("read %s: %v", name, err)
 		}
 		text := string(source)
-		if !strings.Contains(text, "applyLaunchStamp(") {
+		// A route that hands construction to newFlowLaunchContext no longer
+		// spells applyLaunchStamp itself, but it still reserves and writes, so
+		// the fence follows the builder's call sites too.
+		if !strings.Contains(text, "applyLaunchStamp(") && !strings.Contains(text, "newFlowLaunchContext(") {
 			continue
 		}
 		if reason, exempt := unverifiedLaunchPinFiles[name]; exempt {
@@ -620,7 +627,7 @@ func TestEveryFlowLaunchRouteRefusesAnUnverifiedPin(t *testing.T) {
 			continue
 		}
 		if !strings.Contains(text, "refuseUnverifiedLaunchPin(") {
-			t.Fatalf("%s stamps a launch pin but never refuses an unverified one, so it can launch a binary the "+
+			t.Fatalf("%s builds a pinned launch but never refuses an unverified pin, so it can launch a binary the "+
 				"state root lost or an upgrade replaced. Refuse before it reserves or writes, or document the file "+
 				"in unverifiedLaunchPinFiles with the reason it cannot.", name)
 		}

--- a/model/model.go
+++ b/model/model.go
@@ -182,6 +182,7 @@ type Model struct {
 	listChildrenBeads         func(string, string) ([]beadsquery.Bead, error)
 	listReadyBeads            func(string) ([]beadsquery.Bead, error)
 	claimBead                 func(repoPath, beadID string) error
+	closeBead                 func(repoPath, beadID, reason string) error
 	readEpicProgression       func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error)
 	setEpicProgression        func(flowstore.EpicProgressionUpdate) (flowstore.EpicProgression, error)
 	haltEpicProgression       func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error)
@@ -366,6 +367,7 @@ type Options struct {
 	ListReadyBeads            func(repoPath string) ([]beadsquery.Bead, error)
 	ListChildrenBeads         func(repoPath, parentID string) ([]beadsquery.Bead, error)
 	ClaimBead                 func(repoPath, beadID string) error
+	CloseBead                 func(repoPath, beadID, reason string) error
 	ReadEpicProgression       func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error)
 	SetEpicProgression        func(flowstore.EpicProgressionUpdate) (flowstore.EpicProgression, error)
 	HaltEpicProgression       func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error)
@@ -589,6 +591,10 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	claimBead := opts.ClaimBead
 	if claimBead == nil {
 		claimBead = beadsmutate.Claim
+	}
+	closeBead := opts.CloseBead
+	if closeBead == nil {
+		closeBead = beadsmutate.Close
 	}
 	readEpicProgression := opts.ReadEpicProgression
 	if readEpicProgression == nil {
@@ -1058,6 +1064,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		listChildrenBeads:         listChildrenBeads,
 		listReadyBeads:            listReadyBeads,
 		claimBead:                 claimBead,
+		closeBead:                 closeBead,
 		readEpicProgression:       readEpicProgression,
 		setEpicProgression:        setEpicProgression,
 		haltEpicProgression:       haltEpicProgression,


### PR DESCRIPTION
## The problem

Enabling auto-progression on an epic ran through exactly one child and then declared the epic finished.

The cause is a claim with no release. Enablement runs `bd update --claim` on the first ready child, but nothing ever closes that Bead again — merging a Flow doesn't touch the tracker. So when the child's Flow merged, its Bead stayed `in_progress`, every sibling depending on it stayed out of `bd ready`, and the advance edge intersected the epic's direct children with an empty ready set. No candidate meant the exhausted branch: status "auto-progression complete", `Done=true`, chain over after one child.

The failure mode is what makes it worth fixing carefully — "no ready children" and "the next child is blocked by a Bead we forgot to close" are very different states that reached the same terminal.

## The fix

The advance worker closes the merged child's Bead before it queries children and `bd ready`.

The ordering *is* the fix. A close that landed after the readiness query would still be selecting against a stale snapshot, and the epic would report complete exactly as before.

Three constraints on it:

- **Only a durable merge closes a Bead.** The gate keys on `Merge.Status`, not the derived `status` field. A child that reached `completed` without landing anything on the base branch keeps its Bead open, and a hand-edited status can't retire real work.
- **Close failures are retryable** and stop the edge *before* the queries and before any exhaustion write. A `bd` outage can no longer be mistaken for a finished epic — which is the original bug's shape, so it seemed worth not reintroducing it through the fix.
- **`bd close` is idempotent** (exit 0 on an already-closed Bead), which is what makes this safe on a level-triggered edge that refires every poll until an advance completes.

## Scope

This stays inside epic progression. `docs/beads-view-spec.md` story 25 holds manual Flow creation to tracker-read-only, with progression's claim as the sanctioned exception — so progression releasing its own claim is symmetric, whereas closing Beads for every merged Flow would break that invariant. Manual Flows are unchanged.

`beadsmutate.Close` joins `Claim` at that boundary. It places `--reason` ahead of the `--` separator because `bd` resolves everything after `--` as positional, and a trailing `--reason` gets parsed as a second issue ID.

## Verification

- 8 new tests across `beadsmutate` and the advance edge, covering the ordering guarantee, the merged-vs-completed gate, retryable close failure, idempotent re-close, and the `--reason` placement.
- Two of them were mutation-tested rather than trusted: inverting the merged gate fails the unmerged test, and moving the close after the readiness query fails the ordering test. Neither passes vacuously.
- `make fmt-check`, `make build`, and the full `make test` are green.

## Known gap

A child whose phase graph has no merge phase terminates at `completed`, so its Bead won't auto-close and that epic stalls the same way. Not addressed here — closing on `completed` would mean retiring Beads for work that never landed, which is the worse failure. Epics on presets that merge (including `lite-flow`) are covered.
