### PR TITLE
Take repair's launch context away from the call site that kept rewriting it

### DIFF
--- a/docs/adr/0002-flow-launch-context-deep-module.md
+++ b/docs/adr/0002-flow-launch-context-deep-module.md
@@ -367,3 +367,51 @@ it reserves. The builder itself is exempt: it never reserves or writes, and the
 refusal has to happen earlier than it runs.
 
 The ADR's status stays `proposed`; the remaining open questions are unanswered.
+
+## Implementation note — repair (`approach-hyl.3`)
+
+The second slice migrated `RoleRepair`, the kind the migration order nominated
+first and the tracer deferred. It is the first migration where the call site was
+doing real work after the literal, so it is the first that tests the seam's
+central claim.
+
+- **Post-literal mutation was the whole point.** `refreshFlowRepairLaunchContext`
+  ran after the composed literal and overwrote seven fields from the reserved
+  record, treating the literal's `RepoPath`/`WorktreePath`/`PlanPath` as a
+  fallback chain rather than as values. That made the literal's fields mean two
+  different things at two different instants, and it is why the call site's own
+  comment had to explain the seeding order. Under the builder the read stage's
+  resolutions are named for what they are — `FallbackRepoPath`,
+  `FallbackWorktreePath`, `PlanID`, `PlanPath` — and the precedence between them
+  and the record lives in one function. The refresh is deleted, not shimmed.
+- **Stamp-last forced the prompt off `ctx.Executable`.** `flowRepairPrompt` read
+  the stamped executable, which only had a value because the old call site
+  stamped *before* refreshing. The builder stamps last — registration reads the
+  finished context to name the launch — so the prompt renders from
+  `settings.Pin.ExecutablePath` instead. It is the same string
+  `applyLaunchStamp` writes, and the empty-pin case is what `flowPromptBinary`
+  already falls back from. This regression would have been silent (a well-formed
+  prompt naming ambient `approach`), so it has its own test.
+- **Repair's payload validation is deliberately looser than the worktree
+  agent's.** The builder requires a launch ID and a flow ID but *not* a worktree
+  path: repair exists for Flows whose recorded directories are gone, so copying
+  the tracer's check would have refused exactly the Flows repair is for. The
+  no-usable-directory refusal stays in the read stage, where it can name what it
+  refused.
+- **Resolved agent settings ride on the target, not the snapshot.** Repair's
+  command, model and effort come from the obstruction phase's persisted settings,
+  and resolving them needs the reserved record. Overwriting the snapshot's three
+  fields before calling was rejected: it would make the snapshot mean one thing
+  for repair and another for every other kind.
+- **D3 is still deferred.** `docs/flow-launch-variant-matrix.md:54` records that
+  `repair × tmux` is unreachable, so repair has no route to decide and the
+  builder still returns `flowLaunchRoute` without taking a routing probe. Open
+  question 4 remains open, now for the second slice running.
+
+The acceptance evidence is that `model/flow_launch_repair_internal_test.go`
+passes unedited, as `model/flow_launch_generic_agent_internal_test.go` did for
+the tracer, and that the module-interface variant test's whole-struct comparison
+now has a repair row pinning the empty `FlowPhaseID`, `FlowLaunchTracked` false,
+and the empty `WorkingDir`.
+
+The ADR's status stays `proposed`.

--- a/model/flow_launch_autofix_internal_test.go
+++ b/model/flow_launch_autofix_internal_test.go
@@ -1589,7 +1589,7 @@ func TestToggleFlowHeadlessRefusedWhileAutofixAttemptHoldsTheFlow(t *testing.T) 
 // half of the same fence. A repair takes its lifecycle attempt at the key press
 // and only reads the Flow later, in prepare, through ReserveRepairLaunch — the
 // same launch/close lock, and the same lack of ordering against SetHeadless —
-// before refreshFlowRepairLaunchContext resolves ctx.Headless from that record.
+// before the repair launch builder resolves ctx.Headless from that record.
 // So the toggle has to stand off for a repair attempt exactly as it does for a
 // autofix agent, or the repair runs interactively or headlessly depending on
 // which command finished first.

--- a/model/flow_launch_context.go
+++ b/model/flow_launch_context.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/flowstore"
 )
 
@@ -31,6 +32,38 @@ type worktreeAgentTarget struct {
 
 func (worktreeAgentTarget) role() actions.FlowLaunchRole { return actions.RoleWorktreeAgent }
 
+// repairTarget is the untracked repair session started by R. Its record is the
+// reserved one — the authority for branch, commit, plan, headless and the
+// prompt — while the read stage's resolutions ride alongside as fallbacks with
+// a defined precedence. They stay separate fields rather than being folded into
+// a synthesized record because flattening them would hide the ladder the path
+// resolution depends on.
+type repairTarget struct {
+	// LaunchID is the admission token, never a fresh ID: every LaunchID-keyed
+	// fence downstream is on it.
+	LaunchID string
+	Record   flowstore.FlowRecord
+	// Agent is the obstruction phase's resolved settings. Repair's command,
+	// model and effort come from what that phase persisted rather than from the
+	// TUI preference snapshot, and resolving them needs the reserved record, so
+	// the resolution belongs to admission and travels on the payload. Folding it
+	// into the settings snapshot instead would make that snapshot mean two
+	// different things depending on which caller filled it.
+	Agent agent.Settings
+	// FallbackRepoPath and FallbackWorktreePath are the read stage's resolved
+	// directories, tried after the record's own when the record points at
+	// directories that are gone.
+	FallbackRepoPath     string
+	FallbackWorktreePath string
+	// PlanID and PlanPath are the read stage's plan resolution. PlanPath is kept
+	// only while PlanID still matches the record's, so a Flow that has moved to
+	// another plan cannot carry the old plan's markdown into the repair session.
+	PlanID   string
+	PlanPath string
+}
+
+func (repairTarget) role() actions.FlowLaunchRole { return actions.RoleRepair }
+
 // errIncompleteFlowLaunchTarget reports a payload that upstream admission
 // should already have guaranteed. The builder still checks: it is the one
 // place every Flow launch context is constructed, so it is the only place the
@@ -49,6 +82,8 @@ func newFlowLaunchContext(
 	switch payload := target.(type) {
 	case worktreeAgentTarget:
 		return newWorktreeAgentLaunchContext(payload, settings)
+	case repairTarget:
+		return newRepairLaunchContext(payload, settings)
 	default:
 		return actions.AgentLaunchContext{}, 0, errIncompleteFlowLaunchTarget
 	}
@@ -73,5 +108,47 @@ func newWorktreeAgentLaunchContext(
 		Branch: record.Branch, Commit: record.Commit, Model: settings.Model, ReasoningEffort: settings.ReasoningEffort,
 		SessionStateRoot: settings.SessionStateRoot, PlanID: record.PlanID, PlanPath: target.PlanPath,
 		FlowID: record.FlowID, FlowAgent: true, Embedded: true, Headless: false, InitialPrompt: "",
+	}, settings.stamp()), flowLaunchRouteEmbedded, nil
+}
+
+// newRepairLaunchContext deliberately validates less than the worktree agent
+// does: it requires a launch ID and a flow ID, but not a worktree path. Repair
+// exists precisely for Flows whose recorded directories are gone, so copying the
+// worktree agent's check here would refuse exactly the Flows repair is for. The
+// no-usable-directory refusal is admission's, in the read stage.
+func newRepairLaunchContext(
+	target repairTarget,
+	settings flowLaunchAgentSettingsSnapshot,
+) (actions.AgentLaunchContext, flowLaunchRoute, error) {
+	record := target.Record
+	if strings.TrimSpace(target.LaunchID) == "" || strings.TrimSpace(record.FlowID) == "" {
+		return actions.AgentLaunchContext{}, 0, errIncompleteFlowLaunchTarget
+	}
+	repoPath, worktreePath, ok := flowRepairLaunchPaths(
+		record.RepoPath, record.WorktreePath, target.FallbackWorktreePath, target.FallbackRepoPath)
+	if !ok {
+		// Nothing on the ladder was a usable directory. Keeping the read stage's
+		// pair verbatim leaves the repair agent pointed at what the user was
+		// looking at rather than at a path the record only claims exists.
+		repoPath = target.FallbackRepoPath
+		worktreePath = target.FallbackWorktreePath
+	}
+	planPath := strings.TrimSpace(record.PlanPath)
+	if planPath == "" && record.PlanID == target.PlanID {
+		planPath = target.PlanPath
+	}
+	obstruction, _ := flowRepairObstructionForRecord(record)
+	// The prompt renders settings.Pin.ExecutablePath, not the stamped
+	// ctx.Executable: the stamp is applied last, so there is no stamped value to
+	// read yet. This is the same string applyLaunchStamp would write, and the
+	// empty-pin case is what flowPromptBinary already falls back from.
+	return applyLaunchStamp(actions.AgentLaunchContext{
+		Command: target.Agent.Command, LaunchID: target.LaunchID,
+		RepoPath: repoPath, WorktreePath: worktreePath,
+		Branch: record.Branch, Commit: record.Commit,
+		Model: target.Agent.Model, ReasoningEffort: target.Agent.ReasoningEffort,
+		SessionStateRoot: settings.SessionStateRoot, PlanID: record.PlanID, PlanPath: planPath,
+		FlowID: record.FlowID, FlowRepair: true, Embedded: true, Headless: record.Headless,
+		InitialPrompt: flowRepairPrompt(record, obstruction, settings.Pin.ExecutablePath),
 	}, settings.stamp()), flowLaunchRouteEmbedded, nil
 }

--- a/model/flow_launch_context_internal_test.go
+++ b/model/flow_launch_context_internal_test.go
@@ -1,10 +1,12 @@
 package model
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/internal/controlplane"
 )
@@ -43,6 +45,7 @@ func launchContextVariantSettings() flowLaunchAgentSettingsSnapshot {
 // launch context has to be declared in this table before it can ship.
 func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 	record := launchContextVariantRecord()
+	repair, repairRecord := launchContextRepairTarget(t)
 	for _, variant := range []struct {
 		name   string
 		target flowLaunchTarget
@@ -72,6 +75,37 @@ func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 				Embedded:         true,
 				Model:            "gpt-5",
 				ReasoningEffort:  "high",
+			},
+			route: flowLaunchRouteEmbedded,
+		},
+		{
+			// Repair sets no FlowPhaseID and leaves FlowLaunchTracked false. That
+			// empty phase ID is load-bearing: it is what makes
+			// flowLaunchFailureUpdate refuse, which is what keeps a failed repair
+			// from mutating a phase. WorkingDir stays empty too — unlike the
+			// worktree agent, repair does not chdir into a directory it cannot
+			// assume still exists.
+			name:   "repair",
+			target: repair,
+			want: actions.AgentLaunchContext{
+				// Command, Model and effort come from the obstruction phase's
+				// resolved settings on the target, not from the TUI snapshot.
+				Command:          "claude",
+				LaunchID:         "launch-1",
+				RepoPath:         repairRecord.RepoPath,
+				WorktreePath:     repairRecord.WorktreePath,
+				Branch:           repairRecord.Branch,
+				Commit:           repairRecord.Commit,
+				SessionStateRoot: "/state",
+				PlanID:           repairRecord.PlanID,
+				PlanPath:         repairRecord.PlanPath,
+				FlowID:           repairRecord.FlowID,
+				FlowRepair:       true,
+				Embedded:         true,
+				Headless:         true,
+				Model:            "opus",
+				ReasoningEffort:  "medium",
+				InitialPrompt:    launchContextRepairPrompt(repairRecord, ""),
 			},
 			route: flowLaunchRouteEmbedded,
 		},
@@ -149,6 +183,232 @@ func TestNewFlowLaunchContextRejectsIncompletePayloads(t *testing.T) {
 			}
 			if route != 0 {
 				t.Fatalf("failed build returned route %v", route)
+			}
+		})
+	}
+}
+
+// launchContextRepairTarget is the repair fixture. Unlike the worktree agent's
+// record it needs real directories: the builder resolves paths through
+// flowRepairLaunchPaths, whose ladder is an os.Stat probe, so a fixture built
+// from names that merely happen not to exist would pin the fallback branch by
+// accident rather than by intent.
+func launchContextRepairTarget(t *testing.T) (repairTarget, flowstore.FlowRecord) {
+	t.Helper()
+	dir := t.TempDir()
+	record := flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		Title:        "Flow one",
+		RepoPath:     dir,
+		WorktreePath: dir,
+		Branch:       "flow/one",
+		Commit:       "abc123",
+		PlanID:       "plan-1",
+		PlanPath:     "/state/plan.md",
+		Status:       flowstore.StatusInProgress,
+		Headless:     true,
+		UpdatedAt:    time.Now(),
+		Phases: []flowstore.FlowPhase{{
+			PhaseID: "implementation",
+			Title:   "Implementation",
+			Kind:    flowstore.KindImplementation,
+			Status:  flowstore.PhaseBlocked,
+			Outcome: flowstore.OutcomeBlocked,
+			Notes:   "persisted metadata is inconsistent",
+			Order:   1,
+		}},
+	}
+	return repairTarget{
+		LaunchID:             "launch-1",
+		Record:               record,
+		Agent:                agent.Settings{Command: "claude", Model: "opus", ReasoningEffort: "medium"},
+		FallbackRepoPath:     dir,
+		FallbackWorktreePath: dir,
+		PlanID:               record.PlanID,
+		PlanPath:             record.PlanPath,
+	}, record
+}
+
+// launchContextRepairPrompt computes the expectation rather than pasting it, so
+// an edit to the repair prompt copy does not have to be mirrored here. What the
+// row pins is that the builder renders the prompt from this record with this
+// binary — not the wording.
+func launchContextRepairPrompt(record flowstore.FlowRecord, binary string) string {
+	obstruction, _ := flowRepairObstructionForRecord(record)
+	return flowRepairPrompt(record, obstruction, binary)
+}
+
+// TestNewFlowLaunchContextBuildsRepairFromTheRecordsPlanRule pins the rule the
+// call site used to own: the record's own plan path always wins, and the read
+// stage's resolved path survives only while the record still points at the same
+// plan. A record that has moved to another plan must not carry the old plan's
+// markdown into the repair session.
+func TestNewFlowLaunchContextBuildsRepairFromTheRecordsPlanRule(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		recordPlanPath string
+		recordPlanID   string
+		want           string
+	}{
+		{name: "record plan path wins", recordPlanPath: "/state/record-plan.md", recordPlanID: "plan-1", want: "/state/record-plan.md"},
+		{name: "matching plan id keeps the read stage path", recordPlanPath: "", recordPlanID: "plan-1", want: "/state/read-plan.md"},
+		{name: "different plan id drops the read stage path", recordPlanPath: "", recordPlanID: "plan-2", want: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			target, _ := launchContextRepairTarget(t)
+			target.Record.PlanPath = tt.recordPlanPath
+			target.Record.PlanID = tt.recordPlanID
+			target.PlanID = "plan-1"
+			target.PlanPath = "/state/read-plan.md"
+
+			ctx, _, err := newFlowLaunchContext(target, launchContextVariantSettings())
+			if err != nil {
+				t.Fatalf("newFlowLaunchContext: %v", err)
+			}
+			if ctx.PlanPath != tt.want {
+				t.Fatalf("plan path = %q, want %q", ctx.PlanPath, tt.want)
+			}
+			if ctx.PlanID != tt.recordPlanID {
+				t.Fatalf("plan id = %q, want the record's %q", ctx.PlanID, tt.recordPlanID)
+			}
+		})
+	}
+}
+
+// TestNewFlowLaunchContextResolvesRepairPathsThroughTheFallbackLadder covers the
+// argument order the builder has to transcribe correctly: recorded worktree,
+// then recorded repo, then the read stage's worktree, then its repo — and, when
+// nothing is usable, the read stage's pair kept verbatim so repair can still
+// reach a Flow whose directories are all gone.
+func TestNewFlowLaunchContextResolvesRepairPathsThroughTheFallbackLadder(t *testing.T) {
+	fallbackWorktree := t.TempDir()
+	fallbackRepo := t.TempDir()
+	for _, tt := range []struct {
+		name             string
+		recordRepo       string
+		recordWorktree   string
+		fallbackWorktree string
+		fallbackRepo     string
+		wantRepo         string
+		wantWorktree     string
+	}{
+		{
+			name:             "unusable record falls back to the read stage worktree",
+			recordRepo:       "/dev/null/missing-repo",
+			recordWorktree:   "/dev/null/missing-worktree",
+			fallbackWorktree: fallbackWorktree,
+			fallbackRepo:     fallbackRepo,
+			wantRepo:         fallbackWorktree,
+			wantWorktree:     fallbackWorktree,
+		},
+		{
+			name:             "no read stage worktree falls back to its repo",
+			recordRepo:       "/dev/null/missing-repo",
+			recordWorktree:   "/dev/null/missing-worktree",
+			fallbackWorktree: "/dev/null/missing-fallback",
+			fallbackRepo:     fallbackRepo,
+			wantRepo:         fallbackRepo,
+			wantWorktree:     fallbackRepo,
+		},
+		{
+			name:             "nothing usable keeps the read stage pair",
+			recordRepo:       "/dev/null/missing-repo",
+			recordWorktree:   "/dev/null/missing-worktree",
+			fallbackWorktree: "/dev/null/missing-fallback-worktree",
+			fallbackRepo:     "/dev/null/missing-fallback-repo",
+			wantRepo:         "/dev/null/missing-fallback-repo",
+			wantWorktree:     "/dev/null/missing-fallback-worktree",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			target, _ := launchContextRepairTarget(t)
+			target.Record.RepoPath = tt.recordRepo
+			target.Record.WorktreePath = tt.recordWorktree
+			target.FallbackWorktreePath = tt.fallbackWorktree
+			target.FallbackRepoPath = tt.fallbackRepo
+
+			ctx, _, err := newFlowLaunchContext(target, launchContextVariantSettings())
+			if err != nil {
+				t.Fatalf("newFlowLaunchContext: %v", err)
+			}
+			if ctx.RepoPath != tt.wantRepo || ctx.WorktreePath != tt.wantWorktree {
+				t.Fatalf("paths = (%q, %q), want (%q, %q)", ctx.RepoPath, ctx.WorktreePath, tt.wantRepo, tt.wantWorktree)
+			}
+		})
+	}
+}
+
+// TestNewFlowLaunchContextRendersTheRepairPromptWithThePinnedBinary is the
+// ordering guard. The prompt used to read ctx.Executable, which only had a value
+// because the old call site stamped before refreshing; the builder stamps last,
+// so it must render from the pin directly. A regression here is silent — the
+// prompt would still be well-formed, just telling the agent to run whatever
+// `approach` is on PATH instead of the pinned build.
+func TestNewFlowLaunchContextRendersTheRepairPromptWithThePinnedBinary(t *testing.T) {
+	stubRetainLaunchPin(t)
+	target, record := launchContextRepairTarget(t)
+	settings := launchContextVariantSettings()
+	settings.Pin = controlplane.Pin{
+		ExecutablePath: "/state/bin/approach-abc123",
+		Version:        "v0.10.3",
+		SchemaVersion:  6,
+		Digest:         "abc123def456",
+	}
+
+	ctx, _, err := newFlowLaunchContext(target, settings)
+	if err != nil {
+		t.Fatalf("newFlowLaunchContext: %v", err)
+	}
+	if !strings.Contains(ctx.InitialPrompt, settings.Pin.ExecutablePath) {
+		t.Fatalf("repair prompt does not name the pinned binary:\n%s", ctx.InitialPrompt)
+	}
+	if ctx.InitialPrompt != launchContextRepairPrompt(record, settings.Pin.ExecutablePath) {
+		t.Fatalf("repair prompt = %q, want the pinned-binary rendering", ctx.InitialPrompt)
+	}
+	if ctx.Executable != settings.Pin.ExecutablePath {
+		t.Fatalf("repair context was not stamped: %#v", ctx)
+	}
+}
+
+// TestNewFlowLaunchContextRejectsIncompleteRepairPayloads pins repair's
+// validation as deliberately looser than the worktree agent's: repair exists for
+// Flows whose recorded directories are gone, so an empty worktree path is an
+// accepted payload here. The no-usable-directory refusal is admission's.
+func TestNewFlowLaunchContextRejectsIncompleteRepairPayloads(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		mutate  func(*repairTarget)
+		wantErr bool
+	}{
+		{name: "missing launch id", mutate: func(target *repairTarget) { target.LaunchID = "  " }, wantErr: true},
+		{name: "missing flow id", mutate: func(target *repairTarget) { target.Record.FlowID = "  " }, wantErr: true},
+		{
+			name: "empty worktree path is accepted",
+			mutate: func(target *repairTarget) {
+				target.Record.WorktreePath = ""
+				target.FallbackWorktreePath = ""
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			target, _ := launchContextRepairTarget(t)
+			tt.mutate(&target)
+
+			ctx, route, err := newFlowLaunchContext(target, launchContextVariantSettings())
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("incomplete payload built a context: %#v", ctx)
+				}
+				if route != 0 {
+					t.Fatalf("failed build returned route %v", route)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("newFlowLaunchContext: %v", err)
+			}
+			if route != flowLaunchRouteEmbedded {
+				t.Fatalf("route = %v, want embedded", route)
 			}
 		})
 	}

--- a/model/flow_launch_repair.go
+++ b/model/flow_launch_repair.go
@@ -6,7 +6,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
@@ -389,10 +388,10 @@ func (m Model) repairFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flowL
 		}
 		if strings.TrimSpace(current.FlowID) != msg.FlowID {
 			// The reservation is supposed to return the Flow it locked. A seam
-			// that returns a zero or foreign record would otherwise reach
-			// refreshFlowRepairLaunchContext, which rebuilds branch, commit,
-			// plan, and the prompt from whatever it is handed — producing a
-			// repair agent pointed at the wrong record, or at none.
+			// that returns a zero or foreign record would otherwise reach the
+			// repair builder, which takes branch, commit, plan, and the prompt
+			// from the record it is handed — producing a repair agent pointed at
+			// the wrong record, or at none.
 			event.Err = flowRepairNotRepairableStatus
 			return event
 		}
@@ -400,11 +399,6 @@ func (m Model) repairFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flowL
 			event.Err = flowRepairNotRepairableStatus
 			return event
 		}
-		// Seeded before the refresh, not after: refreshFlowRepairLaunchContext
-		// treats ctx.WorktreePath/ctx.RepoPath as its fallback chain and keeps
-		// ctx.PlanPath only when the record's plan ID still matches, so an
-		// unseeded context would silently discard the read stage's repo
-		// fallback and its PlanMarkdownPath lookup.
 		resolved, err := resolveFlowRepairAgentSettings(current, settings.Preferences)
 		if err != nil {
 			event.Err = flowRepairAgentSettingsError(current, settings.Preferences, err)
@@ -417,27 +411,27 @@ func (m Model) repairFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flowL
 			event.Err = fmt.Sprintf("Flow repair does not support agent %q; press A to choose codex, claude, or cursor-agent", resolved.Command)
 			return event
 		}
-		ctx := applyLaunchStamp(actions.AgentLaunchContext{
-			Command: resolved.Command,
-			// The admission token, never a fresh ID: every LaunchID-keyed fence
-			// downstream is on it.
-			LaunchID:         msg.Token,
-			RepoPath:         msg.RepoPath,
-			WorktreePath:     msg.WorktreePath,
-			SessionStateRoot: settings.SessionStateRoot,
-			PlanID:           msg.Record.PlanID,
-			PlanPath:         msg.PlanPath,
-			FlowID:           msg.FlowID,
-			FlowRepair:       true,
-			Embedded:         true,
-			Model:            resolved.Model,
-			ReasoningEffort:  resolved.ReasoningEffort,
-		}, settings.stamp())
-		// FlowPhaseID stays empty and FlowLaunchTracked stays false. The empty
-		// phase ID is what makes flowLaunchFailureUpdate refuse, which is what
-		// keeps a failed repair from ever mutating a phase.
-		event.Context = refreshFlowRepairLaunchContext(ctx, current)
-		event.Route = flowLaunchRouteEmbedded
+		// The read stage's paths and plan resolution are submitted as fallbacks
+		// rather than applied here: the builder owns the precedence between them
+		// and the reserved record, and it is the builder that sets repair's
+		// markers. FlowPhaseID stays empty and FlowLaunchTracked stays false
+		// there — the empty phase ID is what makes flowLaunchFailureUpdate
+		// refuse, which is what keeps a failed repair from ever mutating a phase.
+		ctx, route, err := newFlowLaunchContext(repairTarget{
+			LaunchID:             msg.Token,
+			Record:               current,
+			Agent:                resolved,
+			FallbackRepoPath:     msg.RepoPath,
+			FallbackWorktreePath: msg.WorktreePath,
+			PlanID:               msg.Record.PlanID,
+			PlanPath:             msg.PlanPath,
+		}, settings)
+		if err != nil {
+			event.Err = "Prepare Flow repair launch: " + err.Error()
+			return event
+		}
+		event.Context = ctx
+		event.Route = route
 		return event
 	}
 }

--- a/model/flow_repair.go
+++ b/model/flow_repair.go
@@ -7,7 +7,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
 )
@@ -177,28 +176,6 @@ func (m Model) handleRepairSelectedFlow() (tea.Model, tea.Cmd) {
 	}
 	next, cmd, _ := m.requestFlowLaunch(intent)
 	return next, cmd
-}
-
-func refreshFlowRepairLaunchContext(ctx actions.AgentLaunchContext, record flowstore.FlowRecord) actions.AgentLaunchContext {
-	repoPath, worktreePath, ok := flowRepairLaunchPaths(record.RepoPath, record.WorktreePath, ctx.WorktreePath, ctx.RepoPath)
-	if !ok {
-		repoPath = ctx.RepoPath
-		worktreePath = ctx.WorktreePath
-	}
-	planPath := strings.TrimSpace(record.PlanPath)
-	if planPath == "" && record.PlanID == ctx.PlanID {
-		planPath = ctx.PlanPath
-	}
-	obstruction, _ := flowRepairObstructionForRecord(record)
-	ctx.RepoPath = repoPath
-	ctx.WorktreePath = worktreePath
-	ctx.Branch = record.Branch
-	ctx.Commit = record.Commit
-	ctx.PlanID = record.PlanID
-	ctx.PlanPath = planPath
-	ctx.Headless = record.Headless
-	ctx.InitialPrompt = flowRepairPrompt(record, obstruction, ctx.Executable)
-	return ctx
 }
 
 func flowRepairLaunchPaths(repoPath, worktreePath string, fallbacks ...string) (string, string, bool) {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1134,7 +1134,7 @@ func (m Model) handleToggleFlowHeadless() (tea.Model, tea.Cmd) {
 	// each resolves
 	// headless in its prepare stage from a record read under the launch/close
 	// lock — autofix from ReserveAgentLaunch, repair from
-	// ReserveRepairLaunch by way of refreshFlowRepairLaunchContext. SetHeadless
+	// ReserveRepairLaunch by way of the repair launch builder. SetHeadless
 	// writes under the Flow store's own lock and so is ordered against neither,
 	// leaving both free to observe either value; for autofix the
 	// route turns on it too, since a headless launch is never tmux-eligible.


### PR DESCRIPTION
## Problem

Repair built an `AgentLaunchContext` literal at the call site and then handed it to `refreshFlowRepairLaunchContext`, which overwrote seven of its fields from the reserved record and re-read three more as a fallback chain. The repo, worktree, and plan paths in that literal meant one thing before the refresh and something else after, so the call site carried a comment explaining the seeding order just to stay correct. Every other launch kind had already moved to the builder; repair was the last holdout.

## Solution

Repair now submits a `repairTarget` to `newFlowLaunchContext` and gets back a finished context and route, the same way the worktree agent does. `refreshFlowRepairLaunchContext` is deleted outright rather than kept as a shim.

- The read stage's resolutions are named for what they are — `FallbackRepoPath`, `FallbackWorktreePath`, `PlanID`, `PlanPath` — so precedence between them and the reserved record lives in the builder instead of being implied by statement order.
- Resolved agent settings ride on the target instead of being written over the settings snapshot's fields, so the snapshot doesn't mean one thing for repair and another for every other launch kind.
- Repair's payload validation stays deliberately looser than the worktree agent's: it requires a launch ID and a flow ID but not a worktree path, because repair exists precisely for Flows whose recorded directories are gone. The no-usable-directory refusal stays in the read stage, where it can name what it refused.
- ADR 0002 records the deep-module shape the launch context is converging on.

Two things the move forced:

**The prompt's executable path.** The prompt rendered `ctx.Executable`, which only had a value because the old call site stamped before refreshing. The builder stamps last, so the prompt now renders `settings.Pin.ExecutablePath` — the same string `applyLaunchStamp` writes. Getting this wrong would have failed silently: a well-formed prompt telling the repair agent to run whatever `approach` happens to be on `PATH`. It has its own test.

**The variant test.** The module-interface variant test's whole-struct comparison gains a repair row pinning the empty `FlowPhaseID`, `FlowLaunchTracked` false, and the empty `WorkingDir`.

## Verification

`model/flow_launch_repair.go`'s internal tests pass unedited. `go test ./model ./actions` and `go vet ./model` pass; gofmt clean.