### PR TITLE
Let phase resume's launch builder own its markers and tmux route

### DIFF
--- a/docs/adr/0002-flow-launch-context-deep-module.md
+++ b/docs/adr/0002-flow-launch-context-deep-module.md
@@ -465,3 +465,77 @@ that the module-interface variant test gained autofix rows for the embedded,
 headless, and tmux variants, each comparing the whole struct and the decision.
 
 The ADR's status stays `proposed`.
+
+## Implementation note — saved-session resume (`approach-hyl.5`)
+
+The fourth slice migrated `RoleSavedSessionResume`, the first role whose
+*identity* comes from somewhere other than the settings snapshot.
+
+- **The session record is the authority, not the snapshot.** Command is
+  `string(session.Provider)`, and `Model`/`ReasoningEffort` must stay empty:
+  `agentCommandSpec` errors with "model cannot be set for session resume" if the
+  snapshot's preferences leak in. Passing the whole `sessions.SessionRecord` on
+  the target rather than pre-mapped fields is what keeps that rule inside the
+  builder — the CWD-then-worktree `WorkingDir` fallback and the "no usable
+  directory" refusal (`errSavedSessionResumeNoWorkingDir`) moved with it.
+- **`Commit` is the session's, and the marker is what keeps it so.**
+  `agentCommandSpec` skips `ResolveWorktreeCommit` exactly when
+  `FlowSavedSessionResume` is set, so the marker and the carried commit are one
+  decision, now made in one place.
+- **The Flow ID is the reserved record's while every other field is the
+  session's.** The lease and the release key on the reservation; the resumed
+  session's own branch, commit and plan are what the agent gets back. Two
+  records on one target is the honest shape of that split.
+- **Route stays a constant.** `tmuxRouteEligible` refuses
+  `FlowSavedSessionResume` outright, so this arm ignores `routing` and returns
+  `{flowLaunchRouteEmbedded, ""}` — a constant, not an unrouted gap.
+
+The acceptance evidence is that `model/flow_launch_saved_session_resume.go`'s
+prepare stage no longer composes a literal and that the module-interface variant
+test gained a saved-session-resume row comparing the whole struct and the
+decision.
+
+The ADR's status stays `proposed`.
+
+## Implementation note — phase resume (`approach-hyl.6`)
+
+The fifth slice migrated `RolePhaseResume` — V7–V10, the only variants with
+`FlowPhaseTerminal` and the last tracked kind before manual/auto/create.
+
+- **The route probe stopped being a Model-side literal.** Resume used to build a
+  throwaway `AgentLaunchContext` on the Model purely to ask
+  `tmuxRouteEligible` a question (formerly `model/flow_launch_resume.go:299`),
+  then clear `Embedded` after construction. The prepare stage now snapshots only
+  `flowLaunchRouting{Backend, TmuxAvailable}` and the builder decides against
+  the finished context. That is not a refactor of equals: `tmuxRouteEligible`
+  reads `Headless`, `FlowRepair` and `Command`, and this role sets neither
+  marker, so the finished-context decision is identical to the Command-only
+  probe — but it can no longer drift from the context it routes.
+- **`FlowPhaseTerminal` is the flag that stops a failed resume from regressing a
+  completed phase**, so which phase decides it is load-bearing. The persisted
+  record from `AddPhaseLaunchID` wins, with the read stage's phase as the
+  fallback, and the lookup is guarded: an unguarded `flowPhaseByID` would answer
+  with the zero phase — "not terminal" — for every phase-less record a seam
+  returns. `FlowPhaseKind` comes off the same phase so one cannot describe a
+  phase the other no longer does.
+- **Two records, again, for a different reason than saved-session resume.**
+  Resume reads a record and then writes one. `Record` is the read stage's and
+  stays the authority for branch, commit, plan ID and worktree — prepare never
+  refreshes it, so the worktree it names is the one the read stage validated.
+  `PersistedRecord` is consulted only for the phase.
+- **Model and effort stay empty here too**, for the same `agentCommandSpec`
+  reason as saved-session resume: the snapshot is in scope and deliberately
+  unread.
+- **The builder's worktree check is an invariant, not a new refusal path.** The
+  read stage already refuses a worktree-less resume with
+  `flowPhaseResumeNoWorktreeStatus`; the builder-side check exists because this
+  role chdirs into the worktree and the builder is the one place every Flow
+  launch context is constructed.
+
+The acceptance evidence is that `model/flow_launch_resume.go`'s prepare stage
+carries no context literal and no post-construction `Embedded` mutation, and
+that the module-interface variant test gained phase-resume rows for the
+embedded, tmux and terminal-phase variants, each comparing the whole struct and
+the decision.
+
+The ADR's status stays `proposed`.

--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -1,8 +1,11 @@
 # Flow launch variant matrix
 
 Evidence base for `approach-hyl` (typed Flow launch intent). Every cell cites
-`file:line` against commit `e1dd62e`. This document describes the code as it is
-today; the proposed redesign is ADR 0002.
+`file:line` against commit `e1dd62e`, the state of the code before the ADR 0002
+migration began; the proposed redesign is ADR 0002. Sections 1-3 are that
+frozen survey. What has moved since is recorded in "Migration status" at the end
+of section 2, which is the authority for where a kind is constructed and routed
+today.
 
 Scope: the eight launch kinds in `model/flow_launch_intent.go:14`, crossed with
 route (embedded/tmux), headless, and phase-terminal resume, and every consumer
@@ -82,12 +85,27 @@ The reachable variants:
 | V16 | worktreeAgent | embedded | false | false |
 | V17 | savedSessionResume | embedded | false | false |
 
-V11–V12 (repair), V13–V15 (autofix) and V16 (worktreeAgent) are built by
-`newFlowLaunchContext` (`model/flow_launch_context.go`) rather than by a literal
-at their prepare stage. V13–V15 are also the first variants whose *route* the
-builder decides: it takes the snapshotted backend and tmux probe and returns the
-route with the fallback note, so V15's cleared `Embedded` is set where the rule
-lives rather than after construction.
+### Migration status
+
+V7–V17 are built by `newFlowLaunchContext` (`model/flow_launch_context.go`)
+rather than by a literal at their prepare stage: V16 (worktreeAgent), V11–V12
+(repair), V13–V15 (autofix), V17 (savedSessionResume) and V7–V10
+(phaseResume), in that migration order. Only V1–V6 — manual, auto and create
+phase launches — still compose a literal at their call site, so the
+construction sites in section 1 and the `C:` line numbers in section 3 read as
+the pre-migration snapshot for every other row.
+
+Two of those roles decide their own *route*. V13–V15 were the first: the
+builder takes the snapshotted backend and tmux probe and returns the route with
+the fallback note, so V15's cleared `Embedded` is set where the rule lives
+rather than after construction. V7–V10 followed — the probe the call site used
+to run on the Model (formerly `model/flow_launch_resume.go:299`) is now the same
+decision taken against the finished context, and V9–V10's cleared `Embedded`
+moved with it. The remaining builder arms return a constant embedded route,
+which keeps the pruning rules at rows `repair × tmux`, `worktreeAgent × tmux`
+and `savedSessionResume × tmux` true by construction rather than by a missing
+call site. The `phaseResume × headless` and `savedSessionResume × headless`
+rules likewise now hold because neither builder arm assigns `Headless`.
 
 ## 3. Field values, with the pipeline point that sets them
 
@@ -141,7 +159,9 @@ Every kind additionally passes through `applyLaunchStamp`
 3. `Embedded` is forced false on the tmux route in four places:
    `model/flow_phase_launch.go:406`, `model/flow_launch_resume.go:388`,
    `model/flow_launch_autofix.go:399`, `model/tmux_mode.go:132`, and once more
-   inside actions at `actions/tmux_mode.go:313`.
+   inside actions at `actions/tmux_mode.go:313`. Two of those five have since
+   moved inside the builder with their roles: the autofix and phase-resume
+   clears now happen in the arm that decides the route.
 4. `Headless` is resolved twice for manual launches — from the record at
    `model/flow_launch_lifecycle.go:620` and again from the persisted reservation
    at `model/flow_phase_launch.go:398` — and for repair only at refresh time

--- a/model/flow_launch_context.go
+++ b/model/flow_launch_context.go
@@ -110,6 +110,47 @@ func (savedSessionResumeTarget) role() actions.FlowLaunchRole {
 	return actions.RoleSavedSessionResume
 }
 
+// phaseResumeTarget is the phase-tracked resume of a Flow phase's saved
+// provider session, started by r. Unlike savedSessionResumeTarget it re-enters
+// the phase itself: the launch is tracked, carries the phase's ID, kind and
+// terminal flag, and its failure handling turns on that flag. It carries two
+// records rather than one because the resume reads a record and then writes
+// one, and the two answer different questions.
+type phaseResumeTarget struct {
+	// LaunchID is the admission token, never a fresh ID: the prefill-failure
+	// re-reservation and the failure-persisted fence both key on it.
+	LaunchID string
+	// Record is the read stage's record — the authority for branch, commit,
+	// plan ID, worktree and Flow ID. Prepare never refreshes it, so the
+	// worktree it names is the same value the read stage validated.
+	Record flowstore.FlowRecord
+	// PersistedRecord is the record AddPhaseLaunchID returned, consulted only
+	// for the phase. It decides whether this resume preserved a terminal phase
+	// or reopened a running one, and seams routinely return phase-less records,
+	// which is why the lookup below is guarded rather than direct.
+	PersistedRecord flowstore.FlowRecord
+	// ReadPhase is the read stage's phase, used when PersistedRecord carries
+	// none. Falling back rather than defaulting to the zero phase is what keeps
+	// a phase-less write from silently reporting "not terminal".
+	ReadPhase flowstore.FlowPhase
+	PhaseID   string
+	// Command is the provider the session was written by, resolved by the read
+	// stage — not the settings snapshot's preference, which may have moved on
+	// since the session was recorded.
+	Command string
+	// ResumeSessionID is the provider's own session ID, carried verbatim: the
+	// trim in the validation below is an emptiness test, never a rewrite.
+	ResumeSessionID string
+	// PlanPath is the read stage's resolution, passed through with no
+	// PlanMarkdownPath step, exactly as resume has always resolved it.
+	PlanPath string
+	// FallbackRepoPath is the intent's repository, used only when the record
+	// carries none of its own.
+	FallbackRepoPath string
+}
+
+func (phaseResumeTarget) role() actions.FlowLaunchRole { return actions.RolePhaseResume }
+
 // errIncompleteFlowLaunchTarget reports a payload that upstream admission
 // should already have guaranteed. The builder still checks: it is the one
 // place every Flow launch context is constructed, so it is the only place the
@@ -163,6 +204,8 @@ func newFlowLaunchContext(
 		return newAutofixLaunchContext(payload, settings, routing)
 	case savedSessionResumeTarget:
 		return newSavedSessionResumeLaunchContext(payload, settings)
+	case phaseResumeTarget:
+		return newPhaseResumeLaunchContext(payload, settings, routing)
 	default:
 		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errIncompleteFlowLaunchTarget
 	}
@@ -344,4 +387,76 @@ func newSavedSessionResumeLaunchContext(
 		FlowID: target.Record.FlowID, FlowSavedSessionResume: true,
 		Embedded: true, Headless: false, InitialPrompt: "",
 	}, settings.stamp()), flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded}, nil
+}
+
+// newPhaseResumeLaunchContext is the second arm whose route is a decision
+// rather than a constant, after autofix. Phase resume is genuinely
+// tmux-eligible where repair and saved-session resume are not:
+// tmuxRouteEligible reads only Headless, FlowRepair and Command, and this role
+// sets neither marker, so deciding against the finished context is identical to
+// the Command-only probe the call site used to make on the Model.
+//
+// Like saved-session resume it must leave Model and ReasoningEffort empty:
+// agentCommandSpec refuses a resume that carries a model, and setting either
+// would silently change the resumed command line.
+func newPhaseResumeLaunchContext(
+	target phaseResumeTarget,
+	settings flowLaunchAgentSettingsSnapshot,
+	routing flowLaunchRouting,
+) (actions.AgentLaunchContext, flowLaunchRouteDecision, error) {
+	record := target.Record
+	// The worktree is required here even though the read stage already refuses a
+	// worktree-less resume with flowPhaseResumeNoWorktreeStatus: this is the
+	// builder-side invariant for a role that chdirs into the worktree, not a new
+	// refusal path the user can reach.
+	if strings.TrimSpace(target.LaunchID) == "" ||
+		strings.TrimSpace(record.FlowID) == "" ||
+		strings.TrimSpace(record.WorktreePath) == "" ||
+		strings.TrimSpace(target.PhaseID) == "" ||
+		strings.TrimSpace(target.Command) == "" ||
+		strings.TrimSpace(target.ResumeSessionID) == "" {
+		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errIncompleteFlowLaunchTarget
+	}
+	repoPath := strings.TrimSpace(record.RepoPath)
+	if repoPath == "" {
+		repoPath = target.FallbackRepoPath
+	}
+	// The persisted phase wins, and the guard is load-bearing: an unguarded
+	// lookup would answer with the zero phase — "not terminal" — for every
+	// phase-less record a seam returns, which is exactly the case the read
+	// stage's phase exists to cover. Kind and terminal come from the same phase
+	// so one cannot describe a phase the other no longer does.
+	launchPhase := target.ReadPhase
+	if persistedPhase, ok := flowPhaseByID(target.PersistedRecord, target.PhaseID); ok {
+		launchPhase = persistedPhase
+	}
+	ctx := applyLaunchStamp(actions.AgentLaunchContext{
+		// The command is the provider that wrote the session, resolved by the
+		// read stage, for the reason saved-session resume takes it off the
+		// session record: a resume re-enters the agent it came from.
+		Command: target.Command, LaunchID: target.LaunchID,
+		RepoPath: repoPath, WorktreePath: record.WorktreePath, WorkingDir: record.WorktreePath,
+		Branch: record.Branch, Commit: record.Commit,
+		// No Model or ReasoningEffort: the snapshot is in scope and deliberately
+		// unread here.
+		SessionStateRoot: settings.SessionStateRoot,
+		ResumeSessionID:  target.ResumeSessionID,
+		PlanID:           record.PlanID, PlanPath: target.PlanPath,
+		FlowID: record.FlowID, FlowPhaseID: target.PhaseID,
+		FlowPhaseKind:     flowstore.SemanticKind(launchPhase),
+		FlowPhaseTerminal: flowstore.PhaseStatusTerminal(launchPhase.Status),
+		Embedded:          true, FlowLaunchTracked: true,
+	}, settings.stamp())
+	tmuxRoute, fellBack := tmuxLaunchRouteFor(routing.Backend, routing.TmuxAvailable, ctx)
+	if tmuxRoute {
+		// A tmux window has no dock to prefill and renders its own output, so
+		// clearing Embedded is what sends the resume to argv instead.
+		ctx.Embedded = false
+		return ctx, flowLaunchRouteDecision{Route: flowLaunchRouteTmux}, nil
+	}
+	decision := flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded}
+	if fellBack {
+		decision.FallbackNote = tmuxFallbackNote
+	}
+	return ctx, decision, nil
 }

--- a/model/flow_launch_context_internal_test.go
+++ b/model/flow_launch_context_internal_test.go
@@ -53,6 +53,13 @@ func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 	resumeRecord, resumeSession := launchContextSavedSessionResumeTarget()
 	headlessAutofixRecord := launchContextAutofixRecord()
 	headlessAutofixRecord.Headless = true
+	phaseResume := launchContextPhaseResumeTarget()
+	// The read phase stays running while the persisted one is completed, so the
+	// row cannot pass by reading the wrong record.
+	terminalPhaseResume := launchContextPhaseResumeTarget()
+	terminalPhase := terminalPhaseResume.ReadPhase
+	terminalPhase.Status = flowstore.PhaseCompleted
+	terminalPhaseResume.PersistedRecord.Phases = []flowstore.FlowPhase{terminalPhase}
 	for _, variant := range []struct {
 		name     string
 		target   flowLaunchTarget
@@ -251,6 +258,47 @@ func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 				FlowSavedSessionResume: true,
 				Embedded:               true,
 			},
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
+		},
+		{
+			// The tracked resume: FlowLaunchTracked and the phase's ID, kind and
+			// terminal flag all set, every untracked role's marker
+			// (FlowAgent/FlowRepair/FlowAutofix/FlowSavedSessionResume) zero. That
+			// exact shape is what validateTrackedRepoTmuxRole accepts.
+			name:     "phase resume embedded",
+			target:   phaseResume,
+			want:     launchContextPhaseResumeContext(phaseResume.Record),
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
+		},
+		{
+			// Phase resume is genuinely tmux-eligible where repair and
+			// saved-session resume are not: it sets neither Headless nor
+			// FlowRepair, the only markers tmuxRouteEligible refuses on. Embedded
+			// clears because a tmux window has no dock to prefill.
+			name:   "phase resume tmux",
+			target: phaseResume,
+			routing: flowLaunchRouting{
+				Backend:       config.LaunchBackendTmux,
+				TmuxAvailable: func() bool { return true },
+			},
+			want: func() actions.AgentLaunchContext {
+				ctx := launchContextPhaseResumeContext(phaseResume.Record)
+				ctx.Embedded = false
+				return ctx
+			}(),
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteTmux},
+		},
+		{
+			// The persisted phase decides the terminal flag, not the read one:
+			// resuming a completed phase must keep FlowPhaseTerminal set, which is
+			// what stops a failed resume from regressing it back to running.
+			name:   "phase resume terminal phase",
+			target: terminalPhaseResume,
+			want: func() actions.AgentLaunchContext {
+				ctx := launchContextPhaseResumeContext(terminalPhaseResume.Record)
+				ctx.FlowPhaseTerminal = true
+				return ctx
+			}(),
 			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
 		},
 	} {
@@ -795,6 +843,133 @@ func TestNewFlowLaunchContextKeepsTheSavedSessionIDVerbatim(t *testing.T) {
 	ctx, _, err := newFlowLaunchContext(savedSessionResumeTarget{
 		LaunchID: "launch-1", Record: record, Session: session,
 	}, launchContextVariantSettings(), flowLaunchRouting{})
+	if err != nil {
+		t.Fatalf("newFlowLaunchContext: %v", err)
+	}
+	if ctx.ResumeSessionID != "  session-1  " {
+		t.Fatalf("resume session id = %q, want the untrimmed session ID", ctx.ResumeSessionID)
+	}
+}
+
+// launchContextPhaseResumeTarget is the phase-resume fixture: the variant
+// record plus a running phase whose kind is set explicitly, so the row pins
+// what SemanticKind read off the phase rather than what it inferred from the
+// phase ID. PersistedRecord carries the same phase the read stage saw, which is
+// the ordinary case; the terminal row is what moves them apart.
+func launchContextPhaseResumeTarget() phaseResumeTarget {
+	record := launchContextVariantRecord()
+	phase := flowstore.FlowPhase{
+		PhaseID: "implementation",
+		Title:   "Implementation",
+		Kind:    flowstore.KindImplementation,
+		Status:  flowstore.PhaseRunning,
+		Order:   1,
+	}
+	record.Phases = []flowstore.FlowPhase{phase}
+	return phaseResumeTarget{
+		LaunchID:         "launch-1",
+		Record:           record,
+		PersistedRecord:  record,
+		ReadPhase:        phase,
+		PhaseID:          phase.PhaseID,
+		Command:          "codex",
+		ResumeSessionID:  "session-1",
+		PlanPath:         record.PlanPath,
+		FallbackRepoPath: "/dev/read-stage",
+	}
+}
+
+// launchContextPhaseResumeContext is the embedded context every phase-resume
+// row starts from: the tmux row clears Embedded, and the terminal row flips
+// FlowPhaseTerminal. Model, ReasoningEffort and InitialPrompt stay empty —
+// agentCommandSpec refuses a resume that carries a model, so the snapshot's
+// gpt-5/high must not reach the context.
+func launchContextPhaseResumeContext(record flowstore.FlowRecord) actions.AgentLaunchContext {
+	return actions.AgentLaunchContext{
+		Command:           "codex",
+		LaunchID:          "launch-1",
+		RepoPath:          record.RepoPath,
+		WorktreePath:      record.WorktreePath,
+		WorkingDir:        record.WorktreePath,
+		Branch:            record.Branch,
+		Commit:            record.Commit,
+		SessionStateRoot:  "/state",
+		ResumeSessionID:   "session-1",
+		PlanID:            record.PlanID,
+		PlanPath:          record.PlanPath,
+		FlowID:            record.FlowID,
+		FlowPhaseID:       "implementation",
+		FlowPhaseKind:     flowstore.KindImplementation,
+		FlowPhaseTerminal: false,
+		Embedded:          true,
+		FlowLaunchTracked: true,
+	}
+}
+
+// TestNewFlowLaunchContextFallsBackToTheReadPhaseWhenTheWriteReturnsNone pins
+// the guard that moved into the builder with the rest of phase resume's
+// context. Seams routinely return phase-less records, and an unguarded lookup
+// would answer with the zero phase — kind empty, terminal false — for every one
+// of them, quietly clearing the flag that stops a failed resume from regressing
+// a completed phase.
+func TestNewFlowLaunchContextFallsBackToTheReadPhaseWhenTheWriteReturnsNone(t *testing.T) {
+	target := launchContextPhaseResumeTarget()
+	target.ReadPhase.Status = flowstore.PhaseCompleted
+	target.PersistedRecord.Phases = nil
+
+	ctx, _, err := newFlowLaunchContext(target, launchContextVariantSettings(), flowLaunchRouting{})
+	if err != nil {
+		t.Fatalf("newFlowLaunchContext: %v", err)
+	}
+	if !ctx.FlowPhaseTerminal {
+		t.Fatal("a phase-less persisted record must fall back to the read phase, not to the zero phase")
+	}
+	if ctx.FlowPhaseKind != flowstore.KindImplementation {
+		t.Fatalf("phase kind = %q, want the read phase's", ctx.FlowPhaseKind)
+	}
+}
+
+// TestNewFlowLaunchContextRejectsIncompletePhaseResumePayloads pins the six
+// fields this role cannot do without. The worktree is required even though the
+// read stage already refuses a worktree-less resume: this role chdirs into it,
+// so it is the builder-side invariant rather than a refusal the user can reach.
+func TestNewFlowLaunchContextRejectsIncompletePhaseResumePayloads(t *testing.T) {
+	for _, missing := range []struct {
+		name   string
+		mutate func(*phaseResumeTarget)
+	}{
+		{name: "launch id", mutate: func(target *phaseResumeTarget) { target.LaunchID = "  " }},
+		{name: "flow id", mutate: func(target *phaseResumeTarget) { target.Record.FlowID = "  " }},
+		{name: "worktree path", mutate: func(target *phaseResumeTarget) { target.Record.WorktreePath = " " }},
+		{name: "phase id", mutate: func(target *phaseResumeTarget) { target.PhaseID = "  " }},
+		{name: "command", mutate: func(target *phaseResumeTarget) { target.Command = "  " }},
+		{name: "resume session id", mutate: func(target *phaseResumeTarget) { target.ResumeSessionID = "  " }},
+	} {
+		t.Run("missing "+missing.name, func(t *testing.T) {
+			target := launchContextPhaseResumeTarget()
+			missing.mutate(&target)
+
+			ctx, decision, err := newFlowLaunchContext(
+				target, launchContextVariantSettings(), flowLaunchRouting{})
+			if !errors.Is(err, errIncompleteFlowLaunchTarget) {
+				t.Fatalf("err = %v, want errIncompleteFlowLaunchTarget (context %#v)", err, ctx)
+			}
+			if decision != (flowLaunchRouteDecision{}) {
+				t.Fatalf("failed build returned decision %#v", decision)
+			}
+		})
+	}
+}
+
+// TestNewFlowLaunchContextKeepsThePhaseResumeSessionIDVerbatim is the
+// counterpart to the trim in the emptiness check, for the reason the
+// saved-session row gives: a builder that assigned the trimmed value would
+// rewrite the ID the provider stored and resume the wrong session, or none.
+func TestNewFlowLaunchContextKeepsThePhaseResumeSessionIDVerbatim(t *testing.T) {
+	target := launchContextPhaseResumeTarget()
+	target.ResumeSessionID = "  session-1  "
+
+	ctx, _, err := newFlowLaunchContext(target, launchContextVariantSettings(), flowLaunchRouting{})
 	if err != nil {
 		t.Fatalf("newFlowLaunchContext: %v", err)
 	}

--- a/model/flow_launch_resume.go
+++ b/model/flow_launch_resume.go
@@ -6,7 +6,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/flowstore"
 )
@@ -289,14 +288,13 @@ func (m Model) phaseResumeFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings 
 	readPhase, _ := flowPhaseByID(msg.Record, msg.PhaseID)
 	reserve := m.reserveTrackedFlowLaunch
 	addPhaseLaunchID := m.launchSeams.AddPhaseLaunchID
-	sessionStateRoot := settings.SessionStateRoot
-	// A resume does not go through flowLaunchPreparation.prepare, so the tmux
-	// decision is made here instead. It is taken on the Model, before the
-	// closure runs, for the same reason the launcher snapshots it at admission:
-	// the route this launch takes must be the one it was admitted with. A resume
-	// is interactive by construction and never a repair, so the command is the
-	// whole input.
-	tmuxRoute, tmuxFellBack := m.tmuxLaunchRoute(actions.AgentLaunchContext{Command: msg.ResumeCommand})
+	// A resume does not go through flowLaunchPreparation.prepare, but it
+	// snapshots the routing inputs the same way that stage does, so the route
+	// this launch takes is still the one it was admitted with. Only the decision
+	// moves into the closure, where the builder makes it against the finished
+	// context.
+	backend := m.launchBackend
+	tmuxAvailable := m.tmuxLaunchAvailable
 	return func() tea.Msg {
 		event := msg
 		event.Stage = flowLaunchStagePrepared
@@ -344,52 +342,30 @@ func (m Model) phaseResumeFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings 
 			event.Err = fmt.Sprintf("failed to mark flow phase resume: %v", err)
 			return event
 		}
-		// The write's record decides whether this resume preserved a terminal
-		// phase or reopened a running one, and that flag is what stops a failed
-		// resume from regressing a completed phase. The kind is taken from the
-		// same phase rather than the key press's, which is wider than the old
-		// plumbing and deliberate: both values feed failure handling, and
-		// splitting their sources would let one describe a phase the other no
-		// longer does. The guard matters: seams routinely return phase-less
-		// records, and an unguarded lookup would silently answer "not terminal"
-		// for every one of them.
-		launchPhase := readPhase
-		if persistedPhase, ok := flowPhaseByID(updated, msg.PhaseID); ok {
-			launchPhase = persistedPhase
+		// The read stage's phase and the write's record both travel on the
+		// payload: the builder owns which of them decides FlowPhaseKind and
+		// FlowPhaseTerminal, and that flag is what stops a failed resume from
+		// regressing a completed phase. The read stage's repo path rides along as
+		// a fallback for the same reason autofix's does — the precedence between
+		// it and the record is the builder's, not this stage's.
+		ctx, decision, buildErr := newFlowLaunchContext(phaseResumeTarget{
+			LaunchID:         msg.Token,
+			Record:           msg.Record,
+			PersistedRecord:  updated,
+			ReadPhase:        readPhase,
+			PhaseID:          msg.PhaseID,
+			Command:          msg.ResumeCommand,
+			ResumeSessionID:  msg.ProviderSessionID,
+			PlanPath:         msg.PlanPath,
+			FallbackRepoPath: msg.RepoPath,
+		}, settings, flowLaunchRouting{Backend: backend, TmuxAvailable: tmuxAvailable})
+		if buildErr != nil {
+			event.Err = buildErr.Error()
+			return event
 		}
-		event.Context = applyLaunchStamp(actions.AgentLaunchContext{
-			Command: msg.ResumeCommand,
-			// The admission token, never a fresh ID: the prefill-failure
-			// re-reservation and the failure-persisted fence both key on it.
-			LaunchID:     msg.Token,
-			RepoPath:     msg.RepoPath,
-			WorktreePath: msg.WorktreePath,
-			WorkingDir:   msg.Record.WorktreePath,
-			Branch:       msg.Record.Branch,
-			Commit:       msg.Record.Commit,
-			// Model and ReasoningEffort stay empty, as they are today. The
-			// settings snapshot is in scope, and setting them would silently
-			// change the resumed command line.
-			SessionStateRoot:  sessionStateRoot,
-			ResumeSessionID:   msg.ProviderSessionID,
-			PlanID:            msg.Record.PlanID,
-			PlanPath:          msg.PlanPath,
-			FlowID:            msg.Record.FlowID,
-			FlowPhaseID:       msg.PhaseID,
-			FlowPhaseKind:     flowstore.SemanticKind(launchPhase),
-			FlowPhaseTerminal: flowstore.PhaseStatusTerminal(launchPhase.Status),
-			Embedded:          true,
-			FlowLaunchTracked: true,
-		}, settings.stamp())
-		event.Route = flowLaunchRouteEmbedded
-		if tmuxRoute {
-			// A tmux window has no dock to prefill and renders its own output,
-			// so clearing Embedded is what sends the resume to argv instead.
-			event.Context.Embedded = false
-			event.Route = flowLaunchRouteTmux
-		} else if tmuxFellBack {
-			event.FallbackNote = tmuxFallbackNote
-		}
+		event.Context = ctx
+		event.Route = decision.Route
+		event.FallbackNote = decision.FallbackNote
 		return event
 	}
 }


### PR DESCRIPTION
Phase resume was the last resume path still hand-building its own launch context. `phaseResumeFlowLaunchPrepareCmd` assembled an `actions.AgentLaunchContext` literal at the call site and separately decided on the Model whether the launch should take the tmux route, using a Command-only probe that duplicated the routing rule. Anyone changing what markers this role sets had to find and edit both places.

This moves both decisions behind `actions.RolePhaseResume`, so the builder owns the markers and the route. Fifth of six roles; no user-visible behavior changes.

## What moved

- `phaseResumeTarget` carries two records, because the resume reads one and writes one: `Record` is the read stage's authority for branch, commit, plan and worktree, while `PersistedRecord` is consulted only for the phase.
- The guarded `flowPhaseByID` lookup moves into the builder alongside them. That guard is what stops a phase-less write from silently reporting "not terminal", and it is now pinned at the builder interface as well as through the existing prepare-stage test.
- Paths (`RepoPath`, `WorktreePath`, `PlanPath`) map from the record with `FallbackRepoPath` as an explicit payload field, mirroring `autofixTarget`.
- The Model-side route probe is gone. Phase resume is genuinely tmux-eligible where repair and saved-session resume are not, so this is the second arm (after autofix) that actually takes routing.

## Why it's safe

`tmuxRouteEligible` reads only `Headless`, `FlowRepair` and `Command`, and phase resume sets neither marker, so deciding against the finished context is identical to the old probe.

## Docs

The variant matrix still routed phase resume and saved-session resume to prepare-stage literals that no longer exist, and its status paragraph named only the repair, autofix and worktree-agent slices — so it would have pointed anyone doing the remaining migrations at the wrong construction sites. Sections 1-3 are now explicitly framed as the frozen pre-migration survey against `e1dd62e`, and the status paragraph is promoted to a "Migration status" section naming V7-V17 as builder-constructed. ADR 0002 gains the per-slice implementation notes that the saved-session-resume and phase-resume slices skipped.

## Verification

Three new variant rows (embedded, tmux, terminal phase) plus builder-level tests for the phase fallback, the six required payload fields, and the verbatim resume session ID. The existing resume internal tests are unchanged and still pass.

Refs approach-hyl.6
