### PR TITLE
Group Model and render state into named clusters

### DIFF
--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -92,6 +92,20 @@ const (
 
 type embeddedTerminalID int
 
+// embeddedTerminalState is the docked-terminal cluster on Model: slots, focus,
+// the starter seam, and the prefix/confirm command mode.
+type embeddedTerminalState struct {
+	startEmbeddedTerminal   EmbeddedTerminalStarter
+	embeddedTerminals       []embeddedTerminalSlot
+	nextEmbeddedTerminalID  int
+	activeTerminalNum       int
+	terminalDockVisible     bool
+	terminalFocus           terminalFocus
+	embeddedTerminalTickGen uint64
+	terminalPrefixActive    bool
+	terminalConfirmID       embeddedTerminalID
+}
+
 type embeddedTerminalRemovalReason int
 
 const (

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -307,11 +307,10 @@ func TestFlowEmbeddedTerminalIdentityAutofix(t *testing.T) {
 }
 
 func TestEmbeddedTerminalNumbersAreGlobalAcrossScopes(t *testing.T) {
-	m := Model{
+	m := Model{embeddedTerminalState: embeddedTerminalState{
 		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
 			return internalFakeEmbeddedTerminal{}, nil
-		},
-	}
+		}}}
 
 	var opened bool
 	var err error
@@ -333,14 +332,13 @@ func TestEmbeddedTerminalNumbersAreGlobalAcrossScopes(t *testing.T) {
 }
 
 func TestDismissEmbeddedTerminalRenumbersGloballyAndPreservesActiveSlot(t *testing.T) {
-	m := Model{
+	m := Model{embeddedTerminalState: embeddedTerminalState{
 		activeTerminalNum: 3,
 		embeddedTerminals: []embeddedTerminalSlot{
 			{Number: 1, Scope: embeddedTerminalScopeSession, Identity: "session-one", ID: 1, Terminal: internalFakeEmbeddedTerminal{}},
 			{Number: 2, Scope: embeddedTerminalScopeFlow, Identity: "implementation", ID: 2, Terminal: internalFakeEmbeddedTerminal{}},
 			{Number: 3, Scope: embeddedTerminalScopeSession, Identity: "session-two", ID: 3, Terminal: internalFakeEmbeddedTerminal{}},
-		},
-	}
+		}}}
 
 	m = m.dismissEmbeddedTerminal(2)
 
@@ -355,14 +353,13 @@ func TestDismissEmbeddedTerminalRenumbersGloballyAndPreservesActiveSlot(t *testi
 
 func TestEmbeddedTerminalPresentationUsesOneActiveTerminalAcrossScopes(t *testing.T) {
 	m := Model{
-		height:              24,
-		terminalDockVisible: true,
-		activeTerminalNum:   2,
-		embeddedTerminals: []embeddedTerminalSlot{
-			{Number: 1, Scope: embeddedTerminalScopeSession, Identity: "session", ID: 1, Terminal: internalFakeEmbeddedTerminal{lines: []string{"session output"}}},
-			{Number: 2, Scope: embeddedTerminalScopeFlow, Identity: "implementation", ID: 2, Terminal: internalFakeEmbeddedTerminal{lines: []string{"flow output"}}},
-		},
-	}
+		height: 24, embeddedTerminalState: embeddedTerminalState{
+			terminalDockVisible: true,
+			activeTerminalNum:   2,
+			embeddedTerminals: []embeddedTerminalSlot{
+				{Number: 1, Scope: embeddedTerminalScopeSession, Identity: "session", ID: 1, Terminal: internalFakeEmbeddedTerminal{lines: []string{"session output"}}},
+				{Number: 2, Scope: embeddedTerminalScopeFlow, Identity: "implementation", ID: 2, Terminal: internalFakeEmbeddedTerminal{lines: []string{"flow output"}}},
+			}}}
 
 	tabs := m.embeddedTerminalTabs()
 	if len(tabs) != 2 || tabs[0].Active || !tabs[1].Active {
@@ -379,17 +376,16 @@ func TestFirstAndLastEmbeddedTerminalReflowSessionSelection(t *testing.T) {
 		records[i] = sessions.SessionRecord{SessionID: fmt.Sprintf("session-%02d", i)}
 	}
 	m := Model{
-		topMode:             ui.ModeWorktrees,
-		bottomMode:          ui.ModeSessions,
-		contentPane:         ui.PaneBottom,
-		width:               160,
-		height:              20 + ui.TerminalChipRows,
-		terminalDockVisible: true,
-		sessions:            newSessionPane().SetItems(records).Move(13, 14, 80),
-		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
-			return internalFakeEmbeddedTerminal{}, nil
-		},
-	}
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom,
+		width:       160,
+		height:      20 + ui.TerminalChipRows,
+		sessions:    newSessionPane().SetItems(records).Move(13, 14, 80), embeddedTerminalState: embeddedTerminalState{
+			terminalDockVisible: true,
+			startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
+				return internalFakeEmbeddedTerminal{}, nil
+			}}}
 	if got := m.sessions.Scroll(); got != 0 {
 		t.Fatalf("session scroll before opening terminal = %d, want 0", got)
 	}
@@ -409,7 +405,7 @@ func TestFirstAndLastEmbeddedTerminalReflowSessionSelection(t *testing.T) {
 }
 
 func TestRepoContentHeightAccountsForTerminalDockState(t *testing.T) {
-	m := Model{height: 24, terminalDockVisible: true}
+	m := Model{height: 24, embeddedTerminalState: embeddedTerminalState{terminalDockVisible: true}}
 	if got := m.repoContentHeight(); got != 20 {
 		t.Fatalf("no-terminals repo height = %d, want 20 (chip row reserved)", got)
 	}
@@ -431,8 +427,8 @@ func TestEmbeddedTerminalSpansFullAppWidth(t *testing.T) {
 }
 
 func TestEmbeddedTerminalAllocationIsModeIndependent(t *testing.T) {
-	base := Model{height: 24, topMode: ui.ModeWorktrees, bottomMode: ui.ModeSessions, contentPane: ui.PaneBottom, terminalDockVisible: true, embeddedTerminals: []embeddedTerminalSlot{{Terminal: internalFakeEmbeddedTerminal{}}}}
-	activeFlows := Model{height: 24, topMode: ui.ModeWorktrees, bottomMode: ui.ModeFlows, contentPane: ui.PaneTop, activeFlowSurface: true, terminalDockVisible: true, embeddedTerminals: []embeddedTerminalSlot{{Terminal: internalFakeEmbeddedTerminal{}}}}
+	base := Model{height: 24, topMode: ui.ModeWorktrees, bottomMode: ui.ModeSessions, contentPane: ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{terminalDockVisible: true, embeddedTerminals: []embeddedTerminalSlot{{Terminal: internalFakeEmbeddedTerminal{}}}}}
+	activeFlows := Model{height: 24, topMode: ui.ModeWorktrees, bottomMode: ui.ModeFlows, contentPane: ui.PaneTop, activeFlowSurface: true, embeddedTerminalState: embeddedTerminalState{terminalDockVisible: true, embeddedTerminals: []embeddedTerminalSlot{{Terminal: internalFakeEmbeddedTerminal{}}}}}
 	if base.embeddedTerminalDockAllocation() != activeFlows.embeddedTerminalDockAllocation() {
 		t.Fatalf("terminal allocation differs by mode: %#v vs %#v", base.embeddedTerminalDockAllocation(), activeFlows.embeddedTerminalDockAllocation())
 	}
@@ -440,17 +436,16 @@ func TestEmbeddedTerminalAllocationIsModeIndependent(t *testing.T) {
 
 func TestResponsiveTerminalAllocationControlsModelVisibility(t *testing.T) {
 	m := Model{
-		height:              23,
-		topMode:             ui.ModeWorktrees,
-		bottomMode:          ui.ModeSessions,
-		contentPane:         ui.PaneBottom,
-		activePane:          ui.PaneBottom,
-		terminalDockVisible: true,
-		activeTerminalNum:   1,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number: 1, ID: 1, Terminal: internalFakeEmbeddedTerminal{},
-		}},
-	}
+		height:      23,
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			terminalDockVisible: true,
+			activeTerminalNum:   1,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number: 1, ID: 1, Terminal: internalFakeEmbeddedTerminal{},
+			}}}}
 	allocation := m.embeddedTerminalDockAllocation()
 	if allocation.State != ui.EmbeddedTerminalDockCollapsed || allocation.SharedOuterRows != 21 {
 		t.Fatalf("height 23 allocation = %#v", allocation)
@@ -468,20 +463,19 @@ func TestResponsiveTerminalAllocationControlsModelVisibility(t *testing.T) {
 
 func TestWindowResizeEvacuatesAutoCollapsedTerminalFocus(t *testing.T) {
 	m := Model{
-		width:                120,
-		height:               24,
-		topMode:              ui.ModeWorktrees,
-		bottomMode:           ui.ModeSessions,
-		contentPane:          ui.PaneBottom,
-		activePane:           ui.PaneBottom,
-		terminalDockVisible:  true,
-		terminalFocus:        terminalFocusTerminal,
-		terminalPrefixActive: true,
-		activeTerminalNum:    1,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number: 1, ID: 1, Terminal: internalFakeEmbeddedTerminal{},
-		}},
-	}
+		width:       120,
+		height:      24,
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			terminalDockVisible:  true,
+			terminalFocus:        terminalFocusTerminal,
+			terminalPrefixActive: true,
+			activeTerminalNum:    1,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number: 1, ID: 1, Terminal: internalFakeEmbeddedTerminal{},
+			}}}}
 	nextModel, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 23})
 	next := nextModel.(Model)
 	if !next.terminalDockVisible || next.activePane != ui.PaneBottom || next.contentPane != ui.PaneBottom || next.terminalFocus != terminalFocusList || next.terminalPrefixActive {
@@ -492,18 +486,17 @@ func TestWindowResizeEvacuatesAutoCollapsedTerminalFocus(t *testing.T) {
 func TestFirstTerminalStartupUsesProspectiveRequestedState(t *testing.T) {
 	newModel := func(started *[2]int) Model {
 		return Model{
-			width:               180,
-			height:              65,
-			topMode:             ui.ModeWorktrees,
-			bottomMode:          ui.ModeFlows,
-			contentPane:         ui.PaneBottom,
-			activePane:          ui.PaneBottom,
-			terminalDockVisible: false,
-			startEmbeddedTerminal: func(_ actions.AgentLaunchContext, width, height int) (EmbeddedTerminal, error) {
-				*started = [2]int{width, height}
-				return internalFakeEmbeddedTerminal{}, nil
-			},
-		}
+			width:       180,
+			height:      65,
+			topMode:     ui.ModeWorktrees,
+			bottomMode:  ui.ModeFlows,
+			contentPane: ui.PaneBottom,
+			activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+				terminalDockVisible: false,
+				startEmbeddedTerminal: func(_ actions.AgentLaunchContext, width, height int) (EmbeddedTerminal, error) {
+					*started = [2]int{width, height}
+					return internalFakeEmbeddedTerminal{}, nil
+				}}}
 	}
 
 	t.Run("interactive session requests expansion", func(t *testing.T) {
@@ -542,22 +535,21 @@ func TestFirstTerminalStartupUsesProspectiveRequestedState(t *testing.T) {
 func TestInteractiveFlowPrefillImmediatelyResizesExistingHiddenTerminals(t *testing.T) {
 	newModel := func(existing *internalFakeDetachableEmbeddedTerminal, started EmbeddedTerminal) Model {
 		return Model{
-			width:                  180,
-			height:                 65,
-			topMode:                ui.ModeWorktrees,
-			bottomMode:             ui.ModeFlows,
-			contentPane:            ui.PaneBottom,
-			activePane:             ui.PaneBottom,
-			terminalDockVisible:    false,
-			activeTerminalNum:      1,
-			nextEmbeddedTerminalID: 1,
-			embeddedTerminals: []embeddedTerminalSlot{{
-				Number: 1, ID: 1, Terminal: existing,
-			}},
-			startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
-				return started, nil
-			},
-		}
+			width:       180,
+			height:      65,
+			topMode:     ui.ModeWorktrees,
+			bottomMode:  ui.ModeFlows,
+			contentPane: ui.PaneBottom,
+			activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+				terminalDockVisible:    false,
+				activeTerminalNum:      1,
+				nextEmbeddedTerminalID: 1,
+				embeddedTerminals: []embeddedTerminalSlot{{
+					Number: 1, ID: 1, Terminal: existing,
+				}},
+				startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
+					return started, nil
+				}}}
 	}
 	ctx := actions.AgentLaunchContext{
 		Command:           "codex",
@@ -602,18 +594,17 @@ func TestInteractiveFlowPrefillImmediatelyResizesExistingHiddenTerminals(t *test
 
 func TestAutoCollapsedRequestedPreferenceRestoresOnlyWhileStillOpen(t *testing.T) {
 	base := Model{
-		width:               120,
-		height:              23,
-		topMode:             ui.ModeWorktrees,
-		bottomMode:          ui.ModeSessions,
-		contentPane:         ui.PaneBottom,
-		activePane:          ui.PaneBottom,
-		terminalDockVisible: true,
-		activeTerminalNum:   1,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number: 1, ID: 1, Terminal: internalFakeEmbeddedTerminal{},
-		}},
-	}
+		width:       120,
+		height:      23,
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			terminalDockVisible: true,
+			activeTerminalNum:   1,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number: 1, ID: 1, Terminal: internalFakeEmbeddedTerminal{},
+			}}}}
 
 	grownModel, _ := base.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
 	grown := grownModel.(Model)
@@ -654,7 +645,7 @@ func TestContentHeightForModeAccountsForTerminalDockState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := modelWithModeForTest(Model{height: 24, terminalDockVisible: true}, tt.mode)
+			m := modelWithModeForTest(Model{height: 24, embeddedTerminalState: embeddedTerminalState{terminalDockVisible: true}}, tt.mode)
 			if got := m.contentHeightForMode(); got != tt.wantNoDock {
 				t.Fatalf("no-dock content height = %d, want %d", got, tt.wantNoDock)
 			}
@@ -674,15 +665,14 @@ func TestCyclePaneFocusIncludesExpandedTerminalDockInEveryMode(t *testing.T) {
 	for _, mode := range []ui.Mode{ui.ModeWorktrees, ui.ModeSessions, ui.ModePlans, ui.ModeFlows} {
 		t.Run(fmt.Sprintf("mode_%d", mode), func(t *testing.T) {
 			m := modelWithModeForTest(Model{
-				height:              24,
-				activePane:          ui.PaneRepos,
-				terminalFocus:       terminalFocusList,
-				terminalDockVisible: true,
-				activeTerminalNum:   1,
-				embeddedTerminals: []embeddedTerminalSlot{{
-					Number: 1, Scope: embeddedTerminalScopeSession, ID: 1, Terminal: internalFakeEmbeddedTerminal{},
-				}},
-			}, mode)
+				height:     24,
+				activePane: ui.PaneRepos, embeddedTerminalState: embeddedTerminalState{
+					terminalFocus:       terminalFocusList,
+					terminalDockVisible: true,
+					activeTerminalNum:   1,
+					embeddedTerminals: []embeddedTerminalSlot{{
+						Number: 1, Scope: embeddedTerminalScopeSession, ID: 1, Terminal: internalFakeEmbeddedTerminal{},
+					}}}}, mode)
 
 			m = m.cyclePaneFocusForward()
 			if m.activePane == ui.PaneRepos || m.terminalFocus != terminalFocusList {
@@ -714,7 +704,7 @@ func TestCyclePaneFocusSkipsCollapsedOrEmptyTerminalDock(t *testing.T) {
 		{name: "empty", visible: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			m := Model{topMode: ui.ModeWorktrees, bottomMode: ui.ModePlans, contentPane: ui.PaneBottom, activePane: ui.PaneRepos, terminalDockVisible: tt.visible, embeddedTerminals: tt.terminals}
+			m := Model{topMode: ui.ModeWorktrees, bottomMode: ui.ModePlans, contentPane: ui.PaneBottom, activePane: ui.PaneRepos, embeddedTerminalState: embeddedTerminalState{terminalDockVisible: tt.visible, embeddedTerminals: tt.terminals}}
 			m = m.cyclePaneFocusForward()
 			m = m.cyclePaneFocusForward()
 			m = m.cyclePaneFocusForward()
@@ -739,20 +729,19 @@ func TestCtrlTTogglesTerminalDockOutsideInputMode(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			term := &internalFakeDetachableEmbeddedTerminal{}
 			m := Model{
-				topMode:              ui.ModeWorktrees,
-				bottomMode:           ui.ModePlans,
-				contentPane:          ui.PaneBottom,
-				width:                160,
-				height:               24,
-				activePane:           tt.activePane,
-				terminalFocus:        tt.focus,
-				terminalPrefixActive: tt.prefixActive,
-				terminalDockVisible:  true,
-				activeTerminalNum:    1,
-				embeddedTerminals: []embeddedTerminalSlot{{
-					Number: 1, ID: 1, Scope: embeddedTerminalScopeSession, Terminal: term,
-				}},
-			}
+				topMode:     ui.ModeWorktrees,
+				bottomMode:  ui.ModePlans,
+				contentPane: ui.PaneBottom,
+				width:       160,
+				height:      24,
+				activePane:  tt.activePane, embeddedTerminalState: embeddedTerminalState{
+					terminalFocus:        tt.focus,
+					terminalPrefixActive: tt.prefixActive,
+					terminalDockVisible:  true,
+					activeTerminalNum:    1,
+					embeddedTerminals: []embeddedTerminalSlot{{
+						Number: 1, ID: 1, Scope: embeddedTerminalScopeSession, Terminal: term,
+					}}}}
 
 			nextModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
 			next := nextModel.(Model)
@@ -775,18 +764,17 @@ func TestCtrlTTogglesTerminalDockOutsideInputMode(t *testing.T) {
 func TestCtrlTInTerminalInputModePassesThroughToPTY(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{}
 	m := Model{
-		height:              24,
-		topMode:             ui.ModeWorktrees,
-		bottomMode:          ui.ModePlans,
-		contentPane:         ui.PaneBottom,
-		activePane:          ui.PaneBottom,
-		terminalFocus:       terminalFocusTerminal,
-		terminalDockVisible: true,
-		activeTerminalNum:   1,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number: 1, ID: 1, Scope: embeddedTerminalScopeSession, Terminal: term,
-		}},
-	}
+		height:      24,
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModePlans,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			terminalFocus:       terminalFocusTerminal,
+			terminalDockVisible: true,
+			activeTerminalNum:   1,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number: 1, ID: 1, Scope: embeddedTerminalScopeSession, Terminal: term,
+			}}}}
 
 	nextModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
 	next := nextModel.(Model)
@@ -801,18 +789,17 @@ func TestCtrlTInTerminalInputModePassesThroughToPTY(t *testing.T) {
 func TestTerminalCommandTogglesDockFromInputMode(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{}
 	m := Model{
-		height:              24,
-		topMode:             ui.ModeWorktrees,
-		bottomMode:          ui.ModeFlows,
-		contentPane:         ui.PaneBottom,
-		activePane:          ui.PaneBottom,
-		terminalFocus:       terminalFocusTerminal,
-		terminalDockVisible: true,
-		activeTerminalNum:   1,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number: 1, ID: 1, Scope: embeddedTerminalScopeFlow, Terminal: term,
-		}},
-	}
+		height:      24,
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeFlows,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			terminalFocus:       terminalFocusTerminal,
+			terminalDockVisible: true,
+			activeTerminalNum:   1,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number: 1, ID: 1, Scope: embeddedTerminalScopeFlow, Terminal: term,
+			}}}}
 
 	nextModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlCloseBracket})
 	next := nextModel.(Model)
@@ -832,19 +819,18 @@ func TestTerminalCommandTogglesDockFromInputMode(t *testing.T) {
 func TestShowingTerminalDockResizesLiveTerminals(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{}
 	m := Model{
-		topMode:             ui.ModeWorktrees,
-		bottomMode:          ui.ModeFlows,
-		contentPane:         ui.PaneTop,
-		width:               160,
-		height:              24,
-		activePane:          ui.PaneTop,
-		terminalFocus:       terminalFocusList,
-		terminalDockVisible: false,
-		activeTerminalNum:   1,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number: 1, ID: 1, Scope: embeddedTerminalScopeSession, Terminal: term,
-		}},
-	}
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeFlows,
+		contentPane: ui.PaneTop,
+		width:       160,
+		height:      24,
+		activePane:  ui.PaneTop, embeddedTerminalState: embeddedTerminalState{
+			terminalFocus:       terminalFocusList,
+			terminalDockVisible: false,
+			activeTerminalNum:   1,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number: 1, ID: 1, Scope: embeddedTerminalScopeSession, Terminal: term,
+			}}}}
 
 	nextModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
 	next := nextModel.(Model)
@@ -858,7 +844,7 @@ func TestShowingTerminalDockResizesLiveTerminals(t *testing.T) {
 }
 
 func TestCtrlTWithNoTerminalsReportsStatusAndSearchDoesNotToggle(t *testing.T) {
-	m := Model{terminalDockVisible: true}
+	m := Model{embeddedTerminalState: embeddedTerminalState{terminalDockVisible: true}}
 	nextModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
 	next := nextModel.(Model)
 	if !next.terminalDockVisible || !strings.Contains(next.status.Text, "No embedded terminals") {
@@ -866,17 +852,16 @@ func TestCtrlTWithNoTerminalsReportsStatusAndSearchDoesNotToggle(t *testing.T) {
 	}
 
 	next = Model{
-		topMode:             ui.ModeWorktrees,
-		bottomMode:          ui.ModeSessions,
-		contentPane:         ui.PaneBottom,
-		activePane:          ui.PaneBottom,
-		searchActive:        true,
-		terminalDockVisible: true,
-		activeTerminalNum:   1,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number: 1, ID: 1, Terminal: internalFakeEmbeddedTerminal{},
-		}},
-	}
+		topMode:      ui.ModeWorktrees,
+		bottomMode:   ui.ModeSessions,
+		contentPane:  ui.PaneBottom,
+		activePane:   ui.PaneBottom,
+		searchActive: true, embeddedTerminalState: embeddedTerminalState{
+			terminalDockVisible: true,
+			activeTerminalNum:   1,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number: 1, ID: 1, Terminal: internalFakeEmbeddedTerminal{},
+			}}}}
 	nextModel, _ = next.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
 	next = nextModel.(Model)
 	if !next.terminalDockVisible {
@@ -886,21 +871,20 @@ func TestCtrlTWithNoTerminalsReportsStatusAndSearchDoesNotToggle(t *testing.T) {
 
 func terminalPickerTestModel(listSessions func(sessions.SessionFilter) ([]sessions.SessionRecord, error)) Model {
 	return Model{
-		height:               24,
-		topMode:              ui.ModeWorktrees,
-		bottomMode:           ui.ModeFlows,
-		contentPane:          ui.PaneBottom,
-		activePane:           ui.PaneBottom,
-		terminalFocus:        terminalFocusTerminal,
-		terminalPrefixActive: true,
-		terminalDockVisible:  true,
-		activeTerminalNum:    1,
-		repos:                newRepoPane().SetItems([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}),
-		listSessions:         listSessions,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number: 1, ID: 1, Scope: embeddedTerminalScopeFlow, Terminal: internalFakeEmbeddedTerminal{},
-		}},
-	}
+		height:       24,
+		topMode:      ui.ModeWorktrees,
+		bottomMode:   ui.ModeFlows,
+		contentPane:  ui.PaneBottom,
+		activePane:   ui.PaneBottom,
+		repos:        newRepoPane().SetItems([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}),
+		listSessions: listSessions, embeddedTerminalState: embeddedTerminalState{
+			terminalFocus:        terminalFocusTerminal,
+			terminalPrefixActive: true,
+			terminalDockVisible:  true,
+			activeTerminalNum:    1,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number: 1, ID: 1, Scope: embeddedTerminalScopeFlow, Terminal: internalFakeEmbeddedTerminal{},
+			}}}}
 }
 
 func TestTerminalCommandSessionPickerLoadsStoredSessionsOnDemand(t *testing.T) {
@@ -958,18 +942,17 @@ func TestTerminalCommandSessionPickerLoadHandlesEmptyErrorAndStaleResults(t *tes
 func TestSessionResumeExpandsCollapsedDockAndFocusesTerminalInInputMode(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{}
 	m := Model{
-		topMode:             ui.ModeWorktrees,
-		bottomMode:          ui.ModeSessions,
-		contentPane:         ui.PaneBottom,
-		width:               160,
-		height:              24,
-		activePane:          ui.PaneBottom,
-		terminalFocus:       terminalFocusList,
-		terminalDockVisible: false,
-		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
-			return term, nil
-		},
-	}
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom,
+		width:       160,
+		height:      24,
+		activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			terminalFocus:       terminalFocusList,
+			terminalDockVisible: false,
+			startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
+				return term, nil
+			}}}
 	next, _ := m.resumeSessionInEmbeddedTerminal(actions.AgentLaunchContext{}, sessions.SessionRecord{Provider: sessions.ProviderCodex, SessionID: "session-1"}, nil)
 	if !next.terminalDockVisible || next.activePane == ui.PaneRepos || next.terminalFocus != terminalFocusTerminal || next.terminalPrefixActive {
 		t.Fatalf("session resume state = visible %v pane %d focus %d prefix %v, want expanded terminal input", next.terminalDockVisible, next.activePane, next.terminalFocus, next.terminalPrefixActive)
@@ -982,19 +965,18 @@ func TestSessionResumeExpandsCollapsedDockAndFocusesTerminalInInputMode(t *testi
 func TestInteractiveFlowLaunchFocusExpandsCollapsedDock(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{}
 	m := Model{
-		topMode:             ui.ModeWorktrees,
-		bottomMode:          ui.ModeFlows,
-		contentPane:         ui.PaneBottom,
-		width:               160,
-		height:              24,
-		activePane:          ui.PaneBottom,
-		terminalFocus:       terminalFocusList,
-		terminalDockVisible: false,
-		activeTerminalNum:   1,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number: 1, ID: 1, Scope: embeddedTerminalScopeFlow, Terminal: term,
-		}},
-	}
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeFlows,
+		contentPane: ui.PaneBottom,
+		width:       160,
+		height:      24,
+		activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			terminalFocus:       terminalFocusList,
+			terminalDockVisible: false,
+			activeTerminalNum:   1,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number: 1, ID: 1, Scope: embeddedTerminalScopeFlow, Terminal: term,
+			}}}}
 
 	next := m.updateFlowTerminalFocusAfterLaunch(actions.AgentLaunchContext{})
 	if !next.terminalDockVisible || next.activePane == ui.PaneRepos || next.terminalFocus != terminalFocusTerminal || next.terminalPrefixActive {
@@ -1008,19 +990,18 @@ func TestInteractiveFlowLaunchFocusExpandsCollapsedDock(t *testing.T) {
 func TestGitAndNonGitModeSwitchesKeepTerminalDockSize(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{}
 	m := Model{
-		topMode:             ui.ModeWorktrees,
-		bottomMode:          ui.ModeSessions,
-		contentPane:         ui.PaneBottom,
-		lastGitMode:         ui.ModeWorktrees,
-		width:               160,
-		height:              24,
-		activePane:          ui.PaneBottom,
-		terminalDockVisible: true,
-		activeTerminalNum:   1,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number: 1, ID: 1, Scope: embeddedTerminalScopeSession, Terminal: term,
-		}},
-	}
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom,
+		lastGitMode: ui.ModeWorktrees,
+		width:       160,
+		height:      24,
+		activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			terminalDockVisible: true,
+			activeTerminalNum:   1,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number: 1, ID: 1, Scope: embeddedTerminalScopeSession, Terminal: term,
+			}}}}
 
 	m.activePane = ui.PaneTop
 	m.contentPane = ui.PaneTop
@@ -1048,15 +1029,14 @@ func TestGitAndNonGitModeSwitchesKeepTerminalDockSize(t *testing.T) {
 
 func TestDismissActiveTerminalWithOnlyPendingSurvivorsReturnsToListFocus(t *testing.T) {
 	m := Model{
-		activePane:           ui.PaneBottom,
-		terminalFocus:        terminalFocusTerminal,
-		terminalPrefixActive: true,
-		activeTerminalNum:    1,
-		embeddedTerminals: []embeddedTerminalSlot{
-			{Number: 1, ID: 1, Terminal: internalFakeEmbeddedTerminal{}},
-			{Number: 2, ID: 2, PrefillPending: true, Terminal: internalFakeEmbeddedTerminal{}},
-		},
-	}
+		activePane: ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			terminalFocus:        terminalFocusTerminal,
+			terminalPrefixActive: true,
+			activeTerminalNum:    1,
+			embeddedTerminals: []embeddedTerminalSlot{
+				{Number: 1, ID: 1, Terminal: internalFakeEmbeddedTerminal{}},
+				{Number: 2, ID: 2, PrefillPending: true, Terminal: internalFakeEmbeddedTerminal{}},
+			}}}
 
 	next := m.dismissEmbeddedTerminal(1)
 	if next.activeTerminalNum != 0 || next.terminalFocus != terminalFocusList || next.terminalPrefixActive {
@@ -1076,18 +1056,17 @@ func TestNumberedModeKeysRemainAvailableWithSessionTerminalListFocused(t *testin
 	} {
 		t.Run(string(tt.key), func(t *testing.T) {
 			m := Model{
-				topMode:             ui.ModeWorktrees,
-				bottomMode:          ui.ModeSessions,
-				contentPane:         ui.PaneBottom,
-				lastGitMode:         ui.ModeWorktrees,
-				activePane:          ui.PaneBottom,
-				terminalFocus:       terminalFocusList,
-				terminalDockVisible: true,
-				activeTerminalNum:   1,
-				embeddedTerminals: []embeddedTerminalSlot{{
-					Number: 1, ID: 1, Scope: embeddedTerminalScopeSession, Terminal: internalFakeEmbeddedTerminal{},
-				}},
-			}
+				topMode:     ui.ModeWorktrees,
+				bottomMode:  ui.ModeSessions,
+				contentPane: ui.PaneBottom,
+				lastGitMode: ui.ModeWorktrees,
+				activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+					terminalFocus:       terminalFocusList,
+					terminalDockVisible: true,
+					activeTerminalNum:   1,
+					embeddedTerminals: []embeddedTerminalSlot{{
+						Number: 1, ID: 1, Scope: embeddedTerminalScopeSession, Terminal: internalFakeEmbeddedTerminal{},
+					}}}}
 			nextModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tt.key}})
 			next := nextModel.(Model)
 			if next.focusedMode() != tt.wantMode {
@@ -1096,7 +1075,7 @@ func TestNumberedModeKeysRemainAvailableWithSessionTerminalListFocused(t *testin
 		})
 	}
 
-	m := Model{topMode: ui.ModeWorktrees, bottomMode: ui.ModeSessions, contentPane: ui.PaneBottom, activePane: ui.PaneRepos, terminalDockVisible: true, embeddedTerminals: []embeddedTerminalSlot{{Number: 1, Terminal: internalFakeEmbeddedTerminal{}}}}
+	m := Model{topMode: ui.ModeWorktrees, bottomMode: ui.ModeSessions, contentPane: ui.PaneBottom, activePane: ui.PaneRepos, embeddedTerminalState: embeddedTerminalState{terminalDockVisible: true, embeddedTerminals: []embeddedTerminalSlot{{Number: 1, Terminal: internalFakeEmbeddedTerminal{}}}}}
 	nextModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	if next := nextModel.(Model); next.focusedMode() != ui.ModeSessions {
 		t.Fatalf("repo-pane numbered key changed mode to %d, want sessions", next.focusedMode())
@@ -1249,22 +1228,22 @@ func TestFlowEmbeddedInteractivePrefillRunsAfterUpdateAndActivatesByStableID(t *
 	t.Cleanup(term.release)
 	startCalls := 0
 	m := Model{
-		height:        24,
-		topMode:       ui.ModeWorktrees,
-		bottomMode:    ui.ModeFlows,
-		contentPane:   ui.PaneBottom,
-		activePane:    ui.PaneBottom,
-		terminalFocus: terminalFocusList,
+		height:      24,
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeFlows,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom,
 		// Seeded so the stable IDs handed out below (41, 42) cannot coincide
 		// with the Flow terminal numbers the same slots receive (1, 2). In a
 		// zero-valued model both counters start at 1, and activation keyed on
 		// slot.Number would satisfy every assertion in this test.
-		nextEmbeddedTerminalID: 40,
-		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
-			startCalls++
-			return term, nil
-		},
-	}
+		embeddedTerminalState: embeddedTerminalState{
+			nextEmbeddedTerminalID: 40,
+			terminalFocus:          terminalFocusList,
+			startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
+				startCalls++
+				return term, nil
+			}}}
 	ctx := actions.AgentLaunchContext{
 		Command:           "codex",
 		FlowID:            "flow-1",
@@ -1453,17 +1432,16 @@ func TestFlowEmbeddedInteractivePrefillWritesAfterReadinessTimeout(t *testing.T)
 	term := &prefillReadyFakeEmbeddedTerminal{lines: [][]string{{"", "   "}}}
 	startCalls := 0
 	m := Model{
-		height:        24,
-		topMode:       ui.ModeWorktrees,
-		bottomMode:    ui.ModeFlows,
-		contentPane:   ui.PaneBottom,
-		activePane:    ui.PaneBottom,
-		terminalFocus: terminalFocusList,
-		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
-			startCalls++
-			return term, nil
-		},
-	}
+		height:      24,
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeFlows,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			terminalFocus: terminalFocusList,
+			startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
+				startCalls++
+				return term, nil
+			}}}
 	ctx := actions.AgentLaunchContext{
 		Command:           "codex",
 		FlowID:            "flow-1",
@@ -1500,16 +1478,15 @@ func TestFlowEmbeddedInteractivePrefillWritesAfterReadinessTimeout(t *testing.T)
 func TestStaleEmbeddedPromptPrefillResultIsIgnoredAfterSlotRemoval(t *testing.T) {
 	phaseMutationRan := false
 	m := Model{
-		topMode:       ui.ModeWorktrees,
-		bottomMode:    ui.ModeFlows,
-		contentPane:   ui.PaneBottom,
-		activePane:    ui.PaneBottom,
-		terminalFocus: terminalFocusList,
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeFlows,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom,
 		setFlowPhase: func(flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
 			phaseMutationRan = true
 			return flowstore.FlowRecord{}, nil
-		},
-	}
+		}, embeddedTerminalState: embeddedTerminalState{
+			terminalFocus: terminalFocusList}}
 
 	nextModel, cmd := m.Update(embeddedPromptPrefillResultMsg{
 		ID:            42,
@@ -1733,15 +1710,14 @@ func waitInternalFileContains(t *testing.T, path, want string) {
 }
 
 func TestActiveTerminalRepoPathsIncludesOnlyRunningOwnedTerminals(t *testing.T) {
-	m := Model{
+	m := Model{embeddedTerminalState: embeddedTerminalState{
 		embeddedTerminals: []embeddedTerminalSlot{
 			{RepoPath: "/dev/alpha", Terminal: internalFakeEmbeddedTerminal{}},
 			{RepoPath: "/dev/beta", Terminal: internalFakeEmbeddedTerminal{state: "exited"}},
 			{RepoPath: "/dev/gamma", Terminal: internalFakeEmbeddedTerminal{state: "starting"}},
 			{RepoPath: "", Terminal: internalFakeEmbeddedTerminal{}},
 			{RepoPath: "/dev/delta", Terminal: nil},
-		},
-	}
+		}}}
 
 	active := m.activeTerminalRepoPaths()
 
@@ -1758,12 +1734,11 @@ func TestActiveTerminalRepoPathsIncludesOnlyRunningOwnedTerminals(t *testing.T) 
 }
 
 func TestActiveTerminalRepoPathsClearsWhenLastRunningSlotIsDismissed(t *testing.T) {
-	m := Model{
+	m := Model{embeddedTerminalState: embeddedTerminalState{
 		embeddedTerminals: []embeddedTerminalSlot{
 			{ID: 1, Number: 1, Scope: embeddedTerminalScopeSession, RepoPath: "/dev/alpha", Terminal: internalFakeEmbeddedTerminal{state: "exited"}},
 			{ID: 2, Number: 2, Scope: embeddedTerminalScopeSession, RepoPath: "/dev/alpha", Terminal: internalFakeEmbeddedTerminal{}},
-		},
-	}
+		}}}
 
 	if !m.activeTerminalRepoPaths()["/dev/alpha"] {
 		t.Fatalf("repo should remain active while one matching slot is running")
@@ -1777,11 +1752,10 @@ func TestActiveTerminalRepoPathsClearsWhenLastRunningSlotIsDismissed(t *testing.
 }
 
 func TestOpenEmbeddedTerminalStoresSessionRepoPath(t *testing.T) {
-	m := Model{
+	m := Model{embeddedTerminalState: embeddedTerminalState{
 		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
 			return internalFakeEmbeddedTerminal{}, nil
-		},
-	}
+		}}}
 
 	next, opened, err := m.openEmbeddedTerminal(actions.AgentLaunchContext{
 		RepoPath:     "/dev/alpha/",
@@ -1809,11 +1783,10 @@ func TestOpenEmbeddedTerminalStoresSessionRepoPath(t *testing.T) {
 }
 
 func TestOpenFlowEmbeddedTerminalStoresFlowRepoPath(t *testing.T) {
-	m := Model{
+	m := Model{embeddedTerminalState: embeddedTerminalState{
 		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
 			return internalFakeEmbeddedTerminal{}, nil
-		},
-	}
+		}}}
 
 	next, opened, err, _ := m.openFlowEmbeddedTerminal(actions.AgentLaunchContext{
 		Command:       "codex",
@@ -1848,14 +1821,13 @@ func TestViewMarksRepoWithRunningTerminalByCleanRepoPath(t *testing.T) {
 		repos: newRepoPane().SetItems([]scanner.Repo{
 			{Path: "/dev/alpha", DisplayName: "alpha"},
 			{Path: "/dev/alpha-worktrees/feature", DisplayName: "feature"},
-		}),
-		embeddedTerminals: []embeddedTerminalSlot{
-			{
-				RepoPath: "/dev/alpha/",
-				Terminal: internalFakeEmbeddedTerminal{},
-			},
-		},
-	}
+		}), embeddedTerminalState: embeddedTerminalState{
+			embeddedTerminals: []embeddedTerminalSlot{
+				{
+					RepoPath: "/dev/alpha/",
+					Terminal: internalFakeEmbeddedTerminal{},
+				},
+			}}}
 
 	view := ansi.Strip(m.View())
 
@@ -2234,34 +2206,33 @@ func TestHandleFlowResultPreservesActiveTerminalWhenClampedSelectionHasNoMatch(t
 
 func TestDismissActiveFlowTerminalKeepsUnifiedDockFocusedOnSurvivor(t *testing.T) {
 	m := Model{
-		topMode:              ui.ModeWorktrees,
-		bottomMode:           ui.ModeFlows,
-		contentPane:          ui.PaneBottom,
-		activePane:           ui.PaneBottom,
-		activeTerminalNum:    2,
-		terminalFocus:        terminalFocusTerminal,
-		terminalPrefixActive: true,
-		embeddedTerminals: []embeddedTerminalSlot{
-			{
-				Number:   1,
-				Scope:    embeddedTerminalScopeSession,
-				Provider: "codex",
-				Identity: "session",
-				Terminal: internalFakeEmbeddedTerminal{},
-				ID:       1,
-			},
-			{
-				Number:      2,
-				Scope:       embeddedTerminalScopeFlow,
-				Provider:    "codex",
-				Identity:    "implementation",
-				FlowID:      "flow-1",
-				FlowPhaseID: "implementation",
-				Terminal:    internalFakeEmbeddedTerminal{state: "exited"},
-				ID:          2,
-			},
-		},
-	}
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeFlows,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			activeTerminalNum:    2,
+			terminalFocus:        terminalFocusTerminal,
+			terminalPrefixActive: true,
+			embeddedTerminals: []embeddedTerminalSlot{
+				{
+					Number:   1,
+					Scope:    embeddedTerminalScopeSession,
+					Provider: "codex",
+					Identity: "session",
+					Terminal: internalFakeEmbeddedTerminal{},
+					ID:       1,
+				},
+				{
+					Number:      2,
+					Scope:       embeddedTerminalScopeFlow,
+					Provider:    "codex",
+					Identity:    "implementation",
+					FlowID:      "flow-1",
+					FlowPhaseID: "implementation",
+					Terminal:    internalFakeEmbeddedTerminal{state: "exited"},
+					ID:          2,
+				},
+			}}}
 
 	m = m.dismissEmbeddedTerminal(2)
 
@@ -2281,33 +2252,32 @@ func TestDismissActiveFlowTerminalKeepsUnifiedDockFocusedOnSurvivor(t *testing.T
 
 func TestDismissLastFlowTerminalPreservesSessionCommandState(t *testing.T) {
 	m := Model{
-		topMode:              ui.ModeWorktrees,
-		bottomMode:           ui.ModeSessions,
-		contentPane:          ui.PaneBottom,
-		activeTerminalNum:    1,
-		terminalFocus:        terminalFocusTerminal,
-		terminalPrefixActive: true,
-		embeddedTerminals: []embeddedTerminalSlot{
-			{
-				Number:   1,
-				Scope:    embeddedTerminalScopeSession,
-				Provider: "codex",
-				Identity: "session",
-				Terminal: internalFakeEmbeddedTerminal{},
-				ID:       1,
-			},
-			{
-				Number:      2,
-				Scope:       embeddedTerminalScopeFlow,
-				Provider:    "codex",
-				Identity:    "implementation",
-				FlowID:      "flow-1",
-				FlowPhaseID: "implementation",
-				Terminal:    internalFakeEmbeddedTerminal{state: "exited"},
-				ID:          2,
-			},
-		},
-	}
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			activeTerminalNum:    1,
+			terminalFocus:        terminalFocusTerminal,
+			terminalPrefixActive: true,
+			embeddedTerminals: []embeddedTerminalSlot{
+				{
+					Number:   1,
+					Scope:    embeddedTerminalScopeSession,
+					Provider: "codex",
+					Identity: "session",
+					Terminal: internalFakeEmbeddedTerminal{},
+					ID:       1,
+				},
+				{
+					Number:      2,
+					Scope:       embeddedTerminalScopeFlow,
+					Provider:    "codex",
+					Identity:    "implementation",
+					FlowID:      "flow-1",
+					FlowPhaseID: "implementation",
+					Terminal:    internalFakeEmbeddedTerminal{state: "exited"},
+					ID:          2,
+				},
+			}}}
 
 	m = m.dismissEmbeddedTerminal(2)
 
@@ -2326,11 +2296,9 @@ func TestSessionTerminalPrefixDDetachesActiveTerminal(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{target: "approach-agent-session"}
 	var gotTarget, gotCWD string
 	m := Model{
-		topMode:              ui.ModeWorktrees,
-		bottomMode:           ui.ModeSessions,
-		contentPane:          ui.PaneBottom,
-		activeTerminalNum:    1,
-		terminalPrefixActive: true,
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom,
 		launchDetachedTerminal: func(target, cwd string) (actions.TerminalLaunchSpec, error) {
 			gotTarget = target
 			gotCWD = cwd
@@ -2339,19 +2307,20 @@ func TestSessionTerminalPrefixDDetachesActiveTerminal(t *testing.T) {
 		finalizeAgentSession: func(actions.AgentLaunchContext) error {
 			t.Fatal("detach should not finalize the agent session")
 			return nil
-		},
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number:       1,
-			Scope:        embeddedTerminalScopeSession,
-			Provider:     "codex",
-			Identity:     "session",
-			RepoPath:     "/dev/repo",
-			WorktreePath: "/dev/worktree",
-			WorkingDir:   "/dev/worktree/subdir",
-			Terminal:     term,
-			ID:           1,
-		}},
-	}
+		}, embeddedTerminalState: embeddedTerminalState{
+			activeTerminalNum:    1,
+			terminalPrefixActive: true,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number:       1,
+				Scope:        embeddedTerminalScopeSession,
+				Provider:     "codex",
+				Identity:     "session",
+				RepoPath:     "/dev/repo",
+				WorktreePath: "/dev/worktree",
+				WorkingDir:   "/dev/worktree/subdir",
+				Terminal:     term,
+				ID:           1,
+			}}}}
 
 	next, cmd, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeSession)
 
@@ -2394,15 +2363,11 @@ func TestFlowTerminalPrefixDDetachesActiveTerminalAndRenumbers(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{target: "approach-flow-agent"}
 	var gotTarget, gotCWD string
 	m := Model{
-		topMode:              ui.ModeWorktrees,
-		bottomMode:           ui.ModeFlows,
-		contentPane:          ui.PaneBottom,
-		activePane:           ui.PaneBottom,
-		terminalFocus:        terminalFocusTerminal,
-		activeTerminalNum:    1,
-		terminalPrefixActive: true,
-		terminalConfirmID:    1,
-		modal:                modal.OpenConfirm(embeddedTerminalTerminatePrompt, nil),
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeFlows,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom,
+		modal:       modal.OpenConfirm(embeddedTerminalTerminatePrompt, nil),
 		launchDetachedTerminal: func(target, cwd string) (actions.TerminalLaunchSpec, error) {
 			gotTarget = target
 			gotCWD = cwd
@@ -2411,40 +2376,43 @@ func TestFlowTerminalPrefixDDetachesActiveTerminalAndRenumbers(t *testing.T) {
 		finalizeAgentSession: func(actions.AgentLaunchContext) error {
 			t.Fatal("detach should not finalize the agent session")
 			return nil
-		},
-		embeddedTerminals: []embeddedTerminalSlot{
-			{
-				Number:       1,
-				Scope:        embeddedTerminalScopeFlow,
-				Provider:     "codex",
-				Identity:     "implementation",
-				RepoPath:     "/dev/repo",
-				WorktreePath: "/dev/worktree",
-				FlowID:       "flow-1",
-				FlowPhaseID:  "implementation",
-				Terminal:     term,
-				ID:           1,
-			},
-			{
-				Number:      2,
-				Scope:       embeddedTerminalScopeFlow,
-				Provider:    "claude",
-				Identity:    "review",
-				FlowID:      "flow-1",
-				FlowPhaseID: "review",
-				Terminal:    internalFakeEmbeddedTerminal{},
-				ID:          2,
-			},
-			{
-				Number:   3,
-				Scope:    embeddedTerminalScopeSession,
-				Provider: "codex",
-				Identity: "session",
-				Terminal: internalFakeEmbeddedTerminal{},
-				ID:       3,
-			},
-		},
-	}
+		}, embeddedTerminalState: embeddedTerminalState{
+			terminalFocus:        terminalFocusTerminal,
+			activeTerminalNum:    1,
+			terminalPrefixActive: true,
+			terminalConfirmID:    1,
+			embeddedTerminals: []embeddedTerminalSlot{
+				{
+					Number:       1,
+					Scope:        embeddedTerminalScopeFlow,
+					Provider:     "codex",
+					Identity:     "implementation",
+					RepoPath:     "/dev/repo",
+					WorktreePath: "/dev/worktree",
+					FlowID:       "flow-1",
+					FlowPhaseID:  "implementation",
+					Terminal:     term,
+					ID:           1,
+				},
+				{
+					Number:      2,
+					Scope:       embeddedTerminalScopeFlow,
+					Provider:    "claude",
+					Identity:    "review",
+					FlowID:      "flow-1",
+					FlowPhaseID: "review",
+					Terminal:    internalFakeEmbeddedTerminal{},
+					ID:          2,
+				},
+				{
+					Number:   3,
+					Scope:    embeddedTerminalScopeSession,
+					Provider: "codex",
+					Identity: "session",
+					Terminal: internalFakeEmbeddedTerminal{},
+					ID:       3,
+				},
+			}}}
 
 	next, cmd, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeFlow)
 
@@ -2483,23 +2451,22 @@ func TestFlowTerminalPrefixDDetachesActiveTerminalAndRenumbers(t *testing.T) {
 func TestTerminalPrefixDReportsHandoffConstructionFailureAfterDetach(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{target: "approach-agent-session"}
 	m := Model{
-		topMode:              ui.ModeWorktrees,
-		bottomMode:           ui.ModeSessions,
-		contentPane:          ui.PaneBottom,
-		activeTerminalNum:    1,
-		terminalPrefixActive: true,
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom,
 		launchDetachedTerminal: func(string, string) (actions.TerminalLaunchSpec, error) {
 			return actions.TerminalLaunchSpec{}, errors.New("no external terminal")
-		},
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number:   1,
-			Scope:    embeddedTerminalScopeSession,
-			Provider: "codex",
-			Identity: "session",
-			Terminal: term,
-			ID:       1,
-		}},
-	}
+		}, embeddedTerminalState: embeddedTerminalState{
+			activeTerminalNum:    1,
+			terminalPrefixActive: true,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number:   1,
+				Scope:    embeddedTerminalScopeSession,
+				Provider: "codex",
+				Identity: "session",
+				Terminal: term,
+				ID:       1,
+			}}}}
 
 	next, cmd, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeSession)
 
@@ -2524,26 +2491,25 @@ func TestTerminalPrefixDReportsHandoffRunFailureAfterDetach(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{target: "approach-agent-session"}
 	cleaned := false
 	m := Model{
-		topMode:              ui.ModeWorktrees,
-		bottomMode:           ui.ModeSessions,
-		contentPane:          ui.PaneBottom,
-		activeTerminalNum:    1,
-		terminalPrefixActive: true,
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom,
 		launchDetachedTerminal: func(string, string) (actions.TerminalLaunchSpec, error) {
 			return actions.TerminalLaunchSpec{
 				Cmd:     exec.Command("sh", "-c", "exit 7"),
 				Cleanup: func() { cleaned = true },
 			}, nil
-		},
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number:   1,
-			Scope:    embeddedTerminalScopeSession,
-			Provider: "codex",
-			Identity: "session",
-			Terminal: term,
-			ID:       1,
-		}},
-	}
+		}, embeddedTerminalState: embeddedTerminalState{
+			activeTerminalNum:    1,
+			terminalPrefixActive: true,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number:   1,
+				Scope:    embeddedTerminalScopeSession,
+				Provider: "codex",
+				Identity: "session",
+				Terminal: term,
+				ID:       1,
+			}}}}
 
 	next, cmd, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeSession)
 
@@ -2575,20 +2541,19 @@ func TestTerminalPrefixDReportsHandoffRunFailureAfterDetach(t *testing.T) {
 
 func TestTerminalPrefixDReportsUnavailableForDirectPTY(t *testing.T) {
 	m := Model{
-		topMode:              ui.ModeWorktrees,
-		bottomMode:           ui.ModeSessions,
-		contentPane:          ui.PaneBottom,
-		activeTerminalNum:    1,
-		terminalPrefixActive: true,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number:   1,
-			Scope:    embeddedTerminalScopeSession,
-			Provider: "codex",
-			Identity: "session",
-			Terminal: internalFakeEmbeddedTerminal{},
-			ID:       1,
-		}},
-	}
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			activeTerminalNum:    1,
+			terminalPrefixActive: true,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number:   1,
+				Scope:    embeddedTerminalScopeSession,
+				Provider: "codex",
+				Identity: "session",
+				Terminal: internalFakeEmbeddedTerminal{},
+				ID:       1,
+			}}}}
 
 	next, _, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeSession)
 
@@ -2606,22 +2571,21 @@ func TestTerminalPrefixDReportsUnavailableForDirectPTY(t *testing.T) {
 func TestFlowTerminalInputModeDPassesThrough(t *testing.T) {
 	term := &internalFakeDetachableEmbeddedTerminal{target: "approach-flow-agent"}
 	m := Model{
-		topMode:              ui.ModeWorktrees,
-		bottomMode:           ui.ModeFlows,
-		contentPane:          ui.PaneBottom,
-		activePane:           ui.PaneBottom,
-		terminalFocus:        terminalFocusTerminal,
-		activeTerminalNum:    1,
-		terminalPrefixActive: false,
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Number:   1,
-			Scope:    embeddedTerminalScopeFlow,
-			Provider: "codex",
-			Identity: "implementation",
-			Terminal: term,
-			ID:       1,
-		}},
-	}
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeFlows,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom, embeddedTerminalState: embeddedTerminalState{
+			terminalFocus:        terminalFocusTerminal,
+			activeTerminalNum:    1,
+			terminalPrefixActive: false,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number:   1,
+				Scope:    embeddedTerminalScopeFlow,
+				Provider: "codex",
+				Identity: "implementation",
+				Terminal: term,
+				ID:       1,
+			}}}}
 
 	next, _, consumed := m.handleEmbeddedTerminalKeyForScope(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, embeddedTerminalScopeFlow)
 

--- a/model/epic_progression_advance_internal_test.go
+++ b/model/epic_progression_advance_internal_test.go
@@ -27,7 +27,7 @@ func TestEpicProgressionEnableIgnoresAlreadyInFlightTerminalSnapshot(t *testing.
 	terminal := cloneFlowRecord(pending)
 	terminal.Status = flowstore.StatusCompleted
 
-	m := Model{autoAdvanceRequestSeq: 1, autoAdvanceInFlight: 1}
+	m := Model{autoAdvanceState: autoAdvanceState{autoAdvanceRequestSeq: 1, autoAdvanceInFlight: 1}}
 	m, _ = m.handleEpicProgressionToggleResult(epicProgressionToggleResultMsg{
 		target:              beadExpansionTarget{repoPath: repo, epicID: epic},
 		flow:                pending,
@@ -54,9 +54,7 @@ func TestEpicProgressionAdvanceUsesReadyOrderAndSkipsExactLinkedChildren(t *test
 	linked := progressionAdvanceFlow("linked-a", repo, "epic.a", epic, flowstore.StatusCompleted)
 	beadQueries := 0
 	m := Model{
-		autoAdvanceInFlight:      1,
 		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
-		agentCommand:             "codex",
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -70,8 +68,9 @@ func TestEpicProgressionAdvanceUsesReadyOrderAndSkipsExactLinkedChildren(t *test
 		},
 		listFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{terminal, linked}, nil
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}, agentConfig: agentConfig{
+			agentCommand: "codex"}}
 
 	next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
 	result := epicProgressionAdvanceMessage(t, cmd)
@@ -105,7 +104,6 @@ func TestEpicProgressionAdvanceSkipsAnEpicWhoseChildIsAlreadyInFlight(t *testing
 	terminal := cloneFlowRecord(source)
 	terminal.Status = flowstore.StatusCompleted
 	m := Model{
-		autoAdvanceInFlight:      1,
 		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 		epicProgressionOwnedSuccessors: map[string]epicProgressionOwnedSuccessor{
 			key: {SourceFlowID: source.FlowID, ChildID: "epic.b", FlowID: "flow-b"},
@@ -113,8 +111,8 @@ func TestEpicProgressionAdvanceSkipsAnEpicWhoseChildIsAlreadyInFlight(t *testing
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			t.Fatal("advance ran for an epic with a child already in flight")
 			return flowstore.EpicProgression{}, false, nil
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}}
 	next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
 	for _, msg := range immediateFlowRefreshMessages(cmd) {
 		if _, ok := msg.(epicProgressionAdvanceResultMsg); ok {
@@ -139,15 +137,14 @@ func TestEpicProgressionAdvanceRotatesRetryingEpics(t *testing.T) {
 	secondTerminal.Status = flowstore.StatusCompleted
 
 	m := Model{
-		autoAdvanceInFlight: 1,
 		epicProgressionBaselines: map[string]flowstore.FlowRecord{
 			firstKey:  firstSource,
 			secondKey: secondSource,
 		},
 		readEpicProgression: func(key flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{}, false, errors.New("store unavailable for " + key.EpicID)
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}}
 	terminalFlows := []flowstore.FlowRecord{firstTerminal, secondTerminal}
 
 	next, firstCmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: terminalFlows, Request: 1})
@@ -175,7 +172,7 @@ func TestEpicProgressionRuntimeBaselineLifecycle(t *testing.T) {
 	terminal.Status = flowstore.StatusCompleted
 
 	t.Run("startup terminal snapshot does not catch up", func(t *testing.T) {
-		m := Model{autoAdvanceInFlight: 1}
+		m := Model{autoAdvanceState: autoAdvanceState{autoAdvanceInFlight: 1}}
 		next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
 		for _, msg := range immediateFlowRefreshMessages(cmd) {
 			if _, ok := msg.(epicProgressionAdvanceResultMsg); ok {
@@ -188,7 +185,7 @@ func TestEpicProgressionRuntimeBaselineLifecycle(t *testing.T) {
 	})
 
 	t.Run("non terminal observation refreshes exact baseline", func(t *testing.T) {
-		m := Model{autoAdvanceInFlight: 1, epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source}}
+		m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source}, autoAdvanceState: autoAdvanceState{autoAdvanceInFlight: 1}}
 		next, _ := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{nonSuccess}, Request: 1})
 		if next.epicProgressionBaselines[key].Title != "refreshed" {
 			t.Fatalf("baseline = %#v", next.epicProgressionBaselines[key])
@@ -204,7 +201,7 @@ func TestEpicProgressionRuntimeBaselineLifecycle(t *testing.T) {
 		{name: "missing tracked flow", msg: AutoAdvanceResultMsg{Flows: nil, Request: 1}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			m := Model{autoAdvanceInFlight: 1, epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source}}
+			m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source}, autoAdvanceState: autoAdvanceState{autoAdvanceInFlight: 1}}
 			next, _ := updateFlowRefreshTest(m, tt.msg)
 			if next.epicProgressionBaselines[key].FlowID != source.FlowID {
 				t.Fatalf("baseline changed: %#v", next.epicProgressionBaselines)
@@ -234,15 +231,14 @@ func TestEpicProgressionAdvanceChecksAuthoritativeStateBeforeSideEffects(t *test
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			sideEffects := 0
-			m := Model{
-				autoAdvanceInFlight: 1, epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+			m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 				readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 					return tt.progression, tt.found, tt.err
 				},
 				listChildrenBeads: func(string, string) ([]beadsquery.Bead, error) { sideEffects++; return nil, nil },
 				listReadyBeads:    func(string) ([]beadsquery.Bead, error) { sideEffects++; return nil, nil },
-				listFlows:         func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) { sideEffects++; return nil, nil },
-			}
+				listFlows:         func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) { sideEffects++; return nil, nil }, autoAdvanceState: autoAdvanceState{
+					autoAdvanceInFlight: 1}}
 			next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
 			result := epicProgressionAdvanceMessage(t, cmd)
 			next, _ = updateFlowRefreshTest(next, result)
@@ -284,8 +280,7 @@ func TestEpicProgressionExhaustionReconciliationMatrix(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			reads := 0
-			m := Model{
-				autoAdvanceInFlight: 1, epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+			m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 				readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 					reads++
 					if reads == 1 {
@@ -305,8 +300,8 @@ func TestEpicProgressionExhaustionReconciliationMatrix(t *testing.T) {
 						t.Fatalf("exhaustion update = %#v, want enabled=false done=true", update)
 					}
 					return flowstore.EpicProgression{RepoPath: repo, EpicID: epic}, tt.setErr
-				},
-			}
+				}, autoAdvanceState: autoAdvanceState{
+					autoAdvanceInFlight: 1}}
 			next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
 			result := epicProgressionAdvanceMessage(t, cmd)
 			next, _ = updateFlowRefreshTest(next, result)
@@ -324,9 +319,7 @@ func TestEpicProgressionPreparationAdmissionIsSingleFlightAndStaleResultFenced(t
 	source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
 	terminal := cloneFlowRecord(source)
 	terminal.Status = flowstore.StatusCompleted
-	m := Model{
-		autoAdvanceInFlight: 1, epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
-		agentCommand: "codex",
+	m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -334,8 +327,9 @@ func TestEpicProgressionPreparationAdmissionIsSingleFlightAndStaleResultFenced(t
 		listReadyBeads:    func(string) ([]beadsquery.Bead, error) { return []beadsquery.Bead{{ID: "epic.b"}}, nil },
 		listFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{terminal}, nil
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}, agentConfig: agentConfig{
+			agentCommand: "codex"}}
 
 	next, firstCmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
 	if !next.flowPreparationAdmission {
@@ -389,9 +383,7 @@ func TestEpicProgressionSelectionScopeDoesNotSuppressOtherRepositoryLink(t *test
 	source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
 	terminal := cloneFlowRecord(source)
 	terminal.Status = flowstore.StatusCompleted
-	m := Model{
-		autoAdvanceInFlight: 1, epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
-		agentCommand: "codex",
+	m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -404,8 +396,9 @@ func TestEpicProgressionSelectionScopeDoesNotSuppressOtherRepositoryLink(t *test
 		setEpicProgression: func(flowstore.EpicProgressionUpdate) (flowstore.EpicProgression, error) {
 			t.Fatal("noncanonical or foreign links exhausted the epic")
 			return flowstore.EpicProgression{}, nil
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}, agentConfig: agentConfig{
+			agentCommand: "codex"}}
 	next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
 	result := epicProgressionAdvanceMessage(t, cmd)
 	next, selectedCmd := updateFlowRefreshTest(next, result)
@@ -424,8 +417,7 @@ func TestEpicProgressionExhaustionReportsAllReadyChildrenAlreadyLinked(t *testin
 	terminal := cloneFlowRecord(source)
 	terminal.Status = flowstore.StatusCompleted
 	linked := progressionAdvanceFlow("flow-b", repo, "epic.b", epic, flowstore.StatusPending)
-	m := Model{
-		autoAdvanceInFlight: 1, epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+	m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -434,8 +426,8 @@ func TestEpicProgressionExhaustionReportsAllReadyChildrenAlreadyLinked(t *testin
 		listFlows:         func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) { return []flowstore.FlowRecord{linked}, nil },
 		setEpicProgression: func(flowstore.EpicProgressionUpdate) (flowstore.EpicProgression, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic}, nil
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}}
 	next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
 	result := epicProgressionAdvanceMessage(t, cmd)
 	if result.disposition == epicProgressionAdvanceSelected {
@@ -544,8 +536,7 @@ func TestEpicProgressionSelectionMatchesBeadSlotGuard(t *testing.T) {
 			terminal := cloneFlowRecord(source)
 			terminal.Status = flowstore.StatusCompleted
 			existing := tt.existing()
-			m := Model{
-				autoAdvanceInFlight: 1, epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+			m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 				readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 					return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 				},
@@ -560,8 +551,8 @@ func TestEpicProgressionSelectionMatchesBeadSlotGuard(t *testing.T) {
 				},
 				setEpicProgression: func(flowstore.EpicProgressionUpdate) (flowstore.EpicProgression, error) {
 					return flowstore.EpicProgression{RepoPath: repo, EpicID: epic}, nil
-				},
-			}
+				}, autoAdvanceState: autoAdvanceState{
+					autoAdvanceInFlight: 1}}
 			_, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
 			result := epicProgressionAdvanceMessage(t, cmd)
 			if tt.wantSelected {
@@ -672,9 +663,7 @@ func TestEpicProgressionAdvanceClosesMergedChildBeadBeforeReadyQuery(t *testing.
 	// whole point: a close that lands after the query selects nothing.
 	ready := []beadsquery.Bead{}
 	m := Model{
-		autoAdvanceInFlight:      1,
 		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
-		agentCommand:             "codex",
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -694,8 +683,9 @@ func TestEpicProgressionAdvanceClosesMergedChildBeadBeforeReadyQuery(t *testing.
 		},
 		listFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{merged}, nil
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}, agentConfig: agentConfig{
+			agentCommand: "codex"}}
 
 	_, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{merged}, Request: 1})
 	result := epicProgressionAdvanceMessage(t, cmd)
@@ -724,9 +714,7 @@ func TestEpicProgressionAdvanceDoesNotCloseUnmergedChildBead(t *testing.T) {
 
 	closes := 0
 	m := Model{
-		autoAdvanceInFlight:      1,
 		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
-		agentCommand:             "codex",
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -739,8 +727,9 @@ func TestEpicProgressionAdvanceDoesNotCloseUnmergedChildBead(t *testing.T) {
 		},
 		listFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
 			return []flowstore.FlowRecord{completed}, nil
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}, agentConfig: agentConfig{
+			agentCommand: "codex"}}
 
 	_, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{completed}, Request: 1})
 	result := epicProgressionAdvanceMessage(t, cmd)
@@ -763,9 +752,7 @@ func TestEpicProgressionAdvanceCloseFailureIsRetryable(t *testing.T) {
 	queries := 0
 	setProgressionCalls := 0
 	m := Model{
-		autoAdvanceInFlight:      1,
 		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
-		agentCommand:             "codex",
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -781,8 +768,9 @@ func TestEpicProgressionAdvanceCloseFailureIsRetryable(t *testing.T) {
 		setEpicProgression: func(flowstore.EpicProgressionUpdate) (flowstore.EpicProgression, error) {
 			setProgressionCalls++
 			return flowstore.EpicProgression{}, nil
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}, agentConfig: agentConfig{
+			agentCommand: "codex"}}
 
 	_, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{merged}, Request: 1})
 	result := epicProgressionAdvanceMessage(t, cmd)

--- a/model/epic_progression_halt_internal_test.go
+++ b/model/epic_progression_halt_internal_test.go
@@ -99,8 +99,6 @@ func TestEpicProgressionFailureTerminalHaltsAndDropsTracking(t *testing.T) {
 			var updates []flowstore.EpicProgressionHaltUpdate
 			sideEffects := 0
 			m := Model{
-				autoAdvanceInFlight:                    1,
-				autoAdvanceRequestSeq:                  1,
 				epicProgressionBaselines:               map[string]flowstore.FlowRecord{key: source},
 				epicProgressionBaselineMinimumRequests: map[string]uint64{key: 1},
 				epicProgressionOwnedSuccessors: map[string]epicProgressionOwnedSuccessor{
@@ -117,8 +115,9 @@ func TestEpicProgressionFailureTerminalHaltsAndDropsTracking(t *testing.T) {
 				},
 				listChildrenBeads: func(string, string) ([]beadsquery.Bead, error) { sideEffects++; return nil, nil },
 				listReadyBeads:    func(string) ([]beadsquery.Bead, error) { sideEffects++; return nil, nil },
-				createFlow:        func(FlowStartRequest) (FlowStartResult, error) { sideEffects++; return FlowStartResult{}, nil },
-			}
+				createFlow:        func(FlowStartRequest) (FlowStartResult, error) { sideEffects++; return FlowStartResult{}, nil }, autoAdvanceState: autoAdvanceState{
+					autoAdvanceInFlight:   1,
+					autoAdvanceRequestSeq: 1}}
 
 			next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{observed}, Request: 1})
 			if !next.flowPreparationAdmission || next.flowPreparationOwner.Kind != flowPreparationEpicHalt {
@@ -219,7 +218,6 @@ func TestEpicProgressionSuccessAndNonTerminalObservationsDoNotHalt(t *testing.T)
 			source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
 			observed := tt.observed(cloneFlowRecord(source))
 			m := Model{
-				autoAdvanceInFlight:      1,
 				epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 				haltEpicProgression: func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 					t.Fatal("non-failure observation halted progression")
@@ -227,8 +225,8 @@ func TestEpicProgressionSuccessAndNonTerminalObservationsDoNotHalt(t *testing.T)
 				},
 				readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 					return flowstore.EpicProgression{}, false, nil
-				},
-			}
+				}, autoAdvanceState: autoAdvanceState{
+					autoAdvanceInFlight: 1}}
 			next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{observed}, Request: 1})
 			advanced := false
 			for _, msg := range immediateFlowRefreshMessages(cmd) {
@@ -305,7 +303,6 @@ func TestEpicProgressionHaltPersistenceFailureUsesAuthoritativeState(t *testing.
 			observed.Status = flowstore.StatusBlocked
 			halts := 0
 			m := Model{
-				autoAdvanceInFlight:      1,
 				epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 				haltEpicProgression: func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 					halts++
@@ -313,8 +310,8 @@ func TestEpicProgressionHaltPersistenceFailureUsesAuthoritativeState(t *testing.
 				},
 				readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 					return tt.progression, tt.found, tt.readErr
-				},
-			}
+				}, autoAdvanceState: autoAdvanceState{
+					autoAdvanceInFlight: 1}}
 			next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{observed}, Request: 1})
 			result := epicProgressionHaltMessage(t, cmd)
 			if result.disposition != tt.wantDisposition {
@@ -360,15 +357,14 @@ func TestEpicProgressionHaltSharesPreparationAdmissionAndRotates(t *testing.T) {
 
 	t.Run("held admission defers without losing the edge", func(t *testing.T) {
 		m := Model{
-			autoAdvanceInFlight:      1,
 			epicProgressionBaselines: map[string]flowstore.FlowRecord{firstKey: firstSource},
 			flowPreparationAdmission: true,
 			flowPreparationSeq:       7,
 			flowPreparationOwner:     flowPreparationOwner{Kind: flowPreparationEpicAdvance, Token: 7},
 			haltEpicProgression: func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 				return flowstore.EpicProgression{RepoPath: repo, EpicID: firstEpic}, nil
-			},
-		}
+			}, autoAdvanceState: autoAdvanceState{
+				autoAdvanceInFlight: 1}}
 		next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{firstBlocked}, Request: 1})
 		for _, msg := range immediateFlowRefreshMessages(cmd) {
 			if _, ok := msg.(epicProgressionHaltResultMsg); ok {
@@ -388,7 +384,6 @@ func TestEpicProgressionHaltSharesPreparationAdmissionAndRotates(t *testing.T) {
 
 	t.Run("failing halt rotates to the next tracked epic", func(t *testing.T) {
 		m := Model{
-			autoAdvanceInFlight: 1,
 			epicProgressionBaselines: map[string]flowstore.FlowRecord{
 				firstKey: firstSource, secondKey: secondSource,
 			},
@@ -397,8 +392,8 @@ func TestEpicProgressionHaltSharesPreparationAdmissionAndRotates(t *testing.T) {
 			},
 			readEpicProgression: func(key flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 				return flowstore.EpicProgression{RepoPath: key.RepoPath, EpicID: key.EpicID, Enabled: true}, true, nil
-			},
-		}
+			}, autoAdvanceState: autoAdvanceState{
+				autoAdvanceInFlight: 1}}
 		next, firstCmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: blocked, Request: 1})
 		first := epicProgressionHaltMessage(t, firstCmd)
 		if first.epicKey != firstKey {
@@ -423,13 +418,12 @@ func TestEpicProgressionStaleHaltResultIsFencedAndReleasesAdmission(t *testing.T
 	blocked := cloneFlowRecord(source)
 	blocked.Status = flowstore.StatusBlocked
 	m := Model{
-		autoAdvanceInFlight:      1,
 		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 		haltEpicProgression: func(update flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 			halt := update.Halt
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Halt: &halt}, nil
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}}
 	next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{blocked}, Request: 1})
 	result := epicProgressionHaltMessage(t, cmd)
 	if result.ownerToken == 0 {
@@ -633,13 +627,12 @@ func TestEpicProgressionHaltAnnouncesTheRetainedCause(t *testing.T) {
 		Message:     "child Flow flow-z halted auto-progression",
 	}
 	m := Model{
-		autoAdvanceInFlight:      1,
 		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 		haltEpicProgression: func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 			first := retained
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Halt: &first}, nil
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}}
 	next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{blocked}, Request: 1})
 	result := epicProgressionHaltMessage(t, cmd)
 	if result.disposition != epicProgressionHaltPersisted {
@@ -668,7 +661,6 @@ func TestEpicProgressionHaltWriteErrorReportsADurableHalt(t *testing.T) {
 		Message:     "child Flow flow-z halted auto-progression",
 	}
 	m := Model{
-		autoAdvanceInFlight:      1,
 		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
 		haltEpicProgression: func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 			return flowstore.EpicProgression{}, errors.New("commit failed")
@@ -676,8 +668,8 @@ func TestEpicProgressionHaltWriteErrorReportsADurableHalt(t *testing.T) {
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			halt := durable
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Halt: &halt}, true, nil
-		},
-	}
+		}, autoAdvanceState: autoAdvanceState{
+			autoAdvanceInFlight: 1}}
 	next, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{observed}, Request: 1})
 	result := epicProgressionHaltMessage(t, cmd)
 	if result.disposition != epicProgressionHaltPersisted {

--- a/model/flow_advance_tick.go
+++ b/model/flow_advance_tick.go
@@ -19,6 +19,15 @@ import (
 // never wait on wall time.
 const defaultAutoAdvanceTickInterval = time.Second
 
+// autoAdvanceState is the AutoMode poll/launch cluster on Model.
+type autoAdvanceState struct {
+	autoAdvanceDrainFlows   map[string]struct{}
+	autoAdvanceTickInterval time.Duration
+	autoAdvanceRequestSeq   uint64
+	autoAdvanceInFlight     uint64
+	autoAdvanceSnapshot     []flowstore.FlowRecord
+}
+
 // autoAdvanceTickDelay is the cadence this Model polls at. A zero field means
 // "unset" — a directly constructed Model still ticks at the production rate.
 func (m Model) autoAdvanceTickDelay() time.Duration {

--- a/model/flow_advance_tick_test.go
+++ b/model/flow_advance_tick_test.go
@@ -596,16 +596,15 @@ func TestRepairTerminalRemovalRecordsCleanAndSuppressingOutcomes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := Model{
-				autoAdvanceRequestSeq: 11,
+			m := Model{embeddedTerminalState: embeddedTerminalState{
 				embeddedTerminals: []embeddedTerminalSlot{{
 					FlowID:     "flow-repair",
 					FlowRepair: tt.repair,
 					Scope:      embeddedTerminalScopeFlow,
 					ID:         1,
 					Terminal:   internalFakeEmbeddedTerminal{state: tt.state},
-				}},
-			}
+				}}}, autoAdvanceState: autoAdvanceState{
+				autoAdvanceRequestSeq: 11}}
 			m = m.dismissEmbeddedTerminalForReason(1, tt.reason)
 			marker, got := m.pendingRepairAutoDrainFlowIDs["flow-repair"]
 			if tt.wantClean == nil {

--- a/model/flow_launch_generic_agent_internal_test.go
+++ b/model/flow_launch_generic_agent_internal_test.go
@@ -405,7 +405,7 @@ func TestGenericWorktreeAgentRetainedSlotRejectsDetachBeforeCallingTerminal(t *t
 
 func TestGenericWorktreeAgentExitedSlotRetainsOccupancyUntilDismissed(t *testing.T) {
 	record := genericFlowAgentRecord(t)
-	m := Model{embeddedTerminals: []embeddedTerminalSlot{
+	m := Model{embeddedTerminalState: embeddedTerminalState{embeddedTerminals: []embeddedTerminalSlot{
 		{
 			Number:    1,
 			ID:        1,
@@ -414,7 +414,7 @@ func TestGenericWorktreeAgentExitedSlotRetainsOccupancyUntilDismissed(t *testing
 			FlowAgent: true,
 			Terminal:  internalFakeEmbeddedTerminal{state: "exited"},
 		},
-	}}
+	}}}
 
 	if m.hasExitedFlowEmbeddedTerminalAutoClose() {
 		t.Fatal("exited generic Flow-agent slot should not schedule automatic dismissal")

--- a/model/flow_launch_repair_internal_test.go
+++ b/model/flow_launch_repair_internal_test.go
@@ -1043,7 +1043,7 @@ func TestFlowRepairInstallBackstopRefusesAnyFlowTerminal(t *testing.T) {
 			slot.Terminal = flowPhaseLaunchTestTerminal{state: "running"}
 
 			attempt := flowLaunchAttempt{Token: "token-1", Kind: flowLaunchKindRepair, FlowID: record.FlowID}
-			m := Model{embeddedTerminals: []embeddedTerminalSlot{slot}}
+			m := Model{embeddedTerminalState: embeddedTerminalState{embeddedTerminals: []embeddedTerminalSlot{slot}}}
 
 			canceled, blocked := m.flowLaunchEmbeddedBackstop(attempt.Kind, record.FlowID)
 			if !blocked {
@@ -1058,12 +1058,12 @@ func TestFlowRepairInstallBackstopRefusesAnyFlowTerminal(t *testing.T) {
 	// The other kinds keep their narrower rung: a non-repair Flow terminal is
 	// their ordinary one-per-Flow case, refused at admission, not here.
 	record := repairLaunchFlowRecord(t)
-	m := Model{embeddedTerminals: []embeddedTerminalSlot{{
+	m := Model{embeddedTerminalState: embeddedTerminalState{embeddedTerminals: []embeddedTerminalSlot{{
 		Scope:       embeddedTerminalScopeFlow,
 		FlowID:      record.FlowID,
 		FlowPhaseID: "implementation",
 		Terminal:    flowPhaseLaunchTestTerminal{state: "running"},
-	}}}
+	}}}}
 	for _, kind := range []flowLaunchKind{flowLaunchKindManualPhase, flowLaunchKindAutoPhase, flowLaunchKindPhaseResume} {
 		if _, blocked := m.flowLaunchEmbeddedBackstop(kind, record.FlowID); blocked {
 			t.Fatalf("kind %v must not inherit repair's broad backstop", kind)

--- a/model/flow_repair_internal_test.go
+++ b/model/flow_repair_internal_test.go
@@ -278,21 +278,20 @@ func TestFlowPhaseResumeDoesNotOpenAlongsideRepairTerminal(t *testing.T) {
 	starts := 0
 	var failureUpdate flowstore.PhaseUpdate
 	m := Model{
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Scope:      embeddedTerminalScopeFlow,
-			FlowID:     flowID,
-			FlowRepair: true,
-			Terminal:   internalFakeEmbeddedTerminal{state: "running"},
-		}},
-		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
-			starts++
-			return internalFakeEmbeddedTerminal{state: "running"}, nil
-		},
 		setFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
 			failureUpdate = update
 			return flowstore.FlowRecord{}, nil
-		},
-	}
+		}, embeddedTerminalState: embeddedTerminalState{
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Scope:      embeddedTerminalScopeFlow,
+				FlowID:     flowID,
+				FlowRepair: true,
+				Terminal:   internalFakeEmbeddedTerminal{state: "running"},
+			}},
+			startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
+				starts++
+				return internalFakeEmbeddedTerminal{state: "running"}, nil
+			}}}
 	m.launchSeams.SetPhase = m.setFlowPhase
 	attempt := flowLaunchAttempt{
 		Token:        launchID,
@@ -357,21 +356,20 @@ func TestQueuedAutoLaunchDoesNotOpenAlongsideRepairTerminal(t *testing.T) {
 	starts := 0
 	var failureUpdate flowstore.PhaseUpdate
 	m := Model{
-		embeddedTerminals: []embeddedTerminalSlot{{
-			Scope:      embeddedTerminalScopeFlow,
-			FlowID:     flowID,
-			FlowRepair: true,
-			Terminal:   internalFakeEmbeddedTerminal{state: "running"},
-		}},
-		startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
-			starts++
-			return internalFakeEmbeddedTerminal{state: "running"}, nil
-		},
 		setFlowPhase: func(update flowstore.PhaseUpdate) (flowstore.FlowRecord, error) {
 			failureUpdate = update
 			return flowstore.FlowRecord{}, nil
-		},
-	}
+		}, embeddedTerminalState: embeddedTerminalState{
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Scope:      embeddedTerminalScopeFlow,
+				FlowID:     flowID,
+				FlowRepair: true,
+				Terminal:   internalFakeEmbeddedTerminal{state: "running"},
+			}},
+			startEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
+				starts++
+				return internalFakeEmbeddedTerminal{state: "running"}, nil
+			}}}
 	m.launchSeams.SetPhase = m.setFlowPhase
 	attempt := flowLaunchAttempt{
 		Token:        launchID,

--- a/model/model.go
+++ b/model/model.go
@@ -117,59 +117,32 @@ type Model struct {
 	expandedPRBabysitterFlowID  string
 	selectedPRBabysitterPhaseID string
 	modal                       modal.Modal
-	diffRequestSeq              uint64
-	activeViewRequest           uint64
-	activeViewKind              FetchKind
-	activeViewMode              ui.Mode
-	listRequestSeq              uint64
-	worktreeSessionRequestSeq   uint64
-	activeWorktreeSessionReq    uint64
-	inlineWorktreeSessionRepo   string
-	inlineWorktreeSessionPath   string
-	pendingInlineSessionRepo    string
-	pendingInlineSessionPath    string
-	pendingInlineSessionList    uint64
-	worktreeCreateReq           requestTracker
-	repoCreateReq               requestTracker
-	flowCreateReq               requestTracker
-	readyBeadFlowCreateReq      requestTracker
-	flowPreparationAdmission    bool
-	flowPreparationSeq          uint64
-	flowPreparationOwner        flowPreparationOwner
-	sliceEpicLaunch             sliceEpicLaunchRecord
+	listFetchState
+	flowPreparationAdmission bool
+	flowPreparationSeq       uint64
+	flowPreparationOwner     flowPreparationOwner
+	sliceEpicLaunch          sliceEpicLaunchRecord
 
-	repoRefreshSeq            uint64
-	activeRepoRefresh         uint64
-	pendingRepoSelection      string
-	listRequests              [listRequestSlots]uint64
-	listErrors                [listRequestSlots]string
-	flowDegradations          [listRequestSlots]flowDegradationState
-	gitDegradations           [listRequestSlots]gitDegradationState
-	activePane                ui.Pane
-	repoPaneCollapsed         bool
-	activeFlowSurface         bool
-	takeover                  takeoverMode
-	activeFlowReturnPane      ui.Pane
-	activeFlowReturnContent   ui.Pane
-	activeFlowReturnSet       bool
-	prBabysitterCancel        context.CancelFunc
-	destructive               bool
-	status                    statusError
-	statusSeq                 uint64
-	statusTimer               statusTimerFactory
-	statusSchedule            StatusTimings
-	pendingStatusCmds         []tea.Cmd
-	visibleRepoFetchSeq       uint64
-	visibleRepoFetch          visibleRepoFetchState
-	searchActive              bool
-	pendingBranchSelection    string
-	pendingWorktreeSelection  string
-	agentCommand              string
-	codexModel                string
-	claudeModel               string
-	cursorModel               string
-	codexReasoningEffort      string
-	claudeReasoningEffort     string
+	flowDegradations         [listRequestSlots]flowDegradationState
+	gitDegradations          [listRequestSlots]gitDegradationState
+	activePane               ui.Pane
+	repoPaneCollapsed        bool
+	activeFlowSurface        bool
+	takeover                 takeoverMode
+	activeFlowReturnPane     ui.Pane
+	activeFlowReturnContent  ui.Pane
+	activeFlowReturnSet      bool
+	prBabysitterCancel       context.CancelFunc
+	destructive              bool
+	status                   statusError
+	statusSeq                uint64
+	statusTimer              statusTimerFactory
+	statusSchedule           StatusTimings
+	pendingStatusCmds        []tea.Cmd
+	searchActive             bool
+	pendingBranchSelection   string
+	pendingWorktreeSelection string
+	agentConfig
 	planPromptTemplate        string
 	flowPromptTemplates       FlowPromptTemplates
 	repoCreateRoot            string
@@ -236,17 +209,12 @@ type Model struct {
 	// `list-clients` before the first terminal's client has registered. It is
 	// never the authority — RepoTmuxSessionAttached is — so it needs no expiry
 	// beyond the result message that clears it.
-	repoTmuxTerminalPending  map[string]bool
-	inspectFlowLease         func(string, string) (flowlease.LeaseState, error)
-	leaseInspectInjected     bool
-	tmuxAttachHint           bool
-	startEmbeddedTerminal    EmbeddedTerminalStarter
-	embeddedTerminals        []embeddedTerminalSlot
-	nextEmbeddedTerminalID   int
-	activeTerminalNum        int
-	terminalDockVisible      bool
-	terminalFocus            terminalFocus
-	autoAdvanceDrainFlows    map[string]struct{}
+	repoTmuxTerminalPending map[string]bool
+	inspectFlowLease        func(string, string) (flowlease.LeaseState, error)
+	leaseInspectInjected    bool
+	tmuxAttachHint          bool
+	embeddedTerminalState
+	autoAdvanceState
 	epicProgressionBaselines map[string]flowstore.FlowRecord
 
 	epicProgressionBaselineMinimumRequests map[string]uint64
@@ -281,19 +249,12 @@ type Model struct {
 	interruptAfterFlowLaunch bool
 	launchSeams              flowLaunchSeams
 
-	embeddedTerminalTickGen uint64
 	// Tick cadences for the two 1 Hz poll loops. Zero means the production
 	// default; Options injects a faster value so tests never wait on wall time.
-	autoAdvanceTickInterval time.Duration
 	flowRefreshTickInterval time.Duration
 	flowRefreshTickGen      uint64
 	flowRefreshInFlight     uint64
 	flowRefreshInFlightMode ui.Mode
-	autoAdvanceRequestSeq   uint64
-	autoAdvanceInFlight     uint64
-	autoAdvanceSnapshot     []flowstore.FlowRecord
-	terminalPrefixActive    bool
-	terminalConfirmID       embeddedTerminalID
 	finalizeAgentSession    func(actions.AgentLaunchContext) error
 	sessionStateRoot        string
 	// launchPin is the approach binary agents launched by this Model must run.
@@ -342,6 +303,29 @@ type visibleRepoFetchState struct {
 	FailureNames  []string
 	FailureCount  int
 	CapturedPaths map[string]struct{}
+}
+
+// agentConfig is the command/model/effort cluster shared by Model and Options.
+// Options keeps the exported field names as the public projection; New copies
+// them through agentConfigFromOptions.
+type agentConfig struct {
+	agentCommand          string
+	codexModel            string
+	claudeModel           string
+	cursorModel           string
+	codexReasoningEffort  string
+	claudeReasoningEffort string
+}
+
+func agentConfigFromOptions(opts Options) agentConfig {
+	return agentConfig{
+		agentCommand:          agent.NormalizeStored(opts.AgentCommand),
+		codexModel:            agent.NormalizeModel(opts.CodexModel),
+		claudeModel:           agent.NormalizeModel(opts.ClaudeModel),
+		cursorModel:           agent.NormalizeModel(opts.CursorModel),
+		codexReasoningEffort:  agent.NormalizeReasoningEffort(opts.CodexReasoningEffort),
+		claudeReasoningEffort: agent.NormalizeReasoningEffort(opts.ClaudeReasoningEffort),
+	}
 }
 
 // Options customizes production-only integrations while keeping New(repos)
@@ -1016,23 +1000,28 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	}
 	topMode, bottomMode, contentPane, activeFlowSurface := startupPaneState(ui.ModeBeadsReady)
 	m := Model{
-		repos:                   newRepoPane().SetItems(repos),
-		rows:                    newBranchPane(),
-		stashes:                 newStashPane(),
-		worktrees:               newWorktreePane(),
-		worktreeSessions:        newSessionPane(),
-		commits:                 newCommitPane(),
-		reflogs:                 newReflogPane(),
-		sessions:                newSessionPane(),
-		plans:                   newPlanPane(),
-		flows:                   newFlowPane(),
-		activeFlows:             newFlowPane(),
-		prBabysitterFlows:       newPRBabysitterFlowPane(nil),
-		prBabysitterStatuses:    make(map[string]actions.PullRequestStatus),
-		beads:                   newBeadSubviews(),
-		terminalDockVisible:     true,
+		repos:                newRepoPane().SetItems(repos),
+		rows:                 newBranchPane(),
+		stashes:              newStashPane(),
+		worktrees:            newWorktreePane(),
+		worktreeSessions:     newSessionPane(),
+		commits:              newCommitPane(),
+		reflogs:              newReflogPane(),
+		sessions:             newSessionPane(),
+		plans:                newPlanPane(),
+		flows:                newFlowPane(),
+		activeFlows:          newFlowPane(),
+		prBabysitterFlows:    newPRBabysitterFlowPane(nil),
+		prBabysitterStatuses: make(map[string]actions.PullRequestStatus),
+		beads:                newBeadSubviews(),
+		embeddedTerminalState: embeddedTerminalState{
+			terminalDockVisible:   true,
+			startEmbeddedTerminal: startEmbeddedTerminal,
+		},
+		autoAdvanceState: autoAdvanceState{
+			autoAdvanceTickInterval: opts.AutoAdvanceTickInterval,
+		},
 		flowRefreshTickGen:      1,
-		autoAdvanceTickInterval: opts.AutoAdvanceTickInterval,
 		flowRefreshTickInterval: opts.FlowRefreshTickInterval,
 		statusSchedule:          opts.StatusTimings,
 		topMode:                 topMode,
@@ -1040,12 +1029,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		contentPane:             contentPane,
 		activeFlowSurface:       activeFlowSurface,
 		takeover:                takeoverFromStartup(activeFlowSurface),
-		agentCommand:            agent.NormalizeStored(opts.AgentCommand),
-		codexModel:              agent.NormalizeModel(opts.CodexModel),
-		claudeModel:             agent.NormalizeModel(opts.ClaudeModel),
-		cursorModel:             agent.NormalizeModel(opts.CursorModel),
-		codexReasoningEffort:    agent.NormalizeReasoningEffort(opts.CodexReasoningEffort),
-		claudeReasoningEffort:   agent.NormalizeReasoningEffort(opts.ClaudeReasoningEffort),
+		agentConfig:             agentConfigFromOptions(opts),
 		planPromptTemplate:      opts.PlanPromptTemplate,
 		flowPromptTemplates:     opts.FlowPromptTemplates,
 		repoCreateRoot:          opts.RepoCreateRoot,
@@ -1116,7 +1100,6 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		inspectFlowLease:          inspectFlowLease,
 		leaseInspectInjected:      leaseInspectInjected,
 		tmuxAttachHint:            normalizeLaunchBackend(opts.LaunchBackend) == config.LaunchBackendTmux && tmuxLaunchAvailable(),
-		startEmbeddedTerminal:     startEmbeddedTerminal,
 		finalizeAgentSession:      finalizeAgentSession,
 		sessionStateRoot:          opts.SessionStateRoot,
 		launchPin:                 opts.LaunchPin,
@@ -1526,151 +1509,155 @@ func (m Model) View() string {
 	}
 	modalView := m.modal.View()
 	return ui.Render(ui.RenderParams{
-		Repos:                          repos,
-		ActiveTerminalRepoPaths:        m.activeTerminalRepoPaths(),
-		Selected:                       selected,
-		Width:                          m.width,
-		Height:                         m.height,
-		Mode:                           mode,
-		TopMode:                        m.topMode,
-		BottomMode:                     m.bottomMode,
-		ContentPane:                    m.contentPane,
-		ActiveFlows:                    m.activeFlowSurfaceVisible(),
-		PRBabysitter:                   m.prBabysitterSurfaceVisible(),
-		Branches:                       rows,
-		Stashes:                        stashes,
-		BranchSelected:                 branchSelected,
-		StashSelected:                  stashSelected,
-		Overlay:                        m.overlayState(),
-		OverlayDiff:                    modalView.Diff,
-		OverlayScroll:                  modalView.Scroll,
-		ConfirmPrompt:                  modalView.Prompt,
-		ConfirmForce:                   modalView.Force,
-		InputPrompt:                    modalView.Prompt,
-		InputPlaceholder:               modalView.Placeholder,
-		InputValue:                     modalView.Input,
-		InputError:                     modalView.InputErr,
-		InputMode:                      uiInputMode(modalView.InputMode),
-		InputHeight:                    modalView.InputHeight,
-		InputCursor:                    modalView.InputCursor,
-		Editor:                         uiEditorParams(modalView.Editor),
-		WorktreeInputPrompt:            modalView.Prompt,
-		WorktreeInputPlaceholder:       modalView.Placeholder,
-		WorktreeInput:                  modalView.Input,
-		WorktreeInputErr:               modalView.InputErr,
-		SelectPrompt:                   modalView.Prompt,
-		SelectItems:                    uiSelectItems(modalView.SelectItems),
-		SelectSelected:                 modalView.SelectIndex,
-		SelectWidth:                    modalView.SelectLayout.Width,
-		SelectHeight:                   modalView.SelectLayout.Height,
-		SelectNote:                     modalView.SelectNote,
-		SelectNoteKind:                 uiNoteKind(modalView.SelectNoteKind),
-		SelectPlacement:                uiSelectPlacement(modalView.SelectLayout.Placement),
-		Form:                           uiFormView(modalView.Form),
-		BranchScroll:                   branchScroll,
-		RepoScroll:                     repoScroll,
-		StashScroll:                    stashScroll,
-		ActivePane:                     m.activePane,
-		RepoPaneCollapsed:              m.repoPaneCollapsed,
-		Destructive:                    m.destructive,
-		Worktrees:                      worktrees,
-		WorktreeSelected:               worktreeSelected,
-		WorktreeScroll:                 worktreeScroll,
-		WorktreeSessions:               worktreeSessions,
-		WorktreeSessionSelected:        worktreeSessionSelected,
-		WorktreeSessionScroll:          worktreeSessionScroll,
-		InlineWorktreeSessions:         m.inlineWorktreeSessionPath != "",
-		Commits:                        commits,
-		CommitSelected:                 commitSelected,
-		CommitScroll:                   commitScroll,
-		Reflogs:                        reflogs,
-		ReflogSelected:                 reflogSelected,
-		ReflogScroll:                   reflogScroll,
-		Sessions:                       sessions,
-		SessionSelected:                sessionSelected,
-		SessionScroll:                  sessionScroll,
-		EmbeddedTerminals:              m.embeddedTerminalTabs(),
-		EmbeddedTerminalLines:          m.embeddedTerminalLines(),
-		EmbeddedTerminalPrefix:         m.terminalPrefixActive,
-		EmbeddedTerminalVisible:        m.terminalDockVisible,
-		EmbeddedTerminalFocused:        m.terminalEffectivelyExpanded() && m.activePane != ui.PaneRepos && m.terminalFocus == terminalFocusTerminal,
-		Plans:                          plans,
-		PlanSelected:                   planSelected,
-		PlanScroll:                     planScroll,
-		Flows:                          flows,
-		PRBabysitterRows:               m.prBabysitterRows(flows),
-		FlowSelected:                   flowSelected,
-		FlowScroll:                     flowScroll,
-		FlowDegradationWarning:         m.flowDegradationWarning(ui.ModeFlows),
-		ActiveFlowDegradationWarning:   m.flowDegradationWarning(ui.ModeActiveFlows),
-		PRBabysitterDegradationWarning: m.flowDegradationWarning(ui.ModePRBabysitter),
-		BeadsOpen:                      beadsActive,
-		BeadsOpenSelected:              beadsSelected,
-		BeadsOpenScroll:                beadsScroll,
-		BeadsOpenAvailable:             beadsAvailable,
-		BeadsOpenPending:               beadsPending,
-		ReadyBeadFlowCreateAvailable:   m.canCreateReadyBeadFlow(),
-		ReadyBeadFlowStartAvailable:    m.canStartReadyBeadFlow(),
-		ReadyBeadFlowKeysOwned:         m.readyBeadFlowKeysOwned(),
-		BeadSliceEpicAvailable:         m.canSliceSelectedEpic(),
-		EpicAutoOnAvailable:            m.canEnableEpicProgression(),
-		EpicAutoOffAvailable:           m.canDisableEpicProgression(),
-		EpicAutoKeyOwned:               m.epicProgressionKeysOwned(),
-		BeadsError:                     beadsError,
-		BeadsQuery:                     beadsQuery,
-		BeadsSourceCount:               beadsSourceCount,
-		BeadsClosedTotal:               beadsClosedTotal,
-		BeadExpansion:                  cloneBeadExpansion(m.beadExpansion.projection),
-		FlowTerminalActivity:           m.flowTerminalActivity(),
-		ExpandedPlanID:                 m.expandedPlanID,
-		ExpandedFlowID:                 m.currentExpandedFlowID(),
-		SelectedPlanPhaseID:            m.selectedPlanPhaseID,
-		SelectedFlowPhaseID:            m.currentSelectedFlowPhaseID(),
-		FlowHeadless:                   m.selectedFlowHeadless(),
-		FlowAutoModeSelected:           flowAutoModeSelected,
-		FlowIssueTargetSelected:        flowIssueTargetSelected,
-		FlowPRTargetSelected:           flowPRTargetSelected,
-		FlowAgentLabel:                 m.flowAgentShortcutLabel(),
-		FlowModel:                      m.flowModelLabel(),
-		FlowReasoningEffort:            m.flowReasoningEffortLabel(),
-		FlowNextLaunchReady:            m.selectedFlowHasLaunchablePhase(),
-		FlowWorktreeAgentReady:         m.selectedFlowWorktreeAgentReady(),
-		FlowRepairReady:                m.selectedFlowRepairReady(),
-		FlowManualMergeReadySelected:   m.selectedFlowManualMergeReady(),
-		FlowAutofixReadySelected:       m.selectedFlowAutofixReady(),
-		FlowCloseActionSelected:        m.selectedFlowCloseActionHint(),
-		FlowPhaseResetReadySelected:    m.selectedFlowPhaseResettable(),
-		FlowPhaseReleaseSelected:       m.selectedFlowPhaseSessionReleasable(),
-		FlowPhaseResumableSelected:     m.selectedFlowPhaseResumable(),
-		OverlayText:                    modalView.Text,
-		TransientError:                 m.visibleStatusText(),
-		TransientErrorFadeStep:         m.visibleStatusFadeStep(),
-		SearchActive:                   m.searchActive,
-		RepoSearch:                     m.repos.Query(),
-		ItemSearch:                     m.activeItemPaneQuery(),
-		ItemSourceCount:                m.activeItemPaneSourceCount(),
-		TopItemSearch:                  m.itemPaneQuery(m.topMode),
-		BottomItemSearch:               m.itemPaneQuery(m.bottomMode),
-		TopItemSourceCount:             m.itemPaneSourceCount(m.topMode),
-		BottomItemSourceCount:          m.itemPaneSourceCount(m.bottomMode),
-		RepoEmptyMessage:               repoEmptyMessage,
-		RightEmptyMessage:              rightEmptyMessage,
-		TopListError:                   m.currentListError(m.topMode),
-		BottomListError:                m.currentListError(m.bottomMode),
-		TopDegradationWarning:          m.gitDegradationWarning(m.topMode),
-		BottomDegradationWarning:       m.gitDegradationWarning(m.bottomMode),
-		ActiveFlowsListError:           m.currentListError(ui.ModeActiveFlows),
-		PRBabysitterListError:          m.currentListError(ui.ModePRBabysitter),
-		FetchAvailable:                 m.canFetch(),
-		FetchVisibleAvailable:          m.canFetchVisibleRepos(),
-		RepoCreateAvailable:            m.canCreateRepo(),
-		PullAvailable:                  m.canPull(),
-		WorktreeMoveAvailable:          m.canMoveWorktree(),
-		WorktreeSessionsOpen:           m.inlineWorktreeSessionPath != "",
-		AgentAvailable:                 m.canLaunchAgent(),
-		NewAgentAvailable:              m.canCreateAndLaunchAgent(),
-		TmuxAttachAvailable:            m.tmuxModeAttachAvailable(),
-	})
+		Repos:                        repos,
+		ActiveTerminalRepoPaths:      m.activeTerminalRepoPaths(),
+		Selected:                     selected,
+		Width:                        m.width,
+		Height:                       m.height,
+		Mode:                         mode,
+		TopMode:                      m.topMode,
+		BottomMode:                   m.bottomMode,
+		ContentPane:                  m.contentPane,
+		Branches:                     rows,
+		Stashes:                      stashes,
+		BranchSelected:               branchSelected,
+		StashSelected:                stashSelected,
+		BranchScroll:                 branchScroll,
+		RepoScroll:                   repoScroll,
+		StashScroll:                  stashScroll,
+		ActivePane:                   m.activePane,
+		RepoPaneCollapsed:            m.repoPaneCollapsed,
+		Destructive:                  m.destructive,
+		Worktrees:                    worktrees,
+		WorktreeSelected:             worktreeSelected,
+		WorktreeScroll:               worktreeScroll,
+		WorktreeSessions:             worktreeSessions,
+		WorktreeSessionSelected:      worktreeSessionSelected,
+		WorktreeSessionScroll:        worktreeSessionScroll,
+		InlineWorktreeSessions:       m.inlineWorktreeSessionPath != "",
+		Commits:                      commits,
+		CommitSelected:               commitSelected,
+		CommitScroll:                 commitScroll,
+		Reflogs:                      reflogs,
+		ReflogSelected:               reflogSelected,
+		ReflogScroll:                 reflogScroll,
+		Sessions:                     sessions,
+		SessionSelected:              sessionSelected,
+		SessionScroll:                sessionScroll,
+		Plans:                        plans,
+		PlanSelected:                 planSelected,
+		PlanScroll:                   planScroll,
+		BeadsOpen:                    beadsActive,
+		BeadsOpenSelected:            beadsSelected,
+		BeadsOpenScroll:              beadsScroll,
+		BeadsOpenAvailable:           beadsAvailable,
+		BeadsOpenPending:             beadsPending,
+		ReadyBeadFlowCreateAvailable: m.canCreateReadyBeadFlow(),
+		ReadyBeadFlowStartAvailable:  m.canStartReadyBeadFlow(),
+		ReadyBeadFlowKeysOwned:       m.readyBeadFlowKeysOwned(),
+		BeadSliceEpicAvailable:       m.canSliceSelectedEpic(),
+		EpicAutoOnAvailable:          m.canEnableEpicProgression(),
+		EpicAutoOffAvailable:         m.canDisableEpicProgression(),
+		EpicAutoKeyOwned:             m.epicProgressionKeysOwned(),
+		BeadsError:                   beadsError,
+		BeadsQuery:                   beadsQuery,
+		BeadsSourceCount:             beadsSourceCount,
+		BeadsClosedTotal:             beadsClosedTotal,
+		BeadExpansion:                cloneBeadExpansion(m.beadExpansion.projection),
+		ExpandedPlanID:               m.expandedPlanID,
+		SelectedPlanPhaseID:          m.selectedPlanPhaseID,
+		TransientError:               m.visibleStatusText(),
+		TransientErrorFadeStep:       m.visibleStatusFadeStep(),
+		SearchActive:                 m.searchActive,
+		RepoSearch:                   m.repos.Query(),
+		ItemSearch:                   m.activeItemPaneQuery(),
+		ItemSourceCount:              m.activeItemPaneSourceCount(),
+		TopItemSearch:                m.itemPaneQuery(m.topMode),
+		BottomItemSearch:             m.itemPaneQuery(m.bottomMode),
+		TopItemSourceCount:           m.itemPaneSourceCount(m.topMode),
+		BottomItemSourceCount:        m.itemPaneSourceCount(m.bottomMode),
+		RepoEmptyMessage:             repoEmptyMessage,
+		RightEmptyMessage:            rightEmptyMessage,
+		TopListError:                 m.currentListError(m.topMode),
+		BottomListError:              m.currentListError(m.bottomMode),
+		TopDegradationWarning:        m.gitDegradationWarning(m.topMode),
+		BottomDegradationWarning:     m.gitDegradationWarning(m.bottomMode),
+		FetchAvailable:               m.canFetch(),
+		FetchVisibleAvailable:        m.canFetchVisibleRepos(),
+		RepoCreateAvailable:          m.canCreateRepo(),
+		PullAvailable:                m.canPull(),
+		WorktreeMoveAvailable:        m.canMoveWorktree(),
+		WorktreeSessionsOpen:         m.inlineWorktreeSessionPath != "",
+		AgentAvailable:               m.canLaunchAgent(),
+		NewAgentAvailable:            m.canCreateAndLaunchAgent(),
+		TmuxAttachAvailable:          m.tmuxModeAttachAvailable(),
+		OverlayParams: ui.OverlayParams{
+			Overlay:                  m.overlayState(),
+			OverlayDiff:              modalView.Diff,
+			OverlayScroll:            modalView.Scroll,
+			ConfirmPrompt:            modalView.Prompt,
+			ConfirmForce:             modalView.Force,
+			InputPrompt:              modalView.Prompt,
+			InputPlaceholder:         modalView.Placeholder,
+			InputValue:               modalView.Input,
+			InputError:               modalView.InputErr,
+			InputMode:                uiInputMode(modalView.InputMode),
+			InputHeight:              modalView.InputHeight,
+			InputCursor:              modalView.InputCursor,
+			Editor:                   uiEditorParams(modalView.Editor),
+			WorktreeInputPrompt:      modalView.Prompt,
+			WorktreeInputPlaceholder: modalView.Placeholder,
+			WorktreeInput:            modalView.Input,
+			WorktreeInputErr:         modalView.InputErr,
+			SelectPrompt:             modalView.Prompt,
+			SelectItems:              uiSelectItems(modalView.SelectItems),
+			SelectSelected:           modalView.SelectIndex,
+			SelectWidth:              modalView.SelectLayout.Width,
+			SelectHeight:             modalView.SelectLayout.Height,
+			SelectNote:               modalView.SelectNote,
+			SelectNoteKind:           uiNoteKind(modalView.SelectNoteKind),
+			SelectPlacement:          uiSelectPlacement(modalView.SelectLayout.Placement),
+			Form:                     uiFormView(modalView.Form),
+			OverlayText:              modalView.Text,
+		},
+		FlowParams: ui.FlowParams{
+			ActiveFlows:                    m.activeFlowSurfaceVisible(),
+			PRBabysitter:                   m.prBabysitterSurfaceVisible(),
+			Flows:                          flows,
+			PRBabysitterRows:               m.prBabysitterRows(flows),
+			FlowSelected:                   flowSelected,
+			FlowScroll:                     flowScroll,
+			FlowDegradationWarning:         m.flowDegradationWarning(ui.ModeFlows),
+			ActiveFlowDegradationWarning:   m.flowDegradationWarning(ui.ModeActiveFlows),
+			PRBabysitterDegradationWarning: m.flowDegradationWarning(ui.ModePRBabysitter),
+			ExpandedFlowID:                 m.currentExpandedFlowID(),
+			SelectedFlowPhaseID:            m.currentSelectedFlowPhaseID(),
+			FlowHeadless:                   m.selectedFlowHeadless(),
+			FlowAutoModeSelected:           flowAutoModeSelected,
+			FlowIssueTargetSelected:        flowIssueTargetSelected,
+			FlowPRTargetSelected:           flowPRTargetSelected,
+			FlowAgentLabel:                 m.flowAgentShortcutLabel(),
+			FlowModel:                      m.flowModelLabel(),
+			FlowReasoningEffort:            m.flowReasoningEffortLabel(),
+			FlowNextLaunchReady:            m.selectedFlowHasLaunchablePhase(),
+			FlowWorktreeAgentReady:         m.selectedFlowWorktreeAgentReady(),
+			FlowRepairReady:                m.selectedFlowRepairReady(),
+			FlowManualMergeReadySelected:   m.selectedFlowManualMergeReady(),
+			FlowAutofixReadySelected:       m.selectedFlowAutofixReady(),
+			FlowCloseActionSelected:        m.selectedFlowCloseActionHint(),
+			FlowPhaseResetReadySelected:    m.selectedFlowPhaseResettable(),
+			FlowPhaseReleaseSelected:       m.selectedFlowPhaseSessionReleasable(),
+			FlowPhaseResumableSelected:     m.selectedFlowPhaseResumable(),
+			ActiveFlowsListError:           m.currentListError(ui.ModeActiveFlows),
+			PRBabysitterListError:          m.currentListError(ui.ModePRBabysitter),
+		},
+		EmbeddedTerminalParams: ui.EmbeddedTerminalParams{
+			EmbeddedTerminals:       m.embeddedTerminalTabs(),
+			EmbeddedTerminalLines:   m.embeddedTerminalLines(),
+			EmbeddedTerminalPrefix:  m.terminalPrefixActive,
+			EmbeddedTerminalVisible: m.terminalDockVisible,
+			EmbeddedTerminalFocused: m.terminalEffectivelyExpanded() && m.activePane != ui.PaneRepos && m.terminalFocus == terminalFocusTerminal,
+			FlowTerminalActivity:    m.flowTerminalActivity()}})
 }
 
 func (m Model) repoEmptyMessage(filteredRepos int) string {

--- a/model/request_tracker.go
+++ b/model/request_tracker.go
@@ -1,5 +1,34 @@
 package model
 
+import "github.com/approachcontrol/approach/ui"
+
+// listFetchState is the in-flight list/diff/create request cluster on Model.
+type listFetchState struct {
+	diffRequestSeq            uint64
+	activeViewRequest         uint64
+	activeViewKind            FetchKind
+	activeViewMode            ui.Mode
+	listRequestSeq            uint64
+	worktreeSessionRequestSeq uint64
+	activeWorktreeSessionReq  uint64
+	inlineWorktreeSessionRepo string
+	inlineWorktreeSessionPath string
+	pendingInlineSessionRepo  string
+	pendingInlineSessionPath  string
+	pendingInlineSessionList  uint64
+	worktreeCreateReq         requestTracker
+	repoCreateReq             requestTracker
+	flowCreateReq             requestTracker
+	readyBeadFlowCreateReq    requestTracker
+	repoRefreshSeq            uint64
+	activeRepoRefresh         uint64
+	pendingRepoSelection      string
+	listRequests              [listRequestSlots]uint64
+	listErrors                [listRequestSlots]string
+	visibleRepoFetchSeq       uint64
+	visibleRepoFetch          visibleRepoFetchState
+}
+
 // requestTracker is a single in-flight request ID. next issues the next ID and
 // makes it current; clear drops the current ID after it lands; invalidate
 // makes any in-flight ID stale without issuing a replacement.

--- a/ui/pr_babysitter_test.go
+++ b/ui/pr_babysitter_test.go
@@ -87,24 +87,23 @@ func TestRenderPRBabysitterPaneExpandsPhasesAndTruncatesNarrowRows(t *testing.T)
 func TestRenderPRBabysitterTakeoverKeepsHeadersEmptyStatesWarningsAndTerminalDock(t *testing.T) {
 	flow := flowstore.FlowRecord{FlowID: "flow-1", Title: "Watch me", RepoPath: "/dev/approach"}
 	view := ansi.Strip(Render(RenderParams{
-		Width:                          150,
-		Height:                         30,
-		Mode:                           ModePRBabysitter,
-		TopMode:                        ModeWorktrees,
-		BottomMode:                     ModeFlows,
-		ContentPane:                    PaneBottom,
-		PRBabysitter:                   true,
-		Flows:                          []flowstore.FlowRecord{flow},
-		PRBabysitterRows:               []PRBabysitterRow{{Flow: flow, Repo: "approach", Title: "Watch me", Mergeability: "unknown", Checks: "pending"}},
-		PRBabysitterListError:          "temporary failure",
-		PRBabysitterDegradationWarning: "Skipped 1 unreadable Flow",
-		EmbeddedTerminals:              []EmbeddedTerminalTab{{Number: 1, Provider: "codex", Active: true}},
-		EmbeddedTerminalVisible:        true,
-		EmbeddedTerminalLines:          []string{"terminal output"},
-		ActivePane:                     PaneBottom,
-		Selected:                       0,
-		FlowSelected:                   0,
-	}))
+		Width:       150,
+		Height:      30,
+		Mode:        ModePRBabysitter,
+		TopMode:     ModeWorktrees,
+		BottomMode:  ModeFlows,
+		ContentPane: PaneBottom,
+		ActivePane:  PaneBottom,
+		Selected:    0, FlowParams: FlowParams{
+			PRBabysitter:                   true,
+			Flows:                          []flowstore.FlowRecord{flow},
+			PRBabysitterRows:               []PRBabysitterRow{{Flow: flow, Repo: "approach", Title: "Watch me", Mergeability: "unknown", Checks: "pending"}},
+			PRBabysitterListError:          "temporary failure",
+			PRBabysitterDegradationWarning: "Skipped 1 unreadable Flow",
+			FlowSelected:                   0}, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals:       []EmbeddedTerminalTab{{Number: 1, Provider: "codex", Active: true}},
+			EmbeddedTerminalVisible: true,
+			EmbeddedTerminalLines:   []string{"terminal output"}}}))
 	for _, want := range []string{"[^p] PR babysitter", "^a active flows", "showing cached data", "Skipped 1 unreadable Flow", "Watch me", "terminal output", "ctrl+p"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("takeover missing %q:\n%s", want, view)
@@ -112,9 +111,8 @@ func TestRenderPRBabysitterTakeoverKeepsHeadersEmptyStatesWarningsAndTerminalDoc
 	}
 
 	empty := ansi.Strip(Render(RenderParams{
-		Width: 100, Height: 20, Mode: ModePRBabysitter, TopMode: ModeWorktrees, BottomMode: ModeFlows,
-		PRBabysitter: true, RightEmptyMessage: "loading PR babysitter", Selected: 0,
-	}))
+		Width: 100, Height: 20, Mode: ModePRBabysitter, TopMode: ModeWorktrees, BottomMode: ModeFlows, RightEmptyMessage: "loading PR babysitter", Selected: 0, FlowParams: FlowParams{
+			PRBabysitter: true}}))
 	if !strings.Contains(empty, "loading PR babysitter") {
 		t.Fatalf("initial loading state missing:\n%s", empty)
 	}

--- a/ui/prompt_editor_test.go
+++ b/ui/prompt_editor_test.go
@@ -12,21 +12,20 @@ import (
 
 func editorParams(width, height int, value string, cursor int) RenderParams {
 	return RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:       width,
-		Height:      height,
-		Mode:        ModePlans,
-		Overlay:     OverlayInput,
-		InputPrompt: "Edit Plan launch",
-		InputValue:  value,
-		InputCursor: cursor,
-		InputMode:   InputMultiLine,
-		Editor: EditorParams{
-			Enabled:  true,
-			Title:    "Plan launch",
-			Identity: "agent.plan_prompt  custom",
-		},
-	}
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  width,
+		Height: height,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:     OverlayInput,
+			InputPrompt: "Edit Plan launch",
+			InputValue:  value,
+			InputCursor: cursor,
+			InputMode:   InputMultiLine,
+			Editor: EditorParams{
+				Enabled:  true,
+				Title:    "Plan launch",
+				Identity: "agent.plan_prompt  custom",
+			}}}
 }
 
 // panelBounds reports the rendered editor panel's outer width and row count by
@@ -437,17 +436,16 @@ func TestRender_PromptTemplatePickerReservesANoteRow(t *testing.T) {
 		items[i] = SelectItem{Label: "Template", Value: "t"}
 	}
 	base := RenderParams{
-		Repos:           []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:           80,
-		Height:          24,
-		Mode:            ModePlans,
-		Overlay:         OverlaySelect,
-		SelectPrompt:    PromptTemplateSelectPrompt,
-		SelectItems:     items,
-		SelectWidth:     PromptPickerWidth,
-		SelectHeight:    len(items) + 3 + PromptPickerNoteRows,
-		SelectPlacement: SelectPlacementCenter,
-	}
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:         OverlaySelect,
+			SelectPrompt:    PromptTemplateSelectPrompt,
+			SelectItems:     items,
+			SelectWidth:     PromptPickerWidth,
+			SelectHeight:    len(items) + 3 + PromptPickerNoteRows,
+			SelectPlacement: SelectPlacementCenter}}
 
 	wantRows := len(items) + 3 + PromptPickerNoteRows
 	plainRows := overlaySelectPanelRows(t, Render(base), PromptPickerWidth)
@@ -502,14 +500,13 @@ func TestRenderSelectPanelDropsNoteBeforeStealingItemRows(t *testing.T) {
 func TestRender_SelectPanelWithoutANoteKeepsItsAutoGeometry(t *testing.T) {
 	items := []SelectItem{{Label: "codex", Value: "codex"}, {Label: "claude", Value: "claude"}}
 	view := Render(RenderParams{
-		Repos:        []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:        80,
-		Height:       24,
-		Mode:         ModeWorktrees,
-		Overlay:      OverlaySelect,
-		SelectPrompt: "Choose agent",
-		SelectItems:  items,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   ModeWorktrees, OverlayParams: OverlayParams{
+			Overlay:      OverlaySelect,
+			SelectPrompt: "Choose agent",
+			SelectItems:  items}})
 	if rows := overlaySelectPanelRows(t, view, autoSelectPanelWidth("Choose agent", items)); rows != 2+1+len(items) {
 		t.Fatalf("auto select panel rows = %d, want %d", rows, 2+1+len(items))
 	}
@@ -525,16 +522,15 @@ func TestRender_PromptEditorStatusBarReplacesTheGenericMultilineHints(t *testing
 	}
 
 	generic := ansi.Strip(Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:       80,
-		Height:      24,
-		Mode:        ModePlans,
-		Overlay:     OverlayInput,
-		InputPrompt: "Launch instructions",
-		InputValue:  "body",
-		InputCursor: 4,
-		InputMode:   InputMultiLine,
-	}))
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:     OverlayInput,
+			InputPrompt: "Launch instructions",
+			InputValue:  "body",
+			InputCursor: 4,
+			InputMode:   InputMultiLine}}))
 	if !strings.Contains(generic, "alt+enter: newline") {
 		t.Fatalf("generic multiline input lost its hints:\n%s", generic)
 	}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -390,78 +390,41 @@ const (
 const StashPrefixWidth = 15
 
 // RenderParams holds everything the renderer needs.
-type RenderParams struct {
-	Repos                          []scanner.Repo
-	ActiveTerminalRepoPaths        map[string]bool
-	Selected                       int
-	Width                          int
-	Height                         int
-	Mode                           Mode
-	TopMode                        Mode
-	BottomMode                     Mode
-	ContentPane                    Pane
+// OverlayParams groups modal/overlay fields on RenderParams.
+type OverlayParams struct {
+	Overlay                  OverlayState
+	OverlayDiff              string
+	OverlayScroll            int
+	ConfirmPrompt            string
+	ConfirmForce             bool
+	InputPrompt              string
+	InputPlaceholder         string
+	InputValue               string
+	InputError               string
+	InputMode                InputMode
+	InputHeight              int
+	InputCursor              int
+	Editor                   EditorParams
+	WorktreeInputPrompt      string
+	WorktreeInputPlaceholder string
+	WorktreeInput            string
+	WorktreeInputErr         string
+	SelectPrompt             string
+	SelectItems              []SelectItem
+	SelectSelected           int
+	SelectWidth              int
+	SelectHeight             int
+	SelectNote               string
+	SelectNoteKind           NoteKind
+	SelectPlacement          SelectPlacement
+	Form                     FormView
+	OverlayText              string
+}
+
+// FlowParams groups Flow-surface fields on RenderParams.
+type FlowParams struct {
 	ActiveFlows                    bool
 	PRBabysitter                   bool
-	Branches                       []gitquery.BranchRow
-	Stashes                        []gitquery.Stash
-	BranchSelected                 int
-	StashSelected                  int
-	Overlay                        OverlayState
-	OverlayDiff                    string
-	OverlayScroll                  int
-	ConfirmPrompt                  string
-	ConfirmForce                   bool
-	InputPrompt                    string
-	InputPlaceholder               string
-	InputValue                     string
-	InputError                     string
-	InputMode                      InputMode
-	InputHeight                    int
-	InputCursor                    int
-	Editor                         EditorParams
-	WorktreeInputPrompt            string
-	WorktreeInputPlaceholder       string
-	WorktreeInput                  string
-	WorktreeInputErr               string
-	SelectPrompt                   string
-	SelectItems                    []SelectItem
-	SelectSelected                 int
-	SelectWidth                    int
-	SelectHeight                   int
-	SelectNote                     string
-	SelectNoteKind                 NoteKind
-	SelectPlacement                SelectPlacement
-	Form                           FormView
-	BranchScroll                   int
-	RepoScroll                     int
-	StashScroll                    int
-	ActivePane                     Pane
-	RepoPaneCollapsed              bool
-	Destructive                    bool
-	Worktrees                      []gitquery.Worktree
-	WorktreeSelected               int
-	WorktreeScroll                 int
-	WorktreeSessions               []sessions.SessionRecord
-	WorktreeSessionSelected        int
-	WorktreeSessionScroll          int
-	InlineWorktreeSessions         bool
-	Commits                        []gitquery.Commit
-	CommitSelected                 int
-	CommitScroll                   int
-	Reflogs                        []gitquery.ReflogEntry
-	ReflogSelected                 int
-	ReflogScroll                   int
-	Sessions                       []sessions.SessionRecord
-	SessionSelected                int
-	SessionScroll                  int
-	EmbeddedTerminals              []EmbeddedTerminalTab
-	EmbeddedTerminalLines          []string
-	EmbeddedTerminalPrefix         bool
-	EmbeddedTerminalVisible        bool
-	EmbeddedTerminalFocused        bool
-	Plans                          []planstore.PlanRecord
-	PlanSelected                   int
-	PlanScroll                     int
 	Flows                          []flowstore.FlowRecord
 	PRBabysitterRows               []PRBabysitterRow
 	FlowSelected                   int
@@ -469,29 +432,7 @@ type RenderParams struct {
 	FlowDegradationWarning         string
 	ActiveFlowDegradationWarning   string
 	PRBabysitterDegradationWarning string
-	TopDegradationWarning          string
-	BottomDegradationWarning       string
-	BeadsOpen                      []beadsquery.Bead
-	BeadsOpenSelected              int
-	BeadsOpenScroll                int
-	BeadsOpenAvailable             bool
-	BeadsOpenPending               bool
-	ReadyBeadFlowCreateAvailable   bool
-	ReadyBeadFlowStartAvailable    bool
-	ReadyBeadFlowKeysOwned         bool
-	BeadSliceEpicAvailable         bool
-	EpicAutoOnAvailable            bool
-	EpicAutoOffAvailable           bool
-	EpicAutoKeyOwned               bool
-	BeadsError                     string
-	BeadsQuery                     string
-	BeadsSourceCount               int
-	BeadsClosedTotal               int
-	BeadExpansion                  BeadExpansion
-	FlowTerminalActivity           []FlowTerminalActivity
-	ExpandedPlanID                 string
 	ExpandedFlowID                 string
-	SelectedPlanPhaseID            string
 	SelectedFlowPhaseID            string
 	FlowHeadless                   bool
 	FlowAutoModeSelected           bool
@@ -509,31 +450,105 @@ type RenderParams struct {
 	FlowPhaseResetReadySelected    bool
 	FlowPhaseReleaseSelected       bool
 	FlowPhaseResumableSelected     bool
-	OverlayText                    string
-	TransientError                 string
-	TransientErrorFadeStep         int
-	SearchActive                   bool
-	RepoSearch                     string
-	ItemSearch                     string
-	ItemSourceCount                int
-	TopItemSearch                  string
-	BottomItemSearch               string
-	TopItemSourceCount             int
-	BottomItemSourceCount          int
-	RepoEmptyMessage               string
-	RightEmptyMessage              string
-	TopListError                   string
-	BottomListError                string
 	ActiveFlowsListError           string
 	PRBabysitterListError          string
-	FetchAvailable                 bool
-	FetchVisibleAvailable          bool
-	RepoCreateAvailable            bool
-	PullAvailable                  bool
-	WorktreeMoveAvailable          bool
-	WorktreeSessionsOpen           bool
-	AgentAvailable                 bool
-	NewAgentAvailable              bool
+}
+
+// EmbeddedTerminalParams groups docked-terminal fields on RenderParams.
+type EmbeddedTerminalParams struct {
+	EmbeddedTerminals       []EmbeddedTerminalTab
+	EmbeddedTerminalLines   []string
+	EmbeddedTerminalPrefix  bool
+	EmbeddedTerminalVisible bool
+	EmbeddedTerminalFocused bool
+	FlowTerminalActivity    []FlowTerminalActivity
+}
+
+type RenderParams struct {
+	Repos                   []scanner.Repo
+	ActiveTerminalRepoPaths map[string]bool
+	Selected                int
+	Width                   int
+	Height                  int
+	Mode                    Mode
+	TopMode                 Mode
+	BottomMode              Mode
+	ContentPane             Pane
+	Branches                []gitquery.BranchRow
+	Stashes                 []gitquery.Stash
+	BranchSelected          int
+	StashSelected           int
+	OverlayParams
+	FlowParams
+	EmbeddedTerminalParams
+	BranchScroll                 int
+	RepoScroll                   int
+	StashScroll                  int
+	ActivePane                   Pane
+	RepoPaneCollapsed            bool
+	Destructive                  bool
+	Worktrees                    []gitquery.Worktree
+	WorktreeSelected             int
+	WorktreeScroll               int
+	WorktreeSessions             []sessions.SessionRecord
+	WorktreeSessionSelected      int
+	WorktreeSessionScroll        int
+	InlineWorktreeSessions       bool
+	Commits                      []gitquery.Commit
+	CommitSelected               int
+	CommitScroll                 int
+	Reflogs                      []gitquery.ReflogEntry
+	ReflogSelected               int
+	ReflogScroll                 int
+	Sessions                     []sessions.SessionRecord
+	SessionSelected              int
+	SessionScroll                int
+	Plans                        []planstore.PlanRecord
+	PlanSelected                 int
+	PlanScroll                   int
+	TopDegradationWarning        string
+	BottomDegradationWarning     string
+	BeadsOpen                    []beadsquery.Bead
+	BeadsOpenSelected            int
+	BeadsOpenScroll              int
+	BeadsOpenAvailable           bool
+	BeadsOpenPending             bool
+	ReadyBeadFlowCreateAvailable bool
+	ReadyBeadFlowStartAvailable  bool
+	ReadyBeadFlowKeysOwned       bool
+	BeadSliceEpicAvailable       bool
+	EpicAutoOnAvailable          bool
+	EpicAutoOffAvailable         bool
+	EpicAutoKeyOwned             bool
+	BeadsError                   string
+	BeadsQuery                   string
+	BeadsSourceCount             int
+	BeadsClosedTotal             int
+	BeadExpansion                BeadExpansion
+	ExpandedPlanID               string
+	SelectedPlanPhaseID          string
+	TransientError               string
+	TransientErrorFadeStep       int
+	SearchActive                 bool
+	RepoSearch                   string
+	ItemSearch                   string
+	ItemSourceCount              int
+	TopItemSearch                string
+	BottomItemSearch             string
+	TopItemSourceCount           int
+	BottomItemSourceCount        int
+	RepoEmptyMessage             string
+	RightEmptyMessage            string
+	TopListError                 string
+	BottomListError              string
+	FetchAvailable               bool
+	FetchVisibleAvailable        bool
+	RepoCreateAvailable          bool
+	PullAvailable                bool
+	WorktreeMoveAvailable        bool
+	WorktreeSessionsOpen         bool
+	AgentAvailable               bool
+	NewAgentAvailable            bool
 	// TmuxAttachAvailable reports that [launch].backend is "tmux" and tmux is
 	// installed, so the T attach affordance has something to offer.
 	TmuxAttachAvailable bool

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -16,29 +16,28 @@ import (
 
 func TestRender_FlowsModeShowsHeaderAndRows(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    230,
-		Height:   10,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Add Flow mode",
-			Status:       flowstore.StatusInProgress,
-			Branch:       "flow/add-flow-mode",
-			WorktreePath: "/dev/approach-worktrees/flow-add-flow-mode",
-			PlanID:       "plan-1",
-			Issue:        flowstore.Issue{Number: 456, URL: "https://github.com/approachcontrol/approach/issues/456"},
-			PR:           flowstore.PullRequest{Number: 123, URL: "https://github.com/approachcontrol/approach/pull/123"},
-			UpdatedAt:    time.Date(2026, 6, 7, 14, 0, 0, 0, time.UTC),
-			Phases: []flowstore.FlowPhase{
-				{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted, Order: 1},
-				{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseReady, Order: 2},
-			},
-		}},
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      230,
+		Height:     10,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Add Flow mode",
+				Status:       flowstore.StatusInProgress,
+				Branch:       "flow/add-flow-mode",
+				WorktreePath: "/dev/approach-worktrees/flow-add-flow-mode",
+				PlanID:       "plan-1",
+				Issue:        flowstore.Issue{Number: 456, URL: "https://github.com/approachcontrol/approach/issues/456"},
+				PR:           flowstore.PullRequest{Number: 123, URL: "https://github.com/approachcontrol/approach/pull/123"},
+				UpdatedAt:    time.Date(2026, 6, 7, 14, 0, 0, 0, time.UTC),
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted, Order: 1},
+					{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseReady, Order: 2},
+				},
+			}},
+			FlowSelected: 0}})
 
 	for _, want := range []string{"[4] flows", "Status", "Branch", "Phase", "Issue", "Plan", "PR", "Updated", "Title", "in_progress", "flow/add-flow-mode", "1/2", "#456", "plan-1", "#123", "2026-06-07", "Add Flow mode"} {
 		if !strings.Contains(view, want) {
@@ -98,23 +97,22 @@ func TestRender_FlowTitleIsTerminalSafeSingleLine(t *testing.T) {
 
 func TestRender_FlowsModeShowsMissingIssueCell(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    230,
-		Height:   10,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:    "flow-1",
-			Title:     "Flow without issue",
-			Status:    flowstore.StatusInProgress,
-			Branch:    "flow/no-issue",
-			PlanID:    "plan-1",
-			UpdatedAt: time.Date(2026, 6, 7, 14, 0, 0, 0, time.UTC),
-			Phases:    []flowstore.FlowPhase{{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted}},
-		}},
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      230,
+		Height:     10,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID:    "flow-1",
+				Title:     "Flow without issue",
+				Status:    flowstore.StatusInProgress,
+				Branch:    "flow/no-issue",
+				PlanID:    "plan-1",
+				UpdatedAt: time.Date(2026, 6, 7, 14, 0, 0, 0, time.UTC),
+				Phases:    []flowstore.FlowPhase{{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted}},
+			}},
+			FlowSelected: 0}})
 
 	row := ansi.Strip(lineContaining(view, "Flow without issue"))
 	for _, want := range []string{"flow/no-issue", "1/1", "-", "plan-1"} {
@@ -129,20 +127,19 @@ func TestRender_FlowsModeShowsMissingIssueCell(t *testing.T) {
 
 func TestRender_ActiveFlowsHeaderAndShortcutLabels(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:    0,
-		Width:       180,
-		Height:      24,
-		Mode:        ModeSessions,
-		ActiveFlows: true,
-		ActivePane:  PaneBottom,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Active flow",
-			Status: flowstore.StatusPending,
-		}},
-		FlowSelected: 0,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     24,
+		Mode:       ModeSessions,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			ActiveFlows: true,
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Active flow",
+				Status: flowstore.StatusPending,
+			}},
+			FlowSelected: 0}})
 	pane := shortcutPaneText(ansi.Strip(view))
 	if strings.Contains(pane, "f3") {
 		t.Fatalf("active-flow shortcut pane should not advertise f3 active flows:\n%s", pane)
@@ -167,27 +164,26 @@ func TestRender_ActiveFlowsShowsRepoColumnBetweenStatusAndBranch(t *testing.T) {
 			{Path: "/dev/approach", DisplayName: "approach"},
 			{Path: "/dev/client/api", DisplayName: "client/api"},
 		},
-		Selected:    0,
-		Width:       220,
-		Height:      12,
-		Mode:        ModeSessions,
-		ActiveFlows: true,
-		ActivePane:  PaneBottom,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:   "flow-1",
-			Title:    "Active repo flow",
-			Status:   flowstore.StatusInProgress,
-			RepoPath: "/dev/approach",
-			Branch:   "flow/active-repo",
-		}, {
-			FlowID:   "flow-2",
-			Title:    "Nested active repo flow",
-			Status:   flowstore.StatusInProgress,
-			RepoPath: "/dev/client/api",
-			Branch:   "flow/nested-repo",
-		}},
-		FlowSelected: 0,
-	})
+		Selected:   0,
+		Width:      220,
+		Height:     12,
+		Mode:       ModeSessions,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			ActiveFlows: true,
+			Flows: []flowstore.FlowRecord{{
+				FlowID:   "flow-1",
+				Title:    "Active repo flow",
+				Status:   flowstore.StatusInProgress,
+				RepoPath: "/dev/approach",
+				Branch:   "flow/active-repo",
+			}, {
+				FlowID:   "flow-2",
+				Title:    "Nested active repo flow",
+				Status:   flowstore.StatusInProgress,
+				RepoPath: "/dev/client/api",
+				Branch:   "flow/nested-repo",
+			}},
+			FlowSelected: 0}})
 
 	header := lineContaining(view, "Status")
 	row := lineContaining(view, "flow/active-repo")
@@ -202,41 +198,40 @@ func TestRender_ActiveFlowsShowsRepoColumnBetweenStatusAndBranch(t *testing.T) {
 
 func TestRender_FlowsModeSplitsListAndEmbeddedTerminal(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    260,
-		Height:   29,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Add embedded Flow terminal",
-			Status: flowstore.StatusInProgress,
-			Branch: "flow/embedded-terminal",
-			Phases: []flowstore.FlowPhase{
-				{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning},
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      260,
+		Height:     29,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Add embedded Flow terminal",
+				Status: flowstore.StatusInProgress,
+				Branch: "flow/embedded-terminal",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning},
+				},
+			}},
+			FlowSelected: 0}, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals: []EmbeddedTerminalTab{{
+				Number:   1,
+				Provider: "codex",
+				Identity: "implementation",
+				State:    "running",
+				Active:   true,
+			}},
+			EmbeddedTerminalLines: []string{
+				"terminal line 1",
+				"terminal line 2",
+				"terminal line 3",
+				"terminal line 4",
+				"terminal line 5",
+				"terminal line 6",
+				"terminal line 7",
+				"terminal line 8",
 			},
-		}},
-		FlowSelected: 0,
-		EmbeddedTerminals: []EmbeddedTerminalTab{{
-			Number:   1,
-			Provider: "codex",
-			Identity: "implementation",
-			State:    "running",
-			Active:   true,
-		}},
-		EmbeddedTerminalLines: []string{
-			"terminal line 1",
-			"terminal line 2",
-			"terminal line 3",
-			"terminal line 4",
-			"terminal line 5",
-			"terminal line 6",
-			"terminal line 7",
-			"terminal line 8",
-		},
-		EmbeddedTerminalVisible: true,
-		ActivePane:              PaneBottom,
-	})
+			EmbeddedTerminalVisible: true}})
 
 	for _, want := range []string{
 		"Add embedded Flow terminal",
@@ -255,31 +250,30 @@ func TestRender_FlowsModeSplitsListAndEmbeddedTerminal(t *testing.T) {
 
 func TestRender_ActiveFlowsSplitPaneShowsRepoColumn(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:    0,
-		Width:       240,
-		Height:      24,
-		Mode:        ModeSessions,
-		ActiveFlows: true,
-		ActivePane:  PaneBottom,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:   "flow-1",
-			Title:    "Split active repo flow",
-			Status:   flowstore.StatusInProgress,
-			RepoPath: "/dev/approach",
-			Branch:   "flow/split-repo",
-		}},
-		FlowSelected: 0,
-		EmbeddedTerminals: []EmbeddedTerminalTab{{
-			Number:   1,
-			Provider: "codex",
-			Identity: "implementation",
-			State:    "running",
-			Active:   true,
-		}},
-		EmbeddedTerminalLines:   []string{"terminal line"},
-		EmbeddedTerminalVisible: true,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     24,
+		Mode:       ModeSessions,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			ActiveFlows: true,
+			Flows: []flowstore.FlowRecord{{
+				FlowID:   "flow-1",
+				Title:    "Split active repo flow",
+				Status:   flowstore.StatusInProgress,
+				RepoPath: "/dev/approach",
+				Branch:   "flow/split-repo",
+			}},
+			FlowSelected: 0}, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals: []EmbeddedTerminalTab{{
+				Number:   1,
+				Provider: "codex",
+				Identity: "implementation",
+				State:    "running",
+				Active:   true,
+			}},
+			EmbeddedTerminalLines:   []string{"terminal line"},
+			EmbeddedTerminalVisible: true}})
 
 	header := lineContaining(view, "Status")
 	row := lineContaining(view, "flow/split-repo")
@@ -298,61 +292,59 @@ func TestRender_FlowsModeSplitTerminalTinyViewportDoesNotPanic(t *testing.T) {
 	}()
 
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    120,
-		Height:   BranchContentOverhead - 1,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Tiny split terminal",
-			Status: flowstore.StatusInProgress,
-			Branch: "flow/tiny",
-			Phases: []flowstore.FlowPhase{
-				{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning},
-			},
-		}},
-		EmbeddedTerminals: []EmbeddedTerminalTab{{
-			Number:   1,
-			Provider: "codex",
-			Identity: "implementation",
-			State:    "running",
-			Active:   true,
-		}},
-		EmbeddedTerminalLines:   []string{"terminal output"},
-		EmbeddedTerminalVisible: true,
-		ActivePane:              PaneBottom,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      120,
+		Height:     BranchContentOverhead - 1,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Tiny split terminal",
+				Status: flowstore.StatusInProgress,
+				Branch: "flow/tiny",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning},
+				},
+			}}}, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals: []EmbeddedTerminalTab{{
+				Number:   1,
+				Provider: "codex",
+				Identity: "implementation",
+				State:    "running",
+				Active:   true,
+			}},
+			EmbeddedTerminalLines:   []string{"terminal output"},
+			EmbeddedTerminalVisible: true}})
 
 	requireLinesWithinWidth(t, strippedLines(view), 120)
 }
 
 func TestRender_ActiveFlowsExpandedPhaseRowsKeepRepoColumnAlignment(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:    0,
-		Width:       240,
-		Height:      12,
-		Mode:        ModeSessions,
-		ActiveFlows: true,
-		ActivePane:  PaneBottom,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:   "flow-1",
-			Title:    "Expanded active repo flow",
-			Status:   flowstore.StatusInProgress,
-			RepoPath: "/dev/approach",
-			Branch:   "flow/expanded",
-			Phases: []flowstore.FlowPhase{{
-				PhaseID: "implementation",
-				Title:   "Implementation",
-				Status:  flowstore.PhaseReady,
-				Order:   1,
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     12,
+		Mode:       ModeSessions,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			ActiveFlows: true,
+			Flows: []flowstore.FlowRecord{{
+				FlowID:   "flow-1",
+				Title:    "Expanded active repo flow",
+				Status:   flowstore.StatusInProgress,
+				RepoPath: "/dev/approach",
+				Branch:   "flow/expanded",
+				Phases: []flowstore.FlowPhase{{
+					PhaseID: "implementation",
+					Title:   "Implementation",
+					Status:  flowstore.PhaseReady,
+					Order:   1,
+				}},
 			}},
-		}},
-		FlowSelected:        0,
-		ExpandedFlowID:      "flow-1",
-		SelectedFlowPhaseID: "implementation",
-	})
+			FlowSelected:        0,
+			ExpandedFlowID:      "flow-1",
+			SelectedFlowPhaseID: "implementation"}})
 
 	flowRow := lineContaining(view, "flow/expanded")
 	phaseRow := lineContaining(view, "implementation:ready")
@@ -367,23 +359,22 @@ func TestRender_ActiveFlowsExpandedPhaseRowsKeepRepoColumnAlignment(t *testing.T
 
 func TestRender_ActiveFlowsExpandedNoPhasesKeepsRepoColumnAlignment(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:    0,
-		Width:       240,
-		Height:      12,
-		Mode:        ModeSessions,
-		ActiveFlows: true,
-		ActivePane:  PaneBottom,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:   "flow-1",
-			Title:    "Expanded active repo flow",
-			Status:   flowstore.StatusInProgress,
-			RepoPath: "/dev/approach",
-			Branch:   "flow/empty-phases",
-		}},
-		FlowSelected:   0,
-		ExpandedFlowID: "flow-1",
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     12,
+		Mode:       ModeSessions,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			ActiveFlows: true,
+			Flows: []flowstore.FlowRecord{{
+				FlowID:   "flow-1",
+				Title:    "Expanded active repo flow",
+				Status:   flowstore.StatusInProgress,
+				RepoPath: "/dev/approach",
+				Branch:   "flow/empty-phases",
+			}},
+			FlowSelected:   0,
+			ExpandedFlowID: "flow-1"}})
 
 	flowRow := lineContaining(view, "flow/empty-phases")
 	noPhasesRow := lineContaining(view, "No phases")
@@ -706,16 +697,15 @@ func TestStatusBar_ActiveFlowsHidesNewFlowHint(t *testing.T) {
 
 func TestRender_FlowsModeShowsReasoningEffortShortcut(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:               []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:            0,
-		Width:               180,
-		Height:              12,
-		Mode:                ModeFlows,
-		ActivePane:          PaneBottom,
-		FlowAgentLabel:      "codex",
-		FlowModel:           "gpt-5.5",
-		FlowReasoningEffort: "effort: high",
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			FlowAgentLabel:      "codex",
+			FlowModel:           "gpt-5.5",
+			FlowReasoningEffort: "effort: high"}})
 
 	pane := shortcutPaneText(view)
 	if !strings.Contains(pane, "A      codex\nM      gpt-5.5\nE      effort: high") {
@@ -731,17 +721,16 @@ func TestRender_FlowsModeShowsReasoningEffortShortcut(t *testing.T) {
 
 func TestRender_FlowsModeShowsModelShortcutOnSelectedFlowRow(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:          []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:       0,
-		Width:          180,
-		Height:         28,
-		Mode:           ModeFlows,
-		ActivePane:     PaneBottom,
-		Flows:          []flowstore.FlowRecord{{FlowID: "flow-1", Title: "Flow one", Status: flowstore.StatusInProgress}},
-		FlowSelected:   0,
-		FlowAgentLabel: "codex",
-		FlowModel:      "gpt-5.5",
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     28,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows:          []flowstore.FlowRecord{{FlowID: "flow-1", Title: "Flow one", Status: flowstore.StatusInProgress}},
+			FlowSelected:   0,
+			FlowAgentLabel: "codex",
+			FlowModel:      "gpt-5.5"}})
 
 	pane := shortcutPaneText(view)
 	if !strings.Contains(pane, "M      gpt-5.5") {
@@ -754,19 +743,18 @@ func TestRender_FlowsModeShowsModelShortcutOnSelectedFlowRow(t *testing.T) {
 
 func TestRender_FlowsModeShowsModelShortcutOnSelectedFlowPhaseRow(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:               []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:            0,
-		Width:               180,
-		Height:              28,
-		Mode:                ModeFlows,
-		ActivePane:          PaneBottom,
-		Flows:               []flowstore.FlowRecord{{FlowID: "flow-1", Title: "Flow one", Status: flowstore.StatusInProgress, Phases: []flowstore.FlowPhase{{PhaseID: "merge", Title: "Merge", Status: flowstore.PhaseReady}}}},
-		FlowSelected:        0,
-		ExpandedFlowID:      "flow-1",
-		SelectedFlowPhaseID: "merge",
-		FlowAgentLabel:      "codex",
-		FlowModel:           "gpt-5.5",
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     28,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows:               []flowstore.FlowRecord{{FlowID: "flow-1", Title: "Flow one", Status: flowstore.StatusInProgress, Phases: []flowstore.FlowPhase{{PhaseID: "merge", Title: "Merge", Status: flowstore.PhaseReady}}}},
+			FlowSelected:        0,
+			ExpandedFlowID:      "flow-1",
+			SelectedFlowPhaseID: "merge",
+			FlowAgentLabel:      "codex",
+			FlowModel:           "gpt-5.5"}})
 
 	pane := shortcutPaneText(view)
 	if !strings.Contains(pane, "M      gpt-5.5") {
@@ -776,35 +764,34 @@ func TestRender_FlowsModeShowsModelShortcutOnSelectedFlowPhaseRow(t *testing.T) 
 
 func TestRender_FlowsModeShortcutSectionsUseFlowGroups(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    180,
-		Height:   29,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Grouped shortcuts",
-			Status:       flowstore.StatusInProgress,
-			Branch:       "flow/grouped-shortcuts",
-			WorktreePath: "/dev/approach-worktrees/flow-grouped-shortcuts",
-			PlanID:       "plan-1",
-			AutoMode:     true,
-			Phases: []flowstore.FlowPhase{{
-				PhaseID: "implementation",
-				Title:   "Implementation",
-				Status:  flowstore.PhaseReady,
+		Repos:       []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:    0,
+		Width:       180,
+		Height:      29,
+		Mode:        ModeFlows,
+		ActivePane:  PaneBottom,
+		Destructive: true, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Grouped shortcuts",
+				Status:       flowstore.StatusInProgress,
+				Branch:       "flow/grouped-shortcuts",
+				WorktreePath: "/dev/approach-worktrees/flow-grouped-shortcuts",
+				PlanID:       "plan-1",
+				AutoMode:     true,
+				Phases: []flowstore.FlowPhase{{
+					PhaseID: "implementation",
+					Title:   "Implementation",
+					Status:  flowstore.PhaseReady,
+				}},
 			}},
-		}},
-		ActivePane:                 PaneBottom,
-		Destructive:                true,
-		FlowSelected:               0,
-		FlowHeadless:               true,
-		FlowAutoModeSelected:       true,
-		FlowNextLaunchReady:        true,
-		FlowAgentLabel:             "codex",
-		FlowReasoningEffort:        "effort: high",
-		FlowPhaseResumableSelected: true,
-	})
+			FlowSelected:               0,
+			FlowHeadless:               true,
+			FlowAutoModeSelected:       true,
+			FlowNextLaunchReady:        true,
+			FlowAgentLabel:             "codex",
+			FlowReasoningEffort:        "effort: high",
+			FlowPhaseResumableSelected: true}})
 
 	pane := shortcutPaneText(view)
 	if got, want := shortcutSectionTitles(pane), []string{"Actions", "Mode", "Agent", "Global"}; !slices.Equal(got, want) {
@@ -842,31 +829,30 @@ func TestRender_ActiveFlowsShortcutSectionsHideNewFlow(t *testing.T) {
 		Width:       180,
 		Height:      28,
 		Mode:        ModeFlows,
-		ActiveFlows: true,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Grouped shortcuts",
-			Status:       flowstore.StatusInProgress,
-			Branch:       "flow/grouped-shortcuts",
-			WorktreePath: "/dev/approach-worktrees/flow-grouped-shortcuts",
-			PlanID:       "plan-1",
-			AutoMode:     true,
-			Phases: []flowstore.FlowPhase{{
-				PhaseID: "implementation",
-				Title:   "Implementation",
-				Status:  flowstore.PhaseReady,
+		ActivePane:  PaneBottom,
+		Destructive: true, FlowParams: FlowParams{
+			ActiveFlows: true,
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Grouped shortcuts",
+				Status:       flowstore.StatusInProgress,
+				Branch:       "flow/grouped-shortcuts",
+				WorktreePath: "/dev/approach-worktrees/flow-grouped-shortcuts",
+				PlanID:       "plan-1",
+				AutoMode:     true,
+				Phases: []flowstore.FlowPhase{{
+					PhaseID: "implementation",
+					Title:   "Implementation",
+					Status:  flowstore.PhaseReady,
+				}},
 			}},
-		}},
-		ActivePane:                 PaneBottom,
-		Destructive:                true,
-		FlowSelected:               0,
-		FlowHeadless:               true,
-		FlowAutoModeSelected:       true,
-		FlowNextLaunchReady:        true,
-		FlowAgentLabel:             "codex",
-		FlowReasoningEffort:        "effort: high",
-		FlowPhaseResumableSelected: true,
-	})
+			FlowSelected:               0,
+			FlowHeadless:               true,
+			FlowAutoModeSelected:       true,
+			FlowNextLaunchReady:        true,
+			FlowAgentLabel:             "codex",
+			FlowReasoningEffort:        "effort: high",
+			FlowPhaseResumableSelected: true}})
 
 	pane := shortcutPaneText(view)
 	if strings.Contains(pane, "n      new flow") {
@@ -894,28 +880,27 @@ func TestRender_ActiveFlowsShortcutSectionsHideNewFlow(t *testing.T) {
 
 func TestRender_FlowShortcutPaneShowsOpenPRWhenTargetSelected(t *testing.T) {
 	base := RenderParams{
-		Repos:        []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:     0,
-		Width:        180,
-		Height:       28,
-		Mode:         ModeFlows,
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Flow with PR",
-			Status: flowstore.StatusInProgress,
-			PR: flowstore.PullRequest{
-				Provider:   "github",
-				Number:     123,
-				URL:        "https://github.com/approachcontrol/approach/pull/123",
-				HeadBranch: "flow/add-pr-shortcut",
-				BaseBranch: "main",
-			},
-			Phases: []flowstore.FlowPhase{{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady}},
-		}},
-		FlowPRTargetSelected: true,
-	}
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     28,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			FlowSelected: 0,
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Flow with PR",
+				Status: flowstore.StatusInProgress,
+				PR: flowstore.PullRequest{
+					Provider:   "github",
+					Number:     123,
+					URL:        "https://github.com/approachcontrol/approach/pull/123",
+					HeadBranch: "flow/add-pr-shortcut",
+					BaseBranch: "main",
+				},
+				Phases: []flowstore.FlowPhase{{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady}},
+			}},
+			FlowPRTargetSelected: true}}
 
 	for _, tt := range []struct {
 		name string
@@ -939,26 +924,25 @@ func TestRender_FlowShortcutPaneShowsOpenPRWhenTargetSelected(t *testing.T) {
 
 func TestRender_FlowShortcutPaneShowsOpenIssueWhenTargetSelected(t *testing.T) {
 	base := RenderParams{
-		Repos:        []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:     0,
-		Width:        180,
-		Height:       28,
-		Mode:         ModeFlows,
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Flow with issue",
-			Status: flowstore.StatusInProgress,
-			Issue: flowstore.Issue{
-				Provider: "github",
-				Number:   123,
-				URL:      "https://github.com/approachcontrol/approach/issues/123",
-			},
-			Phases: []flowstore.FlowPhase{{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady}},
-		}},
-		FlowIssueTargetSelected: true,
-	}
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     28,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			FlowSelected: 0,
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Flow with issue",
+				Status: flowstore.StatusInProgress,
+				Issue: flowstore.Issue{
+					Provider: "github",
+					Number:   123,
+					URL:      "https://github.com/approachcontrol/approach/issues/123",
+				},
+				Phases: []flowstore.FlowPhase{{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady}},
+			}},
+			FlowIssueTargetSelected: true}}
 
 	for _, tt := range []struct {
 		name string
@@ -982,20 +966,19 @@ func TestRender_FlowShortcutPaneShowsOpenIssueWhenTargetSelected(t *testing.T) {
 
 func TestRender_FlowShortcutPaneHidesOpenPRWithoutTopLevelPRTarget(t *testing.T) {
 	base := RenderParams{
-		Repos:        []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:     0,
-		Width:        180,
-		Height:       28,
-		Mode:         ModeFlows,
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Flow without PR",
-			Status: flowstore.StatusInProgress,
-			Phases: []flowstore.FlowPhase{{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady}},
-		}},
-	}
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     28,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			FlowSelected: 0,
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Flow without PR",
+				Status: flowstore.StatusInProgress,
+				Phases: []flowstore.FlowPhase{{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady}},
+			}}}}
 
 	for _, tt := range []struct {
 		name string
@@ -1056,15 +1039,14 @@ func TestRender_FlowsModeReasoningEffortShortcutHandlesSpecialLabels(t *testing.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			view := Render(RenderParams{
-				Repos:               []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-				Selected:            0,
-				Width:               180,
-				Height:              12,
-				Mode:                ModeFlows,
-				ActivePane:          PaneBottom,
-				FlowAgentLabel:      tt.agent,
-				FlowReasoningEffort: tt.effort,
-			})
+				Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+				Selected:   0,
+				Width:      180,
+				Height:     12,
+				Mode:       ModeFlows,
+				ActivePane: PaneBottom, FlowParams: FlowParams{
+					FlowAgentLabel:      tt.agent,
+					FlowReasoningEffort: tt.effort}})
 			pane := shortcutPaneText(view)
 			if !strings.Contains(pane, tt.want) {
 				t.Fatalf("flows shortcut pane should expose special labels %q:\n%s", tt.want, pane)
@@ -1149,18 +1131,17 @@ func TestStatusBar_FlowsModeShowsManualMergeOnlyForEligibleFlowRow(t *testing.T)
 func TestRender_FlowDegradationWarningReservesRowWithNoHealthyFlows(t *testing.T) {
 	warning := "Skipped 4 unreadable Flows (id1, id2, id3, …); run approach flow list --json"
 	view := Render(RenderParams{
-		Width:                  180,
-		Height:                 26,
-		Repos:                  []scanner.Repo{{Path: "/repo", DisplayName: "repo"}},
-		Selected:               0,
-		Mode:                   ModeFlows,
-		TopMode:                ModeWorktrees,
-		BottomMode:             ModeFlows,
-		ContentPane:            PaneBottom,
-		ActivePane:             PaneBottom,
-		FlowDegradationWarning: warning,
-		RightEmptyMessage:      "No flows",
-	})
+		Width:             180,
+		Height:            26,
+		Repos:             []scanner.Repo{{Path: "/repo", DisplayName: "repo"}},
+		Selected:          0,
+		Mode:              ModeFlows,
+		TopMode:           ModeWorktrees,
+		BottomMode:        ModeFlows,
+		ContentPane:       PaneBottom,
+		ActivePane:        PaneBottom,
+		RightEmptyMessage: "No flows", FlowParams: FlowParams{
+			FlowDegradationWarning: warning}})
 	plain := ansi.Strip(view)
 	for _, want := range []string{warning, "No flows"} {
 		if !strings.Contains(plain, want) {
@@ -1175,20 +1156,19 @@ func TestRender_FlowDegradationWarningReservesRowWithNoHealthyFlows(t *testing.T
 func TestRender_FlowDegradationAndCachedRefreshWarningsAreDistinct(t *testing.T) {
 	degraded := "Skipped 1 unreadable Flows (bad); run approach flow list --json"
 	view := Render(RenderParams{
-		Width:                  180,
-		Height:                 26,
-		Repos:                  []scanner.Repo{{Path: "/repo", DisplayName: "repo"}},
-		Selected:               0,
-		Mode:                   ModeFlows,
-		TopMode:                ModeWorktrees,
-		BottomMode:             ModeFlows,
-		ContentPane:            PaneBottom,
-		ActivePane:             PaneBottom,
-		Flows:                  []flowstore.FlowRecord{{FlowID: "healthy", Title: "Healthy"}},
-		FlowSelected:           0,
-		BottomListError:        "database unavailable",
-		FlowDegradationWarning: degraded,
-	})
+		Width:           180,
+		Height:          26,
+		Repos:           []scanner.Repo{{Path: "/repo", DisplayName: "repo"}},
+		Selected:        0,
+		Mode:            ModeFlows,
+		TopMode:         ModeWorktrees,
+		BottomMode:      ModeFlows,
+		ContentPane:     PaneBottom,
+		ActivePane:      PaneBottom,
+		BottomListError: "database unavailable", FlowParams: FlowParams{
+			Flows:                  []flowstore.FlowRecord{{FlowID: "healthy", Title: "Healthy"}},
+			FlowSelected:           0,
+			FlowDegradationWarning: degraded}})
 	if !strings.Contains(view, aheadBehindStyle.Render(" "+degraded)) {
 		t.Fatalf("view missing styled degradation warning:\n%q", view)
 	}
@@ -1205,16 +1185,15 @@ func TestRender_FlowsModeCompactSelectedFlowPrioritizesFlowActions(t *testing.T)
 		Width:      180,
 		Height:     12,
 		Mode:       ModeFlows,
-		ActivePane: PaneBottom,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Compact selected flow",
-			Status: flowstore.StatusInProgress,
-		}},
-		FlowSelected:         0,
-		FlowHeadless:         true,
-		FlowAutoModeSelected: true,
-	})
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Compact selected flow",
+				Status: flowstore.StatusInProgress,
+			}},
+			FlowSelected:         0,
+			FlowHeadless:         true,
+			FlowAutoModeSelected: true}})
 
 	pane := shortcutPaneText(view)
 	for _, want := range []string{"enter  phases", "c      copy id", "h      headless on"} {
@@ -1391,21 +1370,20 @@ func TestStatusBar_FlowsModeShowsNextLaunchOnlyWhenFlowHasLaunchablePhase(t *tes
 
 func TestFlowsSurfacesShowRepairShortcutOnlyWhenModelMarksItReady(t *testing.T) {
 	base := RenderParams{
-		Repos:        []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:     0,
-		Width:        180,
-		Height:       12,
-		Mode:         ModeFlows,
-		ActivePane:   1,
-		FlowSelected: 0,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Stalled Flow",
-			RepoPath:     "/dev/approach",
-			WorktreePath: "/dev/approach-worktrees/flow-1",
-			Phases:       []flowstore.FlowPhase{{PhaseID: "implementation", Status: flowstore.PhaseBlocked}},
-		}},
-	}
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: 1, FlowParams: FlowParams{
+			FlowSelected: 0,
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Stalled Flow",
+				RepoPath:     "/dev/approach",
+				WorktreePath: "/dev/approach-worktrees/flow-1",
+				Phases:       []flowstore.FlowPhase{{PhaseID: "implementation", Status: flowstore.PhaseBlocked}},
+			}}}}
 	if pane := shortcutPaneText(Render(base)); strings.Contains(pane, "R      repair") {
 		t.Fatalf("repair shortcut rendered without model availability:\n%s", pane)
 	}
@@ -1434,30 +1412,29 @@ func TestFlowsSurfacesShowRepairShortcutOnlyWhenModelMarksItReady(t *testing.T) 
 
 func TestRender_FlowsModeShowsResumeShortcutForResumableSelectedPhase(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    180,
-		Height:   14,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Resumable flow",
-			Status: flowstore.StatusInProgress,
-			Phases: []flowstore.FlowPhase{{
-				PhaseID: "implementation",
-				Title:   "Implementation",
-				Status:  flowstore.PhaseCompleted,
-				Sessions: []flowstore.Session{
-					{Provider: "codex", SessionID: "codex-1", Status: "ended"},
-				},
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     14,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Resumable flow",
+				Status: flowstore.StatusInProgress,
+				Phases: []flowstore.FlowPhase{{
+					PhaseID: "implementation",
+					Title:   "Implementation",
+					Status:  flowstore.PhaseCompleted,
+					Sessions: []flowstore.Session{
+						{Provider: "codex", SessionID: "codex-1", Status: "ended"},
+					},
+				}},
 			}},
-		}},
-		ActivePane:                 PaneBottom,
-		FlowSelected:               0,
-		ExpandedFlowID:             "flow-1",
-		SelectedFlowPhaseID:        "implementation",
-		FlowPhaseResumableSelected: true,
-	})
+			FlowSelected:               0,
+			ExpandedFlowID:             "flow-1",
+			SelectedFlowPhaseID:        "implementation",
+			FlowPhaseResumableSelected: true}})
 
 	if !strings.Contains(shortcutPaneText(view), "r      resume") {
 		t.Fatalf("resumable Flow phase should expose resume shortcut:\n%s", view)
@@ -1466,27 +1443,26 @@ func TestRender_FlowsModeShowsResumeShortcutForResumableSelectedPhase(t *testing
 
 func TestRender_FlowsModeShowsCopyPathShortcutForSelectedPhase(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    180,
-		Height:   16,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Phase copy flow",
-			Status:       flowstore.StatusInProgress,
-			WorktreePath: "/dev/approach-worktrees/phase-copy-flow",
-			Phases: []flowstore.FlowPhase{{
-				PhaseID: "implementation",
-				Title:   "Implementation",
-				Status:  flowstore.PhaseReady,
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     16,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Phase copy flow",
+				Status:       flowstore.StatusInProgress,
+				WorktreePath: "/dev/approach-worktrees/phase-copy-flow",
+				Phases: []flowstore.FlowPhase{{
+					PhaseID: "implementation",
+					Title:   "Implementation",
+					Status:  flowstore.PhaseReady,
+				}},
 			}},
-		}},
-		ActivePane:          PaneBottom,
-		FlowSelected:        0,
-		ExpandedFlowID:      "flow-1",
-		SelectedFlowPhaseID: "implementation",
-	})
+			FlowSelected:        0,
+			ExpandedFlowID:      "flow-1",
+			SelectedFlowPhaseID: "implementation"}})
 
 	pane := shortcutPaneText(view)
 	if !strings.Contains(pane, "y      copy path") {
@@ -1499,29 +1475,28 @@ func TestRender_FlowsModeShowsCopyPathShortcutForSelectedPhase(t *testing.T) {
 
 func TestRender_FlowsModeShowsResetShortcutForResettableSelectedPhase(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    180,
-		Height:   16,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Resettable flow",
-			Status: flowstore.StatusInProgress,
-			Phases: []flowstore.FlowPhase{{
-				PhaseID:   "implementation",
-				Title:     "Implementation",
-				Status:    flowstore.PhaseRunning,
-				LaunchIDs: []string{"launch-orphan"},
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     16,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Resettable flow",
+				Status: flowstore.StatusInProgress,
+				Phases: []flowstore.FlowPhase{{
+					PhaseID:   "implementation",
+					Title:     "Implementation",
+					Status:    flowstore.PhaseRunning,
+					LaunchIDs: []string{"launch-orphan"},
+				}},
 			}},
-		}},
-		ActivePane:                  PaneBottom,
-		FlowSelected:                0,
-		ExpandedFlowID:              "flow-1",
-		SelectedFlowPhaseID:         "implementation",
-		FlowPhaseResetReadySelected: true,
-		FlowPhaseResumableSelected:  false,
-	})
+			FlowSelected:                0,
+			ExpandedFlowID:              "flow-1",
+			SelectedFlowPhaseID:         "implementation",
+			FlowPhaseResetReadySelected: true,
+			FlowPhaseResumableSelected:  false}})
 
 	pane := shortcutPaneText(view)
 	if !strings.Contains(pane, "x      reset ready") {
@@ -1534,29 +1509,28 @@ func TestRender_FlowsModeShowsResetShortcutForResettableSelectedPhase(t *testing
 
 func TestRender_FlowsModeShowsLaunchAndHeadlessShortcutForLaunchableSelectedPhase(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    180,
-		Height:   16,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Launch phase flow",
-			Status:       flowstore.StatusInProgress,
-			WorktreePath: "/dev/approach-worktrees/launch-phase-flow",
-			Phases: []flowstore.FlowPhase{{
-				PhaseID: "implementation",
-				Title:   "Implementation",
-				Status:  flowstore.PhaseReady,
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     16,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Launch phase flow",
+				Status:       flowstore.StatusInProgress,
+				WorktreePath: "/dev/approach-worktrees/launch-phase-flow",
+				Phases: []flowstore.FlowPhase{{
+					PhaseID: "implementation",
+					Title:   "Implementation",
+					Status:  flowstore.PhaseReady,
+				}},
 			}},
-		}},
-		ActivePane:          PaneBottom,
-		FlowSelected:        0,
-		ExpandedFlowID:      "flow-1",
-		SelectedFlowPhaseID: "implementation",
-		FlowNextLaunchReady: true,
-		FlowHeadless:        false,
-	})
+			FlowSelected:        0,
+			ExpandedFlowID:      "flow-1",
+			SelectedFlowPhaseID: "implementation",
+			FlowNextLaunchReady: true,
+			FlowHeadless:        false}})
 
 	pane := shortcutPaneText(view)
 	for _, want := range []string{"enter  phases", "g      launch next", "h      headless off", "c      copy id", "y      copy path"} {
@@ -1573,24 +1547,23 @@ func TestRender_FlowsModeShowsLaunchAndHeadlessShortcutForLaunchableSelectedPhas
 
 func TestRender_FlowsModeShowsDestructiveModeAndDeleteShortcuts(t *testing.T) {
 	base := RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    180,
-		Height:   12,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Delete flow",
-			Status: flowstore.StatusPending,
-			Phases: []flowstore.FlowPhase{{
-				PhaseID: "implementation",
-				Title:   "Implementation",
-				Status:  flowstore.PhaseReady,
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Delete flow",
+				Status: flowstore.StatusPending,
+				Phases: []flowstore.FlowPhase{{
+					PhaseID: "implementation",
+					Title:   "Implementation",
+					Status:  flowstore.PhaseReady,
+				}},
 			}},
-		}},
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-	}
+			FlowSelected: 0}}
 
 	readOnlyPane := shortcutPaneText(Render(base))
 	if !strings.Contains(readOnlyPane, "D      destructive mode") {
@@ -1877,37 +1850,36 @@ func TestRender_ActiveFlowsOverSessionsUsesFlowTerminalPrefixShortcuts(t *testin
 
 func TestRender_ActiveFlowsIgnoreHiddenSessionTerminalForShortcuts(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:    0,
-		Width:       180,
-		Height:      19,
-		Mode:        ModeSessions,
-		ActiveFlows: true,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Active Flow",
-			Status:       flowstore.StatusInProgress,
-			WorktreePath: "/dev/approach-worktrees/active-flow",
-			Phases: []flowstore.FlowPhase{{
-				PhaseID: "implementation",
-				Title:   "Implementation",
-				Status:  flowstore.PhaseReady,
-				Order:   1,
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     19,
+		Mode:       ModeSessions,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			ActiveFlows: true,
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Active Flow",
+				Status:       flowstore.StatusInProgress,
+				WorktreePath: "/dev/approach-worktrees/active-flow",
+				Phases: []flowstore.FlowPhase{{
+					PhaseID: "implementation",
+					Title:   "Implementation",
+					Status:  flowstore.PhaseReady,
+					Order:   1,
+				}},
 			}},
-		}},
-		EmbeddedTerminals: []EmbeddedTerminalTab{{
-			Number:   1,
-			Provider: "codex",
-			Identity: "hidden-session-terminal",
-			State:    "running",
-			Active:   true,
-		}},
-		EmbeddedTerminalVisible: false,
-		ActivePane:              PaneBottom,
-		FlowSelected:            0,
-		FlowNextLaunchReady:     true,
-		FlowHeadless:            true,
-	})
+			FlowSelected:        0,
+			FlowNextLaunchReady: true,
+			FlowHeadless:        true}, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals: []EmbeddedTerminalTab{{
+				Number:   1,
+				Provider: "codex",
+				Identity: "hidden-session-terminal",
+				State:    "running",
+				Active:   true,
+			}},
+			EmbeddedTerminalVisible: false}})
 
 	pane := shortcutPaneText(view)
 	for _, want := range []string{"Actions", "g      launch next", "Mode", "h      headless on"} {
@@ -1925,27 +1897,26 @@ func TestRender_ActiveFlowsIgnoreHiddenSessionTerminalForShortcuts(t *testing.T)
 
 func TestRender_FlowsModeIgnoresStaleSelectedPhaseForCopyShortcut(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    180,
-		Height:   12,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Stale phase copy flow",
-			Status:       flowstore.StatusInProgress,
-			WorktreePath: "/dev/approach-worktrees/stale-phase-copy-flow",
-			Phases: []flowstore.FlowPhase{{
-				PhaseID: "implementation",
-				Title:   "Implementation",
-				Status:  flowstore.PhaseReady,
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Stale phase copy flow",
+				Status:       flowstore.StatusInProgress,
+				WorktreePath: "/dev/approach-worktrees/stale-phase-copy-flow",
+				Phases: []flowstore.FlowPhase{{
+					PhaseID: "implementation",
+					Title:   "Implementation",
+					Status:  flowstore.PhaseReady,
+				}},
 			}},
-		}},
-		ActivePane:          PaneBottom,
-		FlowSelected:        0,
-		ExpandedFlowID:      "flow-1",
-		SelectedFlowPhaseID: "missing",
-	})
+			FlowSelected:        0,
+			ExpandedFlowID:      "flow-1",
+			SelectedFlowPhaseID: "missing"}})
 
 	pane := shortcutPaneText(view)
 	if !strings.Contains(pane, "y      copy path") {
@@ -1958,24 +1929,23 @@ func TestRender_FlowsModeIgnoresStaleSelectedPhaseForCopyShortcut(t *testing.T) 
 
 func TestRender_FlowsModeHidesCopyPathShortcutWithoutWorktreePath(t *testing.T) {
 	base := RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    180,
-		Height:   16,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "No worktree path",
-			Status: flowstore.StatusInProgress,
-			Phases: []flowstore.FlowPhase{{
-				PhaseID: "implementation",
-				Title:   "Implementation",
-				Status:  flowstore.PhaseReady,
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     16,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "No worktree path",
+				Status: flowstore.StatusInProgress,
+				Phases: []flowstore.FlowPhase{{
+					PhaseID: "implementation",
+					Title:   "Implementation",
+					Status:  flowstore.PhaseReady,
+				}},
 			}},
-		}},
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-	}
+			FlowSelected: 0}}
 
 	if pane := shortcutPaneText(Render(base)); strings.Contains(pane, "y      copy") {
 		t.Fatalf("selected Flow without worktree path should hide copy shortcut:\n%s", pane)
@@ -1991,27 +1961,26 @@ func TestRender_FlowsModeHidesCopyPathShortcutWithoutWorktreePath(t *testing.T) 
 
 func TestRender_FlowsModeHidesResumeShortcutWithoutResumableSelectedPhase(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    180,
-		Height:   12,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Awaiting flow",
-			Status: flowstore.StatusInProgress,
-			Phases: []flowstore.FlowPhase{{
-				PhaseID:   "implementation",
-				Title:     "Implementation",
-				Status:    flowstore.PhaseRunning,
-				LaunchIDs: []string{"launch-new"},
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Awaiting flow",
+				Status: flowstore.StatusInProgress,
+				Phases: []flowstore.FlowPhase{{
+					PhaseID:   "implementation",
+					Title:     "Implementation",
+					Status:    flowstore.PhaseRunning,
+					LaunchIDs: []string{"launch-new"},
+				}},
 			}},
-		}},
-		ActivePane:          PaneBottom,
-		FlowSelected:        0,
-		ExpandedFlowID:      "flow-1",
-		SelectedFlowPhaseID: "implementation",
-	})
+			FlowSelected:        0,
+			ExpandedFlowID:      "flow-1",
+			SelectedFlowPhaseID: "implementation"}})
 
 	if strings.Contains(shortcutPaneText(view), "r      resume") {
 		t.Fatalf("non-resumable Flow phase should not expose resume shortcut:\n%s", view)
@@ -2020,25 +1989,24 @@ func TestRender_FlowsModeHidesResumeShortcutWithoutResumableSelectedPhase(t *tes
 
 func TestRender_FlowsModeShowsExpandedPhaseRowsWithFullPhaseIDs(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   10,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Add Flow mode",
-			Status: flowstore.StatusInProgress,
-			Branch: "flow/add-flow-mode",
-			Phases: []flowstore.FlowPhase{
-				{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Order: 1},
-				{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady, Order: 2},
-			},
-		}},
-		ActivePane:     PaneBottom,
-		FlowSelected:   0,
-		ExpandedFlowID: "flow-1",
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     10,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Add Flow mode",
+				Status: flowstore.StatusInProgress,
+				Branch: "flow/add-flow-mode",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Order: 1},
+					{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseReady, Order: 2},
+				},
+			}},
+			FlowSelected:   0,
+			ExpandedFlowID: "flow-1"}})
 
 	for _, want := range []string{"plan-review:completed", "Plan Review", "implementation:ready", "Implementation"} {
 		if !strings.Contains(view, want) {
@@ -2054,32 +2022,31 @@ func TestRender_FlowsModeShowsExpandedPhaseRowsWithFullPhaseIDs(t *testing.T) {
 
 func TestRender_FlowsModeExpandedPhaseRowsShowSessionSummary(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   10,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Flow sessions",
-			Status:       flowstore.StatusInProgress,
-			Branch:       "flow/sessions",
-			WorktreePath: "/dev/approach-worktrees/flow-sessions",
-			Phases: []flowstore.FlowPhase{{
-				PhaseID:   "implementation",
-				Title:     "Implementation",
-				Status:    flowstore.PhaseCompleted,
-				LaunchIDs: []string{"launch-1", "launch-2"},
-				Sessions: []flowstore.Session{
-					{Provider: "claude", SessionID: "claude-old", LaunchID: "launch-1", Status: "ended", StartedAt: time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)},
-					{Provider: "codex", SessionID: "codex-new", LaunchID: "launch-2", Status: "ended", StartedAt: time.Date(2026, 6, 7, 11, 0, 0, 0, time.UTC)},
-				},
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     10,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Flow sessions",
+				Status:       flowstore.StatusInProgress,
+				Branch:       "flow/sessions",
+				WorktreePath: "/dev/approach-worktrees/flow-sessions",
+				Phases: []flowstore.FlowPhase{{
+					PhaseID:   "implementation",
+					Title:     "Implementation",
+					Status:    flowstore.PhaseCompleted,
+					LaunchIDs: []string{"launch-1", "launch-2"},
+					Sessions: []flowstore.Session{
+						{Provider: "claude", SessionID: "claude-old", LaunchID: "launch-1", Status: "ended", StartedAt: time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)},
+						{Provider: "codex", SessionID: "codex-new", LaunchID: "launch-2", Status: "ended", StartedAt: time.Date(2026, 6, 7, 11, 0, 0, 0, time.UTC)},
+					},
+				}},
 			}},
-		}},
-		ActivePane:     PaneBottom,
-		FlowSelected:   0,
-		ExpandedFlowID: "flow-1",
-	})
+			FlowSelected:   0,
+			ExpandedFlowID: "flow-1"}})
 
 	for _, want := range []string{"implementation:completed", "2 sessions", "codex", "ended"} {
 		if !strings.Contains(view, want) {
@@ -2090,32 +2057,31 @@ func TestRender_FlowsModeExpandedPhaseRowsShowSessionSummary(t *testing.T) {
 
 func TestRender_FlowsModeExpandedPhaseRowsShowMissingSessionID(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   10,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Legacy sessions",
-			Status:       flowstore.StatusNeedsAttention,
-			Branch:       "flow/legacy-sessions",
-			WorktreePath: "/dev/approach-worktrees/flow-legacy-sessions",
-			Phases: []flowstore.FlowPhase{{
-				PhaseID:   "review-loop",
-				Title:     "Review loop",
-				Status:    flowstore.PhaseNeedsAttention,
-				LaunchIDs: []string{"launch-old", "launch-1"},
-				Sessions: []flowstore.Session{
-					{Provider: "codex", LaunchID: "launch-1", Status: "ended"},
-					{Provider: "claude", SessionID: "claude-old", LaunchID: "launch-old", Status: "ended", StartedAt: time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)},
-				},
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     10,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Legacy sessions",
+				Status:       flowstore.StatusNeedsAttention,
+				Branch:       "flow/legacy-sessions",
+				WorktreePath: "/dev/approach-worktrees/flow-legacy-sessions",
+				Phases: []flowstore.FlowPhase{{
+					PhaseID:   "review-loop",
+					Title:     "Review loop",
+					Status:    flowstore.PhaseNeedsAttention,
+					LaunchIDs: []string{"launch-old", "launch-1"},
+					Sessions: []flowstore.Session{
+						{Provider: "codex", LaunchID: "launch-1", Status: "ended"},
+						{Provider: "claude", SessionID: "claude-old", LaunchID: "launch-old", Status: "ended", StartedAt: time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)},
+					},
+				}},
 			}},
-		}},
-		ActivePane:     PaneBottom,
-		FlowSelected:   0,
-		ExpandedFlowID: "flow-1",
-	})
+			FlowSelected:   0,
+			ExpandedFlowID: "flow-1"}})
 
 	if !strings.Contains(view, "review-loop:missing-session-id") {
 		t.Fatalf("malformed attached session should render missing-session-id:\n%s", view)
@@ -2130,31 +2096,30 @@ func TestRender_FlowsModeExpandedPhaseRowsShowMissingSessionID(t *testing.T) {
 
 func TestRender_FlowsModeExpandedPhaseRowsShowEndedSessionRecovery(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   10,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Ended latest session",
-			Status:       flowstore.StatusInProgress,
-			Branch:       "flow/ended-session",
-			WorktreePath: "/dev/approach-worktrees/flow-ended-session",
-			Phases: []flowstore.FlowPhase{{
-				PhaseID:   "implementation",
-				Title:     "Implementation",
-				Status:    flowstore.PhaseRunning,
-				LaunchIDs: []string{"launch-1"},
-				Sessions: []flowstore.Session{
-					{Provider: "codex", SessionID: "codex-1", LaunchID: "launch-1", Status: "ended"},
-				},
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     10,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Ended latest session",
+				Status:       flowstore.StatusInProgress,
+				Branch:       "flow/ended-session",
+				WorktreePath: "/dev/approach-worktrees/flow-ended-session",
+				Phases: []flowstore.FlowPhase{{
+					PhaseID:   "implementation",
+					Title:     "Implementation",
+					Status:    flowstore.PhaseRunning,
+					LaunchIDs: []string{"launch-1"},
+					Sessions: []flowstore.Session{
+						{Provider: "codex", SessionID: "codex-1", LaunchID: "launch-1", Status: "ended"},
+					},
+				}},
 			}},
-		}},
-		ActivePane:     PaneBottom,
-		FlowSelected:   0,
-		ExpandedFlowID: "flow-1",
-	})
+			FlowSelected:   0,
+			ExpandedFlowID: "flow-1"}})
 
 	if !strings.Contains(view, "implementation:ended-session") {
 		t.Fatalf("running phase with ended latest session should render ended-session:\n%s", view)
@@ -2163,32 +2128,31 @@ func TestRender_FlowsModeExpandedPhaseRowsShowEndedSessionRecovery(t *testing.T)
 
 func TestRender_FlowsModeExpandedPhaseRowsShowEndedLatestSessionWithOlderLiveSession(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   10,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Ended latest session with live older session",
-			Status:       flowstore.StatusInProgress,
-			Branch:       "flow/ended-session",
-			WorktreePath: "/dev/approach-worktrees/flow-ended-session",
-			Phases: []flowstore.FlowPhase{{
-				PhaseID:   "implementation",
-				Title:     "Implementation",
-				Status:    flowstore.PhaseRunning,
-				LaunchIDs: []string{"launch-old", "launch-new"},
-				Sessions: []flowstore.Session{
-					{Provider: "claude", SessionID: "claude-old", LaunchID: "launch-old", Status: "last_seen"},
-					{Provider: "codex", SessionID: "codex-new", LaunchID: "launch-new", Status: "ended"},
-				},
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     10,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Ended latest session with live older session",
+				Status:       flowstore.StatusInProgress,
+				Branch:       "flow/ended-session",
+				WorktreePath: "/dev/approach-worktrees/flow-ended-session",
+				Phases: []flowstore.FlowPhase{{
+					PhaseID:   "implementation",
+					Title:     "Implementation",
+					Status:    flowstore.PhaseRunning,
+					LaunchIDs: []string{"launch-old", "launch-new"},
+					Sessions: []flowstore.Session{
+						{Provider: "claude", SessionID: "claude-old", LaunchID: "launch-old", Status: "last_seen"},
+						{Provider: "codex", SessionID: "codex-new", LaunchID: "launch-new", Status: "ended"},
+					},
+				}},
 			}},
-		}},
-		ActivePane:     PaneBottom,
-		FlowSelected:   0,
-		ExpandedFlowID: "flow-1",
-	})
+			FlowSelected:   0,
+			ExpandedFlowID: "flow-1"}})
 
 	if !strings.Contains(view, "implementation:ended-session") {
 		t.Fatalf("running phase with ended latest session should render ended-session:\n%s", view)
@@ -2197,31 +2161,30 @@ func TestRender_FlowsModeExpandedPhaseRowsShowEndedLatestSessionWithOlderLiveSes
 
 func TestRender_FlowsModeExpandedPhaseRowsShowAwaitingLatestSessionWithOlderLiveSession(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   10,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID:       "flow-1",
-			Title:        "Await latest session with live older session",
-			Status:       flowstore.StatusInProgress,
-			Branch:       "flow/await-session",
-			WorktreePath: "/dev/approach-worktrees/flow-await-session",
-			Phases: []flowstore.FlowPhase{{
-				PhaseID:   "implementation",
-				Title:     "Implementation",
-				Status:    flowstore.PhaseRunning,
-				LaunchIDs: []string{"launch-old", "launch-new"},
-				Sessions: []flowstore.Session{
-					{Provider: "claude", SessionID: "claude-old", LaunchID: "launch-old", Status: "last_seen"},
-				},
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     10,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID:       "flow-1",
+				Title:        "Await latest session with live older session",
+				Status:       flowstore.StatusInProgress,
+				Branch:       "flow/await-session",
+				WorktreePath: "/dev/approach-worktrees/flow-await-session",
+				Phases: []flowstore.FlowPhase{{
+					PhaseID:   "implementation",
+					Title:     "Implementation",
+					Status:    flowstore.PhaseRunning,
+					LaunchIDs: []string{"launch-old", "launch-new"},
+					Sessions: []flowstore.Session{
+						{Provider: "claude", SessionID: "claude-old", LaunchID: "launch-old", Status: "last_seen"},
+					},
+				}},
 			}},
-		}},
-		ActivePane:     PaneBottom,
-		FlowSelected:   0,
-		ExpandedFlowID: "flow-1",
-	})
+			FlowSelected:   0,
+			ExpandedFlowID: "flow-1"}})
 
 	if !strings.Contains(view, "implementation:await-session") {
 		t.Fatalf("running phase awaiting latest session should render await-session:\n%s", view)
@@ -2230,27 +2193,26 @@ func TestRender_FlowsModeExpandedPhaseRowsShowAwaitingLatestSessionWithOlderLive
 
 func TestRender_FlowsModeGroupsChildImplementationPhasesUnderParent(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   12,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "flow-1",
-			Title:  "Child phases",
-			Status: flowstore.StatusInProgress,
-			Branch: "flow/children",
-			Phases: []flowstore.FlowPhase{
-				{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: "approved", Order: 2},
-				{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted, Order: 3},
-				{PhaseID: "review-loop", Title: "Review Loop", Status: flowstore.PhasePending, Order: 4},
-				{PhaseID: "implementation-api", ParentPhaseID: "implementation", Title: "API integration", Status: flowstore.PhaseReady, Order: 10},
-			},
-		}},
-		ActivePane:     PaneBottom,
-		FlowSelected:   0,
-		ExpandedFlowID: "flow-1",
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "flow-1",
+				Title:  "Child phases",
+				Status: flowstore.StatusInProgress,
+				Branch: "flow/children",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: "approved", Order: 2},
+					{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted, Order: 3},
+					{PhaseID: "review-loop", Title: "Review Loop", Status: flowstore.PhasePending, Order: 4},
+					{PhaseID: "implementation-api", ParentPhaseID: "implementation", Title: "API integration", Status: flowstore.PhaseReady, Order: 10},
+				},
+			}},
+			FlowSelected:   0,
+			ExpandedFlowID: "flow-1"}})
 
 	implementation := strings.Index(view, "implementation:completed")
 	child := strings.LastIndex(view, "implementation-api:ready")
@@ -2268,46 +2230,45 @@ func TestRender_FlowsModeGroupsChildImplementationPhasesUnderParent(t *testing.T
 
 func TestRender_FlowsModeShowsUpdatedPhaseDrivenStates(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    230,
-		Height:   12,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{
-			{
-				FlowID: "blocked-flow",
-				Title:  "Blocked implementation",
-				Status: flowstore.StatusBlocked,
-				Branch: "flow/blocked",
-				Phases: []flowstore.FlowPhase{
-					{PhaseID: "plan", Status: flowstore.PhaseCompleted},
-					{PhaseID: "implementation", Status: flowstore.PhaseBlocked},
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      230,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{
+				{
+					FlowID: "blocked-flow",
+					Title:  "Blocked implementation",
+					Status: flowstore.StatusBlocked,
+					Branch: "flow/blocked",
+					Phases: []flowstore.FlowPhase{
+						{PhaseID: "plan", Status: flowstore.PhaseCompleted},
+						{PhaseID: "implementation", Status: flowstore.PhaseBlocked},
+					},
+				},
+				{
+					FlowID: "attention-flow",
+					Title:  "Needs review input",
+					Status: flowstore.StatusNeedsAttention,
+					Branch: "flow/needs-attention",
+					Phases: []flowstore.FlowPhase{
+						{PhaseID: "plan", Status: flowstore.PhaseCompleted},
+						{PhaseID: "review-loop", Status: flowstore.PhaseNeedsAttention},
+					},
+				},
+				{
+					FlowID: "completed-flow",
+					Title:  "Completed flow",
+					Status: flowstore.StatusCompleted,
+					Branch: "flow/completed",
+					Phases: []flowstore.FlowPhase{
+						{PhaseID: "plan", Status: flowstore.PhaseCompleted},
+						{PhaseID: "review-loop", Status: flowstore.PhaseSkipped},
+					},
 				},
 			},
-			{
-				FlowID: "attention-flow",
-				Title:  "Needs review input",
-				Status: flowstore.StatusNeedsAttention,
-				Branch: "flow/needs-attention",
-				Phases: []flowstore.FlowPhase{
-					{PhaseID: "plan", Status: flowstore.PhaseCompleted},
-					{PhaseID: "review-loop", Status: flowstore.PhaseNeedsAttention},
-				},
-			},
-			{
-				FlowID: "completed-flow",
-				Title:  "Completed flow",
-				Status: flowstore.StatusCompleted,
-				Branch: "flow/completed",
-				Phases: []flowstore.FlowPhase{
-					{PhaseID: "plan", Status: flowstore.PhaseCompleted},
-					{PhaseID: "review-loop", Status: flowstore.PhaseSkipped},
-				},
-			},
-		},
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-	})
+			FlowSelected: 0}})
 
 	for _, want := range []string{
 		"blocked", "flow/blocked", "Blocked implementation",
@@ -2324,33 +2285,32 @@ func TestRender_FlowsModeShowsUpdatedPhaseDrivenStates(t *testing.T) {
 func TestRender_FlowsModeShowsMergedFlowsAsInspectableRows(t *testing.T) {
 	mergedAt := time.Date(2026, 6, 8, 15, 4, 5, 0, time.UTC)
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   12,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "merged-flow",
-			Title:  "Merged flow",
-			Status: flowstore.StatusMerged,
-			Branch: "flow/merged",
-			PlanID: "plan-merged",
-			PR:     flowstore.PullRequest{Number: 116, URL: "https://github.com/approachcontrol/approach/pull/116"},
-			Merge: flowstore.Merge{
-				Status:   flowstore.MergeMerged,
-				Commit:   "0123456789abcdef",
-				MergedAt: &mergedAt,
-			},
-			Phases: []flowstore.FlowPhase{
-				{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
-				{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseCompleted, Outcome: "passed"},
-				{PhaseID: "merge", Title: "Merge", Status: flowstore.PhaseCompleted, Outcome: "merged"},
-			},
-		}},
-		ActivePane:     PaneBottom,
-		FlowSelected:   0,
-		ExpandedFlowID: "merged-flow",
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "merged-flow",
+				Title:  "Merged flow",
+				Status: flowstore.StatusMerged,
+				Branch: "flow/merged",
+				PlanID: "plan-merged",
+				PR:     flowstore.PullRequest{Number: 116, URL: "https://github.com/approachcontrol/approach/pull/116"},
+				Merge: flowstore.Merge{
+					Status:   flowstore.MergeMerged,
+					Commit:   "0123456789abcdef",
+					MergedAt: &mergedAt,
+				},
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
+					{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseCompleted, Outcome: "passed"},
+					{PhaseID: "merge", Title: "Merge", Status: flowstore.PhaseCompleted, Outcome: "merged"},
+				},
+			}},
+			FlowSelected:   0,
+			ExpandedFlowID: "merged-flow"}})
 
 	for _, want := range []string{"merged", "flow/merged", "3/3", "plan-merged", "#116", "Merged flow", "merge:merged", "Merge"} {
 		if !strings.Contains(view, want) {
@@ -2361,27 +2321,26 @@ func TestRender_FlowsModeShowsMergedFlowsAsInspectableRows(t *testing.T) {
 
 func TestRender_FlowsModeShowsPlanReviewGateState(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   13,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "review-flow",
-			Title:  "Plan needs revision",
-			Status: flowstore.StatusNeedsAttention,
-			Branch: "flow/review",
-			PlanID: "plan-1",
-			Phases: []flowstore.FlowPhase{
-				{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
-				{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseNeedsAttention, Outcome: "changes_requested"},
-				{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhasePending},
-			},
-		}},
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-		FlowHeadless: true,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     13,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "review-flow",
+				Title:  "Plan needs revision",
+				Status: flowstore.StatusNeedsAttention,
+				Branch: "flow/review",
+				PlanID: "plan-1",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
+					{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseNeedsAttention, Outcome: "changes_requested"},
+					{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhasePending},
+				},
+			}},
+			FlowSelected: 0,
+			FlowHeadless: true}})
 
 	for _, want := range []string{"plan-review", "changes_requested", "1/3", "enter", "phases", "headless on"} {
 		if !strings.Contains(view, want) {
@@ -2397,28 +2356,27 @@ func TestRender_FlowsModeShowsPlanReviewGateState(t *testing.T) {
 
 func TestRender_FlowsModeShowsAutoreviewMissingPRMetadata(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   12,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "missing-pr-flow",
-			Title:  "Needs PR metadata",
-			Status: flowstore.StatusInProgress,
-			Branch: "flow/missing-pr",
-			Phases: []flowstore.FlowPhase{
-				{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
-				{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
-				{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted},
-				{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseCompleted},
-				{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhaseCompleted},
-				{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhasePending},
-			},
-		}},
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "missing-pr-flow",
+				Title:  "Needs PR metadata",
+				Status: flowstore.StatusInProgress,
+				Branch: "flow/missing-pr",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseCompleted},
+					{PhaseID: "plan-review", Title: "Plan Review", Status: flowstore.PhaseCompleted, Outcome: flowstore.OutcomeApproved},
+					{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseCompleted},
+					{PhaseID: "review-loop", Title: "Review loop", Status: flowstore.PhaseCompleted},
+					{PhaseID: "pr-creation", Title: "PR creation", Status: flowstore.PhaseCompleted},
+					{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhasePending},
+				},
+			}},
+			FlowSelected: 0}})
 
 	for _, want := range []string{"autoreview:missing-pr", "missing", "Needs PR metadata"} {
 		if !strings.Contains(view, want) {
@@ -2429,24 +2387,23 @@ func TestRender_FlowsModeShowsAutoreviewMissingPRMetadata(t *testing.T) {
 
 func TestRender_FlowsModeShowsAutoreviewKindMissingPRMetadata(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   12,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{{
-			FlowID: "missing-pr-flow",
-			Title:  "Needs PR metadata",
-			Status: flowstore.StatusInProgress,
-			Branch: "flow/missing-pr",
-			Phases: []flowstore.FlowPhase{
-				{PhaseID: "open-pr", Kind: flowstore.KindPRCreation, Title: "Open PR", Status: flowstore.PhaseCompleted},
-				{PhaseID: "second-review", Kind: flowstore.KindAutoreview, Title: "Second Review", Status: flowstore.PhasePending},
-			},
-		}},
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{
+				FlowID: "missing-pr-flow",
+				Title:  "Needs PR metadata",
+				Status: flowstore.StatusInProgress,
+				Branch: "flow/missing-pr",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "open-pr", Kind: flowstore.KindPRCreation, Title: "Open PR", Status: flowstore.PhaseCompleted},
+					{PhaseID: "second-review", Kind: flowstore.KindAutoreview, Title: "Second Review", Status: flowstore.PhasePending},
+				},
+			}},
+			FlowSelected: 0}})
 
 	if !strings.Contains(view, "second-review:missing-pr") {
 		t.Fatalf("missing PR metadata view should key off autoreview kind:\n%s", view)
@@ -2455,69 +2412,68 @@ func TestRender_FlowsModeShowsAutoreviewKindMissingPRMetadata(t *testing.T) {
 
 func TestRender_FlowsModeShowsRecoveryWarnings(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    240,
-		Height:   14,
-		Mode:     ModeFlows,
-		Flows: []flowstore.FlowRecord{
-			{
-				FlowID: "missing-worktree",
-				Title:  "Saved flow needs worktree metadata",
-				Status: flowstore.StatusBlocked,
-				Phases: []flowstore.FlowPhase{
-					{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseBlocked, LaunchIDs: []string{"launch-1"}},
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     14,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{
+				{
+					FlowID: "missing-worktree",
+					Title:  "Saved flow needs worktree metadata",
+					Status: flowstore.StatusBlocked,
+					Phases: []flowstore.FlowPhase{
+						{PhaseID: "plan", Title: "Plan", Status: flowstore.PhaseBlocked, LaunchIDs: []string{"launch-1"}},
+					},
 				},
-			},
-			{
-				FlowID:       "awaiting-session",
-				Title:        "Launch has not attached a session",
-				Status:       flowstore.StatusInProgress,
-				Branch:       "flow/awaiting-session",
-				WorktreePath: "/dev/approach-worktrees/flow-awaiting-session",
-				Phases: []flowstore.FlowPhase{
-					{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning, LaunchIDs: []string{"launch-2"}},
+				{
+					FlowID:       "awaiting-session",
+					Title:        "Launch has not attached a session",
+					Status:       flowstore.StatusInProgress,
+					Branch:       "flow/awaiting-session",
+					WorktreePath: "/dev/approach-worktrees/flow-awaiting-session",
+					Phases: []flowstore.FlowPhase{
+						{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning, LaunchIDs: []string{"launch-2"}},
+					},
 				},
-			},
-			{
-				FlowID:       "mismatched-session",
-				Title:        "Session launch mismatch",
-				Status:       flowstore.StatusNeedsAttention,
-				Branch:       "flow/session-mismatch",
-				WorktreePath: "/dev/approach-worktrees/flow-session-mismatch",
-				Phases: []flowstore.FlowPhase{
-					{
-						PhaseID:   "review-loop",
-						Title:     "Review Loop",
-						Status:    flowstore.PhaseNeedsAttention,
-						LaunchIDs: []string{"launch-3"},
-						Sessions: []flowstore.Session{
-							{Provider: "codex", SessionID: "codex-1", LaunchID: "other-launch", Status: "ended"},
+				{
+					FlowID:       "mismatched-session",
+					Title:        "Session launch mismatch",
+					Status:       flowstore.StatusNeedsAttention,
+					Branch:       "flow/session-mismatch",
+					WorktreePath: "/dev/approach-worktrees/flow-session-mismatch",
+					Phases: []flowstore.FlowPhase{
+						{
+							PhaseID:   "review-loop",
+							Title:     "Review Loop",
+							Status:    flowstore.PhaseNeedsAttention,
+							LaunchIDs: []string{"launch-3"},
+							Sessions: []flowstore.Session{
+								{Provider: "codex", SessionID: "codex-1", LaunchID: "other-launch", Status: "ended"},
+							},
 						},
 					},
 				},
-			},
-			{
-				FlowID:       "ended-session",
-				Title:        "Latest session ended",
-				Status:       flowstore.StatusInProgress,
-				Branch:       "flow/ended-session",
-				WorktreePath: "/dev/approach-worktrees/flow-ended-session",
-				Phases: []flowstore.FlowPhase{
-					{
-						PhaseID:   "implementation",
-						Title:     "Implementation",
-						Status:    flowstore.PhaseRunning,
-						LaunchIDs: []string{"launch-4"},
-						Sessions: []flowstore.Session{
-							{Provider: "codex", SessionID: "codex-4", LaunchID: "launch-4", Status: "ended"},
+				{
+					FlowID:       "ended-session",
+					Title:        "Latest session ended",
+					Status:       flowstore.StatusInProgress,
+					Branch:       "flow/ended-session",
+					WorktreePath: "/dev/approach-worktrees/flow-ended-session",
+					Phases: []flowstore.FlowPhase{
+						{
+							PhaseID:   "implementation",
+							Title:     "Implementation",
+							Status:    flowstore.PhaseRunning,
+							LaunchIDs: []string{"launch-4"},
+							Sessions: []flowstore.Session{
+								{Provider: "codex", SessionID: "codex-4", LaunchID: "launch-4", Status: "ended"},
+							},
 						},
 					},
 				},
-			},
-		},
-		ActivePane: PaneBottom,
-	})
+			}}})
 
 	for _, want := range []string{"plan:recover-worktree", "implementation:await-session", "review-loop:session-mismatch", "implementation:ended-session"} {
 		if !strings.Contains(view, want) {
@@ -2574,15 +2530,14 @@ func TestRender_FlowRecoveryWarningsFlagLatestRelaunchWithoutSession(t *testing.
 		t.Fatalf("phase progress = %q, want latest relaunch without session to await session", got)
 	}
 	view := Render(RenderParams{
-		Repos:        []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:     0,
-		Width:        240,
-		Height:       10,
-		Mode:         ModeFlows,
-		Flows:        []flowstore.FlowRecord{record},
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     10,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows:        []flowstore.FlowRecord{record},
+			FlowSelected: 0}})
 	if !strings.Contains(view, "implementation:await-session") {
 		t.Fatalf("rendered relaunch without session should await session:\n%s", view)
 	}
@@ -2603,16 +2558,15 @@ func TestRender_FlowRecoveryWarningsPreservePhaseSpecificStates(t *testing.T) {
 		},
 	}
 	view := Render(RenderParams{
-		Repos:          []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:       0,
-		Width:          240,
-		Height:         12,
-		Mode:           ModeFlows,
-		Flows:          []flowstore.FlowRecord{flow},
-		ActivePane:     PaneBottom,
-		FlowSelected:   0,
-		ExpandedFlowID: flow.FlowID,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows:          []flowstore.FlowRecord{flow},
+			FlowSelected:   0,
+			ExpandedFlowID: flow.FlowID}})
 
 	for _, want := range []string{"autoreview:missing-pr", "plan:completed"} {
 		if !strings.Contains(view, want) {
@@ -2625,16 +2579,15 @@ func TestRender_FlowRecoveryWarningsPreservePhaseSpecificStates(t *testing.T) {
 
 	flow.Phases[2].Status = flowstore.PhaseCompleted
 	view = Render(RenderParams{
-		Repos:          []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:       0,
-		Width:          240,
-		Height:         12,
-		Mode:           ModeFlows,
-		Flows:          []flowstore.FlowRecord{flow},
-		ActivePane:     PaneBottom,
-		FlowSelected:   0,
-		ExpandedFlowID: flow.FlowID,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     12,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows:          []flowstore.FlowRecord{flow},
+			FlowSelected:   0,
+			ExpandedFlowID: flow.FlowID}})
 	if !strings.Contains(view, "autoreview:completed") || strings.Contains(view, "autoreview:missing-pr") {
 		t.Fatalf("completed autoreview history should not be overwritten by missing PR recovery:\n%s", view)
 	}
@@ -2662,15 +2615,14 @@ func TestFlowRecoveryLabelsDoNotFlagHealthySessionOrBranchOnlyRecord(t *testing.
 		t.Fatalf("phase progress = %q, want healthy session and branch-only state preserved", got)
 	}
 	view := Render(RenderParams{
-		Repos:        []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:     0,
-		Width:        240,
-		Height:       10,
-		Mode:         ModeFlows,
-		Flows:        []flowstore.FlowRecord{record},
-		ActivePane:   PaneBottom,
-		FlowSelected: 0,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      240,
+		Height:     10,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows:        []flowstore.FlowRecord{record},
+			FlowSelected: 0}})
 	if !strings.Contains(view, "review-loop:needs_attention") {
 		t.Fatalf("rendered branch-only healthy session should preserve phase state:\n%s", view)
 	}
@@ -2750,16 +2702,15 @@ func TestStatusBar_FlowsModeShowsAutofixAlongsideManualMergeOnlyWhenReady(t *tes
 
 func TestRender_FlowsModeAutofixHintNeedsAFlowRowSelection(t *testing.T) {
 	params := RenderParams{
-		Repos:                        []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Width:                        200,
-		Height:                       20,
-		Mode:                         ModeFlows,
-		ActivePane:                   PaneBottom,
-		Flows:                        []flowstore.FlowRecord{{FlowID: "flow-1", Title: "Autofix flow", Status: flowstore.StatusInProgress}},
-		FlowSelected:                 0,
-		FlowManualMergeReadySelected: true,
-		FlowAutofixReadySelected:     true,
-	}
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Width:      200,
+		Height:     20,
+		Mode:       ModeFlows,
+		ActivePane: PaneBottom, FlowParams: FlowParams{
+			Flows:                        []flowstore.FlowRecord{{FlowID: "flow-1", Title: "Autofix flow", Status: flowstore.StatusInProgress}},
+			FlowSelected:                 0,
+			FlowManualMergeReadySelected: true,
+			FlowAutofixReadySelected:     true}}
 	if view := Render(params); !strings.Contains(view, "autofix PR") {
 		t.Fatalf("selected Flow row should expose the autofix shortcut, got %q", view)
 	}

--- a/ui/ui_plan_test.go
+++ b/ui/ui_plan_test.go
@@ -325,14 +325,13 @@ func TestRender_PlansModeShowsNoPhasesOnlyWhenExpanded(t *testing.T) {
 
 func TestRender_PlanTextOverlayShowsBody(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:    0,
-		Width:       120,
-		Height:      10,
-		Mode:        ModePlans,
-		Overlay:     OverlayPlanText,
-		OverlayText: "# Persist plans\n\nfull body line\n",
-	})
+		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected: 0,
+		Width:    120,
+		Height:   10,
+		Mode:     ModePlans, OverlayParams: OverlayParams{
+			Overlay:     OverlayPlanText,
+			OverlayText: "# Persist plans\n\nfull body line\n"}})
 	for _, want := range []string{"# Persist plans", "full body line", "esc: close"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("plan text overlay missing %q:\n%s", want, view)

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -218,12 +218,11 @@ func TestRenderConfirmDialogPromptIsTerminalSafeSingleLine(t *testing.T) {
 func TestRenderInputDialogPromptIsTerminalSafeSingleLine(t *testing.T) {
 	const unsafePrompt = "Close Flow bd-1: \x1b]52;c;dGVzdA==\aUnsafe\nTitle? Reason"
 	view := Render(RenderParams{
-		Width:            120,
-		Height:           12,
-		Overlay:          OverlayInput,
-		InputPrompt:      unsafePrompt,
-		InputPlaceholder: "why this Flow is closed",
-	})
+		Width:  120,
+		Height: 12, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      unsafePrompt,
+			InputPlaceholder: "why this Flow is closed"}})
 
 	if strings.Contains(view, "\x1b]52;") {
 		t.Fatalf("input dialog retained OSC sequence: %q", view)
@@ -383,23 +382,22 @@ func TestRender_LeftPaneHidesNewRepoWhenUnavailable(t *testing.T) {
 
 func TestRenderRepoCreateFormOverlayShowsFieldsDefaultsFocusAndError(t *testing.T) {
 	view := Render(RenderParams{
-		Width:   72,
-		Height:  12,
-		Overlay: OverlayForm,
-		Form: FormView{
-			Title:      "New repo",
-			FocusIndex: 0,
-			Error:      "repo name cannot be empty",
-			Fields: []FormField{
-				{ID: "name", Kind: FormText, Label: "Repo name", Placeholder: "my-repo", Value: "app", Cursor: 3},
-				{ID: "github", Kind: FormCheckbox, Label: "Create GitHub repo", Checked: true},
-				{ID: "visibility", Kind: FormChoice, Label: "Visibility", Options: []SelectItem{
-					{Label: "Public", Value: "public"},
-					{Label: "Private", Value: "private"},
-				}, SelectedIndex: 0},
-			},
-		},
-	})
+		Width:  72,
+		Height: 12, OverlayParams: OverlayParams{
+			Overlay: OverlayForm,
+			Form: FormView{
+				Title:      "New repo",
+				FocusIndex: 0,
+				Error:      "repo name cannot be empty",
+				Fields: []FormField{
+					{ID: "name", Kind: FormText, Label: "Repo name", Placeholder: "my-repo", Value: "app", Cursor: 3},
+					{ID: "github", Kind: FormCheckbox, Label: "Create GitHub repo", Checked: true},
+					{ID: "visibility", Kind: FormChoice, Label: "Visibility", Options: []SelectItem{
+						{Label: "Public", Value: "public"},
+						{Label: "Private", Value: "private"},
+					}, SelectedIndex: 0},
+				},
+			}}})
 	text := ansi.Strip(view)
 	for _, want := range []string{
 		"New repo",
@@ -419,16 +417,15 @@ func TestRenderRepoCreateFormOverlayShowsFieldsDefaultsFocusAndError(t *testing.
 
 func TestRenderRepoCreateFormStatusBarUsesFormControls(t *testing.T) {
 	view := Render(RenderParams{
-		Width:   90,
-		Height:  8,
-		Overlay: OverlayForm,
-		Form: FormView{
-			Title: "New repo",
-			Fields: []FormField{
-				{ID: "name", Kind: FormText, Label: "Repo name"},
-			},
-		},
-	})
+		Width:  90,
+		Height: 8, OverlayParams: OverlayParams{
+			Overlay: OverlayForm,
+			Form: FormView{
+				Title: "New repo",
+				Fields: []FormField{
+					{ID: "name", Kind: FormText, Label: "Repo name"},
+				},
+			}}})
 	lines := strippedLines(view)
 	status := lines[len(lines)-1]
 	for _, want := range []string{"tab/shift+tab", "space", "enter: submit", "esc: cancel"} {
@@ -476,10 +473,9 @@ func TestRenderFlowCreateFormOverlayIsCompactAndLeavesBackgroundVisible(t *testi
 		Selected: 0,
 		Width:    120,
 		Height:   16,
-		Mode:     ModeFlows,
-		Overlay:  OverlayForm,
-		Form:     form,
-	})
+		Mode:     ModeFlows, OverlayParams: OverlayParams{
+			Overlay: OverlayForm,
+			Form:    form}})
 	text := ansi.Strip(view)
 	for _, want := range []string{"alpha", "New flow", "Title", "Instructions", "Base ref", "main", shortcutOverflowMarker, "alt+enter: newline"} {
 		if !strings.Contains(text, want) {
@@ -521,20 +517,19 @@ func TestRenderFlowCreateFormOverlayFitsNarrowTerminal(t *testing.T) {
 		Selected: 0,
 		Width:    38,
 		Height:   14,
-		Mode:     ModeFlows,
-		Overlay:  OverlayForm,
-		Form: FormView{
-			Purpose:    "flow-create",
-			Title:      "New flow",
-			FocusIndex: 1,
-			Error:      "flow instructions must explain the work to perform",
-			Fields: []FormField{
-				{ID: "title", Kind: FormText, Label: "Title", Placeholder: FlowTitleInputPlaceholder, Value: "Very long flow title that wraps", Cursor: len([]rune("Very long flow title that wraps"))},
-				{ID: "instructions", Kind: FormMultilineText, Label: "Instructions", Placeholder: FlowInstructionsInputPlaceholder, Value: "Implement a compact single form with multiline instructions and narrow terminal wrapping.", Cursor: len([]rune("Implement a compact single form with multiline instructions and narrow terminal wrapping."))},
-				{ID: "base-ref", Kind: FormText, Label: "Base ref", Placeholder: FlowBaseRefInputPlaceholder, Value: "feature/some-long-base-ref", Cursor: len([]rune("feature/some-long-base-ref"))},
-			},
-		},
-	})
+		Mode:     ModeFlows, OverlayParams: OverlayParams{
+			Overlay: OverlayForm,
+			Form: FormView{
+				Purpose:    "flow-create",
+				Title:      "New flow",
+				FocusIndex: 1,
+				Error:      "flow instructions must explain the work to perform",
+				Fields: []FormField{
+					{ID: "title", Kind: FormText, Label: "Title", Placeholder: FlowTitleInputPlaceholder, Value: "Very long flow title that wraps", Cursor: len([]rune("Very long flow title that wraps"))},
+					{ID: "instructions", Kind: FormMultilineText, Label: "Instructions", Placeholder: FlowInstructionsInputPlaceholder, Value: "Implement a compact single form with multiline instructions and narrow terminal wrapping.", Cursor: len([]rune("Implement a compact single form with multiline instructions and narrow terminal wrapping."))},
+					{ID: "base-ref", Kind: FormText, Label: "Base ref", Placeholder: FlowBaseRefInputPlaceholder, Value: "feature/some-long-base-ref", Cursor: len([]rune("feature/some-long-base-ref"))},
+				},
+			}}})
 
 	requireLinesWithinWidth(t, strippedLines(view), 38)
 }
@@ -595,18 +590,17 @@ func TestRender_SessionsModeShowsSessionRowsAboveEmbeddedTerminalDock(t *testing
 			Branch:    "feature/saved",
 			Summary:   "saved session row",
 		}},
-		EmbeddedTerminals: []EmbeddedTerminalTab{{
-			Number:   1,
-			Provider: "codex",
-			Identity: "feature/api",
-			State:    "running",
-			Active:   true,
-		}},
-		EmbeddedTerminalLines:   []string{"agent output"},
-		EmbeddedTerminalVisible: true,
-		ActivePane:              PaneTop,
-		SessionSelected:         0,
-	})
+		ActivePane:      PaneTop,
+		SessionSelected: 0, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals: []EmbeddedTerminalTab{{
+				Number:   1,
+				Provider: "codex",
+				Identity: "feature/api",
+				State:    "running",
+				Active:   true,
+			}},
+			EmbeddedTerminalLines:   []string{"agent output"},
+			EmbeddedTerminalVisible: true}})
 
 	for _, want := range []string{"[2] sessions", "Provider", "saved session row", "1 codex feature/api running", "agent output"} {
 		if !strings.Contains(view, want) {
@@ -735,17 +729,16 @@ func TestRenderEmbeddedTerminalDockPaneShowsCollapsedChip(t *testing.T) {
 
 func TestRenderExpandedTerminalDockIsTopLevelFullWidthPane(t *testing.T) {
 	p := RenderParams{
-		Repos:                   []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:                0,
-		Width:                   120,
-		Height:                  24,
-		Mode:                    ModeSessions,
-		ActivePane:              PaneTop,
-		Sessions:                []sessions.SessionRecord{{Provider: sessions.ProviderCodex, Branch: "feature/dock"}},
-		EmbeddedTerminals:       []EmbeddedTerminalTab{{Number: 1, Provider: "codex", Identity: "dock", State: "running", Active: true}},
-		EmbeddedTerminalLines:   []string{"persistent terminal output"},
-		EmbeddedTerminalVisible: true,
-	}
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      120,
+		Height:     24,
+		Mode:       ModeSessions,
+		ActivePane: PaneTop,
+		Sessions:   []sessions.SessionRecord{{Provider: sessions.ProviderCodex, Branch: "feature/dock"}}, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals:       []EmbeddedTerminalTab{{Number: 1, Provider: "codex", Identity: "dock", State: "running", Active: true}},
+			EmbeddedTerminalLines:   []string{"persistent terminal output"},
+			EmbeddedTerminalVisible: true}}
 	view := Render(p)
 	lines := strippedLines(view)
 	dockRows := EmbeddedTerminalDockRows(p.Height, EmbeddedTerminalDockExpanded)
@@ -788,21 +781,20 @@ func TestRenderResponsiveTerminalPreservesStackedPanesAtThreshold(t *testing.T) 
 		flows[i] = flowstore.FlowRecord{FlowID: fmt.Sprintf("flow-%d", i+1), Title: fmt.Sprintf("bottom-%d", i+1), Branch: fmt.Sprintf("bottom-%d", i+1), WorktreePath: fmt.Sprintf("/dev/bottom-%d", i+1), Status: flowstore.StatusPending}
 	}
 	p := RenderParams{
-		Repos:                   []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:                0,
-		Width:                   180,
-		Height:                  24,
-		Mode:                    ModeFlows,
-		TopMode:                 ModeWorktrees,
-		BottomMode:              ModeFlows,
-		ContentPane:             PaneBottom,
-		ActivePane:              PaneBottom,
-		Worktrees:               worktrees,
-		Flows:                   flows,
-		EmbeddedTerminals:       []EmbeddedTerminalTab{{Number: 1, Provider: "codex", Identity: "implementation", State: "running", Active: true}},
-		EmbeddedTerminalLines:   []string{"threshold output"},
-		EmbeddedTerminalVisible: true,
-	}
+		Repos:       []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:    0,
+		Width:       180,
+		Height:      24,
+		Mode:        ModeFlows,
+		TopMode:     ModeWorktrees,
+		BottomMode:  ModeFlows,
+		ContentPane: PaneBottom,
+		ActivePane:  PaneBottom,
+		Worktrees:   worktrees, FlowParams: FlowParams{
+			Flows: flows}, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals:       []EmbeddedTerminalTab{{Number: 1, Provider: "codex", Identity: "implementation", State: "running", Active: true}},
+			EmbeddedTerminalLines:   []string{"threshold output"},
+			EmbeddedTerminalVisible: true}}
 
 	plain := ansi.Strip(Render(p))
 	for _, want := range []string{"[1] git", "[3] flows", "top-1", "top-6", "Status", "bottom-1", "bottom-5", "threshold output"} {
@@ -820,18 +812,17 @@ func TestRenderResponsiveTerminalPreservesStackedPanesAtThreshold(t *testing.T) 
 
 func TestRenderAutoCollapsedTerminalChipAndShortcutRailAgree(t *testing.T) {
 	p := RenderParams{
-		Repos:                 []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:              0,
-		Width:                 180,
-		Height:                23,
-		Mode:                  ModeSessions,
-		TopMode:               ModeWorktrees,
-		BottomMode:            ModeSessions,
-		ContentPane:           PaneBottom,
-		ActivePane:            PaneBottom,
-		EmbeddedTerminals:     []EmbeddedTerminalTab{{Number: 1, Provider: "codex", Identity: "implementation", State: "running", Active: true}},
-		EmbeddedTerminalLines: []string{"invisible output"},
-	}
+		Repos:       []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:    0,
+		Width:       180,
+		Height:      23,
+		Mode:        ModeSessions,
+		TopMode:     ModeWorktrees,
+		BottomMode:  ModeSessions,
+		ContentPane: PaneBottom,
+		ActivePane:  PaneBottom, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals:     []EmbeddedTerminalTab{{Number: 1, Provider: "codex", Identity: "implementation", State: "running", Active: true}},
+			EmbeddedTerminalLines: []string{"invisible output"}}}
 
 	p.EmbeddedTerminalVisible = true
 	autoCollapsed := ansi.Strip(Render(p))
@@ -858,15 +849,14 @@ func TestRenderAutoCollapsedTerminalChipAndShortcutRailAgree(t *testing.T) {
 
 func TestRenderCollapsedTerminalDockChipIsFullWidthAboveStatusBar(t *testing.T) {
 	p := RenderParams{
-		Repos:             []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected:          0,
-		Width:             120,
-		Height:            16,
-		Mode:              ModeSessions,
-		ActivePane:        PaneTop,
-		Sessions:          []sessions.SessionRecord{{Provider: sessions.ProviderCodex, Branch: "feature/dock"}},
-		EmbeddedTerminals: []EmbeddedTerminalTab{{Number: 1, Provider: "codex", Identity: "dock", State: "running", Active: true}},
-	}
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      120,
+		Height:     16,
+		Mode:       ModeSessions,
+		ActivePane: PaneTop,
+		Sessions:   []sessions.SessionRecord{{Provider: sessions.ProviderCodex, Branch: "feature/dock"}}, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals: []EmbeddedTerminalTab{{Number: 1, Provider: "codex", Identity: "dock", State: "running", Active: true}}}}
 	view := Render(p)
 	lines := strippedLines(view)
 	if len(lines) != p.Height {
@@ -898,14 +888,13 @@ func TestRenderNeverOverflowsViewportHeight(t *testing.T) {
 		for _, state := range states {
 			for height := 5; height <= 30; height++ {
 				view := Render(RenderParams{
-					Repos:                   []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-					Width:                   90,
-					Height:                  height,
-					Mode:                    mode,
-					ActivePane:              PaneTop,
-					EmbeddedTerminals:       state.terminals,
-					EmbeddedTerminalVisible: state.visible,
-				})
+					Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+					Width:      90,
+					Height:     height,
+					Mode:       mode,
+					ActivePane: PaneTop, EmbeddedTerminalParams: EmbeddedTerminalParams{
+						EmbeddedTerminals:       state.terminals,
+						EmbeddedTerminalVisible: state.visible}})
 				if got := len(strippedLines(view)); got != height {
 					t.Fatalf("mode %d %s dock at height %d rendered %d lines:\n%s", mode, state.name, height, got, view)
 				}
@@ -925,9 +914,8 @@ func TestRenderStackedStoredPanesUsesPaneLocalHeaders(t *testing.T) {
 		BottomMode:  ModeFlows,
 		ContentPane: PaneTop,
 		ActivePane:  PaneTop,
-		BeadsOpen:   nil,
-		Flows:       []flowstore.FlowRecord{{FlowID: "flow-1", Title: "Bottom flow", RepoPath: "/dev/approach", Branch: "flow/bottom"}},
-	}
+		BeadsOpen:   nil, FlowParams: FlowParams{
+			Flows: []flowstore.FlowRecord{{FlowID: "flow-1", Title: "Bottom flow", RepoPath: "/dev/approach", Branch: "flow/bottom"}}}}
 	view := Render(p)
 	if got := len(strippedLines(view)); got != p.Height {
 		t.Fatalf("stacked view line count = %d, want %d:\n%s", got, p.Height, view)
@@ -953,10 +941,9 @@ func TestRenderActiveFlowsTakesOverCombinedStackedColumn(t *testing.T) {
 		TopMode:     ModeBeadsOpen,
 		BottomMode:  ModeFlows,
 		ContentPane: PaneTop,
-		ActivePane:  PaneRepos,
-		ActiveFlows: true,
-		Flows:       []flowstore.FlowRecord{{FlowID: "flow-1", RepoPath: "/dev/approach", Branch: "flow/takeover"}},
-	}
+		ActivePane:  PaneRepos, FlowParams: FlowParams{
+			ActiveFlows: true,
+			Flows:       []flowstore.FlowRecord{{FlowID: "flow-1", RepoPath: "/dev/approach", Branch: "flow/takeover"}}}}
 	plain := ansi.Strip(Render(p))
 	if strings.Count(plain, "[^a] active flows") != 1 || !strings.Contains(plain, "flow/takeover") {
 		t.Fatalf("Active Flows did not render once across the content column:\n%s", plain)
@@ -979,12 +966,11 @@ func TestRender_ShortcutRailSurvivesExpandedDock(t *testing.T) {
 		Height:     60,
 		Mode:       ModeSessions,
 		ActivePane: PaneTop,
-		Sessions:   []sessions.SessionRecord{{Provider: sessions.ProviderCodex, Branch: "feature/dock"}},
-		EmbeddedTerminals: []EmbeddedTerminalTab{{
-			Number: 1, Provider: "codex", Identity: "dock", State: "running", Active: true,
-		}},
-		EmbeddedTerminalVisible: true,
-	})
+		Sessions:   []sessions.SessionRecord{{Provider: sessions.ProviderCodex, Branch: "feature/dock"}}, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals: []EmbeddedTerminalTab{{
+				Number: 1, Provider: "codex", Identity: "dock", State: "running", Active: true,
+			}},
+			EmbeddedTerminalVisible: true}})
 	pane := shortcutPaneText(view)
 	for _, want := range []string{"Actions", "r      resume"} {
 		if !strings.Contains(pane, want) {
@@ -1069,8 +1055,8 @@ func TestRenderCollapsedTerminalChipPersistsInEveryMode(t *testing.T) {
 		{name: "worktrees", params: RenderParams{Mode: ModeWorktrees, Worktrees: []gitquery.Worktree{{Path: "/dev/dock", BranchName: "feature/dock"}}}, listText: "feature/dock"},
 		{name: "sessions", params: RenderParams{Mode: ModeSessions, Sessions: []sessions.SessionRecord{{Provider: sessions.ProviderCodex, Branch: "feature/dock"}}}, listText: "feature/dock"},
 		{name: "plans", params: RenderParams{Mode: ModePlans, Plans: []planstore.PlanRecord{{PlanID: "plan-1", Title: "Dock plan", Status: "approved"}}}, listText: "Dock plan"},
-		{name: "flows", params: RenderParams{Mode: ModeFlows, Flows: []flowstore.FlowRecord{flow}}, listText: "flow/dock"},
-		{name: "active flows", params: RenderParams{Mode: ModeSessions, ActiveFlows: true, Flows: []flowstore.FlowRecord{flow}}, listText: "flow/dock"},
+		{name: "flows", params: RenderParams{Mode: ModeFlows, FlowParams: FlowParams{Flows: []flowstore.FlowRecord{flow}}}, listText: "flow/dock"},
+		{name: "active flows", params: RenderParams{Mode: ModeSessions, FlowParams: FlowParams{ActiveFlows: true, Flows: []flowstore.FlowRecord{flow}}}, listText: "flow/dock"},
 	}
 
 	for _, tt := range tests {
@@ -1102,8 +1088,8 @@ func TestRenderEmptyTerminalChipPersistsInEveryMode(t *testing.T) {
 		{name: "worktrees", params: RenderParams{Mode: ModeWorktrees, Worktrees: []gitquery.Worktree{{Path: "/dev/dock", BranchName: "feature/dock"}}}, listText: "feature/dock"},
 		{name: "sessions", params: RenderParams{Mode: ModeSessions, Sessions: []sessions.SessionRecord{{Provider: sessions.ProviderCodex, Branch: "feature/dock"}}}, listText: "feature/dock"},
 		{name: "plans", params: RenderParams{Mode: ModePlans, Plans: []planstore.PlanRecord{{PlanID: "plan-1", Title: "Dock plan", Status: "approved"}}}, listText: "Dock plan"},
-		{name: "flows", params: RenderParams{Mode: ModeFlows, Flows: []flowstore.FlowRecord{flow}}, listText: "flow/dock"},
-		{name: "active flows", params: RenderParams{Mode: ModeSessions, ActiveFlows: true, Flows: []flowstore.FlowRecord{flow}}, listText: "flow/dock"},
+		{name: "flows", params: RenderParams{Mode: ModeFlows, FlowParams: FlowParams{Flows: []flowstore.FlowRecord{flow}}}, listText: "flow/dock"},
+		{name: "active flows", params: RenderParams{Mode: ModeSessions, FlowParams: FlowParams{ActiveFlows: true, Flows: []flowstore.FlowRecord{flow}}}, listText: "flow/dock"},
 	}
 
 	for _, tt := range tests {
@@ -1257,23 +1243,22 @@ func TestRenderEmbeddedTerminalPaneBorderUsesFocusColor(t *testing.T) {
 
 func TestRender_SessionsEmbeddedTerminalShowsPrefixCue(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:    []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
-		Selected: 0,
-		Width:    180,
-		Height:   24,
-		Mode:     ModeSessions,
-		EmbeddedTerminals: []EmbeddedTerminalTab{{
-			Number:   1,
-			Provider: "codex",
-			Identity: "feature/api",
-			State:    "running",
-			Active:   true,
-		}},
-		EmbeddedTerminalLines:   []string{"agent output"},
-		EmbeddedTerminalPrefix:  true,
-		EmbeddedTerminalVisible: true,
-		ActivePane:              PaneTop,
-	})
+		Repos:      []scanner.Repo{{Path: "/dev/approach", DisplayName: "approach"}},
+		Selected:   0,
+		Width:      180,
+		Height:     24,
+		Mode:       ModeSessions,
+		ActivePane: PaneTop, EmbeddedTerminalParams: EmbeddedTerminalParams{
+			EmbeddedTerminals: []EmbeddedTerminalTab{{
+				Number:   1,
+				Provider: "codex",
+				Identity: "feature/api",
+				State:    "running",
+				Active:   true,
+			}},
+			EmbeddedTerminalLines:   []string{"agent output"},
+			EmbeddedTerminalPrefix:  true,
+			EmbeddedTerminalVisible: true}})
 
 	if !strings.Contains(view, "ctrl+]") {
 		t.Fatalf("embedded terminal prefix cue missing:\n%s", view)
@@ -1824,13 +1809,12 @@ func TestRender_OmitsDefaultViewSetting(t *testing.T) {
 
 func TestStatusBar_InputOverlayShowsSingleLineHints(t *testing.T) {
 	bar := Render(RenderParams{
-		Width:       120,
-		Height:      8,
-		Mode:        ModeWorktrees,
-		Overlay:     OverlayInput,
-		InputPrompt: "Create worktree from",
-		InputMode:   InputSingleLine,
-	})
+		Width:  120,
+		Height: 8,
+		Mode:   ModeWorktrees, OverlayParams: OverlayParams{
+			Overlay:     OverlayInput,
+			InputPrompt: "Create worktree from",
+			InputMode:   InputSingleLine}})
 	status := strings.Split(bar, "\n")[7]
 	for _, hint := range []string{"enter: submit", "esc: cancel", "bksp/del: edit"} {
 		if !strings.Contains(bar, hint) {
@@ -1844,13 +1828,12 @@ func TestStatusBar_InputOverlayShowsSingleLineHints(t *testing.T) {
 
 func TestStatusBar_InputOverlayShowsMultiLineHints(t *testing.T) {
 	view := Render(RenderParams{
-		Width:       120,
-		Height:      8,
-		Mode:        ModePlans,
-		Overlay:     OverlayInput,
-		InputPrompt: LaunchInstructionsPrompt,
-		InputMode:   InputMultiLine,
-	})
+		Width:  120,
+		Height: 8,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:     OverlayInput,
+			InputPrompt: LaunchInstructionsPrompt,
+			InputMode:   InputMultiLine}})
 	status := strings.Split(view, "\n")[7]
 	for _, hint := range []string{"enter: submit", "alt+enter: newline", "esc: cancel"} {
 		if !strings.Contains(status, hint) {
@@ -1875,16 +1858,15 @@ func TestStatusBar_SelectOverlayShowsSelectHints(t *testing.T) {
 
 func TestStatusBar_LaunchInstructionsOverlayShowsLaunchHint(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:            120,
-		Height:           12,
-		Mode:             ModePlans,
-		Overlay:          OverlayInput,
-		InputPrompt:      LaunchInstructionsPrompt,
-		InputPlaceholder: "launch instructions",
-		InputValue:       "Implement the selected plan",
-		InputMode:        InputMultiLine,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  120,
+		Height: 12,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      LaunchInstructionsPrompt,
+			InputPlaceholder: "launch instructions",
+			InputValue:       "Implement the selected plan",
+			InputMode:        InputMultiLine}})
 	status := strings.Split(view, "\n")[11]
 	for _, hint := range []string{"enter: submit", "alt+enter: newline", "esc: cancel"} {
 		if !strings.Contains(status, hint) {
@@ -3407,13 +3389,12 @@ func TestRender_CombinesPanesWithDivider(t *testing.T) {
 
 func TestRender_ConfirmDialogShowsPrompt(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:         []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:         80,
-		Height:        24,
-		Mode:          1,
-		Overlay:       OverlayConfirm,
-		ConfirmPrompt: "Remove worktree /dev/alpha/feat? (y/n)",
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   1, OverlayParams: OverlayParams{
+			Overlay:       OverlayConfirm,
+			ConfirmPrompt: "Remove worktree /dev/alpha/feat? (y/n)"}})
 	if !strings.Contains(view, "Remove worktree /dev/alpha/feat") {
 		t.Error("confirm dialog should show prompt text")
 	}
@@ -3424,14 +3405,13 @@ func TestRender_ConfirmDialogShowsPrompt(t *testing.T) {
 
 func TestRender_ForceConfirmDialogShowsPrompt(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:         []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:         80,
-		Height:        24,
-		Mode:          1,
-		Overlay:       OverlayConfirm,
-		ConfirmPrompt: "Force delete /dev/alpha/feat? (y/n)",
-		ConfirmForce:  true,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   1, OverlayParams: OverlayParams{
+			Overlay:       OverlayConfirm,
+			ConfirmPrompt: "Force delete /dev/alpha/feat? (y/n)",
+			ConfirmForce:  true}})
 	if !strings.Contains(view, "Force delete /dev/alpha/feat") {
 		t.Error("force confirm dialog should show prompt text")
 	}
@@ -3439,17 +3419,16 @@ func TestRender_ForceConfirmDialogShowsPrompt(t *testing.T) {
 
 func TestRender_WorktreeInputDialogShowsInputAndError(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:            80,
-		Height:           24,
-		Mode:             1,
-		Overlay:          OverlayInput,
-		InputPrompt:      "Create worktree from",
-		InputPlaceholder: WorktreeInputPlaceholder,
-		InputValue:       "feature/new",
-		InputCursor:      len([]rune("feature/new")),
-		InputError:       "already exists",
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   1, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      "Create worktree from",
+			InputPlaceholder: WorktreeInputPlaceholder,
+			InputValue:       "feature/new",
+			InputCursor:      len([]rune("feature/new")),
+			InputError:       "already exists"}})
 	if !strings.Contains(view, "Create worktree from: feature/new") {
 		t.Error("worktree input dialog should show typed input")
 	}
@@ -3462,14 +3441,13 @@ func TestRender_WorktreeInputDialogShowsPlaceholder(t *testing.T) {
 	forceTrueColor(t)
 
 	view := Render(RenderParams{
-		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:            80,
-		Height:           24,
-		Mode:             1,
-		Overlay:          OverlayInput,
-		InputPrompt:      "Create worktree from",
-		InputPlaceholder: WorktreeInputPlaceholder,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   1, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      "Create worktree from",
+			InputPlaceholder: WorktreeInputPlaceholder}})
 	stripped := ansi.Strip(view)
 	if !strings.Contains(stripped, "Create worktree from: "+WorktreeInputPlaceholder) {
 		t.Fatalf("worktree input dialog should show prompt and placeholder when input is empty:\n%s", stripped)
@@ -3493,14 +3471,13 @@ func TestRender_InputDialogWrappedPlaceholderUsesPlaceholderStyle(t *testing.T) 
 
 	placeholder := "alpha beta gamma delta epsilon zeta"
 	view := Render(RenderParams{
-		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:            36,
-		Height:           18,
-		Mode:             ModeWorktrees,
-		Overlay:          OverlayInput,
-		InputPrompt:      "Create worktree from",
-		InputPlaceholder: placeholder,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  36,
+		Height: 18,
+		Mode:   ModeWorktrees, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      "Create worktree from",
+			InputPlaceholder: placeholder}})
 
 	stripped := ansi.Strip(view)
 	for _, want := range []string{
@@ -3533,16 +3510,15 @@ func TestRender_InputDialogNonEmptyDoesNotRenderPlaceholderStyle(t *testing.T) {
 	forceTrueColor(t)
 
 	view := Render(RenderParams{
-		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:            80,
-		Height:           24,
-		Mode:             ModeWorktrees,
-		Overlay:          OverlayInput,
-		InputPrompt:      "Create worktree from",
-		InputPlaceholder: WorktreeInputPlaceholder,
-		InputValue:       "feature/new",
-		InputCursor:      len([]rune("feature/new")),
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   ModeWorktrees, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      "Create worktree from",
+			InputPlaceholder: WorktreeInputPlaceholder,
+			InputValue:       "feature/new",
+			InputCursor:      len([]rune("feature/new"))}})
 
 	stripped := ansi.Strip(view)
 	if !strings.Contains(stripped, "Create worktree from: feature/new") {
@@ -3559,16 +3535,15 @@ func TestRender_InputDialogNonEmptyDoesNotRenderPlaceholderStyle(t *testing.T) {
 func TestRender_InputDialogWrapsLongSingleLineAndShowsCursorInPlace(t *testing.T) {
 	longWord := strings.Repeat("x", 90)
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:       60,
-		Height:      18,
-		Mode:        ModeWorktrees,
-		Overlay:     OverlayInput,
-		InputPrompt: "New branch",
-		InputValue:  "feature/" + longWord,
-		InputCursor: len([]rune("feature/xxx")),
-		InputMode:   InputSingleLine,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  60,
+		Height: 18,
+		Mode:   ModeWorktrees, OverlayParams: OverlayParams{
+			Overlay:     OverlayInput,
+			InputPrompt: "New branch",
+			InputValue:  "feature/" + longWord,
+			InputCursor: len([]rune("feature/xxx")),
+			InputMode:   InputSingleLine}})
 	stripped := ansi.Strip(view)
 	if strings.Contains(stripped, "feature/"+longWord) {
 		t.Fatalf("long input should wrap instead of rendering on one line:\n%s", view)
@@ -3590,18 +3565,17 @@ func TestRender_InputDialogWrapsLongSingleLineAndShowsCursorInPlace(t *testing.T
 
 func TestRender_InputDialogPreservesMultiLineBreaksAndWrapsError(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:            72,
-		Height:           18,
-		Mode:             ModePlans,
-		Overlay:          OverlayInput,
-		InputPrompt:      LaunchInstructionsPrompt,
-		InputPlaceholder: "launch instructions",
-		InputValue:       "first line\nsecond line with detail",
-		InputCursor:      len([]rune("first line\nsecond")),
-		InputMode:        InputMultiLine,
-		InputError:       "this validation message is intentionally long enough to wrap inside the input modal",
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  72,
+		Height: 18,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      LaunchInstructionsPrompt,
+			InputPlaceholder: "launch instructions",
+			InputValue:       "first line\nsecond line with detail",
+			InputCursor:      len([]rune("first line\nsecond")),
+			InputMode:        InputMultiLine,
+			InputError:       "this validation message is intentionally long enough to wrap inside the input modal"}})
 	stripped := ansi.Strip(view)
 	if !strings.Contains(stripped, "first line") || !strings.Contains(stripped, "second█ line with detail") {
 		t.Fatalf("multi-line input should preserve breaks and cursor position:\n%s", view)
@@ -3616,16 +3590,15 @@ func TestRender_InputDialogPreservesMultiLineBreaksAndWrapsError(t *testing.T) {
 
 func TestRender_InputDialogPreservesEditableSpacing(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:       90,
-		Height:      18,
-		Mode:        ModePlans,
-		Overlay:     OverlayInput,
-		InputPrompt: LaunchInstructionsPrompt,
-		InputValue:  "first  line\n  - second  item",
-		InputCursor: len([]rune("first  line\n  - second")),
-		InputMode:   InputMultiLine,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  90,
+		Height: 18,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:     OverlayInput,
+			InputPrompt: LaunchInstructionsPrompt,
+			InputValue:  "first  line\n  - second  item",
+			InputCursor: len([]rune("first  line\n  - second")),
+			InputMode:   InputMultiLine}})
 	stripped := ansi.Strip(view)
 	if !strings.Contains(stripped, "first  line") {
 		t.Fatalf("input dialog collapsed repeated spaces on first line:\n%s", stripped)
@@ -3647,16 +3620,15 @@ func TestRender_InputDialogOverflowKeepsCursorVisible(t *testing.T) {
 		"target line",
 	}, "\n")
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:       64,
-		Height:      10,
-		Mode:        ModePlans,
-		Overlay:     OverlayInput,
-		InputPrompt: "Instructions",
-		InputValue:  value,
-		InputCursor: len([]rune(value)) - len([]rune(" line")),
-		InputMode:   InputMultiLine,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  64,
+		Height: 10,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:     OverlayInput,
+			InputPrompt: "Instructions",
+			InputValue:  value,
+			InputCursor: len([]rune(value)) - len([]rune(" line")),
+			InputMode:   InputMultiLine}})
 	stripped := ansi.Strip(view)
 	if !strings.Contains(stripped, "target█ line") {
 		t.Fatalf("overflow window should keep cursor line visible:\n%s", view)
@@ -3683,28 +3655,26 @@ func TestRender_InputDialogConfiguredHeightShowsMoreText(t *testing.T) {
 	}, "\n")
 
 	defaultView := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:       72,
-		Height:      22,
-		Mode:        ModePlans,
-		Overlay:     OverlayInput,
-		InputPrompt: "Edit Plan launch",
-		InputValue:  value,
-		InputCursor: len([]rune(value)),
-		InputMode:   InputMultiLine,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  72,
+		Height: 22,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:     OverlayInput,
+			InputPrompt: "Edit Plan launch",
+			InputValue:  value,
+			InputCursor: len([]rune(value)),
+			InputMode:   InputMultiLine}})
 	tallView := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:       72,
-		Height:      22,
-		Mode:        ModePlans,
-		Overlay:     OverlayInput,
-		InputPrompt: "Edit Plan launch",
-		InputValue:  value,
-		InputCursor: len([]rune(value)),
-		InputMode:   InputMultiLine,
-		InputHeight: 16,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  72,
+		Height: 22,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:     OverlayInput,
+			InputPrompt: "Edit Plan launch",
+			InputValue:  value,
+			InputCursor: len([]rune(value)),
+			InputMode:   InputMultiLine,
+			InputHeight: 16}})
 
 	if strings.Contains(ansi.Strip(defaultView), "line 01") {
 		t.Fatalf("default input height unexpectedly shows the first line:\n%s", ansi.Strip(defaultView))
@@ -3724,16 +3694,15 @@ func TestRender_InputDialogTinyHeightKeepsCursorVisible(t *testing.T) {
 		"line three",
 	}, "\n")
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:       64,
-		Height:      4,
-		Mode:        ModePlans,
-		Overlay:     OverlayInput,
-		InputPrompt: "Instructions",
-		InputValue:  value,
-		InputCursor: len([]rune("line one\nline")),
-		InputMode:   InputMultiLine,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  64,
+		Height: 4,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:     OverlayInput,
+			InputPrompt: "Instructions",
+			InputValue:  value,
+			InputCursor: len([]rune("line one\nline")),
+			InputMode:   InputMultiLine}})
 	stripped := ansi.Strip(view)
 	if !strings.Contains(stripped, "line█ two") {
 		t.Fatalf("tiny input dialog should keep the cursor line visible:\n%s", stripped)
@@ -3747,17 +3716,16 @@ func TestRender_InputDialogTinyHeightWithErrorKeepsCursorVisible(t *testing.T) {
 		"line three",
 	}, "\n")
 	view := Render(RenderParams{
-		Repos:       []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:       64,
-		Height:      4,
-		Mode:        ModePlans,
-		Overlay:     OverlayInput,
-		InputPrompt: "Instructions",
-		InputValue:  value,
-		InputCursor: len([]rune("line one\nline two\nline")),
-		InputMode:   InputMultiLine,
-		InputError:  "validation failed",
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  64,
+		Height: 4,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:     OverlayInput,
+			InputPrompt: "Instructions",
+			InputValue:  value,
+			InputCursor: len([]rune("line one\nline two\nline")),
+			InputMode:   InputMultiLine,
+			InputError:  "validation failed"}})
 	stripped := ansi.Strip(view)
 	if !strings.Contains(stripped, "line█ three") {
 		t.Fatalf("tiny input dialog with error should keep the cursor line visible:\n%s", stripped)
@@ -3766,14 +3734,13 @@ func TestRender_InputDialogTinyHeightWithErrorKeepsCursorVisible(t *testing.T) {
 
 func TestRender_WorktreeMoveInputDialogShowsPromptAndPlaceholder(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:            80,
-		Height:           24,
-		Mode:             1,
-		Overlay:          OverlayInput,
-		InputPrompt:      WorktreeMovePrompt,
-		InputPlaceholder: WorktreeMoveInputPlaceholder,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   1, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      WorktreeMovePrompt,
+			InputPlaceholder: WorktreeMoveInputPlaceholder}})
 	if !strings.Contains(view, "Move worktree to:") {
 		t.Error("move input dialog should show move prompt")
 	}
@@ -3784,14 +3751,13 @@ func TestRender_WorktreeMoveInputDialogShowsPromptAndPlaceholder(t *testing.T) {
 
 func TestRender_BranchInputDialogShowsPromptAndPlaceholder(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:            80,
-		Height:           24,
-		Mode:             2,
-		Overlay:          OverlayInput,
-		InputPrompt:      BranchPrompt,
-		InputPlaceholder: BranchInputPlaceholder,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   2, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      BranchPrompt,
+			InputPlaceholder: BranchInputPlaceholder}})
 	if !strings.Contains(view, "Create branch:") {
 		t.Error("branch input dialog should show prompt")
 	}
@@ -3802,14 +3768,13 @@ func TestRender_BranchInputDialogShowsPromptAndPlaceholder(t *testing.T) {
 
 func TestRender_PullRequestWorktreeInputDialogShowsPromptAndPlaceholder(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:            80,
-		Height:           24,
-		Mode:             1,
-		Overlay:          OverlayInput,
-		InputPrompt:      PRWorktreePrompt,
-		InputPlaceholder: PRWorktreeInputPlaceholder,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   1, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      PRWorktreePrompt,
+			InputPlaceholder: PRWorktreeInputPlaceholder}})
 	if !strings.Contains(view, "Create PR worktree from:") {
 		t.Error("PR input dialog should show prompt")
 	}
@@ -3820,15 +3785,14 @@ func TestRender_PullRequestWorktreeInputDialogShowsPromptAndPlaceholder(t *testi
 
 func TestRender_SelectDialogShowsPromptItemsAndSelection(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:          80,
-		Height:         24,
-		Mode:           1,
-		Overlay:        OverlaySelect,
-		SelectPrompt:   "Choose interactive helper",
-		SelectItems:    []SelectItem{{Label: "codex", Value: "codex"}, {Label: "claude", Value: "claude"}},
-		SelectSelected: 1,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  80,
+		Height: 24,
+		Mode:   1, OverlayParams: OverlayParams{
+			Overlay:        OverlaySelect,
+			SelectPrompt:   "Choose interactive helper",
+			SelectItems:    []SelectItem{{Label: "codex", Value: "codex"}, {Label: "claude", Value: "claude"}},
+			SelectSelected: 1}})
 	stripped := ansi.Strip(view)
 	for _, want := range []string{"Choose interactive helper", "codex", "claude"} {
 		if !strings.Contains(stripped, want) {
@@ -3842,15 +3806,14 @@ func TestRender_SelectDialogShowsPromptItemsAndSelection(t *testing.T) {
 
 func TestRender_PromptTemplateSelectShowsPromptSpecificFooter(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:          90,
-		Height:         16,
-		Mode:           ModeWorktrees,
-		Overlay:        OverlaySelect,
-		SelectPrompt:   "Prompt templates",
-		SelectItems:    []SelectItem{{Label: "Plan launch     default", Value: "agent.plan_prompt"}},
-		SelectSelected: 0,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  90,
+		Height: 16,
+		Mode:   ModeWorktrees, OverlayParams: OverlayParams{
+			Overlay:        OverlaySelect,
+			SelectPrompt:   "Prompt templates",
+			SelectItems:    []SelectItem{{Label: "Plan launch     default", Value: "agent.plan_prompt"}},
+			SelectSelected: 0}})
 
 	stripped := ansi.Strip(view)
 	for _, want := range []string{"enter: edit", "r: reset", "v: preview", "esc: cancel"} {
@@ -3872,14 +3835,13 @@ func TestRender_SelectOverlayUsesBoundedPanelAndKeepsBaseVisible(t *testing.T) {
 		Mode:             ModeWorktrees,
 		ActivePane:       PaneTop,
 		Worktrees:        []gitquery.Worktree{{Path: "/dev/alpha-worktrees/feature", BranchName: "feature/picker"}},
-		WorktreeSelected: 0,
-		Overlay:          OverlaySelect,
-		SelectPrompt:     "Choose helper",
-		SelectItems:      []SelectItem{{Label: "codex", Value: "codex"}, {Label: "claude", Value: "claude"}},
-		SelectWidth:      32,
-		SelectHeight:     6,
-		SelectPlacement:  SelectPlacementTopCenter,
-	})
+		WorktreeSelected: 0, OverlayParams: OverlayParams{
+			Overlay:         OverlaySelect,
+			SelectPrompt:    "Choose helper",
+			SelectItems:     []SelectItem{{Label: "codex", Value: "codex"}, {Label: "claude", Value: "claude"}},
+			SelectWidth:     32,
+			SelectHeight:    6,
+			SelectPlacement: SelectPlacementTopCenter}})
 
 	bounds := requireSelectPanelBounds(t, view, "Choose helper")
 	if bounds.width != 32 || bounds.height != 6 {
@@ -3909,15 +3871,14 @@ func TestRender_SelectOverlayUsesBoundedPanelAndKeepsBaseVisible(t *testing.T) {
 
 func TestRender_SelectOverlayAutoSizesFromPromptAndItems(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:          40,
-		Height:         10,
-		Mode:           ModeWorktrees,
-		Overlay:        OverlaySelect,
-		SelectPrompt:   "Pick",
-		SelectItems:    []SelectItem{{Label: "", Value: "fallback-value"}, {Label: "tiny", Value: "tiny"}},
-		SelectSelected: 0,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  40,
+		Height: 10,
+		Mode:   ModeWorktrees, OverlayParams: OverlayParams{
+			Overlay:        OverlaySelect,
+			SelectPrompt:   "Pick",
+			SelectItems:    []SelectItem{{Label: "", Value: "fallback-value"}, {Label: "tiny", Value: "tiny"}},
+			SelectSelected: 0}})
 
 	bounds := requireSelectPanelBounds(t, view, "Pick")
 	if bounds.width != len("fallback-value")+4 {
@@ -3933,15 +3894,14 @@ func TestRender_SelectOverlayAutoSizesFromPromptAndItems(t *testing.T) {
 
 func TestRender_SelectOverlayAutoWidthFitsLongestUnselectedItem(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:          40,
-		Height:         10,
-		Mode:           ModeWorktrees,
-		Overlay:        OverlaySelect,
-		SelectPrompt:   "Pick",
-		SelectItems:    []SelectItem{{Label: "tiny", Value: "tiny"}, {Label: "", Value: "fallback-value"}},
-		SelectSelected: 0,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  40,
+		Height: 10,
+		Mode:   ModeWorktrees, OverlayParams: OverlayParams{
+			Overlay:        OverlaySelect,
+			SelectPrompt:   "Pick",
+			SelectItems:    []SelectItem{{Label: "tiny", Value: "tiny"}, {Label: "", Value: "fallback-value"}},
+			SelectSelected: 0}})
 
 	bounds := requireSelectPanelBounds(t, view, "Pick")
 	if bounds.width != len("fallback-value")+4 {
@@ -3965,17 +3925,16 @@ func TestRender_SelectOverlayPlacementsUseTerminalBody(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			view := Render(RenderParams{
-				Repos:           []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-				Width:           40,
-				Height:          13,
-				Mode:            ModeWorktrees,
-				Overlay:         OverlaySelect,
-				SelectPrompt:    "Pick",
-				SelectItems:     []SelectItem{{Label: "one", Value: "1"}},
-				SelectWidth:     20,
-				SelectHeight:    5,
-				SelectPlacement: tt.placement,
-			})
+				Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+				Width:  40,
+				Height: 13,
+				Mode:   ModeWorktrees, OverlayParams: OverlayParams{
+					Overlay:         OverlaySelect,
+					SelectPrompt:    "Pick",
+					SelectItems:     []SelectItem{{Label: "one", Value: "1"}},
+					SelectWidth:     20,
+					SelectHeight:    5,
+					SelectPlacement: tt.placement}})
 			bounds := requireSelectPanelBounds(t, view, "Pick")
 			if bounds.x != 10 || bounds.y != tt.wantY {
 				t.Fatalf("select panel position = (%d,%d), want (10,%d):\n%s", bounds.x, bounds.y, tt.wantY, ansi.Strip(view))
@@ -3995,21 +3954,20 @@ func TestRender_SelectOverlayPreservesStyledBaseRowsAroundPanel(t *testing.T) {
 	})
 
 	view := Render(RenderParams{
-		Repos:           []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Selected:        0,
-		Width:           72,
-		Height:          12,
-		Mode:            ModeBranches,
-		ActivePane:      PaneTop,
-		Branches:        []gitquery.BranchRow{{Branch: gitquery.Branch{Name: "main", IsWorktree: true}, WorktreePath: "/dev/alpha"}},
-		BranchSelected:  0,
-		Overlay:         OverlaySelect,
-		SelectPrompt:    "Pick",
-		SelectItems:     []SelectItem{{Label: "codex", Value: "codex"}},
-		SelectWidth:     24,
-		SelectHeight:    4,
-		SelectPlacement: SelectPlacementBottomCenter,
-	})
+		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Selected:       0,
+		Width:          72,
+		Height:         12,
+		Mode:           ModeBranches,
+		ActivePane:     PaneTop,
+		Branches:       []gitquery.BranchRow{{Branch: gitquery.Branch{Name: "main", IsWorktree: true}, WorktreePath: "/dev/alpha"}},
+		BranchSelected: 0, OverlayParams: OverlayParams{
+			Overlay:         OverlaySelect,
+			SelectPrompt:    "Pick",
+			SelectItems:     []SelectItem{{Label: "codex", Value: "codex"}},
+			SelectWidth:     24,
+			SelectHeight:    4,
+			SelectPlacement: SelectPlacementBottomCenter}})
 
 	if !strings.Contains(view, "\x1b[") {
 		t.Fatalf("expected styled base rows to remain styled:\n%s", view)
@@ -4027,17 +3985,16 @@ func TestRender_SelectOverlayPreservesStyledBaseRowsAroundPanel(t *testing.T) {
 
 func TestRender_SelectOverlayShortHeightKeepsSelectedItemVisible(t *testing.T) {
 	view := Render(RenderParams{
-		Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:          64,
-		Height:         10,
-		Mode:           ModeWorktrees,
-		Overlay:        OverlaySelect,
-		SelectPrompt:   "Pick",
-		SelectItems:    []SelectItem{{Label: "first", Value: "1"}, {Label: "second", Value: "2"}, {Label: "third", Value: "3"}, {Label: "fourth", Value: "4"}, {Label: "fifth", Value: "5"}},
-		SelectSelected: 4,
-		SelectWidth:    20,
-		SelectHeight:   5,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  64,
+		Height: 10,
+		Mode:   ModeWorktrees, OverlayParams: OverlayParams{
+			Overlay:        OverlaySelect,
+			SelectPrompt:   "Pick",
+			SelectItems:    []SelectItem{{Label: "first", Value: "1"}, {Label: "second", Value: "2"}, {Label: "third", Value: "3"}, {Label: "fourth", Value: "4"}, {Label: "fifth", Value: "5"}},
+			SelectSelected: 4,
+			SelectWidth:    20,
+			SelectHeight:   5}})
 
 	stripped := ansi.Strip(view)
 	if !strings.Contains(stripped, "> fifth") {
@@ -4061,17 +4018,16 @@ func TestRender_SelectOverlayTinyTerminalsClampWithoutOverflow(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%dx%d", size.width, size.height), func(t *testing.T) {
 			view := Render(RenderParams{
-				Repos:          []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-				Width:          size.width,
-				Height:         size.height,
-				Mode:           ModeWorktrees,
-				Overlay:        OverlaySelect,
-				SelectPrompt:   "Pick a helper",
-				SelectItems:    []SelectItem{{Label: "codex", Value: "codex"}},
-				SelectSelected: 0,
-				SelectWidth:    32,
-				SelectHeight:   6,
-			})
+				Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+				Width:  size.width,
+				Height: size.height,
+				Mode:   ModeWorktrees, OverlayParams: OverlayParams{
+					Overlay:        OverlaySelect,
+					SelectPrompt:   "Pick a helper",
+					SelectItems:    []SelectItem{{Label: "codex", Value: "codex"}},
+					SelectSelected: 0,
+					SelectWidth:    32,
+					SelectHeight:   6}})
 			lines := strings.Split(ansi.Strip(view), "\n")
 			if len(lines) != size.height {
 				t.Fatalf("line count = %d, want %d:\n%s", len(lines), size.height, ansi.Strip(view))
@@ -4162,17 +4118,16 @@ func selectPanelCandidateContainsPrompt(lines []string, bounds selectPanelBounds
 func TestRender_LaunchInstructionsInputDialogWrapsInCompactPanel(t *testing.T) {
 	longInput := `Implement the saved approach plan "Persist custom launch instructions" at /state/approach/plans/plan-1/plan.md. Read the plan file, then begin implementation.`
 	view := Render(RenderParams{
-		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:            120,
-		Height:           24,
-		Mode:             ModePlans,
-		Overlay:          OverlayInput,
-		InputPrompt:      LaunchInstructionsPrompt,
-		InputPlaceholder: "launch instructions",
-		InputValue:       longInput,
-		InputCursor:      len([]rune(longInput)),
-		InputMode:        InputMultiLine,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  120,
+		Height: 24,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      LaunchInstructionsPrompt,
+			InputPlaceholder: "launch instructions",
+			InputValue:       longInput,
+			InputCursor:      len([]rune(longInput)),
+			InputMode:        InputMultiLine}})
 
 	if !strings.Contains(view, LaunchInstructionsPrompt) {
 		t.Fatalf("launch instructions dialog should show prompt:\n%s", view)
@@ -4208,17 +4163,16 @@ func TestRender_LaunchInstructionsInputDialogMarksOverflow(t *testing.T) {
 		"Finish by launching the selected agent with the edited instructions.",
 	}, " ")
 	view := Render(RenderParams{
-		Repos:            []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
-		Width:            52,
-		Height:           20,
-		Mode:             ModePlans,
-		Overlay:          OverlayInput,
-		InputPrompt:      LaunchInstructionsPrompt,
-		InputPlaceholder: "launch instructions",
-		InputValue:       longInput,
-		InputCursor:      len([]rune(longInput)),
-		InputMode:        InputMultiLine,
-	})
+		Repos:  []scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}},
+		Width:  52,
+		Height: 20,
+		Mode:   ModePlans, OverlayParams: OverlayParams{
+			Overlay:          OverlayInput,
+			InputPrompt:      LaunchInstructionsPrompt,
+			InputPlaceholder: "launch instructions",
+			InputValue:       longInput,
+			InputCursor:      len([]rune(longInput)),
+			InputMode:        InputMultiLine}})
 
 	for _, want := range []string{shortcutOverflowMarker, "Finish by launching"} {
 		if !strings.Contains(view, want) {
@@ -5238,12 +5192,11 @@ func TestRender_ActiveFlowsTakeoverPreservesFilterEmptyMessage(t *testing.T) {
 		Mode:              ModeActiveFlows,
 		TopMode:           ModeWorktrees,
 		BottomMode:        ModeFlows,
-		ActiveFlows:       true,
 		ActivePane:        PaneBottom,
 		ContentPane:       PaneBottom,
 		ItemSearch:        "zzz",
-		RightEmptyMessage: "No flow results for zzz",
-	}))
+		RightEmptyMessage: "No flow results for zzz", FlowParams: FlowParams{
+			ActiveFlows: true}}))
 	if !strings.Contains(view, "No flow results for zzz") {
 		t.Fatalf("Active Flows filter-empty view lost query-specific message:\n%s", view)
 	}
@@ -5257,20 +5210,18 @@ func TestRender_CollapsedRepoPaneHidesRestoreHintWhileTerminalOwnsInput(t *testi
 		{
 			name: "session terminal",
 			params: RenderParams{
-				Mode:                    ModeSessions,
-				EmbeddedTerminals:       []EmbeddedTerminalTab{{Active: true}},
-				EmbeddedTerminalVisible: true,
-				EmbeddedTerminalFocused: true,
-			},
+				Mode: ModeSessions, EmbeddedTerminalParams: EmbeddedTerminalParams{
+					EmbeddedTerminals:       []EmbeddedTerminalTab{{Active: true}},
+					EmbeddedTerminalVisible: true,
+					EmbeddedTerminalFocused: true}},
 		},
 		{
 			name: "flow terminal",
 			params: RenderParams{
-				Mode:                    ModeFlows,
-				EmbeddedTerminals:       []EmbeddedTerminalTab{{Active: true}},
-				EmbeddedTerminalVisible: true,
-				EmbeddedTerminalFocused: true,
-			},
+				Mode: ModeFlows, EmbeddedTerminalParams: EmbeddedTerminalParams{
+					EmbeddedTerminals:       []EmbeddedTerminalTab{{Active: true}},
+					EmbeddedTerminalVisible: true,
+					EmbeddedTerminalFocused: true}},
 		},
 	}
 
@@ -5373,11 +5324,12 @@ func TestReflogPane_SelectedHighlighted(t *testing.T) {
 
 func TestReflogDiffOverlay_EmptyDiffShowsMessage(t *testing.T) {
 	view := Render(RenderParams{
-		Width:   80,
-		Height:  24,
-		Mode:    5,
-		Overlay: OverlayReflogDiff,
-		// OverlayDiff is empty
+		Width:  80,
+		Height: 24,
+		Mode:   5,
+		OverlayParams: OverlayParams{
+			Overlay: OverlayReflogDiff,
+		},
 	})
 	if !strings.Contains(view, "No changes at this reflog entry") {
 		t.Error("expected 'No changes at this reflog entry' in empty reflog diff overlay")
@@ -5386,12 +5338,11 @@ func TestReflogDiffOverlay_EmptyDiffShowsMessage(t *testing.T) {
 
 func TestReflogDiffOverlay_NonEmptyDiffShowsContent(t *testing.T) {
 	view := Render(RenderParams{
-		Width:       80,
-		Height:      24,
-		Mode:        5,
-		Overlay:     OverlayReflogDiff,
-		OverlayDiff: "diff --git a/f.txt\n+added line",
-	})
+		Width:  80,
+		Height: 24,
+		Mode:   5, OverlayParams: OverlayParams{
+			Overlay:     OverlayReflogDiff,
+			OverlayDiff: "diff --git a/f.txt\n+added line"}})
 	if !strings.Contains(view, "diff --git") {
 		t.Error("expected diff content in reflog diff overlay")
 	}


### PR DESCRIPTION
Model, Options, and RenderParams had grown into 100+ field bags, so a later change had no obvious home and #27's maintainability finding stayed open after #381–#384 shrunk the other copies.

Terminal, list-fetch, auto-advance, and agent-identity fields now live in named sub-structs on Model. `agentConfigFromOptions` is the seam Options uses to populate that cluster — Options keeps its exported field names as the public injection API. RenderParams embeds OverlayParams, FlowParams, and EmbeddedTerminalParams. Existing field names stay promoted, so `m.embeddedTerminals` and `p.Overlay` still compile; only composite literals nest the group.

No field was renamed in the same step as the move. No user-visible behavior change.

Stacked on #384. Fifth of five. Closes finding #27 on #277.

**Test plan**
- [x] `gofmt` clean
- [x] `go test ./model ./ui` after each sub-struct
- [x] `make test` and `make build`