### PR TITLE
Let autofix's launch builder decide the tmux route instead of the call site

### DIFF
--- a/docs/adr/0002-flow-launch-context-deep-module.md
+++ b/docs/adr/0002-flow-launch-context-deep-module.md
@@ -333,7 +333,9 @@ For each field the role does *not* carry, "which consumer proves it is payload?"
 4. **D3 makes `newFlowLaunchContext` take the routing probe**, which means the
    builder does I/O-adjacent work (`actions.TmuxAvailable`). Confirm, or keep
    routing outside and accept a two-step `(build, route)` with a documented
-   ordering contract.
+   ordering contract. *Answered in the code by the autofix slice
+   (`approach-hyl.4`): the builder takes `flowLaunchRouting` and returns a
+   `flowLaunchRouteDecision`.*
 5. **D1's six roles vs. seven** — splitting `RoleTrackedPhase` into
    manual/auto/create would make the enum mirror `flowLaunchKind` exactly, at
    the cost of three roles no consumer distinguishes. Confirm the collapse.
@@ -358,7 +360,8 @@ them:
 - **The builder takes no routing probe yet (D3 deferred).** The worktree agent
   has no tmux call site and no route to decide, so the builder returns
   `flowLaunchRoute` without taking a probe. The routing input arrives with the
-  first tmux-capable kind. Open question 4 remains open.
+  first tmux-capable kind. Open question 4 remains open. *(Answered in the
+  autofix slice below.)*
 
 `TestEveryFlowLaunchRouteRefusesAnUnverifiedPin` now follows
 `newFlowLaunchContext` call sites as well as `applyLaunchStamp` ones, so a
@@ -406,12 +409,59 @@ central claim.
 - **D3 is still deferred.** `docs/flow-launch-variant-matrix.md:54` records that
   `repair × tmux` is unreachable, so repair has no route to decide and the
   builder still returns `flowLaunchRoute` without taking a routing probe. Open
-  question 4 remains open, now for the second slice running.
+  question 4 remains open, now for the second slice running. *(Answered in the
+  autofix slice below.)*
 
 The acceptance evidence is that `model/flow_launch_repair_internal_test.go`
 passes unedited, as `model/flow_launch_generic_agent_internal_test.go` did for
 the tracer, and that the module-interface variant test's whole-struct comparison
 now has a repair row pinning the empty `FlowPhaseID`, `FlowLaunchTracked` false,
 and the empty `WorkingDir`.
+
+The ADR's status stays `proposed`.
+
+## Implementation note — autofix (`approach-hyl.4`)
+
+The third slice migrated `RoleAutofix`, the first tmux-capable kind, so it is
+the slice that answers **open question 4: the builder takes the routing input.**
+D3 is implemented, not deferred.
+
+- **Routing in, decision out.** `newFlowLaunchContext` takes a third argument,
+  `flowLaunchRouting{Backend, TmuxAvailable}` — the values a lifecycle attempt
+  snapshots at admission so its route is decided against what it was admitted
+  with — and its second return is a `flowLaunchRouteDecision{Route,
+  FallbackNote}`. The note rides on the decision rather than being recomputed at
+  the call site because `fellBack` is a second output of the same rule
+  (`tmuxLaunchRouteFor`); returning only the route would put two readers on one
+  decision. A fourth bare return value was rejected on Go style grounds.
+  `RoleWorktreeAgent` and `RoleRepair` ignore `routing` and keep returning
+  `{flowLaunchRouteEmbedded, ""}`: their route is a constant, not an unrouted
+  gap, and `tmuxRouteEligible` already refuses `FlowRepair` on its own.
+- **The ordering hazard is now structural.** The matrix's `any kind × tmux ×
+  headless` pruning rule holds only because headless is resolved *before* the
+  route is decided. Inside the builder that ordering is not a call-site
+  convention: the context's `Headless` comes off the payload's record and the
+  route is decided from the finished context, so the two cannot be reordered
+  from outside. The prepare stage still sets `event.Headless` for the
+  lifecycle's own consumers.
+- **`Embedded` is written in exactly one place for this role.** The tmux route's
+  cleared `Embedded` — what sends the prompt to argv instead of the dock — is
+  set inside the arm that decides the route, replacing a post-construction
+  `event.Context.Embedded = false` at the call site.
+- **The PR number comes off the record.** The sketch in this ADR had
+  `AutofixTarget{PRNumber int}`. The payload carries the whole record instead,
+  because the prompt needs the record anyway and two sources for one number is
+  exactly the drift this epic removes. Builder validation refuses `PR.Number <=
+  0` along with a blank launch ID, flow ID, or worktree path: nothing on this
+  path may emit `autofix pr #0`, and the worktree is the point of the shortcut.
+- **Stamp-last again.** As in the repair slice, the prompt renders from
+  `settings.Pin.ExecutablePath` rather than `ctx.Executable`, which has no value
+  yet when the prompt is composed. The embedded variant row pins the rendered
+  string.
+
+The acceptance evidence is that `model/flow_launch_autofix_internal_test.go`
+passes unedited — including the tmux row asserting a cleared `Embedded` — and
+that the module-interface variant test gained autofix rows for the embedded,
+headless, and tmux variants, each comparing the whole struct and the decision.
 
 The ADR's status stays `proposed`.

--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -82,6 +82,13 @@ The reachable variants:
 | V16 | worktreeAgent | embedded | false | false |
 | V17 | savedSessionResume | embedded | false | false |
 
+V11–V12 (repair), V13–V15 (autofix) and V16 (worktreeAgent) are built by
+`newFlowLaunchContext` (`model/flow_launch_context.go`) rather than by a literal
+at their prepare stage. V13–V15 are also the first variants whose *route* the
+builder decides: it takes the snapshotted backend and tmux probe and returns the
+route with the fallback note, so V15's cleared `Embedded` is set where the rule
+lives rather than after construction.
+
 ## 3. Field values, with the pipeline point that sets them
 
 `C` = construction, `L` = lifecycle install (`installFlowLaunchEmbedded`),

--- a/model/flow_launch_autofix.go
+++ b/model/flow_launch_autofix.go
@@ -5,7 +5,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
@@ -297,10 +296,10 @@ func flowRecordHasLivePhaseSession(record flowstore.FlowRecord, records []sessio
 // reservation would launch in the previous mode, and on the wrong route with it,
 // since a headless launch is never tmux-eligible.
 //
-// The prompt is rendered here from the reserved record and the snapshotted
-// `[flow_prompts].autofix` template, so prepare still cannot compose a prompt
-// no stage authorized. Headless and tmux send that text on argv; interactive
-// embedded launches prefill the dock with it.
+// The prompt is rendered by the builder from the reserved record and the
+// snapshotted `[flow_prompts].autofix` template, so prepare still cannot compose
+// a prompt no stage authorized. Headless and tmux send that text on argv;
+// interactive embedded launches prefill the dock with it.
 func (m Model) autofixFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flowLaunchAgentSettingsSnapshot) tea.Cmd {
 	reserve := m.reserveTrackedFlowLaunch
 	// Snapshotted at admission, as flowLaunchPreparation snapshots them, so the route
@@ -363,44 +362,23 @@ func (m Model) autofixFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flow
 			// through: this agent needs no plan body.
 			event.PlanPath = record.PlanPath
 		}
-		ctx := applyLaunchStamp(actions.AgentLaunchContext{
-			Command: settings.Command,
-			// The admission token, never a fresh ID: every LaunchID-keyed fence and
-			// the tmux window registry key on it.
-			LaunchID:     msg.Token,
-			RepoPath:     repoPath,
-			WorktreePath: record.WorktreePath,
-			// WorkingDir is what actions turns into the agent's cwd, and it is the
-			// worktree by construction: the gate refuses a worktree-less Flow.
-			WorkingDir:       record.WorktreePath,
-			Branch:           record.Branch,
-			Commit:           record.Commit,
-			Model:            settings.Model,
-			ReasoningEffort:  settings.ReasoningEffort,
-			SessionStateRoot: settings.SessionStateRoot,
-			PlanID:           record.PlanID,
+		// The read stage's repo path is submitted as a fallback rather than
+		// applied here: the builder owns the precedence between it and the record,
+		// and it is the builder that sets autofix's markers and decides the route
+		// from the headless preference resolved just above.
+		ctx, decision, err := newFlowLaunchContext(autofixTarget{
+			LaunchID:         msg.Token,
+			Record:           record,
 			PlanPath:         event.PlanPath,
-			FlowID:           record.FlowID,
-			// No FlowPhaseID, no FlowLaunchTracked, no FlowRepair: this is the
-			// phase-untracked autofix agent. FlowAutofix is the explicit signal the
-			// prefill boundary reads rather than inferring it from those absences.
-			FlowAutofix:         true,
-			FlowAutofixPRNumber: record.PR.Number,
-			Embedded:            true,
-			Headless:            headless,
-			InitialPrompt:       autofixPrompt(record, settings.PromptTemplates, settings.Pin.ExecutablePath),
-		}, settings.stamp())
-		event.Context = ctx
-		event.Route = flowLaunchRouteEmbedded
-		tmuxRoute, tmuxFellBack := tmuxLaunchRouteFor(backend, tmuxAvailable, ctx)
-		if tmuxRoute {
-			// A tmux window has no dock to prefill and renders its own output,
-			// so clearing Embedded is what sends the prompt to argv instead.
-			event.Context.Embedded = false
-			event.Route = flowLaunchRouteTmux
-		} else if tmuxFellBack {
-			event.FallbackNote = tmuxFallbackNote
+			FallbackRepoPath: repoPath,
+		}, settings, flowLaunchRouting{Backend: backend, TmuxAvailable: tmuxAvailable})
+		if err != nil {
+			event.Err = err.Error()
+			return event
 		}
+		event.Context = ctx
+		event.Route = decision.Route
+		event.FallbackNote = decision.FallbackNote
 		return event
 	}
 }

--- a/model/flow_launch_context.go
+++ b/model/flow_launch_context.go
@@ -64,11 +64,55 @@ type repairTarget struct {
 
 func (repairTarget) role() actions.FlowLaunchRole { return actions.RoleRepair }
 
+// autofixTarget is the prompted, PR-gated untracked agent started by U. Its
+// record is the reserved one when the reservation answered: it is the authority
+// for the worktree, the headless preference, and the PR number the prompt
+// names. The PR number is read off that record rather than travelling as its own
+// scalar so one launch can never carry two sources for it.
+type autofixTarget struct {
+	// LaunchID is the admission token, never a fresh ID: every LaunchID-keyed
+	// fence and the tmux window registry key on it.
+	LaunchID string
+	Record   flowstore.FlowRecord
+	// PlanPath is the record's plan path verbatim, with no PlanMarkdownPath
+	// resolution: this agent needs no plan body, so a plan-linked Flow launching
+	// with an empty PlanPath is expected.
+	PlanPath string
+	// FallbackRepoPath is the read stage's resolved repository, used only when
+	// the record carries none of its own.
+	FallbackRepoPath string
+}
+
+func (autofixTarget) role() actions.FlowLaunchRole { return actions.RoleAutofix }
+
 // errIncompleteFlowLaunchTarget reports a payload that upstream admission
 // should already have guaranteed. The builder still checks: it is the one
 // place every Flow launch context is constructed, so it is the only place the
 // launch invariants can be enforced for all of them at once.
 var errIncompleteFlowLaunchTarget = errors.New("flow launch target is missing required fields")
+
+// flowLaunchRouting is the routing input a role's builder decides against. It
+// is a snapshot rather than a receiver read: a lifecycle attempt takes both at
+// admission so its route is decided against what the attempt was admitted with,
+// while Model reads config's value live.
+type flowLaunchRouting struct {
+	// Backend is the launch backend the attempt was admitted with.
+	Backend string
+	// TmuxAvailable is the snapshotted probe. A nil probe means the real PATH.
+	TmuxAvailable func() bool
+}
+
+// flowLaunchRouteDecision is the route a role's builder chose plus the note the
+// user is owed when it could not take the one it wanted. The note rides here
+// rather than being recomputed by the caller because fellBack is a second
+// output of the same rule: returning only the route would put two readers on
+// one decision.
+type flowLaunchRouteDecision struct {
+	Route flowLaunchRoute
+	// FallbackNote is tmuxFallbackNote exactly when the tmux route was eligible
+	// and tmux was missing. Every other decline is by design, not a fallback.
+	FallbackNote string
+}
 
 // newFlowLaunchContext builds the launch context and handoff route for target,
 // stamping the launching build and registering the launch with the controller
@@ -78,26 +122,32 @@ var errIncompleteFlowLaunchTarget = errors.New("flow launch target is missing re
 func newFlowLaunchContext(
 	target flowLaunchTarget,
 	settings flowLaunchAgentSettingsSnapshot,
-) (actions.AgentLaunchContext, flowLaunchRoute, error) {
+	routing flowLaunchRouting,
+) (actions.AgentLaunchContext, flowLaunchRouteDecision, error) {
 	switch payload := target.(type) {
 	case worktreeAgentTarget:
 		return newWorktreeAgentLaunchContext(payload, settings)
 	case repairTarget:
 		return newRepairLaunchContext(payload, settings)
+	case autofixTarget:
+		return newAutofixLaunchContext(payload, settings, routing)
 	default:
-		return actions.AgentLaunchContext{}, 0, errIncompleteFlowLaunchTarget
+		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errIncompleteFlowLaunchTarget
 	}
 }
 
+// newWorktreeAgentLaunchContext ignores routing: this kind's route is a
+// constant, not an unrouted gap. The generic worktree agent always takes the
+// embedded slot.
 func newWorktreeAgentLaunchContext(
 	target worktreeAgentTarget,
 	settings flowLaunchAgentSettingsSnapshot,
-) (actions.AgentLaunchContext, flowLaunchRoute, error) {
+) (actions.AgentLaunchContext, flowLaunchRouteDecision, error) {
 	record := target.Record
 	if strings.TrimSpace(target.LaunchID) == "" ||
 		strings.TrimSpace(record.FlowID) == "" ||
 		strings.TrimSpace(record.WorktreePath) == "" {
-		return actions.AgentLaunchContext{}, 0, errIncompleteFlowLaunchTarget
+		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errIncompleteFlowLaunchTarget
 	}
 	// The stamp is applied last, after every field is set: registration reads
 	// the finished context to name the launch, so stamping early would change
@@ -108,21 +158,83 @@ func newWorktreeAgentLaunchContext(
 		Branch: record.Branch, Commit: record.Commit, Model: settings.Model, ReasoningEffort: settings.ReasoningEffort,
 		SessionStateRoot: settings.SessionStateRoot, PlanID: record.PlanID, PlanPath: target.PlanPath,
 		FlowID: record.FlowID, FlowAgent: true, Embedded: true, Headless: false, InitialPrompt: "",
-	}, settings.stamp()), flowLaunchRouteEmbedded, nil
+	}, settings.stamp()), flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded}, nil
+}
+
+// newAutofixLaunchContext is the first kind whose route is a decision rather
+// than a constant, so it is the arm that takes routing. The order matters and is
+// enforced by construction here: the record's headless preference is read into
+// the context before the route is decided, because a headless launch is never
+// tmux-eligible.
+func newAutofixLaunchContext(
+	target autofixTarget,
+	settings flowLaunchAgentSettingsSnapshot,
+	routing flowLaunchRouting,
+) (actions.AgentLaunchContext, flowLaunchRouteDecision, error) {
+	record := target.Record
+	// The strictest validation of the three kinds. The worktree is required
+	// rather than falling back to the repository root because the agent's cwd is
+	// the whole point of the shortcut, and PR.Number > 0 is required because
+	// nothing on this path may ever emit `autofix pr #0`.
+	if strings.TrimSpace(target.LaunchID) == "" ||
+		strings.TrimSpace(record.FlowID) == "" ||
+		strings.TrimSpace(record.WorktreePath) == "" ||
+		record.PR.Number <= 0 {
+		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errIncompleteFlowLaunchTarget
+	}
+	repoPath := strings.TrimSpace(record.RepoPath)
+	if repoPath == "" {
+		repoPath = target.FallbackRepoPath
+	}
+	ctx := applyLaunchStamp(actions.AgentLaunchContext{
+		Command: settings.Command, LaunchID: target.LaunchID,
+		RepoPath: repoPath, WorktreePath: record.WorktreePath,
+		// WorkingDir is what actions turns into the agent's cwd, and it is the
+		// worktree by construction: the validation above refuses a worktree-less
+		// payload, as the U gate refuses a worktree-less Flow.
+		WorkingDir: record.WorktreePath,
+		Branch:     record.Branch, Commit: record.Commit,
+		Model: settings.Model, ReasoningEffort: settings.ReasoningEffort,
+		SessionStateRoot: settings.SessionStateRoot, PlanID: record.PlanID, PlanPath: target.PlanPath,
+		FlowID: record.FlowID,
+		// No FlowPhaseID, no FlowLaunchTracked, no FlowRepair, no FlowAgent: this
+		// is the phase-untracked autofix agent. FlowAutofix is the explicit signal
+		// the prefill boundary reads rather than inferring it from those absences.
+		FlowAutofix: true, FlowAutofixPRNumber: record.PR.Number,
+		Embedded: true, Headless: record.Headless,
+		// The prompt renders settings.Pin.ExecutablePath, not the stamped
+		// ctx.Executable, for the reason newRepairLaunchContext gives: the stamp
+		// is applied last, so there is no stamped value to read yet.
+		InitialPrompt: autofixPrompt(record, settings.PromptTemplates, settings.Pin.ExecutablePath),
+	}, settings.stamp())
+	tmuxRoute, fellBack := tmuxLaunchRouteFor(routing.Backend, routing.TmuxAvailable, ctx)
+	if tmuxRoute {
+		// A tmux window has no dock to prefill and renders its own output, so
+		// clearing Embedded is what sends the prompt to argv instead.
+		ctx.Embedded = false
+		return ctx, flowLaunchRouteDecision{Route: flowLaunchRouteTmux}, nil
+	}
+	decision := flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded}
+	if fellBack {
+		decision.FallbackNote = tmuxFallbackNote
+	}
+	return ctx, decision, nil
 }
 
 // newRepairLaunchContext deliberately validates less than the worktree agent
 // does: it requires a launch ID and a flow ID, but not a worktree path. Repair
 // exists precisely for Flows whose recorded directories are gone, so copying the
 // worktree agent's check here would refuse exactly the Flows repair is for. The
-// no-usable-directory refusal is admission's, in the read stage.
+// no-usable-directory refusal is admission's, in the read stage. Like the
+// worktree agent it ignores routing: tmuxRouteEligible refuses FlowRepair on its
+// own, so repair's route is a constant rather than an unrouted gap.
 func newRepairLaunchContext(
 	target repairTarget,
 	settings flowLaunchAgentSettingsSnapshot,
-) (actions.AgentLaunchContext, flowLaunchRoute, error) {
+) (actions.AgentLaunchContext, flowLaunchRouteDecision, error) {
 	record := target.Record
 	if strings.TrimSpace(target.LaunchID) == "" || strings.TrimSpace(record.FlowID) == "" {
-		return actions.AgentLaunchContext{}, 0, errIncompleteFlowLaunchTarget
+		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errIncompleteFlowLaunchTarget
 	}
 	repoPath, worktreePath, ok := flowRepairLaunchPaths(
 		record.RepoPath, record.WorktreePath, target.FallbackWorktreePath, target.FallbackRepoPath)
@@ -150,5 +262,5 @@ func newRepairLaunchContext(
 		SessionStateRoot: settings.SessionStateRoot, PlanID: record.PlanID, PlanPath: planPath,
 		FlowID: record.FlowID, FlowRepair: true, Embedded: true, Headless: record.Headless,
 		InitialPrompt: flowRepairPrompt(record, obstruction, settings.Pin.ExecutablePath),
-	}, settings.stamp()), flowLaunchRouteEmbedded, nil
+	}, settings.stamp()), flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded}, nil
 }

--- a/model/flow_launch_context_internal_test.go
+++ b/model/flow_launch_context_internal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
+	"github.com/approachcontrol/approach/config"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/internal/controlplane"
 )
@@ -46,11 +47,15 @@ func launchContextVariantSettings() flowLaunchAgentSettingsSnapshot {
 func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 	record := launchContextVariantRecord()
 	repair, repairRecord := launchContextRepairTarget(t)
+	autofixRecord := launchContextAutofixRecord()
+	headlessAutofixRecord := launchContextAutofixRecord()
+	headlessAutofixRecord.Headless = true
 	for _, variant := range []struct {
-		name   string
-		target flowLaunchTarget
-		want   actions.AgentLaunchContext
-		route  flowLaunchRoute
+		name     string
+		target   flowLaunchTarget
+		routing  flowLaunchRouting
+		want     actions.AgentLaunchContext
+		decision flowLaunchRouteDecision
 	}{
 		{
 			name: "worktree agent",
@@ -76,7 +81,7 @@ func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 				Model:            "gpt-5",
 				ReasoningEffort:  "high",
 			},
-			route: flowLaunchRouteEmbedded,
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
 		},
 		{
 			// Repair sets no FlowPhaseID and leaves FlowLaunchTracked false. That
@@ -107,19 +112,125 @@ func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 				ReasoningEffort:  "medium",
 				InitialPrompt:    launchContextRepairPrompt(repairRecord, ""),
 			},
-			route: flowLaunchRouteEmbedded,
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
+		},
+		{
+			// Autofix is phase-untracked like repair, but it chdirs into the
+			// worktree the gate guaranteed and it carries the two markers the
+			// prefill boundary reads. Every phase/tracked/repair/agent marker
+			// stays zero.
+			name: "autofix embedded",
+			target: autofixTarget{
+				LaunchID:         "launch-1",
+				Record:           autofixRecord,
+				PlanPath:         autofixRecord.PlanPath,
+				FallbackRepoPath: "/dev/read-stage",
+			},
+			want: actions.AgentLaunchContext{
+				Command:             "codex",
+				LaunchID:            "launch-1",
+				RepoPath:            autofixRecord.RepoPath,
+				WorktreePath:        autofixRecord.WorktreePath,
+				WorkingDir:          autofixRecord.WorktreePath,
+				Branch:              autofixRecord.Branch,
+				Commit:              autofixRecord.Commit,
+				SessionStateRoot:    "/state",
+				PlanID:              autofixRecord.PlanID,
+				PlanPath:            autofixRecord.PlanPath,
+				FlowID:              autofixRecord.FlowID,
+				FlowAutofix:         true,
+				FlowAutofixPRNumber: autofixRecord.PR.Number,
+				Embedded:            true,
+				Model:               "gpt-5",
+				ReasoningEffort:     "high",
+				InitialPrompt:       launchContextAutofixPrompt(autofixRecord, ""),
+			},
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
+		},
+		{
+			// A headless launch is never tmux-eligible, so it stays embedded even
+			// with the tmux backend and tmux on PATH — and declining a route the
+			// design excludes is not a fallback, so no note is owed.
+			name: "autofix headless",
+			target: autofixTarget{
+				LaunchID:         "launch-1",
+				Record:           headlessAutofixRecord,
+				PlanPath:         headlessAutofixRecord.PlanPath,
+				FallbackRepoPath: "/dev/read-stage",
+			},
+			routing: flowLaunchRouting{
+				Backend:       config.LaunchBackendTmux,
+				TmuxAvailable: func() bool { return true },
+			},
+			want: actions.AgentLaunchContext{
+				Command:             "codex",
+				LaunchID:            "launch-1",
+				RepoPath:            headlessAutofixRecord.RepoPath,
+				WorktreePath:        headlessAutofixRecord.WorktreePath,
+				WorkingDir:          headlessAutofixRecord.WorktreePath,
+				Branch:              headlessAutofixRecord.Branch,
+				Commit:              headlessAutofixRecord.Commit,
+				SessionStateRoot:    "/state",
+				PlanID:              headlessAutofixRecord.PlanID,
+				PlanPath:            headlessAutofixRecord.PlanPath,
+				FlowID:              headlessAutofixRecord.FlowID,
+				FlowAutofix:         true,
+				FlowAutofixPRNumber: headlessAutofixRecord.PR.Number,
+				Embedded:            true,
+				Headless:            true,
+				Model:               "gpt-5",
+				ReasoningEffort:     "high",
+				InitialPrompt:       launchContextAutofixPrompt(headlessAutofixRecord, ""),
+			},
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
+		},
+		{
+			// The tmux route's context is the embedded one with Embedded cleared:
+			// a tmux window has no dock to prefill, so clearing it is what sends
+			// the prompt to argv.
+			name: "autofix tmux",
+			target: autofixTarget{
+				LaunchID:         "launch-1",
+				Record:           autofixRecord,
+				PlanPath:         autofixRecord.PlanPath,
+				FallbackRepoPath: "/dev/read-stage",
+			},
+			routing: flowLaunchRouting{
+				Backend:       config.LaunchBackendTmux,
+				TmuxAvailable: func() bool { return true },
+			},
+			want: actions.AgentLaunchContext{
+				Command:             "codex",
+				LaunchID:            "launch-1",
+				RepoPath:            autofixRecord.RepoPath,
+				WorktreePath:        autofixRecord.WorktreePath,
+				WorkingDir:          autofixRecord.WorktreePath,
+				Branch:              autofixRecord.Branch,
+				Commit:              autofixRecord.Commit,
+				SessionStateRoot:    "/state",
+				PlanID:              autofixRecord.PlanID,
+				PlanPath:            autofixRecord.PlanPath,
+				FlowID:              autofixRecord.FlowID,
+				FlowAutofix:         true,
+				FlowAutofixPRNumber: autofixRecord.PR.Number,
+				Model:               "gpt-5",
+				ReasoningEffort:     "high",
+				InitialPrompt:       launchContextAutofixPrompt(autofixRecord, ""),
+			},
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteTmux},
 		},
 	} {
 		t.Run(variant.name, func(t *testing.T) {
-			ctx, route, err := newFlowLaunchContext(variant.target, launchContextVariantSettings())
+			ctx, decision, err := newFlowLaunchContext(
+				variant.target, launchContextVariantSettings(), variant.routing)
 			if err != nil {
 				t.Fatalf("newFlowLaunchContext: %v", err)
 			}
 			if ctx != variant.want {
 				t.Fatalf("context = %#v, want %#v", ctx, variant.want)
 			}
-			if route != variant.route {
-				t.Fatalf("route = %v, want %v", route, variant.route)
+			if decision != variant.decision {
+				t.Fatalf("decision = %#v, want %#v", decision, variant.decision)
 			}
 		})
 	}
@@ -138,7 +249,7 @@ func TestNewFlowLaunchContextStampsThePinnedBuild(t *testing.T) {
 	ctx, _, err := newFlowLaunchContext(worktreeAgentTarget{
 		LaunchID: "launch-1",
 		Record:   launchContextVariantRecord(),
-	}, settings)
+	}, settings, flowLaunchRouting{})
 	if err != nil {
 		t.Fatalf("newFlowLaunchContext: %v", err)
 	}
@@ -177,12 +288,13 @@ func TestNewFlowLaunchContextRejectsIncompletePayloads(t *testing.T) {
 		},
 	} {
 		t.Run("missing "+missing.name, func(t *testing.T) {
-			ctx, route, err := newFlowLaunchContext(missing.target, launchContextVariantSettings())
+			ctx, decision, err := newFlowLaunchContext(
+				missing.target, launchContextVariantSettings(), flowLaunchRouting{})
 			if err == nil {
 				t.Fatalf("incomplete payload built a context: %#v", ctx)
 			}
-			if route != 0 {
-				t.Fatalf("failed build returned route %v", route)
+			if decision != (flowLaunchRouteDecision{}) {
+				t.Fatalf("failed build returned decision %#v", decision)
 			}
 		})
 	}
@@ -261,7 +373,7 @@ func TestNewFlowLaunchContextBuildsRepairFromTheRecordsPlanRule(t *testing.T) {
 			target.PlanID = "plan-1"
 			target.PlanPath = "/state/read-plan.md"
 
-			ctx, _, err := newFlowLaunchContext(target, launchContextVariantSettings())
+			ctx, _, err := newFlowLaunchContext(target, launchContextVariantSettings(), flowLaunchRouting{})
 			if err != nil {
 				t.Fatalf("newFlowLaunchContext: %v", err)
 			}
@@ -327,7 +439,7 @@ func TestNewFlowLaunchContextResolvesRepairPathsThroughTheFallbackLadder(t *test
 			target.FallbackWorktreePath = tt.fallbackWorktree
 			target.FallbackRepoPath = tt.fallbackRepo
 
-			ctx, _, err := newFlowLaunchContext(target, launchContextVariantSettings())
+			ctx, _, err := newFlowLaunchContext(target, launchContextVariantSettings(), flowLaunchRouting{})
 			if err != nil {
 				t.Fatalf("newFlowLaunchContext: %v", err)
 			}
@@ -355,7 +467,7 @@ func TestNewFlowLaunchContextRendersTheRepairPromptWithThePinnedBinary(t *testin
 		Digest:         "abc123def456",
 	}
 
-	ctx, _, err := newFlowLaunchContext(target, settings)
+	ctx, _, err := newFlowLaunchContext(target, settings, flowLaunchRouting{})
 	if err != nil {
 		t.Fatalf("newFlowLaunchContext: %v", err)
 	}
@@ -394,22 +506,145 @@ func TestNewFlowLaunchContextRejectsIncompleteRepairPayloads(t *testing.T) {
 			target, _ := launchContextRepairTarget(t)
 			tt.mutate(&target)
 
-			ctx, route, err := newFlowLaunchContext(target, launchContextVariantSettings())
+			ctx, decision, err := newFlowLaunchContext(
+				target, launchContextVariantSettings(), flowLaunchRouting{})
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("incomplete payload built a context: %#v", ctx)
 				}
-				if route != 0 {
-					t.Fatalf("failed build returned route %v", route)
+				if decision != (flowLaunchRouteDecision{}) {
+					t.Fatalf("failed build returned decision %#v", decision)
 				}
 				return
 			}
 			if err != nil {
 				t.Fatalf("newFlowLaunchContext: %v", err)
 			}
-			if route != flowLaunchRouteEmbedded {
-				t.Fatalf("route = %v, want embedded", route)
+			if decision != (flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded}) {
+				t.Fatalf("decision = %#v, want embedded with no note", decision)
 			}
 		})
+	}
+}
+
+// launchContextAutofixRecord is the autofix fixture: the variant record plus the
+// PR target the gate guarantees. Nothing on this path may emit `autofix pr #0`,
+// so the number is what the prompt row and the validation row both turn on.
+func launchContextAutofixRecord() flowstore.FlowRecord {
+	record := launchContextVariantRecord()
+	record.PR = flowstore.PullRequest{Number: 116}
+	return record
+}
+
+// launchContextAutofixPrompt computes the expectation rather than pasting it,
+// for the same reason the repair helper does: the rows pin that the builder
+// renders autofix's prompt from this record with this binary, not the wording.
+func launchContextAutofixPrompt(record flowstore.FlowRecord, binary string) string {
+	return autofixPrompt(record, FlowPromptTemplates{}, binary)
+}
+
+// TestNewFlowLaunchContextFallsBackWhenTmuxIsMissing pins the one case that owes
+// the user a note: the tmux route was eligible and tmux was not on PATH. The
+// launch still lands in the embedded slot, so Embedded stays set.
+func TestNewFlowLaunchContextFallsBackWhenTmuxIsMissing(t *testing.T) {
+	record := launchContextAutofixRecord()
+	ctx, decision, err := newFlowLaunchContext(autofixTarget{
+		LaunchID: "launch-1",
+		Record:   record,
+		PlanPath: record.PlanPath,
+	}, launchContextVariantSettings(), flowLaunchRouting{
+		Backend:       config.LaunchBackendTmux,
+		TmuxAvailable: func() bool { return false },
+	})
+	if err != nil {
+		t.Fatalf("newFlowLaunchContext: %v", err)
+	}
+	if decision != (flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded, FallbackNote: tmuxFallbackNote}) {
+		t.Fatalf("decision = %#v, want the embedded route with the tmux fallback note", decision)
+	}
+	if !ctx.Embedded {
+		t.Fatal("a tmux fallback lands in the embedded slot, so Embedded must stay set")
+	}
+}
+
+// TestNewFlowLaunchContextRendersTheAutofixPromptWithThePinnedBinary is the same
+// ordering guard the repair prompt has: the builder stamps last, so the prompt
+// has to render from the pin rather than from the not-yet-stamped ctx.Executable.
+func TestNewFlowLaunchContextRendersTheAutofixPromptWithThePinnedBinary(t *testing.T) {
+	stubRetainLaunchPin(t)
+	record := launchContextAutofixRecord()
+	settings := launchContextVariantSettings()
+	settings.PromptTemplates = FlowPromptTemplates{Autofix: "run {approach_bin} autofix pr #{pr_number}"}
+	settings.Pin = controlplane.Pin{
+		ExecutablePath: "/state/bin/approach-abc123",
+		Version:        "v0.10.3",
+		SchemaVersion:  6,
+		Digest:         "abc123def456",
+	}
+
+	ctx, _, err := newFlowLaunchContext(autofixTarget{
+		LaunchID: "launch-1",
+		Record:   record,
+		PlanPath: record.PlanPath,
+	}, settings, flowLaunchRouting{})
+	if err != nil {
+		t.Fatalf("newFlowLaunchContext: %v", err)
+	}
+	if !strings.Contains(ctx.InitialPrompt, settings.Pin.ExecutablePath) {
+		t.Fatalf("autofix prompt does not name the pinned binary:\n%s", ctx.InitialPrompt)
+	}
+	if ctx.Executable != settings.Pin.ExecutablePath {
+		t.Fatalf("autofix context was not stamped: %#v", ctx)
+	}
+}
+
+// TestNewFlowLaunchContextRejectsIncompleteAutofixPayloads pins autofix's
+// validation as the strictest of the three: the worktree is the point of the
+// shortcut, and a zero PR number would emit `autofix pr #0` — the one string
+// this path may never produce.
+func TestNewFlowLaunchContextRejectsIncompleteAutofixPayloads(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		mutate func(*autofixTarget)
+	}{
+		{name: "missing launch id", mutate: func(target *autofixTarget) { target.LaunchID = "  " }},
+		{name: "missing flow id", mutate: func(target *autofixTarget) { target.Record.FlowID = "  " }},
+		{name: "missing worktree path", mutate: func(target *autofixTarget) { target.Record.WorktreePath = " " }},
+		{name: "missing pr number", mutate: func(target *autofixTarget) { target.Record.PR.Number = 0 }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			record := launchContextAutofixRecord()
+			target := autofixTarget{LaunchID: "launch-1", Record: record, PlanPath: record.PlanPath}
+			tt.mutate(&target)
+
+			ctx, decision, err := newFlowLaunchContext(
+				target, launchContextVariantSettings(), flowLaunchRouting{})
+			if err == nil {
+				t.Fatalf("incomplete payload built a context: %#v", ctx)
+			}
+			if decision != (flowLaunchRouteDecision{}) {
+				t.Fatalf("failed build returned decision %#v", decision)
+			}
+		})
+	}
+}
+
+// TestNewFlowLaunchContextFallsBackToTheReadStageRepoPath pins autofix's one
+// path precedence: the record's repo path wins, and the read stage's resolution
+// is used only when the record has none.
+func TestNewFlowLaunchContextFallsBackToTheReadStageRepoPath(t *testing.T) {
+	record := launchContextAutofixRecord()
+	record.RepoPath = ""
+	ctx, _, err := newFlowLaunchContext(autofixTarget{
+		LaunchID:         "launch-1",
+		Record:           record,
+		PlanPath:         record.PlanPath,
+		FallbackRepoPath: "/dev/read-stage",
+	}, launchContextVariantSettings(), flowLaunchRouting{})
+	if err != nil {
+		t.Fatalf("newFlowLaunchContext: %v", err)
+	}
+	if ctx.RepoPath != "/dev/read-stage" {
+		t.Fatalf("repo path = %q, want the read stage's", ctx.RepoPath)
 	}
 }

--- a/model/flow_launch_generic_agent.go
+++ b/model/flow_launch_generic_agent.go
@@ -288,15 +288,16 @@ func (m Model) worktreeAgentFlowLaunchPrepareCmd(msg flowLaunchEventMsg, setting
 		event.RepoPath = record.RepoPath
 		event.WorktreePath = record.WorktreePath
 		event.PlanPath = planPath
-		ctx, route, err := newFlowLaunchContext(worktreeAgentTarget{
+		ctx, decision, err := newFlowLaunchContext(worktreeAgentTarget{
 			LaunchID: msg.Token, Record: record, PlanPath: planPath,
-		}, settings)
+		}, settings, flowLaunchRouting{})
 		if err != nil {
 			event.Err = err.Error()
 			return event
 		}
 		event.Context = ctx
-		event.Route = route
+		event.Route = decision.Route
+		event.FallbackNote = decision.FallbackNote
 		return event
 	}
 }

--- a/model/flow_launch_repair.go
+++ b/model/flow_launch_repair.go
@@ -417,7 +417,7 @@ func (m Model) repairFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flowL
 		// markers. FlowPhaseID stays empty and FlowLaunchTracked stays false
 		// there — the empty phase ID is what makes flowLaunchFailureUpdate
 		// refuse, which is what keeps a failed repair from ever mutating a phase.
-		ctx, route, err := newFlowLaunchContext(repairTarget{
+		ctx, decision, err := newFlowLaunchContext(repairTarget{
 			LaunchID:             msg.Token,
 			Record:               current,
 			Agent:                resolved,
@@ -425,13 +425,14 @@ func (m Model) repairFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flowL
 			FallbackWorktreePath: msg.WorktreePath,
 			PlanID:               msg.Record.PlanID,
 			PlanPath:             msg.PlanPath,
-		}, settings)
+		}, settings, flowLaunchRouting{})
 		if err != nil {
 			event.Err = "Prepare Flow repair launch: " + err.Error()
 			return event
 		}
 		event.Context = ctx
-		event.Route = route
+		event.Route = decision.Route
+		event.FallbackNote = decision.FallbackNote
 		return event
 	}
 }


### PR DESCRIPTION
The autofix (U) prepare stage built its own launch context literal, then reached
back in and flipped `Embedded` off once it decided the launch belonged in a tmux
window. The route rule lived in two places at once, and the context's `Embedded`
field meant different things at two different instants of the same launch.

Autofix now hands an `autofixTarget` payload to `newFlowLaunchContext`, which
owns the markers, the headless value, the prompt render, the route decision, and
the `Embedded` clearing that sends the prompt to argv on the tmux route. The call
site describes the target and takes back a finished context.

## What changed

- `newFlowLaunchContext` gained the routing input ADR 0002 D3 called for: it
  takes a `flowLaunchRouting{Backend, TmuxAvailable}` snapshot and returns a
  `flowLaunchRouteDecision{Route, FallbackNote}`. The fallback note rides on the
  decision because it is a second output of the same rule — recomputing it at the
  call site would put two readers on one decision. This answers ADR 0002's open
  question 4.
- The worktree agent and repair roles ignore the routing input. Their route is a
  constant, not an unrouted gap.
- The PR number is read off the payload's `Record.PR.Number` rather than
  travelling as its own scalar, so one launch can never carry two sources for it.
- Builder validation refuses a blank launch ID, flow ID, or worktree path, and a
  non-positive PR number — the worktree is the whole point of the shortcut, and
  nothing on this path may emit `autofix pr #0`.
- ADR 0002 and `docs/flow-launch-variant-matrix.md` record the new routing
  contract and the autofix rows.

## Behavior

No user-visible change. `model/flow_launch_autofix_internal_test.go` passes
unedited — including the row asserting that a tmux launch clears `Embedded` — as
do the repair and generic-agent internal tests. The module-interface variant
table gained autofix rows for the embedded, headless, and tmux variants plus the
tmux-missing fallback and the validation cases.

## Verification

`gofmt -l`, `go vet ./model ./actions`, `go test ./model ./actions`, `make build`.
