### PR TITLE
Fix last timestamped ID candidate and extract shared git/root/slug helpers

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -19,6 +19,7 @@ import (
 	"unicode"
 
 	"github.com/approachcontrol/approach/agent"
+	"github.com/approachcontrol/approach/internal/artifacts"
 	"github.com/google/shlex"
 )
 
@@ -528,7 +529,7 @@ func CreateFlowWorktree(repoPath, title, baseRef string) (FlowWorktreeCreateResu
 		return FlowWorktreeCreateResult{}, fmt.Errorf("flow title cannot be empty")
 	}
 	baseRef = strings.TrimSpace(baseRef)
-	slug := slugPathPart(title)
+	slug := artifacts.Slug(title, "flow")
 	for i := 1; i < 1000; i++ {
 		suffix := ""
 		if i > 1 {
@@ -1299,6 +1300,10 @@ func agentSessionName(worktreePath, launchID string) string {
 }
 
 func sanitizeSessionSuffix(s string) string {
+	return sanitizeIdentifierPart(s, "")
+}
+
+func sanitizeIdentifierPart(s, fallback string) string {
 	var b strings.Builder
 	lastDash := false
 	for _, r := range s {
@@ -1312,7 +1317,11 @@ func sanitizeSessionSuffix(s string) string {
 			lastDash = true
 		}
 	}
-	return strings.Trim(b.String(), ".-")
+	name := strings.Trim(b.String(), ".-")
+	if name == "" {
+		return fallback
+	}
+	return name
 }
 
 // AgentCommand builds the direct command for launching a supported coding agent
@@ -2367,25 +2376,7 @@ func WorktreeSessionName(path string) string {
 		hashPath = absPath
 	}
 
-	name := filepath.Base(cleanPath)
-	var b strings.Builder
-	lastDash := false
-	for _, r := range name {
-		allowed := unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.'
-		if allowed {
-			b.WriteRune(r)
-			lastDash = false
-			continue
-		}
-		if !lastDash {
-			b.WriteByte('-')
-			lastDash = true
-		}
-	}
-	name = strings.Trim(b.String(), ".-")
-	if name == "" {
-		name = "worktree"
-	}
+	name := sanitizeIdentifierPart(filepath.Base(cleanPath), "worktree")
 
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(hashPath))
@@ -2507,31 +2498,6 @@ func sanitizePathPart(s string) string {
 		return "worktree"
 	}
 	return s
-}
-
-func slugPathPart(s string) string {
-	var b strings.Builder
-	prevDash := false
-	for _, r := range strings.ToLower(s) {
-		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-			prevDash = false
-		default:
-			if !prevDash && b.Len() > 0 {
-				b.WriteByte('-')
-				prevDash = true
-			}
-		}
-	}
-	out := strings.Trim(b.String(), "-")
-	if len(out) > 48 {
-		out = strings.Trim(out[:48], "-")
-	}
-	if out == "" {
-		return "flow"
-	}
-	return out
 }
 
 const tmuxSwitchScript = `

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -744,6 +744,8 @@ func TestWorktreeSessionName(t *testing.T) {
 		{"/tmp/repo-worktrees/feature/api:oauth", "api-oauth-"},
 		{"/tmp/repo-worktrees/../repo", "repo-"},
 		{"/", "worktree-"},
+		{"/tmp/repo-worktrees/café", "café-"},
+		{"/tmp/repo-worktrees/!!!", "worktree-"},
 	}
 
 	for _, tt := range tests {

--- a/actions/tmux_mode_internal_test.go
+++ b/actions/tmux_mode_internal_test.go
@@ -609,6 +609,7 @@ func TestRepoTmuxWindowNameNeverEmpty(t *testing.T) {
 		// Nothing sanitizable in the launch ID, so the name carries no suffix.
 		{name: "unusable launch id", phaseKind: "review", launchID: "...", wantPrefix: "review", wantNoTrailer: true},
 		{name: "no launch id", phaseKind: "review", wantPrefix: "review", wantNoTrailer: true},
+		{name: "unicode phase kind", phaseKind: "café", launchID: "...", wantPrefix: "café", wantNoTrailer: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/approach/main.go
+++ b/cmd/approach/main.go
@@ -684,16 +684,36 @@ func modelOptionsFromConfig(cfg config.Config, scanRepos func() ([]scanner.Repo,
 }
 
 func runtimeArtifactRoot(cfg config.Config) string {
-	if envRoot := os.Getenv("APPROACH_FLOW_STATE_ROOT"); envRoot != "" {
-		return envRoot
+	root, err := resolveArtifactRoot("", os.Getenv, func() (config.Config, error) {
+		return cfg, nil
+	})
+	if err != nil {
+		return cfg.Sessions.Root
 	}
-	if envRoot := os.Getenv("APPROACH_PLAN_STATE_ROOT"); envRoot != "" {
-		return envRoot
+	return root
+}
+
+// resolveArtifactRoot applies the documented precedence:
+// explicit --state-root > APPROACH_FLOW_STATE_ROOT > APPROACH_PLAN_STATE_ROOT >
+// APPROACH_SESSION_STATE_ROOT > [sessions].root from config.
+func resolveArtifactRoot(explicit string, getenv func(string) string, loadConfig func() (config.Config, error)) (string, error) {
+	if explicit != "" {
+		return explicit, nil
 	}
-	if envRoot := os.Getenv("APPROACH_SESSION_STATE_ROOT"); envRoot != "" {
-		return envRoot
+	if root := getenv("APPROACH_FLOW_STATE_ROOT"); root != "" {
+		return root, nil
 	}
-	return cfg.Sessions.Root
+	if root := getenv("APPROACH_PLAN_STATE_ROOT"); root != "" {
+		return root, nil
+	}
+	if root := getenv("APPROACH_SESSION_STATE_ROOT"); root != "" {
+		return root, nil
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return "", fmt.Errorf("error loading config: %w", err)
+	}
+	return cfg.Sessions.Root, nil
 }
 
 func bootstrapHookResolver(cfg config.Config) func(string) (actions.BootstrapHook, bool) {

--- a/cmd/approach/main_test.go
+++ b/cmd/approach/main_test.go
@@ -385,6 +385,33 @@ func TestRun_PassesConfigToProgram(t *testing.T) {
 	}
 }
 
+func TestResolveArtifactRootExplicitTierBeatsEnv(t *testing.T) {
+	cfg := config.Config{Sessions: config.SessionsConfig{Root: "/from/config"}}
+	getenv := func(key string) string {
+		switch key {
+		case "APPROACH_FLOW_STATE_ROOT":
+			return "/from/flow"
+		case "APPROACH_PLAN_STATE_ROOT":
+			return "/from/plan"
+		case "APPROACH_SESSION_STATE_ROOT":
+			return "/from/session"
+		}
+		return ""
+	}
+	loadConfig := func() (config.Config, error) {
+		t.Fatal("loadConfig should not run when an explicit root is set")
+		return cfg, nil
+	}
+
+	got, err := resolveArtifactRoot("/explicit", getenv, loadConfig)
+	if err != nil {
+		t.Fatalf("resolveArtifactRoot() error = %v", err)
+	}
+	if got != "/explicit" {
+		t.Fatalf("resolveArtifactRoot() = %q, want explicit root", got)
+	}
+}
+
 func TestRuntimeArtifactRootPrecedenceIncludesFlowRoot(t *testing.T) {
 	cfg := config.Config{Sessions: config.SessionsConfig{Root: "/from/config"}}
 	t.Setenv("APPROACH_SESSION_STATE_ROOT", "/from/session")

--- a/cmd/approach/plan.go
+++ b/cmd/approach/plan.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/approachcontrol/approach/internal/gitmeta"
 	"github.com/approachcontrol/approach/planstore"
 )
 
@@ -71,23 +71,7 @@ Most commands accept:
 // APPROACH_SESSION_STATE_ROOT >
 // [sessions].root from config > planstore.DefaultRoot() (resolved by NewStore).
 func resolvePlanRoot(stateRoot string, deps runDeps) (string, error) {
-	if stateRoot != "" {
-		return stateRoot, nil
-	}
-	if root := deps.getenv("APPROACH_FLOW_STATE_ROOT"); root != "" {
-		return root, nil
-	}
-	if root := deps.getenv("APPROACH_PLAN_STATE_ROOT"); root != "" {
-		return root, nil
-	}
-	if root := deps.getenv("APPROACH_SESSION_STATE_ROOT"); root != "" {
-		return root, nil
-	}
-	cfg, err := deps.loadConfig()
-	if err != nil {
-		return "", fmt.Errorf("error loading config: %w", err)
-	}
-	return cfg.Sessions.Root, nil
+	return resolveArtifactRoot(stateRoot, deps.getenv, deps.loadConfig)
 }
 
 func newPlanStore(stateRoot string, deps runDeps) (*planstore.Store, error) {
@@ -496,14 +480,6 @@ func fallbackEnv(value, key string, deps runDeps) string {
 	return deps.getenv(key)
 }
 
-type planGitMetadata struct {
-	RepoPath     string
-	WorktreePath string
-	Branch       string
-	Commit       string
-	Linked       bool
-}
-
 func shouldResolvePlanGitMetadata(store *planstore.Store, record planstore.PlanRecord) bool {
 	if record.PlanID == "" {
 		return true
@@ -524,12 +500,14 @@ func resolvePlanGitMetadata(record *planstore.PlanRecord, deps runDeps) {
 	if candidate == "" {
 		candidate = cwd
 	}
-	if meta, ok := resolvePlanGitMetadataAt(candidate); ok {
-		applyPlanGitMetadata(record, meta)
+	info, err := gitmeta.Resolve(candidate)
+	if err != nil || info == (gitmeta.Info{}) {
+		return
 	}
+	applyPlanGitMetadata(record, info)
 }
 
-func applyPlanGitMetadata(record *planstore.PlanRecord, meta planGitMetadata) {
+func applyPlanGitMetadata(record *planstore.PlanRecord, meta gitmeta.Info) {
 	if record.RepoPath == "" {
 		record.RepoPath = meta.RepoPath
 	} else if meta.Linked && meta.RepoPath != "" && samePlanPath(record.RepoPath, meta.WorktreePath) {
@@ -551,115 +529,4 @@ func samePlanPath(a, b string) bool {
 		return false
 	}
 	return filepath.Clean(a) == filepath.Clean(b)
-}
-
-func resolvePlanGitMetadataAt(cwd string) (planGitMetadata, bool) {
-	if cwd == "" {
-		return planGitMetadata{}, false
-	}
-	worktreePath, _ := planGitOutput(cwd, "rev-parse", "--show-toplevel")
-	commonDir, _ := planGitOutput(cwd, "rev-parse", "--path-format=absolute", "--git-common-dir")
-	gitDir, _ := planGitOutput(cwd, "rev-parse", "--path-format=absolute", "--git-dir")
-	if worktreePath == "" && commonDir == "" && gitDir == "" {
-		return planGitMetadata{}, false
-	}
-	isBare := false
-	if out, err := planGitOutput(cwd, "rev-parse", "--is-bare-repository"); err == nil {
-		isBare = out == "true"
-	}
-	commonDirIsBare := false
-	if commonDir != "" {
-		if out, err := planGitOutput(commonDir, "rev-parse", "--is-bare-repository"); err == nil {
-			commonDirIsBare = out == "true"
-		}
-	}
-	linked := planIsLinkedWorktreeGitDir(gitDir, commonDir)
-	repoPath := planRepoPathFromGitMetadata(worktreePath, gitDir, commonDir, isBare, commonDirIsBare)
-	branch, _ := planGitOutput(cwd, "branch", "--show-current")
-	commit, _ := planGitOutput(cwd, "rev-parse", "HEAD")
-	return planGitMetadata{
-		RepoPath:     repoPath,
-		WorktreePath: worktreePath,
-		Branch:       branch,
-		Commit:       commit,
-		Linked:       linked,
-	}, true
-}
-
-func planRepoPathFromGitMetadata(worktreePath, gitDir, commonDir string, isBare, commonDirIsBare bool) string {
-	if isBare {
-		if commonDir != "" {
-			return filepath.Clean(commonDir)
-		}
-		if gitDir == "" {
-			return ""
-		}
-		return filepath.Clean(gitDir)
-	}
-	if commonDir != "" && gitDir != "" && planIsLinkedWorktreeGitDir(gitDir, commonDir) {
-		if commonDirIsBare {
-			return filepath.Clean(commonDir)
-		}
-		if filepath.Base(filepath.Clean(commonDir)) != ".git" {
-			return worktreePath
-		}
-		return planRepoPathFromGitCommonDir(commonDir)
-	}
-	if worktreePath != "" {
-		return worktreePath
-	}
-	if commonDir != "" {
-		return planRepoPathFromGitCommonDir(commonDir)
-	}
-	if gitDir == "" {
-		return ""
-	}
-	return planRepoPathFromGitCommonDir(gitDir)
-}
-
-func planIsLinkedWorktreeGitDir(gitDir, commonDir string) bool {
-	if gitDir == "" || commonDir == "" {
-		return false
-	}
-	rel, err := filepath.Rel(filepath.Join(filepath.Clean(commonDir), "worktrees"), filepath.Clean(gitDir))
-	if err != nil {
-		return false
-	}
-	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
-func planRepoPathFromGitCommonDir(commonDir string) string {
-	commonDir = filepath.Clean(commonDir)
-	if filepath.Base(commonDir) == ".git" {
-		return filepath.Dir(commonDir)
-	}
-	return commonDir
-}
-
-func planGitOutput(cwd string, args ...string) (string, error) {
-	cleaned, err := plausiblePlanGitCWD(cwd)
-	if err != nil {
-		return "", err
-	}
-	cmd := exec.Command("git", append([]string{"-C", cleaned}, args...)...)
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
-func plausiblePlanGitCWD(cwd string) (string, error) {
-	cwd = filepath.Clean(strings.TrimSpace(cwd))
-	if cwd == "." || !filepath.IsAbs(cwd) {
-		return "", fmt.Errorf("git cwd must be an absolute path")
-	}
-	info, err := os.Stat(cwd)
-	if err != nil {
-		return "", fmt.Errorf("inspect git cwd %q: %w", cwd, err)
-	}
-	if !info.IsDir() {
-		return "", fmt.Errorf("git cwd %q is not a directory", cwd)
-	}
-	return cwd, nil
 }

--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -359,11 +359,13 @@ func TimestampedIDCandidates(opts IDOptions) []string {
 		opts.MaxAttempts = defaultCollisionTries
 	}
 	base := opts.Now.UTC().Format("20060102T150405Z") + "-" + Slug(opts.Title, opts.FallbackSlug)
-	candidates := make([]string, 0, opts.MaxAttempts-1)
-	candidate := base
-	for i := 2; i < opts.MaxAttempts; i++ {
-		candidates = append(candidates, candidate)
-		candidate = fmt.Sprintf("%s-%d", base, i)
+	candidates := make([]string, 0, opts.MaxAttempts)
+	for attempt := 1; attempt <= opts.MaxAttempts; attempt++ {
+		if attempt == 1 {
+			candidates = append(candidates, base)
+			continue
+		}
+		candidates = append(candidates, fmt.Sprintf("%s-%d", base, attempt))
 	}
 	return candidates
 }

--- a/internal/artifacts/artifacts_test.go
+++ b/internal/artifacts/artifacts_test.go
@@ -218,6 +218,59 @@ func TestSafeIDRejectsPathSegments(t *testing.T) {
 	}
 }
 
+func TestTimestampedIDCandidatesIncludesEveryAttemptThroughFinalSuffix(t *testing.T) {
+	now := time.Date(2026, 6, 8, 1, 44, 47, 0, time.UTC)
+	got := artifacts.TimestampedIDCandidates(artifacts.IDOptions{
+		Title:        "!!!",
+		FallbackSlug: "plan",
+		Now:          now,
+		MaxAttempts:  3,
+	})
+	want := []string{
+		"20260608T014447Z-plan",
+		"20260608T014447Z-plan-2",
+		"20260608T014447Z-plan-3",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("TimestampedIDCandidates() len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("TimestampedIDCandidates()[%d] = %q, want %q (full=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestAllocateTimestampedIDSucceedsWhenOnlyFinalCandidateIsFree(t *testing.T) {
+	root := t.TempDir()
+	if err := artifacts.EnsureCollection(root, "plans"); err != nil {
+		t.Fatalf("EnsureCollection() error = %v", err)
+	}
+	now := time.Date(2026, 6, 8, 1, 44, 47, 0, time.UTC)
+	opts := artifacts.IDOptions{
+		Root:         root,
+		Collection:   "plans",
+		Title:        "!!!",
+		FallbackSlug: "plan",
+		Kind:         "plan",
+		Now:          now,
+		MaxAttempts:  3,
+	}
+	for _, taken := range []string{"20260608T014447Z-plan", "20260608T014447Z-plan-2"} {
+		if _, err := artifacts.EnsureRecordDir(root, "plans", taken); err != nil {
+			t.Fatalf("create taken record dir %q: %v", taken, err)
+		}
+	}
+
+	id, err := artifacts.AllocateTimestampedID(opts)
+	if err != nil {
+		t.Fatalf("AllocateTimestampedID() error = %v, want final candidate", err)
+	}
+	if id != "20260608T014447Z-plan-3" {
+		t.Fatalf("AllocateTimestampedID() = %q, want final candidate", id)
+	}
+}
+
 func TestAllocateTimestampedIDSlugFallbackAndCollisionSuffix(t *testing.T) {
 	root := t.TempDir()
 	if err := artifacts.EnsureCollection(root, "plans"); err != nil {

--- a/internal/gitmeta/gitmeta.go
+++ b/internal/gitmeta/gitmeta.go
@@ -1,0 +1,145 @@
+// Package gitmeta resolves worktree, repository, branch, and commit from a
+// working directory by asking git. Callers apply the result only to empty
+// fields; git errors stay inside this package.
+package gitmeta
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Info is the git identity of a working directory. Zero value means the
+// directory is not a repository, or git could not be asked.
+type Info struct {
+	WorktreePath string
+	RepoPath     string
+	Branch       string
+	Commit       string
+	Linked       bool
+}
+
+// Resolve asks git for the worktree, repository, branch, and commit at cwd.
+// A non-repository or unusable cwd returns a zero Info and a nil error so
+// callers can keep filling fields from other sources.
+func Resolve(cwd string) (Info, error) {
+	if cwd == "" {
+		return Info{}, nil
+	}
+	worktreePath := ""
+	if out, err := gitOutput(cwd, "rev-parse", "--show-toplevel"); err == nil {
+		worktreePath = out
+	}
+	gitCommonDir := ""
+	if out, err := gitOutput(cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"); err == nil {
+		gitCommonDir = out
+	}
+	gitDir := ""
+	if out, err := gitOutput(cwd, "rev-parse", "--path-format=absolute", "--git-dir"); err == nil {
+		gitDir = out
+	}
+	isBare := false
+	if out, err := gitOutput(cwd, "rev-parse", "--is-bare-repository"); err == nil {
+		isBare = out == "true"
+	}
+	commonDirIsBare := false
+	if gitCommonDir != "" {
+		if out, err := gitOutput(gitCommonDir, "rev-parse", "--is-bare-repository"); err == nil {
+			commonDirIsBare = out == "true"
+		}
+	}
+	repoPath := repoPathFromGitMetadata(worktreePath, gitDir, gitCommonDir, isBare, commonDirIsBare)
+	info := Info{
+		Linked: isLinkedWorktreeGitDir(gitDir, gitCommonDir),
+	}
+	if repoPath != "" {
+		info.RepoPath = repoPath
+	} else if worktreePath != "" {
+		info.RepoPath = worktreePath
+	}
+	info.WorktreePath = worktreePath
+	if out, err := gitOutput(cwd, "branch", "--show-current"); err == nil {
+		info.Branch = out
+	}
+	if out, err := gitOutput(cwd, "rev-parse", "HEAD"); err == nil {
+		info.Commit = out
+	}
+	return info, nil
+}
+
+func repoPathFromGitMetadata(worktreePath, gitDir, commonDir string, isBare, commonDirIsBare bool) string {
+	if isBare {
+		if commonDir != "" {
+			return filepath.Clean(commonDir)
+		}
+		if gitDir == "" {
+			return ""
+		}
+		return filepath.Clean(gitDir)
+	}
+	if commonDir != "" && gitDir != "" && isLinkedWorktreeGitDir(gitDir, commonDir) {
+		if commonDirIsBare {
+			return filepath.Clean(commonDir)
+		}
+		if filepath.Base(filepath.Clean(commonDir)) != ".git" {
+			return worktreePath
+		}
+		return repoPathFromGitCommonDir(commonDir)
+	}
+	if worktreePath != "" {
+		return worktreePath
+	}
+	if commonDir != "" {
+		return repoPathFromGitCommonDir(commonDir)
+	}
+	if gitDir == "" {
+		return ""
+	}
+	return repoPathFromGitCommonDir(gitDir)
+}
+
+func isLinkedWorktreeGitDir(gitDir, commonDir string) bool {
+	rel, err := filepath.Rel(filepath.Join(filepath.Clean(commonDir), "worktrees"), filepath.Clean(gitDir))
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func repoPathFromGitCommonDir(commonDir string) string {
+	commonDir = filepath.Clean(commonDir)
+	if filepath.Base(commonDir) == ".git" {
+		return filepath.Dir(commonDir)
+	}
+	return commonDir
+}
+
+func gitOutput(cwd string, args ...string) (string, error) {
+	cleaned, err := plausibleGitCWD(cwd)
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command("git", append([]string{"-C", cleaned}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func plausibleGitCWD(cwd string) (string, error) {
+	cwd = filepath.Clean(strings.TrimSpace(cwd))
+	if cwd == "." || !filepath.IsAbs(cwd) {
+		return "", fmt.Errorf("git cwd must be an absolute path")
+	}
+	info, err := os.Stat(cwd)
+	if err != nil {
+		return "", fmt.Errorf("inspect git cwd %q: %w", cwd, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("git cwd %q is not a directory", cwd)
+	}
+	return cwd, nil
+}

--- a/internal/gitmeta/gitmeta_test.go
+++ b/internal/gitmeta/gitmeta_test.go
@@ -1,0 +1,117 @@
+package gitmeta_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/approachcontrol/approach/internal/gitmeta"
+	"github.com/approachcontrol/approach/internal/testgit"
+)
+
+func TestResolvePlainRepoPathEqualsToplevel(t *testing.T) {
+	repoPath := t.TempDir()
+	testgit.Run(t, repoPath, "init")
+	testgit.ConfigureRepo(t, repoPath)
+	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("test\n"), 0o600); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	testgit.Run(t, repoPath, "add", "README.md")
+	testgit.Run(t, repoPath, "commit", "-m", "initial")
+
+	info, err := gitmeta.Resolve(repoPath)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	toplevel := testgit.Output(t, repoPath, "rev-parse", "--show-toplevel")
+	if info.RepoPath != toplevel {
+		t.Fatalf("RepoPath = %q, want toplevel %q", info.RepoPath, toplevel)
+	}
+}
+
+func TestResolveLinkedWorktreeRepoPathIsParentOfGitCommonDir(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	worktreePath := filepath.Join(root, "repo-worktrees", "feature")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("create repo dir: %v", err)
+	}
+	testgit.Run(t, repoPath, "init")
+	testgit.ConfigureRepo(t, repoPath)
+	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("test\n"), 0o600); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	testgit.Run(t, repoPath, "add", "README.md")
+	testgit.Run(t, repoPath, "commit", "-m", "initial")
+	testgit.Run(t, repoPath, "worktree", "add", "-b", "feature/gitmeta", worktreePath, "HEAD")
+
+	info, err := gitmeta.Resolve(worktreePath)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	commonDir := testgit.Output(t, worktreePath, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	wantRepo := filepath.Dir(commonDir)
+	if filepath.Base(commonDir) != ".git" {
+		t.Fatalf("common dir = %q, want a .git directory", commonDir)
+	}
+	if info.RepoPath != wantRepo {
+		t.Fatalf("RepoPath = %q, want parent of common dir %q", info.RepoPath, wantRepo)
+	}
+	if !info.Linked {
+		t.Fatal("Linked = false, want true for a linked worktree")
+	}
+}
+
+func TestResolveBareRepoPathIsCommonDir(t *testing.T) {
+	root := t.TempDir()
+	barePath := filepath.Join(root, "repo.git")
+	testgit.Run(t, root, "init", "--bare", barePath)
+
+	info, err := gitmeta.Resolve(barePath)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	commonDir := testgit.Output(t, barePath, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if info.RepoPath != filepath.Clean(commonDir) {
+		t.Fatalf("RepoPath = %q, want common dir %q", info.RepoPath, commonDir)
+	}
+	if info.WorktreePath != "" {
+		t.Fatalf("WorktreePath = %q, want empty for a bare repo", info.WorktreePath)
+	}
+}
+
+func TestResolveWorktreeOfBareRepoUsesBareCommonDir(t *testing.T) {
+	root := t.TempDir()
+	bareRepoPath := filepath.Join(root, "container", ".git")
+	worktreePath := filepath.Join(root, "worktrees", "feature")
+	if err := os.MkdirAll(filepath.Dir(bareRepoPath), 0o755); err != nil {
+		t.Fatalf("create bare parent dir: %v", err)
+	}
+	testgit.Run(t, root, "init", "--bare", bareRepoPath)
+	testgit.Run(t, bareRepoPath, "worktree", "add", "-b", "feature/gitmeta", worktreePath)
+
+	info, err := gitmeta.Resolve(worktreePath)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	commonDir := testgit.Output(t, worktreePath, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if info.RepoPath != filepath.Clean(commonDir) {
+		t.Fatalf("RepoPath = %q, want bare common dir %q", info.RepoPath, commonDir)
+	}
+	toplevel := testgit.Output(t, worktreePath, "rev-parse", "--show-toplevel")
+	if info.WorktreePath != toplevel {
+		t.Fatalf("WorktreePath = %q, want toplevel %q", info.WorktreePath, toplevel)
+	}
+}
+
+func TestResolveNonRepoReturnsZeroInfoWithoutError(t *testing.T) {
+	cwd := t.TempDir()
+
+	info, err := gitmeta.Resolve(cwd)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+	if info != (gitmeta.Info{}) {
+		t.Fatalf("Resolve() = %#v, want zero Info", info)
+	}
+}

--- a/sessions/ingest.go
+++ b/sessions/ingest.go
@@ -4,15 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/internal/artifacts"
+	"github.com/approachcontrol/approach/internal/gitmeta"
 	"github.com/approachcontrol/approach/internal/launchcontrol"
 )
 
@@ -298,52 +296,25 @@ func resolveGitMetadata(record *SessionRecord) {
 	if record.CWD == "" {
 		return
 	}
-	worktreePath := ""
-	if out, err := gitOutput(record.CWD, "rev-parse", "--show-toplevel"); err == nil {
-		worktreePath = out
+	info, err := gitmeta.Resolve(record.CWD)
+	if err != nil {
+		return
 	}
-	gitCommonDir := ""
-	if out, err := gitOutput(record.CWD, "rev-parse", "--path-format=absolute", "--git-common-dir"); err == nil {
-		gitCommonDir = out
-	}
-	gitDir := ""
-	if out, err := gitOutput(record.CWD, "rev-parse", "--path-format=absolute", "--git-dir"); err == nil {
-		gitDir = out
-	}
-	isBare := false
-	if out, err := gitOutput(record.CWD, "rev-parse", "--is-bare-repository"); err == nil {
-		isBare = out == "true"
-	}
-	commonDirIsBare := false
-	if gitCommonDir != "" {
-		if out, err := gitOutput(gitCommonDir, "rev-parse", "--is-bare-repository"); err == nil {
-			commonDirIsBare = out == "true"
-		}
-	}
-	repoPath := repoPathFromGitMetadata(worktreePath, gitDir, gitCommonDir, isBare, commonDirIsBare)
 	if record.RepoPath == "" {
-		if repoPath != "" {
-			record.RepoPath = repoPath
-		} else if worktreePath != "" {
-			record.RepoPath = worktreePath
-		}
+		record.RepoPath = info.RepoPath
 	}
 	if record.WorktreePath == "" {
-		if worktreePath != "" {
-			record.WorktreePath = worktreePath
+		if info.WorktreePath != "" {
+			record.WorktreePath = info.WorktreePath
 		} else {
 			record.WorktreePath = record.RepoPath
 		}
 	}
 	if record.Branch == "" {
-		if out, err := gitOutput(record.CWD, "branch", "--show-current"); err == nil {
-			record.Branch = out
-		}
+		record.Branch = info.Branch
 	}
 	if record.Commit == "" {
-		if out, err := gitOutput(record.CWD, "rev-parse", "HEAD"); err == nil {
-			record.Commit = out
-		}
+		record.Commit = info.Commit
 	}
 }
 
@@ -486,79 +457,4 @@ func flowStateRoot(opts IngestOptions) (string, bool) {
 		return opts.StateRoot, opts.StateRootExplicit
 	}
 	return opts.Env["APPROACH_SESSION_STATE_ROOT"], false
-}
-
-func repoPathFromGitMetadata(worktreePath, gitDir, commonDir string, isBare, commonDirIsBare bool) string {
-	if isBare {
-		if commonDir != "" {
-			return filepath.Clean(commonDir)
-		}
-		if gitDir == "" {
-			return ""
-		}
-		return filepath.Clean(gitDir)
-	}
-	if commonDir != "" && gitDir != "" && isLinkedWorktreeGitDir(gitDir, commonDir) {
-		if commonDirIsBare {
-			return filepath.Clean(commonDir)
-		}
-		if filepath.Base(filepath.Clean(commonDir)) != ".git" {
-			return worktreePath
-		}
-		return repoPathFromGitCommonDir(commonDir)
-	}
-	if worktreePath != "" {
-		return worktreePath
-	}
-	if commonDir != "" {
-		return repoPathFromGitCommonDir(commonDir)
-	}
-	if gitDir == "" {
-		return ""
-	}
-	return repoPathFromGitCommonDir(gitDir)
-}
-
-func isLinkedWorktreeGitDir(gitDir, commonDir string) bool {
-	rel, err := filepath.Rel(filepath.Join(filepath.Clean(commonDir), "worktrees"), filepath.Clean(gitDir))
-	if err != nil {
-		return false
-	}
-	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
-func repoPathFromGitCommonDir(commonDir string) string {
-	commonDir = filepath.Clean(commonDir)
-	if filepath.Base(commonDir) == ".git" {
-		return filepath.Dir(commonDir)
-	}
-	return commonDir
-}
-
-func gitOutput(cwd string, args ...string) (string, error) {
-	cleaned, err := plausibleGitCWD(cwd)
-	if err != nil {
-		return "", err
-	}
-	cmd := exec.Command("git", append([]string{"-C", cleaned}, args...)...)
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
-func plausibleGitCWD(cwd string) (string, error) {
-	cwd = filepath.Clean(strings.TrimSpace(cwd))
-	if cwd == "." || !filepath.IsAbs(cwd) {
-		return "", fmt.Errorf("git cwd must be an absolute path")
-	}
-	info, err := os.Stat(cwd)
-	if err != nil {
-		return "", fmt.Errorf("inspect git cwd %q: %w", cwd, err)
-	}
-	if !info.IsDir() {
-		return "", fmt.Errorf("git cwd %q is not a directory", cwd)
-	}
-	return cwd, nil
 }


### PR DESCRIPTION
Timestamped ID allocation never tried the last collision suffix, so a store that already occupied every earlier candidate failed even when the final slot was free. This also collapses four duplicated helpers that the rest of the #277 P2 stack needs as a single owner each.

`TimestampedIDCandidates` now emits all `MaxAttempts` names, ending in `-N`. Git metadata resolution moves to `internal/gitmeta.Resolve`; sessions still copy a bare repo path into `WorktreePath`, while plan save still leaves that field empty — that difference is preserved, not unified. Flow worktree dirs go through `artifacts.Slug`, artifact-root lookup is one cascade (`--state-root` then the three env vars then config), and session-name sanitizing shares one Unicode-aware helper parameterized only by fallback (`"worktree"` vs empty).

No compatibility shims. The ID-candidate sequence is a clean break for any caller that depended on the short list; in-repo SQLite stores (`flowstore`, `planstore`, `sessions`) stay green.

Closes findings #41, #15, #16, #17-remainder, and #24 on #277. First of five stacked PRs.

**Test plan**
- [x] `gofmt` clean
- [x] `go test ./internal/artifacts ./internal/gitmeta ./sessions ./actions ./cmd/approach`
- [x] `make test` and `make build`