### PR TITLE
Build the tracked phase launch in the role builder, not at the call site

### DIFF
--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -51,8 +51,8 @@ marker" from "constructs a Flow launch".
 
 | Pruned | Why unreachable |
 | --- | --- |
-| any kind × tmux × headless | `tmuxRouteEligible` refuses `ctx.Headless` (`model/tmux_mode.go:64`). The route is decided *after* headless resolution (`model/flow_phase_launch.go:396–402`), so this holds for every kind. |
-| `autoPhase` × interactive | Both AutoMode read commands hardcode `Headless: true` (`model/flow_launch_lifecycle.go:665`, `:692`), and prepare's reservation override is skipped when `req.AutoLaunch` (`model/flow_phase_launch.go:396`). |
+| any kind × tmux × headless | `tmuxRouteEligible` refuses `ctx.Headless` (`model/tmux_mode.go:64`). The route is decided *after* headless resolution (`model/flow_launch_context.go:286–309`), so this holds for every kind. |
+| `autoPhase` × interactive | Both AutoMode read commands hardcode `Headless: true` (`model/flow_launch_lifecycle.go:665`, `:692`), and the tracked-phase builder skips the reservation override when `target.AutoLaunch` (`model/flow_launch_context.go:286`). |
 | `autoPhase` × tmux | Follows from the previous two rows: auto ⇒ headless ⇒ embedded. |
 | `repair` × tmux | Refused twice: `tmuxRouteEligible` rejects `ctx.FlowRepair` (`model/tmux_mode.go:64`), and prepare has no tmux call site (`model/flow_launch_repair.go:440`). |
 | `createPhase` × tmux | No call site; route is hardcoded embedded (`model/flow_launch_create.go:373`). |
@@ -87,13 +87,14 @@ The reachable variants:
 
 ### Migration status
 
-V7–V17 are built by `newFlowLaunchContext` (`model/flow_launch_context.go`)
-rather than by a literal at their prepare stage: V16 (worktreeAgent), V11–V12
-(repair), V13–V15 (autofix), V17 (savedSessionResume) and V7–V10
-(phaseResume), in that migration order. Only V1–V6 — manual, auto and create
-phase launches — still compose a literal at their call site, so the
-construction sites in section 1 and the `C:` line numbers in section 3 read as
-the pre-migration snapshot for every other row.
+V1–V4 and V7–V17 are built by `newFlowLaunchContext`
+(`model/flow_launch_context.go`) rather than by a literal at their prepare
+stage: V16 (worktreeAgent), V11–V12 (repair), V13–V15 (autofix), V17
+(savedSessionResume), V7–V10 (phaseResume) and V1–V4 (manual and auto phase),
+in that migration order. Only V5–V6 — the create-phase launch — still composes
+a literal at its call site, so the construction sites in section 1 and the `C:`
+line numbers in section 3 read as the pre-migration snapshot for every other
+row.
 
 Two of those roles decide their own *route*. V13–V15 were the first: the
 builder takes the snapshotted backend and tmux probe and returns the route with
@@ -106,6 +107,14 @@ which keeps the pruning rules at rows `repair × tmux`, `worktreeAgent × tmux`
 and `savedSessionResume × tmux` true by construction rather than by a missing
 call site. The `phaseResume × headless` and `savedSessionResume × headless`
 rules likewise now hold because neither builder arm assigns `Headless`.
+
+V1–V4 were the last route-deciding arm to move. The tracked-phase builder
+resolves the reservation-vs-requested headless rule and *then* decides the
+route against the finished context, which is what keeps the
+`any kind × tmux × headless` pruning rule true by construction rather than by
+call-site ordering. `prepare` now maps the builder's route onto
+`flowPhaseLaunchRoute`, and an unmapped route is an error rather than a silent
+embedded default. Unifying those two route enums is the remaining follow-up.
 
 ## 3. Field values, with the pipeline point that sets them
 

--- a/model/flow_launch_context.go
+++ b/model/flow_launch_context.go
@@ -151,6 +151,47 @@ type phaseResumeTarget struct {
 
 func (phaseResumeTarget) role() actions.FlowLaunchRole { return actions.RolePhaseResume }
 
+// trackedPhaseTarget is the phase-attached launch started by g and by AutoMode.
+// It is the only role that reserves the Flow lease and writes phase attempt
+// history, and it carries two records for the reason phase resume does: the
+// launch reads a record and then writes one, and the two answer different
+// questions.
+type trackedPhaseTarget struct {
+	// LaunchID is the admission token, never a fresh ID: the reservation and
+	// every LaunchID-keyed fence downstream are already on it.
+	LaunchID string
+	// Record is the prepared snapshot, not the reservation's return value.
+	// AddFlowPhaseLaunchID linearizes the target phase only; branch, commit,
+	// plan ID and worktree stay on the snapshot the plan body and plan path
+	// were already read from.
+	Record flowstore.FlowRecord
+	// PersistedRecord is what AddFlowPhaseLaunchID returned, consulted only for
+	// the headless reservation rule below.
+	PersistedRecord flowstore.FlowRecord
+	// Phase is the launch phase prepare already resolved (the persisted phase
+	// when the write returned one, the requested phase otherwise). It arrives
+	// resolved because prepare must resolve agent settings against it first, and
+	// that refusal is prepare's flowPhaseLaunchValidationError to raise.
+	Phase flowstore.FlowPhase
+	// Agent is the phase's resolved settings, carried for the reason
+	// repairTarget carries its own: resolution can fail with a typed refusal
+	// that belongs to admission, not to the builder.
+	Agent        agent.Settings
+	RepoPath     string
+	WorktreePath string
+	PlanPath     string
+	// PlanBody is the linked plan's markdown when this phase's prompt needs it,
+	// read by prepare through the ReadPlan seam.
+	PlanBody string
+	// AutoLaunch is the FlowAutoLaunch marker and half of the headless rule.
+	AutoLaunch bool
+	// RequestedHeadless is the caller's requested value, which the reservation
+	// may override for a manual launch.
+	RequestedHeadless bool
+}
+
+func (trackedPhaseTarget) role() actions.FlowLaunchRole { return actions.RoleTrackedPhase }
+
 // errIncompleteFlowLaunchTarget reports a payload that upstream admission
 // should already have guaranteed. The builder still checks: it is the one
 // place every Flow launch context is constructed, so it is the only place the
@@ -196,6 +237,8 @@ func newFlowLaunchContext(
 	routing flowLaunchRouting,
 ) (actions.AgentLaunchContext, flowLaunchRouteDecision, error) {
 	switch payload := target.(type) {
+	case trackedPhaseTarget:
+		return newTrackedPhaseLaunchContext(payload, settings, routing)
 	case worktreeAgentTarget:
 		return newWorktreeAgentLaunchContext(payload, settings)
 	case repairTarget:
@@ -209,6 +252,72 @@ func newFlowLaunchContext(
 	default:
 		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errIncompleteFlowLaunchTarget
 	}
+}
+
+// newTrackedPhaseLaunchContext is the third arm whose route is a decision
+// rather than a constant, after autofix and phase resume. The order below is
+// load-bearing and now enforced by construction: headless is resolved before
+// the route is decided, because a headless launch is never tmux-eligible.
+//
+// Unlike the two resume roles this one does set Model and ReasoningEffort —
+// they come from the phase's resolved settings, which is what agentCommandSpec
+// expects from a fresh launch. It sets no WorkingDir: actions falls back to
+// WorktreePath, and copying the worktree agent's explicit assignment here would
+// be a silent behavior change rather than a tidy-up.
+func newTrackedPhaseLaunchContext(
+	target trackedPhaseTarget,
+	settings flowLaunchAgentSettingsSnapshot,
+	routing flowLaunchRouting,
+) (actions.AgentLaunchContext, flowLaunchRouteDecision, error) {
+	// Defensive invariants, not new user-reachable refusals: prepare's
+	// flowPhaseLaunchNoWorktreeStatus check and preflight's agent.Validate fire
+	// first and keep their own messages.
+	if strings.TrimSpace(target.LaunchID) == "" ||
+		strings.TrimSpace(target.Record.FlowID) == "" ||
+		strings.TrimSpace(target.WorktreePath) == "" ||
+		strings.TrimSpace(target.Phase.PhaseID) == "" ||
+		strings.TrimSpace(target.Agent.Command) == "" {
+		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errIncompleteFlowLaunchTarget
+	}
+	record := target.Record
+	headless := target.RequestedHeadless
+	// Persisted reservations carry UpdatedAt. A zero-time partial result from an
+	// injected launcher seam cannot authoritatively replace preferences.
+	if !target.AutoLaunch && !target.PersistedRecord.UpdatedAt.IsZero() {
+		headless = target.PersistedRecord.Headless
+	}
+	ctx := applyLaunchStamp(actions.AgentLaunchContext{
+		Command: target.Agent.Command, LaunchID: target.LaunchID,
+		RepoPath: target.RepoPath, WorktreePath: target.WorktreePath,
+		Branch: record.Branch, Commit: record.Commit,
+		Model: target.Agent.Model, ReasoningEffort: target.Agent.ReasoningEffort,
+		SessionStateRoot: settings.SessionStateRoot, PlanID: record.PlanID, PlanPath: target.PlanPath,
+		FlowID: record.FlowID, FlowPhaseID: target.Phase.PhaseID,
+		FlowPhaseKind: string(flowstore.SemanticKind(target.Phase)),
+		// FlowPhaseTerminal stays unset: the variant matrix prunes it for every
+		// role but phase resume, which is the only one that re-enters a phase
+		// that may already be terminal.
+		FlowAutoLaunch: target.AutoLaunch, FlowLaunchTracked: true,
+		Embedded: true, Headless: headless,
+		// The prompt renders settings.Pin.ExecutablePath, not the stamped
+		// ctx.Executable, for the reason repair and autofix give: the stamp is
+		// applied last, so there is no stamped value to read yet.
+		InitialPrompt: flowPhasePrompt(
+			record, target.Phase, target.PlanPath, target.PlanBody,
+			settings.PromptTemplates, settings.Pin.ExecutablePath),
+	}, settings.stamp())
+	tmuxRoute, fellBack := tmuxLaunchRouteFor(routing.Backend, routing.TmuxAvailable, ctx)
+	if tmuxRoute {
+		// A tmux window has no dock to prefill and renders its own output, so
+		// clearing Embedded is what sends the prompt to argv instead.
+		ctx.Embedded = false
+		return ctx, flowLaunchRouteDecision{Route: flowLaunchRouteTmux}, nil
+	}
+	decision := flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded}
+	if fellBack {
+		decision.FallbackNote = tmuxFallbackNote
+	}
+	return ctx, decision, nil
 }
 
 // newWorktreeAgentLaunchContext ignores routing: this kind's route is a

--- a/model/flow_launch_context_internal_test.go
+++ b/model/flow_launch_context_internal_test.go
@@ -977,3 +977,213 @@ func TestNewFlowLaunchContextKeepsThePhaseResumeSessionIDVerbatim(t *testing.T) 
 		t.Fatalf("resume session id = %q, want the untrimmed session ID", ctx.ResumeSessionID)
 	}
 }
+
+// launchContextTrackedPhaseTarget is the tracked-phase fixture: the variant
+// record plus a running implementation phase, with PersistedRecord carrying a
+// non-zero UpdatedAt so the reservation override rule is live by default. Rows
+// that need the zero-time guard clear it explicitly.
+func launchContextTrackedPhaseTarget() trackedPhaseTarget {
+	record := launchContextVariantRecord()
+	phase := flowstore.FlowPhase{
+		PhaseID: "implementation",
+		Title:   "Implementation",
+		Kind:    flowstore.KindImplementation,
+		Status:  flowstore.PhaseRunning,
+		Order:   1,
+	}
+	record.Phases = []flowstore.FlowPhase{phase}
+	return trackedPhaseTarget{
+		LaunchID:        "launch-1",
+		Record:          record,
+		PersistedRecord: record,
+		Phase:           phase,
+		Agent: agent.Settings{
+			Command:         "codex",
+			Model:           "gpt-5",
+			ReasoningEffort: "high",
+		},
+		RepoPath:     record.RepoPath,
+		WorktreePath: record.WorktreePath,
+		PlanPath:     record.PlanPath,
+	}
+}
+
+// launchContextTrackedPhaseContext is the embedded, interactive, manual context
+// every tracked-phase row starts from. WorkingDir stays empty on purpose: this
+// role has never set it, and actions falls back to WorktreePath, so adding it
+// here would be a silent behavior change rather than a tidy-up.
+func launchContextTrackedPhaseContext(target trackedPhaseTarget) actions.AgentLaunchContext {
+	return actions.AgentLaunchContext{
+		Command:           "codex",
+		Model:             "gpt-5",
+		ReasoningEffort:   "high",
+		LaunchID:          "launch-1",
+		RepoPath:          target.RepoPath,
+		WorktreePath:      target.WorktreePath,
+		Branch:            target.Record.Branch,
+		Commit:            target.Record.Commit,
+		SessionStateRoot:  "/state",
+		PlanID:            target.Record.PlanID,
+		PlanPath:          target.PlanPath,
+		FlowID:            target.Record.FlowID,
+		FlowPhaseID:       "implementation",
+		FlowPhaseKind:     string(flowstore.KindImplementation),
+		FlowLaunchTracked: true,
+		Embedded:          true,
+		InitialPrompt: flowPhasePrompt(
+			target.Record, target.Phase, target.PlanPath, target.PlanBody, FlowPromptTemplates{}, ""),
+	}
+}
+
+// TestNewFlowLaunchContextPinsTheTrackedPhaseVariants covers the four reachable
+// tracked-phase variants from docs/flow-launch-variant-matrix.md. It compares
+// whole structs for the reason the shared variant table does: a field this role
+// starts setting has to be declared here before it can ship.
+func TestNewFlowLaunchContextPinsTheTrackedPhaseVariants(t *testing.T) {
+	for _, variant := range []struct {
+		name     string
+		mutate   func(*trackedPhaseTarget)
+		routing  flowLaunchRouting
+		want     func(trackedPhaseTarget) actions.AgentLaunchContext
+		decision flowLaunchRouteDecision
+	}{
+		{
+			// V1: the ordinary g launch. The reservation answered with an
+			// interactive record, so the requested value and the persisted one
+			// agree and Headless stays false.
+			name:     "tracked phase manual embedded",
+			want:     launchContextTrackedPhaseContext,
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
+		},
+		{
+			// V2: the reservation override. The caller asked for an interactive
+			// launch and the persisted record says headless, so the persisted
+			// value wins. A row that merely requested headless would pass without
+			// the rule.
+			name: "tracked phase manual headless",
+			mutate: func(target *trackedPhaseTarget) {
+				target.RequestedHeadless = false
+				target.PersistedRecord.Headless = true
+			},
+			want: func(target trackedPhaseTarget) actions.AgentLaunchContext {
+				ctx := launchContextTrackedPhaseContext(target)
+				ctx.Headless = true
+				return ctx
+			},
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
+		},
+		{
+			// V3: interactive plus a tmux backend with tmux on PATH. Embedded
+			// clears because a tmux window has no dock to prefill.
+			name: "tracked phase manual tmux",
+			routing: flowLaunchRouting{
+				Backend:       config.LaunchBackendTmux,
+				TmuxAvailable: func() bool { return true },
+			},
+			want: func(target trackedPhaseTarget) actions.AgentLaunchContext {
+				ctx := launchContextTrackedPhaseContext(target)
+				ctx.Embedded = false
+				return ctx
+			},
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteTmux},
+		},
+		{
+			// V4: AutoMode. The persisted record says interactive and the request
+			// says headless, and headless wins — auto launches skip the
+			// reservation override entirely.
+			name: "tracked phase auto headless",
+			mutate: func(target *trackedPhaseTarget) {
+				target.AutoLaunch = true
+				target.RequestedHeadless = true
+				target.PersistedRecord.Headless = false
+			},
+			want: func(target trackedPhaseTarget) actions.AgentLaunchContext {
+				ctx := launchContextTrackedPhaseContext(target)
+				ctx.FlowAutoLaunch = true
+				ctx.Headless = true
+				return ctx
+			},
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
+		},
+	} {
+		t.Run(variant.name, func(t *testing.T) {
+			target := launchContextTrackedPhaseTarget()
+			if variant.mutate != nil {
+				variant.mutate(&target)
+			}
+
+			ctx, decision, err := newFlowLaunchContext(
+				target, launchContextVariantSettings(), variant.routing)
+			if err != nil {
+				t.Fatalf("newFlowLaunchContext: %v", err)
+			}
+			if want := variant.want(target); ctx != want {
+				t.Fatalf("context = %#v, want %#v", ctx, want)
+			}
+			if decision != variant.decision {
+				t.Fatalf("decision = %#v, want %#v", decision, variant.decision)
+			}
+		})
+	}
+}
+
+// TestNewFlowLaunchContextKeepsRequestedHeadlessOnAZeroTimeReservation pins the
+// guard that travelled with the rule: a zero-time partial result from an
+// injected launcher seam is not a persisted reservation, so it cannot replace
+// the requested preference.
+func TestNewFlowLaunchContextKeepsRequestedHeadlessOnAZeroTimeReservation(t *testing.T) {
+	for _, tt := range []struct {
+		name              string
+		requestedHeadless bool
+		persistedHeadless bool
+	}{
+		{name: "requested interactive", requestedHeadless: false, persistedHeadless: true},
+		{name: "requested headless", requestedHeadless: true, persistedHeadless: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			target := launchContextTrackedPhaseTarget()
+			target.RequestedHeadless = tt.requestedHeadless
+			target.PersistedRecord.Headless = tt.persistedHeadless
+			target.PersistedRecord.UpdatedAt = time.Time{}
+
+			ctx, _, err := newFlowLaunchContext(target, launchContextVariantSettings(), flowLaunchRouting{})
+			if err != nil {
+				t.Fatalf("newFlowLaunchContext: %v", err)
+			}
+			if ctx.Headless != tt.requestedHeadless {
+				t.Fatalf("headless = %v, want the requested %v", ctx.Headless, tt.requestedHeadless)
+			}
+		})
+	}
+}
+
+// TestNewFlowLaunchContextRejectsIncompleteTrackedPhasePayloads pins the
+// builder-side invariants. These are defensive: prepare's
+// flowPhaseLaunchNoWorktreeStatus refusal and preflight's agent.Validate still
+// fire first and keep their own messages.
+func TestNewFlowLaunchContextRejectsIncompleteTrackedPhasePayloads(t *testing.T) {
+	for _, missing := range []struct {
+		name   string
+		mutate func(*trackedPhaseTarget)
+	}{
+		{name: "launch id", mutate: func(target *trackedPhaseTarget) { target.LaunchID = "  " }},
+		{name: "flow id", mutate: func(target *trackedPhaseTarget) { target.Record.FlowID = "  " }},
+		{name: "worktree path", mutate: func(target *trackedPhaseTarget) { target.WorktreePath = " " }},
+		{name: "phase id", mutate: func(target *trackedPhaseTarget) { target.Phase.PhaseID = "  " }},
+		{name: "agent command", mutate: func(target *trackedPhaseTarget) { target.Agent.Command = "  " }},
+	} {
+		t.Run("missing "+missing.name, func(t *testing.T) {
+			target := launchContextTrackedPhaseTarget()
+			missing.mutate(&target)
+
+			ctx, decision, err := newFlowLaunchContext(
+				target, launchContextVariantSettings(), flowLaunchRouting{})
+			if !errors.Is(err, errIncompleteFlowLaunchTarget) {
+				t.Fatalf("err = %v, want errIncompleteFlowLaunchTarget (context %#v)", err, ctx)
+			}
+			if decision != (flowLaunchRouteDecision{}) {
+				t.Fatalf("failed build returned decision %#v", decision)
+			}
+		})
+	}
+}

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -362,58 +362,49 @@ func (l flowLaunchPreparation) prepare(req flowPhaseLaunchPreparedRequest) (flow
 	if err != nil {
 		return flowPhaseLaunchResult{}, flowPhaseLaunchValidationError{Message: err.Error()}
 	}
-	command := settings.Command
 	// AddFlowPhaseLaunchID is the linearization point for the target phase only.
 	// Keep every other launch input on the prepared snapshot: the linked plan
 	// body and path were already read from it, and mixing later record metadata
 	// into that context could identify a different plan or worktree.
-	launchRecord := req.Record
-	ctx := actions.AgentLaunchContext{
-		Command:          command,
-		Model:            settings.Model,
-		ReasoningEffort:  settings.ReasoningEffort,
-		LaunchID:         req.LaunchID,
-		RepoPath:         req.RepoPath,
-		WorktreePath:     req.WorktreePath,
-		Branch:           launchRecord.Branch,
-		Commit:           launchRecord.Commit,
-		SessionStateRoot: l.SessionStateRoot,
-		PlanID:           launchRecord.PlanID,
-		PlanPath:         req.PlanPath,
-		FlowID:           launchRecord.FlowID,
-		FlowPhaseID:      launchPhase.PhaseID,
-		FlowPhaseKind:    string(flowstore.SemanticKind(launchPhase)),
-		FlowAutoLaunch:   req.AutoLaunch,
-		InitialPrompt:    flowPhasePrompt(launchRecord, launchPhase, req.PlanPath, planBody, l.PromptTemplates, l.Pin.ExecutablePath),
+	ctx, decision, err := newFlowLaunchContext(trackedPhaseTarget{
+		LaunchID:          req.LaunchID,
+		Record:            req.Record,
+		PersistedRecord:   updated,
+		Phase:             launchPhase,
+		Agent:             settings,
+		RepoPath:          req.RepoPath,
+		WorktreePath:      req.WorktreePath,
+		PlanPath:          req.PlanPath,
+		PlanBody:          planBody,
+		AutoLaunch:        req.AutoLaunch,
+		RequestedHeadless: req.Headless,
+	}, snapshotFlowLaunchAgentSettings(l), flowLaunchRouting{
+		Backend:       l.Backend,
+		TmuxAvailable: l.TmuxAvailable,
+	})
+	if err != nil {
+		return flowPhaseLaunchResult{}, err
 	}
-	ctx = applyLaunchStamp(ctx, l.stamp())
-	route := flowPhaseLaunchEmbedded
-	fallbackNote := ""
-	ctx.FlowLaunchTracked = true
-	ctx.Embedded = true
-	ctx.Headless = req.Headless
-	// Persisted reservations carry UpdatedAt. A zero-time partial result from
-	// an injected launcher seam cannot authoritatively replace preferences.
-	if !req.AutoLaunch && !updated.UpdatedAt.IsZero() {
-		ctx.Headless = updated.Headless
+	route, err := flowPhaseLaunchRouteFor(decision.Route)
+	if err != nil {
+		return flowPhaseLaunchResult{}, err
 	}
-	// Headless is resolved above, so the tmux decision is made against the
-	// value that actually launches rather than the requested one.
-	if tmuxRoute, fellBack := l.tmuxLaunchRoute(ctx); tmuxRoute {
-		route = flowPhaseLaunchTmux
-		// A tmux window has no dock to prefill and renders its own output,
-		// so it is external-style: the TUI owns no part of the process.
-		ctx.Embedded = false
-	} else if fellBack {
-		fallbackNote = tmuxFallbackNote
-	}
-	return flowPhaseLaunchResult{Context: ctx, Route: route, FallbackNote: fallbackNote}, nil
+	return flowPhaseLaunchResult{Context: ctx, Route: route, FallbackNote: decision.FallbackNote}, nil
 }
 
-// tmuxLaunchRoute applies the shared routing rule to the launcher's own copy of
-// the backend and probe, which a lifecycle attempt snapshots at admission.
-func (l flowLaunchPreparation) tmuxLaunchRoute(ctx actions.AgentLaunchContext) (route bool, fellBack bool) {
-	return tmuxLaunchRouteFor(l.Backend, l.TmuxAvailable, ctx)
+// flowPhaseLaunchRouteFor maps the builder's route onto the phase launch's own
+// enum. An unmapped route is an error rather than a silent embedded default: a
+// routing bug that fell through to embedded would launch a wrong-but-plausible
+// agent instead of announcing itself.
+func flowPhaseLaunchRouteFor(route flowLaunchRoute) (flowPhaseLaunchRoute, error) {
+	switch route {
+	case flowLaunchRouteEmbedded:
+		return flowPhaseLaunchEmbedded, nil
+	case flowLaunchRouteTmux:
+		return flowPhaseLaunchTmux, nil
+	default:
+		return 0, fmt.Errorf("unroutable flow phase launch: route %d", route)
+	}
 }
 
 func (l flowLaunchPreparation) readPlan(planID string) (string, error) {


### PR DESCRIPTION
`prepare` (`model/flow_phase_launch.go`) was the last Flow launch path that hand-built its `actions.AgentLaunchContext` and then kept mutating it — setting `FlowLaunchTracked`, `Embedded` and `Headless` after construction, resolving the reservation-vs-requested headless rule inline, and deciding the tmux route at the call site. Manual (`g`) and auto (AutoMode) phase launches were the only ones whose markers and routing lived somewhere other than the builder every other role already goes through.

## What changed

- New `trackedPhaseTarget` payload and `newTrackedPhaseLaunchContext` arm in `model/flow_launch_context.go`, registered in `newFlowLaunchContext`. This is what finally uses `actions.RoleTrackedPhase`.
- The arm resolves headless **before** deciding the route, so the variant matrix's `any kind × tmux × headless` pruning rule holds by construction rather than by call-site ordering. It is the third route-deciding arm, after autofix and phase resume.
- `prepare` keeps everything that is genuinely admission's: the `WorktreePath == ""` refusal, the plan-body read, `AddFlowPhaseLaunchID` with its auto-launch-outdated skip, and `resolvePhaseAgentSettings` with its typed `flowPhaseLaunchValidationError`. Moving that resolution into the builder would have downgraded a typed refusal to a plain error.
- `prepare` maps the builder's `flowLaunchRoute` onto `flowPhaseLaunchRoute` via `flowPhaseLaunchRouteFor`, which **errors** on an unmapped route instead of defaulting to embedded — a routing bug should announce itself, not launch a wrong-but-plausible agent.
- `flowLaunchPreparation.tmuxLaunchRoute` is gone; nothing else referenced it.

## Behavior

Unchanged. Manual and auto launches keep identical hook env, prompt delivery (dock prefill vs argv), `FlowAutoLaunch`, and headless semantics.

One deliberate non-change: this role still sets **no** `WorkingDir`, where four of its five sibling roles do. `actions` falls back to `WorktreePath`, so copying the worktree agent's explicit assignment would have been a silent behavior change. The whole-struct comparison in the matrix test is what pins that.

## Verification

- Four new matrix rows: manual embedded, the manual reservation override (requested interactive + persisted headless → headless), manual tmux, and auto headless (persisted interactive + requested headless → headless, i.e. auto skips the override).
- The zero-time reservation guard: a partial result from an injected seam cannot replace the requested preference.
- Builder-side incomplete-payload refusals for launch ID, flow ID, worktree, phase ID and agent command.
- `flow_phase_launch_internal_test.go` and `flow_launch_lifecycle_internal_test.go` pass **unedited** — they are the parity oracle for both the manual and auto paths. The architecture fence in the former now stops matching `flow_phase_launch.go` for the `applyLaunchStamp` scan, as expected, without touching its exempt list.
- `gofmt -l model actions`, `go vet ./model ./actions`, `go test ./model ./actions` all pass.

`docs/flow-launch-variant-matrix.md` is updated: V1–V4 move into the migrated set, leaving only V5–V6 (create phase) composing a literal at the call site.

## Follow-up (filed, not done)

`approach-hyl.14` — unify `flowPhaseLaunchRoute` with `flowLaunchRoute`. It would touch `flow_launch_lifecycle.go` and every `flowPhaseLaunchResult` caller, so it stayed out of scope here.