### PR TITLE
Fix remaining P1 robustness findings from audit #277

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -132,31 +132,35 @@ type PullRequestStatus struct {
 // then prunes stale references to ensure the worktree no longer appears
 // in listings.
 func RemoveWorktree(repoPath, worktreePath string) error {
-	err := exec.Command("git", "-C", repoPath, "worktree", "remove", worktreePath).Run()
-	if err == nil {
-		_ = exec.Command("git", "-C", repoPath, "worktree", "prune").Run()
+	if err := runGit(repoPath, "worktree", "remove", worktreePath); err != nil {
+		return err
 	}
-	return err
+	if err := runGit(repoPath, "worktree", "prune"); err != nil {
+		return fmt.Errorf("worktree removed but prune failed: %w", err)
+	}
+	return nil
 }
 
 // ForceRemoveWorktree runs `git worktree remove --force`, then prunes
 // stale references.
 func ForceRemoveWorktree(repoPath, worktreePath string) error {
-	err := exec.Command("git", "-C", repoPath, "worktree", "remove", "--force", worktreePath).Run()
-	if err == nil {
-		_ = exec.Command("git", "-C", repoPath, "worktree", "prune").Run()
+	if err := runGit(repoPath, "worktree", "remove", "--force", worktreePath); err != nil {
+		return err
 	}
-	return err
+	if err := runGit(repoPath, "worktree", "prune"); err != nil {
+		return fmt.Errorf("worktree removed but prune failed: %w", err)
+	}
+	return nil
 }
 
 // PruneWorktree runs `git worktree prune` to remove stale admin references.
 func PruneWorktree(repoPath string) error {
-	return exec.Command("git", "-C", repoPath, "worktree", "prune").Run()
+	return runGit(repoPath, "worktree", "prune")
 }
 
 // UnlockWorktree runs `git worktree unlock` for the given worktree path.
 func UnlockWorktree(repoPath, worktreePath string) error {
-	return exec.Command("git", "-C", repoPath, "worktree", "unlock", worktreePath).Run()
+	return runGit(repoPath, "worktree", "unlock", worktreePath)
 }
 
 // MoveWorktree runs `git worktree move` for a linked worktree and returns the
@@ -243,10 +247,18 @@ func runGit(path string, args ...string) error {
 		if msg == "" {
 			return err
 		}
-		return errors.New(msg)
+		return gitCommandError{message: msg, cause: err}
 	}
 	return nil
 }
+
+type gitCommandError struct {
+	message string
+	cause   error
+}
+
+func (e gitCommandError) Error() string { return e.message }
+func (e gitCommandError) Unwrap() error { return e.cause }
 
 // RunBootstrapHook executes a configured bootstrap script directly, with the
 // created worktree as its working directory.
@@ -1719,7 +1731,9 @@ func claudeSessionHookSettings(hookCommand string) string {
 // approachSessionHookCommand builds the provider hook argv. It takes the pinned
 // executable rather than calling os.Executable itself so the hook and
 // APPROACH_EXECUTABLE can never name different builds; an empty pin keeps the
-// previous running-binary behaviour for untracked launches.
+// previous running-binary behaviour for untracked launches. The executable is
+// path data crossing a shell boundary and must remain shellQuote'd. Provider is
+// a closed value supplied only by agentLaunchArgs, never untrusted input.
 func approachSessionHookCommand(provider, executable string) string {
 	if strings.TrimSpace(executable) == "" {
 		resolved, err := os.Executable()

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -128,6 +128,17 @@ type PullRequestStatus struct {
 	Checks       string
 }
 
+// ErrWorktreePruneFailed reports that git removed the worktree but failed to
+// prune stale admin references. Callers should treat the worktree as gone.
+var ErrWorktreePruneFailed = errors.New("worktree removed but prune failed")
+
+func pruneAfterWorktreeRemove(repoPath string) error {
+	if err := runGit(repoPath, "worktree", "prune"); err != nil {
+		return fmt.Errorf("%w: %w", ErrWorktreePruneFailed, err)
+	}
+	return nil
+}
+
 // RemoveWorktree runs `git worktree remove` for the given worktree path,
 // then prunes stale references to ensure the worktree no longer appears
 // in listings.
@@ -135,10 +146,7 @@ func RemoveWorktree(repoPath, worktreePath string) error {
 	if err := runGit(repoPath, "worktree", "remove", worktreePath); err != nil {
 		return err
 	}
-	if err := runGit(repoPath, "worktree", "prune"); err != nil {
-		return fmt.Errorf("worktree removed but prune failed: %w", err)
-	}
-	return nil
+	return pruneAfterWorktreeRemove(repoPath)
 }
 
 // ForceRemoveWorktree runs `git worktree remove --force`, then prunes
@@ -147,10 +155,7 @@ func ForceRemoveWorktree(repoPath, worktreePath string) error {
 	if err := runGit(repoPath, "worktree", "remove", "--force", worktreePath); err != nil {
 		return err
 	}
-	if err := runGit(repoPath, "worktree", "prune"); err != nil {
-		return fmt.Errorf("worktree removed but prune failed: %w", err)
-	}
-	return nil
+	return pruneAfterWorktreeRemove(repoPath)
 }
 
 // PruneWorktree runs `git worktree prune` to remove stale admin references.

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -194,10 +194,18 @@ exit 2
 	if err == nil {
 		t.Fatal("RemoveWorktree() error = nil, want prune failure")
 	}
+	if !errors.Is(err, actions.ErrWorktreePruneFailed) {
+		t.Fatalf("RemoveWorktree() error = %v, want ErrWorktreePruneFailed", err)
+	}
 	for _, want := range []string{"worktree removed but prune failed", "prune unavailable"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("RemoveWorktree() error = %q, want %q", err, want)
 		}
+	}
+
+	err = actions.ForceRemoveWorktree("/repo", "/worktree")
+	if !errors.Is(err, actions.ErrWorktreePruneFailed) {
+		t.Fatalf("ForceRemoveWorktree() error = %v, want ErrWorktreePruneFailed", err)
 	}
 }
 

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -170,6 +170,35 @@ func TestRemoveWorktree_Error(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for nonexistent paths, got nil")
 	}
+	if !strings.Contains(err.Error(), "cannot change to") {
+		t.Fatalf("RemoveWorktree() error = %q, want git stderr diagnostic", err)
+	}
+}
+
+func TestRemoveWorktreeReportsSuccessfulRemovalWhenPruneFails(t *testing.T) {
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	script := `#!/bin/sh
+case " $* " in
+  *" worktree remove "*) exit 0 ;;
+  *" worktree prune "*) echo "prune unavailable" >&2; exit 1 ;;
+esac
+exit 2
+`
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	err := actions.RemoveWorktree("/repo", "/worktree")
+	if err == nil {
+		t.Fatal("RemoveWorktree() error = nil, want prune failure")
+	}
+	for _, want := range []string{"worktree removed but prune failed", "prune unavailable"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("RemoveWorktree() error = %q, want %q", err, want)
+		}
+	}
 }
 
 func TestMoveWorktree(t *testing.T) {

--- a/actions/agent_launch_internal_test.go
+++ b/actions/agent_launch_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -727,6 +728,34 @@ func TestSessionHookCommandFallsBackToRunningBinary(t *testing.T) {
 	}
 	if got := approachSessionHookCommand("claude", ""); got != shellQuote(executable)+" session-hook --provider claude" {
 		t.Fatalf("hook command = %q", got)
+	}
+}
+
+func TestSessionHookCommandTreatsExecutablePathAsOneShellWord(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("session hooks use a POSIX shell command")
+	}
+	tmp := t.TempDir()
+	executable := filepath.Join(tmp, "approach $(touch pwned_hook) 'quoted'")
+	argsPath := filepath.Join(tmp, "hook-args")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + shellQuote(argsPath) + "\n"
+	if err := os.WriteFile(executable, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("sh", "-c", approachSessionHookCommand("claude", executable))
+	cmd.Dir = tmp
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("session hook command failed: %v\n%s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "pwned_hook")); !os.IsNotExist(err) {
+		t.Fatalf("command substitution escaped executable quoting: %v", err)
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(args), "session-hook\n--provider\nclaude\n"; got != want {
+		t.Fatalf("hook argv = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/approach/plan.go
+++ b/cmd/approach/plan.go
@@ -182,10 +182,22 @@ func runPlanSave(args []string, deps runDeps) error {
 		if err != nil {
 			return fmt.Errorf("encode saved plan: %w", err)
 		}
-		fmt.Fprintln(deps.stdout, string(data))
-		return nil
+		return writePlanLine(deps.stdout, string(data), "saved plan JSON")
 	}
-	fmt.Fprintln(deps.stdout, savedID)
+	return writePlanLine(deps.stdout, savedID, "saved plan id")
+}
+
+func writePlanLine(w io.Writer, value, label string) error {
+	if _, err := fmt.Fprintln(w, value); err != nil {
+		return fmt.Errorf("write %s: %w", label, err)
+	}
+	return nil
+}
+
+func writePlanText(w io.Writer, value, label string) error {
+	if _, err := fmt.Fprint(w, value); err != nil {
+		return fmt.Errorf("write %s: %w", label, err)
+	}
 	return nil
 }
 
@@ -276,8 +288,7 @@ func runPlanList(args []string, deps runDeps) error {
 	if err != nil {
 		return fmt.Errorf("encode plan list: %w", err)
 	}
-	fmt.Fprintln(deps.stdout, string(data))
-	return nil
+	return writePlanLine(deps.stdout, string(data), "plan list JSON")
 }
 
 func runPlanRead(args []string, deps runDeps) error {
@@ -321,11 +332,9 @@ func runPlanRead(args []string, deps runDeps) error {
 		if err != nil {
 			return fmt.Errorf("encode plan: %w", err)
 		}
-		fmt.Fprintln(deps.stdout, string(data))
-		return nil
+		return writePlanLine(deps.stdout, string(data), "plan JSON")
 	}
-	fmt.Fprint(deps.stdout, markdown)
-	return nil
+	return writePlanText(deps.stdout, markdown, "plan Markdown")
 }
 
 func runPlanStatus(args []string, deps runDeps) error {
@@ -371,8 +380,7 @@ func runPlanStatus(args []string, deps runDeps) error {
 	if err != nil {
 		return fmt.Errorf("encode plan: %w", err)
 	}
-	fmt.Fprintln(deps.stdout, string(data))
-	return nil
+	return writePlanLine(deps.stdout, string(data), "plan status JSON")
 }
 
 func printPlanStatusSetHelp(w io.Writer) {
@@ -629,10 +637,29 @@ func planRepoPathFromGitCommonDir(commonDir string) string {
 }
 
 func planGitOutput(cwd string, args ...string) (string, error) {
-	cmd := exec.Command("git", append([]string{"-C", cwd}, args...)...)
+	cleaned, err := plausiblePlanGitCWD(cwd)
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command("git", append([]string{"-C", cleaned}, args...)...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+func plausiblePlanGitCWD(cwd string) (string, error) {
+	cwd = filepath.Clean(strings.TrimSpace(cwd))
+	if cwd == "." || !filepath.IsAbs(cwd) {
+		return "", fmt.Errorf("git cwd must be an absolute path")
+	}
+	info, err := os.Stat(cwd)
+	if err != nil {
+		return "", fmt.Errorf("inspect git cwd %q: %w", cwd, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("git cwd %q is not a directory", cwd)
+	}
+	return cwd, nil
 }

--- a/cmd/approach/plan_test.go
+++ b/cmd/approach/plan_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -354,6 +355,21 @@ func TestRunPlanStatusSetPreservesPlanContentAndPhases(t *testing.T) {
 	}
 }
 
+func TestRunPlanStatusSetReturnsWriterFailure(t *testing.T) {
+	root := t.TempDir()
+	mustRun(t, []string{"approach", "plan", "save", "--title", "Lifecycle", "--plan-id", "lifecycle", "--state-root", root}, "body")
+	wantErr := errors.New("stdout unavailable")
+	err := run([]string{
+		"approach", "plan", "status", "set",
+		"--plan-id", "lifecycle",
+		"--status", "in_progress",
+		"--state-root", root,
+	}, noScanDeps(t, runDeps{stdout: failingWriter{err: wantErr}}))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("run error = %v, want stdout writer failure", err)
+	}
+}
+
 func TestRunPlanStatusSetRejectsPositionalArgumentsBeforeOpeningTheStore(t *testing.T) {
 	root := t.TempDir()
 	if err := run([]string{
@@ -558,6 +574,24 @@ func TestRunPlanSaveFromLinkedWorktreeUsesRootRepoPath(t *testing.T) {
 	}
 	if record.Commit == "" {
 		t.Fatal("expected commit metadata from linked worktree")
+	}
+}
+
+func TestRunPlanSaveDoesNotResolveGitMetadataFromRelativeCWD(t *testing.T) {
+	stateRoot := t.TempDir()
+	var stdout bytes.Buffer
+	err := run([]string{"approach", "plan", "save", "--title", "Relative", "--plan-id", "relative", "--state-root", stateRoot},
+		noScanDeps(t, runDeps{
+			getwd:  func() (string, error) { return ".", nil },
+			stdin:  strings.NewReader("body"),
+			stdout: &stdout,
+		}))
+	if err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	record := readPlanRecord(t, stateRoot, "relative")
+	if record.RepoPath != "" || record.WorktreePath != "" || record.Branch != "" || record.Commit != "" {
+		t.Fatalf("relative cwd resolved process-directory Git metadata: %#v", record)
 	}
 }
 
@@ -766,6 +800,17 @@ func TestRunPlanListRequiresJSON(t *testing.T) {
 	}
 }
 
+func TestRunPlanListReturnsWriterFailure(t *testing.T) {
+	root := t.TempDir()
+	mustRun(t, []string{"approach", "plan", "save", "--title", "Alpha", "--plan-id", "alpha", "--state-root", root}, "body")
+	wantErr := errors.New("stdout unavailable")
+	err := run([]string{"approach", "plan", "list", "--json", "--state-root", root},
+		noScanDeps(t, runDeps{stdout: failingWriter{err: wantErr}}))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("run error = %v, want stdout writer failure", err)
+	}
+}
+
 func TestRunPlanReadPrintsMarkdownOnly(t *testing.T) {
 	root := t.TempDir()
 	mustRun(t, []string{"approach", "plan", "save", "--title", "Readable", "--plan-id", "readable", "--state-root", root}, "# Readable\n\nbody\n")
@@ -781,11 +826,53 @@ func TestRunPlanReadPrintsMarkdownOnly(t *testing.T) {
 	}
 }
 
+func TestRunPlanReadReturnsWriterFailure(t *testing.T) {
+	root := t.TempDir()
+	mustRun(t, []string{"approach", "plan", "save", "--title", "Readable", "--plan-id", "readable", "--state-root", root}, "body")
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "markdown", args: []string{"approach", "plan", "read", "--plan-id", "readable", "--state-root", root}},
+		{name: "json", args: []string{"approach", "plan", "read", "--plan-id", "readable", "--state-root", root, "--json"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			wantErr := errors.New("stdout unavailable")
+			err := run(tc.args, noScanDeps(t, runDeps{stdout: failingWriter{err: wantErr}}))
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("run error = %v, want stdout writer failure", err)
+			}
+		})
+	}
+}
+
 func TestRunPlanSaveRequiresTitle(t *testing.T) {
 	err := run([]string{"approach", "plan", "save", "--state-root", t.TempDir()},
 		noScanDeps(t, runDeps{stdin: strings.NewReader("body"), stdout: &bytes.Buffer{}}))
 	if err == nil {
 		t.Fatal("expected error requiring --title")
+	}
+}
+
+func TestRunPlanSaveReturnsWriterFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		json bool
+	}{
+		{name: "plain"},
+		{name: "json", json: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := []string{"approach", "plan", "save", "--title", "Writable", "--plan-id", "writable", "--state-root", t.TempDir()}
+			if tc.json {
+				args = append(args, "--json")
+			}
+			wantErr := errors.New("stdout unavailable")
+			err := run(args, noScanDeps(t, runDeps{stdin: strings.NewReader("body"), stdout: failingWriter{err: wantErr}}))
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("run error = %v, want stdout writer failure", err)
+			}
+		})
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -563,8 +563,12 @@ func saveAgentConfigTo(path string, options []Option, patch func([]byte) []byte)
 
 func lockedConfigUpdate(path string, options []Option, createIfMissing bool, patch func([]byte) []byte) error {
 	opts := defaultOptions(options...)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("create config dir %s: %w", filepath.Dir(path), err)
+	configDir := filepath.Dir(path)
+	if err := os.MkdirAll(configDir, artifacts.DirPerm); err != nil {
+		return fmt.Errorf("create config dir %s: %w", configDir, err)
+	}
+	if err := os.Chmod(configDir, artifacts.DirPerm); err != nil {
+		return fmt.Errorf("secure config dir %s: %w", configDir, err)
 	}
 	release, err := acquireConfigFileLock(path+".lock", fmt.Sprintf("config lock %q", path), opts.lockTimeout)
 	if err != nil {
@@ -580,15 +584,20 @@ func lockedConfigUpdate(path string, options []Option, createIfMissing bool, pat
 		if !createIfMissing {
 			return nil
 		}
-	} else if _, err := parseConfigData(path, data, opts); err != nil {
-		return err
+	} else {
+		if err := os.Chmod(path, artifacts.FilePerm); err != nil {
+			return fmt.Errorf("secure config %s: %w", path, err)
+		}
+		if _, err := parseConfigData(path, data, opts); err != nil {
+			return err
+		}
 	}
 
 	patched := patch(data)
 	if bytes.Equal(patched, data) {
 		return nil
 	}
-	if err := os.WriteFile(path, patched, 0o644); err != nil {
+	if err := artifacts.WriteFileAtomic(path, patched); err != nil {
 		return fmt.Errorf("write config %s: %w", path, err)
 	}
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -597,10 +597,32 @@ func lockedConfigUpdate(path string, options []Option, createIfMissing bool, pat
 	if bytes.Equal(patched, data) {
 		return nil
 	}
-	if err := artifacts.WriteFileAtomic(path, patched); err != nil {
+	writePath, err := resolveConfigWritePath(path)
+	if err != nil {
+		return err
+	}
+	if err := artifacts.WriteFileAtomic(writePath, patched); err != nil {
 		return fmt.Errorf("write config %s: %w", path, err)
 	}
 	return nil
+}
+
+func resolveConfigWritePath(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return path, nil
+		}
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return path, nil
+	}
+	target, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve config symlink %s: %w", path, err)
+	}
+	return target, nil
 }
 
 func patchAgentCommand(data []byte, command string) []byte {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -835,6 +835,51 @@ func TestSaveAgentCommand_UpdatesExistingAgentSection(t *testing.T) {
 	}
 }
 
+func TestSaveAgentCommand_UpdatesSymlinkTarget(t *testing.T) {
+	xdg := t.TempDir()
+	managed := filepath.Join(t.TempDir(), "managed-config.toml")
+	if err := os.WriteFile(managed, []byte("[agent]\ncommand = \"codex\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(xdg, "approach", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(managed, path); err != nil {
+		t.Fatal(err)
+	}
+
+	err := config.SaveAgentCommand("claude",
+		config.WithGetenv(func(key string) string {
+			if key == "XDG_CONFIG_HOME" {
+				return xdg
+			}
+			return ""
+		}),
+		config.WithHomeDir(func() (string, error) {
+			return t.TempDir(), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("SaveAgentCommand returned error: %v", err)
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("config.toml should remain a symlink")
+	}
+	raw, err := os.ReadFile(managed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `command = "claude"`) {
+		t.Fatalf("managed target = %q, want updated command", raw)
+	}
+}
+
 func TestSaveAgentReasoningEffort_CreatesMissingConfig(t *testing.T) {
 	xdg := t.TempDir()
 	err := config.SaveAgentReasoningEffort("codex", "high",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -546,6 +546,18 @@ func TestSaveAgentCommand_CreatesMissingConfig(t *testing.T) {
 	if cfg.Agent.Command != "claude" {
 		t.Fatalf("expected saved agent claude, got %q", cfg.Agent.Command)
 	}
+	for checkedPath, want := range map[string]os.FileMode{
+		filepath.Dir(path): 0o700,
+		path:               0o600,
+	} {
+		info, err := os.Stat(checkedPath)
+		if err != nil {
+			t.Fatalf("Stat(%s) error = %v", checkedPath, err)
+		}
+		if got := info.Mode().Perm(); got != want {
+			t.Fatalf("%s mode = %o, want %o", checkedPath, got, want)
+		}
+	}
 }
 
 func TestLoadFrom_NormalizesStoredCodexAppAgent(t *testing.T) {
@@ -652,6 +664,35 @@ func TestLoadFrom_RejectsInvalidModels(t *testing.T) {
 				t.Fatalf("expected error to mention %q, got %q", tt.want, err.Error())
 			}
 		})
+	}
+}
+
+func TestSaveAgentCommand_RepairsPermissiveConfigOnNoOp(t *testing.T) {
+	configHome := t.TempDir()
+	configDir := filepath.Join(configHome, "approach")
+	path := filepath.Join(configDir, "config.toml")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("[agent]\ncommand = \"codex\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveAgentCommand("codex", config.WithGetenv(func(key string) string {
+		if key == "XDG_CONFIG_HOME" {
+			return configHome
+		}
+		return ""
+	})); err != nil {
+		t.Fatalf("SaveAgentCommand() error = %v", err)
+	}
+	for checkedPath, want := range map[string]os.FileMode{configDir: 0o700, path: 0o600} {
+		info, err := os.Stat(checkedPath)
+		if err != nil {
+			t.Fatalf("Stat(%s) error = %v", checkedPath, err)
+		}
+		if got := info.Mode().Perm(); got != want {
+			t.Fatalf("%s mode = %o, want %o", checkedPath, got, want)
+		}
 	}
 }
 

--- a/config/locking_internal_test.go
+++ b/config/locking_internal_test.go
@@ -132,7 +132,8 @@ func TestAllConfigMutationFamiliesSerializeAtOneTransactionLock(t *testing.T) {
 	if strings.Contains(text, "plan_prompt") {
 		t.Fatalf("config retained reset target:\n%s", text)
 	}
-	assertConfigLockMode(t, path, 0o644)
+	assertConfigLockMode(t, filepath.Dir(path), 0o700)
+	assertConfigLockMode(t, path, 0o600)
 	assertConfigLockMode(t, lockPath, 0o600)
 }
 

--- a/embeddedterm/terminal.go
+++ b/embeddedterm/terminal.go
@@ -61,6 +61,14 @@ var newEmulator = func(width, height int) (*vt.SafeEmulator, error) {
 	return vt.NewSafeEmulator(width, height), nil
 }
 
+var closeFailedStartPTY = func(ptmx *os.File) error {
+	return ptmx.Close()
+}
+
+var terminateFailedStartProcess = terminateProcessGroup
+
+var waitFailedStartProcess = waitForTerminatedCommandExit
+
 type Manager struct{}
 
 func NewManager() *Manager {
@@ -100,10 +108,7 @@ func (m *Manager) StartCommandWithOptions(ctx context.Context, cmd *exec.Cmd, wi
 	}
 	emu, err := newEmulator(width, height)
 	if err != nil {
-		_ = ptmx.Close()
-		_ = terminateProcessGroup(cmd)
-		_ = waitForCommandExit(cmd, terminateWaitTimeout)
-		return nil, err
+		return nil, errors.Join(err, cleanupFailedStart(ptmx, cmd))
 	}
 	emu.SetScrollbackSize(defaultScrollbackLines)
 	t := &Terminal{
@@ -490,6 +495,30 @@ func waitForCommandExit(cmd *exec.Cmd, timeout time.Duration) error {
 	case <-time.After(timeout):
 		return context.DeadlineExceeded
 	}
+}
+
+func waitForTerminatedCommandExit(cmd *exec.Cmd, timeout time.Duration) error {
+	err := waitForCommandExit(cmd, timeout)
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return nil
+	}
+	return err
+}
+
+func cleanupFailedStart(ptmx *os.File, cmd *exec.Cmd) error {
+	return errors.Join(
+		wrapCleanupError("close pty", closeFailedStartPTY(ptmx)),
+		wrapCleanupError("terminate process", terminateFailedStartProcess(cmd)),
+		wrapCleanupError("wait for process", waitFailedStartProcess(cmd, terminateWaitTimeout)),
+	)
+}
+
+func wrapCleanupError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", operation, err)
 }
 
 type terminalQueryFilter struct {

--- a/embeddedterm/terminal_test.go
+++ b/embeddedterm/terminal_test.go
@@ -761,6 +761,48 @@ func TestTerminalStartCommandCleansUpProcessWhenEmulatorCreationFails(t *testing
 	}
 }
 
+func TestTerminalStartCommandJoinsEmulatorAndCleanupFailures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pty tests require a Unix-like platform")
+	}
+	emulatorErr := errors.New("emulator failed")
+	closeErr := errors.New("close pty failed")
+	terminateErr := errors.New("terminate process failed")
+	waitErr := errors.New("wait process failed")
+	originalFactory := newEmulator
+	originalClose := closeFailedStartPTY
+	originalTerminate := terminateFailedStartProcess
+	originalWait := waitFailedStartProcess
+	t.Cleanup(func() {
+		newEmulator = originalFactory
+		closeFailedStartPTY = originalClose
+		terminateFailedStartProcess = originalTerminate
+		waitFailedStartProcess = originalWait
+	})
+	newEmulator = func(int, int) (*vt.SafeEmulator, error) { return nil, emulatorErr }
+	closeFailedStartPTY = func(ptmx *os.File) error {
+		_ = originalClose(ptmx)
+		return closeErr
+	}
+	terminateFailedStartProcess = func(cmd *exec.Cmd) error {
+		_ = originalTerminate(cmd)
+		return terminateErr
+	}
+	waitFailedStartProcess = func(cmd *exec.Cmd, timeout time.Duration) error {
+		_ = originalWait(cmd, timeout)
+		return waitErr
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := NewManager().StartCommand(ctx, exec.CommandContext(ctx, "sh", "-c", "sleep 30"), 20, 2)
+	for _, want := range []error{emulatorErr, closeErr, terminateErr, waitErr} {
+		if !errors.Is(err, want) {
+			t.Fatalf("StartCommand() error = %v, want joined %v", err, want)
+		}
+	}
+}
+
 func TestTerminalAddsTermOnlyWhenAbsentOrDumb(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("pty tests require a Unix-like platform")

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -1,8 +1,10 @@
 package gitquery
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -185,17 +187,13 @@ func (q *Querier) readDirtyStatus(path string) (files, added, deleted int, err e
 
 func (q *Querier) populateWorktreeDirtyStatus(wt *Worktree) error {
 	files, added, deleted, err := q.readDirtyStatus(wt.Path)
-	if err != nil {
-		return err
+	if files > 0 {
+		wt.Dirty = true
+		wt.FilesChanged = files
+		wt.LinesAdded = added
+		wt.LinesDeleted = deleted
 	}
-	if files == 0 {
-		return nil
-	}
-	wt.Dirty = true
-	wt.FilesChanged = files
-	wt.LinesAdded = added
-	wt.LinesDeleted = deleted
-	return nil
+	return err
 }
 
 // ListCommits returns the most recent 50 commits for the given repo path.
@@ -461,6 +459,9 @@ func (q *Querier) defaultCleanupBranch(repoPath string, branchLines []string, fa
 	}
 	out, err := q.git.Run(repoPath, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
 	if err != nil {
+		if isQuietRefMiss(err) {
+			return "", nil
+		}
 		return "", err
 	}
 	ref := strings.TrimSpace(out)
@@ -486,18 +487,21 @@ func (q *Querier) unpushedCommits(repoPath, branchName, upstream string) ([]stri
 func (q *Querier) populateDirtyStatus(b *Branch, paths []string, warnings *queryWarnings) {
 	for _, path := range paths {
 		files, added, deleted, err := q.readDirtyStatus(path)
+		if files > 0 {
+			b.Dirty = true
+			b.FilesChanged += files
+			b.LinesAdded += added
+			b.LinesDeleted += deleted
+		}
 		if err != nil {
 			warnings.add("dirty status", path, err)
-			continue
 		}
-		if files == 0 {
-			continue
-		}
-		b.Dirty = true
-		b.FilesChanged += files
-		b.LinesAdded += added
-		b.LinesDeleted += deleted
 	}
+}
+
+func isQuietRefMiss(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && exitErr.ExitCode() == 1
 }
 
 func checkStale(paths []string) []bool {

--- a/gitquery/gitquery.go
+++ b/gitquery/gitquery.go
@@ -116,6 +116,7 @@ func (q *Querier) CurrentBranch(path string) (string, error) {
 // ListWorktrees returns non-bare worktree checkouts for the given repo.
 // Bare roots are omitted, so a central bare repository can return zero rows.
 func (q *Querier) ListWorktrees(repoPath string) ([]Worktree, error) {
+	var warnings queryWarnings
 	out, err := q.git.Run(repoPath, "worktree", "list", "--porcelain")
 	if err != nil {
 		return nil, err
@@ -151,11 +152,13 @@ func (q *Querier) ListWorktrees(repoPath string) ([]Worktree, error) {
 	for i := range worktrees {
 		worktrees[i].Stale = staleFlags[i]
 		if !worktrees[i].Stale {
-			q.populateWorktreeDirtyStatus(&worktrees[i])
+			if err := q.populateWorktreeDirtyStatus(&worktrees[i]); err != nil {
+				warnings.add("dirty status", worktrees[i].Path, err)
+			}
 		}
 	}
 
-	return worktrees, nil
+	return worktrees, warnings.err()
 }
 
 // readDirtyStatus inspects a worktree path and reports how many files are
@@ -180,15 +183,19 @@ func (q *Querier) readDirtyStatus(path string) (files, added, deleted int, err e
 	return files, added, deleted, nil
 }
 
-func (q *Querier) populateWorktreeDirtyStatus(wt *Worktree) {
-	files, added, deleted, _ := q.readDirtyStatus(wt.Path)
+func (q *Querier) populateWorktreeDirtyStatus(wt *Worktree) error {
+	files, added, deleted, err := q.readDirtyStatus(wt.Path)
+	if err != nil {
+		return err
+	}
 	if files == 0 {
-		return
+		return nil
 	}
 	wt.Dirty = true
 	wt.FilesChanged = files
 	wt.LinesAdded = added
 	wt.LinesDeleted = deleted
+	return nil
 }
 
 // ListCommits returns the most recent 50 commits for the given repo path.
@@ -291,6 +298,7 @@ func ListBranches(repoPath string) ([]Branch, error) {
 
 // ListBranches returns all local branches sorted alphabetically by name.
 func (q *Querier) ListBranches(repoPath string) ([]Branch, error) {
+	var warnings queryWarnings
 	out, err := q.git.Run(repoPath, "for-each-ref", "--format="+refFormat, "refs/heads/")
 	if err != nil {
 		return nil, err
@@ -302,8 +310,14 @@ func (q *Querier) ListBranches(repoPath string) ([]Branch, error) {
 	}
 
 	lines := splitLines(out)
-	rootBranch := q.rootWorktreeBranch(repoPath, wtMap)
-	cleanupBranch := q.defaultCleanupBranch(repoPath, lines, rootBranch)
+	rootBranch, err := q.rootWorktreeBranch(repoPath, wtMap)
+	if err != nil {
+		warnings.add("root branch", repoPath, err)
+	}
+	cleanupBranch, err := q.defaultCleanupBranch(repoPath, lines, rootBranch)
+	if err != nil {
+		warnings.add("default branch", repoPath, err)
+	}
 
 	branches := make([]Branch, 0, len(lines))
 	for _, line := range lines {
@@ -317,9 +331,16 @@ func (q *Querier) ListBranches(repoPath string) ([]Branch, error) {
 			if err == nil {
 				b.Ahead = ahead
 				b.Behind = behind
+			} else {
+				warnings.add("ahead/behind", b.Name, err)
 			}
 			if b.Ahead > 0 {
-				b.Unpushed = q.unpushedCommits(repoPath, b.Name, upstream)
+				unpushed, err := q.unpushedCommits(repoPath, b.Name, upstream)
+				if err != nil {
+					warnings.add("unpushed commits", b.Name, err)
+				} else {
+					b.Unpushed = unpushed
+				}
 			}
 		}
 
@@ -327,13 +348,18 @@ func (q *Querier) ListBranches(repoPath string) ([]Branch, error) {
 			b.IsWorktree = true
 			b.WorktreePaths = wtPaths
 			b.WorktreeStale = checkStale(wtPaths)
-			q.populateDirtyStatus(&b, wtPaths)
+			q.populateDirtyStatus(&b, nonStalePaths(wtPaths, b.WorktreeStale), &warnings)
 		}
 		// Do not mark the user's active root worktree branch as a cleanup
 		// candidate, even when it is technically an ancestor of cleanupBranch.
-		if cleanupBranch != "" && b.Name != cleanupBranch && b.Name != rootBranch && q.branchMergedInto(repoPath, b.Name, cleanupBranch) {
-			b.Merged = true
-			b.MergedInto = cleanupBranch
+		if cleanupBranch != "" && b.Name != cleanupBranch && b.Name != rootBranch {
+			merged, err := q.branchMergedInto(repoPath, b.Name, cleanupBranch)
+			if err != nil {
+				warnings.add("merged status", b.Name, err)
+			} else if merged {
+				b.Merged = true
+				b.MergedInto = cleanupBranch
+			}
 		}
 
 		branches = append(branches, b)
@@ -346,7 +372,7 @@ func (q *Querier) ListBranches(repoPath string) ([]Branch, error) {
 			WorktreePaths: []string{path},
 			WorktreeStale: checkStale([]string{path}),
 		}
-		q.populateDirtyStatus(&b, b.WorktreePaths)
+		q.populateDirtyStatus(&b, nonStalePaths(b.WorktreePaths, b.WorktreeStale), &warnings)
 		branches = append(branches, b)
 	}
 
@@ -357,7 +383,7 @@ func (q *Querier) ListBranches(repoPath string) ([]Branch, error) {
 		return firstWorktreePath(branches[i].WorktreePaths) < firstWorktreePath(branches[j].WorktreePaths)
 	})
 
-	return branches, nil
+	return branches, warnings.err()
 }
 
 // BranchDiff returns the diff output for a worktree.
@@ -403,18 +429,19 @@ func (q *Querier) branchAheadBehind(repoPath, branchName, upstream string) (int,
 	return ahead, behind, nil
 }
 
-func (q *Querier) rootWorktreeBranch(repoPath string, wtMap map[string][]string) string {
+func (q *Querier) rootWorktreeBranch(repoPath string, wtMap map[string][]string) (string, error) {
 	for branch, paths := range wtMap {
 		for _, path := range paths {
 			if samePath(path, repoPath) {
-				return branch
+				return branch, nil
 			}
 		}
 	}
-	return strings.TrimSpace(q.maybeGitCmd(repoPath, "branch", "--show-current"))
+	out, err := q.git.Run(repoPath, "branch", "--show-current")
+	return strings.TrimSpace(out), err
 }
 
-func (q *Querier) defaultCleanupBranch(repoPath string, branchLines []string, fallback string) string {
+func (q *Querier) defaultCleanupBranch(repoPath string, branchLines []string, fallback string) (string, error) {
 	branches := make(map[string]bool, len(branchLines))
 	for _, line := range branchLines {
 		b, _ := ParseBranchLine(line)
@@ -424,37 +451,45 @@ func (q *Querier) defaultCleanupBranch(repoPath string, branchLines []string, fa
 	}
 	for _, name := range []string{"main", "master"} {
 		if branches[name] {
-			return name
+			return name, nil
 		}
 	}
 	// Repos without main/master fall back to the root worktree branch, treating
 	// branches already merged into that active branch as cleanup candidates.
 	if fallback != "" && branches[fallback] {
-		return fallback
+		return fallback, nil
 	}
-	ref := strings.TrimSpace(q.maybeGitCmd(repoPath, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"))
+	out, err := q.git.Run(repoPath, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+	if err != nil {
+		return "", err
+	}
+	ref := strings.TrimSpace(out)
 	ref = strings.TrimPrefix(ref, "origin/")
 	if branches[ref] {
-		return ref
+		return ref, nil
 	}
-	return ""
+	return "", nil
 }
 
-func (q *Querier) branchMergedInto(repoPath, branchName, cleanupBranch string) bool {
-	return q.git.Ok(repoPath, "merge-base", "--is-ancestor", branchName, cleanupBranch) == nil
+func (q *Querier) branchMergedInto(repoPath, branchName, cleanupBranch string) (bool, error) {
+	return q.git.Predicate(repoPath, "merge-base", "--is-ancestor", branchName, cleanupBranch)
 }
 
-func (q *Querier) unpushedCommits(repoPath, branchName, upstream string) []string {
+func (q *Querier) unpushedCommits(repoPath, branchName, upstream string) ([]string, error) {
 	out, err := q.git.Run(repoPath, "log", "--oneline", upstream+".."+branchName)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return splitLines(out)
+	return splitLines(out), nil
 }
 
-func (q *Querier) populateDirtyStatus(b *Branch, paths []string) {
+func (q *Querier) populateDirtyStatus(b *Branch, paths []string, warnings *queryWarnings) {
 	for _, path := range paths {
-		files, added, deleted, _ := q.readDirtyStatus(path)
+		files, added, deleted, err := q.readDirtyStatus(path)
+		if err != nil {
+			warnings.add("dirty status", path, err)
+			continue
+		}
 		if files == 0 {
 			continue
 		}
@@ -478,6 +513,16 @@ func checkStale(paths []string) []bool {
 	return stale
 }
 
+func nonStalePaths(paths []string, stale []bool) []string {
+	fresh := make([]string, 0, len(paths))
+	for i, path := range paths {
+		if i >= len(stale) || !stale[i] {
+			fresh = append(fresh, path)
+		}
+	}
+	return fresh
+}
+
 func firstWorktreePath(paths []string) string {
 	if len(paths) == 0 {
 		return ""
@@ -494,14 +539,6 @@ func canonicalPath(path string) string {
 		return filepath.Clean(abs)
 	}
 	return filepath.Clean(path)
-}
-
-func (q *Querier) maybeGitCmd(dir string, args ...string) string {
-	out, err := q.git.Run(dir, args...)
-	if err != nil {
-		return ""
-	}
-	return out
 }
 
 func splitLines(s string) []string {

--- a/gitquery/partial_query.go
+++ b/gitquery/partial_query.go
@@ -1,0 +1,107 @@
+package gitquery
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const maxQueryWarnings = 20
+
+// QueryWarning identifies one failed best-effort enrichment while preserving
+// the primary Git query's usable rows.
+type QueryWarning struct {
+	Operation string
+	Subject   string
+	Cause     error
+}
+
+// PartialQueryError accompanies usable worktree or branch rows whose optional
+// Git metadata could not be fully resolved.
+type PartialQueryError struct {
+	Warnings []QueryWarning
+}
+
+func (e *PartialQueryError) Error() string {
+	if e == nil {
+		return ""
+	}
+	limit := min(3, len(e.Warnings))
+	parts := make([]string, 0, limit+1)
+	for _, warning := range e.Warnings[:limit] {
+		parts = append(parts, fmt.Sprintf("%s for %s: %s", warning.Operation, diagnosticSubject(warning.Subject), safeDiagnosticText(warning.Cause.Error(), 160)))
+	}
+	if len(e.Warnings) > limit {
+		parts = append(parts, fmt.Sprintf("… %d more", len(e.Warnings)-limit))
+	}
+	return fmt.Sprintf("%d Git metadata warning(s): %s", len(e.Warnings), strings.Join(parts, "; "))
+}
+
+func (e *PartialQueryError) Unwrap() []error {
+	if e == nil {
+		return nil
+	}
+	causes := make([]error, 0, len(e.Warnings))
+	for _, warning := range e.Warnings {
+		if warning.Cause != nil {
+			causes = append(causes, warning.Cause)
+		}
+	}
+	return causes
+}
+
+// AsPartialQuery classifies a standalone partial-query diagnostic without
+// requiring callers to match its human-readable text.
+func AsPartialQuery(err error) (*PartialQueryError, bool) {
+	partial, ok := err.(*PartialQueryError)
+	if !ok || partial == nil || len(partial.Warnings) == 0 {
+		return nil, false
+	}
+	for _, warning := range partial.Warnings {
+		if warning.Operation == "" || warning.Cause == nil {
+			return nil, false
+		}
+	}
+	return partial, true
+}
+
+type queryWarnings []QueryWarning
+
+func (w *queryWarnings) add(operation, subject string, cause error) {
+	if cause == nil || len(*w) >= maxQueryWarnings {
+		return
+	}
+	*w = append(*w, QueryWarning{Operation: operation, Subject: subject, Cause: cause})
+}
+
+func (w queryWarnings) err() error {
+	if len(w) == 0 {
+		return nil
+	}
+	return &PartialQueryError{Warnings: append([]QueryWarning(nil), w...)}
+}
+
+func diagnosticSubject(subject string) string {
+	if strings.TrimSpace(subject) == "" {
+		return strconv.QuoteToASCII(subject)
+	}
+	return safeDiagnosticText(subject, 120)
+}
+
+func safeDiagnosticText(value string, limit int) string {
+	var b strings.Builder
+	count := 0
+	for _, r := range value {
+		if count >= limit {
+			b.WriteRune('…')
+			break
+		}
+		if strconv.IsPrint(r) {
+			b.WriteRune(r)
+		} else {
+			fmt.Fprintf(&b, "\\u%04X", r)
+		}
+		count++
+	}
+	return b.String()
+}

--- a/gitquery/partial_query_internal_test.go
+++ b/gitquery/partial_query_internal_test.go
@@ -1,0 +1,26 @@
+package gitquery
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestPartialQueryDiagnosticIsBoundedAndTerminalSafe(t *testing.T) {
+	cause := errors.New(strings.Repeat("x", 2000) + "\n\x1b]8;;https://example.invalid\a")
+	warnings := queryWarnings{}
+	for i := 0; i < maxQueryWarnings+5; i++ {
+		warnings.add("dirty status", "/repo/worktree", cause)
+	}
+	partial := warnings.err().(*PartialQueryError)
+	if len(partial.Warnings) != maxQueryWarnings {
+		t.Fatalf("warnings = %d, want cap %d", len(partial.Warnings), maxQueryWarnings)
+	}
+	diagnostic := partial.Error()
+	if len(diagnostic) > 800 {
+		t.Fatalf("diagnostic length = %d, want bounded output", len(diagnostic))
+	}
+	if strings.ContainsAny(diagnostic, "\n\x1b\a") {
+		t.Fatalf("diagnostic contains terminal control bytes: %q", diagnostic)
+	}
+}

--- a/gitquery/runner.go
+++ b/gitquery/runner.go
@@ -1,25 +1,31 @@
 package gitquery
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
+
+const defaultGitTimeout = 30 * time.Second
 
 // Runner is the seam between query orchestration and the git CLI.
 type Runner interface {
 	// Run executes git and returns stdout. On failure, git stderr is folded
 	// into the error, matching the historical gitCmd contract.
 	Run(dir string, args ...string) (string, error)
-	// Ok executes git only for its exit code. Predicate commands such as
-	// merge-base --is-ancestor use nil as the affirmative answer.
-	Ok(dir string, args ...string) error
+	// Predicate executes a Git predicate. Exit 0 is true, exit 1 is false, and
+	// execution failures remain distinguishable from an ordinary false result.
+	Predicate(dir string, args ...string) (bool, error)
 }
 
-type execRunner struct{}
+type execRunner struct {
+	timeout time.Duration
+}
 
-var defaultRunner Runner = execRunner{}
+var defaultRunner Runner = execRunner{timeout: defaultGitTimeout}
 
 // DefaultRunner is used by package-level query functions. Override it only for
 // process-wide integration hooks; tests should prefer NewQuerier with a fake.
@@ -43,14 +49,20 @@ func defaultQuery() *Querier {
 	return NewQuerier(DefaultRunner)
 }
 
-func (execRunner) Run(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+func (r execRunner) Run(dir string, args ...string) (string, error) {
+	timeout := r.commandTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	// Output captures stderr into (*exec.ExitError).Stderr when cmd.Stderr is
 	// nil, but its error string is only "exit status N". Fold the git stderr
 	// diagnostic into the returned error while keeping stdout clean for parsing.
 	out, err := cmd.Output()
 	if err != nil {
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("git %s timed out after %s: %w", gitOperation(args), timeout, ctx.Err())
+		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			if msg := strings.TrimSpace(string(exitErr.Stderr)); msg != "" {
@@ -62,8 +74,36 @@ func (execRunner) Run(dir string, args ...string) (string, error) {
 	return string(out), nil
 }
 
-func (execRunner) Ok(dir string, args ...string) error {
-	cmd := exec.Command("git", args...)
+func (r execRunner) Predicate(dir string, args ...string) (bool, error) {
+	timeout := r.commandTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
-	return cmd.Run()
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		return false, fmt.Errorf("git %s timed out after %s: %w", gitOperation(args), timeout, ctx.Err())
+	}
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
+}
+
+func (r execRunner) commandTimeout() time.Duration {
+	if r.timeout <= 0 {
+		return defaultGitTimeout
+	}
+	return r.timeout
+}
+
+func gitOperation(args []string) string {
+	if len(args) == 0 {
+		return "command"
+	}
+	return args[0]
 }

--- a/gitquery/runner.go
+++ b/gitquery/runner.go
@@ -10,6 +10,7 @@ import (
 )
 
 const defaultGitTimeout = 30 * time.Second
+const gitWaitDelay = 2 * time.Second
 
 // Runner is the seam between query orchestration and the git CLI.
 type Runner interface {
@@ -55,6 +56,7 @@ func (r execRunner) Run(dir string, args ...string) (string, error) {
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
+	cmd.WaitDelay = gitWaitDelay
 	// Output captures stderr into (*exec.ExitError).Stderr when cmd.Stderr is
 	// nil, but its error string is only "exit status N". Fold the git stderr
 	// diagnostic into the returned error while keeping stdout clean for parsing.
@@ -80,6 +82,7 @@ func (r execRunner) Predicate(dir string, args ...string) (bool, error) {
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
+	cmd.WaitDelay = gitWaitDelay
 	err := cmd.Run()
 	if ctx.Err() != nil {
 		return false, fmt.Errorf("git %s timed out after %s: %w", gitOperation(args), timeout, ctx.Err())

--- a/gitquery/runner_internal_test.go
+++ b/gitquery/runner_internal_test.go
@@ -50,3 +50,29 @@ func TestExecRunnerPredicateTimesOutHungGit(t *testing.T) {
 		t.Fatalf("Predicate() error = %q, want operation and timeout", err)
 	}
 }
+
+func TestExecRunnerWaitDelayUnblocksOrphanedStdout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test git shim is a shell script")
+	}
+	bin := t.TempDir()
+	script := `#!/bin/sh
+sleep 30 &
+exec sleep 30
+`
+	if err := os.WriteFile(filepath.Join(bin, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	r := execRunner{timeout: 200 * time.Millisecond}
+	start := time.Now()
+	_, err := r.Run(t.TempDir(), "status")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("Run() error = nil, want timeout after the parent git process is killed")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("Run hung for %s; WaitDelay should unblock orphaned stdout", elapsed)
+	}
+}

--- a/gitquery/runner_internal_test.go
+++ b/gitquery/runner_internal_test.go
@@ -1,0 +1,52 @@
+package gitquery
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExecRunnerRunTimesOutHungGit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test git shim is a shell script")
+	}
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	if err := os.WriteFile(gitPath, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := (execRunner{timeout: 20 * time.Millisecond}).Run(t.TempDir(), "status", "--porcelain")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Run() error = %v, want deadline exceeded", err)
+	}
+	if !strings.Contains(err.Error(), "git status timed out after 20ms") {
+		t.Fatalf("Run() error = %q, want operation and timeout", err)
+	}
+}
+
+func TestExecRunnerPredicateTimesOutHungGit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test git shim is a shell script")
+	}
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	if err := os.WriteFile(gitPath, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	matched, err := (execRunner{timeout: 20 * time.Millisecond}).Predicate(t.TempDir(), "merge-base", "--is-ancestor", "a", "b")
+	if matched || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Predicate() = %t, %v, want false and deadline exceeded", matched, err)
+	}
+	if !strings.Contains(err.Error(), "git merge-base timed out after 20ms") {
+		t.Fatalf("Predicate() error = %q, want operation and timeout", err)
+	}
+}

--- a/gitquery/runner_test.go
+++ b/gitquery/runner_test.go
@@ -2,12 +2,23 @@ package gitquery_test
 
 import (
 	"errors"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/approachcontrol/approach/gitquery"
 )
+
+func quietRefMissingError(t *testing.T) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", "exit 1").Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("quietRefMissingError() = %v, want exit status 1", err)
+	}
+	return err
+}
 
 type fakeReply struct {
 	out string
@@ -309,6 +320,35 @@ func TestQuerierListBranches_ReportsMergedPredicateFailure(t *testing.T) {
 	}
 }
 
+func TestQuerierListBranches_MissingOriginHEADIsNotAFailure(t *testing.T) {
+	featurePath := t.TempDir()
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
+				out: "dev\t\t\nfeature\t\t\n",
+			},
+			fakeKey("/repo", "worktree", "list", "--porcelain"): {
+				out: "worktree " + featurePath + "\nHEAD abc123\nbranch refs/heads/feature\n",
+			},
+			fakeKey("/repo", "branch", "--show-current"): {},
+			fakeKey("/repo", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"): {
+				err: quietRefMissingError(t),
+			},
+			fakeKey(featurePath, "status", "--porcelain"): {},
+		},
+		ok: map[string]error{},
+	}
+
+	branches, err := gitquery.NewQuerier(f).ListBranches("/repo")
+	if err != nil {
+		t.Fatalf("ListBranches() error = %v, want no warning for a missing origin HEAD", err)
+	}
+	if len(branches) != 2 {
+		t.Fatalf("ListBranches() = %#v, want retained rows", branches)
+	}
+}
+
 func TestQuerierListBranches_ReportsRootAndDefaultBranchFallbackFailures(t *testing.T) {
 	wantRootErr := errors.New("cannot identify current branch")
 	wantDefaultErr := errors.New("origin HEAD is corrupt")
@@ -381,6 +421,69 @@ func TestQuerierListWorktrees_UsesInjectedRunnerForDirtyStatus(t *testing.T) {
 	}
 	if fakeCallContains(f.calls, stalePath+" | status --porcelain") {
 		t.Fatalf("stale worktree should not read dirty status; calls: %v", f.calls)
+	}
+}
+
+func TestQuerierListWorktrees_KeepsDirtyFlagWhenDiffHEADFails(t *testing.T) {
+	worktreePath := t.TempDir()
+	wantErr := errors.New("fatal: bad revision 'HEAD'")
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey("/repo", "worktree", "list", "--porcelain"): {
+				out: "worktree " + worktreePath + "\nHEAD abc123\nbranch refs/heads/main\n",
+			},
+			fakeKey(worktreePath, "status", "--porcelain"): {
+				out: "?? new.txt\n",
+			},
+			fakeKey(worktreePath, "diff", "HEAD", "--numstat"): {err: wantErr},
+		},
+	}
+
+	worktrees, err := gitquery.NewQuerier(f).ListWorktrees("/repo")
+	if len(worktrees) != 1 || !worktrees[0].Dirty || worktrees[0].FilesChanged != 1 {
+		t.Fatalf("ListWorktrees() = %#v, want dirty row with file count", worktrees)
+	}
+	if worktrees[0].LinesAdded != 0 || worktrees[0].LinesDeleted != 0 {
+		t.Fatalf("line counts = +%d/-%d, want zeros when numstat fails", worktrees[0].LinesAdded, worktrees[0].LinesDeleted)
+	}
+	partial, ok := gitquery.AsPartialQuery(err)
+	if !ok || len(partial.Warnings) != 1 || partial.Warnings[0].Operation != "dirty status" || !errors.Is(partial.Warnings[0].Cause, wantErr) {
+		t.Fatalf("partial = %#v, err = %v, want dirty-status warning", partial, err)
+	}
+}
+
+func TestQuerierListBranches_KeepsDirtyFlagWhenDiffHEADFails(t *testing.T) {
+	featurePath := t.TempDir()
+	wantErr := errors.New("fatal: bad revision 'HEAD'")
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
+				out: "feature\t\t\nmain\t\t\n",
+			},
+			fakeKey("/repo", "worktree", "list", "--porcelain"): {
+				out: "worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree " + featurePath + "\nHEAD def456\nbranch refs/heads/feature\n",
+			},
+			fakeKey("/repo", "status", "--porcelain"): {},
+			fakeKey(featurePath, "status", "--porcelain"): {
+				out: "?? new.txt\n",
+			},
+			fakeKey(featurePath, "diff", "HEAD", "--numstat"): {err: wantErr},
+		},
+		ok: map[string]error{
+			fakeKey("/repo", "merge-base", "--is-ancestor", "feature", "main"): errors.New("not merged"),
+		},
+	}
+
+	branches, err := gitquery.NewQuerier(f).ListBranches("/repo")
+	feature := findBranch(branches, "feature")
+	if feature == nil || !feature.Dirty || feature.FilesChanged != 1 {
+		t.Fatalf("feature = %#v, want dirty row with file count", feature)
+	}
+	partial, ok := gitquery.AsPartialQuery(err)
+	if !ok || len(partial.Warnings) != 1 || partial.Warnings[0].Operation != "dirty status" || !errors.Is(partial.Warnings[0].Cause, wantErr) {
+		t.Fatalf("partial = %#v, err = %v, want dirty-status warning", partial, err)
 	}
 }
 

--- a/gitquery/runner_test.go
+++ b/gitquery/runner_test.go
@@ -15,10 +15,11 @@ type fakeReply struct {
 }
 
 type fakeRunner struct {
-	t     *testing.T
-	run   map[string]fakeReply
-	ok    map[string]error
-	calls []string
+	t                 *testing.T
+	run               map[string]fakeReply
+	ok                map[string]error
+	predicateFailures map[string]error
+	calls             []string
 }
 
 func (f *fakeRunner) Run(dir string, args ...string) (string, error) {
@@ -31,14 +32,17 @@ func (f *fakeRunner) Run(dir string, args ...string) (string, error) {
 	return reply.out, reply.err
 }
 
-func (f *fakeRunner) Ok(dir string, args ...string) error {
+func (f *fakeRunner) Predicate(dir string, args ...string) (bool, error) {
 	key := fakeKey(dir, args...)
 	f.calls = append(f.calls, "ok "+key)
+	if err, ok := f.predicateFailures[key]; ok {
+		return false, err
+	}
 	err, ok := f.ok[key]
 	if !ok {
 		f.t.Fatalf("unexpected Ok call: %s", key)
 	}
-	return err
+	return err == nil, nil
 }
 
 func fakeKey(dir string, args ...string) string {
@@ -75,8 +79,12 @@ func TestQuerierListBranches_AheadBehindFailureLeavesCountsZero(t *testing.T) {
 	}
 
 	branches, err := gitquery.NewQuerier(f).ListBranches("/repo")
-	if err != nil {
-		t.Fatalf("unexpected hard error: %v", err)
+	partial, ok := gitquery.AsPartialQuery(err)
+	if !ok {
+		t.Fatalf("AsPartialQuery(%v) = false, want non-fatal enrichment diagnostic", err)
+	}
+	if len(partial.Warnings) != 1 || partial.Warnings[0].Operation != "ahead/behind" || partial.Warnings[0].Subject != "feature" {
+		t.Fatalf("partial warnings = %#v, want feature ahead/behind failure", partial.Warnings)
 	}
 
 	feature := findBranch(branches, "feature")
@@ -165,6 +173,37 @@ func TestQuerierListBranches_UnpushedCommitsOnlyReadForAheadBranches(t *testing.
 	}
 }
 
+func TestQuerierListBranches_ReportsUnpushedCommitFailure(t *testing.T) {
+	wantErr := errors.New("cannot read commit graph")
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
+				out: "feature\trefs/remotes/origin/feature\t[ahead 2]\nmain\t\t\n",
+			},
+			fakeKey("/repo", "worktree", "list", "--porcelain"): {
+				out: "worktree /repo\nHEAD abc123\nbranch refs/heads/main\n",
+			},
+			fakeKey("/repo", "rev-list", "--count", "--left-right", "feature...refs/remotes/origin/feature"): {out: "2 0\n"},
+			fakeKey("/repo", "log", "--oneline", "refs/remotes/origin/feature..feature"):                     {err: wantErr},
+			fakeKey("/repo", "status", "--porcelain"):                                                        {},
+		},
+		ok: map[string]error{
+			fakeKey("/repo", "merge-base", "--is-ancestor", "feature", "main"): errors.New("not merged"),
+		},
+	}
+
+	branches, err := gitquery.NewQuerier(f).ListBranches("/repo")
+	feature := findBranch(branches, "feature")
+	if feature == nil || len(feature.Unpushed) != 0 {
+		t.Fatalf("feature = %#v, want retained row without unpushed details", feature)
+	}
+	partial, ok := gitquery.AsPartialQuery(err)
+	if !ok || len(partial.Warnings) != 1 || partial.Warnings[0].Operation != "unpushed commits" || !errors.Is(partial.Warnings[0].Cause, wantErr) {
+		t.Fatalf("partial = %#v, err = %v, want unpushed-commit failure", partial, err)
+	}
+}
+
 func TestQuerierListBranches_DirtyStatusFailureIsBestEffort(t *testing.T) {
 	featurePath := t.TempDir()
 	f := &fakeRunner{
@@ -187,8 +226,12 @@ func TestQuerierListBranches_DirtyStatusFailureIsBestEffort(t *testing.T) {
 	}
 
 	branches, err := gitquery.NewQuerier(f).ListBranches("/repo")
-	if err != nil {
-		t.Fatalf("unexpected hard error: %v", err)
+	partial, ok := gitquery.AsPartialQuery(err)
+	if !ok {
+		t.Fatalf("AsPartialQuery(%v) = false, want non-fatal enrichment diagnostic", err)
+	}
+	if len(partial.Warnings) != 1 || partial.Warnings[0].Operation != "dirty status" || partial.Warnings[0].Subject != featurePath {
+		t.Fatalf("partial warnings = %#v, want feature dirty-status failure", partial.Warnings)
 	}
 
 	feature := findBranch(branches, "feature")
@@ -237,6 +280,69 @@ func TestQuerierListBranches_OkProbeMarksMergedBranches(t *testing.T) {
 	}
 }
 
+func TestQuerierListBranches_ReportsMergedPredicateFailure(t *testing.T) {
+	wantErr := errors.New("merge-base unavailable")
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
+				out: "feature\t\t\nmain\t\t\n",
+			},
+			fakeKey("/repo", "worktree", "list", "--porcelain"): {
+				out: "worktree /repo\nHEAD abc123\nbranch refs/heads/main\n",
+			},
+			fakeKey("/repo", "status", "--porcelain"): {},
+		},
+		predicateFailures: map[string]error{
+			fakeKey("/repo", "merge-base", "--is-ancestor", "feature", "main"): wantErr,
+		},
+	}
+
+	branches, err := gitquery.NewQuerier(f).ListBranches("/repo")
+	feature := findBranch(branches, "feature")
+	if feature == nil || feature.Merged {
+		t.Fatalf("feature = %#v, want retained unmerged row", feature)
+	}
+	partial, ok := gitquery.AsPartialQuery(err)
+	if !ok || len(partial.Warnings) != 1 || partial.Warnings[0].Operation != "merged status" || !errors.Is(partial.Warnings[0].Cause, wantErr) {
+		t.Fatalf("partial = %#v, err = %v, want merged-status failure", partial, err)
+	}
+}
+
+func TestQuerierListBranches_ReportsRootAndDefaultBranchFallbackFailures(t *testing.T) {
+	wantRootErr := errors.New("cannot identify current branch")
+	wantDefaultErr := errors.New("origin HEAD is corrupt")
+	featurePath := t.TempDir()
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey("/repo", "for-each-ref", "--format=%(refname:short)\t%(refname)\t%(upstream)\t%(upstream:track)", "refs/heads/"): {
+				out: "dev\t\t\nfeature\t\t\n",
+			},
+			fakeKey("/repo", "worktree", "list", "--porcelain"): {
+				out: "worktree " + featurePath + "\nHEAD abc123\nbranch refs/heads/feature\n",
+			},
+			fakeKey("/repo", "branch", "--show-current"):                                       {err: wantRootErr},
+			fakeKey("/repo", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"): {err: wantDefaultErr},
+			fakeKey(featurePath, "status", "--porcelain"):                                      {},
+		},
+		ok: map[string]error{},
+	}
+
+	branches, err := gitquery.NewQuerier(f).ListBranches("/repo")
+	if len(branches) != 2 {
+		t.Fatalf("ListBranches() = %#v, want retained rows", branches)
+	}
+	partial, ok := gitquery.AsPartialQuery(err)
+	if !ok || len(partial.Warnings) != 2 {
+		t.Fatalf("partial = %#v, err = %v, want two fallback warnings", partial, err)
+	}
+	if partial.Warnings[0].Operation != "root branch" || !errors.Is(partial.Warnings[0].Cause, wantRootErr) ||
+		partial.Warnings[1].Operation != "default branch" || !errors.Is(partial.Warnings[1].Cause, wantDefaultErr) {
+		t.Fatalf("partial warnings = %#v", partial.Warnings)
+	}
+}
+
 func TestQuerierListWorktrees_UsesInjectedRunnerForDirtyStatus(t *testing.T) {
 	mainPath := t.TempDir()
 	dirtyPath := t.TempDir()
@@ -275,6 +381,32 @@ func TestQuerierListWorktrees_UsesInjectedRunnerForDirtyStatus(t *testing.T) {
 	}
 	if fakeCallContains(f.calls, stalePath+" | status --porcelain") {
 		t.Fatalf("stale worktree should not read dirty status; calls: %v", f.calls)
+	}
+}
+
+func TestQuerierListWorktrees_ReturnsRowsWithDirtyStatusDiagnostic(t *testing.T) {
+	worktreePath := t.TempDir()
+	wantErr := errors.New("fatal: cannot read index")
+	f := &fakeRunner{
+		t: t,
+		run: map[string]fakeReply{
+			fakeKey("/repo", "worktree", "list", "--porcelain"): {
+				out: "worktree " + worktreePath + "\nHEAD abc123\nbranch refs/heads/main\n",
+			},
+			fakeKey(worktreePath, "status", "--porcelain"): {err: wantErr},
+		},
+	}
+
+	worktrees, err := gitquery.NewQuerier(f).ListWorktrees("/repo")
+	if len(worktrees) != 1 || worktrees[0].Path != worktreePath {
+		t.Fatalf("ListWorktrees() = %#v, want usable worktree row", worktrees)
+	}
+	partial, ok := gitquery.AsPartialQuery(err)
+	if !ok {
+		t.Fatalf("AsPartialQuery(%v) = false, want non-fatal enrichment diagnostic", err)
+	}
+	if len(partial.Warnings) != 1 || partial.Warnings[0].Operation != "dirty status" || partial.Warnings[0].Subject != worktreePath || !errors.Is(partial.Warnings[0].Cause, wantErr) {
+		t.Fatalf("partial warnings = %#v, want worktree dirty-status failure", partial.Warnings)
 	}
 }
 

--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -225,6 +225,94 @@ func WriteFileAtomicFunc(path string, write func(io.Writer) error) error {
 	return os.Rename(tempName, path)
 }
 
+// StageReplace snapshots path so a replacement can be published without
+// buffering the previous contents or leaving the canonical name empty.
+// The replacement must be a new inode (WriteFileAtomic); an in-place
+// truncate would mutate a hardlinked backup. commit deletes the backup;
+// rollback restores it by renaming over the canonical path, or removes
+// path when there was no previous file.
+//
+// Backups are for in-process rollback only. A crash after WriteFileAtomic
+// publishes the replacement has the same torn window as WriteFileAtomic
+// alone: metadata remains the publication marker. A leftover sibling named
+// path+".prev" is removed the next time StageReplace runs.
+func StageReplace(path string) (commit, rollback func() error, err error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		if rmErr := os.Remove(path + ".prev"); rmErr != nil && !os.IsNotExist(rmErr) {
+			return nil, nil, rmErr
+		}
+		return func() error { return nil }, func() error {
+			if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) {
+				return rmErr
+			}
+			return nil
+		}, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("replace %s: not a regular file", path)
+	}
+	backup := path + ".prev"
+	if err := os.Remove(backup); err != nil && !os.IsNotExist(err) {
+		return nil, nil, err
+	}
+	if err := cloneFile(path, backup); err != nil {
+		return nil, nil, err
+	}
+	return func() error {
+			if err := os.Remove(backup); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+			return nil
+		}, func() error {
+			pathInfo, pathErr := os.Lstat(path)
+			backupInfo, backupErr := os.Lstat(backup)
+			if pathErr == nil && backupErr == nil && os.SameFile(pathInfo, backupInfo) {
+				if err := os.Remove(backup); err != nil && !os.IsNotExist(err) {
+					return fmt.Errorf("remove unused backup %s: %w", path, err)
+				}
+				return nil
+			}
+			if err := os.Rename(backup, path); err != nil {
+				return fmt.Errorf("restore %s: %w", path, err)
+			}
+			return nil
+		}, nil
+}
+
+func cloneFile(src, dst string) error {
+	if err := os.Link(src, dst); err == nil {
+		return nil
+	}
+	input, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	output, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, FilePerm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(output, input); err != nil {
+		_ = output.Close()
+		_ = os.Remove(dst)
+		return err
+	}
+	if err := output.Chmod(FilePerm); err != nil {
+		_ = output.Close()
+		_ = os.Remove(dst)
+		return err
+	}
+	if err := output.Close(); err != nil {
+		_ = os.Remove(dst)
+		return err
+	}
+	return nil
+}
+
 // IsSafeID reports whether id can be used as one artifact path segment.
 func IsSafeID(id string) bool {
 	return safeIDPattern.MatchString(id) && id != "." && id != ".."

--- a/internal/artifacts/artifacts_test.go
+++ b/internal/artifacts/artifacts_test.go
@@ -64,6 +64,105 @@ func TestEnsureRecordDirSecuresRecordDirectory(t *testing.T) {
 	assertMode(t, dir, 0o700)
 }
 
+func TestStageReplaceRestoresAndRemovesWithoutBuffering(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "plan.md")
+	if err := os.WriteFile(existing, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, rollback, err := artifacts.StageReplace(existing)
+	if err != nil {
+		t.Fatalf("StageReplace(existing) error = %v", err)
+	}
+	assertFile(t, existing, "old")
+	if err := rollback(); err != nil {
+		t.Fatalf("rollback unchanged() error = %v", err)
+	}
+	assertFile(t, existing, "old")
+	if _, statErr := os.Stat(existing + ".prev"); !os.IsNotExist(statErr) {
+		t.Fatalf("unused backup still present: %v", statErr)
+	}
+
+	_, rollback, err = artifacts.StageReplace(existing)
+	if err != nil {
+		t.Fatalf("StageReplace(existing rewrite) error = %v", err)
+	}
+	assertFile(t, existing, "old")
+	if err := artifacts.WriteFileAtomic(existing, []byte("new")); err != nil {
+		t.Fatal(err)
+	}
+	if err := rollback(); err != nil {
+		t.Fatalf("rollback() error = %v", err)
+	}
+	assertFile(t, existing, "old")
+
+	missing := filepath.Join(dir, "new.md")
+	if err := os.WriteFile(missing+".prev", []byte("stale missing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, rollback, err = artifacts.StageReplace(missing)
+	if err != nil {
+		t.Fatalf("StageReplace(missing) error = %v", err)
+	}
+	if err := artifacts.WriteFileAtomic(missing, []byte("created")); err != nil {
+		t.Fatal(err)
+	}
+	if err := rollback(); err != nil {
+		t.Fatalf("rollback missing() error = %v", err)
+	}
+	if _, statErr := os.Stat(missing); !os.IsNotExist(statErr) {
+		t.Fatalf("unpublished file still present: %v", statErr)
+	}
+	if _, statErr := os.Stat(missing + ".prev"); !os.IsNotExist(statErr) {
+		t.Fatalf("leftover backup still present after missing-file stage: %v", statErr)
+	}
+
+	if err := os.WriteFile(existing, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	commit, _, err := artifacts.StageReplace(existing)
+	if err != nil {
+		t.Fatalf("StageReplace(commit) error = %v", err)
+	}
+	if err := artifacts.WriteFileAtomic(existing, []byte("next")); err != nil {
+		t.Fatal(err)
+	}
+	if err := commit(); err != nil {
+		t.Fatalf("commit() error = %v", err)
+	}
+	assertFile(t, existing, "next")
+	if _, statErr := os.Stat(existing + ".prev"); !os.IsNotExist(statErr) {
+		t.Fatalf("backup still present after commit: %v", statErr)
+	}
+
+	if err := os.WriteFile(existing+".prev", []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	commit, _, err = artifacts.StageReplace(existing)
+	if err != nil {
+		t.Fatalf("StageReplace(leftover) error = %v", err)
+	}
+	assertFile(t, existing, "next")
+	if err := artifacts.WriteFileAtomic(existing, []byte("newer")); err != nil {
+		t.Fatal(err)
+	}
+	if err := commit(); err != nil {
+		t.Fatalf("commit leftover() error = %v", err)
+	}
+	assertFile(t, existing, "newer")
+	if _, statErr := os.Stat(existing + ".prev"); !os.IsNotExist(statErr) {
+		t.Fatalf("leftover backup still present: %v", statErr)
+	}
+
+	blocked := filepath.Join(dir, "blocked")
+	if err := os.Mkdir(blocked, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := artifacts.StageReplace(blocked); err == nil {
+		t.Fatal("StageReplace(directory) error = nil, want refusal")
+	}
+}
+
 func TestWriteFileAtomicWrites0600AndReplacesContents(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "meta.json")
 

--- a/model/git_partial_query_internal_test.go
+++ b/model/git_partial_query_internal_test.go
@@ -1,0 +1,81 @@
+package model
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/approachcontrol/approach/gitquery"
+	"github.com/approachcontrol/approach/scanner"
+	"github.com/approachcontrol/approach/ui"
+)
+
+type partialGitRunner struct {
+	worktreePath string
+	wantErr      error
+}
+
+func (r partialGitRunner) Run(dir string, args ...string) (string, error) {
+	joined := strings.Join(args, " ")
+	switch joined {
+	case "worktree list --porcelain":
+		return "worktree " + r.worktreePath + "\nHEAD abc123\nbranch refs/heads/main\n", nil
+	case "status --porcelain":
+		return "", r.wantErr
+	default:
+		return "", errors.New("unexpected Git query: " + joined)
+	}
+}
+
+func (partialGitRunner) Predicate(string, ...string) (bool, error) { return false, nil }
+
+func TestWorktreePartialQueryWarningTracksCurrentResultAndClearsOnCleanRefresh(t *testing.T) {
+	m := newModelForTest([]scanner.Repo{{Path: "/repo", DisplayName: "repo"}}, Options{})
+	request := m.currentListRequest(ui.ModeWorktrees)
+	partial := &gitquery.PartialQueryError{Warnings: []gitquery.QueryWarning{{
+		Operation: "dirty status",
+		Subject:   "/repo/worktree",
+		Cause:     errors.New("cannot read index"),
+	}}}
+
+	nextModel, _ := m.Update(WorktreeResultMsg{
+		RepoPath:    "/repo",
+		Worktrees:   []gitquery.Worktree{{Path: "/repo/worktree"}},
+		ListRequest: request,
+		Degradation: partial,
+	})
+	next := nextModel.(Model)
+	if warning := next.gitDegradationWarning(ui.ModeWorktrees); !strings.Contains(warning, "cannot read index") {
+		t.Fatalf("warning = %q, want partial Git diagnostic", warning)
+	}
+
+	cleanModel, _ := next.Update(WorktreeResultMsg{
+		RepoPath:    "/repo",
+		Worktrees:   []gitquery.Worktree{{Path: "/repo/worktree"}},
+		ListRequest: request,
+	})
+	clean := cleanModel.(Model)
+	if warning := clean.gitDegradationWarning(ui.ModeWorktrees); warning != "" {
+		t.Fatalf("clean refresh retained warning %q", warning)
+	}
+}
+
+func TestWorktreeFetchCarriesPartialQueryRowsInsteadOfFailing(t *testing.T) {
+	oldRunner := gitquery.DefaultRunner
+	t.Cleanup(func() { gitquery.DefaultRunner = oldRunner })
+	wantErr := errors.New("cannot read index")
+	gitquery.DefaultRunner = partialGitRunner{worktreePath: t.TempDir(), wantErr: wantErr}
+	descriptor, ok := listFetchDescriptorForMode(ui.ModeWorktrees)
+	if !ok {
+		t.Fatal("worktree fetch descriptor unavailable")
+	}
+
+	message, err := descriptor.load(Model{}, "/repo", 7)
+	if err != nil {
+		t.Fatalf("load() error = %v, want usable partial result", err)
+	}
+	result, ok := message.(WorktreeResultMsg)
+	if !ok || len(result.Worktrees) != 1 || result.Degradation == nil || !errors.Is(result.Degradation, wantErr) {
+		t.Fatalf("load() message = %#v, want worktree row plus diagnostic", message)
+	}
+}

--- a/model/mode_fetch.go
+++ b/model/mode_fetch.go
@@ -31,6 +31,9 @@ func listFetchDescriptorForMode(mode ui.Mode) (listFetchDescriptor, bool) {
 			errorPrefix: "failed to load worktrees",
 			load: func(_ Model, repoPath string, request uint64) (tea.Msg, error) {
 				worktrees, err := gitquery.ListWorktrees(repoPath)
+				if partial, ok := gitquery.AsPartialQuery(err); ok {
+					return WorktreeResultMsg{RepoPath: repoPath, Worktrees: worktrees, ListRequest: request, Degradation: partial}, nil
+				}
 				if err != nil {
 					return nil, err
 				}
@@ -44,6 +47,9 @@ func listFetchDescriptorForMode(mode ui.Mode) (listFetchDescriptor, bool) {
 			errorPrefix: "failed to load branches",
 			load: func(_ Model, repoPath string, request uint64) (tea.Msg, error) {
 				branches, err := gitquery.ListBranches(repoPath)
+				if partial, ok := gitquery.AsPartialQuery(err); ok {
+					return BranchResultMsg{RepoPath: repoPath, Branches: branches, ListRequest: request, Degradation: partial}, nil
+				}
 				if err != nil {
 					return nil, err
 				}

--- a/model/model.go
+++ b/model/model.go
@@ -66,6 +66,11 @@ type flowDegradationState struct {
 	diagnostic *flowstore.PartialListError
 }
 
+type gitDegradationState struct {
+	repoPath   string
+	diagnostic *gitquery.PartialQueryError
+}
+
 type takeoverMode uint8
 
 const (
@@ -143,6 +148,7 @@ type Model struct {
 	listRequests              [listRequestSlots]uint64
 	listErrors                [listRequestSlots]string
 	flowDegradations          [listRequestSlots]flowDegradationState
+	gitDegradations           [listRequestSlots]gitDegradationState
 	activePane                ui.Pane
 	repoPaneCollapsed         bool
 	activeFlowSurface         bool
@@ -1655,6 +1661,8 @@ func (m Model) View() string {
 		RightEmptyMessage:              rightEmptyMessage,
 		TopListError:                   m.currentListError(m.topMode),
 		BottomListError:                m.currentListError(m.bottomMode),
+		TopDegradationWarning:          m.gitDegradationWarning(m.topMode),
+		BottomDegradationWarning:       m.gitDegradationWarning(m.bottomMode),
 		ActiveFlowsListError:           m.currentListError(ui.ModeActiveFlows),
 		PRBabysitterListError:          m.currentListError(ui.ModePRBabysitter),
 		FetchAvailable:                 m.canFetch(),

--- a/model/model_action_test.go
+++ b/model/model_action_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
@@ -6911,6 +6912,40 @@ func TestModel_DKeyOnWorktreeRequiresDestructiveMode(t *testing.T) {
 	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
 	if m.Overlay() != ui.OverlayNone {
 		t.Errorf("d without destructive mode should be no-op, got overlay %d", m.Overlay())
+	}
+}
+
+func TestModel_WorktreeRemoveSucceedsWhenPruneFails(t *testing.T) {
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+case " $* " in
+  *" worktree remove "*) exit 0 ;;
+  *" worktree prune "*) echo "prune unavailable" >&2; exit 1 ;;
+esac
+exit 2
+`
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	m := modelWithWorktrees([]gitquery.Worktree{
+		{Path: "/dev/alpha", BranchName: "main", IsMain: true},
+		{Path: "/dev/alpha-feat", BranchName: "feat"},
+	})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	_, cmd := update(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Fatal("expected cmd from confirm, got nil")
+	}
+	msg := cmd()
+	removed, ok := msg.(model.WorktreeRemovedMsg)
+	if !ok {
+		t.Fatalf("expected WorktreeRemovedMsg after successful remove + prune failure, got %T (%v)", msg, msg)
+	}
+	if removed.RepoPath != "/dev/alpha" || removed.BranchName != "feat" {
+		t.Fatalf("WorktreeRemovedMsg = %#v", removed)
 	}
 }
 

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -141,6 +141,44 @@ func (m Model) currentListError(mode ui.Mode) string {
 	return m.listErrors[int(mode)]
 }
 
+func (m Model) gitDegradationWarning(mode ui.Mode) string {
+	if mode != ui.ModeWorktrees && mode != ui.ModeBranches {
+		return ""
+	}
+	state := m.gitDegradations[int(mode)]
+	if state.diagnostic == nil || len(state.diagnostic.Warnings) == 0 {
+		return ""
+	}
+	repoPath, ok := m.currentRepoPath()
+	if !ok || !sameRepoPath(repoPath, state.repoPath) {
+		return ""
+	}
+	return "Git metadata incomplete: " + state.diagnostic.Error()
+}
+
+func (m Model) setGitDegradation(mode ui.Mode, repoPath string, diagnostic *gitquery.PartialQueryError) Model {
+	if mode != ui.ModeWorktrees && mode != ui.ModeBranches {
+		return m
+	}
+	beforeRows := m.paneGitDegradationWarningRows(mode)
+	state := gitDegradationState{repoPath: repoPath}
+	if diagnostic != nil && len(diagnostic.Warnings) > 0 {
+		state.diagnostic = &gitquery.PartialQueryError{Warnings: append([]gitquery.QueryWarning(nil), diagnostic.Warnings...)}
+	}
+	m.gitDegradations[int(mode)] = state
+	if m.paneGitDegradationWarningRows(mode) != beforeRows {
+		m = m.reflowMode(mode)
+	}
+	return m
+}
+
+func (m Model) paneGitDegradationWarningRows(mode ui.Mode) int {
+	if m.gitDegradationWarning(mode) == "" {
+		return 0
+	}
+	return 1
+}
+
 func (m Model) setCurrentListError(mode ui.Mode, detail string) Model {
 	if int(mode) < 0 || int(mode) >= len(m.listErrors) {
 		return m

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -3486,7 +3487,7 @@ func (m Model) confirmWorktreeDelete() (tea.Model, tea.Cmd) {
 
 	m.modal = modal.OpenConfirm(fmt.Sprintf("Remove worktree at %s? (y/n)", wtPath), func() tea.Cmd {
 		return func() tea.Msg {
-			if err := actions.RemoveWorktree(repoPath, wtPath); err != nil {
+			if err := actions.RemoveWorktree(repoPath, wtPath); err != nil && !errors.Is(err, actions.ErrWorktreePruneFailed) {
 				return DeleteFailedMsg{
 					RepoPath:    repoPath,
 					Target:      wtPath,

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -3746,6 +3746,7 @@ func (m Model) paneContentHeight(mode ui.Mode) int {
 	}
 	rows -= m.paneCachedWarningRows(mode)
 	rows -= m.paneFlowDegradationWarningRows(mode)
+	rows -= m.paneGitDegradationWarningRows(mode)
 	// The positive floor predates the warning row and also covers hidden
 	// background panes, which are allocated no rows at all. Viewports this
 	// small cannot show a cached row either way, so the floor stays.

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -26,6 +26,7 @@ type BranchResultMsg struct {
 	RepoPath    string
 	Branches    []gitquery.Branch
 	ListRequest uint64
+	Degradation *gitquery.PartialQueryError
 }
 
 type StashResultMsg struct {
@@ -75,6 +76,7 @@ type WorktreeResultMsg struct {
 	RepoPath    string
 	Worktrees   []gitquery.Worktree
 	ListRequest uint64
+	Degradation *gitquery.PartialQueryError
 }
 
 type CommitResultMsg struct {
@@ -802,6 +804,7 @@ func (m Model) handleWorktreeResult(msg WorktreeResultMsg) (Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
+	m = m.setGitDegradation(ui.ModeWorktrees, msg.RepoPath, msg.Degradation)
 	inlineRefreshPath, refreshInline := m.pendingInlineSessionRefresh(msg.RepoPath, msg.ListRequest)
 	m.worktrees = m.worktrees.SetItems(msg.Worktrees)
 	m = m.clearInlineWorktreeSessions()
@@ -1257,6 +1260,7 @@ func (m Model) handleBranchResult(msg BranchResultMsg) Model {
 	if !ok {
 		return m
 	}
+	m = m.setGitDegradation(ui.ModeBranches, msg.RepoPath, msg.Degradation)
 	repo, _ := m.currentRepo()
 	m.rows = m.rows.SetItems(branchRowsForRepo(repo, msg.Branches))
 	if m.pendingBranchSelection != "" {

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -1401,7 +1402,7 @@ func (m Model) handleDeleteFailed(msg DeleteFailedMsg) Model {
 		forceAction := msg.ForceAction
 		m.modal = modal.OpenForce(fmt.Sprintf("Force delete %s? (y/n)", msg.Target), func() tea.Cmd {
 			return func() tea.Msg {
-				if err := forceAction(); err != nil {
+				if err := forceAction(); err != nil && !errors.Is(err, actions.ErrWorktreePruneFailed) {
 					return ForceDeleteFailedMsg{
 						RepoPath: repoPath,
 						Target:   target,

--- a/planstore/store.go
+++ b/planstore/store.go
@@ -488,15 +488,35 @@ func (s *Store) write(record PlanRecord) error {
 	// non-empty Markdown; metadata-only updates such as SetPhase carry whatever
 	// readRecord loaded, so guarding here avoids clobbering an existing plan.md
 	// if its body could not be read back.
+	markdownPath := filepath.Join(dir, "plan.md")
+	var commitBody, rollbackBody func() error
 	if record.Markdown != "" {
-		if err := artifacts.WriteFileAtomic(filepath.Join(dir, "plan.md"), []byte(record.Markdown)); err != nil {
+		var err error
+		commitBody, rollbackBody, err = artifacts.StageReplace(markdownPath)
+		if err != nil {
+			return fmt.Errorf("stage plan markdown: %w", err)
+		}
+		if err := artifacts.WriteFileAtomic(markdownPath, []byte(record.Markdown)); err != nil {
+			if rollbackErr := rollbackBody(); rollbackErr != nil {
+				return fmt.Errorf("write plan markdown: %w; %v", err, rollbackErr)
+			}
 			return fmt.Errorf("write plan markdown: %w", err)
 		}
 	}
 	// Metadata is the publication marker used by List and ReadMetadata. Write it
 	// last so a failed body write cannot expose a torn plan record.
 	if err := artifacts.WriteFileAtomic(filepath.Join(dir, "meta.json"), data); err != nil {
+		if rollbackBody != nil {
+			if rollbackErr := rollbackBody(); rollbackErr != nil {
+				return fmt.Errorf("write plan metadata: %w; %v", err, rollbackErr)
+			}
+		}
 		return fmt.Errorf("write plan metadata: %w", err)
+	}
+	if commitBody != nil {
+		if err := commitBody(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/planstore/store.go
+++ b/planstore/store.go
@@ -484,9 +484,6 @@ func (s *Store) write(record PlanRecord) error {
 	if err != nil {
 		return fmt.Errorf("encode plan metadata: %w", err)
 	}
-	if err := artifacts.WriteFileAtomic(filepath.Join(dir, "meta.json"), data); err != nil {
-		return fmt.Errorf("write plan metadata: %w", err)
-	}
 	// Only (re)write the body when we actually have one. Save always supplies
 	// non-empty Markdown; metadata-only updates such as SetPhase carry whatever
 	// readRecord loaded, so guarding here avoids clobbering an existing plan.md
@@ -495,6 +492,11 @@ func (s *Store) write(record PlanRecord) error {
 		if err := artifacts.WriteFileAtomic(filepath.Join(dir, "plan.md"), []byte(record.Markdown)); err != nil {
 			return fmt.Errorf("write plan markdown: %w", err)
 		}
+	}
+	// Metadata is the publication marker used by List and ReadMetadata. Write it
+	// last so a failed body write cannot expose a torn plan record.
+	if err := artifacts.WriteFileAtomic(filepath.Join(dir, "meta.json"), data); err != nil {
+		return fmt.Errorf("write plan metadata: %w", err)
 	}
 	return nil
 }

--- a/planstore/store_test.go
+++ b/planstore/store_test.go
@@ -140,6 +140,159 @@ func TestStoreKeepsExistingMetadataWhenMarkdownWriteFails(t *testing.T) {
 	}
 }
 
+func TestStoreRemovesNewPlanBodyWhenMetadataWriteFails(t *testing.T) {
+	root := t.TempDir()
+	store, err := planstore.NewStore(planstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	planDir := filepath.Join(root, "plans", "new-plan")
+	if err := os.MkdirAll(planDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(planDir, "meta.json"), 0o700); err != nil {
+		t.Fatalf("create blocking meta.json directory: %v", err)
+	}
+
+	_, err = store.Save(planstore.PlanRecord{
+		PlanID:   "new-plan",
+		Title:    "New",
+		Markdown: "new body",
+		Status:   "draft",
+	})
+	if err == nil {
+		t.Fatal("Save() error = nil, want metadata write failure")
+	}
+	if _, statErr := os.Stat(filepath.Join(planDir, "plan.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("unpublished plan.md still present: %v", statErr)
+	}
+}
+
+func TestStoreRestoresPlanBodyWhenMetadataWriteFails(t *testing.T) {
+	root := t.TempDir()
+	store, err := planstore.NewStore(planstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if _, err := store.Save(planstore.PlanRecord{
+		PlanID:   "existing-plan",
+		Title:    "Before",
+		Markdown: "old body",
+		Status:   "draft",
+	}); err != nil {
+		t.Fatalf("seed Save() error = %v", err)
+	}
+	metaPath := filepath.Join(root, "plans", "existing-plan", "meta.json")
+	if err := os.Remove(metaPath); err != nil {
+		t.Fatalf("remove meta.json: %v", err)
+	}
+	if err := os.Mkdir(metaPath, 0o700); err != nil {
+		t.Fatalf("create blocking meta.json directory: %v", err)
+	}
+
+	_, err = store.Save(planstore.PlanRecord{
+		PlanID:   "existing-plan",
+		Title:    "After",
+		Markdown: "new body",
+		Status:   "completed",
+	})
+	if err == nil {
+		t.Fatal("update Save() error = nil, want metadata write failure")
+	}
+	got, readErr := os.ReadFile(filepath.Join(root, "plans", "existing-plan", "plan.md"))
+	if readErr != nil {
+		t.Fatalf("read plan.md: %v", readErr)
+	}
+	if string(got) != "old body" {
+		t.Fatalf("plan.md = %q, want restored previous body", got)
+	}
+}
+
+func TestStoreFailsClosedOnUnreadablePreviousPlanBody(t *testing.T) {
+	root := t.TempDir()
+	store, err := planstore.NewStore(planstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if _, err := store.Save(planstore.PlanRecord{
+		PlanID:   "existing-plan",
+		Title:    "Before",
+		Markdown: "old body",
+		Status:   "draft",
+	}); err != nil {
+		t.Fatalf("seed Save() error = %v", err)
+	}
+	bodyPath := filepath.Join(root, "plans", "existing-plan", "plan.md")
+	if err := os.Remove(bodyPath); err != nil {
+		t.Fatalf("remove plan.md: %v", err)
+	}
+	if err := os.Mkdir(bodyPath, 0o700); err != nil {
+		t.Fatalf("block plan.md: %v", err)
+	}
+
+	_, err = store.Save(planstore.PlanRecord{
+		PlanID:   "existing-plan",
+		Title:    "After",
+		Markdown: "new body",
+		Status:   "completed",
+	})
+	if err == nil {
+		t.Fatal("update Save() error = nil, want unreadable previous plan body")
+	}
+	info, statErr := os.Stat(bodyPath)
+	if statErr != nil {
+		t.Fatalf("previous plan.md was removed: %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Fatalf("previous plan.md = file, want blocking directory left in place")
+	}
+	metadata, readErr := store.ReadMetadata("existing-plan")
+	if readErr != nil {
+		t.Fatalf("ReadMetadata() error = %v", readErr)
+	}
+	if metadata.Title != "Before" || metadata.Status != "draft" {
+		t.Fatalf("ReadMetadata() = %#v, want unchanged existing metadata", metadata)
+	}
+}
+
+func TestStoreKeepsUnreadablePlanBodyOnMetadataOnlyUpdate(t *testing.T) {
+	root := t.TempDir()
+	store, err := planstore.NewStore(planstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if _, err := store.Save(planstore.PlanRecord{
+		PlanID:   "existing-plan",
+		Title:    "Before",
+		Markdown: "old body",
+		Status:   "draft",
+	}); err != nil {
+		t.Fatalf("seed Save() error = %v", err)
+	}
+	bodyPath := filepath.Join(root, "plans", "existing-plan", "plan.md")
+	if err := os.Remove(bodyPath); err != nil {
+		t.Fatalf("remove plan.md: %v", err)
+	}
+	if err := os.Mkdir(bodyPath, 0o700); err != nil {
+		t.Fatalf("block plan.md: %v", err)
+	}
+
+	updated, err := store.SetStatus("existing-plan", "approved")
+	if err != nil {
+		t.Fatalf("SetStatus() error = %v", err)
+	}
+	if updated.Status != "approved" {
+		t.Fatalf("SetStatus() status = %q, want approved", updated.Status)
+	}
+	info, statErr := os.Stat(bodyPath)
+	if statErr != nil {
+		t.Fatalf("previous plan.md was removed: %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Fatalf("previous plan.md = file, want blocking directory left in place")
+	}
+}
+
 func TestStoreSavesAndListsPlansByRepoPath(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")

--- a/planstore/store_test.go
+++ b/planstore/store_test.go
@@ -75,6 +75,71 @@ func TestStoreReadMetadataReturnsPlanMetadataAndReportsCorruptMetadata(t *testin
 	}
 }
 
+func TestStoreDoesNotPublishMetadataWhenMarkdownWriteFails(t *testing.T) {
+	root := t.TempDir()
+	store, err := planstore.NewStore(planstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	planDir := filepath.Join(root, "plans", "failed-markdown")
+	if err := os.MkdirAll(filepath.Join(planDir, "plan.md"), 0o700); err != nil {
+		t.Fatalf("create blocking plan.md directory: %v", err)
+	}
+
+	_, err = store.Save(planstore.PlanRecord{
+		PlanID:   "failed-markdown",
+		Title:    "Failed Markdown",
+		Markdown: "new body",
+		Status:   "draft",
+	})
+	if err == nil {
+		t.Fatal("Save() error = nil, want Markdown write failure")
+	}
+	if _, readErr := store.ReadMetadata("failed-markdown"); readErr == nil {
+		t.Fatal("ReadMetadata() error = nil, metadata was published before Markdown")
+	}
+}
+
+func TestStoreKeepsExistingMetadataWhenMarkdownWriteFails(t *testing.T) {
+	root := t.TempDir()
+	store, err := planstore.NewStore(planstore.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if _, err := store.Save(planstore.PlanRecord{
+		PlanID:   "existing-plan",
+		Title:    "Before",
+		Markdown: "old body",
+		Status:   "draft",
+	}); err != nil {
+		t.Fatalf("seed Save() error = %v", err)
+	}
+	markdownPath := filepath.Join(root, "plans", "existing-plan", "plan.md")
+	if err := os.Remove(markdownPath); err != nil {
+		t.Fatalf("remove plan.md: %v", err)
+	}
+	if err := os.Mkdir(markdownPath, 0o700); err != nil {
+		t.Fatalf("create blocking plan.md directory: %v", err)
+	}
+
+	_, err = store.Save(planstore.PlanRecord{
+		PlanID:   "existing-plan",
+		Title:    "After",
+		Markdown: "new body",
+		Status:   "completed",
+	})
+	if err == nil {
+		t.Fatal("update Save() error = nil, want Markdown write failure")
+	}
+	metadata, readErr := store.ReadMetadata("existing-plan")
+	if readErr != nil {
+		t.Fatalf("ReadMetadata() error = %v", readErr)
+	}
+	if metadata.Title != "Before" || metadata.Status != "draft" {
+		t.Fatalf("ReadMetadata() = %#v, want unchanged existing metadata", metadata)
+	}
+}
+
 func TestStoreSavesAndListsPlansByRepoPath(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")

--- a/sessions/ingest.go
+++ b/sessions/ingest.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -535,10 +536,29 @@ func repoPathFromGitCommonDir(commonDir string) string {
 }
 
 func gitOutput(cwd string, args ...string) (string, error) {
-	cmd := exec.Command("git", append([]string{"-C", cwd}, args...)...)
+	cleaned, err := plausibleGitCWD(cwd)
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command("git", append([]string{"-C", cleaned}, args...)...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+func plausibleGitCWD(cwd string) (string, error) {
+	cwd = filepath.Clean(strings.TrimSpace(cwd))
+	if cwd == "." || !filepath.IsAbs(cwd) {
+		return "", fmt.Errorf("git cwd must be an absolute path")
+	}
+	info, err := os.Stat(cwd)
+	if err != nil {
+		return "", fmt.Errorf("inspect git cwd %q: %w", cwd, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("git cwd %q is not a directory", cwd)
+	}
+	return cwd, nil
 }

--- a/sessions/ingest_test.go
+++ b/sessions/ingest_test.go
@@ -272,6 +272,17 @@ func TestIngestHookResolvesGitMetadataFromCWD(t *testing.T) {
 	}
 }
 
+func TestIngestHookDoesNotResolveGitMetadataFromRelativeCWD(t *testing.T) {
+	stateRoot := t.TempDir()
+	record, err := sessions.IngestHook(sessions.ProviderCodex, strings.NewReader(`{"session_id":"relative-cwd","cwd":"."}`), sessions.IngestOptions{StateRoot: stateRoot})
+	if err != nil {
+		t.Fatalf("IngestHook() error = %v", err)
+	}
+	if record.RepoPath != "" || record.WorktreePath != "" || record.Branch != "" || record.Commit != "" {
+		t.Fatalf("relative cwd resolved process-directory Git metadata: %#v", record)
+	}
+}
+
 func TestIngestHookResolvesLinkedWorktreeToMainRepoPath(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")

--- a/sessions/store.go
+++ b/sessions/store.go
@@ -36,12 +36,13 @@ const (
 )
 
 type Store struct {
-	root               string
-	copyRawTranscripts bool
-	lockTimeout        time.Duration
-	env                map[string]string
-	launchStale        launchStaleFunc
-	acquireFileLock    acquireFileLockFunc
+	root                string
+	copyRawTranscripts  bool
+	lockTimeout         time.Duration
+	env                 map[string]string
+	launchStale         launchStaleFunc
+	acquireFileLock     acquireFileLockFunc
+	beforeMetadataWrite func()
 }
 
 type launchStaleFunc func(existing, incoming SessionRecord) (stale, known bool)
@@ -173,14 +174,34 @@ func (s *Store) upsert(record SessionRecord) (SessionRecord, error) {
 	if record.SchemaVersion == 0 {
 		record.SchemaVersion = schemaVersion
 	}
+	var payloadStages []payloadStage
 	if hasIncomingTranscript && record.Provider != ProviderCursor {
-		if err := s.writeTranscriptFiles(record, transcript); err != nil {
+		dir := s.sessionDir(record.Provider, record.SessionID)
+		transcriptStage, err := stageSessionPayload(filepath.Join(dir, "transcript.jsonl"))
+		if err != nil {
 			return SessionRecord{}, err
+		}
+		payloadStages = append(payloadStages, transcriptStage)
+		if s.copyRawTranscripts {
+			rawStage, err := stageSessionPayload(filepath.Join(dir, "raw.jsonl"))
+			if err != nil {
+				return SessionRecord{}, rollbackPayloadStages(payloadStages, err)
+			}
+			payloadStages = append(payloadStages, rawStage)
+		}
+		if err := s.writeTranscriptFiles(record, transcript); err != nil {
+			return SessionRecord{}, rollbackPayloadStages(payloadStages, err)
 		}
 	}
 	// Metadata is the publication marker used by List. Write payloads first so
 	// a failed transcript copy or normalization cannot expose a torn record.
 	if err := s.writeMetadata(record); err != nil {
+		if len(payloadStages) > 0 {
+			return SessionRecord{}, rollbackPayloadStages(payloadStages, err)
+		}
+		return SessionRecord{}, err
+	}
+	if err := commitPayloadStages(payloadStages); err != nil {
 		return SessionRecord{}, err
 	}
 	return record, nil
@@ -198,32 +219,120 @@ func (s *Store) writeMetadata(record SessionRecord) error {
 	if err != nil {
 		return fmt.Errorf("encode session metadata: %w", err)
 	}
+	if s.beforeMetadataWrite != nil {
+		s.beforeMetadataWrite()
+	}
 	if err := artifacts.WriteFileAtomic(filepath.Join(dir, "meta.json"), data); err != nil {
 		return fmt.Errorf("write session metadata: %w", err)
 	}
 	return nil
 }
 
+type payloadStage struct {
+	commit   func() error
+	rollback func() error
+}
+
+func stageSessionPayload(path string) (payloadStage, error) {
+	commit, rollback, err := artifacts.StageReplace(path)
+	if err != nil {
+		return payloadStage{}, fmt.Errorf("stage %s: %w", filepath.Base(path), err)
+	}
+	return payloadStage{commit: commit, rollback: rollback}, nil
+}
+
+func rollbackPayloadStages(stages []payloadStage, cause ...error) error {
+	var first error
+	if len(cause) > 0 {
+		first = cause[0]
+	}
+	for i := len(stages) - 1; i >= 0; i-- {
+		if err := stages[i].rollback(); err != nil && first == nil {
+			first = err
+		} else if err != nil {
+			first = fmt.Errorf("%w; %v", first, err)
+		}
+	}
+	return first
+}
+
+func commitPayloadStages(stages []payloadStage) error {
+	var first error
+	for _, stage := range stages {
+		if err := stage.commit(); err != nil {
+			if first == nil {
+				first = err
+			} else {
+				first = fmt.Errorf("%w; %v", first, err)
+			}
+		}
+	}
+	return first
+}
+
 func (s *Store) List(filter SessionFilter) ([]SessionRecord, error) {
 	var records []SessionRecord
 	root := filepath.Join(s.root, "sessions")
+	if info, statErr := os.Lstat(root); statErr == nil && (info.Mode()&os.ModeSymlink != 0 || !info.IsDir()) {
+		return nil, fmt.Errorf("list sessions: %s is not a directory", root)
+	}
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() || d.Name() != "meta.json" {
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		parts := strings.Split(filepath.ToSlash(rel), "/")
+		if d.Name() != "meta.json" {
+			if rel != "." && len(parts) <= 2 && parts[0] != ".locks" {
+				info, infoErr := d.Info()
+				if infoErr != nil {
+					if os.IsNotExist(infoErr) {
+						return nil
+					}
+					return infoErr
+				}
+				if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+					return fmt.Errorf("session path %s is not a directory", path)
+				}
+			}
+			// Directories without meta.json are unpublished. Metadata is the
+			// publication marker, so those leftovers are not occupancy records.
 			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			if os.IsNotExist(infoErr) {
+				if _, dirErr := os.Lstat(filepath.Dir(path)); os.IsNotExist(dirErr) {
+					return nil
+				}
+			}
+			return infoErr
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("session metadata %s is not a regular file", path)
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {
-			// A single unreadable record should not make every other session
-			// unavailable, just as corrupt metadata below is record-local.
-			return nil
+			if os.IsNotExist(err) {
+				if _, dirErr := os.Lstat(filepath.Dir(path)); os.IsNotExist(dirErr) {
+					return nil
+				}
+			}
+			return err
 		}
 		var record SessionRecord
 		if err := json.Unmarshal(data, &record); err != nil {
-			// Corrupt metadata should not make every other session unavailable.
-			return nil
+			return fmt.Errorf("decode %s: %w", path, err)
+		}
+		if err := validateRecordKey(record.Provider, record.SessionID); err != nil {
+			return fmt.Errorf("session metadata %s: %w", path, err)
+		}
+		expected := filepath.Join(s.sessionDir(record.Provider, record.SessionID), "meta.json")
+		if filepath.Clean(path) != filepath.Clean(expected) {
+			return fmt.Errorf("session metadata %s does not match key %q/%q", path, record.Provider, record.SessionID)
 		}
 		if matchesFilter(record, filter) {
 			records = append(records, record)
@@ -350,6 +459,23 @@ func (s *Store) sessionDir(provider Provider, sessionID string) string {
 	return filepath.Join(s.root, "sessions", providerPathPart(provider), safeSessionDirName(sessionID))
 }
 
+func (s *Store) rejectSessionPathSymlinks(provider Provider, sessionID string) error {
+	for _, path := range []string{
+		filepath.Join(s.root, "sessions"),
+		filepath.Join(s.root, "sessions", providerPathPart(provider)),
+		s.sessionDir(provider, sessionID),
+	} {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("session path %s is not a directory", path)
+		}
+	}
+	return nil
+}
+
 func safeSessionDirName(sessionID string) string {
 	sum := sha256.Sum256([]byte(sessionID))
 	return hex.EncodeToString(sum[:])
@@ -373,16 +499,37 @@ func (s *Store) acquireSessionLock(provider Provider, sessionID string) (func(),
 }
 
 func (s *Store) readMetadata(provider Provider, sessionID string) (SessionRecord, bool, error) {
-	data, err := os.ReadFile(filepath.Join(s.sessionDir(provider, sessionID), "meta.json"))
+	dir := s.sessionDir(provider, sessionID)
+	if err := s.rejectSessionPathSymlinks(provider, sessionID); err != nil {
+		if os.IsNotExist(err) {
+			return SessionRecord{}, false, nil
+		}
+		return SessionRecord{}, false, err
+	}
+	metaPath := filepath.Join(dir, "meta.json")
+	info, err := os.Lstat(metaPath)
 	if os.IsNotExist(err) {
 		return SessionRecord{}, false, nil
 	}
 	if err != nil {
 		return SessionRecord{}, false, fmt.Errorf("read session metadata: %w", err)
 	}
+	if !info.Mode().IsRegular() {
+		return SessionRecord{}, false, fmt.Errorf("session metadata %s is not a regular file", metaPath)
+	}
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return SessionRecord{}, false, fmt.Errorf("read session metadata: %w", err)
+	}
 	var record SessionRecord
 	if err := json.Unmarshal(data, &record); err != nil {
 		return SessionRecord{}, false, fmt.Errorf("decode session metadata: %w", err)
+	}
+	if record.Provider != provider || record.SessionID != sessionID {
+		return SessionRecord{}, false, fmt.Errorf(
+			"session metadata key %q/%q does not match requested key %q/%q",
+			record.Provider, record.SessionID, provider, sessionID,
+		)
 	}
 	return record, true, nil
 }

--- a/sessions/store.go
+++ b/sessions/store.go
@@ -173,13 +173,15 @@ func (s *Store) upsert(record SessionRecord) (SessionRecord, error) {
 	if record.SchemaVersion == 0 {
 		record.SchemaVersion = schemaVersion
 	}
-	if err := s.writeMetadata(record); err != nil {
-		return SessionRecord{}, err
-	}
 	if hasIncomingTranscript && record.Provider != ProviderCursor {
 		if err := s.writeTranscriptFiles(record, transcript); err != nil {
 			return SessionRecord{}, err
 		}
+	}
+	// Metadata is the publication marker used by List. Write payloads first so
+	// a failed transcript copy or normalization cannot expose a torn record.
+	if err := s.writeMetadata(record); err != nil {
+		return SessionRecord{}, err
 	}
 	return record, nil
 }
@@ -214,7 +216,9 @@ func (s *Store) List(filter SessionFilter) ([]SessionRecord, error) {
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return err
+			// A single unreadable record should not make every other session
+			// unavailable, just as corrupt metadata below is record-local.
+			return nil
 		}
 		var record SessionRecord
 		if err := json.Unmarshal(data, &record); err != nil {
@@ -524,6 +528,12 @@ func sortTime(record SessionRecord) time.Time {
 }
 
 func (s *Store) writeTranscriptFiles(record SessionRecord, input *os.File) error {
+	if err := artifacts.EnsureCollection(filepath.Join(s.root, "sessions"), providerPathPart(record.Provider)); err != nil {
+		return fmt.Errorf("create session provider directory: %w", err)
+	}
+	if _, err := artifacts.EnsureRecordDir(filepath.Join(s.root, "sessions", providerPathPart(record.Provider)), "", safeSessionDirName(record.SessionID)); err != nil {
+		return fmt.Errorf("secure session directory: %w", err)
+	}
 	dir := s.sessionDir(record.Provider, record.SessionID)
 	if s.copyRawTranscripts {
 		if _, err := input.Seek(0, 0); err != nil {

--- a/sessions/store_restore_internal_test.go
+++ b/sessions/store_restore_internal_test.go
@@ -1,0 +1,286 @@
+package sessions
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpsertRestoresTranscriptWhenMetadataWriteFails(t *testing.T) {
+	root := t.TempDir()
+	codexHome := t.TempDir()
+	providerDir := filepath.Join(codexHome, "sessions")
+	if err := os.MkdirAll(providerDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldProvider := filepath.Join(providerDir, "old.jsonl")
+	if err := os.WriteFile(oldProvider, []byte(`{"role":"user","kind":"message","text":"old"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write old provider transcript: %v", err)
+	}
+	newProvider := filepath.Join(providerDir, "new.jsonl")
+	if err := os.WriteFile(newProvider, []byte(`{"role":"user","kind":"message","text":"new"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write new provider transcript: %v", err)
+	}
+	store, err := NewStore(StoreOptions{Root: root, Env: map[string]string{"CODEX_HOME": codexHome}})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(SessionRecord{
+		Provider:       ProviderCodex,
+		SessionID:      "existing-session",
+		Status:         "running",
+		TranscriptPath: oldProvider,
+	}); err != nil {
+		t.Fatalf("seed Upsert() error = %v", err)
+	}
+	transcriptPath := filepath.Join(store.sessionDir(ProviderCodex, "existing-session"), "transcript.jsonl")
+	metaPath := filepath.Join(store.sessionDir(ProviderCodex, "existing-session"), "meta.json")
+	store.beforeMetadataWrite = func() {
+		if err := os.Remove(metaPath); err != nil {
+			t.Fatalf("remove meta.json: %v", err)
+		}
+		if err := os.Mkdir(metaPath, 0o700); err != nil {
+			t.Fatalf("block meta.json: %v", err)
+		}
+	}
+
+	err = store.Upsert(SessionRecord{
+		Provider:       ProviderCodex,
+		SessionID:      "existing-session",
+		Status:         "ended",
+		TranscriptPath: newProvider,
+	})
+	if err == nil {
+		t.Fatal("update Upsert() error = nil, want metadata write failure")
+	}
+	got, readErr := os.ReadFile(transcriptPath)
+	if readErr != nil {
+		t.Fatalf("read restored transcript: %v", readErr)
+	}
+	if !strings.Contains(string(got), `"text":"old"`) || strings.Contains(string(got), `"text":"new"`) {
+		t.Fatalf("transcript = %q, want restored previous body", got)
+	}
+}
+
+func TestUpsertRemovesNewTranscriptWhenMetadataWriteFails(t *testing.T) {
+	root := t.TempDir()
+	codexHome := t.TempDir()
+	providerDir := filepath.Join(codexHome, "sessions")
+	if err := os.MkdirAll(providerDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	providerTranscript := filepath.Join(providerDir, "new.jsonl")
+	if err := os.WriteFile(providerTranscript, []byte(`{"role":"user","kind":"message","text":"new"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write provider transcript: %v", err)
+	}
+	store, err := NewStore(StoreOptions{Root: root, Env: map[string]string{"CODEX_HOME": codexHome}})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	dir := store.sessionDir(ProviderCodex, "new-session")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	store.beforeMetadataWrite = func() {
+		if err := os.Mkdir(filepath.Join(dir, "meta.json"), 0o700); err != nil {
+			t.Fatalf("block meta.json: %v", err)
+		}
+	}
+
+	err = store.Upsert(SessionRecord{
+		Provider:       ProviderCodex,
+		SessionID:      "new-session",
+		Status:         "ended",
+		TranscriptPath: providerTranscript,
+	})
+	if err == nil {
+		t.Fatal("Upsert() error = nil, want metadata write failure")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "transcript.jsonl")); !os.IsNotExist(statErr) {
+		t.Fatalf("unpublished transcript still present: %v", statErr)
+	}
+}
+
+func TestUpsertKeepsExistingTranscriptWhenMetadataOnlyWriteFails(t *testing.T) {
+	root := t.TempDir()
+	codexHome := t.TempDir()
+	providerDir := filepath.Join(codexHome, "sessions")
+	if err := os.MkdirAll(providerDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldProvider := filepath.Join(providerDir, "old.jsonl")
+	if err := os.WriteFile(oldProvider, []byte(`{"role":"user","kind":"message","text":"old"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write old provider transcript: %v", err)
+	}
+	store, err := NewStore(StoreOptions{Root: root, Env: map[string]string{"CODEX_HOME": codexHome}})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(SessionRecord{
+		Provider:       ProviderCodex,
+		SessionID:      "existing-session",
+		Status:         "running",
+		TranscriptPath: oldProvider,
+	}); err != nil {
+		t.Fatalf("seed Upsert() error = %v", err)
+	}
+	transcriptPath := filepath.Join(store.sessionDir(ProviderCodex, "existing-session"), "transcript.jsonl")
+	metaPath := filepath.Join(store.sessionDir(ProviderCodex, "existing-session"), "meta.json")
+	store.beforeMetadataWrite = func() {
+		if err := os.Remove(metaPath); err != nil {
+			t.Fatalf("remove meta.json: %v", err)
+		}
+		if err := os.Mkdir(metaPath, 0o700); err != nil {
+			t.Fatalf("block meta.json: %v", err)
+		}
+	}
+
+	err = store.Upsert(SessionRecord{
+		Provider:  ProviderCodex,
+		SessionID: "existing-session",
+		Status:    "ended",
+		Summary:   "metadata only",
+	})
+	if err == nil {
+		t.Fatal("update Upsert() error = nil, want metadata write failure")
+	}
+	got, readErr := os.ReadFile(transcriptPath)
+	if readErr != nil {
+		t.Fatalf("existing transcript was removed: %v", readErr)
+	}
+	if !strings.Contains(string(got), `"text":"old"`) {
+		t.Fatalf("transcript = %q, want existing body left in place", got)
+	}
+}
+
+func TestUpsertRestoresRawCopyWhenNormalizationFails(t *testing.T) {
+	root := t.TempDir()
+	codexHome := t.TempDir()
+	providerDir := filepath.Join(codexHome, "sessions")
+	if err := os.MkdirAll(providerDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldProvider := filepath.Join(providerDir, "old.jsonl")
+	if err := os.WriteFile(oldProvider, []byte(`{"role":"user","kind":"message","text":"old"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write old provider transcript: %v", err)
+	}
+	badProvider := filepath.Join(providerDir, "bad.jsonl")
+	if err := os.WriteFile(badProvider, []byte("{not-json}\n"), 0o600); err != nil {
+		t.Fatalf("write invalid provider transcript: %v", err)
+	}
+	store, err := NewStore(StoreOptions{Root: root, CopyRawTranscripts: true, Env: map[string]string{"CODEX_HOME": codexHome}})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(SessionRecord{
+		Provider:       ProviderCodex,
+		SessionID:      "existing-session",
+		Status:         "running",
+		TranscriptPath: oldProvider,
+	}); err != nil {
+		t.Fatalf("seed Upsert() error = %v", err)
+	}
+	rawPath := filepath.Join(store.sessionDir(ProviderCodex, "existing-session"), "raw.jsonl")
+
+	err = store.Upsert(SessionRecord{
+		Provider:       ProviderCodex,
+		SessionID:      "existing-session",
+		Status:         "ended",
+		TranscriptPath: badProvider,
+	})
+	if err == nil {
+		t.Fatal("update Upsert() error = nil, want transcript normalization failure")
+	}
+	got, readErr := os.ReadFile(rawPath)
+	if readErr != nil {
+		t.Fatalf("raw transcript was removed: %v", readErr)
+	}
+	if !strings.Contains(string(got), `"text":"old"`) {
+		t.Fatalf("raw.jsonl = %q, want restored previous raw copy", got)
+	}
+	if _, statErr := os.Stat(rawPath + ".prev"); !os.IsNotExist(statErr) {
+		t.Fatalf("unused raw backup still present: %v", statErr)
+	}
+	transcriptPath := filepath.Join(store.sessionDir(ProviderCodex, "existing-session"), "transcript.jsonl")
+	if _, statErr := os.Stat(transcriptPath + ".prev"); !os.IsNotExist(statErr) {
+		t.Fatalf("unused transcript backup still present: %v", statErr)
+	}
+}
+
+func TestUpsertFailsClosedOnUnreadablePreviousTranscript(t *testing.T) {
+	root := t.TempDir()
+	codexHome := t.TempDir()
+	providerDir := filepath.Join(codexHome, "sessions")
+	if err := os.MkdirAll(providerDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	oldProvider := filepath.Join(providerDir, "old.jsonl")
+	if err := os.WriteFile(oldProvider, []byte(`{"role":"user","kind":"message","text":"old"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write old provider transcript: %v", err)
+	}
+	newProvider := filepath.Join(providerDir, "new.jsonl")
+	if err := os.WriteFile(newProvider, []byte(`{"role":"user","kind":"message","text":"new"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write new provider transcript: %v", err)
+	}
+	store, err := NewStore(StoreOptions{Root: root, Env: map[string]string{"CODEX_HOME": codexHome}})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(SessionRecord{
+		Provider:       ProviderCodex,
+		SessionID:      "existing-session",
+		Status:         "running",
+		TranscriptPath: oldProvider,
+	}); err != nil {
+		t.Fatalf("seed Upsert() error = %v", err)
+	}
+	transcriptPath := filepath.Join(store.sessionDir(ProviderCodex, "existing-session"), "transcript.jsonl")
+	if err := os.Remove(transcriptPath); err != nil {
+		t.Fatalf("remove transcript.jsonl: %v", err)
+	}
+	if err := os.Mkdir(transcriptPath, 0o700); err != nil {
+		t.Fatalf("block transcript.jsonl: %v", err)
+	}
+
+	err = store.Upsert(SessionRecord{
+		Provider:       ProviderCodex,
+		SessionID:      "existing-session",
+		Status:         "ended",
+		TranscriptPath: newProvider,
+	})
+	if err == nil {
+		t.Fatal("update Upsert() error = nil, want unreadable previous transcript")
+	}
+	info, statErr := os.Stat(transcriptPath)
+	if statErr != nil {
+		t.Fatalf("previous transcript path was removed: %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Fatalf("previous transcript path = file, want blocking directory left in place")
+	}
+}
+
+func TestRollbackPayloadStagesIncludesCauseAndRollbackError(t *testing.T) {
+	err := rollbackPayloadStages([]payloadStage{
+		{rollback: func() error { return errors.New("restore failed") }},
+	}, errors.New("raw stage failed"))
+	if err == nil || !strings.Contains(err.Error(), "raw stage failed") || !strings.Contains(err.Error(), "restore failed") {
+		t.Fatalf("error = %v, want both cause and rollback failure", err)
+	}
+}
+
+func TestCommitPayloadStagesContinuesAfterFirstError(t *testing.T) {
+	second := false
+	err := commitPayloadStages([]payloadStage{
+		{commit: func() error { return errors.New("first") }},
+		{commit: func() error { second = true; return nil }},
+	})
+	if err == nil || !strings.Contains(err.Error(), "first") {
+		t.Fatalf("error = %v, want first commit error", err)
+	}
+	if !second {
+		t.Fatal("second commit was not attempted")
+	}
+}

--- a/sessions/store_test.go
+++ b/sessions/store_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -156,6 +157,9 @@ func TestStoreReadRejectsInvalidMissingCorruptAndMismatchedMetadata(t *testing.T
 	}
 	if _, err := store.Read(sessions.ProviderCodex, "requested"); err == nil || !strings.Contains(err.Error(), "does not match") {
 		t.Fatalf("Read(mismatch) error = %v, want key mismatch", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{Provider: sessions.ProviderCodex, SessionID: "requested", Status: "ended"}); err == nil {
+		t.Fatal("Upsert(mismatch) error = nil, want fail-closed key mismatch")
 	}
 }
 
@@ -427,7 +431,7 @@ func TestStoreUpsertReportsSessionLockTimeout(t *testing.T) {
 	}
 }
 
-func TestStoreListSkipsCorruptMetadata(t *testing.T) {
+func TestStoreListFailsClosedOnCorruptMetadata(t *testing.T) {
 	root := t.TempDir()
 	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
 	if err != nil {
@@ -450,15 +454,119 @@ func TestStoreListSkipsCorruptMetadata(t *testing.T) {
 	}
 
 	records, err := store.List(sessions.SessionFilter{})
-	if err != nil {
-		t.Fatalf("List() error = %v", err)
+	if err == nil {
+		t.Fatal("List() error = nil, want fail-closed corrupt metadata")
 	}
-	if len(records) != 1 || records[0].SessionID != "good-session" {
-		t.Fatalf("List() = %#v, want only good-session", records)
+	if records != nil {
+		t.Fatalf("List() = %#v, want no rows when occupancy cannot be inspected", records)
 	}
 }
 
-func TestStoreListSkipsUnreadableMetadata(t *testing.T) {
+func TestStoreListFailsClosedOnUnreadableMetadata(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "good-session",
+		RepoPath:  "/repo",
+		Status:    "ended",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	badDir := filepath.Join(root, "sessions", "codex", "blocked")
+	if err := os.MkdirAll(badDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(badDir, filepath.Join(badDir, "meta.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err == nil {
+		t.Fatal("List() error = nil, want fail-closed unreadable metadata")
+	}
+	if records != nil {
+		t.Fatalf("List() = %#v, want no rows when occupancy cannot be inspected", records)
+	}
+}
+
+func TestStoreRejectsLiveMetadataSymlinkOnListAndUpsert(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "existing-session",
+		Status:    "running",
+	}); err != nil {
+		t.Fatalf("seed Upsert() error = %v", err)
+	}
+	metaPath := singleSessionFile(t, root, sessions.ProviderCodex, "meta.json")
+	realPath := metaPath + ".real"
+	if err := os.Rename(metaPath, realPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realPath, metaPath); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err == nil {
+		t.Fatal("List() error = nil, want fail-closed metadata symlink")
+	}
+	if records != nil {
+		t.Fatalf("List() = %#v, want no rows when occupancy cannot be inspected", records)
+	}
+	if _, err := store.Read(sessions.ProviderCodex, "existing-session"); err == nil {
+		t.Fatal("Read() error = nil, want fail-closed metadata symlink")
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "existing-session",
+		Status:    "ended",
+	}); err == nil {
+		t.Fatal("Upsert() error = nil, want fail-closed metadata symlink")
+	}
+}
+
+func TestStoreListFailsClosedOnNonRegularMetadata(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "good-session",
+		RepoPath:  "/repo",
+		Status:    "ended",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	badDir := filepath.Join(root, "sessions", "codex", "fifo")
+	if err := os.MkdirAll(badDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	fifoPath := filepath.Join(badDir, "meta.json")
+	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err == nil {
+		t.Fatal("List() error = nil, want fail-closed non-regular metadata")
+	}
+	if records != nil {
+		t.Fatalf("List() = %#v, want no rows when occupancy cannot be inspected", records)
+	}
+}
+
+func TestStoreListFailsClosedOnDanglingMetadataSymlink(t *testing.T) {
 	root := t.TempDir()
 	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
 	if err != nil {
@@ -481,11 +589,291 @@ func TestStoreListSkipsUnreadableMetadata(t *testing.T) {
 	}
 
 	records, err := store.List(sessions.SessionFilter{})
+	if err == nil {
+		t.Fatal("List() error = nil, want fail-closed dangling metadata symlink")
+	}
+	if records != nil {
+		t.Fatalf("List() = %#v, want no rows when occupancy cannot be inspected", records)
+	}
+}
+
+func TestStoreListFailsClosedOnDirectoryMetadata(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "good-session",
+		RepoPath:  "/repo",
+		Status:    "ended",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	badDir := filepath.Join(root, "sessions", "codex", "blocked-dir")
+	if err := os.MkdirAll(filepath.Join(badDir, "meta.json"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err == nil {
+		t.Fatal("List() error = nil, want fail-closed directory metadata")
+	}
+	if records != nil {
+		t.Fatalf("List() = %#v, want no rows when occupancy cannot be inspected", records)
+	}
+}
+
+func TestStoreListFailsClosedOnInvalidDecodedMetadata(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "good-session",
+		RepoPath:  "/repo",
+		Status:    "ended",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	badDir := filepath.Join(root, "sessions", "codex", "empty")
+	if err := os.MkdirAll(badDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(badDir, "meta.json"), []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err == nil {
+		t.Fatal("List() error = nil, want fail-closed empty metadata")
+	}
+	if records != nil {
+		t.Fatalf("List() = %#v, want no rows when occupancy cannot be inspected", records)
+	}
+}
+
+func TestStoreListFailsClosedOnNonDirectorySessionsRoot(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	sessionsDir := filepath.Join(root, "sessions")
+	if err := os.RemoveAll(sessionsDir); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(sessionsDir, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err == nil {
+		t.Fatal("List() error = nil, want fail-closed non-directory sessions root")
+	}
+	if records != nil {
+		t.Fatalf("List() = %#v, want no rows when occupancy cannot be inspected", records)
+	}
+}
+
+func TestStoreUpsertPublishesExistingDirectoryWithoutMetadata(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	sum := sha256.Sum256([]byte("existing-session"))
+	dir := filepath.Join(root, "sessions", "codex", hex.EncodeToString(sum[:]))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "existing-session",
+		Status:    "running",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	got, err := store.Read(sessions.ProviderCodex, "existing-session")
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if got.Status != "running" {
+		t.Fatalf("Read() status = %q, want running", got.Status)
+	}
+}
+
+func TestStoreListFailsClosedOnSymlinkedSessionsRoot(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "good-session",
+		RepoPath:  "/repo",
+		Status:    "ended",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	sessionsDir := filepath.Join(root, "sessions")
+	hidden := filepath.Join(root, "hidden-sessions")
+	if err := os.Rename(sessionsDir, hidden); err != nil {
+		t.Fatalf("rename sessions dir: %v", err)
+	}
+	if err := os.Symlink(hidden, sessionsDir); err != nil {
+		t.Fatalf("symlink sessions dir: %v", err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err == nil {
+		t.Fatal("List() error = nil, want fail-closed symlinked sessions root")
+	}
+	if records != nil {
+		t.Fatalf("List() = %#v, want no rows when occupancy cannot be inspected", records)
+	}
+}
+
+func TestStoreListIgnoresPayloadSymlinksInUnpublishedDirs(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "good-session",
+		RepoPath:  "/repo",
+		Status:    "ended",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	leftover := filepath.Join(root, "sessions", "codex", "unpublished")
+	if err := os.MkdirAll(leftover, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(leftover, "missing.jsonl"), filepath.Join(leftover, "transcript.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
 	if len(records) != 1 || records[0].SessionID != "good-session" {
 		t.Fatalf("List() = %#v, want only good-session", records)
+	}
+}
+
+func TestStoreListFailsClosedOnSymlinkedProviderDir(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "good-session",
+		RepoPath:  "/repo",
+		Status:    "ended",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	providerDir := filepath.Join(root, "sessions", "codex")
+	hidden := filepath.Join(root, "hidden-codex")
+	if err := os.Rename(providerDir, hidden); err != nil {
+		t.Fatalf("rename provider dir: %v", err)
+	}
+	if err := os.Symlink(hidden, providerDir); err != nil {
+		t.Fatalf("symlink provider dir: %v", err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err == nil {
+		t.Fatal("List() error = nil, want fail-closed symlinked provider directory")
+	}
+	if records != nil {
+		t.Fatalf("List() = %#v, want no rows when occupancy cannot be inspected", records)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "good-session",
+		Status:    "running",
+	}); err == nil {
+		t.Fatal("Upsert() error = nil, want fail-closed symlinked provider directory")
+	}
+}
+
+func TestStoreUpsertFailsClosedOnDanglingMetadata(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "existing-session",
+		Status:    "running",
+	}); err != nil {
+		t.Fatalf("seed Upsert() error = %v", err)
+	}
+	metaPath := singleSessionFile(t, root, sessions.ProviderCodex, "meta.json")
+	if err := os.Remove(metaPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(filepath.Dir(metaPath), "missing.json"), metaPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "existing-session",
+		Status:    "ended",
+	}); err == nil {
+		t.Fatal("Upsert() error = nil, want fail-closed dangling metadata")
+	}
+	info, err := os.Lstat(metaPath)
+	if err != nil {
+		t.Fatalf("dangling metadata was removed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("dangling metadata was replaced, want original symlink left in place")
+	}
+}
+
+func TestStoreListFailsClosedOnMismatchedMetadataPath(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "good-session",
+		RepoPath:  "/repo",
+		Status:    "ended",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	wrongDir := filepath.Join(root, "sessions", "codex", "not-the-hash")
+	if err := os.MkdirAll(wrongDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wrongDir, "meta.json"), []byte(`{"provider":"codex","session_id":"good-session","status":"running"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err == nil {
+		t.Fatal("List() error = nil, want fail-closed mismatched metadata path")
+	}
+	if records != nil {
+		t.Fatalf("List() = %#v, want no rows when occupancy cannot be inspected", records)
 	}
 }
 
@@ -715,7 +1103,7 @@ func TestStoreMarkLaunchEndedAdvancesResumedLaunch(t *testing.T) {
 	}
 }
 
-func TestStoreMarkLaunchEndedSkipsLegacyBlankSessionIDRecords(t *testing.T) {
+func TestStoreMarkLaunchEndedFailsClosedOnLegacyBlankSessionIDRecords(t *testing.T) {
 	root := t.TempDir()
 	endedAt := time.Date(2026, 6, 6, 15, 0, 0, 0, time.UTC)
 	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
@@ -740,16 +1128,16 @@ func TestStoreMarkLaunchEndedSkipsLegacyBlankSessionIDRecords(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := store.MarkLaunchEnded("launch-1", endedAt); err != nil {
-		t.Fatalf("MarkLaunchEnded() error = %v, want legacy blank-ID record skipped", err)
+	if err := store.MarkLaunchEnded("launch-1", endedAt); err == nil {
+		t.Fatal("MarkLaunchEnded() error = nil, want fail-closed blank-ID metadata")
 	}
 
-	records, err := store.List(sessions.SessionFilter{RepoPath: "/repo"})
+	good, err := store.Read(sessions.ProviderClaude, "claude-1")
 	if err != nil {
-		t.Fatalf("List() error = %v", err)
+		t.Fatalf("Read() error = %v", err)
 	}
-	if len(records) != 1 || records[0].Status != "ended" {
-		t.Fatalf("valid launch record was not ended: %#v", records)
+	if good.Status != "last_seen" {
+		t.Fatalf("valid launch record status = %q, want left unchanged when occupancy cannot be inspected", good.Status)
 	}
 }
 

--- a/sessions/store_test.go
+++ b/sessions/store_test.go
@@ -458,6 +458,37 @@ func TestStoreListSkipsCorruptMetadata(t *testing.T) {
 	}
 }
 
+func TestStoreListSkipsUnreadableMetadata(t *testing.T) {
+	root := t.TempDir()
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "good-session",
+		RepoPath:  "/repo",
+		Status:    "ended",
+	}); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+	badDir := filepath.Join(root, "sessions", "codex", "unreadable")
+	if err := os.MkdirAll(badDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(badDir, "missing.json"), filepath.Join(badDir, "meta.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := store.List(sessions.SessionFilter{})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(records) != 1 || records[0].SessionID != "good-session" {
+		t.Fatalf("List() = %#v, want only good-session", records)
+	}
+}
+
 func TestStoreWritesArtifactsWithRestrictivePermissions(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "state")
 	providerTranscript := providerTranscriptPath(t, sessions.ProviderCodex, "provider.jsonl")
@@ -487,6 +518,73 @@ func TestStoreWritesArtifactsWithRestrictivePermissions(t *testing.T) {
 	assertMode(t, metaPath, 0o600)
 	assertMode(t, filepath.Join(sessionDir, "transcript.jsonl"), 0o600)
 	assertMode(t, filepath.Join(sessionDir, "raw.jsonl"), 0o600)
+}
+
+func TestStoreDoesNotPublishNewMetadataWhenTranscriptNormalizationFails(t *testing.T) {
+	root := t.TempDir()
+	providerTranscript := providerTranscriptPath(t, sessions.ProviderCodex, "invalid.jsonl")
+	if err := os.WriteFile(providerTranscript, []byte("{not-json}\n"), 0o600); err != nil {
+		t.Fatalf("write provider transcript: %v", err)
+	}
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root, CopyRawTranscripts: true})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	err = store.Upsert(sessions.SessionRecord{
+		Provider:       sessions.ProviderCodex,
+		SessionID:      "failed-transcript",
+		Status:         "ended",
+		TranscriptPath: providerTranscript,
+	})
+	if err == nil {
+		t.Fatal("Upsert() error = nil, want transcript normalization failure")
+	}
+	records, listErr := store.List(sessions.SessionFilter{})
+	if listErr != nil {
+		t.Fatalf("List() error = %v", listErr)
+	}
+	if len(records) != 0 {
+		t.Fatalf("List() = %#v, want no published session", records)
+	}
+}
+
+func TestStoreKeepsExistingMetadataWhenTranscriptNormalizationFails(t *testing.T) {
+	root := t.TempDir()
+	providerTranscript := providerTranscriptPath(t, sessions.ProviderCodex, "invalid-update.jsonl")
+	if err := os.WriteFile(providerTranscript, []byte("{not-json}\n"), 0o600); err != nil {
+		t.Fatalf("write provider transcript: %v", err)
+	}
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	if err := store.Upsert(sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "existing-session",
+		Status:    "running",
+		Summary:   "before",
+	}); err != nil {
+		t.Fatalf("seed Upsert() error = %v", err)
+	}
+
+	err = store.Upsert(sessions.SessionRecord{
+		Provider:       sessions.ProviderCodex,
+		SessionID:      "existing-session",
+		Status:         "ended",
+		Summary:        "after",
+		TranscriptPath: providerTranscript,
+	})
+	if err == nil {
+		t.Fatal("update Upsert() error = nil, want transcript normalization failure")
+	}
+	record, readErr := store.Read(sessions.ProviderCodex, "existing-session")
+	if readErr != nil {
+		t.Fatalf("Read() error = %v", readErr)
+	}
+	if record.Status != "running" || record.Summary != "before" || record.TranscriptPath != "" {
+		t.Fatalf("Read() = %#v, want unchanged existing metadata", record)
+	}
 }
 
 func TestStoreMarksLaunchEnded(t *testing.T) {

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -469,6 +469,8 @@ type RenderParams struct {
 	FlowDegradationWarning         string
 	ActiveFlowDegradationWarning   string
 	PRBabysitterDegradationWarning string
+	TopDegradationWarning          string
+	BottomDegradationWarning       string
 	BeadsOpen                      []beadsquery.Bead
 	BeadsOpenSelected              int
 	BeadsOpenScroll                int
@@ -1051,7 +1053,7 @@ func renderStackedModePane(p RenderParams, mode Mode, width, outerRows int, focu
 	hasRows := stackedModePaneHasRows(p, mode, takeover)
 	_, sourceCount := paneItemFilterState(p, mode)
 	showCachedWarning := ShowsCachedListWarning(paneListError(p, mode), hasRows, sourceCount)
-	degradationWarning := paneFlowDegradationWarning(p, mode)
+	degradationWarning := paneDegradationWarning(p, mode)
 	bodyRows := listRows
 	if showCachedWarning && bodyRows > 0 {
 		bodyRows--
@@ -1105,7 +1107,7 @@ func renderStackedModePane(p RenderParams, mode Mode, width, outerRows int, focu
 	}
 	var warnings []string
 	if degradationWarning != "" {
-		warnings = append(warnings, truncateToWidth(aheadBehindStyle.Render(" "+degradationWarning), width))
+		warnings = append(warnings, truncateToWidth(aheadBehindStyle.Render(" "+terminalSafeSingleLine(degradationWarning)), width))
 	}
 	if showCachedWarning {
 		warning := " Could not refresh " + modeDataLabel(mode) + "; showing cached data"
@@ -1249,7 +1251,7 @@ func paneListError(p RenderParams, mode Mode) string {
 	}
 }
 
-func paneFlowDegradationWarning(p RenderParams, mode Mode) string {
+func paneDegradationWarning(p RenderParams, mode Mode) string {
 	switch mode {
 	case ModeFlows:
 		return p.FlowDegradationWarning
@@ -1257,9 +1259,15 @@ func paneFlowDegradationWarning(p RenderParams, mode Mode) string {
 		return p.ActiveFlowDegradationWarning
 	case ModePRBabysitter:
 		return p.PRBabysitterDegradationWarning
-	default:
+	}
+	pane, ok := PaneForMode(mode)
+	if !ok {
 		return ""
 	}
+	if pane == PaneTop {
+		return p.TopDegradationWarning
+	}
+	return p.BottomDegradationWarning
 }
 
 func paneItemFilterState(p RenderParams, mode Mode) (string, int) {

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -5149,6 +5149,27 @@ func TestRender_StackedPaneRetainedRowsShowPersistentFetchWarning(t *testing.T) 
 	}
 }
 
+func TestRender_StackedPaneShowsPartialGitMetadataWarningWithFreshRows(t *testing.T) {
+	view := ansi.Strip(Render(RenderParams{
+		Width:                 160,
+		Height:                26,
+		Repos:                 []scanner.Repo{{Path: "/repo", DisplayName: "repo"}},
+		Selected:              0,
+		Mode:                  ModeWorktrees,
+		TopMode:               ModeWorktrees,
+		BottomMode:            ModePlans,
+		ContentPane:           PaneTop,
+		ActivePane:            PaneTop,
+		Worktrees:             []gitquery.Worktree{{Path: "/repo", BranchName: "main"}},
+		TopDegradationWarning: "Git metadata incomplete: cannot read index",
+	}))
+	for _, want := range []string{"Git metadata incomplete: cannot read index", "main"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("partial metadata view missing %q:\n%s", want, view)
+		}
+	}
+}
+
 func TestRender_StackedPaneFilterEmptyKeepsPersistentFetchWarning(t *testing.T) {
 	view := ansi.Strip(Render(RenderParams{
 		Width:              160,


### PR DESCRIPTION
Issue #277 identified several P1 failure modes where Approach could publish incomplete artifacts, hide Git failures, trust invalid working directories, or discard cleanup and output errors. This PR fixes all remaining P1 findings while leaving the P2 and P3 audit scope unchanged.

## What changed

- Publish session transcripts and plan Markdown before their metadata markers, and skip isolated unreadable session metadata during listing.
- Enforce restrictive configuration permissions for both new and existing config files.
- Preserve Git stderr and wrapped causes for worktree operations, including the partial-success case where removal succeeds but pruning fails.
- Bound Git queries with timeouts and distinguish a false merge predicate from an execution failure.
- Return usable branch and worktree rows alongside typed, bounded diagnostics when optional Git enrichment fails, and surface those diagnostics in the TUI.
- Reject relative, missing, and non-directory Git working paths during session and plan ingestion.
- Preserve all emulator startup cleanup failures while still terminating and waiting for the spawned process.
- Keep session-hook executable paths shell-safe and propagate Plan CLI stdout write failures.

## TDD and verification

Regression tests cover findings 5, 7 through 9, 11 through 14, 39, and the Plan CLI portion of 40.

- make fmt-check
- make test
- make build
- go test -race ./sessions ./planstore ./gitquery ./model
- git diff --check

The branch was fast-forwarded to the latest main before the final quality-gate run.