### PR TITLE
Build saved-session resume's launch context in the module, not the call site

### DIFF
--- a/model/flow_launch_context.go
+++ b/model/flow_launch_context.go
@@ -7,6 +7,7 @@ import (
 	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/sessions"
 )
 
 // flowLaunchTarget is the payload half of a Flow launch: the role plus exactly
@@ -85,11 +86,40 @@ type autofixTarget struct {
 
 func (autofixTarget) role() actions.FlowLaunchRole { return actions.RoleAutofix }
 
+// savedSessionResumeTarget is the phase-untracked resume of a Flow's saved
+// session, started from the Sessions pane, the dock picker or an inline
+// worktree row. It carries the whole refreshed session record for the reason
+// worktreeAgentTarget carries its record: the mapping from session fields onto
+// context fields — WorkingDir being CWD-then-worktree, Command coming from the
+// provider — is the part that belongs inside the builder.
+type savedSessionResumeTarget struct {
+	// LaunchID is the admission token, never a fresh ID: the reservation and
+	// every LaunchID-keyed fence downstream are already on it.
+	LaunchID string
+	// Record is the reserved Flow record. Only its FlowID reaches the context —
+	// the resumed session's own branch, commit and plan are what the agent gets
+	// back, not the Flow's current ones.
+	Record flowstore.FlowRecord
+	// Session is the exact-key refreshed session record. It is the authority for
+	// command and provider identity here, unlike every other role, which takes
+	// them from the settings snapshot.
+	Session sessions.SessionRecord
+}
+
+func (savedSessionResumeTarget) role() actions.FlowLaunchRole {
+	return actions.RoleSavedSessionResume
+}
+
 // errIncompleteFlowLaunchTarget reports a payload that upstream admission
 // should already have guaranteed. The builder still checks: it is the one
 // place every Flow launch context is constructed, so it is the only place the
 // launch invariants can be enforced for all of them at once.
 var errIncompleteFlowLaunchTarget = errors.New("flow launch target is missing required fields")
+
+// errSavedSessionResumeNoWorkingDir reports a session with neither a cwd nor a
+// worktree to resume into. Its message is what the user sees, so it is the
+// prepare stage's wording verbatim rather than a builder-shaped restatement.
+var errSavedSessionResumeNoWorkingDir = errors.New("Session has no worktree path or cwd to resume from")
 
 // flowLaunchRouting is the routing input a role's builder decides against. It
 // is a snapshot rather than a receiver read: a lifecycle attempt takes both at
@@ -131,6 +161,8 @@ func newFlowLaunchContext(
 		return newRepairLaunchContext(payload, settings)
 	case autofixTarget:
 		return newAutofixLaunchContext(payload, settings, routing)
+	case savedSessionResumeTarget:
+		return newSavedSessionResumeLaunchContext(payload, settings)
 	default:
 		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errIncompleteFlowLaunchTarget
 	}
@@ -262,5 +294,54 @@ func newRepairLaunchContext(
 		SessionStateRoot: settings.SessionStateRoot, PlanID: record.PlanID, PlanPath: planPath,
 		FlowID: record.FlowID, FlowRepair: true, Embedded: true, Headless: record.Headless,
 		InitialPrompt: flowRepairPrompt(record, obstruction, settings.Pin.ExecutablePath),
+	}, settings.stamp()), flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded}, nil
+}
+
+// newSavedSessionResumeLaunchContext ignores routing: tmuxRouteEligible refuses
+// FlowSavedSessionResume outright, so this kind's route is the constant
+// embedded slot rather than an unrouted gap. It is also the one role whose
+// command and provider identity come from the session record instead of the
+// settings snapshot — Model and ReasoningEffort must stay empty, because
+// agentCommandSpec refuses a resume that carries them.
+func newSavedSessionResumeLaunchContext(
+	target savedSessionResumeTarget,
+	settings flowLaunchAgentSettingsSnapshot,
+) (actions.AgentLaunchContext, flowLaunchRouteDecision, error) {
+	session := target.Session
+	if strings.TrimSpace(target.LaunchID) == "" ||
+		strings.TrimSpace(target.Record.FlowID) == "" ||
+		strings.TrimSpace(string(session.Provider)) == "" ||
+		strings.TrimSpace(session.SessionID) == "" {
+		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errIncompleteFlowLaunchTarget
+	}
+	workingDir := session.CWD
+	if strings.TrimSpace(workingDir) == "" {
+		workingDir = session.WorktreePath
+	}
+	if strings.TrimSpace(workingDir) == "" {
+		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errSavedSessionResumeNoWorkingDir
+	}
+	return applyLaunchStamp(actions.AgentLaunchContext{
+		// The provider is the command: a resume re-enters the agent that wrote
+		// the session, so the TUI's current preference has no say here.
+		Command: string(session.Provider), LaunchID: target.LaunchID,
+		RepoPath: session.RepoPath, WorktreePath: session.WorktreePath, WorkingDir: workingDir,
+		Branch: session.Branch,
+		// Commit is the session's, not a re-resolved one: agentCommandSpec skips
+		// ResolveWorktreeCommit exactly when FlowSavedSessionResume is set, and
+		// setting that marker here is what keeps that true.
+		Commit:           session.Commit,
+		SessionStateRoot: settings.SessionStateRoot,
+		// Assigned untrimmed: resumeSessionIDForContext returns this field
+		// verbatim for this role, so the trim above is a test for emptiness
+		// only, never a rewrite of the ID the provider stored.
+		ResumeSessionID: session.SessionID,
+		PlanID:          session.PlanID, PlanPath: session.PlanPath,
+		// The Flow ID is the reserved record's, while every other field is the
+		// session's: the reservation is what the lease and the release are keyed
+		// on. No Model or ReasoningEffort — agentCommandSpec errors with "model
+		// cannot be set for session resume" if the snapshot's ever leak in.
+		FlowID: target.Record.FlowID, FlowSavedSessionResume: true,
+		Embedded: true, Headless: false, InitialPrompt: "",
 	}, settings.stamp()), flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded}, nil
 }

--- a/model/flow_launch_context_internal_test.go
+++ b/model/flow_launch_context_internal_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/approachcontrol/approach/config"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/internal/controlplane"
+	"github.com/approachcontrol/approach/sessions"
 )
 
 // launchContextVariantRecord is the fixture every variant row derives its
@@ -48,6 +50,7 @@ func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 	record := launchContextVariantRecord()
 	repair, repairRecord := launchContextRepairTarget(t)
 	autofixRecord := launchContextAutofixRecord()
+	resumeRecord, resumeSession := launchContextSavedSessionResumeTarget()
 	headlessAutofixRecord := launchContextAutofixRecord()
 	headlessAutofixRecord.Headless = true
 	for _, variant := range []struct {
@@ -218,6 +221,37 @@ func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 				InitialPrompt:       launchContextAutofixPrompt(autofixRecord, ""),
 			},
 			decision: flowLaunchRouteDecision{Route: flowLaunchRouteTmux},
+		},
+		{
+			// The one role whose command comes from the session rather than the
+			// snapshot, and the one that must leave Model and ReasoningEffort
+			// empty: agentCommandSpec refuses a resume that carries them, so the
+			// snapshot's gpt-5/high must not reach the context. Every
+			// phase/tracked/repair/agent/autofix marker stays zero, and the Flow
+			// ID is the reserved record's while everything else is the session's.
+			name: "saved session resume",
+			target: savedSessionResumeTarget{
+				LaunchID: "launch-1",
+				Record:   resumeRecord,
+				Session:  resumeSession,
+			},
+			want: actions.AgentLaunchContext{
+				Command:                "codex-cli",
+				LaunchID:               "launch-1",
+				RepoPath:               resumeSession.RepoPath,
+				WorktreePath:           resumeSession.WorktreePath,
+				WorkingDir:             resumeSession.CWD,
+				Branch:                 resumeSession.Branch,
+				Commit:                 resumeSession.Commit,
+				SessionStateRoot:       "/state",
+				ResumeSessionID:        resumeSession.SessionID,
+				PlanID:                 resumeSession.PlanID,
+				PlanPath:               resumeSession.PlanPath,
+				FlowID:                 resumeRecord.FlowID,
+				FlowSavedSessionResume: true,
+				Embedded:               true,
+			},
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
 		},
 	} {
 		t.Run(variant.name, func(t *testing.T) {
@@ -646,5 +680,125 @@ func TestNewFlowLaunchContextFallsBackToTheReadStageRepoPath(t *testing.T) {
 	}
 	if ctx.RepoPath != "/dev/read-stage" {
 		t.Fatalf("repo path = %q, want the read stage's", ctx.RepoPath)
+	}
+}
+
+// launchContextSavedSessionResumeTarget is the saved-resume fixture: the
+// reserved Flow record plus the exact-key refreshed session. They differ in
+// every overlapping field on purpose — the variant row is what pins that the
+// session wins everywhere except the Flow ID.
+func launchContextSavedSessionResumeTarget() (flowstore.FlowRecord, sessions.SessionRecord) {
+	record := launchContextVariantRecord()
+	record.Branch = "flow/record-branch"
+	record.Commit = "recordcommit"
+	return record, sessions.SessionRecord{
+		Provider:     sessions.Provider("codex-cli"),
+		SessionID:    "session-1",
+		CWD:          "/dev/alpha-worktree/nested",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktree",
+		Branch:       "flow/session-branch",
+		Commit:       "sessioncommit",
+		PlanID:       "plan-session",
+		PlanPath:     "/state/session-plan.md",
+		FlowID:       record.FlowID,
+	}
+}
+
+// TestNewFlowLaunchContextRejectsIncompleteSavedSessionResumePayloads pins the
+// four fields the role cannot do without. Provider and session ID are the strict
+// ones: resumeSessionIDForContext refuses a blank ResumeSessionID, and an empty
+// Command would leave agentCommandSpec with no binary to resume.
+func TestNewFlowLaunchContextRejectsIncompleteSavedSessionResumePayloads(t *testing.T) {
+	for _, missing := range []struct {
+		name   string
+		mutate func(*savedSessionResumeTarget)
+	}{
+		{name: "launch id", mutate: func(target *savedSessionResumeTarget) { target.LaunchID = "  " }},
+		{name: "flow id", mutate: func(target *savedSessionResumeTarget) { target.Record.FlowID = "  " }},
+		{name: "provider", mutate: func(target *savedSessionResumeTarget) { target.Session.Provider = "  " }},
+		{name: "session id", mutate: func(target *savedSessionResumeTarget) { target.Session.SessionID = "  " }},
+	} {
+		t.Run("missing "+missing.name, func(t *testing.T) {
+			record, session := launchContextSavedSessionResumeTarget()
+			target := savedSessionResumeTarget{LaunchID: "launch-1", Record: record, Session: session}
+			missing.mutate(&target)
+
+			ctx, decision, err := newFlowLaunchContext(
+				target, launchContextVariantSettings(), flowLaunchRouting{})
+			if !errors.Is(err, errIncompleteFlowLaunchTarget) {
+				t.Fatalf("err = %v, want errIncompleteFlowLaunchTarget (context %#v)", err, ctx)
+			}
+			if decision != (flowLaunchRouteDecision{}) {
+				t.Fatalf("failed build returned decision %#v", decision)
+			}
+		})
+	}
+}
+
+// TestNewFlowLaunchContextResolvesSavedSessionResumeWorkingDir pins the ladder
+// the prepare stage used to own: the session's cwd wins, the worktree is the
+// fallback, and neither is a refusal whose wording is what the user reads.
+func TestNewFlowLaunchContextResolvesSavedSessionResumeWorkingDir(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		cwd      string
+		worktree string
+		want     string
+		wantErr  error
+	}{
+		{name: "cwd wins", cwd: "/dev/session-cwd", worktree: "/dev/alpha-worktree", want: "/dev/session-cwd"},
+		{name: "blank cwd falls back to the worktree", cwd: "  ", worktree: "/dev/alpha-worktree", want: "/dev/alpha-worktree"},
+		{name: "neither is refused", cwd: "", worktree: "", wantErr: errSavedSessionResumeNoWorkingDir},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			record, session := launchContextSavedSessionResumeTarget()
+			session.CWD = tt.cwd
+			session.WorktreePath = tt.worktree
+
+			ctx, decision, err := newFlowLaunchContext(savedSessionResumeTarget{
+				LaunchID: "launch-1", Record: record, Session: session,
+			}, launchContextVariantSettings(), flowLaunchRouting{})
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tt.wantErr)
+				}
+				// The message is the user-visible status the prepare stage used to
+				// set inline, so it is pinned as copy, not just as an identity.
+				if err.Error() != "Session has no worktree path or cwd to resume from" {
+					t.Fatalf("refusal message = %q", err.Error())
+				}
+				if decision != (flowLaunchRouteDecision{}) {
+					t.Fatalf("failed build returned decision %#v", decision)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("newFlowLaunchContext: %v", err)
+			}
+			if ctx.WorkingDir != tt.want {
+				t.Fatalf("working dir = %q, want %q", ctx.WorkingDir, tt.want)
+			}
+		})
+	}
+}
+
+// TestNewFlowLaunchContextKeepsTheSavedSessionIDVerbatim is the counterpart to
+// the trim in the emptiness check. resumeSessionIDForContext returns
+// ctx.ResumeSessionID unmodified for this role — every other path trims — so a
+// builder that assigned the trimmed value would silently rewrite the ID the
+// provider stored and resume the wrong session, or none.
+func TestNewFlowLaunchContextKeepsTheSavedSessionIDVerbatim(t *testing.T) {
+	record, session := launchContextSavedSessionResumeTarget()
+	session.SessionID = "  session-1  "
+
+	ctx, _, err := newFlowLaunchContext(savedSessionResumeTarget{
+		LaunchID: "launch-1", Record: record, Session: session,
+	}, launchContextVariantSettings(), flowLaunchRouting{})
+	if err != nil {
+		t.Fatalf("newFlowLaunchContext: %v", err)
+	}
+	if ctx.ResumeSessionID != "  session-1  " {
+		t.Fatalf("resume session id = %q, want the untrimmed session ID", ctx.ResumeSessionID)
 	}
 }

--- a/model/flow_launch_lifecycle.go
+++ b/model/flow_launch_lifecycle.go
@@ -907,7 +907,7 @@ func (m Model) handleFlowLaunchEvent(msg flowLaunchEventMsg) (Model, tea.Cmd) {
 		}
 		m = next.withFlowLaunchAttemptPhase(attempt.FlowID, attempt.Token, msg.PhaseID)
 		if msg.Kind == flowLaunchKindSavedSessionResume {
-			return m, m.savedSessionFlowLaunchPrepareCmd(msg)
+			return m, m.savedSessionFlowLaunchPrepareCmd(msg, settings)
 		}
 		return m, m.flowLaunchPrepareCmd(msg, settings)
 	case flowLaunchStagePrepared:

--- a/model/flow_launch_saved_session_resume.go
+++ b/model/flow_launch_saved_session_resume.go
@@ -6,7 +6,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
 )
@@ -205,13 +204,18 @@ func validateSavedSessionResumeFlow(flowID string, record flowstore.FlowRecord, 
 	return nil
 }
 
-func (m Model) savedSessionFlowLaunchPrepareCmd(msg flowLaunchEventMsg) tea.Cmd {
+func (m Model) savedSessionFlowLaunchPrepareCmd(
+	msg flowLaunchEventMsg,
+	settings flowLaunchAgentSettingsSnapshot,
+) tea.Cmd {
 	reserve := m.reserveFlowLaunch
 	seams := m.launchSeams
-	stamp := m.launchStamp()
-	sessionStateRoot := m.sessionStateRoot
-	if root := strings.TrimSpace(m.flowLaunchAttempts[msg.FlowID].Settings.SessionStateRoot); root != "" {
-		sessionStateRoot = root
+	// The snapshot is frozen at admission and the Model field is live, but they
+	// are the same value: flowLaunchPreparation sources SessionStateRoot, Pin and
+	// Control from these Model fields. The fallback keeps a snapshot that never
+	// carried a root — a synthesized attempt in a test — pointed at the Model's.
+	if strings.TrimSpace(settings.SessionStateRoot) == "" {
+		settings.SessionStateRoot = m.sessionStateRoot
 	}
 	return func() tea.Msg {
 		event := flowLaunchEventMsg{
@@ -223,7 +227,6 @@ func (m Model) savedSessionFlowLaunchPrepareCmd(msg flowLaunchEventMsg) tea.Cmd 
 			Session:    msg.Session,
 			SessionKey: msg.SessionKey,
 			RepoPath:   msg.Session.RepoPath,
-			Route:      flowLaunchRouteEmbedded,
 		}
 		if reserve == nil {
 			event.Err = "Flow launch reservation is unavailable"
@@ -232,7 +235,7 @@ func (m Model) savedSessionFlowLaunchPrepareCmd(msg flowLaunchEventMsg) tea.Cmd 
 		// Ahead of the reservation, as on every other route: a resume bakes the
 		// pinned path into the resumed session's hook argv just as a fresh
 		// launch does, so an unusable pin is refused before anything is held.
-		if refusal := refuseUnverifiedLaunchPin(stamp.Pin); refusal != "" {
+		if refusal := refuseUnverifiedLaunchPin(settings.Pin); refusal != "" {
 			event.Err = refusal
 			return event
 		}
@@ -286,33 +289,23 @@ func (m Model) savedSessionFlowLaunchPrepareCmd(msg flowLaunchEventMsg) tea.Cmd 
 			event.Err = err.Error()
 			return event
 		}
-		workingDir := refreshed.CWD
-		if strings.TrimSpace(workingDir) == "" {
-			workingDir = refreshed.WorktreePath
-		}
-		if strings.TrimSpace(workingDir) == "" {
-			event.Err = "Session has no worktree path or cwd to resume from"
-			return event
-		}
 		event.Record = record
 		event.Session = refreshed
 		event.RepoPath = refreshed.RepoPath
-		event.Context = applyLaunchStamp(actions.AgentLaunchContext{
-			Command:                string(refreshed.Provider),
-			LaunchID:               msg.Token,
-			RepoPath:               refreshed.RepoPath,
-			WorktreePath:           refreshed.WorktreePath,
-			WorkingDir:             workingDir,
-			Branch:                 refreshed.Branch,
-			Commit:                 refreshed.Commit,
-			SessionStateRoot:       sessionStateRoot,
-			ResumeSessionID:        refreshed.SessionID,
-			PlanID:                 refreshed.PlanID,
-			PlanPath:               refreshed.PlanPath,
-			FlowID:                 record.FlowID,
-			FlowSavedSessionResume: true,
-			Embedded:               true,
-		}, stamp)
+		// The builder owns the working-dir ladder and the resume marker, and it
+		// is what refuses a session with neither cwd nor worktree — including
+		// the wording of that refusal.
+		ctx, decision, err := newFlowLaunchContext(savedSessionResumeTarget{
+			LaunchID: msg.Token,
+			Record:   record,
+			Session:  refreshed,
+		}, settings, flowLaunchRouting{})
+		if err != nil {
+			event.Err = err.Error()
+			return event
+		}
+		event.Context = ctx
+		event.Route = decision.Route
 		return event
 	}
 }


### PR DESCRIPTION
## Problem

Saved-session resume was the last untracked Flow launch kind still hand-assembling its `actions.AgentLaunchContext` as a struct literal at the call site. `actions.resumeSessionIDForContext` validates a strict shape for that role — resume marker set, a Flow ID, no phase/tracked/repair/agent/autofix markers, embedded, no prompt, a non-blank session ID — and every one of those fields was transcribed by hand in the prepare stage. Every sibling launch kind (repair, autofix, tracked) had already moved behind `newFlowLaunchContext`; this one kept its own copy of the rules.

## Solution

Add a `savedSessionResumeTarget` role handled by `newFlowLaunchContext`, so the shape is produced by construction in the single place every Flow launch context is built. The role encodes the two rules unique to it:

- The session ID is assigned **untrimmed** — this path returns it verbatim, unlike every other role.
- Setting `FlowSavedSessionResume` is what stops `agentCommandSpec` from re-resolving the worktree commit over the session's.

Command comes from the session's provider rather than the settings snapshot, and `Model`/`ReasoningEffort` stay empty because `agentCommandSpec` refuses a resume that carries them.

The prepare stage now takes the settings snapshot its siblings already take and submits the payload. Everything ahead of the build is untouched: the reservation, the lease re-check, the exact-key refresh, the tmux live-window probes, and the Flow re-validation. The no-working-directory refusal keeps its exact wording, now as `errSavedSessionResumeNoWorkingDir`, so the user-visible status is unchanged.

## Verification

Refactor with a pinned interface test. The variant table gains a saved-resume row comparing the whole struct, plus rejection, working-directory precedence, and untrimmed-session-ID cases.

Verified with `make fmt-check`, `make build`, and `make test`.