### PR TITLE
Read the Flow launch role instead of raw marker flags

### DIFF
--- a/actions/flow_launch_role.go
+++ b/actions/flow_launch_role.go
@@ -1,5 +1,7 @@
 package actions
 
+import "strings"
+
 // FlowLaunchRole names the kind of Flow-scoped launch a context represents. It
 // is a closed enum: every Flow launch the TUI can start is exactly one of these
 // seven, and the launch context's marker flags are the role's encoding rather
@@ -9,6 +11,14 @@ package actions
 // imports, not the other way round, and because the role's consumers — resume
 // identity, tmux role validation, the tracked-lease branch — already live here.
 type FlowLaunchRole int
+
+const (
+	// RoleNone is the zero value: a context that is not a Flow launch at all,
+	// or one whose markers name no role. It is deliberately the zero value so a
+	// context nobody classified reads as "not a Flow launch" rather than as the
+	// first real role.
+	RoleNone FlowLaunchRole = 0
+)
 
 const (
 	// RoleTrackedPhase is a phase-attached launch that reserves the Flow lease
@@ -32,10 +42,90 @@ const (
 	RoleCreatePhase
 )
 
+// Tracked reports whether this role reserves the Flow launch lease and writes
+// phase attempt history. Stating it once here is what keeps the reservation and
+// the failure-update refusal from each re-deriving "tracked" from raw markers
+// and disagreeing.
+func (role FlowLaunchRole) Tracked() bool {
+	switch role {
+	case RoleTrackedPhase, RolePhaseResume, RoleCreatePhase:
+		return true
+	default:
+		return false
+	}
+}
+
+// FlowLaunchRoleOf is the inverse of the builder: it recovers the role a
+// finished launch context encodes. It is total — a context that names no role,
+// including every non-Flow launch, classifies as RoleNone.
+//
+// The order is precedence, not arbitrary sequence. Contexts that set more than
+// one marker are malformed, but they do reach the consumers this classifier
+// serves, and the ordering here reproduces exactly what those consumers'
+// hand-written predicates already answered for them: the repair / agent /
+// saved-session chain first, then the phase-attached roles, then autofix.
+//
+// Embedded, Headless and FlowAutofixPRNumber are deliberately not inputs. They
+// are transport and payload rather than role, and the one consumer that cares
+// reads them itself alongside the role.
+func FlowLaunchRoleOf(ctx AgentLaunchContext) FlowLaunchRole {
+	switch {
+	case ctx.FlowRepair:
+		return RoleRepair
+	case ctx.FlowAgent:
+		return RoleWorktreeAgent
+	case ctx.FlowSavedSessionResume:
+		return RoleSavedSessionResume
+	}
+	// The phase roles need the Flow they attach to as well as the phase: their
+	// consumers reserve that Flow's lease and write that Flow's phase, and a
+	// phase ID with no Flow behind it has never done either.
+	if strings.TrimSpace(ctx.FlowPhaseID) != "" && strings.TrimSpace(ctx.FlowID) != "" {
+		switch {
+		// ResumeSessionID is set by exactly one phase-attached arm, and
+		// PlanPhaseID by exactly one other, so each discriminates its role.
+		case ctx.ResumeSessionID != "":
+			return RolePhaseResume
+		case ctx.PlanPhaseID != "":
+			return RoleCreatePhase
+		default:
+			return RoleTrackedPhase
+		}
+	}
+	// Autofix carries its well-formedness conjuncts here rather than at the
+	// call site: the marker on its own, without a Flow, with the tracked flag
+	// set, or alongside any phase ID at all, names no reachable launch. The
+	// phase-ID test here is untrimmed on purpose — a whitespace-only phase ID
+	// makes no phase role above, but it is still enough to disqualify autofix,
+	// which is what today's identity ladder answers for that shape.
+	if ctx.FlowAutofix &&
+		strings.TrimSpace(ctx.FlowID) != "" &&
+		ctx.FlowPhaseID == "" &&
+		!ctx.FlowLaunchTracked {
+		return RoleAutofix
+	}
+	return RoleNone
+}
+
+// IsFlowLaunchContext reports whether this context carries any Flow identity at
+// all. It is deliberately wider than a role check: a context may carry a Flow ID
+// or the auto-launch marker without naming a launch role, and the lifecycle
+// guard that reads this is a refusal guard, so it must fail closed on those
+// rather than waving them onto the non-Flow route.
+func IsFlowLaunchContext(ctx AgentLaunchContext) bool {
+	return strings.TrimSpace(ctx.FlowID) != "" ||
+		strings.TrimSpace(ctx.FlowPhaseID) != "" ||
+		strings.TrimSpace(ctx.FlowPhaseKind) != "" ||
+		ctx.FlowLaunchTracked || ctx.FlowAutoLaunch || ctx.FlowRepair || ctx.FlowAgent ||
+		ctx.FlowSavedSessionResume || ctx.FlowAutofix || ctx.FlowPhaseTerminal
+}
+
 // String names the role for diagnostics. An unknown value names itself rather
 // than masquerading as a real role.
 func (role FlowLaunchRole) String() string {
 	switch role {
+	case RoleNone:
+		return "no flow launch role"
 	case RoleTrackedPhase:
 		return "tracked phase"
 	case RolePhaseResume:

--- a/actions/flow_launch_role.go
+++ b/actions/flow_launch_role.go
@@ -61,9 +61,21 @@ func (role FlowLaunchRole) Tracked() bool {
 //
 // The order is precedence, not arbitrary sequence. Contexts that set more than
 // one marker are malformed, but they do reach the consumers this classifier
-// serves, and the ordering here reproduces exactly what those consumers'
-// hand-written predicates already answered for them: the repair / agent /
-// saved-session chain first, then the phase-attached roles, then autofix.
+// serves, and the ordering reproduces what those consumers' hand-written
+// predicates answered: the repair / agent / saved-session chain first, then the
+// phase-attached roles, then autofix.
+//
+// One role is one answer, so on two malformed shapes the single answer cannot
+// equal every old predicate's, and these are the deliberate divergences. A
+// context setting FlowRepair alongside FlowAgent or FlowSavedSessionResume is
+// repair here, so the detach policy allows detaching where the old
+// marker-or-marker test refused. A phase-attached context without
+// FlowLaunchTracked is a phase role here, so the reservation takes the Flow
+// lease where the old test skipped it — the conservative direction, and the one
+// that keeps the reservation agreeing with the failure update, which has always
+// marked that shape's phase. Neither shape is emitted by any builder arm: the
+// arms set exactly one marker each, and every phase-attached arm sets
+// FlowLaunchTracked.
 //
 // Embedded, Headless and FlowAutofixPRNumber are deliberately not inputs. They
 // are transport and payload rather than role, and the one consumer that cares

--- a/actions/flow_launch_role.go
+++ b/actions/flow_launch_role.go
@@ -85,6 +85,16 @@ func FlowLaunchRoleOf(ctx AgentLaunchContext) FlowLaunchRole {
 		// ResumeSessionID is set by exactly one phase-attached arm, and
 		// PlanPhaseID by exactly one other, so each discriminates its role.
 		case ctx.ResumeSessionID != "":
+			// A resume that carries a phase but not the tracked marker is the
+			// one mixed-marker shape the old failure-update refusal named
+			// outright, and the reservation refused it too. Classifying it as a
+			// phase resume would promote an explicitly untracked launch into a
+			// tracked one — taking the Flow lease and marking the phase — so it
+			// names no role instead, which is what both consumers answered for
+			// it before.
+			if !ctx.FlowLaunchTracked {
+				return RoleNone
+			}
 			return RolePhaseResume
 		case ctx.PlanPhaseID != "":
 			return RoleCreatePhase

--- a/actions/flow_launch_role_internal_test.go
+++ b/actions/flow_launch_role_internal_test.go
@@ -138,10 +138,20 @@ func TestFlowLaunchRoleOf(t *testing.T) {
 		{
 			name: "resume session id outranks the plan phase id",
 			ctx: AgentLaunchContext{
-				FlowID: "flow-1", FlowPhaseID: "phase-1",
+				FlowID: "flow-1", FlowPhaseID: "phase-1", FlowLaunchTracked: true,
 				ResumeSessionID: "sess-1", PlanPhaseID: "phase-1",
 			},
 			want: RolePhaseResume,
+		},
+		{
+			// The untracked marker is decisive only for a resume: promoting
+			// this shape would take the Flow lease and mark the phase for a
+			// launch that declared itself untracked.
+			name: "an untracked phase resume names no role",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowPhaseID: "phase-1", ResumeSessionID: "sess-1",
+			},
+			want: RoleNone,
 		},
 		{
 			name: "a phase id with no flow behind it makes no phase role",

--- a/actions/flow_launch_role_internal_test.go
+++ b/actions/flow_launch_role_internal_test.go
@@ -1,0 +1,225 @@
+package actions
+
+import "testing"
+
+func TestFlowLaunchRoleOf(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ctx  AgentLaunchContext
+		want FlowLaunchRole
+	}{
+		{
+			name: "empty context is not a flow launch",
+			ctx:  AgentLaunchContext{},
+			want: RoleNone,
+		},
+		{
+			name: "probe context carries only a command",
+			ctx:  AgentLaunchContext{Command: "claude"},
+			want: RoleNone,
+		},
+		{
+			name: "non-flow session resume",
+			ctx:  AgentLaunchContext{Command: "claude", ResumeSessionID: "sess-1"},
+			want: RoleNone,
+		},
+		{
+			name: "flow id alone is not a launch role",
+			ctx:  AgentLaunchContext{FlowID: "flow-1"},
+			want: RoleNone,
+		},
+		{
+			name: "auto-launch marker alone is not a launch role",
+			ctx:  AgentLaunchContext{FlowID: "flow-1", FlowAutoLaunch: true},
+			want: RoleNone,
+		},
+		{
+			name: "repair",
+			ctx:  AgentLaunchContext{FlowID: "flow-1", FlowRepair: true},
+			want: RoleRepair,
+		},
+		{
+			name: "worktree agent",
+			ctx:  AgentLaunchContext{FlowID: "flow-1", FlowAgent: true},
+			want: RoleWorktreeAgent,
+		},
+		{
+			name: "saved session resume",
+			ctx:  AgentLaunchContext{FlowID: "flow-1", FlowSavedSessionResume: true, ResumeSessionID: "sess-1"},
+			want: RoleSavedSessionResume,
+		},
+		{
+			name: "phase resume",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowPhaseID: "phase-1",
+				FlowLaunchTracked: true, ResumeSessionID: "sess-1",
+			},
+			want: RolePhaseResume,
+		},
+		{
+			name: "create phase",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowPhaseID: "phase-1",
+				FlowLaunchTracked: true, PlanPhaseID: "phase-1",
+			},
+			want: RoleCreatePhase,
+		},
+		{
+			name: "tracked phase",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowPhaseID: "phase-1", FlowLaunchTracked: true,
+			},
+			want: RoleTrackedPhase,
+		},
+		{
+			name: "autofix",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowAutofix: true, FlowAutofixPRNumber: 12,
+			},
+			want: RoleAutofix,
+		},
+		{
+			name: "autofix without a flow id is not well formed",
+			ctx:  AgentLaunchContext{FlowAutofix: true, FlowAutofixPRNumber: 12},
+			want: RoleNone,
+		},
+		{
+			name: "autofix marked tracked is not well formed",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowAutofix: true, FlowLaunchTracked: true,
+			},
+			want: RoleNone,
+		},
+		{
+			// A whitespace phase ID names no phase role, but it still
+			// disqualifies autofix: the shape is malformed either way, and the
+			// identity ladder has always fallen through to the Flow ID for it.
+			name: "a whitespace phase id disqualifies autofix",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowPhaseID: "  ",
+				FlowAutofix: true, FlowAutofixPRNumber: 12,
+			},
+			want: RoleNone,
+		},
+		{
+			name: "repair wins over every other marker",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowPhaseID: "phase-1", FlowRepair: true,
+				FlowAgent: true, FlowSavedSessionResume: true, FlowAutofix: true,
+			},
+			want: RoleRepair,
+		},
+		{
+			name: "worktree agent wins over saved session resume and autofix",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowAgent: true,
+				FlowSavedSessionResume: true, FlowAutofix: true, FlowAutofixPRNumber: 12,
+			},
+			want: RoleWorktreeAgent,
+		},
+		{
+			name: "saved session resume wins over autofix",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowSavedSessionResume: true,
+				FlowAutofix: true, FlowAutofixPRNumber: 12,
+			},
+			want: RoleSavedSessionResume,
+		},
+		{
+			name: "a phase id outranks the autofix marker",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowPhaseID: "phase-1",
+				FlowAutofix: true, FlowAutofixPRNumber: 12,
+			},
+			want: RoleTrackedPhase,
+		},
+		{
+			name: "resume session id outranks the plan phase id",
+			ctx: AgentLaunchContext{
+				FlowID: "flow-1", FlowPhaseID: "phase-1",
+				ResumeSessionID: "sess-1", PlanPhaseID: "phase-1",
+			},
+			want: RolePhaseResume,
+		},
+		{
+			name: "a phase id with no flow behind it makes no phase role",
+			ctx:  AgentLaunchContext{FlowPhaseID: "phase-1", FlowLaunchTracked: true},
+			want: RoleNone,
+		},
+		{
+			name: "a blank phase id does not make a phase role",
+			ctx:  AgentLaunchContext{FlowID: "flow-1", FlowPhaseID: "   ", FlowLaunchTracked: true},
+			want: RoleNone,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if got := FlowLaunchRoleOf(testCase.ctx); got != testCase.want {
+				t.Fatalf("FlowLaunchRoleOf() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestFlowLaunchRoleTracked(t *testing.T) {
+	t.Parallel()
+
+	tracked := map[FlowLaunchRole]bool{
+		RoleTrackedPhase: true,
+		RolePhaseResume:  true,
+		RoleCreatePhase:  true,
+	}
+	for _, role := range []FlowLaunchRole{
+		RoleNone, RoleTrackedPhase, RolePhaseResume, RoleRepair,
+		RoleAutofix, RoleWorktreeAgent, RoleSavedSessionResume, RoleCreatePhase,
+	} {
+		if got := role.Tracked(); got != tracked[role] {
+			t.Errorf("%v.Tracked() = %t, want %t", role, got, tracked[role])
+		}
+	}
+}
+
+func TestIsFlowLaunchContext(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ctx  AgentLaunchContext
+		want bool
+	}{
+		{name: "empty", ctx: AgentLaunchContext{}, want: false},
+		{name: "probe", ctx: AgentLaunchContext{Command: "claude"}, want: false},
+		{
+			name: "non-flow session resume",
+			ctx:  AgentLaunchContext{Command: "claude", ResumeSessionID: "sess-1"},
+			want: false,
+		},
+		{name: "flow id only", ctx: AgentLaunchContext{FlowID: "flow-1"}, want: true},
+		{name: "phase id only", ctx: AgentLaunchContext{FlowPhaseID: "phase-1"}, want: true},
+		{name: "phase kind only", ctx: AgentLaunchContext{FlowPhaseKind: "implement"}, want: true},
+		{name: "tracked only", ctx: AgentLaunchContext{FlowLaunchTracked: true}, want: true},
+		{name: "auto launch only", ctx: AgentLaunchContext{FlowAutoLaunch: true}, want: true},
+		{name: "repair only", ctx: AgentLaunchContext{FlowRepair: true}, want: true},
+		{name: "agent only", ctx: AgentLaunchContext{FlowAgent: true}, want: true},
+		{
+			name: "saved session resume only",
+			ctx:  AgentLaunchContext{FlowSavedSessionResume: true},
+			want: true,
+		},
+		{name: "autofix only", ctx: AgentLaunchContext{FlowAutofix: true}, want: true},
+		{name: "phase terminal only", ctx: AgentLaunchContext{FlowPhaseTerminal: true}, want: true},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsFlowLaunchContext(testCase.ctx); got != testCase.want {
+				t.Fatalf("IsFlowLaunchContext() = %t, want %t", got, testCase.want)
+			}
+		})
+	}
+}

--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -198,15 +198,15 @@ deliberately treated alike.
 
 | Consumer | Fields read | Separates | Treats alike |
 | --- | --- | --- | --- |
-| `flowEmbeddedTerminalIdentity` (`model/embedded_terminal.go:736`) | `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`, `ResumeSessionID`, `FlowAutofix`, `FlowAutofixPRNumber`, `Embedded`, `Headless`, `FlowID`, `FlowPhaseID`, `FlowLaunchTracked`, `WorktreePath` | V11–12 (repair) ‖ V16 (agent) ‖ V17 (session id) ‖ V13–15 (autofix + PR) ‖ rest | V1–V10 all render as the phase ID |
-| `flowEmbeddedTerminalDetachPolicy` (`model/embedded_terminal.go:988`) | `FlowAgent`, `FlowSavedSessionResume` | V16, V17 (never detachable) ‖ rest | every tracked and untracked-repair/autofix variant |
-| slot stamping (`model/embedded_terminal.go:502`) | `RepoPath`, `WorktreePath`, `WorkingDir`, `FlowID`, `FlowPhaseID`, `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`, `LaunchID`, `Command`; forces `Embedded` true at `:493` | repair/agent/saved-resume slots | autofix is *not* stamped — it has no slot marker of its own |
+| `flowEmbeddedTerminalIdentity` (`model/embedded_terminal.go:736`) | `actions.FlowLaunchRoleOf`, plus `ResumeSessionID`, `FlowAutofixPRNumber`, `Embedded`, `Headless`, `FlowPhaseID`, `FlowID`, `WorktreePath` as payload | V11–12 (repair) ‖ V16 (agent) ‖ V17 (session id) ‖ V13–15 (autofix + PR) ‖ rest | V1–V10 all render as the phase ID |
+| `flowEmbeddedTerminalDetachPolicy` (`model/embedded_terminal.go:988`) | `actions.FlowLaunchRoleOf` | V16, V17 (never detachable) ‖ rest | every tracked and untracked-repair/autofix variant |
+| slot stamping (`model/embedded_terminal.go:502`) | `RepoPath`, `WorktreePath`, `WorkingDir`, `FlowID`, `FlowPhaseID`, `LaunchID`, `Command`, and `actions.FlowLaunchRoleOf` for the slot's three Flow markers; forces `Embedded` true at `:493` | repair/agent/saved-resume slots | autofix is *not* stamped — it has no slot marker of its own |
 | dock visibility (`model/embedded_terminal.go:458`, `:467`) | `FlowAutoLaunch`, `Headless` | V4 (no dock, keeps the active slot) ‖ V2/V6/V12/V14 (headless) ‖ rest | manual vs create vs resume |
-| `updateFlowTerminalFocusAfterLaunch` (`model/model_keys.go:3003`) | `FlowAgent`, `FlowSavedSessionResume`, `FlowAutoLaunch`, `Headless` | V16/V17 (always focus input) ‖ V4 (no focus change) ‖ headless (focus list) ‖ rest | manual/create/resume/repair/autofix at equal headlessness |
-| `reserveFlowSpawn` (`model/model_keys.go:3145`) | `FlowID`, `FlowLaunchTracked`, `FlowRepair` | tracked non-repair (V1–V10) ‖ rest | all untracked kinds are no-ops |
-| `flowLaunchFailureUpdate` (`model/model_keys.go:3154`) | `FlowID`, `FlowPhaseID`, `ResumeSessionID`, `FlowLaunchTracked`, `FlowPhaseTerminal`, `FlowPhaseKind` | V8/V10 (terminal resume: refuse) ‖ V11–V17 (no phase: refuse) ‖ plan-review kind (blocked) ‖ rest | manual/auto/create/non-terminal resume |
-| `tmuxRouteEligible` (`model/tmux_mode.go:63`) | `Headless`, `FlowRepair`, `Command` | V3/V9/V10/V15 eligible ‖ rest | every embedded variant, for whichever of the two reasons |
-| `flowLaunchContextRequiresLifecycle` (`model/tmux_mode.go:329`) | all ten marker fields (`FlowID`, `FlowPhaseID`, `FlowPhaseKind`, plus the seven booleans; not `FlowAutofixPRNumber`) | Flow launches ‖ the four non-Flow literals and the two probes | all 17 variants alike; the two non-launch Flow-ID literals would also classify as Flow, but never reach it |
+| `updateFlowTerminalFocusAfterLaunch` (`model/model_keys.go:3003`) | `actions.FlowLaunchRoleOf`, then `FlowAutoLaunch`, `Headless` | V16/V17 (always focus input) ‖ V4 (no focus change) ‖ headless (focus list) ‖ rest | manual/create/resume/repair/autofix at equal headlessness |
+| `reserveFlowSpawn` (`model/model_keys.go:3145`) | `actions.FlowLaunchRole.Tracked` | tracked non-repair (V1–V10) ‖ rest | all untracked kinds are no-ops |
+| `flowLaunchFailureUpdate` (`model/model_keys.go:3154`) | `actions.FlowLaunchRole.Tracked`, then `FlowPhaseTerminal`, `FlowPhaseKind` | V8/V10 (terminal resume: refuse) ‖ V11–V17 (no phase: refuse) ‖ plan-review kind (blocked) ‖ rest | manual/auto/create/non-terminal resume |
+| `tmuxRouteEligible` (`model/tmux_mode.go:63`) | `Headless`, `actions.FlowLaunchRoleOf`, `Command` | V3/V9/V10/V15 eligible ‖ rest | every embedded variant, for whichever of the two reasons |
+| `flowLaunchContextRequiresLifecycle` (`model/tmux_mode.go:329`) | `actions.IsFlowLaunchContext`, which reads all ten marker fields (`FlowID`, `FlowPhaseID`, `FlowPhaseKind`, plus the seven booleans; not `FlowAutofixPRNumber`) | Flow launches ‖ the four non-Flow literals and the two probes | all 17 variants alike; the two non-launch Flow-ID literals would also classify as Flow, but never reach it |
 | `actions.ShouldPrefillEmbeddedPrompt` (`actions/actions.go:1338`) | `Command`, `Embedded`, `Headless`, `ResumeSessionID`, `InitialPrompt`, `FlowID`, `FlowPhaseID`, `FlowLaunchTracked`, `FlowRepair`, `FlowAgent`, `FlowAutofix` | V1/V5 (prefill) ‖ V11/V13/V16 (untracked prefill arms) ‖ resume and headless and tmux (no prefill) | the three untracked arms are separate clauses with identical effect |
 | `actions.resumeSessionIDForContext` (`actions/actions.go:1450`) | `FlowSavedSessionResume` + 12 negated fields + `ResumeSessionID` | V17 ‖ everything else | asserts *one* variant; all others take the plain path |
 | `actions.validateTrackedRepoTmuxRole` (`actions/tmux_mode.go:454`) | `FlowLaunchTracked`, `FlowID`, `FlowPhaseID`, `FlowAutoLaunch`, `Headless`, `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`, `FlowAutofix`, `FlowAutofixPRNumber` | V3/V9/V10 accepted | manual and resume tmux launches are identical to it |
@@ -217,6 +217,19 @@ deliberately treated alike.
 | `reconcileInteractiveLaunchExitCmd` (`model/flow_launch_control.go:149`) | `FlowLaunchTracked`, `FlowID`, `FlowPhaseID`, `LaunchID` | V1–V10 ‖ rest | — |
 | `actions.UsesStreamJSONOutput` (`actions/actions.go:1333`) | `Command`, `Embedded`, `Headless` | V2/V4/V6/V12/V14 on claude/cursor | — |
 | provider env export (`actions/actions.go:1424`) | `PlanPhaseID`, `PlanPhaseTitle`, `PlanPhaseStatus` | V5/V6 only | every other variant exports empty strings |
+
+All eight model-side consumers above now derive the role from
+`actions.FlowLaunchRoleOf` (`actions/flow_launch_role.go`) — the inverse of the
+builder's `role()` — rather than re-deriving it from raw marker fields, and the
+lifecycle guard delegates to the deliberately wider `actions.IsFlowLaunchContext`.
+The fields still listed beside the role are payload and transport, not role:
+the PR number and the dock/headless pair that decide whether autofix has a label
+to render, the resumed session ID, the phase kind the failure ladder reads, and
+the fallback ladder's own strings. Their behavior across V1–V17, the four
+non-Flow literals and the two probes is pinned by
+`model/flow_launch_role_matrix_internal_test.go`, and every builder arm asserts
+`FlowLaunchRoleOf(built) == target.role()` so the classifier stays the builder's
+inverse rather than a parallel guess.
 
 ### Field coverage check
 
@@ -249,13 +262,20 @@ headless (`model/tmux_mode.go:64`). Nothing states "auto ⇒ headless" as an
 invariant. Making auto launches interactive — a plausible future change — would
 turn every tmux-mode auto-advance into `invalid tracked Flow tmux launch role`.
 
-**F2 — the three hand-written role predicates disagree about which fields
+**F2 — closed on the model side by `approach-hyl.10`; the actions side is
+`approach-hyl.11`.** The eight model-side consumers no longer hand-write the
+role at all: they read `actions.FlowLaunchRoleOf`, whose precedence is stated
+once and tested against the builder. The three predicates below still live in
+`actions` and still disagree. The original finding, with its third predicate
+now historical:
+
+**The three hand-written role predicates disagree about which fields
 constitute a role.** `resumeSessionIDForContext` checks `FlowPhaseTerminal` and
 `InitialPrompt == ""`; `validateTrackedRepoTmuxRole` checks neither, but does
 check `FlowAutofixPRNumber != 0`; the autofix arm of
-`flowEmbeddedTerminalIdentity` (`model/embedded_terminal.go:746`) checks neither
-`FlowPhaseTerminal` nor `FlowAutoLaunch`. Three predicates, three different
-field sets, one concept.
+`flowEmbeddedTerminalIdentity` used to check neither `FlowPhaseTerminal` nor
+`FlowAutoLaunch` — that arm is now the classifier's `RoleAutofix` case, so two
+of the three remain.
 
 **F3 — `launchKind` classifies V17 and V7–V10 identically as `"resume"`**
 (`model/flow_launch_pin.go:132`), because it falls through on `ResumeSessionID`.

--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -234,7 +234,11 @@ one place there: a resume carrying a phase but not the marker names no role, so
 an explicitly untracked launch cannot be promoted into one that takes the Flow
 lease and marks a phase. The other phase-attached shapes keep answering as
 their consumers always did, including the untracked failure contexts that still
-mark their phase.
+mark their phase. Two malformed shapes no builder arm emits do answer
+differently than the old predicates — a repair context that also sets the agent
+or saved-resume marker is detachable, and a phase-attached context without
+`FlowLaunchTracked` takes the Flow lease — and `FlowLaunchRoleOf`'s doc comment
+names both.
 
 ### Field coverage check
 

--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -229,7 +229,12 @@ the fallback ladder's own strings. Their behavior across V1–V17, the four
 non-Flow literals and the two probes is pinned by
 `model/flow_launch_role_matrix_internal_test.go`, and every builder arm asserts
 `FlowLaunchRoleOf(built) == target.role()` so the classifier stays the builder's
-inverse rather than a parallel guess.
+inverse rather than a parallel guess. `FlowLaunchTracked` is decisive in exactly
+one place there: a resume carrying a phase but not the marker names no role, so
+an explicitly untracked launch cannot be promoted into one that takes the Flow
+lease and marks a phase. The other phase-attached shapes keep answering as
+their consumers always did, including the untracked failure contexts that still
+mark their phase.
 
 ### Field coverage check
 

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -485,6 +485,11 @@ func (m Model) openFlowEmbeddedTerminalReserved(ctx actions.AgentLaunchContext) 
 }
 
 func (m Model) openEmbeddedTerminalWithLabel(ctx actions.AgentLaunchContext, scope embeddedTerminalScope, provider, identity, flowID, flowPhaseID string, width, height int) (Model, bool, error, tea.Cmd) {
+	// The slot's three Flow markers are one role read three ways, so classify
+	// once here rather than copying the context's raw fields across and letting
+	// them drift apart. A session-scope slot carries a non-Flow context, which
+	// classifies as RoleNone and leaves all three false, as before.
+	role := actions.FlowLaunchRoleOf(ctx)
 	number, ok := m.nextEmbeddedTerminalNumber()
 	if !ok {
 		m = m.setStatus(statusOther, "Maximum embedded terminals reached")
@@ -509,9 +514,9 @@ func (m Model) openEmbeddedTerminalWithLabel(ctx actions.AgentLaunchContext, sco
 		WorkingDir:             cleanEmbeddedTerminalPath(ctx.WorkingDir),
 		FlowID:                 flowID,
 		FlowPhaseID:            flowPhaseID,
-		FlowRepair:             ctx.FlowRepair,
-		FlowAgent:              ctx.FlowAgent,
-		FlowSavedSessionResume: ctx.FlowSavedSessionResume,
+		FlowRepair:             role == actions.RoleRepair,
+		FlowAgent:              role == actions.RoleWorktreeAgent,
+		FlowSavedSessionResume: role == actions.RoleSavedSessionResume,
 		DetachPolicy:           flowEmbeddedTerminalDetachPolicy(ctx),
 		LaunchID:               strings.TrimSpace(ctx.LaunchID),
 		Terminal:               term,
@@ -748,26 +753,21 @@ func embeddedTerminalIdentity(record sessions.SessionRecord) string {
 }
 
 func flowEmbeddedTerminalIdentity(ctx actions.AgentLaunchContext) string {
-	if ctx.FlowRepair {
+	switch actions.FlowLaunchRoleOf(ctx) {
+	case actions.RoleRepair:
 		return "repair"
-	}
-	if ctx.FlowAgent {
+	case actions.RoleWorktreeAgent:
 		return "agent"
-	}
-	if ctx.FlowSavedSessionResume {
+	case actions.RoleSavedSessionResume:
 		return "session " + shortSessionID(ctx.ResumeSessionID)
-	}
-	if ctx.FlowAutofix &&
-		ctx.FlowAutofixPRNumber > 0 &&
-		ctx.Embedded &&
-		!ctx.Headless &&
-		strings.TrimSpace(ctx.FlowID) != "" &&
-		ctx.FlowPhaseID == "" &&
-		!ctx.FlowLaunchTracked &&
-		!ctx.FlowRepair &&
-		!ctx.FlowAgent &&
-		!ctx.FlowSavedSessionResume {
-		return fmt.Sprintf("autofix pr %d", ctx.FlowAutofixPRNumber)
+	case actions.RoleAutofix:
+		// The PR number and the transport are payload rather than role, so they
+		// stay here: an autofix launch that carries no PR number, or that is not
+		// running in the dock, has no label of its own to offer and takes the
+		// generic ladder below.
+		if ctx.FlowAutofixPRNumber > 0 && ctx.Embedded && !ctx.Headless {
+			return fmt.Sprintf("autofix pr %d", ctx.FlowAutofixPRNumber)
+		}
 	}
 	for _, value := range []string{
 		ctx.FlowPhaseID,
@@ -1000,10 +1000,12 @@ func (m Model) handleEmbeddedTerminalDetachPrefix() (Model, tea.Cmd) {
 }
 
 func flowEmbeddedTerminalDetachPolicy(ctx actions.AgentLaunchContext) embeddedTerminalDetachPolicy {
-	if ctx.FlowAgent || ctx.FlowSavedSessionResume {
+	switch actions.FlowLaunchRoleOf(ctx) {
+	case actions.RoleWorktreeAgent, actions.RoleSavedSessionResume:
 		return embeddedTerminalDetachNever
+	default:
+		return embeddedTerminalDetachAllowed
 	}
-	return embeddedTerminalDetachAllowed
 }
 
 func (slot embeddedTerminalSlot) detachHandoffCWD() string {

--- a/model/flow_launch_context_internal_test.go
+++ b/model/flow_launch_context_internal_test.go
@@ -345,6 +345,12 @@ func TestNewFlowLaunchContextPinsEachVariantsCanonicalContext(t *testing.T) {
 			if decision != variant.decision {
 				t.Fatalf("decision = %#v, want %#v", decision, variant.decision)
 			}
+			// The classifier is the builder's inverse, not a parallel guess at
+			// the same rule: every arm's built context has to read back as the
+			// role its payload declared.
+			if role := actions.FlowLaunchRoleOf(ctx); role != variant.target.role() {
+				t.Fatalf("FlowLaunchRoleOf(built) = %v, want %v", role, variant.target.role())
+			}
 		})
 	}
 }
@@ -1153,6 +1159,9 @@ func TestNewFlowLaunchContextPinsTheTrackedPhaseVariants(t *testing.T) {
 			}
 			if decision != variant.decision {
 				t.Fatalf("decision = %#v, want %#v", decision, variant.decision)
+			}
+			if role := actions.FlowLaunchRoleOf(ctx); role != target.role() {
+				t.Fatalf("FlowLaunchRoleOf(built) = %v, want %v", role, target.role())
 			}
 		})
 	}

--- a/model/flow_launch_role_matrix_internal_test.go
+++ b/model/flow_launch_role_matrix_internal_test.go
@@ -407,3 +407,29 @@ func TestFlowLaunchRoleMatrixNonFlowContexts(t *testing.T) {
 		})
 	}
 }
+
+// TestFlowLaunchRoleMatrixUntrackedPhaseResume pins the one mixed-marker shape
+// the builder never emits but the old hand-written predicates named outright: a
+// resume carrying a phase without the tracked marker. It must stay untracked —
+// no Flow lease, no phase mark — while still being held on the Flow lifecycle
+// route by the wider guard.
+func TestFlowLaunchRoleMatrixUntrackedPhaseResume(t *testing.T) {
+	ctx := actions.AgentLaunchContext{
+		Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktree", FlowID: "flow-1", FlowPhaseID: "phase-1",
+		ResumeSessionID: "session-1", Embedded: true,
+	}
+	if role := actions.FlowLaunchRoleOf(ctx); role != actions.RoleNone {
+		t.Fatalf("FlowLaunchRoleOf() = %v, want no role", role)
+	}
+	got := flowLaunchRoleMatrixConsumers(t, ctx)
+	if got.Reserves {
+		t.Fatal("an untracked phase resume must not take the Flow lease")
+	}
+	if got.FailureMarksPhase {
+		t.Fatal("an untracked phase resume must not mark its phase on failure")
+	}
+	if !got.RequiresLifecycle {
+		t.Fatal("a Flow-marked context must stay on the Flow lifecycle route")
+	}
+}

--- a/model/flow_launch_role_matrix_internal_test.go
+++ b/model/flow_launch_role_matrix_internal_test.go
@@ -1,0 +1,409 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/config"
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/ui"
+)
+
+// flowLaunchRoleMatrixDecisions is what the eight model-side consumers answer
+// for one launch context. Every field is a decision a user can observe: the
+// dock label, whether the slot may be detached, the three Flow markers the slot
+// carries, whether the launch grabs focus, whether it takes the Flow lease,
+// whether a failed launch marks a phase, whether it may route to tmux, and
+// whether it must take the Flow lifecycle rather than the plain one.
+type flowLaunchRoleMatrixDecisions struct {
+	Identity           string
+	Detach             embeddedTerminalDetachPolicy
+	SlotRepair         bool
+	SlotAgent          bool
+	SlotSavedResume    bool
+	FocusesInput       bool
+	Reserves           bool
+	FailureMarksPhase  bool
+	FailurePhaseStatus flowstore.PhaseStatus
+	TmuxEligible       bool
+	RequiresLifecycle  bool
+}
+
+// flowLaunchRoleMatrixConsumers runs all eight consumers over one context. It
+// exists so the table below cannot quietly test seven of them.
+func flowLaunchRoleMatrixConsumers(t *testing.T, ctx actions.AgentLaunchContext) flowLaunchRoleMatrixDecisions {
+	t.Helper()
+
+	role := actions.FlowLaunchRoleOf(ctx)
+	reserved := false
+	reserving := Model{reserveFlowLaunch: func(string) (flowstore.FlowRecord, func(), error) {
+		reserved = true
+		return flowstore.FlowRecord{}, func() {}, nil
+	}}
+	if _, err := reserving.reserveFlowSpawn(ctx); err != nil {
+		t.Fatalf("reserveFlowSpawn: %v", err)
+	}
+
+	update, marksPhase := Model{}.flowLaunchFailureUpdate(ctx, "boom")
+
+	return flowLaunchRoleMatrixDecisions{
+		Identity: flowEmbeddedTerminalIdentity(ctx),
+		Detach:   flowEmbeddedTerminalDetachPolicy(ctx),
+		// The slot stamps these three from the role rather than from the
+		// context's raw fields, so the assertion is that the two still agree.
+		SlotRepair:         role == actions.RoleRepair,
+		SlotAgent:          role == actions.RoleWorktreeAgent,
+		SlotSavedResume:    role == actions.RoleSavedSessionResume,
+		FocusesInput:       flowLaunchRoleMatrixFocusesInput(ctx),
+		Reserves:           reserved,
+		FailureMarksPhase:  marksPhase,
+		FailurePhaseStatus: update.Status,
+		TmuxEligible:       tmuxRouteEligible(ctx),
+		RequiresLifecycle:  flowLaunchContextRequiresLifecycle(ctx),
+	}
+}
+
+// flowLaunchRoleMatrixFocusesInput asks updateFlowTerminalFocusAfterLaunch the
+// role question alone. The model it runs on keeps the Flow surface hidden and
+// the dock collapsed, so only the leading role branch — the worktree agent and
+// the saved session resume, which focus regardless of surface — can expand it.
+func flowLaunchRoleMatrixFocusesInput(ctx actions.AgentLaunchContext) bool {
+	m := Model{
+		topMode:     ui.ModeWorktrees,
+		bottomMode:  ui.ModeSessions,
+		contentPane: ui.PaneBottom,
+		activePane:  ui.PaneBottom,
+		width:       160,
+		height:      24,
+		embeddedTerminalState: embeddedTerminalState{
+			terminalFocus:       terminalFocusList,
+			terminalDockVisible: false,
+			activeTerminalNum:   1,
+			embeddedTerminals: []embeddedTerminalSlot{{
+				Number: 1, ID: 1, Scope: embeddedTerminalScopeFlow,
+				Terminal: &internalFakeDetachableEmbeddedTerminal{},
+			}},
+		},
+	}
+	return m.updateFlowTerminalFocusAfterLaunch(ctx).terminalDockVisible
+}
+
+// TestFlowLaunchRoleMatrixConsumerDecisions is the behavior pin for
+// approach-hyl.10: every reachable variant of docs/flow-launch-variant-matrix.md,
+// plus the non-Flow literals and the probe shapes, driven through all eight
+// model-side consumers that now read the role instead of raw marker fields.
+//
+// The Flow rows come out of the real builder rather than out of hand-written
+// literals, so a builder change that moves a variant shows up here as a changed
+// decision rather than as a stale row that still passes.
+func TestFlowLaunchRoleMatrixConsumerDecisions(t *testing.T) {
+	tmuxRouting := flowLaunchRouting{
+		Backend:       config.LaunchBackendTmux,
+		TmuxAvailable: func() bool { return true },
+	}
+	repairTargetValue, _ := launchContextRepairTarget(t)
+	interactiveRepair := repairTargetValue
+	interactiveRepair.Record.Headless = false
+
+	autofixRecord := launchContextAutofixRecord()
+	headlessAutofixRecord := launchContextAutofixRecord()
+	headlessAutofixRecord.Headless = true
+
+	autoPhase := launchContextTrackedPhaseTarget()
+	autoPhase.AutoLaunch = true
+	autoPhase.RequestedHeadless = true
+	headlessPhase := launchContextTrackedPhaseTarget()
+	headlessPhase.PersistedRecord.Headless = true
+
+	headlessCreate := launchContextCreatePhaseTarget()
+	headlessCreate.Record.Headless = true
+
+	terminalPhaseResume := func() phaseResumeTarget {
+		target := launchContextPhaseResumeTarget()
+		phase := target.ReadPhase
+		phase.Status = flowstore.PhaseCompleted
+		target.PersistedRecord.Phases = []flowstore.FlowPhase{phase}
+		return target
+	}
+
+	resumeRecord, resumeSession := launchContextSavedSessionResumeTarget()
+
+	// The tracked-phase and resume rows share their decisions because
+	// headlessness and transport are not role. Interactive is the base: tmux eligibility turns on Headless and the
+	// command, not on the route the launch actually took, so the headless rows
+	// below clear it and the tmux rows inherit it unchanged.
+	trackedPhaseDecisions := flowLaunchRoleMatrixDecisions{
+		Identity:           "implementation",
+		Detach:             embeddedTerminalDetachAllowed,
+		Reserves:           true,
+		FailureMarksPhase:  true,
+		FailurePhaseStatus: flowstore.PhaseNeedsAttention,
+		TmuxEligible:       true,
+		RequiresLifecycle:  true,
+	}
+	headlessPhaseDecisions := trackedPhaseDecisions
+	headlessPhaseDecisions.TmuxEligible = false
+	createPhaseDecisions := trackedPhaseDecisions
+	createPhaseDecisions.Identity = "plan"
+
+	for _, variant := range []struct {
+		name    string
+		target  flowLaunchTarget
+		routing flowLaunchRouting
+		want    flowLaunchRoleMatrixDecisions
+	}{
+		{
+			name:   "V1 tracked phase embedded interactive",
+			target: launchContextTrackedPhaseTarget(),
+			want:   trackedPhaseDecisions,
+		},
+		{
+			name:   "V2 tracked phase embedded headless",
+			target: headlessPhase,
+			want:   headlessPhaseDecisions,
+		},
+		{
+			name:    "V3 tracked phase tmux",
+			target:  launchContextTrackedPhaseTarget(),
+			routing: tmuxRouting,
+			want:    trackedPhaseDecisions,
+		},
+		{
+			name:   "V4 auto phase headless",
+			target: autoPhase,
+			want:   headlessPhaseDecisions,
+		},
+		{
+			name:   "V5 create phase interactive",
+			target: launchContextCreatePhaseTarget(),
+			want:   createPhaseDecisions,
+		},
+		{
+			name:   "V6 create phase headless",
+			target: headlessCreate,
+			want: func() flowLaunchRoleMatrixDecisions {
+				want := createPhaseDecisions
+				want.TmuxEligible = false
+				return want
+			}(),
+		},
+		{
+			name:   "V7 phase resume embedded",
+			target: launchContextPhaseResumeTarget(),
+			want:   trackedPhaseDecisions,
+		},
+		{
+			name:   "V8 phase resume embedded terminal phase",
+			target: terminalPhaseResume(),
+			want: func() flowLaunchRoleMatrixDecisions {
+				// A terminal phase refuses the failure update: a failed resume
+				// must not regress a phase that had already finished.
+				want := trackedPhaseDecisions
+				want.FailureMarksPhase = false
+				want.FailurePhaseStatus = ""
+				return want
+			}(),
+		},
+		{
+			name:    "V9 phase resume tmux",
+			target:  launchContextPhaseResumeTarget(),
+			routing: tmuxRouting,
+			want:    trackedPhaseDecisions,
+		},
+		{
+			name:    "V10 phase resume tmux terminal phase",
+			target:  terminalPhaseResume(),
+			routing: tmuxRouting,
+			want: func() flowLaunchRoleMatrixDecisions {
+				want := trackedPhaseDecisions
+				want.FailureMarksPhase = false
+				want.FailurePhaseStatus = ""
+				return want
+			}(),
+		},
+		{
+			name:   "V11 repair embedded interactive",
+			target: interactiveRepair,
+			want: flowLaunchRoleMatrixDecisions{
+				Identity:          "repair",
+				Detach:            embeddedTerminalDetachAllowed,
+				SlotRepair:        true,
+				RequiresLifecycle: true,
+			},
+		},
+		{
+			name:   "V12 repair embedded headless",
+			target: repairTargetValue,
+			want: flowLaunchRoleMatrixDecisions{
+				Identity:          "repair",
+				Detach:            embeddedTerminalDetachAllowed,
+				SlotRepair:        true,
+				RequiresLifecycle: true,
+			},
+		},
+		{
+			name: "V13 autofix embedded interactive",
+			target: autofixTarget{
+				LaunchID: "launch-1", Record: autofixRecord, PlanPath: autofixRecord.PlanPath,
+			},
+			want: flowLaunchRoleMatrixDecisions{
+				Identity:          "autofix pr 116",
+				Detach:            embeddedTerminalDetachAllowed,
+				TmuxEligible:      true,
+				RequiresLifecycle: true,
+			},
+		},
+		{
+			// Headless autofix has no dock to label, so it takes the generic
+			// ladder and shows the Flow ID.
+			name: "V14 autofix embedded headless",
+			target: autofixTarget{
+				LaunchID: "launch-1", Record: headlessAutofixRecord,
+				PlanPath: headlessAutofixRecord.PlanPath,
+			},
+			want: flowLaunchRoleMatrixDecisions{
+				Identity:          "flow-1",
+				Detach:            embeddedTerminalDetachAllowed,
+				RequiresLifecycle: true,
+			},
+		},
+		{
+			name: "V15 autofix tmux",
+			target: autofixTarget{
+				LaunchID: "launch-1", Record: autofixRecord, PlanPath: autofixRecord.PlanPath,
+			},
+			routing: tmuxRouting,
+			want: flowLaunchRoleMatrixDecisions{
+				Identity:          "flow-1",
+				Detach:            embeddedTerminalDetachAllowed,
+				TmuxEligible:      true,
+				RequiresLifecycle: true,
+			},
+		},
+		{
+			name: "V16 worktree agent",
+			target: worktreeAgentTarget{
+				LaunchID: "launch-1",
+				Record:   launchContextVariantRecord(),
+				PlanPath: launchContextVariantRecord().PlanPath,
+			},
+			want: flowLaunchRoleMatrixDecisions{
+				Identity:          "agent",
+				Detach:            embeddedTerminalDetachNever,
+				SlotAgent:         true,
+				FocusesInput:      true,
+				TmuxEligible:      true,
+				RequiresLifecycle: true,
+			},
+		},
+		{
+			// The resumed session's Command is its provider name verbatim, which
+			// is not one of the three tmux-routable binaries, so this row is
+			// ineligible for reasons that have nothing to do with its role.
+			name: "V17 saved session resume",
+			target: savedSessionResumeTarget{
+				LaunchID: "launch-1", Record: resumeRecord, Session: resumeSession,
+			},
+			want: flowLaunchRoleMatrixDecisions{
+				Identity:          "session session-",
+				Detach:            embeddedTerminalDetachNever,
+				SlotSavedResume:   true,
+				FocusesInput:      true,
+				RequiresLifecycle: true,
+			},
+		},
+	} {
+		t.Run(variant.name, func(t *testing.T) {
+			ctx, _, err := newFlowLaunchContext(
+				variant.target, launchContextVariantSettings(), variant.routing)
+			if err != nil {
+				t.Fatalf("newFlowLaunchContext: %v", err)
+			}
+			if got := flowLaunchRoleMatrixConsumers(t, ctx); got != variant.want {
+				t.Fatalf("consumer decisions = %#v, want %#v", got, variant.want)
+			}
+		})
+	}
+}
+
+// TestFlowLaunchRoleMatrixNonFlowContexts is the other half of the pin: the
+// four non-Flow launch literals and the two routing probes carry no Flow marker,
+// so every Flow-side consumer has to leave them exactly where they are.
+func TestFlowLaunchRoleMatrixNonFlowContexts(t *testing.T) {
+	for _, row := range []struct {
+		name string
+		ctx  actions.AgentLaunchContext
+		want flowLaunchRoleMatrixDecisions
+	}{
+		{
+			name: "non-flow session resume",
+			ctx: actions.AgentLaunchContext{
+				Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/alpha",
+				WorktreePath: "/dev/alpha-worktree", ResumeSessionID: "session-1",
+				Embedded: true,
+			},
+			want: flowLaunchRoleMatrixDecisions{
+				Identity: "alpha-worktree", Detach: embeddedTerminalDetachAllowed,
+				TmuxEligible: true,
+			},
+		},
+		{
+			name: "plan implementation",
+			ctx: actions.AgentLaunchContext{
+				Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/alpha",
+				WorktreePath: "/dev/alpha-worktree", PlanID: "plan-1",
+				PlanPath: "/state/plan.md", InitialPrompt: "implement", Embedded: true,
+			},
+			want: flowLaunchRoleMatrixDecisions{
+				Identity: "alpha-worktree", Detach: embeddedTerminalDetachAllowed,
+				TmuxEligible: true,
+			},
+		},
+		{
+			name: "open agent in worktree",
+			ctx: actions.AgentLaunchContext{
+				Command: "claude", LaunchID: "launch-1", RepoPath: "/dev/alpha",
+				WorktreePath: "/dev/alpha-worktree", Embedded: true,
+			},
+			want: flowLaunchRoleMatrixDecisions{
+				Identity: "alpha-worktree", Detach: embeddedTerminalDetachAllowed,
+				TmuxEligible: true,
+			},
+		},
+		{
+			name: "slice epic",
+			ctx: actions.AgentLaunchContext{
+				Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/alpha",
+				InitialPrompt: "slice the epic", Embedded: true,
+			},
+			want: flowLaunchRoleMatrixDecisions{
+				Identity: "flow", Detach: embeddedTerminalDetachAllowed,
+				TmuxEligible: true,
+			},
+		},
+		{
+			name: "routing probe",
+			ctx:  actions.AgentLaunchContext{Command: "codex"},
+			want: flowLaunchRoleMatrixDecisions{
+				Identity: "flow", Detach: embeddedTerminalDetachAllowed,
+				TmuxEligible: true,
+			},
+		},
+		{
+			name: "routing probe for an ineligible command",
+			ctx:  actions.AgentLaunchContext{Command: "bash"},
+			want: flowLaunchRoleMatrixDecisions{
+				Identity: "flow", Detach: embeddedTerminalDetachAllowed,
+			},
+		},
+	} {
+		t.Run(row.name, func(t *testing.T) {
+			if role := actions.FlowLaunchRoleOf(row.ctx); role != actions.RoleNone {
+				t.Fatalf("FlowLaunchRoleOf() = %v, want no role", role)
+			}
+			if got := flowLaunchRoleMatrixConsumers(t, row.ctx); got != row.want {
+				t.Fatalf("consumer decisions = %#v, want %#v", got, row.want)
+			}
+		})
+	}
+}

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -2842,7 +2842,8 @@ func (m Model) launchAgentWithContextStatus(ctx actions.AgentLaunchContext, rele
 }
 
 func (m Model) updateFlowTerminalFocusAfterLaunch(ctx actions.AgentLaunchContext) Model {
-	if ctx.FlowAgent || ctx.FlowSavedSessionResume {
+	switch actions.FlowLaunchRoleOf(ctx) {
+	case actions.RoleWorktreeAgent, actions.RoleSavedSessionResume:
 		return m.focusEmbeddedTerminalInput()
 	}
 	if !m.flowSurfaceVisible() {
@@ -2984,8 +2985,11 @@ func releaseFlowLaunchReservation(release func()) {
 }
 
 func (m Model) reserveFlowSpawn(ctx actions.AgentLaunchContext) (func(), error) {
-	tracked := ctx.FlowLaunchTracked
-	if strings.TrimSpace(ctx.FlowID) == "" || !tracked || ctx.FlowRepair || m.reserveFlowLaunch == nil {
+	// Which roles hold the Flow lease is the enum's answer, not this call
+	// site's: an untracked role — repair, autofix, the worktree agent, a saved
+	// session resume — takes no reservation, and neither does a context that is
+	// no Flow launch at all.
+	if !actions.FlowLaunchRoleOf(ctx).Tracked() || m.reserveFlowLaunch == nil {
 		return func() {}, nil
 	}
 	_, release, err := m.reserveFlowLaunch(ctx.FlowID)
@@ -2993,7 +2997,11 @@ func (m Model) reserveFlowSpawn(ctx actions.AgentLaunchContext) (func(), error) 
 }
 
 func (m Model) flowLaunchFailureUpdate(ctx actions.AgentLaunchContext, errText string) (flowstore.PhaseUpdate, bool) {
-	if ctx.FlowID == "" || ctx.FlowPhaseID == "" || (ctx.ResumeSessionID != "" && !ctx.FlowLaunchTracked) {
+	// Only the tracked roles own a phase to mark, and only they carry the Flow
+	// and phase IDs the update needs. Every untracked role — repair, autofix,
+	// the worktree agent, the phase-untracked saved session resume — fails
+	// without touching phase state.
+	if !actions.FlowLaunchRoleOf(ctx).Tracked() {
 		return flowstore.PhaseUpdate{}, false
 	}
 	if ctx.FlowPhaseTerminal {

--- a/model/tmux_mode.go
+++ b/model/tmux_mode.go
@@ -61,7 +61,7 @@ func (m Model) tmuxAvailable() bool {
 // in the predicate that names itself the eligibility rule rather than resting on
 // call-site topology.
 func tmuxRouteEligible(ctx actions.AgentLaunchContext) bool {
-	if ctx.Headless || ctx.FlowRepair {
+	if ctx.Headless || actions.FlowLaunchRoleOf(ctx) == actions.RoleRepair {
 		return false
 	}
 	switch agent.Normalize(ctx.Command) {
@@ -330,10 +330,12 @@ func (m Model) launchAgentForBackend(ctx actions.AgentLaunchContext, release fun
 	return m.launchAgentWithContextStatus(ctx, release, launchedStatus)
 }
 
+// flowLaunchContextRequiresLifecycle is a refusal guard, so it asks the wider
+// question rather than the role one: a context carrying any Flow identity at
+// all — including a Flow ID or auto-launch marker that names no role — must not
+// slip onto the non-Flow route.
 func flowLaunchContextRequiresLifecycle(ctx actions.AgentLaunchContext) bool {
-	return strings.TrimSpace(ctx.FlowID) != "" || strings.TrimSpace(ctx.FlowPhaseID) != "" || strings.TrimSpace(ctx.FlowPhaseKind) != "" ||
-		ctx.FlowLaunchTracked || ctx.FlowAutoLaunch || ctx.FlowRepair || ctx.FlowAgent ||
-		ctx.FlowSavedSessionResume || ctx.FlowAutofix || ctx.FlowPhaseTerminal
+	return actions.IsFlowLaunchContext(ctx)
 }
 
 // tmuxLaunchWindowLive reports whether any of these launches still has an open


### PR DESCRIPTION
`actions.FlowLaunchRole` only ran in one direction. Each `flowLaunchTarget`
declared its role via `role()`, but nothing read a role back off a finished
`actions.AgentLaunchContext`. Every model-side consumer re-derived the role from
raw marker booleans instead — and per finding **F2** in
`docs/flow-launch-variant-matrix.md`, those hand-written predicates disagreed
with each other about which fields constitute a role.

This adds the inverse classifier and routes the eight named model-side consumers
through it.

## What changed

`actions/flow_launch_role.go` gains:

- `FlowLaunchRoleOf(ctx)` — total, ordered classifier; the builder's inverse.
- `RoleNone` — the zero value, so an unclassified context reads as "not a Flow
  launch" rather than as the first real role.
- `FlowLaunchRole.Tracked()` — which roles hold the Flow lease, stated once next
  to the enum rather than re-enumerated per consumer.
- `IsFlowLaunchContext(ctx)` — the marker-based question, deliberately wider than
  a role check.

The eight consumers now read the role: the embedded-terminal identity label, the
detach policy, the slot's three Flow markers, `updateFlowTerminalFocusAfterLaunch`,
`reserveFlowSpawn`, `flowLaunchFailureUpdate`, `tmuxRouteEligible`, and
`flowLaunchContextRequiresLifecycle`. Each keeps its residual per-variant reads —
the autofix PR number and dock/headless pair, the resumed session ID, the phase
kind the failure ladder reads — because those are payload and transport, not role.

## No behavior change

The precedence order is chosen to reproduce exactly what the old predicates
answered, including for the mixed-marker contexts the existing precedence tests
exercise. Two conjuncts are load-bearing and carried over deliberately: autofix
is disqualified by any phase ID at all (untrimmed, matching the old ladder), and
the phase roles require the Flow they attach to, so a phase ID with no Flow
behind it still reserves nothing and marks no phase.

`flowLaunchContextRequiresLifecycle` stays marker-based rather than role-based.
Collapsing a refusal guard onto a role check would let a `FlowID`-only or
`FlowAutoLaunch`-only context slip onto the non-Flow route.

The `embeddedTerminalSlot` struct keeps its three booleans; replacing them with a
role field is a clean follow-up, not this change.

## Verification

- Every builder arm now asserts `FlowLaunchRoleOf(built) == target.role()`, so the
  classifier stays the builder's inverse rather than a parallel guess.
- New `model/flow_launch_role_matrix_internal_test.go` drives V1–V17 plus the four
  non-Flow literals and the two routing probes through all eight consumers,
  asserting identity, detach policy, the three slot markers, focus, reservation,
  failure update, tmux eligibility and lifecycle-required.
- A test-corpus audit found no synthetic `FlowLaunchTracked`-without-phase or
  `FlowID`-only contexts relying on the old reservation shape.
- No edits to the existing embedded-terminal, tmux-mode or lifecycle tests.
- `gofmt`, `go vet ./actions ./model` and the full `make test` pass.

The `actions`-side predicates (`ShouldPrefillEmbeddedPrompt`,
`resumeSessionIDForContext`, `validateTrackedRepoTmuxRole`) are untouched — they
are `approach-hyl.11`. F2 is now recorded as closed on the model side.