### PR TITLE
Collapse duplicated model request, filter, fetch, and clipboard helpers

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -19,6 +19,7 @@ import (
 	"unicode"
 
 	"github.com/approachcontrol/approach/agent"
+	"github.com/approachcontrol/approach/internal/artifacts"
 	"github.com/google/shlex"
 )
 
@@ -528,7 +529,7 @@ func CreateFlowWorktree(repoPath, title, baseRef string) (FlowWorktreeCreateResu
 		return FlowWorktreeCreateResult{}, fmt.Errorf("flow title cannot be empty")
 	}
 	baseRef = strings.TrimSpace(baseRef)
-	slug := slugPathPart(title)
+	slug := artifacts.Slug(title, "flow")
 	for i := 1; i < 1000; i++ {
 		suffix := ""
 		if i > 1 {
@@ -1299,6 +1300,10 @@ func agentSessionName(worktreePath, launchID string) string {
 }
 
 func sanitizeSessionSuffix(s string) string {
+	return sanitizeIdentifierPart(s, "")
+}
+
+func sanitizeIdentifierPart(s, fallback string) string {
 	var b strings.Builder
 	lastDash := false
 	for _, r := range s {
@@ -1312,7 +1317,11 @@ func sanitizeSessionSuffix(s string) string {
 			lastDash = true
 		}
 	}
-	return strings.Trim(b.String(), ".-")
+	name := strings.Trim(b.String(), ".-")
+	if name == "" {
+		return fallback
+	}
+	return name
 }
 
 // AgentCommand builds the direct command for launching a supported coding agent
@@ -2367,25 +2376,7 @@ func WorktreeSessionName(path string) string {
 		hashPath = absPath
 	}
 
-	name := filepath.Base(cleanPath)
-	var b strings.Builder
-	lastDash := false
-	for _, r := range name {
-		allowed := unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == '.'
-		if allowed {
-			b.WriteRune(r)
-			lastDash = false
-			continue
-		}
-		if !lastDash {
-			b.WriteByte('-')
-			lastDash = true
-		}
-	}
-	name = strings.Trim(b.String(), ".-")
-	if name == "" {
-		name = "worktree"
-	}
+	name := sanitizeIdentifierPart(filepath.Base(cleanPath), "worktree")
 
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(hashPath))
@@ -2507,31 +2498,6 @@ func sanitizePathPart(s string) string {
 		return "worktree"
 	}
 	return s
-}
-
-func slugPathPart(s string) string {
-	var b strings.Builder
-	prevDash := false
-	for _, r := range strings.ToLower(s) {
-		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-			prevDash = false
-		default:
-			if !prevDash && b.Len() > 0 {
-				b.WriteByte('-')
-				prevDash = true
-			}
-		}
-	}
-	out := strings.Trim(b.String(), "-")
-	if len(out) > 48 {
-		out = strings.Trim(out[:48], "-")
-	}
-	if out == "" {
-		return "flow"
-	}
-	return out
 }
 
 const tmuxSwitchScript = `

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -744,6 +744,8 @@ func TestWorktreeSessionName(t *testing.T) {
 		{"/tmp/repo-worktrees/feature/api:oauth", "api-oauth-"},
 		{"/tmp/repo-worktrees/../repo", "repo-"},
 		{"/", "worktree-"},
+		{"/tmp/repo-worktrees/café", "café-"},
+		{"/tmp/repo-worktrees/!!!", "worktree-"},
 	}
 
 	for _, tt := range tests {

--- a/actions/tmux_mode_internal_test.go
+++ b/actions/tmux_mode_internal_test.go
@@ -609,6 +609,7 @@ func TestRepoTmuxWindowNameNeverEmpty(t *testing.T) {
 		// Nothing sanitizable in the launch ID, so the name carries no suffix.
 		{name: "unusable launch id", phaseKind: "review", launchID: "...", wantPrefix: "review", wantNoTrailer: true},
 		{name: "no launch id", phaseKind: "review", wantPrefix: "review", wantNoTrailer: true},
+		{name: "unicode phase kind", phaseKind: "café", launchID: "...", wantPrefix: "café", wantNoTrailer: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/approach/main.go
+++ b/cmd/approach/main.go
@@ -684,16 +684,36 @@ func modelOptionsFromConfig(cfg config.Config, scanRepos func() ([]scanner.Repo,
 }
 
 func runtimeArtifactRoot(cfg config.Config) string {
-	if envRoot := os.Getenv("APPROACH_FLOW_STATE_ROOT"); envRoot != "" {
-		return envRoot
+	root, err := resolveArtifactRoot("", os.Getenv, func() (config.Config, error) {
+		return cfg, nil
+	})
+	if err != nil {
+		return cfg.Sessions.Root
 	}
-	if envRoot := os.Getenv("APPROACH_PLAN_STATE_ROOT"); envRoot != "" {
-		return envRoot
+	return root
+}
+
+// resolveArtifactRoot applies the documented precedence:
+// explicit --state-root > APPROACH_FLOW_STATE_ROOT > APPROACH_PLAN_STATE_ROOT >
+// APPROACH_SESSION_STATE_ROOT > [sessions].root from config.
+func resolveArtifactRoot(explicit string, getenv func(string) string, loadConfig func() (config.Config, error)) (string, error) {
+	if explicit != "" {
+		return explicit, nil
 	}
-	if envRoot := os.Getenv("APPROACH_SESSION_STATE_ROOT"); envRoot != "" {
-		return envRoot
+	if root := getenv("APPROACH_FLOW_STATE_ROOT"); root != "" {
+		return root, nil
 	}
-	return cfg.Sessions.Root
+	if root := getenv("APPROACH_PLAN_STATE_ROOT"); root != "" {
+		return root, nil
+	}
+	if root := getenv("APPROACH_SESSION_STATE_ROOT"); root != "" {
+		return root, nil
+	}
+	cfg, err := loadConfig()
+	if err != nil {
+		return "", fmt.Errorf("error loading config: %w", err)
+	}
+	return cfg.Sessions.Root, nil
 }
 
 func bootstrapHookResolver(cfg config.Config) func(string) (actions.BootstrapHook, bool) {

--- a/cmd/approach/main_test.go
+++ b/cmd/approach/main_test.go
@@ -385,6 +385,33 @@ func TestRun_PassesConfigToProgram(t *testing.T) {
 	}
 }
 
+func TestResolveArtifactRootExplicitTierBeatsEnv(t *testing.T) {
+	cfg := config.Config{Sessions: config.SessionsConfig{Root: "/from/config"}}
+	getenv := func(key string) string {
+		switch key {
+		case "APPROACH_FLOW_STATE_ROOT":
+			return "/from/flow"
+		case "APPROACH_PLAN_STATE_ROOT":
+			return "/from/plan"
+		case "APPROACH_SESSION_STATE_ROOT":
+			return "/from/session"
+		}
+		return ""
+	}
+	loadConfig := func() (config.Config, error) {
+		t.Fatal("loadConfig should not run when an explicit root is set")
+		return cfg, nil
+	}
+
+	got, err := resolveArtifactRoot("/explicit", getenv, loadConfig)
+	if err != nil {
+		t.Fatalf("resolveArtifactRoot() error = %v", err)
+	}
+	if got != "/explicit" {
+		t.Fatalf("resolveArtifactRoot() = %q, want explicit root", got)
+	}
+}
+
 func TestRuntimeArtifactRootPrecedenceIncludesFlowRoot(t *testing.T) {
 	cfg := config.Config{Sessions: config.SessionsConfig{Root: "/from/config"}}
 	t.Setenv("APPROACH_SESSION_STATE_ROOT", "/from/session")

--- a/cmd/approach/plan.go
+++ b/cmd/approach/plan.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/approachcontrol/approach/internal/gitmeta"
 	"github.com/approachcontrol/approach/planstore"
 )
 
@@ -71,23 +71,7 @@ Most commands accept:
 // APPROACH_SESSION_STATE_ROOT >
 // [sessions].root from config > planstore.DefaultRoot() (resolved by NewStore).
 func resolvePlanRoot(stateRoot string, deps runDeps) (string, error) {
-	if stateRoot != "" {
-		return stateRoot, nil
-	}
-	if root := deps.getenv("APPROACH_FLOW_STATE_ROOT"); root != "" {
-		return root, nil
-	}
-	if root := deps.getenv("APPROACH_PLAN_STATE_ROOT"); root != "" {
-		return root, nil
-	}
-	if root := deps.getenv("APPROACH_SESSION_STATE_ROOT"); root != "" {
-		return root, nil
-	}
-	cfg, err := deps.loadConfig()
-	if err != nil {
-		return "", fmt.Errorf("error loading config: %w", err)
-	}
-	return cfg.Sessions.Root, nil
+	return resolveArtifactRoot(stateRoot, deps.getenv, deps.loadConfig)
 }
 
 func newPlanStore(stateRoot string, deps runDeps) (*planstore.Store, error) {
@@ -496,14 +480,6 @@ func fallbackEnv(value, key string, deps runDeps) string {
 	return deps.getenv(key)
 }
 
-type planGitMetadata struct {
-	RepoPath     string
-	WorktreePath string
-	Branch       string
-	Commit       string
-	Linked       bool
-}
-
 func shouldResolvePlanGitMetadata(store *planstore.Store, record planstore.PlanRecord) bool {
 	if record.PlanID == "" {
 		return true
@@ -524,12 +500,14 @@ func resolvePlanGitMetadata(record *planstore.PlanRecord, deps runDeps) {
 	if candidate == "" {
 		candidate = cwd
 	}
-	if meta, ok := resolvePlanGitMetadataAt(candidate); ok {
-		applyPlanGitMetadata(record, meta)
+	info, err := gitmeta.Resolve(candidate)
+	if err != nil || info == (gitmeta.Info{}) {
+		return
 	}
+	applyPlanGitMetadata(record, info)
 }
 
-func applyPlanGitMetadata(record *planstore.PlanRecord, meta planGitMetadata) {
+func applyPlanGitMetadata(record *planstore.PlanRecord, meta gitmeta.Info) {
 	if record.RepoPath == "" {
 		record.RepoPath = meta.RepoPath
 	} else if meta.Linked && meta.RepoPath != "" && samePlanPath(record.RepoPath, meta.WorktreePath) {
@@ -551,115 +529,4 @@ func samePlanPath(a, b string) bool {
 		return false
 	}
 	return filepath.Clean(a) == filepath.Clean(b)
-}
-
-func resolvePlanGitMetadataAt(cwd string) (planGitMetadata, bool) {
-	if cwd == "" {
-		return planGitMetadata{}, false
-	}
-	worktreePath, _ := planGitOutput(cwd, "rev-parse", "--show-toplevel")
-	commonDir, _ := planGitOutput(cwd, "rev-parse", "--path-format=absolute", "--git-common-dir")
-	gitDir, _ := planGitOutput(cwd, "rev-parse", "--path-format=absolute", "--git-dir")
-	if worktreePath == "" && commonDir == "" && gitDir == "" {
-		return planGitMetadata{}, false
-	}
-	isBare := false
-	if out, err := planGitOutput(cwd, "rev-parse", "--is-bare-repository"); err == nil {
-		isBare = out == "true"
-	}
-	commonDirIsBare := false
-	if commonDir != "" {
-		if out, err := planGitOutput(commonDir, "rev-parse", "--is-bare-repository"); err == nil {
-			commonDirIsBare = out == "true"
-		}
-	}
-	linked := planIsLinkedWorktreeGitDir(gitDir, commonDir)
-	repoPath := planRepoPathFromGitMetadata(worktreePath, gitDir, commonDir, isBare, commonDirIsBare)
-	branch, _ := planGitOutput(cwd, "branch", "--show-current")
-	commit, _ := planGitOutput(cwd, "rev-parse", "HEAD")
-	return planGitMetadata{
-		RepoPath:     repoPath,
-		WorktreePath: worktreePath,
-		Branch:       branch,
-		Commit:       commit,
-		Linked:       linked,
-	}, true
-}
-
-func planRepoPathFromGitMetadata(worktreePath, gitDir, commonDir string, isBare, commonDirIsBare bool) string {
-	if isBare {
-		if commonDir != "" {
-			return filepath.Clean(commonDir)
-		}
-		if gitDir == "" {
-			return ""
-		}
-		return filepath.Clean(gitDir)
-	}
-	if commonDir != "" && gitDir != "" && planIsLinkedWorktreeGitDir(gitDir, commonDir) {
-		if commonDirIsBare {
-			return filepath.Clean(commonDir)
-		}
-		if filepath.Base(filepath.Clean(commonDir)) != ".git" {
-			return worktreePath
-		}
-		return planRepoPathFromGitCommonDir(commonDir)
-	}
-	if worktreePath != "" {
-		return worktreePath
-	}
-	if commonDir != "" {
-		return planRepoPathFromGitCommonDir(commonDir)
-	}
-	if gitDir == "" {
-		return ""
-	}
-	return planRepoPathFromGitCommonDir(gitDir)
-}
-
-func planIsLinkedWorktreeGitDir(gitDir, commonDir string) bool {
-	if gitDir == "" || commonDir == "" {
-		return false
-	}
-	rel, err := filepath.Rel(filepath.Join(filepath.Clean(commonDir), "worktrees"), filepath.Clean(gitDir))
-	if err != nil {
-		return false
-	}
-	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
-func planRepoPathFromGitCommonDir(commonDir string) string {
-	commonDir = filepath.Clean(commonDir)
-	if filepath.Base(commonDir) == ".git" {
-		return filepath.Dir(commonDir)
-	}
-	return commonDir
-}
-
-func planGitOutput(cwd string, args ...string) (string, error) {
-	cleaned, err := plausiblePlanGitCWD(cwd)
-	if err != nil {
-		return "", err
-	}
-	cmd := exec.Command("git", append([]string{"-C", cleaned}, args...)...)
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
-func plausiblePlanGitCWD(cwd string) (string, error) {
-	cwd = filepath.Clean(strings.TrimSpace(cwd))
-	if cwd == "." || !filepath.IsAbs(cwd) {
-		return "", fmt.Errorf("git cwd must be an absolute path")
-	}
-	info, err := os.Stat(cwd)
-	if err != nil {
-		return "", fmt.Errorf("inspect git cwd %q: %w", cwd, err)
-	}
-	if !info.IsDir() {
-		return "", fmt.Errorf("git cwd %q is not a directory", cwd)
-	}
-	return cwd, nil
 }

--- a/internal/artifacts/artifacts.go
+++ b/internal/artifacts/artifacts.go
@@ -359,11 +359,13 @@ func TimestampedIDCandidates(opts IDOptions) []string {
 		opts.MaxAttempts = defaultCollisionTries
 	}
 	base := opts.Now.UTC().Format("20060102T150405Z") + "-" + Slug(opts.Title, opts.FallbackSlug)
-	candidates := make([]string, 0, opts.MaxAttempts-1)
-	candidate := base
-	for i := 2; i < opts.MaxAttempts; i++ {
-		candidates = append(candidates, candidate)
-		candidate = fmt.Sprintf("%s-%d", base, i)
+	candidates := make([]string, 0, opts.MaxAttempts)
+	for attempt := 1; attempt <= opts.MaxAttempts; attempt++ {
+		if attempt == 1 {
+			candidates = append(candidates, base)
+			continue
+		}
+		candidates = append(candidates, fmt.Sprintf("%s-%d", base, attempt))
 	}
 	return candidates
 }

--- a/internal/artifacts/artifacts_test.go
+++ b/internal/artifacts/artifacts_test.go
@@ -218,6 +218,59 @@ func TestSafeIDRejectsPathSegments(t *testing.T) {
 	}
 }
 
+func TestTimestampedIDCandidatesIncludesEveryAttemptThroughFinalSuffix(t *testing.T) {
+	now := time.Date(2026, 6, 8, 1, 44, 47, 0, time.UTC)
+	got := artifacts.TimestampedIDCandidates(artifacts.IDOptions{
+		Title:        "!!!",
+		FallbackSlug: "plan",
+		Now:          now,
+		MaxAttempts:  3,
+	})
+	want := []string{
+		"20260608T014447Z-plan",
+		"20260608T014447Z-plan-2",
+		"20260608T014447Z-plan-3",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("TimestampedIDCandidates() len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("TimestampedIDCandidates()[%d] = %q, want %q (full=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestAllocateTimestampedIDSucceedsWhenOnlyFinalCandidateIsFree(t *testing.T) {
+	root := t.TempDir()
+	if err := artifacts.EnsureCollection(root, "plans"); err != nil {
+		t.Fatalf("EnsureCollection() error = %v", err)
+	}
+	now := time.Date(2026, 6, 8, 1, 44, 47, 0, time.UTC)
+	opts := artifacts.IDOptions{
+		Root:         root,
+		Collection:   "plans",
+		Title:        "!!!",
+		FallbackSlug: "plan",
+		Kind:         "plan",
+		Now:          now,
+		MaxAttempts:  3,
+	}
+	for _, taken := range []string{"20260608T014447Z-plan", "20260608T014447Z-plan-2"} {
+		if _, err := artifacts.EnsureRecordDir(root, "plans", taken); err != nil {
+			t.Fatalf("create taken record dir %q: %v", taken, err)
+		}
+	}
+
+	id, err := artifacts.AllocateTimestampedID(opts)
+	if err != nil {
+		t.Fatalf("AllocateTimestampedID() error = %v, want final candidate", err)
+	}
+	if id != "20260608T014447Z-plan-3" {
+		t.Fatalf("AllocateTimestampedID() = %q, want final candidate", id)
+	}
+}
+
 func TestAllocateTimestampedIDSlugFallbackAndCollisionSuffix(t *testing.T) {
 	root := t.TempDir()
 	if err := artifacts.EnsureCollection(root, "plans"); err != nil {

--- a/internal/gitmeta/gitmeta.go
+++ b/internal/gitmeta/gitmeta.go
@@ -1,0 +1,145 @@
+// Package gitmeta resolves worktree, repository, branch, and commit from a
+// working directory by asking git. Callers apply the result only to empty
+// fields; git errors stay inside this package.
+package gitmeta
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Info is the git identity of a working directory. Zero value means the
+// directory is not a repository, or git could not be asked.
+type Info struct {
+	WorktreePath string
+	RepoPath     string
+	Branch       string
+	Commit       string
+	Linked       bool
+}
+
+// Resolve asks git for the worktree, repository, branch, and commit at cwd.
+// A non-repository or unusable cwd returns a zero Info and a nil error so
+// callers can keep filling fields from other sources.
+func Resolve(cwd string) (Info, error) {
+	if cwd == "" {
+		return Info{}, nil
+	}
+	worktreePath := ""
+	if out, err := gitOutput(cwd, "rev-parse", "--show-toplevel"); err == nil {
+		worktreePath = out
+	}
+	gitCommonDir := ""
+	if out, err := gitOutput(cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"); err == nil {
+		gitCommonDir = out
+	}
+	gitDir := ""
+	if out, err := gitOutput(cwd, "rev-parse", "--path-format=absolute", "--git-dir"); err == nil {
+		gitDir = out
+	}
+	isBare := false
+	if out, err := gitOutput(cwd, "rev-parse", "--is-bare-repository"); err == nil {
+		isBare = out == "true"
+	}
+	commonDirIsBare := false
+	if gitCommonDir != "" {
+		if out, err := gitOutput(gitCommonDir, "rev-parse", "--is-bare-repository"); err == nil {
+			commonDirIsBare = out == "true"
+		}
+	}
+	repoPath := repoPathFromGitMetadata(worktreePath, gitDir, gitCommonDir, isBare, commonDirIsBare)
+	info := Info{
+		Linked: isLinkedWorktreeGitDir(gitDir, gitCommonDir),
+	}
+	if repoPath != "" {
+		info.RepoPath = repoPath
+	} else if worktreePath != "" {
+		info.RepoPath = worktreePath
+	}
+	info.WorktreePath = worktreePath
+	if out, err := gitOutput(cwd, "branch", "--show-current"); err == nil {
+		info.Branch = out
+	}
+	if out, err := gitOutput(cwd, "rev-parse", "HEAD"); err == nil {
+		info.Commit = out
+	}
+	return info, nil
+}
+
+func repoPathFromGitMetadata(worktreePath, gitDir, commonDir string, isBare, commonDirIsBare bool) string {
+	if isBare {
+		if commonDir != "" {
+			return filepath.Clean(commonDir)
+		}
+		if gitDir == "" {
+			return ""
+		}
+		return filepath.Clean(gitDir)
+	}
+	if commonDir != "" && gitDir != "" && isLinkedWorktreeGitDir(gitDir, commonDir) {
+		if commonDirIsBare {
+			return filepath.Clean(commonDir)
+		}
+		if filepath.Base(filepath.Clean(commonDir)) != ".git" {
+			return worktreePath
+		}
+		return repoPathFromGitCommonDir(commonDir)
+	}
+	if worktreePath != "" {
+		return worktreePath
+	}
+	if commonDir != "" {
+		return repoPathFromGitCommonDir(commonDir)
+	}
+	if gitDir == "" {
+		return ""
+	}
+	return repoPathFromGitCommonDir(gitDir)
+}
+
+func isLinkedWorktreeGitDir(gitDir, commonDir string) bool {
+	rel, err := filepath.Rel(filepath.Join(filepath.Clean(commonDir), "worktrees"), filepath.Clean(gitDir))
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func repoPathFromGitCommonDir(commonDir string) string {
+	commonDir = filepath.Clean(commonDir)
+	if filepath.Base(commonDir) == ".git" {
+		return filepath.Dir(commonDir)
+	}
+	return commonDir
+}
+
+func gitOutput(cwd string, args ...string) (string, error) {
+	cleaned, err := plausibleGitCWD(cwd)
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command("git", append([]string{"-C", cleaned}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func plausibleGitCWD(cwd string) (string, error) {
+	cwd = filepath.Clean(strings.TrimSpace(cwd))
+	if cwd == "." || !filepath.IsAbs(cwd) {
+		return "", fmt.Errorf("git cwd must be an absolute path")
+	}
+	info, err := os.Stat(cwd)
+	if err != nil {
+		return "", fmt.Errorf("inspect git cwd %q: %w", cwd, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("git cwd %q is not a directory", cwd)
+	}
+	return cwd, nil
+}

--- a/internal/gitmeta/gitmeta_test.go
+++ b/internal/gitmeta/gitmeta_test.go
@@ -1,0 +1,117 @@
+package gitmeta_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/approachcontrol/approach/internal/gitmeta"
+	"github.com/approachcontrol/approach/internal/testgit"
+)
+
+func TestResolvePlainRepoPathEqualsToplevel(t *testing.T) {
+	repoPath := t.TempDir()
+	testgit.Run(t, repoPath, "init")
+	testgit.ConfigureRepo(t, repoPath)
+	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("test\n"), 0o600); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	testgit.Run(t, repoPath, "add", "README.md")
+	testgit.Run(t, repoPath, "commit", "-m", "initial")
+
+	info, err := gitmeta.Resolve(repoPath)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	toplevel := testgit.Output(t, repoPath, "rev-parse", "--show-toplevel")
+	if info.RepoPath != toplevel {
+		t.Fatalf("RepoPath = %q, want toplevel %q", info.RepoPath, toplevel)
+	}
+}
+
+func TestResolveLinkedWorktreeRepoPathIsParentOfGitCommonDir(t *testing.T) {
+	root := t.TempDir()
+	repoPath := filepath.Join(root, "repo")
+	worktreePath := filepath.Join(root, "repo-worktrees", "feature")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("create repo dir: %v", err)
+	}
+	testgit.Run(t, repoPath, "init")
+	testgit.ConfigureRepo(t, repoPath)
+	if err := os.WriteFile(filepath.Join(repoPath, "README.md"), []byte("test\n"), 0o600); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	testgit.Run(t, repoPath, "add", "README.md")
+	testgit.Run(t, repoPath, "commit", "-m", "initial")
+	testgit.Run(t, repoPath, "worktree", "add", "-b", "feature/gitmeta", worktreePath, "HEAD")
+
+	info, err := gitmeta.Resolve(worktreePath)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	commonDir := testgit.Output(t, worktreePath, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	wantRepo := filepath.Dir(commonDir)
+	if filepath.Base(commonDir) != ".git" {
+		t.Fatalf("common dir = %q, want a .git directory", commonDir)
+	}
+	if info.RepoPath != wantRepo {
+		t.Fatalf("RepoPath = %q, want parent of common dir %q", info.RepoPath, wantRepo)
+	}
+	if !info.Linked {
+		t.Fatal("Linked = false, want true for a linked worktree")
+	}
+}
+
+func TestResolveBareRepoPathIsCommonDir(t *testing.T) {
+	root := t.TempDir()
+	barePath := filepath.Join(root, "repo.git")
+	testgit.Run(t, root, "init", "--bare", barePath)
+
+	info, err := gitmeta.Resolve(barePath)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	commonDir := testgit.Output(t, barePath, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if info.RepoPath != filepath.Clean(commonDir) {
+		t.Fatalf("RepoPath = %q, want common dir %q", info.RepoPath, commonDir)
+	}
+	if info.WorktreePath != "" {
+		t.Fatalf("WorktreePath = %q, want empty for a bare repo", info.WorktreePath)
+	}
+}
+
+func TestResolveWorktreeOfBareRepoUsesBareCommonDir(t *testing.T) {
+	root := t.TempDir()
+	bareRepoPath := filepath.Join(root, "container", ".git")
+	worktreePath := filepath.Join(root, "worktrees", "feature")
+	if err := os.MkdirAll(filepath.Dir(bareRepoPath), 0o755); err != nil {
+		t.Fatalf("create bare parent dir: %v", err)
+	}
+	testgit.Run(t, root, "init", "--bare", bareRepoPath)
+	testgit.Run(t, bareRepoPath, "worktree", "add", "-b", "feature/gitmeta", worktreePath)
+
+	info, err := gitmeta.Resolve(worktreePath)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	commonDir := testgit.Output(t, worktreePath, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if info.RepoPath != filepath.Clean(commonDir) {
+		t.Fatalf("RepoPath = %q, want bare common dir %q", info.RepoPath, commonDir)
+	}
+	toplevel := testgit.Output(t, worktreePath, "rev-parse", "--show-toplevel")
+	if info.WorktreePath != toplevel {
+		t.Fatalf("WorktreePath = %q, want toplevel %q", info.WorktreePath, toplevel)
+	}
+}
+
+func TestResolveNonRepoReturnsZeroInfoWithoutError(t *testing.T) {
+	cwd := t.TempDir()
+
+	info, err := gitmeta.Resolve(cwd)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v, want nil", err)
+	}
+	if info != (gitmeta.Info{}) {
+		t.Fatalf("Resolve() = %#v, want zero Info", info)
+	}
+}

--- a/model/export_test.go
+++ b/model/export_test.go
@@ -27,7 +27,7 @@ func modelWithModeForTest(m Model, mode ui.Mode) Model {
 }
 
 func ActiveFlowCreateForTest(m Model) uint64 {
-	return m.activeFlowCreate
+	return m.flowCreateReq.current
 }
 
 func ActiveFlowSelectedForTest(m Model) int {

--- a/model/flow_launch_create_internal_test.go
+++ b/model/flow_launch_create_internal_test.go
@@ -212,7 +212,7 @@ func TestCreateFlowLaunchEmbeddedSuccessRefreshesVisibleUnfocusedFlowPane(t *tes
 		Token: "launch-create-1", Kind: flowLaunchKindCreatePhase, FlowID: h.record.FlowID,
 		Create: flowLaunchCreateRequest{Presentation: flowLaunchCreatePresentation{Origin: flowLaunchOriginNewFlow, Request: 1}, RepoPath: h.record.RepoPath},
 	}
-	m.activeFlowCreate = attempt.Create.Presentation.Request
+	m.flowCreateReq.current = attempt.Create.Presentation.Request
 	m = m.withFlowLaunchAttempt(attempt)
 	beforeRequest := m.ListRequest(ui.ModeFlows)
 	next, _ := m.installFlowLaunchEmbedded(attempt, flowLaunchEventMsg{
@@ -449,8 +449,8 @@ func TestCreateFlowLaunchReadyOriginPersistsBeadAndUsesEmbeddedOnlyHandoff(t *te
 	if len(h.contexts) != 1 || !h.contexts[0].Embedded || !h.contexts[0].Headless {
 		t.Fatalf("Ready launch contexts = %#v", h.contexts)
 	}
-	if m.activeReadyBeadFlowCreate != 0 || m.activeFlowCreate != 0 || h.releases != 1 {
-		t.Fatalf("Ready ownership: ready=%d new=%d releases=%d", m.activeReadyBeadFlowCreate, m.activeFlowCreate, h.releases)
+	if m.readyBeadFlowCreateReq.current != 0 || m.flowCreateReq.current != 0 || h.releases != 1 {
+		t.Fatalf("Ready ownership: ready=%d new=%d releases=%d", m.readyBeadFlowCreateReq.current, m.flowCreateReq.current, h.releases)
 	}
 }
 
@@ -486,15 +486,14 @@ func TestCreateFlowLaunchReadyFreshnessIsSourceAwareAtEveryBoundary(t *testing.T
 			h := newCreateLaunchHarness([]flowstore.FlowPhase{{PhaseID: "plan", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady}})
 			m, cmd := h.admitSource(t, h.model(t), flowLaunchOriginReadyBead)
 			m, event := advanceCreateLaunchToStage(t, m, cmd, stage)
-			m.readyBeadFlowCreateSeq++
-			m.activeReadyBeadFlowCreate = m.readyBeadFlowCreateSeq
+			m.readyBeadFlowCreateReq.next()
 			m, newFlowRequest := m.nextFlowCreateRequest()
 			m = m.setStatusNow(statusOther, "newer presentation")
 			m, cmd = m.handleFlowLaunchEvent(event)
 			m = drainCreateLaunch(t, m, cmd)
 
-			if m.activeReadyBeadFlowCreate == 0 || m.activeFlowCreate != newFlowRequest || m.status.Text != "newer presentation" {
-				t.Fatalf("source fence at %v: ready=%d new=%d status=%q", stage, m.activeReadyBeadFlowCreate, m.activeFlowCreate, m.status.Text)
+			if m.readyBeadFlowCreateReq.current == 0 || m.flowCreateReq.current != newFlowRequest || m.status.Text != "newer presentation" {
+				t.Fatalf("source fence at %v: ready=%d new=%d status=%q", stage, m.readyBeadFlowCreateReq.current, m.flowCreateReq.current, m.status.Text)
 			}
 		})
 	}
@@ -591,8 +590,8 @@ func TestCreateFlowLaunchOwnsExactIdentityAndStartupOrdering(t *testing.T) {
 		ctx.WorktreePath != "/dev/alpha-worktrees/flow-new" || ctx.Commit != "abc123" || !ctx.Embedded || !ctx.FlowLaunchTracked {
 		t.Fatalf("launch context = %#v", ctx)
 	}
-	if h.releases != 1 || m.activeFlowCreate != 0 || len(m.embeddedTerminals) != 1 {
-		t.Fatalf("handoff ownership: releases=%d active=%d terminals=%d", h.releases, m.activeFlowCreate, len(m.embeddedTerminals))
+	if h.releases != 1 || m.flowCreateReq.current != 0 || len(m.embeddedTerminals) != 1 {
+		t.Fatalf("handoff ownership: releases=%d active=%d terminals=%d", h.releases, m.flowCreateReq.current, len(m.embeddedTerminals))
 	}
 }
 
@@ -602,8 +601,8 @@ func TestCreateFlowLaunchParksWithoutLaunchID(t *testing.T) {
 	if strings.Contains(strings.Join(h.order, ","), "launch-id:") || len(h.contexts) != 0 {
 		t.Fatalf("parked Flow launched: order=%#v contexts=%#v", h.order, h.contexts)
 	}
-	if h.releases != 1 || m.activeFlowCreate != 0 || !strings.Contains(m.status.Text, "Created flow") {
-		t.Fatalf("parked result: releases=%d active=%d status=%q", h.releases, m.activeFlowCreate, m.status.Text)
+	if h.releases != 1 || m.flowCreateReq.current != 0 || !strings.Contains(m.status.Text, "Created flow") {
+		t.Fatalf("parked result: releases=%d active=%d status=%q", h.releases, m.flowCreateReq.current, m.status.Text)
 	}
 }
 
@@ -769,8 +768,8 @@ func TestCreateFlowLaunchRefusesEveryPreexistingSessionAssociationBeforeCreate(t
 			if created {
 				t.Fatalf("preexisting %s crossed exact-ID creation: order=%#v", tc.name, h.order)
 			}
-			if m.activeFlowCreate != 0 || h.releases != 0 || !strings.Contains(m.status.Text, tc.status) {
-				t.Fatalf("%s refusal: status=%q active=%d releases=%d", tc.name, m.status.Text, m.activeFlowCreate, h.releases)
+			if m.flowCreateReq.current != 0 || h.releases != 0 || !strings.Contains(m.status.Text, tc.status) {
+				t.Fatalf("%s refusal: status=%q active=%d releases=%d", tc.name, m.status.Text, m.flowCreateReq.current, h.releases)
 			}
 		})
 	}
@@ -783,8 +782,8 @@ func TestCreateFlowLaunchRejectsInvalidAllocatedIdentityBeforeSessionLookup(t *t
 	if !reflect.DeepEqual(h.order, []string{"allocate"}) {
 		t.Fatalf("invalid allocation crossed admission: %#v", h.order)
 	}
-	if m.activeFlowCreate != 0 || !strings.Contains(m.status.Text, "invalid ID") {
-		t.Fatalf("invalid allocation result: active=%d status=%q", m.activeFlowCreate, m.status.Text)
+	if m.flowCreateReq.current != 0 || !strings.Contains(m.status.Text, "invalid ID") {
+		t.Fatalf("invalid allocation result: active=%d status=%q", m.flowCreateReq.current, m.status.Text)
 	}
 }
 
@@ -826,8 +825,8 @@ func TestCreateFlowLaunchCreateAndReservationErrorsDoNotAdoptOrRecoverUnprovenRo
 			if strings.Contains(joined, "worktree") || strings.Contains(joined, "reread:") || strings.Contains(joined, "metadata") || len(h.phaseUpdates) != 0 {
 				t.Fatalf("unproven row crossed into recovery: order=%#v updates=%#v", h.order, h.phaseUpdates)
 			}
-			if !strings.Contains(m.status.Text, tc.want) || m.activeFlowCreate != 0 || h.releases != 0 {
-				t.Fatalf("failure result: status=%q active=%d releases=%d", m.status.Text, m.activeFlowCreate, h.releases)
+			if !strings.Contains(m.status.Text, tc.want) || m.flowCreateReq.current != 0 || h.releases != 0 {
+				t.Fatalf("failure result: status=%q active=%d releases=%d", m.status.Text, m.flowCreateReq.current, h.releases)
 			}
 		})
 	}
@@ -859,8 +858,8 @@ func TestCreateFlowLaunchRejectsRecordClaimedBeforeTrackedReservation(t *testing
 			t.Fatalf("losing create attempt performed %q after contention: %#v", forbidden, h.order)
 		}
 	}
-	if h.releases != 1 || m.activeFlowCreate != 0 || !strings.Contains(m.status.Text, "claimed by another launch") {
-		t.Fatalf("contention result: releases=%d active=%d status=%q", h.releases, m.activeFlowCreate, m.status.Text)
+	if h.releases != 1 || m.flowCreateReq.current != 0 || !strings.Contains(m.status.Text, "claimed by another launch") {
+		t.Fatalf("contention result: releases=%d active=%d status=%q", h.releases, m.flowCreateReq.current, m.status.Text)
 	}
 }
 
@@ -881,8 +880,8 @@ func TestCreateFlowLaunchRejectsSameIDReplacementBeforeTrackedReservation(t *tes
 	m, cmd = m.handleFlowLaunchEvent(reserved)
 	m = drainCreateLaunch(t, m, cmd)
 
-	if strings.Contains(strings.Join(h.order, ","), "worktree") || h.releases != 1 || m.activeFlowCreate != 0 {
-		t.Fatalf("replacement result: order=%#v releases=%d active=%d", h.order, h.releases, m.activeFlowCreate)
+	if strings.Contains(strings.Join(h.order, ","), "worktree") || h.releases != 1 || m.flowCreateReq.current != 0 {
+		t.Fatalf("replacement result: order=%#v releases=%d active=%d", h.order, h.releases, m.flowCreateReq.current)
 	}
 }
 
@@ -924,8 +923,8 @@ func TestCreateFlowLaunchRevalidatesStartupRootAfterMetadata(t *testing.T) {
 	if len(h.contexts) != 0 || strings.Contains(strings.Join(h.order, ","), "terminal") {
 		t.Fatalf("metadata proof drift spawned an agent: contexts=%#v order=%#v", h.contexts, h.order)
 	}
-	if h.releases != 1 || m.activeFlowCreate != 0 || !strings.Contains(m.status.Text, "validate startup root: no longer launchable") {
-		t.Fatalf("metadata proof result: releases=%d active=%d status=%q", h.releases, m.activeFlowCreate, m.status.Text)
+	if h.releases != 1 || m.flowCreateReq.current != 0 || !strings.Contains(m.status.Text, "validate startup root: no longer launchable") {
+		t.Fatalf("metadata proof result: releases=%d active=%d status=%q", h.releases, m.flowCreateReq.current, m.status.Text)
 	}
 }
 
@@ -943,8 +942,8 @@ func TestCreateFlowLaunchRejectsSameIDReplacementAtPostBootstrapReread(t *testin
 			t.Fatalf("replacement reread performed %q: %#v", forbidden, h.order)
 		}
 	}
-	if h.releases != 1 || m.activeFlowCreate != 0 || !strings.Contains(m.status.Text, "flow generation changed") {
-		t.Fatalf("replacement reread result: releases=%d active=%d status=%q", h.releases, m.activeFlowCreate, m.status.Text)
+	if h.releases != 1 || m.flowCreateReq.current != 0 || !strings.Contains(m.status.Text, "flow generation changed") {
+		t.Fatalf("replacement reread result: releases=%d active=%d status=%q", h.releases, m.flowCreateReq.current, m.status.Text)
 	}
 }
 
@@ -965,8 +964,8 @@ func TestCreateFlowLaunchRejectsGenerationLossDuringLaunchIDProofReread(t *testi
 			t.Fatalf("proof reread generation loss performed %q: %#v", forbidden, h.order)
 		}
 	}
-	if h.releases != 1 || m.activeFlowCreate != 0 || !strings.Contains(m.status.Text, "flow generation changed") {
-		t.Fatalf("proof reread generation result: releases=%d active=%d status=%q", h.releases, m.activeFlowCreate, m.status.Text)
+	if h.releases != 1 || m.flowCreateReq.current != 0 || !strings.Contains(m.status.Text, "flow generation changed") {
+		t.Fatalf("proof reread generation result: releases=%d active=%d status=%q", h.releases, m.flowCreateReq.current, m.status.Text)
 	}
 }
 
@@ -993,8 +992,7 @@ func TestCreateFlowLaunchCancellationDoesNotRecoverAfterGenerationLoss(t *testin
 			if !event.GenerationLost {
 				t.Fatal("test event did not lose its Flow generation")
 			}
-			m.flowCreateSeq++
-			m.activeFlowCreate = m.flowCreateSeq
+			m.flowCreateReq.next()
 			m = m.setStatusNow(statusOther, "newer creation status")
 			m, cmd = m.handleFlowLaunchEvent(event)
 			m = drainCreateLaunch(t, m, cmd)
@@ -1002,8 +1000,8 @@ func TestCreateFlowLaunchCancellationDoesNotRecoverAfterGenerationLoss(t *testin
 			if len(h.phaseUpdates) != 0 {
 				t.Fatalf("stale generation loss recovered replacement: order=%#v updates=%#v", h.order, h.phaseUpdates)
 			}
-			if h.releases != 1 || m.status.Text != "newer creation status" || m.activeFlowCreate == 0 {
-				t.Fatalf("stale generation cleanup: releases=%d status=%q active=%d", h.releases, m.status.Text, m.activeFlowCreate)
+			if h.releases != 1 || m.status.Text != "newer creation status" || m.flowCreateReq.current == 0 {
+				t.Fatalf("stale generation cleanup: releases=%d status=%q active=%d", h.releases, m.status.Text, m.flowCreateReq.current)
 			}
 		})
 	}
@@ -1021,8 +1019,7 @@ func TestCreateFlowLaunchStaleMetadataFailureFencesSurvivingWorktree(t *testing.
 		t.Fatal("test metadata event unexpectedly succeeded")
 	}
 
-	m.flowCreateSeq++
-	m.activeFlowCreate = m.flowCreateSeq
+	m.flowCreateReq.next()
 	m = m.setStatusNow(statusOther, "newer creation status")
 	m, cmd = m.handleFlowLaunchEvent(event)
 	m = drainCreateLaunch(t, m, cmd)
@@ -1035,8 +1032,8 @@ func TestCreateFlowLaunchStaleMetadataFailureFencesSurvivingWorktree(t *testing.
 			t.Fatalf("stale metadata recovery omitted surviving worktree: %#v", update)
 		}
 	}
-	if h.releases != 1 || m.status.Text != "newer creation status" || m.activeFlowCreate == 0 {
-		t.Fatalf("stale metadata cleanup: releases=%d status=%q active=%d", h.releases, m.status.Text, m.activeFlowCreate)
+	if h.releases != 1 || m.status.Text != "newer creation status" || m.flowCreateReq.current == 0 {
+		t.Fatalf("stale metadata cleanup: releases=%d status=%q active=%d", h.releases, m.status.Text, m.flowCreateReq.current)
 	}
 }
 
@@ -1049,8 +1046,7 @@ func TestCreateFlowLaunchStaleUnknownPreparationDoesNotCompensate(t *testing.T) 
 		t.Fatalf("test preparation event = %#v, want unknown outcome", event)
 	}
 
-	m.readyBeadFlowCreateSeq++
-	m.activeReadyBeadFlowCreate = m.readyBeadFlowCreateSeq
+	m.readyBeadFlowCreateReq.next()
 	m = m.setStatusNow(statusOther, "newer Ready status")
 	m, cmd = m.handleFlowLaunchEvent(event)
 	m = drainCreateLaunch(t, m, cmd)
@@ -1058,8 +1054,8 @@ func TestCreateFlowLaunchStaleUnknownPreparationDoesNotCompensate(t *testing.T) 
 	if len(h.phaseUpdates) != 0 {
 		t.Fatalf("stale unknown preparation compensated possibly durable receipt: %#v", h.phaseUpdates)
 	}
-	if h.releases != 1 || m.status.Text != "newer Ready status" || m.activeReadyBeadFlowCreate == 0 {
-		t.Fatalf("stale unknown cleanup: releases=%d status=%q active=%d", h.releases, m.status.Text, m.activeReadyBeadFlowCreate)
+	if h.releases != 1 || m.status.Text != "newer Ready status" || m.readyBeadFlowCreateReq.current == 0 {
+		t.Fatalf("stale unknown cleanup: releases=%d status=%q active=%d", h.releases, m.status.Text, m.readyBeadFlowCreateReq.current)
 	}
 }
 
@@ -1102,8 +1098,7 @@ func TestCreateFlowLaunchReadyReservationFailureCompensatesLaunchableRoots(t *te
 			if stale {
 				var event flowLaunchEventMsg
 				m, event = advanceCreateLaunchToStage(t, m, cmd, flowLaunchStageCreateReserved)
-				m.readyBeadFlowCreateSeq++
-				m.activeReadyBeadFlowCreate = m.readyBeadFlowCreateSeq
+				m.readyBeadFlowCreateReq.next()
 				m = m.setStatusNow(statusOther, "newer Ready status")
 				m, cmd = m.handleFlowLaunchEvent(event)
 			}
@@ -1145,8 +1140,7 @@ func TestCreateFlowLaunchReadyWrongReservationIdentityCompensatesCreatedFlow(t *
 			if stale {
 				var event flowLaunchEventMsg
 				m, event = advanceCreateLaunchToStage(t, m, cmd, flowLaunchStageCreateReserved)
-				m.readyBeadFlowCreateSeq++
-				m.activeReadyBeadFlowCreate = m.readyBeadFlowCreateSeq
+				m.readyBeadFlowCreateReq.next()
 				m = m.setStatusNow(statusOther, "newer Ready status")
 				m, cmd = m.handleFlowLaunchEvent(event)
 			}
@@ -1439,8 +1433,8 @@ func TestCreateFlowLaunchParkedMetadataRejectsGenerationLoss(t *testing.T) {
 	}
 	m := h.start(t, h.model(t))
 
-	if h.releases != 1 || m.activeFlowCreate != 0 || strings.Contains(m.status.Text, "Created flow") || !strings.Contains(m.status.Text, "flow generation changed") {
-		t.Fatalf("parked generation result: releases=%d active=%d status=%q", h.releases, m.activeFlowCreate, m.status.Text)
+	if h.releases != 1 || m.flowCreateReq.current != 0 || strings.Contains(m.status.Text, "Created flow") || !strings.Contains(m.status.Text, "flow generation changed") {
+		t.Fatalf("parked generation result: releases=%d active=%d status=%q", h.releases, m.flowCreateReq.current, m.status.Text)
 	}
 }
 
@@ -1466,8 +1460,7 @@ func TestCreateFlowLaunchCancellationMatrixPreservesNewerPresentation(t *testing
 			})
 			m, cmd := h.admit(t, h.model(t))
 			m, event := advanceCreateLaunchToStage(t, m, cmd, tc.stage)
-			m.flowCreateSeq++
-			m.activeFlowCreate = m.flowCreateSeq
+			m.flowCreateReq.next()
 			m = m.setStatusNow(statusOther, "newer creation status")
 			m, cmd = m.handleFlowLaunchEvent(event)
 			m = drainCreateLaunch(t, m, cmd)
@@ -1482,8 +1475,8 @@ func TestCreateFlowLaunchCancellationMatrixPreservesNewerPresentation(t *testing
 			if tc.stage == flowLaunchStageCreateWorktree && h.record.Commit != "abc123" {
 				t.Fatalf("stale post-worktree recovery commit = %q, want abc123", h.record.Commit)
 			}
-			if m.status.Text != "newer creation status" || m.activeFlowCreate == 0 || len(h.contexts) != 0 {
-				t.Fatalf("newer presentation changed: status=%q active=%d contexts=%#v", m.status.Text, m.activeFlowCreate, h.contexts)
+			if m.status.Text != "newer creation status" || m.flowCreateReq.current == 0 || len(h.contexts) != 0 {
+				t.Fatalf("newer presentation changed: status=%q active=%d contexts=%#v", m.status.Text, m.flowCreateReq.current, h.contexts)
 			}
 		})
 	}
@@ -1498,8 +1491,8 @@ func TestCreateFlowLaunchAllocatedIDRefusesRetainedFlowSlots(t *testing.T) {
 			m, cmd := h.admit(t, m)
 			allocated := cmd().(flowLaunchEventMsg)
 			m, cmd = m.handleFlowLaunchEvent(allocated)
-			if cmd != nil || m.activeFlowCreate != 0 || m.flowLaunchAttemptOccupied(h.record.FlowID) {
-				t.Fatalf("retained slot admission: cmd=%T active=%d attempt=%v", cmd, m.activeFlowCreate, m.flowLaunchAttemptOccupied(h.record.FlowID))
+			if cmd != nil || m.flowCreateReq.current != 0 || m.flowLaunchAttemptOccupied(h.record.FlowID) {
+				t.Fatalf("retained slot admission: cmd=%T active=%d attempt=%v", cmd, m.flowCreateReq.current, m.flowLaunchAttemptOccupied(h.record.FlowID))
 			}
 			if !reflect.DeepEqual(h.order, []string{"allocate"}) {
 				t.Fatalf("retained slot crossed admission: %#v", h.order)
@@ -1515,16 +1508,16 @@ func TestCreateFlowLaunchParkedMetadataFailureDoesNotMutatePhases(t *testing.T) 
 	if len(h.phaseUpdates) != 0 || len(h.contexts) != 0 || h.releases != 1 {
 		t.Fatalf("parked metadata recovery: updates=%#v contexts=%#v releases=%d", h.phaseUpdates, h.contexts, h.releases)
 	}
-	if !strings.Contains(m.status.Text, "record start metadata: disk full") || m.activeFlowCreate != 0 {
-		t.Fatalf("parked metadata status=%q active=%d", m.status.Text, m.activeFlowCreate)
+	if !strings.Contains(m.status.Text, "record start metadata: disk full") || m.flowCreateReq.current != 0 {
+		t.Fatalf("parked metadata status=%q active=%d", m.status.Text, m.flowCreateReq.current)
 	}
 }
 
 func TestCreateFlowLaunchInteractivePrefillKeepsOriginFenceUntilResult(t *testing.T) {
 	h := newCreateLaunchHarness([]flowstore.FlowPhase{{PhaseID: "plan", Title: "Plan", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady}})
 	m, prefill := startInteractiveCreateUntilPrefill(t, h)
-	if m.activeFlowCreate != prefill.Create.Presentation.Request {
-		t.Fatalf("active create request = %d, want pending prefill request %d", m.activeFlowCreate, prefill.Create.Presentation.Request)
+	if m.flowCreateReq.current != prefill.Create.Presentation.Request {
+		t.Fatalf("active create request = %d, want pending prefill request %d", m.flowCreateReq.current, prefill.Create.Presentation.Request)
 	}
 	if len(m.embeddedTerminals) != 1 || !m.embeddedTerminals[0].PrefillPending {
 		t.Fatalf("pending terminals = %#v", m.embeddedTerminals)
@@ -1533,8 +1526,7 @@ func TestCreateFlowLaunchInteractivePrefillKeepsOriginFenceUntilResult(t *testin
 	// A repo change invalidates the original create request. Its delayed prefill
 	// result must recover the phase without activating the old terminal or
 	// replacing presentation for the newly selected repo.
-	m.flowCreateSeq++
-	m.activeFlowCreate = m.flowCreateSeq
+	m.flowCreateReq.next()
 	m = m.setStatusNow(statusOther, "new repo status")
 	next, persistCmd := m.Update(prefill)
 	m = next.(Model)
@@ -1563,8 +1555,8 @@ func TestCreateFlowLaunchInteractivePrefillSuccessCompletesRequestAndFocuses(t *
 	m, prefill := startInteractiveCreateUntilPrefill(t, h)
 	next, _ := m.Update(prefill)
 	m = next.(Model)
-	if m.activeFlowCreate != 0 || len(m.embeddedTerminals) != 1 || m.embeddedTerminals[0].PrefillPending {
-		t.Fatalf("successful prefill result: active=%d terminals=%#v", m.activeFlowCreate, m.embeddedTerminals)
+	if m.flowCreateReq.current != 0 || len(m.embeddedTerminals) != 1 || m.embeddedTerminals[0].PrefillPending {
+		t.Fatalf("successful prefill result: active=%d terminals=%#v", m.flowCreateReq.current, m.embeddedTerminals)
 	}
 	if m.activeTerminalNum != 1 {
 		t.Fatalf("successful prefill active terminal = %d, want 1", m.activeTerminalNum)
@@ -1583,8 +1575,8 @@ func TestCreateFlowLaunchMissingPrefillSlotRecoversPhaseAndCompletesRequest(t *t
 	persisted := commandMessageOfType[flowLaunchFailurePersistedMsg](t, cmd)
 	settled, _ := m.Update(persisted)
 	m = settled.(Model)
-	if m.activeFlowCreate != 0 || len(h.phaseUpdates) != 1 || h.phaseUpdates[0].Status != flowstore.PhaseNeedsAttention {
-		t.Fatalf("missing-slot recovery: active=%d updates=%#v", m.activeFlowCreate, h.phaseUpdates)
+	if m.flowCreateReq.current != 0 || len(h.phaseUpdates) != 1 || h.phaseUpdates[0].Status != flowstore.PhaseNeedsAttention {
+		t.Fatalf("missing-slot recovery: active=%d updates=%#v", m.flowCreateReq.current, h.phaseUpdates)
 	}
 	if !strings.Contains(m.status.Text, "embedded terminal closed before prompt prefill completed") {
 		t.Fatalf("missing-slot status = %q", m.status.Text)
@@ -1608,8 +1600,8 @@ func TestCreateFlowLaunchPrefillFailureDoesNotMutatePhaseWhenAnotherAttemptWinsR
 	if cmd != nil {
 		t.Fatalf("old prefill failure returned command %T, want fenced cleanup only", cmd)
 	}
-	if m.activeFlowCreate != 0 {
-		t.Fatalf("active create request = %d, want cleared", m.activeFlowCreate)
+	if m.flowCreateReq.current != 0 {
+		t.Fatalf("active create request = %d, want cleared", m.flowCreateReq.current)
 	}
 	if len(h.phaseUpdates) != 0 {
 		t.Fatalf("old prefill failure mutated phase owned by winner: %#v", h.phaseUpdates)
@@ -1634,8 +1626,7 @@ func TestCreateFlowLaunchPrefillTerminationFailureRetainsNondetachableOccupancy(
 				t.Fatalf("prefill termination result = %#v terminates=%d", prefill, term.terminates)
 			}
 			if stale {
-				m.flowCreateSeq++
-				m.activeFlowCreate = m.flowCreateSeq
+				m.flowCreateReq.next()
 				m = m.setStatusNow(statusOther, "newer status")
 			}
 			next, cmd := m.Update(prefill)

--- a/model/model.go
+++ b/model/model.go
@@ -129,14 +129,10 @@ type Model struct {
 	pendingInlineSessionRepo    string
 	pendingInlineSessionPath    string
 	pendingInlineSessionList    uint64
-	worktreeCreateSeq           uint64
-	activeWorktreeCreate        uint64
-	repoCreateSeq               uint64
-	activeRepoCreate            uint64
-	flowCreateSeq               uint64
-	activeFlowCreate            uint64
-	readyBeadFlowCreateSeq      uint64
-	activeReadyBeadFlowCreate   uint64
+	worktreeCreateReq           requestTracker
+	repoCreateReq               requestTracker
+	flowCreateReq               requestTracker
+	readyBeadFlowCreateReq      requestTracker
 	flowPreparationAdmission    bool
 	flowPreparationSeq          uint64
 	flowPreparationOwner        flowPreparationOwner

--- a/model/model_fetch.go
+++ b/model/model_fetch.go
@@ -340,53 +340,41 @@ func (m Model) pendingInlineSessionRefresh(repoPath string, listRequest uint64) 
 }
 
 func (m Model) nextWorktreeCreateRequest() (Model, uint64) {
-	m.worktreeCreateSeq++
-	m.activeWorktreeCreate = m.worktreeCreateSeq
-	return m, m.activeWorktreeCreate
+	return m, m.worktreeCreateReq.next()
 }
 
 func (m Model) isCurrentWorktreeCreateRequest(request uint64) bool {
-	return request == m.activeWorktreeCreate
+	return m.worktreeCreateReq.isCurrent(request)
 }
 
 func (m Model) clearWorktreeCreateRequest(request uint64) Model {
-	if request != 0 && request == m.activeWorktreeCreate {
-		m.activeWorktreeCreate = 0
-	}
+	m.worktreeCreateReq.clear(request)
 	return m
 }
 
 func (m Model) nextRepoCreateRequest() (Model, uint64) {
-	m.repoCreateSeq++
-	m.activeRepoCreate = m.repoCreateSeq
-	return m, m.activeRepoCreate
+	return m, m.repoCreateReq.next()
 }
 
 func (m Model) isCurrentRepoCreateRequest(request uint64) bool {
-	return request != 0 && request == m.activeRepoCreate
+	return request != 0 && m.repoCreateReq.isCurrent(request)
 }
 
 func (m Model) clearRepoCreateRequest(request uint64) Model {
-	if request != 0 && request == m.activeRepoCreate {
-		m.activeRepoCreate = 0
-	}
+	m.repoCreateReq.clear(request)
 	return m
 }
 
 func (m Model) nextFlowCreateRequest() (Model, uint64) {
-	m.flowCreateSeq++
-	m.activeFlowCreate = m.flowCreateSeq
-	return m, m.activeFlowCreate
+	return m, m.flowCreateReq.next()
 }
 
 func (m Model) isCurrentFlowCreateRequest(request uint64) bool {
-	return request == m.activeFlowCreate
+	return m.flowCreateReq.isCurrent(request)
 }
 
 func (m Model) clearFlowCreateRequest(request uint64) Model {
-	if request != 0 && request == m.activeFlowCreate {
-		m.activeFlowCreate = 0
-	}
+	m.flowCreateReq.clear(request)
 	return m
 }
 
@@ -396,25 +384,20 @@ func (m Model) nextReadyBeadFlowCreateRequest() (Model, uint64) {
 	if !admitted {
 		return m, 0
 	}
-	m.readyBeadFlowCreateSeq++
-	m.activeReadyBeadFlowCreate = m.readyBeadFlowCreateSeq
-	return m, m.activeReadyBeadFlowCreate
+	return m, m.readyBeadFlowCreateReq.next()
 }
 
 func (m Model) isCurrentReadyBeadFlowCreateRequest(request uint64) bool {
-	return request != 0 && request == m.activeReadyBeadFlowCreate
+	return request != 0 && m.readyBeadFlowCreateReq.isCurrent(request)
 }
 
 func (m Model) clearReadyBeadFlowCreateRequest(request uint64) Model {
-	if m.isCurrentReadyBeadFlowCreateRequest(request) {
-		m.activeReadyBeadFlowCreate = 0
-	}
+	m.readyBeadFlowCreateReq.clear(request)
 	return m
 }
 
 func (m Model) invalidateReadyBeadFlowCreateRequest() Model {
-	m.readyBeadFlowCreateSeq++
-	m.activeReadyBeadFlowCreate = 0
+	m.readyBeadFlowCreateReq.invalidate()
 	return m
 }
 
@@ -823,6 +806,42 @@ func createdWorktreeBranch(worktreePath, ref string, kind actions.WorktreeCreate
 	return ""
 }
 
+type textFetch struct {
+	repoPath string
+	pane     string
+	errNoun  string
+	kind     FetchKind
+	mode     ui.Mode
+	load     func() (string, error)
+	fail     func(FetchErrorMsg) tea.Msg
+	ok       func(text string, request uint64) tea.Msg
+}
+
+func (m Model) textFetchCmd(f textFetch) tea.Cmd {
+	if f.repoPath == "" {
+		return nil
+	}
+	request := m.activeViewRequest
+	return func() tea.Msg {
+		text, err := f.load()
+		if err != nil {
+			msg := FetchErrorMsg{
+				RepoPath:    f.repoPath,
+				Pane:        f.pane,
+				Err:         fmt.Sprintf("failed to load %s: %v", f.errNoun, err),
+				Kind:        f.kind,
+				Mode:        f.mode,
+				DiffRequest: request,
+			}
+			if f.fail != nil {
+				return f.fail(msg)
+			}
+			return msg
+		}
+		return f.ok(text, request)
+	}
+}
+
 func (m Model) fetchBranchDiff() tea.Cmd {
 	repoPath, ok := m.currentRepoPath()
 	if !ok {
@@ -837,30 +856,22 @@ func (m Model) fetchBranchDiff() tea.Cmd {
 		worktreePath = repoPath
 	}
 	branchName := row.Branch.Name
-	diffRequest := m.activeViewRequest
-
-	return func() tea.Msg {
-		diff, err := gitquery.BranchDiff(worktreePath)
-		if err != nil {
-			return FetchErrorMsg{
-				RepoPath:     repoPath,
-				Pane:         "branch diff",
-				Err:          fmt.Sprintf("failed to load diff: %v", err),
-				Kind:         FetchBranchDiff,
-				Mode:         ui.ModeBranches,
-				DiffRequest:  diffRequest,
-				BranchName:   branchName,
-				WorktreePath: worktreePath,
-			}
-		}
-		return BranchDiffResultMsg{
-			RepoPath:     repoPath,
-			BranchName:   branchName,
-			WorktreePath: worktreePath,
-			DiffRequest:  diffRequest,
-			Diff:         diff,
-		}
-	}
+	return m.textFetchCmd(textFetch{
+		repoPath: repoPath,
+		pane:     "branch diff",
+		errNoun:  "diff",
+		kind:     FetchBranchDiff,
+		mode:     ui.ModeBranches,
+		load:     func() (string, error) { return gitquery.BranchDiff(worktreePath) },
+		fail: func(msg FetchErrorMsg) tea.Msg {
+			msg.BranchName = branchName
+			msg.WorktreePath = worktreePath
+			return msg
+		},
+		ok: func(text string, request uint64) tea.Msg {
+			return BranchDiffResultMsg{RepoPath: repoPath, BranchName: branchName, WorktreePath: worktreePath, DiffRequest: request, Diff: text}
+		},
+	})
 }
 
 func (m Model) fetchBeadDetail() tea.Cmd {
@@ -909,27 +920,21 @@ func (m Model) fetchWorktreeDiff() tea.Cmd {
 		return nil
 	}
 	worktreePath := wt.Path
-	diffRequest := m.activeViewRequest
-	return func() tea.Msg {
-		diff, err := gitquery.BranchDiff(worktreePath)
-		if err != nil {
-			return FetchErrorMsg{
-				RepoPath:     repoPath,
-				Pane:         "worktree diff",
-				Err:          fmt.Sprintf("failed to load diff: %v", err),
-				Kind:         FetchWorktreeDiff,
-				Mode:         ui.ModeWorktrees,
-				DiffRequest:  diffRequest,
-				WorktreePath: worktreePath,
-			}
-		}
-		return WorktreeDiffResultMsg{
-			RepoPath:     repoPath,
-			WorktreePath: worktreePath,
-			DiffRequest:  diffRequest,
-			Diff:         diff,
-		}
-	}
+	return m.textFetchCmd(textFetch{
+		repoPath: repoPath,
+		pane:     "worktree diff",
+		errNoun:  "diff",
+		kind:     FetchWorktreeDiff,
+		mode:     ui.ModeWorktrees,
+		load:     func() (string, error) { return gitquery.BranchDiff(worktreePath) },
+		fail: func(msg FetchErrorMsg) tea.Msg {
+			msg.WorktreePath = worktreePath
+			return msg
+		},
+		ok: func(text string, request uint64) tea.Msg {
+			return WorktreeDiffResultMsg{RepoPath: repoPath, WorktreePath: worktreePath, DiffRequest: request, Diff: text}
+		},
+	})
 }
 
 func (m Model) fetchStashDiff() tea.Cmd {
@@ -944,31 +949,23 @@ func (m Model) fetchStashDiff() tea.Cmd {
 	index := stash.Index
 	stashDate := stash.Date
 	stashMessage := stash.Message
-	diffRequest := m.activeViewRequest
-	return func() tea.Msg {
-		diff, err := gitquery.StashDiff(repoPath, index)
-		if err != nil {
-			return FetchErrorMsg{
-				RepoPath:     repoPath,
-				Pane:         "stash diff",
-				Err:          fmt.Sprintf("failed to load diff: %v", err),
-				Kind:         FetchStashDiff,
-				Mode:         ui.ModeStashes,
-				DiffRequest:  diffRequest,
-				StashIndex:   index,
-				StashDate:    stashDate,
-				StashMessage: stashMessage,
-			}
-		}
-		return StashDiffResultMsg{
-			RepoPath:    repoPath,
-			Index:       index,
-			Date:        stashDate,
-			Message:     stashMessage,
-			DiffRequest: diffRequest,
-			Diff:        diff,
-		}
-	}
+	return m.textFetchCmd(textFetch{
+		repoPath: repoPath,
+		pane:     "stash diff",
+		errNoun:  "diff",
+		kind:     FetchStashDiff,
+		mode:     ui.ModeStashes,
+		load:     func() (string, error) { return gitquery.StashDiff(repoPath, index) },
+		fail: func(msg FetchErrorMsg) tea.Msg {
+			msg.StashIndex = index
+			msg.StashDate = stashDate
+			msg.StashMessage = stashMessage
+			return msg
+		},
+		ok: func(text string, request uint64) tea.Msg {
+			return StashDiffResultMsg{RepoPath: repoPath, Index: index, Date: stashDate, Message: stashMessage, DiffRequest: request, Diff: text}
+		},
+	})
 }
 
 func (m Model) fetchReflogDiff() tea.Cmd {
@@ -981,22 +978,21 @@ func (m Model) fetchReflogDiff() tea.Cmd {
 		return nil
 	}
 	hash := entry.Hash
-	diffRequest := m.activeViewRequest
-	return func() tea.Msg {
-		diff, err := gitquery.ReflogDiff(repoPath, hash)
-		if err != nil {
-			return FetchErrorMsg{
-				RepoPath:    repoPath,
-				Pane:        "reflog diff",
-				Err:         fmt.Sprintf("failed to load diff: %v", err),
-				Kind:        FetchReflogDiff,
-				Mode:        ui.ModeReflog,
-				DiffRequest: diffRequest,
-				Hash:        hash,
-			}
-		}
-		return ReflogDiffResultMsg{RepoPath: repoPath, Hash: hash, DiffRequest: diffRequest, Diff: diff}
-	}
+	return m.textFetchCmd(textFetch{
+		repoPath: repoPath,
+		pane:     "reflog diff",
+		errNoun:  "diff",
+		kind:     FetchReflogDiff,
+		mode:     ui.ModeReflog,
+		load:     func() (string, error) { return gitquery.ReflogDiff(repoPath, hash) },
+		fail: func(msg FetchErrorMsg) tea.Msg {
+			msg.Hash = hash
+			return msg
+		},
+		ok: func(text string, request uint64) tea.Msg {
+			return ReflogDiffResultMsg{RepoPath: repoPath, Hash: hash, DiffRequest: request, Diff: text}
+		},
+	})
 }
 
 func (m Model) fetchSessionTranscript() tea.Cmd {
@@ -1046,28 +1042,21 @@ func (m Model) fetchPlanTextByID(planID string, mode ui.Mode) tea.Cmd {
 	if !ok || planID == "" {
 		return nil
 	}
-	diffRequest := m.activeViewRequest
-	return func() tea.Msg {
-		body, err := m.readPlan(planID)
-		if err != nil {
-			return FetchErrorMsg{
-				RepoPath:    repoPath,
-				Pane:        "plan",
-				Err:         fmt.Sprintf("failed to load plan: %v", err),
-				Kind:        FetchPlanText,
-				Mode:        mode,
-				DiffRequest: diffRequest,
-				PlanID:      planID,
-			}
-		}
-		return PlanReadResultMsg{
-			RepoPath:    repoPath,
-			PlanID:      planID,
-			Mode:        mode,
-			DiffRequest: diffRequest,
-			Text:        body,
-		}
-	}
+	return m.textFetchCmd(textFetch{
+		repoPath: repoPath,
+		pane:     "plan",
+		errNoun:  "plan",
+		kind:     FetchPlanText,
+		mode:     mode,
+		load:     func() (string, error) { return m.readPlan(planID) },
+		fail: func(msg FetchErrorMsg) tea.Msg {
+			msg.PlanID = planID
+			return msg
+		},
+		ok: func(text string, request uint64) tea.Msg {
+			return PlanReadResultMsg{RepoPath: repoPath, PlanID: planID, Mode: mode, DiffRequest: request, Text: text}
+		},
+	})
 }
 
 func formatTranscript(events []sessions.TranscriptEvent) string {
@@ -1092,20 +1081,19 @@ func (m Model) fetchCommitDiff() tea.Cmd {
 		return nil
 	}
 	hash := commit.Hash
-	diffRequest := m.activeViewRequest
-	return func() tea.Msg {
-		diff, err := gitquery.CommitDiff(repoPath, hash)
-		if err != nil {
-			return FetchErrorMsg{
-				RepoPath:    repoPath,
-				Pane:        "commit diff",
-				Err:         fmt.Sprintf("failed to load diff: %v", err),
-				Kind:        FetchCommitDiff,
-				Mode:        ui.ModeHistory,
-				DiffRequest: diffRequest,
-				Hash:        hash,
-			}
-		}
-		return CommitDiffResultMsg{RepoPath: repoPath, Hash: hash, DiffRequest: diffRequest, Diff: diff}
-	}
+	return m.textFetchCmd(textFetch{
+		repoPath: repoPath,
+		pane:     "commit diff",
+		errNoun:  "diff",
+		kind:     FetchCommitDiff,
+		mode:     ui.ModeHistory,
+		load:     func() (string, error) { return gitquery.CommitDiff(repoPath, hash) },
+		fail: func(msg FetchErrorMsg) tea.Msg {
+			msg.Hash = hash
+			return msg
+		},
+		ok: func(text string, request uint64) tea.Msg {
+			return CommitDiffResultMsg{RepoPath: repoPath, Hash: hash, DiffRequest: request, Diff: text}
+		},
+	})
 }

--- a/model/model_filter.go
+++ b/model/model_filter.go
@@ -332,64 +332,46 @@ func (m Model) selectFilteredRepo(repoPath string) Model {
 }
 
 func (m Model) filteredRepos() []scanner.Repo {
-	repos, _, _ := m.repos.View()
-	return repos
+	return viewItems(m.repos.View())
 }
 
 func (m Model) filteredStashes() []gitquery.Stash {
-	if len(m.filteredRepos()) == 0 {
-		return nil
-	}
-	stashes, _, _ := m.stashes.View()
-	return stashes
+	return filteredIfRepoVisible(m, viewItems(m.stashes.View()))
 }
 
 func (m Model) filteredWorktrees() []gitquery.Worktree {
-	if len(m.filteredRepos()) == 0 {
-		return nil
-	}
-	worktrees, _, _ := m.worktrees.View()
-	return worktrees
+	return filteredIfRepoVisible(m, viewItems(m.worktrees.View()))
 }
 
 func (m Model) filteredCommits() []gitquery.Commit {
-	if len(m.filteredRepos()) == 0 {
-		return nil
-	}
-	commits, _, _ := m.commits.View()
-	return commits
+	return filteredIfRepoVisible(m, viewItems(m.commits.View()))
 }
 
 func (m Model) filteredReflogs() []gitquery.ReflogEntry {
-	if len(m.filteredRepos()) == 0 {
-		return nil
-	}
-	reflogs, _, _ := m.reflogs.View()
-	return reflogs
+	return filteredIfRepoVisible(m, viewItems(m.reflogs.View()))
 }
 
 func (m Model) filteredSessions() []sessions.SessionRecord {
-	if len(m.filteredRepos()) == 0 {
-		return nil
-	}
-	sessions, _, _ := m.sessions.View()
-	return sessions
+	return filteredIfRepoVisible(m, viewItems(m.sessions.View()))
 }
 
 func (m Model) filteredPlans() []planstore.PlanRecord {
-	if len(m.filteredRepos()) == 0 {
-		return nil
-	}
-	plans, _, _ := m.plans.View()
-	return plans
+	return filteredIfRepoVisible(m, viewItems(m.plans.View()))
 }
 
 func (m Model) filteredFlows() []flowstore.FlowRecord {
+	return filteredIfRepoVisible(m, viewItems(m.flows.View()))
+}
+
+func viewItems[T any](items []T, _ int, _ int) []T {
+	return items
+}
+
+func filteredIfRepoVisible[T any](m Model, items []T) []T {
 	if len(m.filteredRepos()) == 0 {
 		return nil
 	}
-	flows, _, _ := m.flows.View()
-	return flows
+	return items
 }
 
 func planSearchText(record planstore.PlanRecord) string {

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -46,7 +46,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else if outcome == modal.Accepted && cmd != nil && isPromptTemplateEditor(view) {
 			cmd = tagPromptTemplateCursor(cmd, view.InputCursor)
 		} else if outcome == modal.Accepted && cmd != nil && isFlowCreateForm(view) {
-			if m.activeFlowCreate != 0 {
+			if m.flowCreateReq.current != 0 {
 				return m.setStatus(statusOther, flowCreateInProgressStatus), nil
 			}
 			var request uint64

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -2469,11 +2469,24 @@ func (m Model) handleCopyHash() (tea.Model, tea.Cmd) {
 	default:
 		return m, nil
 	}
-	return m, func() tea.Msg {
-		if err := m.copyToClipboard(hash); err != nil {
+	return m, m.copyToClipboardCmd(hash)
+}
+
+func (m Model) copyToClipboardCmd(value string) tea.Cmd {
+	return func() tea.Msg {
+		if err := m.copyToClipboard(value); err != nil {
 			return ClipboardResultMsg{Err: err.Error()}
 		}
 		return ClipboardResultMsg{}
+	}
+}
+
+func (m Model) openURLCmd(url, label string) tea.Cmd {
+	return func() tea.Msg {
+		if err := m.openURL(url); err != nil {
+			return OpenURLResultMsg{Err: err.Error()}
+		}
+		return OpenURLResultMsg{Label: label}
 	}
 }
 
@@ -2486,12 +2499,7 @@ func (m Model) handleCopySessionID() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	sessionID := record.SessionID
-	return m, func() tea.Msg {
-		if err := m.copyToClipboard(sessionID); err != nil {
-			return ClipboardResultMsg{Err: err.Error()}
-		}
-		return ClipboardResultMsg{}
-	}
+	return m, m.copyToClipboardCmd(sessionID)
 }
 
 func (m Model) handleCopyPlanPath() (tea.Model, tea.Cmd) {
@@ -2504,12 +2512,7 @@ func (m Model) handleCopyPlanPath() (tea.Model, tea.Cmd) {
 		m = m.setStatus(statusOther, err.Error())
 		return m, nil
 	}
-	return m, func() tea.Msg {
-		if err := m.copyToClipboard(planPath); err != nil {
-			return ClipboardResultMsg{Err: err.Error()}
-		}
-		return ClipboardResultMsg{}
-	}
+	return m, m.copyToClipboardCmd(planPath)
 }
 
 func (m Model) handleCopyFlowWorktreePath() (tea.Model, tea.Cmd) {
@@ -2524,12 +2527,7 @@ func (m Model) handleCopyFlowWorktreePath() (tea.Model, tea.Cmd) {
 	if strings.TrimSpace(value) == "" {
 		return m, nil
 	}
-	return m, func() tea.Msg {
-		if err := m.copyToClipboard(value); err != nil {
-			return ClipboardResultMsg{Err: err.Error()}
-		}
-		return ClipboardResultMsg{}
-	}
+	return m, m.copyToClipboardCmd(value)
 }
 
 func (m Model) handleCopyFlowID() (tea.Model, tea.Cmd) {
@@ -2540,12 +2538,7 @@ func (m Model) handleCopyFlowID() (tea.Model, tea.Cmd) {
 	if strings.TrimSpace(flowID) == "" {
 		return m, nil
 	}
-	return m, func() tea.Msg {
-		if err := m.copyToClipboard(flowID); err != nil {
-			return ClipboardResultMsg{Err: err.Error()}
-		}
-		return ClipboardResultMsg{}
-	}
+	return m, m.copyToClipboardCmd(flowID)
 }
 
 func (m Model) handleOpenSelectedFlowPR() (tea.Model, tea.Cmd) {
@@ -2553,12 +2546,7 @@ func (m Model) handleOpenSelectedFlowPR() (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	return m, func() tea.Msg {
-		if err := m.openURL(pr.URL); err != nil {
-			return OpenURLResultMsg{Err: err.Error()}
-		}
-		return OpenURLResultMsg{Label: fmt.Sprintf("Opened PR #%d in browser", pr.Number)}
-	}
+	return m, m.openURLCmd(pr.URL, fmt.Sprintf("Opened PR #%d in browser", pr.Number))
 }
 
 func (m Model) handleOpenSelectedFlowIssue() (tea.Model, tea.Cmd) {
@@ -2566,12 +2554,7 @@ func (m Model) handleOpenSelectedFlowIssue() (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	return m, func() tea.Msg {
-		if err := m.openURL(issue.URL); err != nil {
-			return OpenURLResultMsg{Err: err.Error()}
-		}
-		return OpenURLResultMsg{Label: fmt.Sprintf("Opened issue #%d in browser", issue.Number)}
-	}
+	return m, m.openURLCmd(issue.URL, fmt.Sprintf("Opened issue #%d in browser", issue.Number))
 }
 
 func (m Model) handleShowSessionSummary() (tea.Model, tea.Cmd) {

--- a/model/request_tracker.go
+++ b/model/request_tracker.go
@@ -1,0 +1,30 @@
+package model
+
+// requestTracker is a single in-flight request ID. next issues the next ID and
+// makes it current; clear drops the current ID after it lands; invalidate
+// makes any in-flight ID stale without issuing a replacement.
+type requestTracker struct {
+	seq     uint64
+	current uint64
+}
+
+func (t *requestTracker) next() uint64 {
+	t.seq++
+	t.current = t.seq
+	return t.current
+}
+
+func (t requestTracker) isCurrent(id uint64) bool {
+	return id == t.current
+}
+
+func (t *requestTracker) clear(id uint64) {
+	if id != 0 && id == t.current {
+		t.current = 0
+	}
+}
+
+func (t *requestTracker) invalidate() {
+	t.seq++
+	t.current = 0
+}

--- a/sessions/ingest.go
+++ b/sessions/ingest.go
@@ -4,15 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/internal/artifacts"
+	"github.com/approachcontrol/approach/internal/gitmeta"
 	"github.com/approachcontrol/approach/internal/launchcontrol"
 )
 
@@ -298,52 +296,25 @@ func resolveGitMetadata(record *SessionRecord) {
 	if record.CWD == "" {
 		return
 	}
-	worktreePath := ""
-	if out, err := gitOutput(record.CWD, "rev-parse", "--show-toplevel"); err == nil {
-		worktreePath = out
+	info, err := gitmeta.Resolve(record.CWD)
+	if err != nil {
+		return
 	}
-	gitCommonDir := ""
-	if out, err := gitOutput(record.CWD, "rev-parse", "--path-format=absolute", "--git-common-dir"); err == nil {
-		gitCommonDir = out
-	}
-	gitDir := ""
-	if out, err := gitOutput(record.CWD, "rev-parse", "--path-format=absolute", "--git-dir"); err == nil {
-		gitDir = out
-	}
-	isBare := false
-	if out, err := gitOutput(record.CWD, "rev-parse", "--is-bare-repository"); err == nil {
-		isBare = out == "true"
-	}
-	commonDirIsBare := false
-	if gitCommonDir != "" {
-		if out, err := gitOutput(gitCommonDir, "rev-parse", "--is-bare-repository"); err == nil {
-			commonDirIsBare = out == "true"
-		}
-	}
-	repoPath := repoPathFromGitMetadata(worktreePath, gitDir, gitCommonDir, isBare, commonDirIsBare)
 	if record.RepoPath == "" {
-		if repoPath != "" {
-			record.RepoPath = repoPath
-		} else if worktreePath != "" {
-			record.RepoPath = worktreePath
-		}
+		record.RepoPath = info.RepoPath
 	}
 	if record.WorktreePath == "" {
-		if worktreePath != "" {
-			record.WorktreePath = worktreePath
+		if info.WorktreePath != "" {
+			record.WorktreePath = info.WorktreePath
 		} else {
 			record.WorktreePath = record.RepoPath
 		}
 	}
 	if record.Branch == "" {
-		if out, err := gitOutput(record.CWD, "branch", "--show-current"); err == nil {
-			record.Branch = out
-		}
+		record.Branch = info.Branch
 	}
 	if record.Commit == "" {
-		if out, err := gitOutput(record.CWD, "rev-parse", "HEAD"); err == nil {
-			record.Commit = out
-		}
+		record.Commit = info.Commit
 	}
 }
 
@@ -486,79 +457,4 @@ func flowStateRoot(opts IngestOptions) (string, bool) {
 		return opts.StateRoot, opts.StateRootExplicit
 	}
 	return opts.Env["APPROACH_SESSION_STATE_ROOT"], false
-}
-
-func repoPathFromGitMetadata(worktreePath, gitDir, commonDir string, isBare, commonDirIsBare bool) string {
-	if isBare {
-		if commonDir != "" {
-			return filepath.Clean(commonDir)
-		}
-		if gitDir == "" {
-			return ""
-		}
-		return filepath.Clean(gitDir)
-	}
-	if commonDir != "" && gitDir != "" && isLinkedWorktreeGitDir(gitDir, commonDir) {
-		if commonDirIsBare {
-			return filepath.Clean(commonDir)
-		}
-		if filepath.Base(filepath.Clean(commonDir)) != ".git" {
-			return worktreePath
-		}
-		return repoPathFromGitCommonDir(commonDir)
-	}
-	if worktreePath != "" {
-		return worktreePath
-	}
-	if commonDir != "" {
-		return repoPathFromGitCommonDir(commonDir)
-	}
-	if gitDir == "" {
-		return ""
-	}
-	return repoPathFromGitCommonDir(gitDir)
-}
-
-func isLinkedWorktreeGitDir(gitDir, commonDir string) bool {
-	rel, err := filepath.Rel(filepath.Join(filepath.Clean(commonDir), "worktrees"), filepath.Clean(gitDir))
-	if err != nil {
-		return false
-	}
-	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
-}
-
-func repoPathFromGitCommonDir(commonDir string) string {
-	commonDir = filepath.Clean(commonDir)
-	if filepath.Base(commonDir) == ".git" {
-		return filepath.Dir(commonDir)
-	}
-	return commonDir
-}
-
-func gitOutput(cwd string, args ...string) (string, error) {
-	cleaned, err := plausibleGitCWD(cwd)
-	if err != nil {
-		return "", err
-	}
-	cmd := exec.Command("git", append([]string{"-C", cleaned}, args...)...)
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
-func plausibleGitCWD(cwd string) (string, error) {
-	cwd = filepath.Clean(strings.TrimSpace(cwd))
-	if cwd == "." || !filepath.IsAbs(cwd) {
-		return "", fmt.Errorf("git cwd must be an absolute path")
-	}
-	info, err := os.Stat(cwd)
-	if err != nil {
-		return "", fmt.Errorf("inspect git cwd %q: %w", cwd, err)
-	}
-	if !info.IsDir() {
-		return "", fmt.Errorf("git cwd %q is not a directory", cwd)
-	}
-	return cwd, nil
 }


### PR DESCRIPTION
The model package had the same in-flight request bookkeeping copied four times, the same filtered-list unpack copied eight times, the same fetch-text-or-error wrapper copied seven times, and the same clipboard/open-URL command blocks copied at every copy/open site. Those copies made later Model decomposition (#27) a field-by-field hunt.

One `requestTracker` now owns next/current/clear/invalidate. The four create-request predicates keep the differences the existing suite already pins (repo and Ready-bead reject request 0; worktree and new-flow do not). Filtered pane lists share `viewItems` and `filteredIfRepoVisible`. Diff and plan-text fetches go through `textFetchCmd`. Clipboard and URL opens go through `copyToClipboardCmd` and `openURLCmd`.

Stacked on #381. No user-visible behavior change.

**Test plan**
- [x] `gofmt` clean
- [x] `go test ./model`
- [x] `make test` and `make build`