### PR TITLE
Survey the sixteen ways a Flow answers "am I busy?" and design one

### DIFF
--- a/docs/adr/0003-flow-occupancy-deep-module.md
+++ b/docs/adr/0003-flow-occupancy-deep-module.md
@@ -97,10 +97,16 @@ of them.
 | `StageInstall` | `flowLaunchEmbeddedBackstop` | Last check before a slot is allocated. Slot sources only. |
 | `StageDrain` | matrix §2.4 | Runs at 1 Hz. Cached only, and must never shell out. |
 
-Two non-launch purposes do not fit the role axis and get `RoleNone` with their
-own stages: `StageSessionRelease` (matrix §2.5,
-`model/flow_session_release.go:115`) and `StageQuit`
-(`model/embedded_terminal.go:920,942`).
+One non-launch purpose does not fit the role axis and gets `RoleNone` with its
+own stage: `StageSessionRelease` (matrix §2.5,
+`model/flow_session_release.go:115`).
+
+The quit deferral (`model/embedded_terminal.go:920,942`) is deliberately *not*
+a purpose, even though matrix §2.5 lists it. It reads S5 alone, and D5 keeps S5
+out of `Sources` because handoff-pending is a process-wide quit policy rather
+than a per-Flow question — nothing in `Sources` could answer it, and a
+`Query` that ignored it or deferred quit on any attempt would change today's
+behavior.
 
 Why a pair and not a flat sixteen-value enum: the flat form makes the source set
 per consumer unrelatable, so nothing catches "repair's preview and repair's

--- a/docs/adr/0003-flow-occupancy-deep-module.md
+++ b/docs/adr/0003-flow-occupancy-deep-module.md
@@ -160,8 +160,10 @@ The rule, stated once so it stops living in comments:
 > alike. This is fail-closed in both directions and matches
 > `model/flow_launch_lifecycle.go:410` today.
 >
-> The tmux window probe is never read at `StageDrain` or `StagePreview`, because
-> it forks a subprocess (`model/tmux_mode.go:425-427`).
+> The tmux window probe is read only at `StageAdmission` and
+> `StageAuthoritative`, because it forks a subprocess
+> (`model/tmux_mode.go:425-427`). Every other stage — including the AutoMode
+> poll's `StageAutoAdvance` and `StageDrain` — never consults it.
 
 ### D4 — `Verdict` exposes a named `Holder` and a `Reason`, never the sources
 

--- a/docs/adr/0003-flow-occupancy-deep-module.md
+++ b/docs/adr/0003-flow-occupancy-deep-module.md
@@ -85,12 +85,13 @@ verbatim from ADR 0002. It already names exactly the seven launches the TUI can
 start, and every occupancy consumer in matrix §2.1–§2.2 belongs to exactly one
 of them.
 
-`Stage` is a new closed enum of six, one per consumer class in matrix §2:
+`Stage` is a new closed enum, one value per consumer class in matrix §2:
 
 | Stage | Consumers | Constraint |
 | --- | --- | --- |
 | `StagePreview` | matrix §2.3 | Runs per frame. Cached only. |
-| `StageAdmission` | matrix §2.1 | Runs on a keypress or a poll admission. In-process sources plus the lease; no session-store walk. |
+| `StageAdmission` | matrix §2.1, keypress rows | Runs on a keypress. In-process sources plus the lease; no session-store walk. |
+| `StageAutoAdvance` | matrix §2.1 "Auto phase", §2.2 "AutoMode read" | The AutoMode advance poll. Never reads S14, refuses in silence, and its read adds S10-minus-the-candidate. |
 | `StageAuthoritative` | matrix §2.2 read stages | Runs in a `tea.Cmd`. Full store access. |
 | `StageReserved` | matrix §2.2 prepare stages | Runs under the cross-process reservation. Re-checks the lease. |
 | `StageInstall` | `flowLaunchEmbeddedBackstop` | Last check before a slot is allocated. Slot sources only. |
@@ -117,12 +118,23 @@ Query{FlowID string, Role actions.FlowLaunchRole, Stage Stage, Freshness Freshne
 `FreshnessDefault` resolves from `Stage` per the table in D2 and is what almost
 every caller passes.
 
-It is not simply *implied* by `Stage`, because one real pair disagrees: the
-AutoMode drain (`model/flow_phase_launch.go:773`) and the AutoMode read
-(`model/flow_launch_lifecycle.go:705`) ask the same role the same question and
-must get answers of different freshness — the first from the poll's own record,
-the second from `ListFlowSessions`. Making it a field keeps that visible instead
-of encoding it as two stages that differ in nothing else.
+It is not simply *implied* by `Stage`, because one real pair disagrees:
+`StageAutoAdvance`'s admission gate (`model/flow_phase_launch.go:773`) and its
+read (`model/flow_launch_lifecycle.go:705`) ask the same role the same question
+and must get answers of different freshness — the first from the poll's own
+record, the second from `ListFlowSessions`. Making it a field keeps that visible
+instead of encoding it as two stages that differ in nothing else.
+
+`StageAutoAdvance` itself is a separate stage on the opposite grounds. The
+AutoMode poll is not `StageAdmission` at a different freshness: matrix §2.1
+records that manual admission reads S14 and refuses loudly where auto reads
+neither, and §2.2 records that the AutoMode read adds
+`flowRecordHasOtherRunningPhase` where the tracked-phase read does not. Since
+`RoleTrackedPhase` covers both consumers — ADR 0002 deliberately kept
+auto-launch out of the role axis — collapsing them into `StageAdmission` would
+leave `Purpose` unable to name two consumers whose source sets differ, and any
+implementation would have to change AutoMode's behavior or drop manual's
+headless-write refusal.
 
 The rule, stated once so it stops living in comments:
 

--- a/docs/adr/0003-flow-occupancy-deep-module.md
+++ b/docs/adr/0003-flow-occupancy-deep-module.md
@@ -1,0 +1,303 @@
+# ADR 0003: Flow occupancy as a deep module
+
+Status: **proposed — pending user approval** (2026-08-21)
+
+`approach-x0r.1` is a HITL bead. This Flow ran headless in auto mode, so the
+bead's "grilled with the user before slice 2 starts" criterion cannot be
+satisfied from inside it. Every decision below is a *proposal* with its
+evidence; the "Decision requests" section lists the open questions. Approval
+happens out of band, and `approach-x0r.2` must not start before it does.
+
+## Context
+
+"Is something already working in this Flow?" is answered sixteen different ways
+in `model/`, by thirteen distinct representations and two composites over them,
+read at roughly forty call sites. The evidence base is
+`docs/flow-occupancy-matrix.md`, pinned to commit `3d147d4`: sixteen sources
+(§1), consumers grouped by mutating/preview/poll/non-launch (§2), ten
+deliberate divergences (§3), and four independent ordered refusal ladders (§4).
+
+Four facts from that matrix drive this design.
+
+**C1 — consumers disagree on purpose, not on truth.** The one composite that
+exists, `flowLaunchAdmissionOccupied` (`model/flow_launch_lifecycle.go:404`),
+has six call sites that take it as-is and five admissions that deliberately
+unroll it. Autofix refuses it because it "would collapse a held or unreadable
+lease into the generic in-flight status"
+(`model/flow_launch_autofix.go:152-154`); phase resume refuses it because it
+"could turn a peer race into a silent refusal before the reservation-protected
+recheck reports the real cause" (`model/flow_launch_resume.go:129-131`); create
+uses the narrower runtime check because a brand-new Flow "remains embedded and
+unleased" (`model/flow_launch_lifecycle.go:414-416`). None of these is wrong. A
+single boolean cannot serve them, because they are not asking the same question.
+
+**C2 — three consumers need an ordered named holder, not a boolean.**
+`flowRepairOccupancyRefusal` (`model/flow_launch_repair.go:201`) ranks five
+holders; `flowLaunchEmbeddedBackstop` (`model/flow_launch_lifecycle.go:1269`)
+ranks per kind with seven distinct strings; autofix inlines a fourth ladder
+(`model/flow_launch_autofix.go:155-168`); the worktree agent a fifth
+(`model/flow_launch_generic_agent.go:100-119`). They overlap, they use four
+vocabularies, and nothing keeps them consistent (matrix F2).
+
+**C3 — the cached/authoritative split is real but is enforced only by comments.**
+The AutoMode drain answers from mirrors because otherwise it "would re-admit and
+call `ListFlowSessions` again at 1 Hz" (`model/flow_phase_launch.go:765-772`);
+the tmux probe never runs from a poll because "a poll on a timer must not shell
+out" (`model/tmux_mode.go:425-427`); the session-release footer is mirror-only
+so that a store-only stall stays reachable
+(`model/flow_session_release.go:80-82`). Nothing structural stops a new preview
+from walking the session store per frame (matrix F4).
+
+**C4 — two source pairs are open-coded everywhere and neither nests.** The Flow
+terminal slot and the repair terminal slot "overlap rather than nest — one
+requires a live terminal, the other a repair slot"
+(`model/flow_launch_lifecycle.go:1261`), and that fact is re-derived at eleven
+sites (matrix F3). The same is true of the phase's mirrored sessions versus the
+store listing, unioned by `flowLaunchPhaseSessionOccupied`
+(`model/flow_launch_lifecycle.go:1488`) and re-scoped four different ways by its
+callers (matrix D5).
+
+## Decision
+
+### D1 — a new top-level package `flowoccupancy/`
+
+`flowoccupancy` is a peer of `flowstore/`, `sessions/`, and `actions/`. It is
+imported by `model`; it must never import `model`.
+
+Top-level rather than `internal/`, because `internal/` in this repo holds
+cross-process and infrastructure concerns — `internal/flowlease`,
+`internal/launchcontrol`, `internal/dblease`, `internal/artifacts` — while this
+is *domain policy* over `flowstore` records, `sessions` records, and injected
+in-process runtime state. It reads the lease through a seam; it does not
+reimplement it. Being a real package with a real import edge is also what makes
+`approach-x0r.11`'s architecture test expressible: "no file under `model/`
+open-codes an occupancy predicate" is checkable only if there is somewhere else
+for the predicate to live.
+
+The dependency edge is `model → flowoccupancy → {actions, flowstore, sessions}`.
+No cycle: `actions` does not import `model`
+(`actions/flow_launch_role.go:10-12`).
+
+### D2 — `Purpose` is a `(Role, Stage)` pair, not a flat enum
+
+`Role` is `actions.FlowLaunchRole` (`actions/flow_launch_role.go:13`), reused
+verbatim from ADR 0002. It already names exactly the seven launches the TUI can
+start, and every occupancy consumer in matrix §2.1–§2.2 belongs to exactly one
+of them.
+
+`Stage` is a new closed enum of six, one per consumer class in matrix §2:
+
+| Stage | Consumers | Constraint |
+| --- | --- | --- |
+| `StagePreview` | matrix §2.3 | Runs per frame. Cached only. |
+| `StageAdmission` | matrix §2.1 | Runs on a keypress or a poll admission. In-process sources plus the lease; no session-store walk. |
+| `StageAuthoritative` | matrix §2.2 read stages | Runs in a `tea.Cmd`. Full store access. |
+| `StageReserved` | matrix §2.2 prepare stages | Runs under the cross-process reservation. Re-checks the lease. |
+| `StageInstall` | `flowLaunchEmbeddedBackstop` | Last check before a slot is allocated. Slot sources only. |
+| `StageDrain` | matrix §2.4 | Runs at 1 Hz. Cached only, and must never shell out. |
+
+Two non-launch purposes do not fit the role axis and get `RoleNone` with their
+own stages: `StageSessionRelease` (matrix §2.5,
+`model/flow_session_release.go:115`) and `StageQuit`
+(`model/embedded_terminal.go:920,942`).
+
+Why a pair and not a flat sixteen-value enum: the flat form makes the source set
+per consumer unrelatable, so nothing catches "repair's preview and repair's
+admission disagree about the lease". As a pair, the source set is a function of
+`Stage` and the *text* is a function of `(Role, Stage)`, which is exactly the
+shape matrix §3 describes. See decision request Q1.
+
+### D3 — `Freshness` is explicit, with a `Stage`-derived default
+
+```
+Query{FlowID string, Role actions.FlowLaunchRole, Stage Stage, Freshness Freshness}
+```
+
+`Freshness` is `FreshnessDefault | FreshnessCached | FreshnessAuthoritative`.
+`FreshnessDefault` resolves from `Stage` per the table in D2 and is what almost
+every caller passes.
+
+It is not simply *implied* by `Stage`, because one real pair disagrees: the
+AutoMode drain (`model/flow_phase_launch.go:773`) and the AutoMode read
+(`model/flow_launch_lifecycle.go:705`) ask the same role the same question and
+must get answers of different freshness — the first from the poll's own record,
+the second from `ListFlowSessions`. Making it a field keeps that visible instead
+of encoding it as two stages that differ in nothing else.
+
+The rule, stated once so it stops living in comments:
+
+> **Cached mirrors answer questions that only render. Authoritative sources
+> answer questions that mutate or reserve.**
+>
+> Cached: the display mirror (`m.sessions.Items()`,
+> `m.worktreeSessions.Items()`), the poll's own `FlowRecord.Phases`, and every
+> in-process runtime source. Authoritative: `ReadFlow`, `ListFlowSessions`, and
+> a live lease inspect.
+>
+> In-process runtime sources (the attempt map, the terminal slots, the pending
+> headless write, the repair drain marker) are *always* authoritative — they are
+> the state, not a mirror of it — and are therefore read at every freshness.
+>
+> Lease-read failure is occupancy under every purpose, cached and authoritative
+> alike. This is fail-closed in both directions and matches
+> `model/flow_launch_lifecycle.go:410` today.
+>
+> The tmux window probe is never read at `StageDrain` or `StagePreview`, because
+> it forks a subprocess (`model/tmux_mode.go:425-427`).
+
+### D4 — `Verdict` exposes a named `Holder` and a `Reason`, never the sources
+
+```
+Verdict.Occupied() bool
+Verdict.Holder()   Holder
+Verdict.Reason()   string
+Verdict.PhaseID()  string
+```
+
+`Holder` is a closed enum over matrix §1, collapsed to what consumers actually
+name: `HolderNone`, `HolderLeaseUnreadable`, `HolderPeerLease`,
+`HolderRepairAttempt`, `HolderPhaseResumeAttempt`, `HolderPhaseAttempt`,
+`HolderOtherAttempt`, `HolderTmuxAgent`, `HolderRepairTerminal`,
+`HolderFlowTerminal`, `HolderRunningPhase`, `HolderPhaseSession`,
+`HolderFlowSession`, `HolderRepairDrain`, `HolderHeadlessWrite`.
+
+`PhaseID` is on the verdict because two existing refusals name a phase and would
+otherwise have to reach back into the record:
+`genericFlowRuntimeOccupancyReason` ("a running phase %s already occupies this
+Flow", `model/flow_launch_generic_agent.go:154-163`) and
+`flowRepairLiveSessionStatus`, whose phase argument comes from
+`flowRepairPhaseSessionOccupied` returning the matching phase rather than a bool
+"because the refusal names its ID" (`model/flow_launch_repair.go:315-318`).
+
+**Priority is a module-owned table keyed by `Purpose`, not one global order.**
+A single global order would be a behavior change, and the matrix says where:
+repair ranks a competing attempt *with* the terminals under one shared string
+(§4.1 rank 4), while autofix ranks the terminals *above* a competing attempt and
+gives them different strings (§4.3). Both orders are observable, because the
+attempt map and a terminal slot can hold simultaneously — the prefill-failure
+path "re-reserves while the slot it is about to dismiss is still installed"
+(`model/flow_launch_attempt.go:64-68`). So: one default order, durable before
+transient, with per-purpose overrides for repair, autofix, and the install
+backstop. Three overrides in one table beats four ladders in four files.
+
+`Reason()` is likewise a table keyed by `(Purpose, Holder)`. The same holder
+gets different text per role by design — `flowRepairTerminalStatus`,
+`flowAutofixTerminalStatus`, `flowWorktreeAgentSlotStatus`, and
+`flowPhaseResumeTerminalStatus` are four strings for one slot — so the strings
+move into `flowoccupancy` with the table. Callers that refuse in silence (auto
+phase, create, phase resume: matrix D3) simply do not read `Reason()`; loudness
+stays the caller's decision, because it is a presentation concern and the poll's
+1 Hz repaint is the reason for it.
+
+### D5 — six adapter interfaces, one per source family
+
+Minimal by construction: a method exists only where matrix §2 shows a consumer.
+
+| Adapter | Method | Sources |
+| --- | --- | --- |
+| `FlowReader` | `ReadFlow(flowID) (flowstore.FlowRecord, error)` | S10, S11 authoritative |
+| `FlowCache` | `CachedFlow(flowID) (flowstore.FlowRecord, bool)` | S10, S11 cached |
+| `SessionStore` | `ListFlowSessions(flowID) ([]sessions.SessionRecord, error)` | S13 |
+| `SessionCache` | `ActiveFlowSessions(flowID) []sessions.SessionRecord` | S12 |
+| `LeaseInspector` | `FlowLeaseOccupied(flowID) (bool, error)` | S1, S2 |
+| `Runtime` | `AttemptHolder(flowID) (actions.FlowLaunchRole, bool)`, `HasFlowTerminal(flowID) bool`, `HasRepairTerminal(flowID) bool`, `HeadlessWritePending(flowID) bool`, `RepairDrainPending(flowID) bool` | S3, S4, S6, S7, S14, S16 |
+| `AgentProbe` | `TmuxAgentRunning(flowID) bool` | S15 |
+
+`AgentProbe` is nil-able and is consulted only at `StageAdmission` and
+`StageAuthoritative`, which is how "admission must not shell out" becomes a
+property of the module rather than of every caller's comment. `Runtime` is one
+interface rather than five because the `Model` implements all of it and
+splitting it would produce five one-method adapters over the same receiver.
+
+Three sources are deliberately *not* adapters. S5 (handoff-pending) is a
+process-wide quit policy, not a per-Flow question, and stays in `model`. S8
+(prefill-pending) and S9 (exited-but-retained) are internal to how `Runtime`
+answers `HasFlowTerminal`; exposing them would export the representation D4
+exists to hide. See decision request Q4.
+
+### D6 — post-migration form of every consumer
+
+| Consumer | After |
+| --- | --- |
+| Each admission | one `Occupancy.Query` call; refuse on `Occupied()`, render `Reason()` or stay silent per role |
+| `previewFlowLaunch`, `previewRepairLaunch`, `previewPhaseResume`, the three footer predicates | one `StagePreview` query, conjoined with the existing launchability half, which is unchanged |
+| `flowAutoAdvanceOccupied` and the drain's session pre-filter | one `StageDrain` query |
+| `flowRepairOccupancyRefusal` | deleted; the ladder is the repair rows of the priority and reason tables |
+| `flowLaunchEmbeddedBackstop` | one `StageInstall` query per kind; the per-kind strings move into the reason table |
+| `flowLaunchAdmissionOccupied`, `flowLaunchRuntimeOccupied` | deleted once the last caller migrates |
+| `flowLaunchPhaseSessionOccupied(Except)`, `phaseHasMatchingLiveSession(Except)` | move into `flowoccupancy` as the phase-session rule; the resume exemption becomes a `Query` field |
+| tmux keypress probes | unchanged in placement, but reached through `AgentProbe` so the module can refuse to call them at the wrong stage |
+
+## Consequences
+
+- The four ladders of matrix F2 become one table, and `approach-x0r.11` can
+  assert that no new one appears.
+- The C3 rule becomes checkable: a `StagePreview` query that reached
+  `ListFlowSessions` is a bug the module can catch, not a review comment.
+- Behavior is preserved exactly, including the per-purpose ordering differences
+  D4 names. `approach-x0r.2` pins that with characterization tests *before* any
+  caller moves; this ADR is written on the assumption that those tests exist
+  first.
+- The user-facing strings move out of `model/`. That is a large, mechanical, and
+  reviewable diff, and it is the point: today's four vocabularies for one holder
+  are only visible once they sit in one table.
+- `flowoccupancy` will import `actions`, `flowstore`, and `sessions`, and
+  nothing else in this repo. Any future need to import `model` means the
+  boundary was drawn wrong.
+
+Proposed migration order for the rest of the epic, cheapest and most-isolated
+first, each slice ending green:
+
+1. `x0r.2` — characterization tests against the current predicates.
+2. `x0r.3` — implement `flowoccupancy` against those tests, still with no callers.
+3. `x0r.4` — the AutoMode drain (`StageDrain`): the smallest source set, and the
+   one consumer whose refusals are all silent, so no strings move yet.
+4. `x0r.5` — the previews and footer predicates (`StagePreview`).
+5. `x0r.6` — repair (admission + the ladder), which is where the priority table
+   earns its overrides.
+6. `x0r.7` — autofix, the second override.
+7. `x0r.8` — the worktree agent and saved-session resume, the two roles that
+   read the session mirror and the whole-Flow session listing.
+8. `x0r.9` — manual, auto, create, and phase-resume admission; delete both
+   composites at the end of it.
+9. `x0r.10` — the install backstop (`StageInstall`) and session release.
+10. `x0r.11` — the architecture test. `x0r.12` — ownership docs.
+
+## Decision requests
+
+These are the grill questions. They are recorded, not resolved.
+
+1. **Q1 — `Purpose` as a `(Role, Stage)` pair vs. a flat enum.** The pair reuses
+   ADR 0002's role and makes the source set a function of `Stage` alone. The
+   flat form is simpler to read at a call site and makes illegal combinations
+   unrepresentable — there is no `(RoleAutofix, StageDrain)` consumer, and the
+   pair admits one. Confirm the pair, or accept a flat enum plus a
+   `Role()`/`Stage()` accessor pair.
+2. **Q2 — per-purpose priority overrides vs. one global order.** Preserving
+   repair's and autofix's differing ranks preserves behavior exactly, at the
+   cost of the module having three exceptions on day one. Unifying them is a
+   deliberate, small, user-visible behavior change (which of two true refusals
+   is shown when an attempt and a terminal both hold). Confirm preservation, or
+   authorize the unification as part of `approach-x0r.6`.
+3. **Q3 — the strings move into `flowoccupancy`.** Roughly a dozen
+   user-facing status constants leave `model/`. The alternative is that the
+   module returns a `Holder` and each caller keeps its own switch, which
+   preserves four vocabularies and gives up most of D4's benefit. Confirm the
+   move.
+4. **Q4 — S8/S9 stay hidden.** A slot that is prefill-pending, or whose process
+   has exited but has not been swept, still reads as occupied (matrix F6). That
+   is today's behavior and this ADR preserves it. Confirm, or file the
+   exited-slot window as a separate bug for the epic to fix rather than freeze.
+5. **Q5 — `AgentProbe` inside the module.** Putting the tmux probe behind an
+   adapter lets the module enforce "never at `StageDrain`", but it also means a
+   query can fork a subprocess, which is a surprising property for a package
+   named `flowoccupancy`. Confirm, or keep the probe entirely in `model` at the
+   keystrokes and accept that the stage rule stays a comment.
+6. **Q6 — F5 is a pre-existing gap, not this epic's to close.** An AutoMode
+   launch can be admitted into a worktree a tmux autofix agent still owns,
+   because the registry is in-process and the drain must not shell out. Confirm
+   that `approach-x0r` freezes this rather than fixing it, or file it.
+7. **Q7 — package name and location.** `flowoccupancy` at top level, per D1.
+   Confirm, or place it under `flowstore/` as a subpackage, which would put the
+   policy next to the records it reads at the cost of implying the Flow store
+   owns runtime state it has no access to.

--- a/docs/flow-occupancy-matrix.md
+++ b/docs/flow-occupancy-matrix.md
@@ -1,0 +1,240 @@
+# Flow occupancy matrix
+
+Evidence base for `approach-x0r` (concentrate Flow occupancy in one deep
+module). Every cell cites `file:line` against commit `3d147d4`, the state of the
+code before any `approach-x0r` migration began; the proposed redesign is
+ADR 0003. This is a frozen survey: later slices of the epic move these call
+sites, and when they do this document stays pinned rather than being rewritten,
+exactly as `docs/flow-launch-variant-matrix.md` does for `approach-hyl`.
+
+Scope: every representation the TUI uses to answer "is something already
+working in this Flow?", and every place that reads one. Not in scope: the
+cross-process reservation itself (`internal/launchcontrol`,
+`internal/flowlease`), which this module reads through a seam rather than
+reimplements.
+
+## 1. Sources
+
+Thirteen distinct representations. "Cached" means answered from a display
+mirror or an in-process map with no store I/O; "authoritative" means it reads
+the Flow store, the session store, or the lease file at the moment of the call.
+
+| # | Source | Definition | What it means | Lifetime | Freshness |
+| --- | --- | --- | --- | --- | --- |
+| S1 | Cross-process tmux lease | `model/flow_launch_lifecycle.go:433` `trackedFlowLeaseOccupied` → `internal/flowlease` | Another process holds a tracked tmux phase agent for this Flow | Until the peer's lease file clears | Authoritative (file read per call) |
+| S2 | Lease unreadable | `model/flow_launch_lifecycle.go:439,445,455` (blank artifact root, nil inspector, inspect error); status text at `:429` `flowLeaseSetupErrorStatus` | Occupancy cannot be determined | Until the artifact root or inspector is usable | Authoritative, fail-closed |
+| S3 | In-process attempt map | `model/flow_launch_attempt.go:95` `flowLaunchAttemptOccupied`, backed by `m.flowLaunchAttempts` (`:118`) | A launch attempt in this process holds the Flow | Reserve → release, one per exact Flow ID | Cached (in-process, but authoritative for this process) |
+| S4 | Attempt kind | `model/flow_launch_attempt.go:110` `flowLaunchAttemptKind` | *Which* launch holds it (repair, phase resume, manual/auto phase, …) | Same as S3 | Same as S3 |
+| S5 | Handoff-pending attempt state | `model/flow_launch_attempt.go:100` `flowLaunchHandoffPending`, state constant at `:19` | A private tmux handoff owns a reservation; quit must not race it | Between prepare and handoff consumption | In-process |
+| S6 | Retained Flow terminal slot | `model/flow_phase_launch.go:811` `hasFlowEmbeddedTerminalForFlow` (scope Flow, `Terminal != nil`) | An embedded terminal with a live object occupies the Flow | Slot install → dismiss | In-process |
+| S7 | Retained repair terminal slot | `model/flow_phase_launch.go:823` `hasFlowRepairEmbeddedTerminalForFlow` (scope Flow, `FlowRepair`, *terminal may be nil*) | A repair slot occupies the Flow | Slot install → dismiss | In-process |
+| S8 | Prefill-pending slot | `model/embedded_terminal.go:136` `PrefillPending`, set at `:524`, cleared at `:552,565` | A slot exists but its prompt has not been delivered; excluded from selection and dock scans (`:309,314,362,795,810,902,1194`) | Install → first prefill tick | In-process |
+| S9 | Exited-but-retained slot | `model/embedded_terminal.go:1048` `dismissExitedFlowEmbeddedTerminals`, `:1064` `hasExitedFlowEmbeddedTerminalAutoClose`, state test at `:1036` `embeddedTerminalRunning`, auto-close rule at `:1076` | A slot whose process ended still holds S6/S7 until the auto-close sweep runs | Process exit → sweep | In-process |
+| S10 | Persisted running phase | `model/flow_phase_launch.go:804` (`phase.Status == flowstore.PhaseRunning` inside `flowAutoAdvanceOccupied`); also `model/flow_launch_generic_agent.go:159`, `model/flow_launch_saved_session_resume.go:192` | The store says a phase of this Flow is running | Until a phase write clears it | Cached when read from a poll record, authoritative when read from `ReadFlow` |
+| S11 | Persisted session-attached phase | `model/flow_repair.go:114` `phaseHasMatchingLiveSession`, `:122` `…Except` | A phase's own mirrored sessions include a live one whose launch ID the phase owns | Until the session record ends | Same as the record it is applied to |
+| S12 | Cached session mirror | `model/flow_launch_generic_agent.go:45` `hasKnownActiveFlowSession` over `m.sessions.Items()` + `m.worktreeSessions.Items()` | The display mirror shows an active session for this Flow | Refreshed by the session poll | Cached |
+| S13 | Authoritative session listing | seam at `model/flow_launch_adapters.go:22`, wired at `:57` `ListFlowSessions`; unioned with S11 by `model/flow_launch_lifecycle.go:1488` `flowLaunchPhaseSessionOccupied` and `:1525` `…Except`; whole-Flow variant `model/flow_launch_generic_agent.go:166` `activeFlowSession` | A live session record exists in the store for this Flow | Store state | Authoritative (walks the whole session store) |
+| S14 | Pending headless write | `model/model_keys.go:1070` `flowHeadlessWritePending` over `m.pendingFlowHeadlessWrites`; status at `:1012` | A headless toggle is in flight and the persisted preference is about to change | Enqueue → resolve (`:1055` `clearFlowHeadlessWritePending`) | In-process, transient |
+| S15 | tmux autofix agent probe | `model/tmux_mode.go:446` `tmuxAutofixAgentStillRunning`; registry written at `model/model.go:2731` `withFlowAutofixTmuxLaunch` and read at `model/tmux_mode.go:462` `flowAutofixTmuxLaunchIDs` | A phase-untracked autofix agent still has a live tmux window in this Flow's worktree | Registry entry lifetime, in-process only | Authoritative but *shells out*; never called from a poll (`model/tmux_mode.go:426`) |
+| S16 | Pending repair auto-drain marker | `model/flow_phase_launch.go:555` `hasPendingRepairAutoDrainMarker`, written at `:551` | A repair terminal was removed and its outcome has not been consumed by the AutoMode poll yet | Removal → poll consumption (`:564` `withoutRepairAutoDrainMarker`) | In-process |
+
+Two composites are built from the above and are what most consumers actually
+call:
+
+| Composite | Definition | Terms |
+| --- | --- | --- |
+| `flowLaunchAdmissionOccupied` | `model/flow_launch_lifecycle.go:404` | S2 ∨ S1 ∨ `flowLaunchRuntimeOccupied` |
+| `flowLaunchRuntimeOccupied` | `model/flow_launch_lifecycle.go:417` | S3 ∨ S6 ∨ S7 |
+
+S6 and S7 overlap rather than nest, which is load-bearing and stated twice in
+the code: `model/flow_launch_lifecycle.go:1261` ("the two predicates overlap
+rather than nest — one requires a live terminal, the other a repair slot") and
+`model/flow_launch_resume.go:135`.
+
+## 2. Consumers
+
+One row per call site. "Reads" lists source IDs; "Deliberately omits" records a
+source the site could have read and does not, with the comment that justifies
+it — those comments are load-bearing and are what §3 turns into `Purpose`
+values.
+
+### 2.1 Admission (mutating; each reserves an attempt on success)
+
+| Consumer | Site | Reads | Deliberately omits | Why |
+| --- | --- | --- | --- | --- |
+| Manual phase | `model/flow_launch_lifecycle.go:285` `admitManualFlowLaunch` | S14 (`:288`), S1/S2 typed (`:294`), S3∨S6∨S7 via runtime (`:304`) | `flowLaunchAdmissionOccupied` | "The typed lease check above owns the actionable cross-process result. Repeating it through `previewFlowLaunch` would collapse a peer race into the generic no-phase status" (`:297-300`) |
+| Auto phase | `model/flow_launch_lifecycle.go:344` `admitAutoFlowLaunch` | S1∨S2∨S3∨S6∨S7 via `flowLaunchAdmissionOccupied` | any status text | "refuses in silence, without exception. The advance poll runs at 1 Hz and is view-independent, so any status a refusal set would be repainted every second" (`:331-333`) |
+| Create phase | `model/flow_launch_create.go:424` `handleCreateFlowAllocated` | S3∨S6∨S7 via runtime | S1/S2 | "Creation-time Plan Now allocates a brand-new Flow and remains embedded and unleased, so it uses this narrower check" (`model/flow_launch_lifecycle.go:414-416`) |
+| Phase resume | `model/flow_launch_resume.go:118` `admitPhaseResumeFlowLaunch` | S1/S2 typed (`:124`), runtime (`:132`), S6∧¬S7 for the status only (`:138`) | `flowLaunchAdmissionOccupied` | "Repeating it through `flowLaunchAdmissionOccupied` could turn a peer race into a silent refusal before the reservation-protected recheck reports the real cause" (`:129-131`) |
+| Repair | `model/flow_launch_repair.go:149` `admitRepairFlowLaunch` | S1/S2 typed (`:157`), runtime (`:164`), S14 (`:164`), then S4/S6/S7/S3 for naming (`:201`) | `flowLaunchAdmissionOccupied` | "durable obstacles before the transient one, because a headless write clears on its own and an open terminal does not" (`:146-148`) |
+| Autofix | `model/flow_launch_autofix.go:134` `admitAutofixFlowLaunch` | S1/S2 typed (`:144`), S4 (`:155,158`), S6∨S7 (`:161`), runtime (`:164`), S14 (`:167`) | `flowLaunchAdmissionOccupied` | "repeating it through `flowLaunchAdmissionOccupied` would collapse a held or unreadable lease into the generic in-flight status" (`:152-154`) |
+| Worktree agent | `model/flow_launch_generic_agent.go:76` `admitWorktreeAgentFlowLaunch` | S1/S2 (`:100`), S3 (`:105`), S15 (`:108`), S6∨S7 (`:111`), S12 (`:114`), S10∨S11 via `genericFlowRuntimeOccupancyReason` (`:117`) | — | The only admission that reads every family; it is Flow-scoped and phase-untracked |
+| Saved-session resume | `model/flow_launch_saved_session_resume.go:136` (post-read), transfer at `model/flow_launch_attempt.go:203` | S1/S2 (`:136`), `flowLaunchAdmissionOccupied` on the *destination* Flow (`flow_launch_attempt.go:203`) | — | Flow identity is not known until the authoritative session read, so admission happens after it |
+
+### 2.2 Authoritative read and prepare stages (mutating)
+
+| Consumer | Site | Reads |
+| --- | --- | --- |
+| Tracked-phase read | `model/flow_launch_lifecycle.go:610` | S11∪S13 via `flowLaunchPhaseSessionOccupied` |
+| AutoMode read | `model/flow_launch_lifecycle.go:684`, `:705` | S10 minus the candidate (`flowRecordHasOtherRunningPhase`, `:534`), then S11∪S13 |
+| Phase-resume read | `model/flow_launch_resume.go:230` | S11∪S13 with the target session exempted (`flowLaunchPhaseSessionOccupiedExcept`) |
+| Repair read | `model/flow_launch_repair.go:325` `flowRepairPhaseSessionOccupied` | S11∪S13 across *every* phase of the record |
+| Autofix read | `model/flow_launch_autofix.go:277` `flowRecordHasLivePhaseSession` | S11∪S13 across every non-terminal phase |
+| Worktree-agent read | `model/flow_launch_generic_agent.go:196`, `:200` | S13 whole-Flow (`activeFlowSession`), then S10∨S11 |
+| Worktree-agent prepare | `model/flow_launch_generic_agent.go:244`, `:263`, `:267` | S1/S2 under the reservation, then S13 and S10∨S11 again |
+| Create sessions read | `model/flow_launch_create.go:468` | S13 whole-Flow (any record at all, then any active one) |
+| Saved-session Flow read | `model/flow_launch_saved_session_resume.go:170` `validateSavedSessionResumeFlow` (`:184`) | S10 (`:192`), S11 (`:195`), S13 (`:200`) |
+| Generic prepare (tracked) | `model/flow_launch_lifecycle.go:801` | S1/S2 under the cross-process reservation |
+| Repair prepare | `model/flow_launch_repair.go:379` | S1/S2 under repair's own reservation |
+| Autofix prepare | `model/flow_launch_autofix.go:330` | S1/S2 under the reservation |
+| Resume prepare | `model/flow_launch_resume.go:325` | S1/S2 under the reservation |
+| Saved-session prepare | `model/flow_launch_saved_session_resume.go:248` | S1/S2 under the reservation |
+| Saved-session slot recheck | `model/flow_launch_lifecycle.go:889` | S6 |
+| Install backstop | `model/flow_launch_lifecycle.go:1269` `flowLaunchEmbeddedBackstop` | S6, S7, per kind — see §4.2 |
+
+### 2.3 Previews and footer affordances (non-mutating; must not do I/O per frame)
+
+| Consumer | Site | Reads | Note |
+| --- | --- | --- | --- |
+| `previewFlowLaunch` | `model/flow_launch_lifecycle.go:380` | `flowLaunchAdmissionOccupied` | Conjoins launchability with occupancy; `cachedFlowLaunchTarget` (`:389`) is the launchability half alone, split so "admission needs the two separately so it can name whichever one is actually blocking; the footer only needs their conjunction" (`:386-388`) |
+| Footer `g` | `model/model.go:2705` `selectedFlowHasLaunchablePhase` | S14 (`:2712`) + `previewFlowLaunch` | "what the footer advertises and what `g` accepts can never disagree" (`:2702-2703`) |
+| `previewPhaseResume` | `model/flow_launch_resume.go:181` | S1/S2 fail-closed (`:183`), S6∧¬S7 (`:186`) | "deliberately narrower than `flowLaunchAdmissionOccupied`: a competing lifecycle attempt and an open repair terminal both refuse a resume silently by design, and withdrawing the key for them would be a behavior change" (`:175-180`) |
+| `previewRepairLaunch` | `model/flow_launch_repair.go:137` | `flowLaunchAdmissionOccupied` | Mirrors `previewFlowLaunch` over `cachedRepairTarget` |
+| Footer `R` | `model/flow_repair.go:154` `selectedFlowRepairReady` | `previewRepairLaunch` + S14 | "The headless term stays outside the preview because admission's occupancy set has no headless notion and `flowLaunchAdmissionOccupied` is shared with kinds that must not inherit one" (`:149-153`) |
+| Footer `U` | `model/flow_launch_autofix.go:90` `selectedFlowAutofixReady` | `flowLaunchAdmissionOccupied` + S14 | Also gates the `U` keypress's tmux probe so an already-owned Flow "neither forks tmux nor answers with the live-window refusal when admission has a more specific one to give" (`:104-107`) |
+| Footer worktree agent | `model/flow_launch_generic_agent.go:39,42` `selectedFlowWorktreeAgentReady` | `flowLaunchAdmissionOccupied`, S12, S10∨S11 | The only footer predicate that reads the session mirror |
+
+### 2.4 Poll-driven (AutoMode drain; must never shell out or walk the session store per tick)
+
+| Consumer | Site | Reads | Note |
+| --- | --- | --- | --- |
+| Drain arm/disarm | `model/flow_phase_launch.go:502` | S7, S16 | A removed-but-unconsumed repair outcome disarms the drain |
+| Drain gate | `model/flow_phase_launch.go:755` `flowAutoAdvanceOccupied` (`:794`) | S1/S2 (`:795`), S3 (`:800`), S10 (`:804`), S6 (`:808`) | Deliberately *not* S7 and not S15: "AutoMode never reaches this function … a poll on a timer must not shell out" (`model/tmux_mode.go:425-427`) |
+| Drain session pre-filter | `model/flow_phase_launch.go:773` | S11 only | "the snapshot half of the lifecycle's session check, and the reason a stalled phase does not cost a session-store walk every second … the mirrored sessions the poll already carries answer the common case for free" (`:765-772`) |
+
+### 2.5 Non-launch consumers
+
+| Consumer | Site | Reads | Note |
+| --- | --- | --- | --- |
+| Session release footer | `model/flow_session_release.go:88,92` `flowPhaseSessionReleasable` | S11 | Mirror-only by design; "Variant B — a live record the mirror never saw — is therefore invisible here" (`:80-82`) |
+| Session release refusal | `model/flow_session_release.go:115` | S3, S14 | "A release must not act while the launch lifecycle holds this Flow, or while a headless write is in flight: both can be about to persist a launch ID the probe has not seen" (`:111-114`) |
+| Session release press refusal | `model/flow_session_release.go:136` | S11 | Names the blocker only when the mirror already shows the stall |
+| Session release probe | `model/flow_session_release.go:204` | S13 | The store walk the keypress pays for |
+| Repair classifier | `model/flow_repair.go:65` | S11 | "Treat any matched non-ended session as active work even when the persisted phase already says blocked or needs_attention" (`:66-68`) |
+| Quit deferral | `model/embedded_terminal.go:170`, `:920`, `:942` | S5 | Quit must not land mid-handoff |
+| Detach policy | `model/embedded_terminal.go:976`, policy at `:1002` | — (role, not occupancy) | Worktree-agent and saved-session-resume terminals are `embeddedTerminalDetachNever` "to preserve occupancy" (`:977`): detaching would destroy S6 while the agent lives |
+| `g` keypress probe | `model/model_keys.go:2308` | S15 | "an autofix agent (U) writes no phase, so in tmux mode nothing admission can see reports that its agent is still working in this Flow's worktree" (`:2303-2307`) |
+| Resume keypress probe | `model/model_keys.go:2573` | S15 | Same gap, from the resume keystroke |
+| Repair keypress probe | `model/flow_repair.go:163` (`tmuxFlowAgentStillRunning`) | S15 + phase launch IDs | "Repair's live-agent fence is `hasFlowEmbeddedTerminalForFlow`, and in tmux mode that slot does not exist" (`:163-165`) |
+| Autofix keypress probe | `model/flow_launch_autofix.go:112` | S15 + phase launch IDs | Gated on the footer predicate first |
+
+## 3. Divergences
+
+Each row is a place two consumers read the same underlying question and answer
+it differently — on purpose. Each becomes a `Purpose` value in ADR 0003.
+
+| # | Divergence | Sites | Justification (verbatim from the code) |
+| --- | --- | --- | --- |
+| D1 | The composite collapses S1 and S2 into one boolean; four consumers refuse it and check the lease typed instead | `model/flow_launch_lifecycle.go:294` vs `:344`; `model/flow_launch_resume.go:124`; `model/flow_launch_repair.go:157`; `model/flow_launch_autofix.go:144` | "would collapse a held or unreadable lease into the generic in-flight status" (`flow_launch_autofix.go:153`) |
+| D2 | Create uses `flowLaunchRuntimeOccupied`, every other existing-Flow route uses the admission composite | `model/flow_launch_create.go:424` vs `model/flow_launch_lifecycle.go:344` | "a brand-new Flow … remains embedded and unleased" (`flow_launch_lifecycle.go:414-416`) |
+| D3 | Refusal is silent for auto, create, and phase resume; loud for manual, repair, autofix, and worktree agent | `flow_launch_lifecycle.go:331` (silent), `:288` (loud) | "any status a refusal set would be repainted every second over whatever the user is actually looking at" |
+| D4 | The footer's occupancy set is narrower than admission's for resume, and wider for repair and autofix (both add S14) | `flow_launch_resume.go:175`; `flow_repair.go:149`; `flow_launch_autofix.go:93` | "withdrawing the key for them would be a behavior change this bead does not make"; "admission's occupancy set has no headless notion" |
+| D5 | Session occupancy is phase-scoped for launch and resume, Flow-scoped for repair, non-terminal-phase-scoped for autofix, whole-Flow for the worktree agent and create | `flow_launch_lifecycle.go:1488`; `flow_launch_repair.go:325`; `flow_launch_autofix.go:277`; `flow_launch_generic_agent.go:166`; `flow_launch_create.go:468` | "the repair prompt authorizes phase reset, phase set, and plan set across the whole record" (`flow_launch_repair.go:294-297`); "a wider rule would let one crashed agent make the Flow permanently unlaunchable" (`flow_launch_autofix.go:265-268`) |
+| D6 | Resume exempts one session identity from S11/S13; every other caller passes the zero identity | `flow_launch_resume.go:230` vs `flow_launch_lifecycle.go:610` | "the session it is reattaching to is expected to look live … so counting it would refuse every resume" (`flow_launch_lifecycle.go:1518-1521`) |
+| D7 | The AutoMode drain answers from mirrors (S11, S10 on the poll record) where the lifecycle answers from the store (S13) | `flow_phase_launch.go:773` vs `flow_launch_lifecycle.go:705` | "without this the next poll would re-admit and call `ListFlowSessions` again at 1 Hz" |
+| D8 | S15 (the tmux probe) lives on keystrokes and never in admission or the poll | `model_keys.go:2308,2573`; `flow_repair.go:163`; `flow_launch_autofix.go:112` | "it shells out, and admission must not"; "AutoMode never reaches this function" (`tmux_mode.go:425-426`) |
+| D9 | S12 (the session mirror) is read by exactly one family — the worktree agent — and by nothing else | `flow_launch_generic_agent.go:39,114` | The worktree agent is Flow-scoped and phase-untracked, so no phase record can speak for it |
+| D10 | S6 and S7 are combined differently per consumer: `∨` for admission, `∧¬` for resume's status, per-kind for the backstop | `flow_launch_lifecycle.go:422`; `flow_launch_resume.go:138`; `flow_launch_lifecycle.go:1271-1294` | "the two predicates overlap rather than nest" (`flow_launch_lifecycle.go:1261`) |
+
+## 4. Ordered refusals
+
+Two consumers need more than a boolean: they need to name the holder, in a
+fixed order. This is the concrete requirement the verdict type must satisfy.
+
+### 4.1 Repair's refusal ladder
+
+`model/flowRepairOccupancyRefusal` — `model/flow_launch_repair.go:201`,
+documented at `:198-200` as "repair attempt, phase-resume attempt, manual/auto
+phase attempt, actual terminal or other-attempt fallback, then pending headless
+write".
+
+| Rank | Condition | Source | Status constant |
+| --- | --- | --- | --- |
+| 1 | attempt kind is repair | S4 | `flowRepairPendingStatus` |
+| 2 | attempt kind is phase resume | S4 | `flowRepairResumePendingStatus` |
+| 3 | attempt kind is manual or auto phase | S4 | `flowRepairPhasePendingStatus` |
+| 4 | any Flow terminal, repair slot, or other attempt | S6 ∨ S7 ∨ S3 | `flowRepairTerminalStatus` |
+| 5 | fallthrough | S14 | `flowHeadlessWritePendingStatus` |
+
+The lease is ranked *above* all of these and answered separately, with its own
+two outcomes (`model/flow_launch_repair.go:157-163`).
+
+### 4.2 The install backstop's per-kind ladder
+
+`flowLaunchEmbeddedBackstop` — `model/flow_launch_lifecycle.go:1269`. Every kind
+refuses S7; repair and three others also refuse S6, and each returns different
+text.
+
+| Kind | Condition | Status |
+| --- | --- | --- |
+| `createPhase` | S6 ∨ S7 | "Flow creation launch canceled because a terminal is already open for this Flow" (`:1272`) |
+| `worktreeAgent` | S6 ∨ S7 | `flowWorktreeAgentSlotStatus` (`:1278`) |
+| `savedSessionResume` | S6 only | "Saved session resume canceled because an embedded terminal already occupies this Flow" (`:1284`) |
+| `repair` | S7 ∨ S6 | `flowRepairTerminalStatus` (`:1290`) |
+| `phaseResume` | S7 | "Flow phase resume canceled because a repair terminal is already open for this Flow" (`:1298`) |
+| `autofix` | S7 | `flowAutofixCanceledStatus` (`:1302`) — "This launch targets no phase, so naming one would be false" |
+| manual / auto phase | S7 | "Flow phase launch canceled because a repair terminal is already open for this Flow" (`:1304`) |
+
+The backstop's own comment states why it must survive the migration:
+"Admission makes every branch here unreachable, but dropping the backstop would
+be a regression against a future unguarded source" (`:1248-1250`), and "keeping
+it here is what stops the migration from quietly narrowing repair's last line of
+defense" (`:1256-1258`).
+
+### 4.3 Autofix's ordered refusal
+
+Not a named function, but the same shape, inline at
+`model/flow_launch_autofix.go:155-168`: repair attempt (S4) → phase-resume
+attempt (S4) → terminal or repair slot (S6 ∨ S7) → any other runtime holder
+(S3) → pending headless write (S14), "ordered durable before transient, as
+repair's are" (`:132-133`).
+
+### 4.4 The worktree agent's ordered refusal
+
+`model/flow_launch_generic_agent.go:100-119`: lease (S1/S2) → attempt (S3) →
+tmux autofix probe (S15) → terminal or repair slot (S6 ∨ S7) → session mirror
+(S12) → persisted running or session-attached phase (S10 ∨ S11, and this one
+names the phase ID: `genericFlowRuntimeOccupancyReason`, `:154`).
+
+## 5. Findings
+
+Recorded as observations against `3d147d4`, not as work items for this slice.
+
+- **F1 — the composite is read by seven consumers and refused by five of
+  them.** `flowLaunchAdmissionOccupied` has four call sites that use it as-is
+  (`flow_launch_lifecycle.go:344,380`, `flow_launch_repair.go:139`,
+  `flow_launch_autofix.go:93`, `flow_launch_generic_agent.go:39`,
+  `flow_launch_attempt.go:203`) and five admissions that deliberately unroll it.
+  That ratio is the epic's whole case: the boolean is not the wrong answer, it
+  is an answer to a question only some callers are asking.
+- **F2 — four ordered ladders exist and none shares a table.** §4.1–§4.4 rank
+  overlapping source sets in three different orders with four different
+  vocabularies. Any of them can drift from the others silently.
+- **F3 — S6/S7 combination is open-coded at eleven sites.** Every one has to
+  re-derive that the two predicates overlap rather than nest. `resume`'s
+  `∧¬` (`flow_launch_resume.go:138`) is the only site whose correctness depends
+  on that overlap being understood, and it carries a five-line comment saying so.
+- **F4 — the cached/authoritative split is real but undocumented as a rule.**
+  It is currently enforced by convention plus per-site comments
+  (`flow_phase_launch.go:765-772`, `tmux_mode.go:425-427`,
+  `flow_session_release.go:80-82`). Nothing prevents a new preview from calling
+  `ListFlowSessions` per frame, or a poll from shelling out.
+- **F5 — S15 is invisible to every non-keystroke consumer.** The tmux autofix
+  registry is in-process only and never consulted by admission or the drain, so
+  a tracked phase launch admitted by AutoMode can land in a worktree an autofix
+  agent still owns. This is stated as a known limit
+  (`tmux_mode.go:421-427`), not a bug this epic introduces.
+- **F6 — S9 keeps a Flow occupied after its process exits.** An exited Flow
+  terminal still satisfies S6 until `dismissExitedFlowEmbeddedTerminals`
+  (`embedded_terminal.go:1048`) sweeps it, so occupancy briefly outlives the
+  agent. Consumers do not distinguish the two states today.

--- a/flowoccupancy/doc.go
+++ b/flowoccupancy/doc.go
@@ -28,7 +28,6 @@
 //	StageInstall         the last check before a terminal slot is allocated
 //	StageDrain           runs at 1 Hz; cached only, and never forks a subprocess
 //	StageSessionRelease  the non-launch release gesture
-//	StageQuit            the quit deferral's handoff check
 //
 // # The freshness rule
 //

--- a/flowoccupancy/doc.go
+++ b/flowoccupancy/doc.go
@@ -22,11 +22,13 @@
 //
 //	StagePreview         renders per frame; cached sources only
 //	StageAdmission       runs on a keypress; in-process sources plus the lease
+//	StageAutoAdvance     the AutoMode advance poll's admission and read
 //	StageAuthoritative   runs in a command; full store access
 //	StageReserved        runs under the cross-process reservation
 //	StageInstall         the last check before a terminal slot is allocated
 //	StageDrain           runs at 1 Hz; cached only, and never forks a subprocess
 //	StageSessionRelease  the non-launch release gesture
+//	StageQuit            the quit deferral's handoff check
 //
 // # The freshness rule
 //
@@ -50,6 +52,9 @@
 //
 // This is the interface skeleton landed by approach-x0r.1. Every method body
 // is a stub; the implementation is approach-x0r.3, behind the characterization
-// tests approach-x0r.2 writes first. No caller in model/ has been migrated, no
-// existing predicate has been deleted, and no behavior has changed.
+// tests approach-x0r.2 writes first. Query fails closed until then: it reports
+// occupancy with ErrUnimplemented, so a caller migrated early breaks loudly
+// rather than being told the Flow is free. No caller in model/ has been
+// migrated, no existing predicate has been deleted, and no behavior has
+// changed.
 package flowoccupancy

--- a/flowoccupancy/doc.go
+++ b/flowoccupancy/doc.go
@@ -1,0 +1,55 @@
+// Package flowoccupancy answers one question: is something already working in
+// this Flow, and if so, what?
+//
+// It exists because that question is currently answered sixteen ways in
+// model/, by thirteen representations and two composites over them, read at
+// roughly forty call sites that deliberately disagree with each other. The
+// evidence is docs/flow-occupancy-matrix.md; the design and its open questions
+// are docs/adr/0003-flow-occupancy-deep-module.md.
+//
+// # The contract
+//
+// A caller states its Flow, its purpose, and how fresh an answer it needs, and
+// gets back a verdict that names the holder and, when the caller renders
+// refusals, the exact text to show. Callers never see the underlying
+// representations — not the lease, not the attempt map, not the terminal slots,
+// not the session mirror. Adding a new source is a change inside this package;
+// today it is a change at every call site that could have read it.
+//
+// Purpose is a (Role, Stage) pair. Role is actions.FlowLaunchRole, reused from
+// ADR 0002, and selects the vocabulary and the refusal order. Stage names the
+// consumer class and selects the source set:
+//
+//	StagePreview         renders per frame; cached sources only
+//	StageAdmission       runs on a keypress; in-process sources plus the lease
+//	StageAuthoritative   runs in a command; full store access
+//	StageReserved        runs under the cross-process reservation
+//	StageInstall         the last check before a terminal slot is allocated
+//	StageDrain           runs at 1 Hz; cached only, and never forks a subprocess
+//	StageSessionRelease  the non-launch release gesture
+//
+// # The freshness rule
+//
+// Cached mirrors answer questions that only render. Authoritative sources
+// answer questions that mutate or reserve.
+//
+// In-process runtime sources — the attempt map, the terminal slots, the pending
+// headless write, the repair drain marker — are always authoritative, because
+// they are the state rather than a mirror of it, and are read at every
+// freshness. A lease that cannot be read is occupancy under every purpose, in
+// both directions, fail-closed. The tmux window probe forks a subprocess and is
+// therefore never consulted at StagePreview or StageDrain.
+//
+// # What this package must never do
+//
+// It must never import model. The dependency edge is
+// model -> flowoccupancy -> {actions, flowstore, sessions}, and a need to
+// reverse it means the boundary was drawn wrong.
+//
+// # Status
+//
+// This is the interface skeleton landed by approach-x0r.1. Every method body
+// is a stub; the implementation is approach-x0r.3, behind the characterization
+// tests approach-x0r.2 writes first. No caller in model/ has been migrated, no
+// existing predicate has been deleted, and no behavior has changed.
+package flowoccupancy

--- a/flowoccupancy/doc.go
+++ b/flowoccupancy/doc.go
@@ -39,7 +39,9 @@
 // they are the state rather than a mirror of it, and are read at every
 // freshness. A lease that cannot be read is occupancy under every purpose, in
 // both directions, fail-closed. The tmux window probe forks a subprocess and is
-// therefore never consulted at StagePreview or StageDrain.
+// therefore consulted only at StageAdmission and StageAuthoritative — never at
+// any other stage, and in particular never from the AutoMode poll path
+// (StageAutoAdvance, StageDrain).
 //
 // # What this package must never do
 //

--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -183,6 +183,8 @@ const (
 // text; that is Verdict.Reason, which varies by purpose for the same holder.
 func (holder Holder) String() string {
 	switch holder {
+	case HolderNone:
+		return "none"
 	case HolderLeaseUnreadable:
 		return "leaseUnreadable"
 	case HolderPeerLease:
@@ -212,7 +214,7 @@ func (holder Holder) String() string {
 	case HolderHeadlessWrite:
 		return "headlessWrite"
 	default:
-		return "none"
+		return "unknown"
 	}
 }
 

--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -45,9 +45,6 @@ const (
 	// StageSessionRelease is the non-launch release gesture, which asks about
 	// the launch lifecycle rather than about a launch of its own.
 	StageSessionRelease
-	// StageQuit is the quit deferral, which asks only whether a handoff is in
-	// flight. It is the other non-launch stage.
-	StageQuit
 )
 
 // String reports the stage's name for diagnostics.
@@ -69,8 +66,6 @@ func (stage Stage) String() string {
 		return "drain"
 	case StageSessionRelease:
 		return "sessionRelease"
-	case StageQuit:
-		return "quit"
 	default:
 		return "unknown"
 	}
@@ -102,9 +97,11 @@ type Purpose struct {
 	Stage Stage
 }
 
-// Valid reports whether this purpose names a consumer that exists. The two
-// non-launch stages carry actions.RoleNone; every other stage requires a real
-// role.
+// Valid reports whether this purpose names a consumer that exists.
+// StageSessionRelease, the one non-launch stage, carries actions.RoleNone;
+// every other stage requires a real role. There is deliberately no quit stage:
+// the handoff-pending check quit defers on is a process-wide policy rather than
+// a per-Flow question, so it stays in model. See ADR 0003 D5.
 func (purpose Purpose) Valid() bool {
 	// implemented in approach-x0r.3
 	return false

--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -1,6 +1,8 @@
 package flowoccupancy
 
 import (
+	"errors"
+
 	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
@@ -18,9 +20,16 @@ const (
 	// StagePreview renders a footer affordance or a preview, every frame.
 	// Cached sources only: no store walk, no subprocess.
 	StagePreview
-	// StageAdmission decides a keypress or a poll admission. In-process sources
-	// plus a lease inspect; still no session-store walk.
+	// StageAdmission decides a keypress admission. In-process sources plus a
+	// lease inspect; still no session-store walk.
 	StageAdmission
+	// StageAutoAdvance is the AutoMode advance poll's own admission and read. It
+	// is a stage of its own rather than StageAdmission with a flag because the
+	// poll's source set genuinely differs: it never reads the pending headless
+	// write, it refuses in silence, and its read adds the other-running-phase
+	// check. Freshness splits its two halves — FreshnessCached is the admission
+	// gate, FreshnessAuthoritative the read.
+	StageAutoAdvance
 	// StageAuthoritative runs inside a tea.Cmd read stage and may read the Flow
 	// store and the session store.
 	StageAuthoritative
@@ -36,6 +45,9 @@ const (
 	// StageSessionRelease is the non-launch release gesture, which asks about
 	// the launch lifecycle rather than about a launch of its own.
 	StageSessionRelease
+	// StageQuit is the quit deferral, which asks only whether a handoff is in
+	// flight. It is the other non-launch stage.
+	StageQuit
 )
 
 // String reports the stage's name for diagnostics.
@@ -45,6 +57,8 @@ func (stage Stage) String() string {
 		return "preview"
 	case StageAdmission:
 		return "admission"
+	case StageAutoAdvance:
+		return "autoAdvance"
 	case StageAuthoritative:
 		return "authoritative"
 	case StageReserved:
@@ -55,6 +69,8 @@ func (stage Stage) String() string {
 		return "drain"
 	case StageSessionRelease:
 		return "sessionRelease"
+	case StageQuit:
+		return "quit"
 	default:
 		return "unknown"
 	}
@@ -62,9 +78,9 @@ func (stage Stage) String() string {
 
 // Freshness selects between the cached mirrors and the authoritative stores.
 // Almost every caller passes FreshnessDefault and lets the stage decide; the
-// field exists because one real pair of consumers disagrees at the same stage.
-// The AutoMode drain and the AutoMode read ask the same role the same question
-// and need answers of different freshness.
+// field exists because one real pair of consumers disagrees at the same stage:
+// StageAutoAdvance's admission gate and its read ask the same role the same
+// question and need answers of different freshness.
 type Freshness int
 
 const (
@@ -310,11 +326,17 @@ func New(sources Sources) Occupancy {
 	return Occupancy{sources: sources}
 }
 
+// ErrUnimplemented is the error every Query carries until approach-x0r.3 lands
+// the source reads. It exists so a caller migrated ahead of the implementation
+// fails loudly instead of being told the Flow is free.
+var ErrUnimplemented = errors.New("flowoccupancy: Query is not implemented yet")
+
 // Query answers one occupancy question. A query whose purpose is not Valid
 // yields an occupied fail-closed verdict rather than a free one.
 func (occupancy Occupancy) Query(query Query) Verdict {
-	// implemented in approach-x0r.3
-	return Verdict{}
+	// implemented in approach-x0r.3. Until then every purpose is invalid, so the
+	// fail-closed branch above is the whole behavior: occupied, with an error.
+	return Verdict{holder: HolderLeaseUnreadable, err: ErrUnimplemented}
 }
 
 // Free is the verdict for an unoccupied Flow. It exists so callers and tests

--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -1,0 +1,323 @@
+package flowoccupancy
+
+import (
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/sessions"
+)
+
+// Stage names the consumer class asking the question. It is a closed enum: one
+// value per group in docs/flow-occupancy-matrix.md section 2, and the value is
+// what selects the source set the query is allowed to read.
+type Stage int
+
+const (
+	// StageUnknown is the zero value and is never a legal query. A caller that
+	// forgot its stage must not silently get the cheapest answer.
+	StageUnknown Stage = iota
+	// StagePreview renders a footer affordance or a preview, every frame.
+	// Cached sources only: no store walk, no subprocess.
+	StagePreview
+	// StageAdmission decides a keypress or a poll admission. In-process sources
+	// plus a lease inspect; still no session-store walk.
+	StageAdmission
+	// StageAuthoritative runs inside a tea.Cmd read stage and may read the Flow
+	// store and the session store.
+	StageAuthoritative
+	// StageReserved runs under the cross-process launch reservation and
+	// re-inspects the lease before anything is written.
+	StageReserved
+	// StageInstall is the last check before an embedded terminal slot is
+	// allocated. Slot sources only, and deliberately per role.
+	StageInstall
+	// StageDrain runs at 1 Hz from the AutoMode poll. Cached only, and it must
+	// never fork a subprocess.
+	StageDrain
+	// StageSessionRelease is the non-launch release gesture, which asks about
+	// the launch lifecycle rather than about a launch of its own.
+	StageSessionRelease
+)
+
+// String reports the stage's name for diagnostics.
+func (stage Stage) String() string {
+	switch stage {
+	case StagePreview:
+		return "preview"
+	case StageAdmission:
+		return "admission"
+	case StageAuthoritative:
+		return "authoritative"
+	case StageReserved:
+		return "reserved"
+	case StageInstall:
+		return "install"
+	case StageDrain:
+		return "drain"
+	case StageSessionRelease:
+		return "sessionRelease"
+	default:
+		return "unknown"
+	}
+}
+
+// Freshness selects between the cached mirrors and the authoritative stores.
+// Almost every caller passes FreshnessDefault and lets the stage decide; the
+// field exists because one real pair of consumers disagrees at the same stage.
+// The AutoMode drain and the AutoMode read ask the same role the same question
+// and need answers of different freshness.
+type Freshness int
+
+const (
+	// FreshnessDefault resolves from the query's Stage.
+	FreshnessDefault Freshness = iota
+	// FreshnessCached reads display mirrors and in-process runtime state only.
+	FreshnessCached
+	// FreshnessAuthoritative reads the Flow store, the session store, and the
+	// lease.
+	FreshnessAuthoritative
+)
+
+// Purpose is why the caller is asking. Role selects the refusal vocabulary and
+// the ordering; Stage selects the source set. Keeping them as one pair rather
+// than a flat enum is what lets a rule be stated about a stage across every
+// role — see decision request Q1 in ADR 0003.
+type Purpose struct {
+	Role  actions.FlowLaunchRole
+	Stage Stage
+}
+
+// Valid reports whether this purpose names a consumer that exists. The two
+// non-launch stages carry actions.RoleNone; every other stage requires a real
+// role.
+func (purpose Purpose) Valid() bool {
+	// implemented in approach-x0r.3
+	return false
+}
+
+// SessionIdentity exempts one provider session from the session-occupancy rule.
+// Phase resume is the only consumer that passes one: the session it is
+// reattaching to is expected to look live, so counting it would refuse every
+// resume. The zero value exempts nothing.
+type SessionIdentity struct {
+	Provider  string
+	SessionID string
+}
+
+// Query is one occupancy question.
+type Query struct {
+	// FlowID is an exact canonical Flow ID. Prefix-like IDs never collide,
+	// matching the attempt map's own rule.
+	FlowID  string
+	Purpose Purpose
+	// Freshness overrides the stage's default. Leave it zero unless the stage
+	// genuinely serves two consumers of different freshness.
+	Freshness Freshness
+	// PhaseID scopes a phase-scoped question. Blank means Flow-scoped, which is
+	// what repair, autofix, the worktree agent, and creation ask.
+	PhaseID string
+	// SkipSession is phase resume's exemption. Zero for every other caller.
+	SkipSession SessionIdentity
+}
+
+// Holder names what is occupying the Flow. It is the only vocabulary callers
+// see; the sixteen underlying representations stay inside this package.
+type Holder int
+
+const (
+	// HolderNone means the Flow is free.
+	HolderNone Holder = iota
+	// HolderLeaseUnreadable means occupancy could not be determined. It is
+	// occupancy, fail-closed, under every purpose.
+	HolderLeaseUnreadable
+	// HolderPeerLease means another process holds the tracked tmux lease.
+	HolderPeerLease
+	// HolderRepairAttempt means an in-process repair launch holds the Flow.
+	HolderRepairAttempt
+	// HolderPhaseResumeAttempt means an in-process phase resume holds it.
+	HolderPhaseResumeAttempt
+	// HolderPhaseAttempt means an in-process manual, auto, or create phase
+	// launch holds it.
+	HolderPhaseAttempt
+	// HolderOtherAttempt means an in-process launch of some other role holds
+	// it.
+	HolderOtherAttempt
+	// HolderTmuxAgent means a phase-untracked agent still has a live tmux
+	// window in this Flow's worktree.
+	HolderTmuxAgent
+	// HolderRepairTerminal means a retained repair terminal slot holds the
+	// Flow, whether or not its terminal is live.
+	HolderRepairTerminal
+	// HolderFlowTerminal means a retained Flow terminal slot with a live
+	// terminal holds it.
+	HolderFlowTerminal
+	// HolderRunningPhase means the persisted record says a phase is running.
+	HolderRunningPhase
+	// HolderPhaseSession means a live session record is attached to a phase of
+	// this Flow.
+	HolderPhaseSession
+	// HolderFlowSession means a live session record names this Flow without
+	// naming a phase of it.
+	HolderFlowSession
+	// HolderRepairDrain means a repair outcome has not been consumed by the
+	// AutoMode poll yet.
+	HolderRepairDrain
+	// HolderHeadlessWrite means a headless toggle is in flight. It is the one
+	// transient holder and is ranked last everywhere.
+	HolderHeadlessWrite
+)
+
+// String reports the holder's name for diagnostics. It is not the user-facing
+// text; that is Verdict.Reason, which varies by purpose for the same holder.
+func (holder Holder) String() string {
+	switch holder {
+	case HolderLeaseUnreadable:
+		return "leaseUnreadable"
+	case HolderPeerLease:
+		return "peerLease"
+	case HolderRepairAttempt:
+		return "repairAttempt"
+	case HolderPhaseResumeAttempt:
+		return "phaseResumeAttempt"
+	case HolderPhaseAttempt:
+		return "phaseAttempt"
+	case HolderOtherAttempt:
+		return "otherAttempt"
+	case HolderTmuxAgent:
+		return "tmuxAgent"
+	case HolderRepairTerminal:
+		return "repairTerminal"
+	case HolderFlowTerminal:
+		return "flowTerminal"
+	case HolderRunningPhase:
+		return "runningPhase"
+	case HolderPhaseSession:
+		return "phaseSession"
+	case HolderFlowSession:
+		return "flowSession"
+	case HolderRepairDrain:
+		return "repairDrain"
+	case HolderHeadlessWrite:
+		return "headlessWrite"
+	default:
+		return "none"
+	}
+}
+
+// Verdict is the answer. Its fields are unexported so a consumer cannot pattern
+// match on a representation this package chose not to expose.
+type Verdict struct {
+	holder  Holder
+	reason  string
+	phaseID string
+	err     error
+}
+
+// Occupied reports whether anything holds the Flow for this purpose.
+func (verdict Verdict) Occupied() bool { return verdict.holder != HolderNone }
+
+// Holder names what holds it, or HolderNone.
+func (verdict Verdict) Holder() Holder { return verdict.holder }
+
+// Reason is the user-facing refusal for this purpose, or "" when the Flow is
+// free or the purpose refuses in silence. The same holder yields different text
+// for different roles by design.
+func (verdict Verdict) Reason() string { return verdict.reason }
+
+// PhaseID names the phase the holder occupies, when the holder is phase-scoped
+// and the refusal names it. Blank otherwise.
+func (verdict Verdict) PhaseID() string { return verdict.phaseID }
+
+// Err reports a source failure that was not itself occupancy. A lease that
+// could not be read is HolderLeaseUnreadable rather than an error, because
+// fail-closed occupancy is the answer; a Flow store or session store read that
+// failed has no safe answer and surfaces here.
+func (verdict Verdict) Err() error { return verdict.err }
+
+// FlowReader reads a Flow authoritatively.
+type FlowReader interface {
+	ReadFlow(flowID string) (flowstore.FlowRecord, error)
+}
+
+// FlowCache answers from the display mirror the poll already carries.
+type FlowCache interface {
+	CachedFlow(flowID string) (flowstore.FlowRecord, bool)
+}
+
+// SessionStore lists this Flow's session records authoritatively.
+type SessionStore interface {
+	ListFlowSessions(flowID string) ([]sessions.SessionRecord, error)
+}
+
+// SessionCache answers from the mirrored session panes.
+type SessionCache interface {
+	ActiveFlowSessions(flowID string) []sessions.SessionRecord
+}
+
+// LeaseInspector reports the cross-process tracked tmux lease. An error is
+// occupancy, not a failure.
+type LeaseInspector interface {
+	FlowLeaseOccupied(flowID string) (bool, error)
+}
+
+// Runtime is the in-process launch state. It is one interface rather than five
+// because a single value implements all of it, and splitting it would produce
+// five one-method adapters over the same receiver.
+type Runtime interface {
+	// AttemptHolder names the role of the in-process launch attempt holding
+	// this Flow, if any.
+	AttemptHolder(flowID string) (actions.FlowLaunchRole, bool)
+	// HasFlowTerminal reports a retained Flow terminal slot with a live
+	// terminal.
+	HasFlowTerminal(flowID string) bool
+	// HasRepairTerminal reports a retained repair slot. It overlaps
+	// HasFlowTerminal rather than nesting inside it: one requires a live
+	// terminal, the other a repair slot.
+	HasRepairTerminal(flowID string) bool
+	// HeadlessWritePending reports an in-flight headless toggle.
+	HeadlessWritePending(flowID string) bool
+	// RepairDrainPending reports a repair outcome the AutoMode poll has not
+	// consumed.
+	RepairDrainPending(flowID string) bool
+}
+
+// AgentProbe reports a live tmux window for a phase-untracked agent. It forks a
+// subprocess, so it is nil-able and this package consults it only at
+// StageAdmission and StageAuthoritative.
+type AgentProbe interface {
+	TmuxAgentRunning(flowID string) bool
+}
+
+// Sources is the set of adapters an Occupancy answers from. Every field is
+// optional in the sense that a stage that does not read it may leave it nil;
+// a stage that does read it and finds nil yields Verdict.Err.
+type Sources struct {
+	Flows     FlowReader
+	FlowCache FlowCache
+	Sessions  SessionStore
+	Cache     SessionCache
+	Lease     LeaseInspector
+	Runtime   Runtime
+	Probe     AgentProbe
+}
+
+// Occupancy answers occupancy queries against one set of sources.
+type Occupancy struct {
+	sources Sources
+}
+
+// New binds an Occupancy to its sources.
+func New(sources Sources) Occupancy {
+	return Occupancy{sources: sources}
+}
+
+// Query answers one occupancy question. A query whose purpose is not Valid
+// yields an occupied fail-closed verdict rather than a free one.
+func (occupancy Occupancy) Query(query Query) Verdict {
+	// implemented in approach-x0r.3
+	return Verdict{}
+}
+
+// Free is the verdict for an unoccupied Flow. It exists so callers and tests
+// can express "nothing holds it" without constructing a zero Verdict literal
+// and depending on the zero value staying free.
+func Free() Verdict { return Verdict{} }

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -33,3 +33,18 @@ func TestFreeIsNotOccupied(t *testing.T) {
 		t.Fatalf("Free().Err() = %v, want nil", Free().Err())
 	}
 }
+
+// A corrupt or future Holder must not be readable as a free Flow. Naming
+// HolderNone explicitly keeps the default branch for values this package does
+// not know, the way Stage.String() already does.
+func TestHolderStringSeparatesNoneFromUnknown(t *testing.T) {
+	if got := HolderNone.String(); got != "none" {
+		t.Fatalf("HolderNone.String() = %q, want %q", got, "none")
+	}
+	if got := (HolderHeadlessWrite + 1).String(); got != "unknown" {
+		t.Fatalf("out-of-range Holder.String() = %q, want %q", got, "unknown")
+	}
+	if got := Holder(-1).String(); got != "unknown" {
+		t.Fatalf("negative Holder.String() = %q, want %q", got, "unknown")
+	}
+}

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -1,0 +1,35 @@
+package flowoccupancy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/approachcontrol/approach/actions"
+)
+
+// The skeleton must never report a Flow free. Until approach-x0r.3 reads the
+// sources, a caller migrated early has to fail closed and fail loudly.
+func TestQueryFailsClosedWhileUnimplemented(t *testing.T) {
+	verdict := New(Sources{}).Query(Query{
+		FlowID:  "flow-1",
+		Purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: StageAdmission},
+	})
+
+	if !verdict.Occupied() {
+		t.Fatalf("Occupied() = false, want true while Query is unimplemented")
+	}
+	if !errors.Is(verdict.Err(), ErrUnimplemented) {
+		t.Fatalf("Err() = %v, want ErrUnimplemented", verdict.Err())
+	}
+}
+
+// Free() stays the way callers and tests express "nothing holds it", and must
+// not drift into occupancy alongside the fail-closed stub.
+func TestFreeIsNotOccupied(t *testing.T) {
+	if Free().Occupied() {
+		t.Fatal("Free().Occupied() = true, want false")
+	}
+	if Free().Err() != nil {
+		t.Fatalf("Free().Err() = %v, want nil", Free().Err())
+	}
+}


### PR DESCRIPTION
"Is something already working in this Flow?" is answered sixteen different ways across `model/`, by thirteen representations and two composites over them, read at roughly forty call sites that deliberately disagree with each other. The one composite that does exist has six callers who take it as-is and five who unroll it, each with a comment explaining why the shared answer is wrong for them. Nothing can be consolidated until that tangle is written down, so this PR surveys it and proposes the deep module that replaces it — without moving a single caller.

## What lands

**`docs/flow-occupancy-matrix.md`** — the frozen survey, pinned to 3d147d4 and shaped after `docs/flow-launch-variant-matrix.md`: sixteen sources with lifetime and freshness, consumers grouped by mutating / preview / poll / non-launch, ten deliberate divergences quoted with the comments that justify them, the four independent ordered refusal ladders, and six findings. Every cell cites `file:line`.

**`docs/adr/0003-flow-occupancy-deep-module.md`** — the design, as a proposal. A top-level `flowoccupancy/` package; a `Query` carrying an (`actions.FlowLaunchRole`, `Stage`) purpose plus freshness; a `Verdict` exposing a named `Holder` and per-purpose refusal text; and the cached-advisory vs authoritative rule written down and justified. Priority stays a per-purpose table rather than one global order, because repair and autofix rank a competing attempt against the terminal slots differently and both can hold at once.

**`flowoccupancy/`** — the compiling skeleton. Types, adapter interfaces, and method signatures, with bodies stubbed for approach-x0r.3.

## Design points worth flagging

- `Query` fails closed: it returns occupancy plus `ErrUnimplemented` rather than the zero `Verdict`. A caller migrated ahead of approach-x0r.3 breaks loudly instead of silently reading every Flow as free — which matters doubly while `Purpose.Valid` is still a stub that rejects every purpose.
- `StageAutoAdvance` splits the AutoMode advance poll out from the tracked-phase read. Matrix §2.1 records that manual admission reads S14 and refuses loudly where auto reads neither, and §2.2 that the AutoMode read adds `flowRecordHasOtherRunningPhase` where the tracked-phase read does not — yet both consumers carry `RoleTrackedPhase`, because ADR 0002 kept auto-launch off the role axis.
- `StageQuit` was added and then removed. ADR 0003's D2 lists it as a purpose; D5 of the same ADR says the opposite and is right — S5 (handoff-pending) is a process-wide quit policy, not a per-Flow question, and nothing in `Sources` can answer a quit query. D2 is corrected so the two halves of the ADR agree.

## Scope

Nothing under `model/` changes. No caller is migrated, no predicate deleted, no behavior moved.

## Open item

The bead is HITL and this Flow ran headless, so its last acceptance criterion — the grill — is left unchecked. The ADR carries seven explicit decision requests and is marked *proposed — pending user approval*; approach-x0r.2 must not start before that lands out of band.

## Verification

`gofmt -l` clean, `go build ./...`, `go vet ./...`, and `go test ./model/... ./flowoccupancy/...` all pass.
