### PR TITLE
Build the generic worktree agent's launch context through a role builder

### DIFF
--- a/actions/flow_launch_role.go
+++ b/actions/flow_launch_role.go
@@ -1,0 +1,49 @@
+package actions
+
+// FlowLaunchRole names the kind of Flow-scoped launch a context represents. It
+// is a closed enum: every Flow launch the TUI can start is exactly one of these
+// six, and the launch context's marker flags are the role's encoding rather
+// than six independent booleans a caller may combine freely.
+//
+// It lives in actions rather than model because actions is the package model
+// imports, not the other way round, and because the role's consumers — resume
+// identity, tmux role validation, the tracked-lease branch — already live here.
+type FlowLaunchRole int
+
+const (
+	// RoleTrackedPhase is a phase-attached launch that reserves the Flow lease
+	// and writes phase attempt history.
+	RoleTrackedPhase FlowLaunchRole = iota + 1
+	// RolePhaseResume resumes a phase's saved provider session.
+	RolePhaseResume
+	// RoleRepair is the untracked Flow-scoped repair session.
+	RoleRepair
+	// RoleAutofix is the prompted, PR-gated untracked agent.
+	RoleAutofix
+	// RoleWorktreeAgent is the generic untracked worktree agent started by s.
+	RoleWorktreeAgent
+	// RoleSavedSessionResume is a phase-untracked resume of a Flow's saved
+	// provider session.
+	RoleSavedSessionResume
+)
+
+// String names the role for diagnostics. An unknown value names itself rather
+// than masquerading as a real role.
+func (role FlowLaunchRole) String() string {
+	switch role {
+	case RoleTrackedPhase:
+		return "tracked phase"
+	case RolePhaseResume:
+		return "phase resume"
+	case RoleRepair:
+		return "repair"
+	case RoleAutofix:
+		return "autofix"
+	case RoleWorktreeAgent:
+		return "worktree agent"
+	case RoleSavedSessionResume:
+		return "saved session resume"
+	default:
+		return "unknown flow launch role"
+	}
+}

--- a/docs/adr/0002-flow-launch-context-deep-module.md
+++ b/docs/adr/0002-flow-launch-context-deep-module.md
@@ -339,3 +339,31 @@ For each field the role does *not* carry, "which consumer proves it is payload?"
    the cost of three roles no consumer distinguishes. Confirm the collapse.
 6. **Enforcement scope**: the boundary test as specified covers `model/` and
    `actions/` only. Confirm no other package should be in scope.
+
+## Implementation note — tracer bullet (`approach-hyl.2`)
+
+The first slice landed the seam and migrated one launch kind. Three things
+about it diverge from the text above and stay true until a later slice changes
+them:
+
+- **The tracer migrated `RoleWorktreeAgent`, not `RoleRepair`.** The migration
+  order above nominates repair; the worktree agent is the strictly simpler
+  tracer — one marker, one hardcoded route, no phase writes, no post-literal
+  field mutation — so it went first. Repair still owns its own slice, where
+  the post-literal refresh write at `model/flow_repair.go` gets handled.
+- **D5 was followed.** `FlowLaunchRole` lives in `actions/flow_launch_role.go`;
+  `newFlowLaunchContext` and the `flowLaunchTarget` sum live in
+  `model/flow_launch_context.go`. Open question 1 is therefore answered in the
+  code, not the ADR's status.
+- **The builder takes no routing probe yet (D3 deferred).** The worktree agent
+  has no tmux call site and no route to decide, so the builder returns
+  `flowLaunchRoute` without taking a probe. The routing input arrives with the
+  first tmux-capable kind. Open question 4 remains open.
+
+`TestEveryFlowLaunchRouteRefusesAnUnverifiedPin` now follows
+`newFlowLaunchContext` call sites as well as `applyLaunchStamp` ones, so a
+route that delegates construction still has to refuse an unverified pin before
+it reserves. The builder itself is exempt: it never reserves or writes, and the
+refusal has to happen earlier than it runs.
+
+The ADR's status stays `proposed`; the remaining open questions are unanswered.

--- a/model/flow_launch_context.go
+++ b/model/flow_launch_context.go
@@ -1,0 +1,77 @@
+package model
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowstore"
+)
+
+// flowLaunchTarget is the payload half of a Flow launch: the role plus exactly
+// the inputs that role needs. It is a sum rather than one wide struct so a
+// role cannot be paired with another role's payload — the pairing is
+// unrepresentable, not merely unreached.
+type flowLaunchTarget interface {
+	role() actions.FlowLaunchRole
+}
+
+// worktreeAgentTarget is the generic untracked worktree agent started by s. It
+// carries the whole record rather than pre-split scalars so the mapping from
+// record fields onto context fields — including WorkingDir being the worktree,
+// not the repo — lives inside the builder instead of at the call site.
+type worktreeAgentTarget struct {
+	LaunchID string
+	Record   flowstore.FlowRecord
+	// PlanPath is the resolved markdown path for the Flow's linked plan. It is
+	// separate from the record because the prepare stage may have had to
+	// resolve it from PlanID, and that resolution is admission's job.
+	PlanPath string
+}
+
+func (worktreeAgentTarget) role() actions.FlowLaunchRole { return actions.RoleWorktreeAgent }
+
+// errIncompleteFlowLaunchTarget reports a payload that upstream admission
+// should already have guaranteed. The builder still checks: it is the one
+// place every Flow launch context is constructed, so it is the only place the
+// launch invariants can be enforced for all of them at once.
+var errIncompleteFlowLaunchTarget = errors.New("flow launch target is missing required fields")
+
+// newFlowLaunchContext builds the launch context and handoff route for target,
+// stamping the launching build and registering the launch with the controller
+// before returning. Callers submit a role payload and take back a finished
+// context; they no longer decide which markers a role sets or which route it
+// takes.
+func newFlowLaunchContext(
+	target flowLaunchTarget,
+	settings flowLaunchAgentSettingsSnapshot,
+) (actions.AgentLaunchContext, flowLaunchRoute, error) {
+	switch payload := target.(type) {
+	case worktreeAgentTarget:
+		return newWorktreeAgentLaunchContext(payload, settings)
+	default:
+		return actions.AgentLaunchContext{}, 0, errIncompleteFlowLaunchTarget
+	}
+}
+
+func newWorktreeAgentLaunchContext(
+	target worktreeAgentTarget,
+	settings flowLaunchAgentSettingsSnapshot,
+) (actions.AgentLaunchContext, flowLaunchRoute, error) {
+	record := target.Record
+	if strings.TrimSpace(target.LaunchID) == "" ||
+		strings.TrimSpace(record.FlowID) == "" ||
+		strings.TrimSpace(record.WorktreePath) == "" {
+		return actions.AgentLaunchContext{}, 0, errIncompleteFlowLaunchTarget
+	}
+	// The stamp is applied last, after every field is set: registration reads
+	// the finished context to name the launch, so stamping early would change
+	// the shape of what the controller records.
+	return applyLaunchStamp(actions.AgentLaunchContext{
+		Command: settings.Command, LaunchID: target.LaunchID,
+		RepoPath: record.RepoPath, WorktreePath: record.WorktreePath, WorkingDir: record.WorktreePath,
+		Branch: record.Branch, Commit: record.Commit, Model: settings.Model, ReasoningEffort: settings.ReasoningEffort,
+		SessionStateRoot: settings.SessionStateRoot, PlanID: record.PlanID, PlanPath: target.PlanPath,
+		FlowID: record.FlowID, FlowAgent: true, Embedded: true, Headless: false, InitialPrompt: "",
+	}, settings.stamp()), flowLaunchRouteEmbedded, nil
+}

--- a/model/flow_launch_context_internal_test.go
+++ b/model/flow_launch_context_internal_test.go
@@ -1,0 +1,155 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/internal/controlplane"
+)
+
+// launchContextVariantRecord is the fixture every variant row derives its
+// target from. It is deliberately a plain literal rather than the generic
+// agent's harness record: the builder is being pinned at its own interface,
+// so the row must not inherit whatever the prepare stage's fixture happens to
+// set.
+func launchContextVariantRecord() flowstore.FlowRecord {
+	return flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		Title:        "Flow one",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktree",
+		Branch:       "flow/one",
+		Commit:       "abc123",
+		PlanID:       "plan-1",
+		PlanPath:     "/state/plan.md",
+		Status:       flowstore.StatusInProgress,
+		UpdatedAt:    time.Now(),
+	}
+}
+
+func launchContextVariantSettings() flowLaunchAgentSettingsSnapshot {
+	return flowLaunchAgentSettingsSnapshot{
+		Command:          "codex",
+		Model:            "gpt-5",
+		ReasoningEffort:  "high",
+		SessionStateRoot: "/state",
+	}
+}
+
+// TestNewFlowLaunchContextPinsEachVariantsCanonicalContext compares the whole
+// returned struct, not a subset of fields, so a field added to any Flow role's
+// launch context has to be declared in this table before it can ship.
+func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
+	record := launchContextVariantRecord()
+	for _, variant := range []struct {
+		name   string
+		target flowLaunchTarget
+		want   actions.AgentLaunchContext
+		route  flowLaunchRoute
+	}{
+		{
+			name: "worktree agent",
+			target: worktreeAgentTarget{
+				LaunchID: "launch-1",
+				Record:   record,
+				PlanPath: record.PlanPath,
+			},
+			want: actions.AgentLaunchContext{
+				Command:          "codex",
+				LaunchID:         "launch-1",
+				RepoPath:         record.RepoPath,
+				WorktreePath:     record.WorktreePath,
+				WorkingDir:       record.WorktreePath,
+				Branch:           record.Branch,
+				Commit:           record.Commit,
+				SessionStateRoot: "/state",
+				PlanID:           record.PlanID,
+				PlanPath:         record.PlanPath,
+				FlowID:           record.FlowID,
+				FlowAgent:        true,
+				Embedded:         true,
+				Model:            "gpt-5",
+				ReasoningEffort:  "high",
+			},
+			route: flowLaunchRouteEmbedded,
+		},
+	} {
+		t.Run(variant.name, func(t *testing.T) {
+			ctx, route, err := newFlowLaunchContext(variant.target, launchContextVariantSettings())
+			if err != nil {
+				t.Fatalf("newFlowLaunchContext: %v", err)
+			}
+			if ctx != variant.want {
+				t.Fatalf("context = %#v, want %#v", ctx, variant.want)
+			}
+			if route != variant.route {
+				t.Fatalf("route = %v, want %v", route, variant.route)
+			}
+		})
+	}
+}
+
+func TestNewFlowLaunchContextStampsThePinnedBuild(t *testing.T) {
+	claims := stubRetainLaunchPin(t)
+	settings := launchContextVariantSettings()
+	settings.Pin = controlplane.Pin{
+		ExecutablePath: "/state/bin/approach-abc123",
+		Version:        "v0.10.3",
+		SchemaVersion:  6,
+		Digest:         "abc123def456",
+	}
+
+	ctx, _, err := newFlowLaunchContext(worktreeAgentTarget{
+		LaunchID: "launch-1",
+		Record:   launchContextVariantRecord(),
+	}, settings)
+	if err != nil {
+		t.Fatalf("newFlowLaunchContext: %v", err)
+	}
+	if ctx.Executable != settings.Pin.ExecutablePath || ctx.BuildVersion != "v0.10.3" || ctx.DBSchemaVersion != 6 {
+		t.Fatalf("builder did not stamp the pin: %#v", ctx)
+	}
+	if len(*claims) != 1 || (*claims)[0] != [3]string{"/state", "launch-1", "abc123def456"} {
+		t.Fatalf("pin claims = %v, want exactly one for this launch", *claims)
+	}
+}
+
+func TestNewFlowLaunchContextRejectsIncompletePayloads(t *testing.T) {
+	for _, missing := range []struct {
+		name   string
+		target worktreeAgentTarget
+	}{
+		{
+			name:   "launch id",
+			target: worktreeAgentTarget{Record: launchContextVariantRecord()},
+		},
+		{
+			name: "flow id",
+			target: func() worktreeAgentTarget {
+				record := launchContextVariantRecord()
+				record.FlowID = "  "
+				return worktreeAgentTarget{LaunchID: "launch-1", Record: record}
+			}(),
+		},
+		{
+			name: "worktree path",
+			target: func() worktreeAgentTarget {
+				record := launchContextVariantRecord()
+				record.WorktreePath = ""
+				return worktreeAgentTarget{LaunchID: "launch-1", Record: record}
+			}(),
+		},
+	} {
+		t.Run("missing "+missing.name, func(t *testing.T) {
+			ctx, route, err := newFlowLaunchContext(missing.target, launchContextVariantSettings())
+			if err == nil {
+				t.Fatalf("incomplete payload built a context: %#v", ctx)
+			}
+			if route != 0 {
+				t.Fatalf("failed build returned route %v", route)
+			}
+		})
+	}
+}

--- a/model/flow_launch_generic_agent.go
+++ b/model/flow_launch_generic_agent.go
@@ -6,7 +6,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
@@ -289,14 +288,15 @@ func (m Model) worktreeAgentFlowLaunchPrepareCmd(msg flowLaunchEventMsg, setting
 		event.RepoPath = record.RepoPath
 		event.WorktreePath = record.WorktreePath
 		event.PlanPath = planPath
-		event.Context = applyLaunchStamp(actions.AgentLaunchContext{
-			Command: settings.Command, LaunchID: msg.Token,
-			RepoPath: record.RepoPath, WorktreePath: record.WorktreePath, WorkingDir: record.WorktreePath,
-			Branch: record.Branch, Commit: record.Commit, Model: settings.Model, ReasoningEffort: settings.ReasoningEffort,
-			SessionStateRoot: settings.SessionStateRoot, PlanID: record.PlanID, PlanPath: planPath,
-			FlowID: record.FlowID, FlowAgent: true, Embedded: true, Headless: false, InitialPrompt: "",
-		}, settings.stamp())
-		event.Route = flowLaunchRouteEmbedded
+		ctx, route, err := newFlowLaunchContext(worktreeAgentTarget{
+			LaunchID: msg.Token, Record: record, PlanPath: planPath,
+		}, settings)
+		if err != nil {
+			event.Err = err.Error()
+			return event
+		}
+		event.Context = ctx
+		event.Route = route
 		return event
 	}
 }

--- a/model/flow_phase_launch_internal_test.go
+++ b/model/flow_phase_launch_internal_test.go
@@ -575,7 +575,11 @@ func TestRefuseUnverifiedLaunchPinIgnoresAnUnpinnedLaunch(t *testing.T) {
 // unverified one, including the non-Flow routes in model_keys.go. A new entry
 // here is a claim that needs a reason as specific as the ones in
 // nonLaunchingContextFiles.
-var unverifiedLaunchPinFiles = map[string]string{}
+var unverifiedLaunchPinFiles = map[string]string{
+	"flow_launch_context.go": "the shared launch-context builder constructs and stamps but never reserves " +
+		"or writes; the refusal has to happen at the route before it reserves, so the fence follows the " +
+		"newFlowLaunchContext call sites instead",
+}
 
 // preflight is not the only path that marks a phase running and bakes the
 // pinned path into a detached agent's argv: create, resume, saved-session
@@ -603,7 +607,10 @@ func TestEveryFlowLaunchRouteRefusesAnUnverifiedPin(t *testing.T) {
 			t.Fatalf("read %s: %v", name, err)
 		}
 		text := string(source)
-		if !strings.Contains(text, "applyLaunchStamp(") {
+		// A route that hands construction to newFlowLaunchContext no longer
+		// spells applyLaunchStamp itself, but it still reserves and writes, so
+		// the fence follows the builder's call sites too.
+		if !strings.Contains(text, "applyLaunchStamp(") && !strings.Contains(text, "newFlowLaunchContext(") {
 			continue
 		}
 		if reason, exempt := unverifiedLaunchPinFiles[name]; exempt {
@@ -620,7 +627,7 @@ func TestEveryFlowLaunchRouteRefusesAnUnverifiedPin(t *testing.T) {
 			continue
 		}
 		if !strings.Contains(text, "refuseUnverifiedLaunchPin(") {
-			t.Fatalf("%s stamps a launch pin but never refuses an unverified one, so it can launch a binary the "+
+			t.Fatalf("%s builds a pinned launch but never refuses an unverified pin, so it can launch a binary the "+
 				"state root lost or an upgrade replaced. Refuse before it reserves or writes, or document the file "+
 				"in unverifiedLaunchPinFiles with the reason it cannot.", name)
 		}


### PR DESCRIPTION
## Problem

Seven Flow launch kinds each hand-compose their own `actions.AgentLaunchContext` literal. Every one of them independently decides which of the eleven Flow marker fields to set, which record field lands on `WorkingDir`, and which route to take. Nothing makes an invalid combination unrepresentable, and nothing keeps the next launch kind consistent with the last — the prepare stage for the generic worktree agent built its literal, wrapped it in `applyLaunchStamp`, and set the route on the following line, entirely by convention.

## Solution

This is the tracer bullet for the seam ADR 0002 proposes:

- `actions.FlowLaunchRole` — a closed six-value enum naming the launch roles.
- `model/flow_launch_context.go` — a `flowLaunchTarget` sum whose only inhabitant today is `worktreeAgentTarget`, plus a single `newFlowLaunchContext` builder that returns the finished context *and* its route.

Callers now submit a role payload; they no longer decide markers, field mapping, or routing. The target carries the whole `flowstore.FlowRecord` rather than pre-split scalars, so `WorkingDir = WorktreePath` moves inside the module with everything else. The builder ends with `applyLaunchStamp`, after every field is set, because registration reads the finished context to name the launch, and it validates its payload so the seam has a failure channel for the invariants later slices assert (upstream admission already guarantees those fields today, so the error is unreachable from the prepare stage).

The generic worktree agent's prepare stage is the one migrated caller.

## Behavior

No user-visible change. The produced context is field-for-field what the literal produced, which is why `model/flow_launch_generic_agent_internal_test.go` is unedited — it already pinned the context end-to-end through the prepare stage and is the regression net here.

## Tests

- New `model/flow_launch_context_internal_test.go` is table-driven over launch variants and compares the *whole* struct against a canonical literal, so a field added to any Flow role's context has to be declared in the table before it can ship. Sub-tests cover builder-applied pin stamping/claiming and rejected payloads.
- `TestEveryFlowLaunchRouteRefusesAnUnverifiedPin` now follows `newFlowLaunchContext` call sites; otherwise a route silently drops out of the fence the moment it delegates construction. The builder itself is exempt with a recorded reason — it never reserves or writes.

Verified: `gofmt` clean, `go vet ./model ./actions`, full `make test` green. Autoreview (codex) came back clean with no actionable findings.

## Deviations from the bead, both from ADR 0002

- The role type lives in `actions`, not `model`: `model` imports `actions`, and three role consumers are actions-side, so defining it in `model` now would force a package move later (D5).
- The tracer migrates `worktreeAgent` rather than `repair` — one marker, one hardcoded route, no phase writes — leaving repair's post-literal refresh for a later slice.

Out of scope as planned: the classifier, the remaining consumer migrations, the AST boundary test, and the routing probe.

---

Stacked on #372; base will retarget to `main` when that merges.
