### PR TITLE
Make the createPhase launch context final at prepare

### DIFF
--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -119,10 +119,10 @@ V5–V6 moved last. Their arm returns a constant embedded route like the repair,
 worktree-agent and saved-session-resume arms, so the `createPhase × tmux`
 pruning rule now holds by construction rather than by a missing call site, and
 the create call site takes the builder's route instead of assigning
-`flowLaunchRouteEmbedded` itself. What did *not* move is createPhase's
-tracked-ness: `FlowLaunchTracked` and `Embedded` are still stamped at install
-(see F4). Unifying `flowLaunchRoute` with `flowPhaseLaunchRoute` remains the
-standing follow-up.
+`flowLaunchRouteEmbedded` itself. Its tracked-ness moved too: `FlowLaunchTracked`
+and `Embedded` are now set in the arm rather than stamped at install, so no Flow
+context is rewritten between prepare and the terminal open (see F4). Unifying
+`flowLaunchRoute` with `flowPhaseLaunchRoute` remains the standing follow-up.
 
 ## 3. Field values, with the pipeline point that sets them
 
@@ -136,7 +136,7 @@ standing follow-up.
 | `FlowID` | record `C:383` | same | `msg.FlowID` `C:813` | record `C:377` | `msg.FlowID` `C:430` | record `C:383` | record `C:297` | record `C:312` |
 | `FlowPhaseID` | phase `C:384` | same | phase `C:813` | `msg.PhaseID` `C:378` | **empty** (deliberate, `model/flow_launch_repair.go:436`) | empty | empty | empty |
 | `FlowPhaseKind` | `SemanticKind` `C:385` | same | `SemanticKind` `C:813` | `SemanticKind` `C:379` | empty | empty | empty | empty |
-| `FlowLaunchTracked` | true `C:392` | true `C:392` | **false at C; true at `L:1105`** | true `C:382` | false (never) | false | false | false |
+| `FlowLaunchTracked` | true `C:392` | true `C:392` | true `C:656` | true `C:382` | false (never) | false | false | false |
 | `FlowAutoLaunch` | false `C:386` | true `C:386` | false | false | false | false | false | false |
 | `FlowRepair` | false | false | false | false | true `C:431` | false | false | false |
 | `FlowAgent` | false | false | false | false | false | false | true `C:297` | false |
@@ -149,7 +149,7 @@ standing follow-up.
 
 | Field | V1–V3 manual | V4 auto | V5–V6 create | V7–V10 resume | V11–V12 repair | V13–V15 autofix | V16 agent | V17 saved |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `Embedded` | true `C:393`; false on tmux `R:406` | true `C:393` | **unset at C; true at `L:1097`, again `T:479`** | true `C:381`; false on tmux `R:388` | true `C:432` | true `C:389`; false on tmux `R:399` | true `C:297` | true `C:314` |
+| `Embedded` | true `C:393`; false on tmux `R:406` | true `C:393` | true `C:656` | true `C:381`; false on tmux `R:388` | true `C:432` | true `C:389`; false on tmux `R:399` | true `C:297` | true `C:314` |
 | `Headless` | `req.Headless` `C:394`, replaced by the persisted reservation `C:398` | `req.Headless` (always true) `C:394` | `msg.Record.Headless` `C:814` | unset (false) | unset at C, then `record.Headless` at refresh (`model/flow_repair.go:199`) | `record`/`reserved.Headless` `C:390` | false `C:297` | unset (false) |
 | `Command` | `settings.Command` `C:372` | same | `settings.Command` `C:809` | `msg.ResumeCommand` `C:361` | `resolved.Command`, restricted to codex/claude/cursor (`model/flow_launch_repair.go:414`) | `settings.Command` `C:367` | `settings.Command` `C:293` | `string(refreshed.Provider)` `C:301` |
 | `ResumeSessionID` | "" | "" | "" | `msg.ProviderSessionID` `C:374` | "" | "" | "" | `refreshed.SessionID` `C:309` |
@@ -164,21 +164,24 @@ Every kind additionally passes through `applyLaunchStamp`
 
 ### The four fields that change value mid-flight
 
-1. `FlowLaunchTracked` is stamped at `model/flow_launch_lifecycle.go:1105` for
-   every kind except repair, autofix, worktreeAgent and savedSessionResume. For
-   manual, auto and resume that stamp is redundant — they already set it at
-   construction. **`createPhase` is the only kind for which it is load-bearing**,
-   and only on the embedded route, which is the only route it has.
-2. `Embedded` is forced true at `model/flow_launch_lifecycle.go:1097` and again
-   at `model/embedded_terminal.go:479`, and a third time inside the terminal
-   starter (`model/embedded_terminal.go:200`) and the embedded tmux command
-   (`actions/actions.go:1248`).
-3. `Embedded` is forced false on the tmux route in four places:
-   `model/flow_phase_launch.go:406`, `model/flow_launch_resume.go:388`,
-   `model/flow_launch_autofix.go:399`, `model/tmux_mode.go:132`, and once more
-   inside actions at `actions/tmux_mode.go:313`. Two of those five have since
-   moved inside the builder with their roles: the autofix and phase-resume
-   clears now happen in the arm that decides the route.
+1. `FlowLaunchTracked` was stamped at install for every kind except repair,
+   autofix, worktreeAgent and savedSessionResume. That stamp is gone: every kind
+   that is tracked now says so at construction, `createPhase` included, and
+   install no longer writes the field.
+2. `Embedded` was forced true at install as well; that write is gone too. It is
+   still forced true at `model/embedded_terminal.go:493`, inside the terminal
+   starter (`model/embedded_terminal.go:214`) and in the embedded tmux command
+   (`actions/actions.go:1351`) — the first two serve *non-Flow* embedded
+   terminals, which have no builder to set the field, and the third is an
+   actions-local normalisation on a value copy.
+3. `Embedded` is forced false on the tmux route in three places:
+   `model/flow_phase_launch.go:406`, `model/flow_launch_resume.go:388` and
+   `model/flow_launch_autofix.go:399`, and once more inside actions at
+   `actions/tmux_mode.go:313`. Two of those three have since moved inside the
+   builder with their roles: the autofix and phase-resume clears now happen in
+   the arm that decides the route. The fourth model-side clear, in
+   `model/tmux_mode.go`, is gone — that spawn is the non-Flow route only, and a
+   non-Flow context arrives with `Embedded` false already.
 4. `Headless` is resolved twice for manual launches — from the record at
    `model/flow_launch_lifecycle.go:620` and again from the persisted reservation
    at `model/flow_phase_launch.go:398` — and for repair only at refresh time
@@ -197,7 +200,7 @@ deliberately treated alike.
 | --- | --- | --- | --- |
 | `flowEmbeddedTerminalIdentity` (`model/embedded_terminal.go:736`) | `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`, `ResumeSessionID`, `FlowAutofix`, `FlowAutofixPRNumber`, `Embedded`, `Headless`, `FlowID`, `FlowPhaseID`, `FlowLaunchTracked`, `WorktreePath` | V11–12 (repair) ‖ V16 (agent) ‖ V17 (session id) ‖ V13–15 (autofix + PR) ‖ rest | V1–V10 all render as the phase ID |
 | `flowEmbeddedTerminalDetachPolicy` (`model/embedded_terminal.go:988`) | `FlowAgent`, `FlowSavedSessionResume` | V16, V17 (never detachable) ‖ rest | every tracked and untracked-repair/autofix variant |
-| slot stamping (`model/embedded_terminal.go:488`) | `RepoPath`, `WorktreePath`, `WorkingDir`, `FlowID`, `FlowPhaseID`, `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`, `LaunchID`, `Command`; forces `Embedded` true at `:479` | repair/agent/saved-resume slots | autofix is *not* stamped — it has no slot marker of its own |
+| slot stamping (`model/embedded_terminal.go:502`) | `RepoPath`, `WorktreePath`, `WorkingDir`, `FlowID`, `FlowPhaseID`, `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`, `LaunchID`, `Command`; forces `Embedded` true at `:493` | repair/agent/saved-resume slots | autofix is *not* stamped — it has no slot marker of its own |
 | dock visibility (`model/embedded_terminal.go:458`, `:467`) | `FlowAutoLaunch`, `Headless` | V4 (no dock, keeps the active slot) ‖ V2/V6/V12/V14 (headless) ‖ rest | manual vs create vs resume |
 | `updateFlowTerminalFocusAfterLaunch` (`model/model_keys.go:3003`) | `FlowAgent`, `FlowSavedSessionResume`, `FlowAutoLaunch`, `Headless` | V16/V17 (always focus input) ‖ V4 (no focus change) ‖ headless (focus list) ‖ rest | manual/create/resume/repair/autofix at equal headlessness |
 | `reserveFlowSpawn` (`model/model_keys.go:3145`) | `FlowID`, `FlowLaunchTracked`, `FlowRepair` | tracked non-repair (V1–V10) ‖ rest | all untracked kinds are no-ops |
@@ -260,25 +263,26 @@ A tracked phase resume and an untracked saved-session resume are different
 policy classes everywhere else in the matrix; `launch.json` cannot tell them
 apart.
 
-**F4 — `createPhase` is the only kind whose tracked-ness is established outside
-its builder.** The `PlanPhase*` trio now lives in the builder with the rest of
-the role (`model/flow_launch_context.go:619`), and createPhase is still the only
-kind that sets it. Its `FlowLaunchTracked` and `Embedded` remain deliberately
-false at construction and are stamped at install
-(`model/flow_launch_lifecycle.go:1105`, `:1097`): between the two, the create
-call site can take `failCreateFlowLaunchEmbedded`, whose
-`flowLaunchFailureUpdate` reads `FlowLaunchTracked` to decide whether the
-failure persists a phase update. Setting either early would change that path, so
-closing this gap is `approach-hyl.9`'s "context is final at prepare", not this
-migration's.
+**F4 — closed by `approach-hyl.9`.** `createPhase` was the last kind whose
+tracked-ness was established outside its builder: `FlowLaunchTracked` and
+`Embedded` were left false at construction and stamped at install, because
+between the two the create call site can take `failCreateFlowLaunchEmbedded`,
+whose `flowLaunchFailureUpdate` reads `FlowLaunchTracked`. That window turned
+out to be safe — the flag is consulted only for a resume
+(`ctx.ResumeSessionID != "" && !ctx.FlowLaunchTracked`) and a createPhase
+context carries no `ResumeSessionID`, so the same phase update is persisted
+either way. Both fields now ship from the builder
+(`model/flow_launch_context.go:656`) and install stamps nothing; the `PlanPhase*`
+trio it also owns (`model/flow_launch_context.go:651`) is still createPhase's
+alone.
 
 **F5 — `WorkingDir` is unset for manual, auto, create and repair launches**, so
 those four rely on the actions-side fallback chain while resume, autofix,
 worktree agent and saved-session resume set it explicitly. The role payload has
 to keep this distinction or change behaviour.
 
-**F6 — the lifecycle branches on `attempt.Kind`, not on the context.** Both the
-tracked stamp (`model/flow_launch_lifecycle.go:1104`) and the mutated-phase mark
-(`model/flow_launch_lifecycle.go:958`) enumerate the same four kinds by hand.
-The context cannot answer the question those branches ask, which is the clearest
+**F6 — the lifecycle branches on `attempt.Kind`, not on the context.** The
+tracked stamp that used to enumerate four kinds by hand is gone with F4, but the
+mutated-phase mark (`model/flow_launch_lifecycle.go:958`) still asks the same
+question of `attempt.Kind`. The context cannot answer it, which is the clearest
 evidence that a role belongs *on* the context.

--- a/model/flow_launch_context.go
+++ b/model/flow_launch_context.go
@@ -608,14 +608,12 @@ func newPhaseResumeLaunchContext(
 // not an unrouted gap. Creation has no tmux call site, so the embedded slot is
 // the rule rather than the leftover branch.
 //
-// Two zero fields are load-bearing and deliberately not set here. It leaves
-// FlowLaunchTracked false because the create call site can still take
-// failCreateFlowLaunchEmbedded between this build and install, and
-// flowLaunchFailureUpdate reads that flag to decide whether a failure persists a
-// phase update. It leaves Embedded unset because install forces it true, and
-// setting it early would change what the pre-install failure path and the
-// registered launch record carry. Both stamps stay where they are today; moving
-// them is approach-hyl.9's "context is final at prepare".
+// Like every other arm, it emits its final transport flags: the context this
+// returns is what installs, with nothing left for install to stamp. The one
+// window between here and install — failCreateFlowLaunchEmbedded — is safe to
+// enter already tracked because flowLaunchFailureUpdate consults
+// FlowLaunchTracked only for a resume, and this role carries no
+// ResumeSessionID, so the phase update it persists is the same either way.
 func newCreatePhaseLaunchContext(
 	target createPhaseTarget,
 	settings flowLaunchAgentSettingsSnapshot,
@@ -654,7 +652,8 @@ func newCreatePhaseLaunchContext(
 		PlanPhaseStatus: string(flowstore.PhaseRunning),
 		// No PlanID or PlanPath: the plan this Flow will have does not exist yet.
 		FlowID: target.Record.FlowID, FlowPhaseID: target.Phase.PhaseID,
-		FlowPhaseKind: string(flowstore.SemanticKind(target.Phase)),
+		FlowPhaseKind:     string(flowstore.SemanticKind(target.Phase)),
+		FlowLaunchTracked: true, Embedded: true,
 		// Headless is the persisted record's, not the synthesized one's: the
 		// preference is what creation was admitted with.
 		Headless: target.Record.Headless,

--- a/model/flow_launch_context_internal_test.go
+++ b/model/flow_launch_context_internal_test.go
@@ -293,13 +293,13 @@ func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 		},
 		{
 			// V5: the first launch of a freshly created Flow. It is the only role
-			// that sets the PlanPhase trio, and the only tracked-in-the-end role
-			// whose FlowLaunchTracked and Embedded are deliberately zero here:
-			// both are stamped at install, and the window between construction
-			// and install is a real failure path (failCreateFlowLaunchEmbedded)
-			// whose behavior turns on FlowLaunchTracked being false. PlanID,
-			// PlanPath and WorkingDir stay zero too — no plan exists yet, and
-			// actions falls back to WorktreePath.
+			// that sets the PlanPhase trio, and like every other role it emits
+			// its final FlowLaunchTracked and Embedded here rather than leaving
+			// them for install: the one window before install
+			// (failCreateFlowLaunchEmbedded) persists the same phase update
+			// either way, since flowLaunchFailureUpdate reads FlowLaunchTracked
+			// only for a resume. PlanID, PlanPath and WorkingDir stay zero too —
+			// no plan exists yet, and actions falls back to WorktreePath.
 			name:     "create phase interactive",
 			target:   createPhase,
 			want:     launchContextCreatePhaseContext(createPhase),
@@ -1261,22 +1261,24 @@ func launchContextCreatePhaseTarget() createPhaseTarget {
 func launchContextCreatePhaseContext(target createPhaseTarget) actions.AgentLaunchContext {
 	promptRecord := flowStartPromptRecord(target.Record, target.Request, target.Worktree, target.Commit)
 	return actions.AgentLaunchContext{
-		Command:          "codex",
-		Model:            "gpt-5",
-		ReasoningEffort:  "high",
-		LaunchID:         "launch-1",
-		RepoPath:         target.Request.RepoPath,
-		WorktreePath:     target.Worktree.WorktreePath,
-		Branch:           target.Worktree.Branch,
-		Commit:           target.Commit,
-		SessionStateRoot: "/state",
-		PlanPhaseID:      target.Phase.PhaseID,
-		PlanPhaseTitle:   target.Phase.Title,
-		PlanPhaseStatus:  string(flowstore.PhaseRunning),
-		FlowID:           target.Record.FlowID,
-		FlowPhaseID:      target.Phase.PhaseID,
-		FlowPhaseKind:    string(flowstore.SemanticKind(target.Phase)),
-		Headless:         target.Record.Headless,
+		Command:           "codex",
+		Model:             "gpt-5",
+		ReasoningEffort:   "high",
+		LaunchID:          "launch-1",
+		RepoPath:          target.Request.RepoPath,
+		WorktreePath:      target.Worktree.WorktreePath,
+		Branch:            target.Worktree.Branch,
+		Commit:            target.Commit,
+		SessionStateRoot:  "/state",
+		PlanPhaseID:       target.Phase.PhaseID,
+		PlanPhaseTitle:    target.Phase.Title,
+		PlanPhaseStatus:   string(flowstore.PhaseRunning),
+		FlowID:            target.Record.FlowID,
+		FlowPhaseID:       target.Phase.PhaseID,
+		FlowPhaseKind:     string(flowstore.SemanticKind(target.Phase)),
+		Headless:          target.Record.Headless,
+		Embedded:          true,
+		FlowLaunchTracked: true,
 		InitialPrompt: initialFlowLaunchPrompt(
 			promptRecord, target.Phase, FlowPromptTemplates{}, ""),
 	}

--- a/model/flow_launch_create_internal_test.go
+++ b/model/flow_launch_create_internal_test.go
@@ -586,6 +586,8 @@ func TestCreateFlowLaunchOwnsExactIdentityAndStartupOrdering(t *testing.T) {
 		t.Fatalf("launch contexts = %#v", h.contexts)
 	}
 	ctx := h.contexts[0]
+	// Embedded and FlowLaunchTracked are the builder's, not install's: this
+	// asserts they survive the whole create route to the terminal unrewritten.
 	if ctx.FlowID != h.record.FlowID || ctx.LaunchID != "launch-create-1" || ctx.FlowPhaseID != "plan" ||
 		ctx.WorktreePath != "/dev/alpha-worktrees/flow-new" || ctx.Commit != "abc123" || !ctx.Embedded || !ctx.FlowLaunchTracked {
 		t.Fatalf("launch context = %#v", ctx)
@@ -1738,5 +1740,69 @@ func TestCreateFlowLaunchReadyOriginSurfacesUnreadableBeadRefusal(t *testing.T) 
 	}
 	if followUp == nil {
 		t.Fatal("refused create did not issue the Flow surface fetch")
+	}
+}
+
+// TestCreateFlowLaunchPreInstallFailureIgnoresTrackedFlags pins the assumption
+// the createPhase builder's final transport flags rest on: the one failure
+// window between building a createPhase context and installing it
+// (failCreateFlowLaunchEmbedded) persists the same phase update whether or not
+// that context carries FlowLaunchTracked and Embedded. flowLaunchFailureUpdate
+// consults FlowLaunchTracked only for a resume, and a createPhase context
+// carries no ResumeSessionID.
+func TestCreateFlowLaunchPreInstallFailureIgnoresTrackedFlags(t *testing.T) {
+	m := newModelForTest(nil, Options{AgentCommand: "codex"})
+	base := launchContextCreatePhaseContext(launchContextCreatePhaseTarget())
+	if base.ResumeSessionID != "" {
+		t.Fatalf("createPhase context carries a resume session: %#v", base)
+	}
+	const errText = "launch proof changed before embedded install"
+	want, ok := m.flowLaunchFailureUpdate(base, errText)
+	if !ok || want.Status != flowstore.PhaseNeedsAttention || !strings.HasPrefix(want.Notes, "Agent launch failed") {
+		t.Fatalf("baseline failure update = %#v, ok=%v", want, ok)
+	}
+	for _, flags := range []struct {
+		embedded bool
+		tracked  bool
+	}{{false, false}, {false, true}, {true, false}, {true, true}} {
+		t.Run(fmt.Sprintf("embedded=%v/tracked=%v", flags.embedded, flags.tracked), func(t *testing.T) {
+			ctx := base
+			ctx.Embedded, ctx.FlowLaunchTracked = flags.embedded, flags.tracked
+			got, ok := m.flowLaunchFailureUpdate(ctx, errText)
+			if !ok || !reflect.DeepEqual(got, want) {
+				t.Fatalf("failure update = %#v (ok=%v), want %#v", got, ok, want)
+			}
+		})
+	}
+}
+
+// TestCreateFlowLaunchProofChangeBeforeInstallBlocksPhase drives the same
+// window end to end: the launch ID is written, but the phase is no longer
+// running by the time the create stage reads it back, so the launch fails
+// before install and regresses the phase it had claimed.
+func TestCreateFlowLaunchProofChangeBeforeInstallBlocksPhase(t *testing.T) {
+	h := newCreateLaunchHarness([]flowstore.FlowPhase{{PhaseID: "plan", Title: "Plan", Kind: flowstore.KindPlan, Status: flowstore.PhaseReady}})
+	m, cmd := h.admit(t, h.model(t))
+	m, event := advanceCreateLaunchToStage(t, m, cmd, flowLaunchStageCreateLaunchID)
+	// The proof is present; only the status moved out from under it.
+	event.Record.Phases = slices.Clone(event.Record.Phases)
+	event.Record.Phases[0].Status = flowstore.PhaseBlocked
+	m, cmd = m.handleFlowLaunchEvent(event)
+	m = drainCreateLaunch(t, m, cmd)
+
+	if strings.Contains(strings.Join(h.order, ","), "terminal") || len(h.contexts) != 0 {
+		t.Fatalf("proof change installed a terminal: order=%#v contexts=%#v", h.order, h.contexts)
+	}
+	if len(h.phaseUpdates) != 1 {
+		t.Fatalf("phase updates = %#v, want one", h.phaseUpdates)
+	}
+	update := h.phaseUpdates[0]
+	if update.PhaseID != "plan" || update.Status != flowstore.PhaseNeedsAttention ||
+		!strings.HasPrefix(update.Notes, "Agent launch failed") ||
+		!strings.Contains(update.Notes, "launch proof changed before embedded install") {
+		t.Fatalf("phase update = %#v", update)
+	}
+	if h.releases != 1 || m.flowCreateReq.current != 0 || !strings.Contains(m.status.Text, "launch proof changed before embedded install") {
+		t.Fatalf("proof change result: releases=%d active=%d status=%q", h.releases, m.flowCreateReq.current, m.status.Text)
 	}
 }

--- a/model/flow_launch_lifecycle.go
+++ b/model/flow_launch_lifecycle.go
@@ -1093,17 +1093,10 @@ func (m Model) installFlowLaunchEmbedded(attempt flowLaunchAttempt, msg flowLaun
 	if attempt.Kind != flowLaunchKindCreatePhase {
 		defer releaseFlowLaunchReservation(msg.Release)
 	}
+	// The context arrives final from newFlowLaunchContext, transport flags
+	// included: install reads it and hands it on, but never rewrites it. The
+	// local copy stays because every path below passes ctx by value.
 	ctx := msg.Context
-	ctx.Embedded = true
-	// All phase-untracked kinds stay untracked. A repair names no phase and must
-	// never be stamped tracked, or its failures would look for a phase to
-	// regress. For either worktree agent, forcing tracked would also run before
-	// the terminal open computes prefill, and the phase-untracked Flow agent would
-	// then fail both of ShouldPrefillEmbeddedPrompt's cases and send its prompt
-	// to argv instead of the dock.
-	if attempt.Kind != flowLaunchKindRepair && attempt.Kind != flowLaunchKindAutofix && attempt.Kind != flowLaunchKindWorktreeAgent && attempt.Kind != flowLaunchKindSavedSessionResume {
-		ctx.FlowLaunchTracked = true
-	}
 	if canceled, blocked := m.flowLaunchEmbeddedBackstop(attempt.Kind, ctx.FlowID); blocked {
 		if attempt.Kind == flowLaunchKindCreatePhase {
 			return m.failCreateFlowLaunchEmbedded(attempt, ctx, canceled, msg.Release)

--- a/model/tmux_mode.go
+++ b/model/tmux_mode.go
@@ -122,14 +122,18 @@ func (m Model) buildRepoTmuxAgentLaunch(ctx actions.AgentLaunchContext) (actions
 	return m.launchRepoTmuxAgent(ctx)
 }
 
-// launchAgentInRepoTmuxSession is the single spawn every tmux-mode route ends
-// at. The window is not an embedded slot: the result is detached, provider
-// hooks own completion, and the caller's reservation covers only the spawn.
+// launchAgentInRepoTmuxSession is the spawn every non-Flow tmux-mode route ends
+// at; Flow launches reach tmux through handoffFlowLaunchTmux instead. The window
+// is not an embedded slot: the result is detached, provider hooks own
+// completion, and the caller's reservation covers only the spawn.
 func (m Model) launchAgentInRepoTmuxSession(ctx actions.AgentLaunchContext, release func()) (Model, tea.Cmd) {
-	// The context may arrive with Embedded set by a pipeline that hardcodes it.
-	// Clearing it is what routes InitialPrompt into argv instead of a dock
-	// prefill that will never happen.
-	ctx.Embedded = false
+	// No Embedded clear here: this spawn is the non-Flow route only. Its two
+	// callers are launchAgentForBackend, which refuses any Flow context via
+	// flowLaunchContextRequiresLifecycle, and resumeSessionForBackend, reached
+	// only from routeNonFlowSavedSessionResume — and a non-Flow context has no
+	// builder that sets Embedded, so it arrives false. The argv-vs-dock rule
+	// itself is held one layer down by actions.RepoTmuxAgentLaunch regardless.
+	//
 	// Sessions captured outside Approach can carry no repo path, and the session
 	// name would then be keyed on the worktree — a session T never finds, since T
 	// asks about the selected repo. Fill it in so "one session per repo" holds.

--- a/model/tmux_mode_internal_test.go
+++ b/model/tmux_mode_internal_test.go
@@ -812,3 +812,34 @@ func TestAttachReportsMissingTmuxWithoutProbing(t *testing.T) {
 		t.Fatal("the T affordance must not be advertised without tmux")
 	}
 }
+
+// TestNonFlowSessionResumeReachesTmuxBuilderUnembedded pins what the removed
+// ctx.Embedded = false in launchAgentInRepoTmuxSession used to guarantee: a
+// non-Flow context arrives at the tmux builder with Embedded already false and
+// its prompt intact, so actions renders that prompt onto argv rather than
+// waiting for a dock prefill this route never performs.
+func TestNonFlowSessionResumeReachesTmuxBuilderUnembedded(t *testing.T) {
+	spy := &tmuxResumeSpy{t: t}
+	m := spy.model("tmux", true)
+	ctx := resumeContext()
+	ctx.InitialPrompt = "resume the session"
+
+	if flowLaunchContextRequiresLifecycle(ctx) {
+		t.Fatal("resume context is not a Flow launch, so this route must accept it")
+	}
+	m.resumeSessionForBackend(ctx, sessions.SessionRecord{
+		Provider:  sessions.ProviderCodex,
+		SessionID: "session-1",
+	}, nil)
+
+	if len(spy.tmuxContexts) != 1 {
+		t.Fatalf("tmux launches = %d, want one", len(spy.tmuxContexts))
+	}
+	built := spy.tmuxContexts[0]
+	if built.Embedded {
+		t.Fatalf("tmux builder saw an embedded context: %#v", built)
+	}
+	if built.InitialPrompt != "resume the session" {
+		t.Fatalf("tmux builder prompt = %q, want it carried to argv", built.InitialPrompt)
+	}
+}


### PR DESCRIPTION
## Problem

A Flow launch context was supposed to be finished the moment it was built, but `createPhase` was the last role that still left its transport flags for a later stage to stamp. `installFlowLaunchEmbedded` set `ctx.Embedded = true` and ran a four-kind switch to decide `FlowLaunchTracked`, so the context that came out of install was not the context that went in. That split made the flags hard to reason about — you could not read the builder and know what a createPhase launch would actually do.

## Solution

`newCreatePhaseLaunchContext` now sets `FlowLaunchTracked` and `Embedded` itself, and `installFlowLaunchEmbedded` installs the context it receives without mutating it. Every Flow launch role is now built entirely by `newFlowLaunchContext`.

The install-time stamps existed to cover a window: the create call site can fail with `failCreateFlowLaunchEmbedded` between build and install, and `flowLaunchFailureUpdate` reads `FlowLaunchTracked`. That read is gated on `ResumeSessionID != "" && !FlowLaunchTracked`, and a createPhase context never carries a `ResumeSessionID`, so the persisted phase update is identical either way. Two new tests fence that: one asserts the failure update is the same across all four flag combinations, the other drives the pre-install failure end to end and pins the `needs_attention` update it writes. Both pass before and after the change.

`launchAgentInRepoTmuxSession` also loses its `ctx.Embedded = false`. Its callers are `launchAgentForBackend`, which refuses Flow contexts outright, and `resumeSessionForBackend`; a non-Flow context has no builder that sets `Embedded`, so it already arrives false. `actions.RepoTmuxAgentLaunch` still enforces the argv-vs-dock rule for the transport.

Left in place deliberately: the two `embedded_terminal.go` forces (non-Flow terminals with no builder arm yet — approach-hyl.15, blocked on approach-hyl.10) and the actions-side normalisations (approach-hyl.11).

## Verification

- New regression tests in `model/flow_launch_create_internal_test.go` and `model/tmux_mode_internal_test.go`
- `go test ./model` passes
- `docs/flow-launch-variant-matrix.md` updated: closes finding F4; F6 stays open