### PR TITLE
Build the create-phase launch in the role builder, not at the call site

### DIFF
--- a/actions/flow_launch_role.go
+++ b/actions/flow_launch_role.go
@@ -2,8 +2,8 @@ package actions
 
 // FlowLaunchRole names the kind of Flow-scoped launch a context represents. It
 // is a closed enum: every Flow launch the TUI can start is exactly one of these
-// six, and the launch context's marker flags are the role's encoding rather
-// than six independent booleans a caller may combine freely.
+// seven, and the launch context's marker flags are the role's encoding rather
+// than seven independent booleans a caller may combine freely.
 //
 // It lives in actions rather than model because actions is the package model
 // imports, not the other way round, and because the role's consumers — resume
@@ -25,6 +25,11 @@ const (
 	// RoleSavedSessionResume is a phase-untracked resume of a Flow's saved
 	// provider session.
 	RoleSavedSessionResume
+	// RoleCreatePhase is the first launch of a freshly created Flow's startup
+	// root, started by Plan Now and by Ready-Bead F. It appends rather than
+	// slotting in beside RoleTrackedPhase so the existing values keep their
+	// numbers.
+	RoleCreatePhase
 )
 
 // String names the role for diagnostics. An unknown value names itself rather
@@ -43,6 +48,8 @@ func (role FlowLaunchRole) String() string {
 		return "worktree agent"
 	case RoleSavedSessionResume:
 		return "saved session resume"
+	case RoleCreatePhase:
+		return "create phase"
 	default:
 		return "unknown flow launch role"
 	}

--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -21,7 +21,7 @@ automatic phase launches share one builder and differ only by `req.AutoLaunch`.
 | --- | --- | --- |
 | `manualPhase` | `model/flow_phase_launch.go:371` | `model/flow_phase_launch.go:402` |
 | `autoPhase` | `model/flow_phase_launch.go:371` (same literal, `req.AutoLaunch` true) | `model/flow_phase_launch.go:402` |
-| `createPhase` | `model/flow_launch_create.go:808` (`createFlowLaunchContext`) | none — hardcoded embedded at `model/flow_launch_create.go:373` |
+| `createPhase` | `newFlowLaunchContext` (`model/flow_launch_context.go:619`, `createPhaseTarget`) | none — the builder returns a constant embedded route |
 | `phaseResume` | `model/flow_launch_resume.go:360` | `model/flow_launch_resume.go:299` (taken on the Model, before the closure) |
 | `repair` | `model/flow_launch_repair.go:420`, refreshed at `model/flow_repair.go:182` | none — hardcoded embedded at `model/flow_launch_repair.go:440` |
 | `autofix` | `model/flow_launch_autofix.go:366` | `model/flow_launch_autofix.go:395` |
@@ -55,7 +55,7 @@ marker" from "constructs a Flow launch".
 | `autoPhase` × interactive | Both AutoMode read commands hardcode `Headless: true` (`model/flow_launch_lifecycle.go:665`, `:692`), and the tracked-phase builder skips the reservation override when `target.AutoLaunch` (`model/flow_launch_context.go:286`). |
 | `autoPhase` × tmux | Follows from the previous two rows: auto ⇒ headless ⇒ embedded. |
 | `repair` × tmux | Refused twice: `tmuxRouteEligible` rejects `ctx.FlowRepair` (`model/tmux_mode.go:64`), and prepare has no tmux call site (`model/flow_launch_repair.go:440`). |
-| `createPhase` × tmux | No call site; route is hardcoded embedded (`model/flow_launch_create.go:373`). |
+| `createPhase` × tmux | The builder returns a constant embedded route (`model/flow_launch_context.go:619`); creation has no tmux call site either. |
 | `worktreeAgent` × tmux | No call site (`model/flow_launch_generic_agent.go:299`). |
 | `savedSessionResume` × tmux | No call site (`model/flow_launch_saved_session_resume.go:226`). |
 | `phaseResume` × headless | `Headless` is never assigned by the resume builder (`model/flow_launch_resume.go:360–383`). |
@@ -87,14 +87,13 @@ The reachable variants:
 
 ### Migration status
 
-V1–V4 and V7–V17 are built by `newFlowLaunchContext`
-(`model/flow_launch_context.go`) rather than by a literal at their prepare
-stage: V16 (worktreeAgent), V11–V12 (repair), V13–V15 (autofix), V17
-(savedSessionResume), V7–V10 (phaseResume) and V1–V4 (manual and auto phase),
-in that migration order. Only V5–V6 — the create-phase launch — still composes
-a literal at its call site, so the construction sites in section 1 and the `C:`
-line numbers in section 3 read as the pre-migration snapshot for every other
-row.
+Every reachable variant is now built by `newFlowLaunchContext`
+(`model/flow_launch_context.go`) rather than by a literal at its prepare stage:
+V16 (worktreeAgent), V11–V12 (repair), V13–V15 (autofix), V17
+(savedSessionResume), V7–V10 (phaseResume), V1–V4 (manual and auto phase) and
+V5–V6 (createPhase), in that migration order. The `C:` line numbers in section 3
+therefore read as the pre-migration snapshot throughout; section 1's builder
+column is the authority for where a kind is constructed today.
 
 Two of those roles decide their own *route*. V13–V15 were the first: the
 builder takes the snapshotted backend and tmux probe and returns the route with
@@ -114,7 +113,16 @@ route against the finished context, which is what keeps the
 `any kind × tmux × headless` pruning rule true by construction rather than by
 call-site ordering. `prepare` now maps the builder's route onto
 `flowPhaseLaunchRoute`, and an unmapped route is an error rather than a silent
-embedded default. Unifying those two route enums is the remaining follow-up.
+embedded default.
+
+V5–V6 moved last. Their arm returns a constant embedded route like the repair,
+worktree-agent and saved-session-resume arms, so the `createPhase × tmux`
+pruning rule now holds by construction rather than by a missing call site, and
+the create call site takes the builder's route instead of assigning
+`flowLaunchRouteEmbedded` itself. What did *not* move is createPhase's
+tracked-ness: `FlowLaunchTracked` and `Embedded` are still stamped at install
+(see F4). Unifying `flowLaunchRoute` with `flowPhaseLaunchRoute` remains the
+standing follow-up.
 
 ## 3. Field values, with the pipeline point that sets them
 
@@ -253,9 +261,16 @@ policy classes everywhere else in the matrix; `launch.json` cannot tell them
 apart.
 
 **F4 — `createPhase` is the only kind whose tracked-ness is established outside
-its builder**, and it is also the only kind that sets `PlanPhase*`. Both are
-consequences of it being the one kind whose builder runs before the Flow record
-exists.
+its builder.** The `PlanPhase*` trio now lives in the builder with the rest of
+the role (`model/flow_launch_context.go:619`), and createPhase is still the only
+kind that sets it. Its `FlowLaunchTracked` and `Embedded` remain deliberately
+false at construction and are stamped at install
+(`model/flow_launch_lifecycle.go:1105`, `:1097`): between the two, the create
+call site can take `failCreateFlowLaunchEmbedded`, whose
+`flowLaunchFailureUpdate` reads `FlowLaunchTracked` to decide whether the
+failure persists a phase update. Setting either early would change that path, so
+closing this gap is `approach-hyl.9`'s "context is final at prepare", not this
+migration's.
 
 **F5 — `WorkingDir` is unset for manual, auto, create and repair launches**, so
 those four rely on the actions-side fallback chain while resume, autofix,

--- a/model/flow_launch_context.go
+++ b/model/flow_launch_context.go
@@ -192,6 +192,38 @@ type trackedPhaseTarget struct {
 
 func (trackedPhaseTarget) role() actions.FlowLaunchRole { return actions.RoleTrackedPhase }
 
+// createPhaseTarget is the first launch of a freshly created Flow's startup
+// root, started by Plan Now and by Ready-Bead F. It is the only role whose
+// prompt record is synthesized rather than persisted: the record was written a
+// moment ago and may not carry the worktree, branch or commit the bootstrap
+// just produced, so those travel alongside it and are merged in here.
+type createPhaseTarget struct {
+	// LaunchID is the attempt token, never a fresh ID: the launch proof the
+	// create stage just verified is keyed on it.
+	LaunchID string
+	// Record is the just-written Flow record — the authority for FlowID and for
+	// the headless preference the creation was admitted with.
+	Record flowstore.FlowRecord
+	// Request is the create request admission already built. It is the authority
+	// for RepoPath and the fallback source for the prompt record's title,
+	// instructions and base ref.
+	Request FlowStartRequest
+	// Worktree and Commit are the bootstrap results. They are the context's
+	// worktree, branch and commit outright, because the record may still carry
+	// none of them.
+	Worktree actions.FlowWorktreeCreateResult
+	Commit   string
+	// Phase is the resolved startup root, running by construction: the call site
+	// refuses a root whose status has moved before install.
+	Phase flowstore.FlowPhase
+	// Agent is the phase's resolved settings, carried for the reason
+	// trackedPhaseTarget carries its own: resolution can fail with a typed
+	// refusal that belongs to admission, not to the builder.
+	Agent agent.Settings
+}
+
+func (createPhaseTarget) role() actions.FlowLaunchRole { return actions.RoleCreatePhase }
+
 // errIncompleteFlowLaunchTarget reports a payload that upstream admission
 // should already have guaranteed. The builder still checks: it is the one
 // place every Flow launch context is constructed, so it is the only place the
@@ -239,6 +271,8 @@ func newFlowLaunchContext(
 	switch payload := target.(type) {
 	case trackedPhaseTarget:
 		return newTrackedPhaseLaunchContext(payload, settings, routing)
+	case createPhaseTarget:
+		return newCreatePhaseLaunchContext(payload, settings)
 	case worktreeAgentTarget:
 		return newWorktreeAgentLaunchContext(payload, settings)
 	case repairTarget:
@@ -568,4 +602,66 @@ func newPhaseResumeLaunchContext(
 		decision.FallbackNote = tmuxFallbackNote
 	}
 	return ctx, decision, nil
+}
+
+// newCreatePhaseLaunchContext ignores routing: this role's route is a constant,
+// not an unrouted gap. Creation has no tmux call site, so the embedded slot is
+// the rule rather than the leftover branch.
+//
+// Two zero fields are load-bearing and deliberately not set here. It leaves
+// FlowLaunchTracked false because the create call site can still take
+// failCreateFlowLaunchEmbedded between this build and install, and
+// flowLaunchFailureUpdate reads that flag to decide whether a failure persists a
+// phase update. It leaves Embedded unset because install forces it true, and
+// setting it early would change what the pre-install failure path and the
+// registered launch record carry. Both stamps stay where they are today; moving
+// them is approach-hyl.9's "context is final at prepare".
+func newCreatePhaseLaunchContext(
+	target createPhaseTarget,
+	settings flowLaunchAgentSettingsSnapshot,
+) (actions.AgentLaunchContext, flowLaunchRouteDecision, error) {
+	// Defensive invariants, not new user-reachable refusals: the create stage's
+	// launch-proof check and resolveFlowStartPhaseAgentSettings refuse first and
+	// keep their own messages. No worktree check — the bootstrap result is the
+	// only source, and the stage above already failed the launch without one.
+	if strings.TrimSpace(target.LaunchID) == "" ||
+		strings.TrimSpace(target.Record.FlowID) == "" ||
+		strings.TrimSpace(target.Phase.PhaseID) == "" ||
+		strings.TrimSpace(target.Agent.Command) == "" {
+		return actions.AgentLaunchContext{}, flowLaunchRouteDecision{}, errIncompleteFlowLaunchTarget
+	}
+	// The prompt reads a record with the bootstrap's gaps filled, while every
+	// other field below reads the persisted record and the request directly:
+	// the synthesis is the prompt's fallback ladder, not a second authority.
+	promptRecord := flowStartPromptRecord(target.Record, target.Request, target.Worktree, target.Commit)
+	// An untitled startup root shows its ID: the prefill names the phase, so an
+	// empty label would be what the user reads.
+	title := target.Phase.Title
+	if strings.TrimSpace(title) == "" {
+		title = target.Phase.PhaseID
+	}
+	// The stamp is applied last, after every field is set, for the reason the
+	// other arms give: registration reads the finished context.
+	return applyLaunchStamp(actions.AgentLaunchContext{
+		Command: target.Agent.Command, Model: target.Agent.Model,
+		ReasoningEffort: target.Agent.ReasoningEffort,
+		LaunchID:        target.LaunchID, RepoPath: target.Request.RepoPath,
+		WorktreePath: target.Worktree.WorktreePath, Branch: target.Worktree.Branch,
+		Commit: target.Commit, SessionStateRoot: settings.SessionStateRoot,
+		// The PlanPhase trio is this role's alone: the create prefill names the
+		// phase it is about to run, and no other launch has one to announce.
+		PlanPhaseID: target.Phase.PhaseID, PlanPhaseTitle: title,
+		PlanPhaseStatus: string(flowstore.PhaseRunning),
+		// No PlanID or PlanPath: the plan this Flow will have does not exist yet.
+		FlowID: target.Record.FlowID, FlowPhaseID: target.Phase.PhaseID,
+		FlowPhaseKind: string(flowstore.SemanticKind(target.Phase)),
+		// Headless is the persisted record's, not the synthesized one's: the
+		// preference is what creation was admitted with.
+		Headless: target.Record.Headless,
+		// The prompt renders settings.Pin.ExecutablePath, not the stamped
+		// ctx.Executable, for the reason every other arm gives: the stamp is
+		// applied last, so there is no stamped value to read yet.
+		InitialPrompt: initialFlowLaunchPrompt(
+			promptRecord, target.Phase, settings.PromptTemplates, settings.Pin.ExecutablePath),
+	}, settings.stamp()), flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded}, nil
 }

--- a/model/flow_launch_context_internal_test.go
+++ b/model/flow_launch_context_internal_test.go
@@ -60,6 +60,9 @@ func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 	terminalPhase := terminalPhaseResume.ReadPhase
 	terminalPhase.Status = flowstore.PhaseCompleted
 	terminalPhaseResume.PersistedRecord.Phases = []flowstore.FlowPhase{terminalPhase}
+	createPhase := launchContextCreatePhaseTarget()
+	headlessCreatePhase := launchContextCreatePhaseTarget()
+	headlessCreatePhase.Record.Headless = true
 	for _, variant := range []struct {
 		name     string
 		target   flowLaunchTarget
@@ -287,6 +290,34 @@ func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 				return ctx
 			}(),
 			decision: flowLaunchRouteDecision{Route: flowLaunchRouteTmux},
+		},
+		{
+			// V5: the first launch of a freshly created Flow. It is the only role
+			// that sets the PlanPhase trio, and the only tracked-in-the-end role
+			// whose FlowLaunchTracked and Embedded are deliberately zero here:
+			// both are stamped at install, and the window between construction
+			// and install is a real failure path (failCreateFlowLaunchEmbedded)
+			// whose behavior turns on FlowLaunchTracked being false. PlanID,
+			// PlanPath and WorkingDir stay zero too — no plan exists yet, and
+			// actions falls back to WorktreePath.
+			name:     "create phase interactive",
+			target:   createPhase,
+			want:     launchContextCreatePhaseContext(createPhase),
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
+		},
+		{
+			// V6: the headless create launch, with the tmux backend and tmux on
+			// PATH to pin that this role's route is a constant rather than a
+			// decision: create always takes the embedded slot, so no note is owed
+			// and Embedded is not cleared for argv.
+			name:   "create phase headless",
+			target: headlessCreatePhase,
+			routing: flowLaunchRouting{
+				Backend:       config.LaunchBackendTmux,
+				TmuxAvailable: func() bool { return true },
+			},
+			want:     launchContextCreatePhaseContext(headlessCreatePhase),
+			decision: flowLaunchRouteDecision{Route: flowLaunchRouteEmbedded},
 		},
 		{
 			// The persisted phase decides the terminal flag, not the read one:
@@ -1174,6 +1205,116 @@ func TestNewFlowLaunchContextRejectsIncompleteTrackedPhasePayloads(t *testing.T)
 	} {
 		t.Run("missing "+missing.name, func(t *testing.T) {
 			target := launchContextTrackedPhaseTarget()
+			missing.mutate(&target)
+
+			ctx, decision, err := newFlowLaunchContext(
+				target, launchContextVariantSettings(), flowLaunchRouting{})
+			if !errors.Is(err, errIncompleteFlowLaunchTarget) {
+				t.Fatalf("err = %v, want errIncompleteFlowLaunchTarget (context %#v)", err, ctx)
+			}
+			if decision != (flowLaunchRouteDecision{}) {
+				t.Fatalf("failed build returned decision %#v", decision)
+			}
+		})
+	}
+}
+
+// launchContextCreatePhaseTarget is the create fixture. Its record carries no
+// worktree, branch or commit on purpose: the just-written record often has none
+// yet, and the bootstrap results travelling alongside it are what
+// flowStartPromptRecord merges in for the prompt.
+func launchContextCreatePhaseTarget() createPhaseTarget {
+	return createPhaseTarget{
+		LaunchID: "launch-1",
+		Record: flowstore.FlowRecord{
+			FlowID:    "flow-1",
+			Title:     "Flow one",
+			Status:    flowstore.StatusInProgress,
+			UpdatedAt: time.Now(),
+		},
+		Request: FlowStartRequest{
+			RepoPath:     "/dev/alpha",
+			Title:        "Flow one",
+			Instructions: "ship the thing",
+			BaseRef:      "main",
+		},
+		Worktree: actions.FlowWorktreeCreateResult{
+			WorktreePath: "/dev/alpha-worktree",
+			Branch:       "flow/one",
+		},
+		Commit: "abc123",
+		Phase: flowstore.FlowPhase{
+			PhaseID: "plan",
+			Title:   "Plan",
+			Kind:    flowstore.KindPlan,
+			Status:  flowstore.PhaseRunning,
+			Order:   1,
+		},
+		Agent: agent.Settings{Command: "codex", Model: "gpt-5", ReasoningEffort: "high"},
+	}
+}
+
+// launchContextCreatePhaseContext computes the expectation from the target for
+// the reason the repair prompt helper does: what the rows pin is the mapping,
+// not the prompt copy. The zero fields it never names — FlowLaunchTracked,
+// Embedded, PlanID, PlanPath, WorkingDir — are the load-bearing ones.
+func launchContextCreatePhaseContext(target createPhaseTarget) actions.AgentLaunchContext {
+	promptRecord := flowStartPromptRecord(target.Record, target.Request, target.Worktree, target.Commit)
+	return actions.AgentLaunchContext{
+		Command:          "codex",
+		Model:            "gpt-5",
+		ReasoningEffort:  "high",
+		LaunchID:         "launch-1",
+		RepoPath:         target.Request.RepoPath,
+		WorktreePath:     target.Worktree.WorktreePath,
+		Branch:           target.Worktree.Branch,
+		Commit:           target.Commit,
+		SessionStateRoot: "/state",
+		PlanPhaseID:      target.Phase.PhaseID,
+		PlanPhaseTitle:   target.Phase.Title,
+		PlanPhaseStatus:  string(flowstore.PhaseRunning),
+		FlowID:           target.Record.FlowID,
+		FlowPhaseID:      target.Phase.PhaseID,
+		FlowPhaseKind:    string(flowstore.SemanticKind(target.Phase)),
+		Headless:         target.Record.Headless,
+		InitialPrompt: initialFlowLaunchPrompt(
+			promptRecord, target.Phase, FlowPromptTemplates{}, ""),
+	}
+}
+
+// TestNewFlowLaunchContextTitlesTheCreatePhaseByIDWhenItHasNoTitle pins the
+// fallback that travelled into the builder with the PlanPhase trio: the prefill
+// names the phase, so an untitled startup root must show its ID rather than an
+// empty label.
+func TestNewFlowLaunchContextTitlesTheCreatePhaseByIDWhenItHasNoTitle(t *testing.T) {
+	target := launchContextCreatePhaseTarget()
+	target.Phase.Title = "   "
+
+	ctx, _, err := newFlowLaunchContext(target, launchContextVariantSettings(), flowLaunchRouting{})
+	if err != nil {
+		t.Fatalf("newFlowLaunchContext: %v", err)
+	}
+	if ctx.PlanPhaseTitle != target.Phase.PhaseID {
+		t.Fatalf("plan phase title = %q, want the phase ID %q", ctx.PlanPhaseTitle, target.Phase.PhaseID)
+	}
+}
+
+// TestNewFlowLaunchContextRejectsIncompleteCreatePhasePayloads pins the
+// builder-side invariants. They are defensive: admission's launch-proof check
+// and resolveFlowStartPhaseAgentSettings refuse first and keep their own
+// messages.
+func TestNewFlowLaunchContextRejectsIncompleteCreatePhasePayloads(t *testing.T) {
+	for _, missing := range []struct {
+		name   string
+		mutate func(*createPhaseTarget)
+	}{
+		{name: "launch id", mutate: func(target *createPhaseTarget) { target.LaunchID = "  " }},
+		{name: "flow id", mutate: func(target *createPhaseTarget) { target.Record.FlowID = "  " }},
+		{name: "phase id", mutate: func(target *createPhaseTarget) { target.Phase.PhaseID = "  " }},
+		{name: "agent command", mutate: func(target *createPhaseTarget) { target.Agent.Command = "  " }},
+	} {
+		t.Run("missing "+missing.name, func(t *testing.T) {
+			target := launchContextCreatePhaseTarget()
 			missing.mutate(&target)
 
 			ctx, decision, err := newFlowLaunchContext(

--- a/model/flow_launch_create.go
+++ b/model/flow_launch_create.go
@@ -361,7 +361,14 @@ func (m Model) handleCreateFlowLaunchEvent(msg flowLaunchEventMsg) (Model, tea.C
 		if err != nil {
 			return m.beginCreateFlowRecovery(attempt, msg, []string{"resolve phase agent settings: " + err.Error()}, false, true)
 		}
-		msg.Context = createFlowLaunchContext(attempt, msg, phase, settings)
+		launchContext, decision, err := newFlowLaunchContext(createPhaseTarget{
+			LaunchID: attempt.Token, Record: msg.Record, Request: createFlowStartRequest(attempt),
+			Worktree: msg.Worktree, Commit: msg.Commit, Phase: phase, Agent: settings,
+		}, attempt.Settings, flowLaunchRouting{})
+		if err != nil {
+			return m.beginCreateFlowRecovery(attempt, msg, []string{"build launch context: " + err.Error()}, false, true)
+		}
+		msg.Context = launchContext
 		if phase.Status != flowstore.PhaseRunning {
 			return m.failCreateFlowLaunchEmbedded(attempt, msg.Context, "launch proof changed before embedded install", msg.Release)
 		}
@@ -370,7 +377,7 @@ func (m Model) handleCreateFlowLaunchEvent(msg flowLaunchEventMsg) (Model, tea.C
 			releaseFlowLaunchReservation(msg.Release)
 			return m, nil
 		}
-		msg.Route = flowLaunchRouteEmbedded
+		msg.Route = decision.Route
 		msg.From = flowLaunchStatePreparing
 		msg.Stage = flowLaunchStagePrepared
 		msg.WorktreeNote = createdFlowWorktreeNote(msg.Record)
@@ -796,25 +803,6 @@ func createFlowStartRequest(attempt flowLaunchAttempt) FlowStartRequest {
 		AgentPreferences: attempt.Settings.Preferences, AgentPreferencesProvided: true,
 		Headless: &headless,
 	}
-}
-
-func createFlowLaunchContext(attempt flowLaunchAttempt, msg flowLaunchEventMsg, phase flowstore.FlowPhase, settings agent.Settings) actions.AgentLaunchContext {
-	req := createFlowStartRequest(attempt)
-	record := flowStartPromptRecord(msg.Record, req, msg.Worktree, msg.Commit)
-	title := phase.Title
-	if strings.TrimSpace(title) == "" {
-		title = phase.PhaseID
-	}
-	ctx := actions.AgentLaunchContext{
-		Command: settings.Command, Model: settings.Model, ReasoningEffort: settings.ReasoningEffort,
-		LaunchID: attempt.Token, RepoPath: req.RepoPath, WorktreePath: msg.Worktree.WorktreePath,
-		Branch: msg.Worktree.Branch, Commit: msg.Commit, SessionStateRoot: attempt.Settings.SessionStateRoot,
-		PlanPhaseID: phase.PhaseID, PlanPhaseTitle: title, PlanPhaseStatus: string(flowstore.PhaseRunning),
-		FlowID: msg.FlowID, FlowPhaseID: phase.PhaseID, FlowPhaseKind: string(flowstore.SemanticKind(phase)),
-		Headless:      msg.Record.Headless,
-		InitialPrompt: initialFlowLaunchPrompt(record, phase, attempt.Settings.PromptTemplates, attempt.Settings.Pin.ExecutablePath),
-	}
-	return applyLaunchStamp(ctx, attempt.Settings.stamp())
 }
 
 func flowPhaseContainsLaunch(phase flowstore.FlowPhase, launchID string) bool {


### PR DESCRIPTION
## Problem

Every Flow launch role now builds its `actions.AgentLaunchContext` through
`newFlowLaunchContext` — except the first launch of a freshly created Flow
(Plan Now and Ready-Bead F), which still composed a literal at its call site in
`model/flow_launch_create.go` and hardcoded its route to embedded. That left
V5–V6 of `docs/flow-launch-variant-matrix.md` as the one construction site
outside the builder, so the role's rules lived somewhere other than where every
other role's do.

## Solution

`createPhase` becomes the seventh role.

- `actions.RoleCreatePhase` is appended to the enum so existing values keep
  their numbers.
- `createPhaseTarget` carries exactly what the arm needs: the attempt token, the
  just-written record, the create request, the bootstrap worktree/commit results
  the record may not carry yet, the resolved startup root, and the phase's
  resolved agent settings (resolved by admission, because its failure is a typed
  refusal).
- `newCreatePhaseLaunchContext` is a field-for-field port of the old literal —
  the `flowStartPromptRecord` composition, the title-or-phase-ID fallback, the
  `PlanPhase*` trio only this role sets, and `applyLaunchStamp` last. It ignores
  routing and returns a constant embedded decision, so the matrix's
  `createPhase × tmux` pruning rule now holds by construction rather than by a
  missing call site.
- The call site takes the builder's route instead of assigning
  `flowLaunchRouteEmbedded` itself, and routes a construction error into
  `beginCreateFlowRecovery` rather than launching a half-formed agent.

Two zero fields are deliberately left zero in the builder. `FlowLaunchTracked`
stays false because the call site can still take `failCreateFlowLaunchEmbedded`
between construction and install, and `flowLaunchFailureUpdate` reads that flag
to decide whether a failure persists a phase update. `Embedded` stays unset
because install forces it true, and setting it early would change what the
pre-install failure path and the registered launch record carry. Moving those
stamps is `approach-hyl.9`'s "context is final at prepare" — finding F4 in the
matrix is restated accordingly rather than closed.

No behavior change: prompt text, prefill wiring and the created context are the
same for both Plan Now and Ready-Bead F.

## Tests

- Two whole-struct rows in the shared variant table: V5 create phase
  (interactive) and V6 (headless, run with a tmux backend and tmux on PATH to
  pin that this role's route is a constant, not a decision). Both pin the
  `PlanPhase*` trio and the deliberately zero
  `FlowLaunchTracked`/`Embedded`/`PlanID`/`PlanPath`/`WorkingDir`.
- A row for the untitled-startup-root title fallback.
- An incomplete-payload table for the builder's defensive invariants.
- `bead_flow_create_test.go` and the create internal tests pass unchanged — no
  test edits outside the new rows.

## Verification

`gofmt -l` clean, `go build ./...`, `go vet ./model ./actions`,
`go test ./model ./actions` — all pass.