### PR TITLE
Ask the Flow launch role once at the actions seam

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1438,24 +1438,27 @@ func UsesStreamJSONOutput(ctx AgentLaunchContext) bool {
 	return (command == agent.CommandClaude || command == agent.CommandCursor) && ctx.Embedded && ctx.Headless
 }
 
+// ShouldPrefillEmbeddedPrompt reports whether an embedded Flow launch fills the
+// dock with its prompt instead of passing it as argv. Which launches prefill is
+// the role's answer; the rest of the conjuncts are transport and payload — the
+// three providers with a dock, the interactive embedded slot, and a prompt that
+// is actually there to place.
+//
+// The role has to be well formed as well as prefilling: a context that mixes
+// markers — a repair carrying a phase, a phase-attached launch that declared
+// itself untracked — is not the launch its role names, and the four
+// hand-written predicates this replaced each refused those shapes by failing a
+// conjunct. That refusal is now stated once, on the role.
 func ShouldPrefillEmbeddedPrompt(ctx AgentLaunchContext) bool {
 	command := agent.Normalize(ctx.Command)
-	trackedPhase := ctx.FlowPhaseID != "" && ctx.FlowLaunchTracked && !ctx.FlowRepair
-	untrackedRepair := ctx.FlowRepair && ctx.FlowPhaseID == "" && !ctx.FlowLaunchTracked
-	// An untracked Flow-worktree agent prefills like every other interactive
-	// embedded Flow launch: the dock is filled and the operator presses enter.
-	// FlowAgent is an explicit signal rather than "Flow ID, no phase, not
-	// repair", so the boundary stays a predicate on the context rather than an
-	// inference about it.
-	untrackedFlowAgent := ctx.FlowAgent && ctx.FlowPhaseID == "" && !ctx.FlowLaunchTracked && !ctx.FlowRepair
-	untrackedFlowAutofix := ctx.FlowAutofix && ctx.FlowPhaseID == "" && !ctx.FlowLaunchTracked && !ctx.FlowRepair
+	role := FlowLaunchRoleOf(ctx)
 	return (command == agent.CommandCodex || command == agent.CommandClaude || command == agent.CommandCursor) &&
 		ctx.Embedded &&
 		!ctx.Headless &&
 		ctx.ResumeSessionID == "" &&
 		ctx.InitialPrompt != "" &&
-		ctx.FlowID != "" &&
-		(trackedPhase || untrackedRepair || untrackedFlowAgent || untrackedFlowAutofix)
+		role.Prefills() &&
+		validateFlowLaunchRole(ctx, role) == nil
 }
 
 func agentCommandSpec(ctx AgentLaunchContext) (*exec.Cmd, []envVar, error) {
@@ -1554,17 +1557,13 @@ func resumeSessionIDForContext(ctx AgentLaunchContext) (string, error) {
 	if !ctx.FlowSavedSessionResume {
 		return resumeSessionIDForLaunch(ctx.ResumeSessionID)
 	}
-	if strings.TrimSpace(ctx.FlowID) == "" ||
-		strings.TrimSpace(ctx.FlowPhaseID) != "" ||
-		strings.TrimSpace(ctx.FlowPhaseKind) != "" ||
-		ctx.FlowLaunchTracked ||
-		ctx.FlowAutoLaunch ||
-		ctx.FlowPhaseTerminal ||
+	// The marker claims the role; the classifier and the marker rows say whether
+	// the context is a well-formed instance of it. What is left here is
+	// transport and payload: this role exists only as an interactive embedded
+	// resume of a session that is actually named, and it carries no prompt.
+	if err := validateFlowLaunchRole(ctx, RoleSavedSessionResume); err != nil ||
 		!ctx.Embedded ||
 		ctx.Headless ||
-		ctx.FlowRepair ||
-		ctx.FlowAgent ||
-		ctx.FlowAutofix ||
 		ctx.InitialPrompt != "" ||
 		strings.TrimSpace(ctx.ResumeSessionID) == "" {
 		return "", fmt.Errorf("invalid Flow saved-session resume role")

--- a/actions/flow_launch_role.go
+++ b/actions/flow_launch_role.go
@@ -1,6 +1,10 @@
 package actions
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
 
 // FlowLaunchRole names the kind of Flow-scoped launch a context represents. It
 // is a closed enum: every Flow launch the TUI can start is exactly one of these
@@ -165,4 +169,116 @@ func (role FlowLaunchRole) String() string {
 	default:
 		return "unknown flow launch role"
 	}
+}
+
+// Prefills reports whether a launch in this role fills the embedded dock with
+// its prompt rather than passing it as argv. The two resume roles carry no
+// prompt to place, and RoleNone is not a Flow launch at all.
+func (role FlowLaunchRole) Prefills() bool {
+	switch role {
+	case RoleTrackedPhase, RoleCreatePhase, RoleRepair, RoleWorktreeAgent, RoleAutofix:
+		return true
+	default:
+		return false
+	}
+}
+
+// errInvalidFlowLaunchRole is the seam's one rejection. Call sites wrap it in
+// their own message so their existing diagnostics survive.
+var errInvalidFlowLaunchRole = errors.New("invalid Flow launch role")
+
+// flowLaunchRoleMarkers is one row of the "Marker fields" table in
+// docs/flow-launch-variant-matrix.md §3, transcribed so the table is executable
+// rather than prose. A role owns exactly the markers its row sets; every other
+// marker on the context is a marker the role does not own.
+type flowLaunchRoleMarkers struct {
+	// phaseAttached roles address a phase of their Flow, so they require a
+	// phase ID and may carry its kind. The rest own neither.
+	phaseAttached bool
+	tracked       bool
+	repair        bool
+	agent         bool
+	savedResume   bool
+	autofix       bool
+	// allowAutoLaunch is the auto-vs-manual distinction inside the tracked
+	// phase role rather than a role of its own (V4). allowPhaseTerminal is the
+	// resumed phase that had already finished (V8, V10).
+	allowAutoLaunch    bool
+	allowPhaseTerminal bool
+}
+
+func flowLaunchRoleMarkersOf(role FlowLaunchRole) (flowLaunchRoleMarkers, bool) {
+	switch role {
+	case RoleTrackedPhase:
+		return flowLaunchRoleMarkers{phaseAttached: true, tracked: true, allowAutoLaunch: true}, true
+	case RolePhaseResume:
+		return flowLaunchRoleMarkers{phaseAttached: true, tracked: true, allowPhaseTerminal: true}, true
+	case RoleCreatePhase:
+		return flowLaunchRoleMarkers{phaseAttached: true, tracked: true}, true
+	case RoleRepair:
+		return flowLaunchRoleMarkers{repair: true}, true
+	case RoleAutofix:
+		return flowLaunchRoleMarkers{autofix: true}, true
+	case RoleWorktreeAgent:
+		return flowLaunchRoleMarkers{agent: true}, true
+	case RoleSavedSessionResume:
+		return flowLaunchRoleMarkers{savedResume: true}, true
+	default:
+		return flowLaunchRoleMarkers{}, false
+	}
+}
+
+// validateFlowLaunchRole reports one canonical rejection when ctx is not a
+// well-formed instance of want: it sets a marker the role does not own, or
+// misses one the role requires. FlowLaunchRoleOf answers which role a context
+// names, by precedence; this answers whether the context is a clean instance of
+// that role, which is the half the hand-written ladders at the seam used to
+// carry on their own.
+//
+// Transport and payload are deliberately not inputs. Embedded, Headless,
+// FlowAutofixPRNumber, InitialPrompt and ResumeSessionID are read by exactly one
+// consumer each, next to that consumer's single role call.
+func validateFlowLaunchRole(ctx AgentLaunchContext, want FlowLaunchRole) error {
+	markers, ok := flowLaunchRoleMarkersOf(want)
+	if !ok {
+		return fmt.Errorf("%w: %v", errInvalidFlowLaunchRole, want)
+	}
+	// Every role is scoped to a Flow: without one there is no lease to take, no
+	// phase to mark and no session to resume.
+	if strings.TrimSpace(ctx.FlowID) == "" {
+		return fmt.Errorf("%w: %v requires a Flow ID", errInvalidFlowLaunchRole, want)
+	}
+	if markers.phaseAttached {
+		if strings.TrimSpace(ctx.FlowPhaseID) == "" {
+			return fmt.Errorf("%w: %v requires a phase ID", errInvalidFlowLaunchRole, want)
+		}
+	} else if strings.TrimSpace(ctx.FlowPhaseID) != "" || strings.TrimSpace(ctx.FlowPhaseKind) != "" {
+		return fmt.Errorf("%w: %v owns no phase", errInvalidFlowLaunchRole, want)
+	}
+	for _, marker := range []struct {
+		name string
+		got  bool
+		want bool
+		// optional markers are the two the role may carry but need not: the
+		// auto-launch flag on a tracked phase and the terminal flag on a
+		// phase resume.
+		optional bool
+	}{
+		{name: "tracked", got: ctx.FlowLaunchTracked, want: markers.tracked},
+		{name: "repair", got: ctx.FlowRepair, want: markers.repair},
+		{name: "worktree agent", got: ctx.FlowAgent, want: markers.agent},
+		{name: "saved session resume", got: ctx.FlowSavedSessionResume, want: markers.savedResume},
+		{name: "autofix", got: ctx.FlowAutofix, want: markers.autofix},
+		{name: "auto launch", got: ctx.FlowAutoLaunch, optional: markers.allowAutoLaunch},
+		{name: "phase terminal", got: ctx.FlowPhaseTerminal, optional: markers.allowPhaseTerminal},
+	} {
+		if marker.got == marker.want || (marker.got && marker.optional) {
+			continue
+		}
+		if marker.want {
+			return fmt.Errorf("%w: %v requires the %s marker", errInvalidFlowLaunchRole, want, marker.name)
+		}
+		return fmt.Errorf("%w: %v does not own the %s marker", errInvalidFlowLaunchRole, want, marker.name)
+	}
+	return nil
 }

--- a/actions/flow_launch_role_seam_internal_test.go
+++ b/actions/flow_launch_role_seam_internal_test.go
@@ -1,0 +1,431 @@
+package actions
+
+import "testing"
+
+// flowLaunchSeamDecisions is what the four actions-side consumers answer for one
+// launch context: whether the context names a well-formed role, whether the
+// embedded dock is prefilled, which session ID the provider resumes (and
+// whether the resume is refused outright), and how the tracked tmux route reads
+// the same context — whether it takes the leased-window branch and whether the
+// role validation accepts it.
+type flowLaunchSeamDecisions struct {
+	Role             FlowLaunchRole
+	WellFormed       bool
+	Prefills         bool
+	ResumeSessionID  string
+	ResumeRefused    bool
+	TrackedTmuxLease bool
+	TrackedTmuxValid bool
+}
+
+// flowLaunchSeamDecisionsOf runs all four consumers over one context. It exists
+// so the table below cannot quietly test three of them.
+func flowLaunchSeamDecisionsOf(ctx AgentLaunchContext) flowLaunchSeamDecisions {
+	role := FlowLaunchRoleOf(ctx)
+	resumeSessionID, resumeErr := resumeSessionIDForContext(ctx)
+	return flowLaunchSeamDecisions{
+		Role:            role,
+		WellFormed:      validateFlowLaunchRole(ctx, role) == nil,
+		Prefills:        ShouldPrefillEmbeddedPrompt(ctx),
+		ResumeSessionID: resumeSessionID,
+		ResumeRefused:   resumeErr != nil,
+		// The tracked tmux route gates its role validation, its lease branch and
+		// its leased window name on the marker — the launch's claim on the Flow
+		// lease — and asks the role whether that claim is well formed.
+		TrackedTmuxLease: ctx.FlowLaunchTracked,
+		TrackedTmuxValid: validateTrackedRepoTmuxRole(ctx, role) == nil,
+	}
+}
+
+// flowLaunchSeamRow is one variant of docs/flow-launch-variant-matrix.md built
+// as the literal the builder produces for it, paired with what the seam answers.
+type flowLaunchSeamRow struct {
+	name string
+	ctx  AgentLaunchContext
+	want flowLaunchSeamDecisions
+}
+
+// flowLaunchSeamPhaseCtx is the shared marker shape of the phase-attached
+// variants V1–V10: a Flow, its phase, the phase kind, and the tracked marker.
+func flowLaunchSeamPhaseCtx() AgentLaunchContext {
+	return AgentLaunchContext{
+		Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktree", FlowID: "flow-1",
+		FlowPhaseID: "phase-1", FlowPhaseKind: "implement",
+		FlowLaunchTracked: true, InitialPrompt: "work the phase", Embedded: true,
+	}
+}
+
+// flowLaunchSeamUntrackedCtx is the shared marker shape of the untracked
+// variants V11–V17: a Flow and nothing else, with the caller free to set the one
+// marker that names the role.
+func flowLaunchSeamUntrackedCtx() AgentLaunchContext {
+	return AgentLaunchContext{
+		Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/alpha",
+		WorktreePath: "/dev/alpha-worktree", FlowID: "flow-1", Embedded: true,
+	}
+}
+
+func flowLaunchSeamReachableRows() []flowLaunchSeamRow {
+	// A tracked phase launch is the base: it prefills the dock, resumes
+	// nothing, takes the leased window and passes the tmux role validation.
+	trackedPhase := flowLaunchSeamDecisions{
+		Role: RoleTrackedPhase, WellFormed: true, Prefills: true,
+		TrackedTmuxLease: true, TrackedTmuxValid: true,
+	}
+	phaseResume := trackedPhase
+	phaseResume.Role = RolePhaseResume
+	phaseResume.Prefills = false
+	phaseResume.ResumeSessionID = "session-1"
+	createPhase := trackedPhase
+	createPhase.Role = RoleCreatePhase
+
+	// Headless clears the dock prefill — the prompt goes to argv — and the tmux
+	// route refuses headless outright.
+	headless := func(row flowLaunchSeamDecisions) flowLaunchSeamDecisions {
+		row.Prefills = false
+		row.TrackedTmuxValid = false
+		return row
+	}
+	// The tmux route clears Embedded, which is the same thing that sends the
+	// prompt to argv; the role and its tmux validation are unchanged.
+	viaTmux := func(ctx AgentLaunchContext) AgentLaunchContext {
+		ctx.Embedded = false
+		return ctx
+	}
+
+	autoPhase := flowLaunchSeamPhaseCtx()
+	autoPhase.FlowAutoLaunch = true
+	autoPhase.Headless = true
+
+	headlessPhase := flowLaunchSeamPhaseCtx()
+	headlessPhase.Headless = true
+
+	createPhaseCtx := flowLaunchSeamPhaseCtx()
+	createPhaseCtx.PlanPhaseID = "phase-1"
+	createPhaseCtx.PlanPhaseTitle = "Implement"
+	createPhaseCtx.PlanPhaseStatus = "running"
+	headlessCreateCtx := createPhaseCtx
+	headlessCreateCtx.Headless = true
+
+	phaseResumeCtx := flowLaunchSeamPhaseCtx()
+	phaseResumeCtx.ResumeSessionID = "session-1"
+	phaseResumeCtx.InitialPrompt = ""
+	phaseResumeCtx.WorkingDir = "/dev/alpha-worktree"
+	terminalPhaseResumeCtx := phaseResumeCtx
+	terminalPhaseResumeCtx.FlowPhaseTerminal = true
+
+	repairCtx := flowLaunchSeamUntrackedCtx()
+	repairCtx.FlowRepair = true
+	repairCtx.InitialPrompt = "repair the flow"
+	headlessRepairCtx := repairCtx
+	headlessRepairCtx.Headless = true
+
+	autofixCtx := flowLaunchSeamUntrackedCtx()
+	autofixCtx.FlowAutofix = true
+	autofixCtx.FlowAutofixPRNumber = 116
+	autofixCtx.InitialPrompt = "address the review"
+	autofixCtx.WorkingDir = "/dev/alpha-worktree"
+	headlessAutofixCtx := autofixCtx
+	headlessAutofixCtx.Headless = true
+
+	agentCtx := flowLaunchSeamUntrackedCtx()
+	agentCtx.FlowAgent = true
+	agentCtx.WorkingDir = "/dev/alpha-worktree"
+	promptedAgentCtx := agentCtx
+	promptedAgentCtx.InitialPrompt = "look around"
+
+	savedResumeCtx := flowLaunchSeamUntrackedCtx()
+	savedResumeCtx.Command = "claude"
+	savedResumeCtx.FlowSavedSessionResume = true
+	savedResumeCtx.ResumeSessionID = "session-9"
+	savedResumeCtx.WorkingDir = "/dev/alpha-worktree"
+
+	untracked := flowLaunchSeamDecisions{WellFormed: true}
+	repairDecisions := untracked
+	repairDecisions.Role = RoleRepair
+	repairDecisions.Prefills = true
+	autofixDecisions := untracked
+	autofixDecisions.Role = RoleAutofix
+	autofixDecisions.Prefills = true
+	agentDecisions := untracked
+	agentDecisions.Role = RoleWorktreeAgent
+	savedResumeDecisions := untracked
+	savedResumeDecisions.Role = RoleSavedSessionResume
+	savedResumeDecisions.ResumeSessionID = "session-9"
+
+	return []flowLaunchSeamRow{
+		{name: "V1 tracked phase embedded interactive", ctx: flowLaunchSeamPhaseCtx(), want: trackedPhase},
+		{name: "V2 tracked phase embedded headless", ctx: headlessPhase, want: headless(trackedPhase)},
+		{name: "V3 tracked phase tmux", ctx: viaTmux(flowLaunchSeamPhaseCtx()), want: func() flowLaunchSeamDecisions {
+			// The tmux route is not an embedded slot, so there is no dock to
+			// prefill; the role and the lease branch are the embedded row's.
+			want := trackedPhase
+			want.Prefills = false
+			return want
+		}()},
+		{name: "V4 auto phase headless", ctx: autoPhase, want: func() flowLaunchSeamDecisions {
+			// The auto-launch marker is refused by the tmux route at the call
+			// site, not by the role: an auto phase launch is a tracked phase.
+			want := headless(trackedPhase)
+			want.TrackedTmuxValid = false
+			return want
+		}()},
+		{name: "V5 create phase interactive", ctx: createPhaseCtx, want: createPhase},
+		{name: "V6 create phase headless", ctx: headlessCreateCtx, want: headless(createPhase)},
+		{name: "V7 phase resume embedded", ctx: phaseResumeCtx, want: phaseResume},
+		{name: "V8 phase resume embedded terminal phase", ctx: terminalPhaseResumeCtx, want: phaseResume},
+		{name: "V9 phase resume tmux", ctx: viaTmux(phaseResumeCtx), want: phaseResume},
+		{name: "V10 phase resume tmux terminal phase", ctx: viaTmux(terminalPhaseResumeCtx), want: phaseResume},
+		{name: "V11 repair embedded interactive", ctx: repairCtx, want: repairDecisions},
+		{name: "V12 repair embedded headless", ctx: headlessRepairCtx, want: func() flowLaunchSeamDecisions {
+			want := repairDecisions
+			want.Prefills = false
+			return want
+		}()},
+		{name: "V13 autofix embedded interactive", ctx: autofixCtx, want: autofixDecisions},
+		{name: "V14 autofix embedded headless", ctx: headlessAutofixCtx, want: func() flowLaunchSeamDecisions {
+			want := autofixDecisions
+			want.Prefills = false
+			return want
+		}()},
+		{name: "V15 autofix tmux", ctx: viaTmux(autofixCtx), want: func() flowLaunchSeamDecisions {
+			want := autofixDecisions
+			want.Prefills = false
+			return want
+		}()},
+		{
+			// The builder gives the worktree agent no prompt, so there is
+			// nothing to prefill; the role still says it would.
+			name: "V16 worktree agent", ctx: agentCtx, want: agentDecisions,
+		},
+		{name: "V16 worktree agent with a prompt", ctx: promptedAgentCtx, want: func() flowLaunchSeamDecisions {
+			want := agentDecisions
+			want.Prefills = true
+			return want
+		}()},
+		{name: "V17 saved session resume", ctx: savedResumeCtx, want: savedResumeDecisions},
+	}
+}
+
+func flowLaunchSeamNonFlowRows() []flowLaunchSeamRow {
+	return []flowLaunchSeamRow{
+		{
+			name: "non-flow session resume",
+			ctx: AgentLaunchContext{
+				Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/alpha",
+				WorktreePath: "/dev/alpha-worktree", ResumeSessionID: "session-1",
+				Embedded: true,
+			},
+			want: flowLaunchSeamDecisions{ResumeSessionID: "session-1"},
+		},
+		{
+			name: "plan implementation",
+			ctx: AgentLaunchContext{
+				Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/alpha",
+				WorktreePath: "/dev/alpha-worktree", PlanID: "plan-1",
+				PlanPath: "/state/plan.md", InitialPrompt: "implement", Embedded: true,
+			},
+		},
+		{
+			name: "open agent in worktree",
+			ctx: AgentLaunchContext{
+				Command: "claude", LaunchID: "launch-1", RepoPath: "/dev/alpha",
+				WorktreePath: "/dev/alpha-worktree", Embedded: true,
+			},
+		},
+		{
+			name: "slice epic",
+			ctx: AgentLaunchContext{
+				Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/alpha",
+				InitialPrompt: "slice the epic", Embedded: true,
+			},
+		},
+		{name: "routing probe", ctx: AgentLaunchContext{Command: "codex"}},
+		{name: "routing probe for an ineligible command", ctx: AgentLaunchContext{Command: "bash"}},
+	}
+}
+
+// flowLaunchSeamInvalidRows are marker combinations no builder arm emits. They
+// exist so the seam's one rejection path is pinned as deliberately as its
+// acceptances: each row states which role, if any, the combination names and
+// what each consumer does with it.
+func flowLaunchSeamInvalidRows() []flowLaunchSeamRow {
+	tracked := flowLaunchSeamPhaseCtx()
+
+	trackedSavedResume := flowLaunchSeamUntrackedCtx()
+	trackedSavedResume.FlowSavedSessionResume = true
+	trackedSavedResume.FlowLaunchTracked = true
+	trackedSavedResume.ResumeSessionID = "session-9"
+
+	repairAndAgent := flowLaunchSeamUntrackedCtx()
+	repairAndAgent.FlowRepair = true
+	repairAndAgent.FlowAgent = true
+	repairAndAgent.InitialPrompt = "repair the flow"
+
+	autofixWithPhase := flowLaunchSeamUntrackedCtx()
+	autofixWithPhase.FlowAutofix = true
+	autofixWithPhase.FlowAutofixPRNumber = 116
+	autofixWithPhase.FlowPhaseID = "phase-1"
+	autofixWithPhase.InitialPrompt = "address the review"
+
+	trackedAutofix := flowLaunchSeamUntrackedCtx()
+	trackedAutofix.FlowAutofix = true
+	trackedAutofix.FlowLaunchTracked = true
+	trackedAutofix.InitialPrompt = "address the review"
+
+	untrackedPhaseResume := flowLaunchSeamPhaseCtx()
+	untrackedPhaseResume.FlowLaunchTracked = false
+	untrackedPhaseResume.InitialPrompt = ""
+	untrackedPhaseResume.ResumeSessionID = "session-1"
+
+	blankFlowRepair := flowLaunchSeamUntrackedCtx()
+	blankFlowRepair.FlowID = "   "
+	blankFlowRepair.FlowRepair = true
+	blankFlowRepair.InitialPrompt = "repair the flow"
+
+	flowlessRepair := blankFlowRepair
+	flowlessRepair.FlowID = ""
+
+	promptedSavedResume := flowLaunchSeamUntrackedCtx()
+	promptedSavedResume.FlowSavedSessionResume = true
+	promptedSavedResume.ResumeSessionID = "session-9"
+	promptedSavedResume.InitialPrompt = "carry on"
+
+	headlessTrackedTmux := flowLaunchSeamPhaseCtx()
+	headlessTrackedTmux.Embedded = false
+	headlessTrackedTmux.Headless = true
+
+	repairWithPhase := flowLaunchSeamPhaseCtx()
+	repairWithPhase.FlowRepair = true
+
+	return []flowLaunchSeamRow{
+		{
+			// The tracked marker on a saved-session resume is the shape the
+			// resume ladder has always named outright: it would promote an
+			// untracked launch into one that takes the Flow lease.
+			name: "saved session resume marked tracked",
+			ctx:  trackedSavedResume,
+			want: flowLaunchSeamDecisions{
+				Role: RoleSavedSessionResume, ResumeRefused: true, TrackedTmuxLease: true,
+			},
+		},
+		{
+			// Repair outranks the agent marker, so this is a repair — but one
+			// carrying a marker the repair role does not own, which is not a
+			// well-formed launch of any role, so nothing prefills it.
+			name: "repair and worktree agent together",
+			ctx:  repairAndAgent,
+			want: flowLaunchSeamDecisions{Role: RoleRepair},
+		},
+		{
+			// A phase ID outranks the autofix marker, so this is a phase-attached
+			// launch that set neither the tracked marker its role requires nor
+			// the empty autofix marker: malformed twice over, and prefilled by
+			// nothing.
+			name: "autofix carrying a phase id",
+			ctx:  autofixWithPhase,
+			want: flowLaunchSeamDecisions{Role: RoleTrackedPhase},
+		},
+		{
+			name: "autofix marked tracked",
+			ctx:  trackedAutofix,
+			want: flowLaunchSeamDecisions{Role: RoleNone, TrackedTmuxLease: true},
+		},
+		{
+			// A resume carrying a phase without the tracked marker names no
+			// role, so the tmux route does not take the leased branch for it.
+			name: "untracked phase resume",
+			ctx:  untrackedPhaseResume,
+			want: flowLaunchSeamDecisions{Role: RoleNone, ResumeSessionID: "session-1"},
+		},
+		{
+			// A whitespace Flow ID is no Flow to the role, so no launch it names
+			// is well formed and the dock stays empty. The old untrimmed
+			// FlowID conjunct filled it.
+			name: "repair with a blank flow id",
+			ctx:  blankFlowRepair,
+			want: flowLaunchSeamDecisions{Role: RoleRepair},
+		},
+		{
+			name: "repair with no flow id at all",
+			ctx:  flowlessRepair,
+			want: flowLaunchSeamDecisions{Role: RoleRepair},
+		},
+		{
+			name: "saved session resume carrying a prompt",
+			ctx:  promptedSavedResume,
+			want: flowLaunchSeamDecisions{
+				Role: RoleSavedSessionResume, WellFormed: true, ResumeRefused: true,
+			},
+		},
+		{
+			name: "headless tracked tmux launch",
+			ctx:  headlessTrackedTmux,
+			want: flowLaunchSeamDecisions{
+				Role: RoleTrackedPhase, WellFormed: true, TrackedTmuxLease: true,
+			},
+		},
+		{
+			// Repair wins the precedence, and a repair role owns no phase, so
+			// the phase markers make it malformed rather than making it a phase.
+			// The tracked marker it also carries claims the tmux lease, and the
+			// role validation is what refuses that claim.
+			name: "repair carrying phase markers",
+			ctx:  repairWithPhase,
+			want: flowLaunchSeamDecisions{Role: RoleRepair, TrackedTmuxLease: true},
+		},
+		{
+			name: "tracked phase carrying an autofix pr number",
+			ctx: func() AgentLaunchContext {
+				ctx := tracked
+				ctx.FlowAutofixPRNumber = 116
+				return ctx
+			}(),
+			want: flowLaunchSeamDecisions{
+				Role: RoleTrackedPhase, WellFormed: true, Prefills: true,
+				TrackedTmuxLease: true,
+			},
+		},
+	}
+}
+
+// TestFlowLaunchRoleSeamDecisions is the behavior pin for approach-hyl.11: every
+// reachable variant, the non-Flow literals and the probes, and the malformed
+// marker combinations, driven through all four actions-side consumers that read
+// the Flow launch role.
+func TestFlowLaunchRoleSeamDecisions(t *testing.T) {
+	t.Parallel()
+
+	rows := flowLaunchSeamReachableRows()
+	rows = append(rows, flowLaunchSeamNonFlowRows()...)
+	rows = append(rows, flowLaunchSeamInvalidRows()...)
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			t.Parallel()
+			if got := flowLaunchSeamDecisionsOf(row.ctx); got != row.want {
+				t.Fatalf("seam decisions = %#v, want %#v", got, row.want)
+			}
+		})
+	}
+}
+
+// TestFlowLaunchRoleSeamCoversEveryRole is the acceptance criterion that the
+// table above names every valid Flow role, not just the ones whose consumers
+// happen to be easy to assert.
+func TestFlowLaunchRoleSeamCoversEveryRole(t *testing.T) {
+	t.Parallel()
+
+	covered := map[FlowLaunchRole]bool{}
+	for _, row := range flowLaunchSeamReachableRows() {
+		covered[row.want.Role] = true
+	}
+	for _, role := range []FlowLaunchRole{
+		RoleTrackedPhase, RolePhaseResume, RoleRepair, RoleAutofix,
+		RoleWorktreeAgent, RoleSavedSessionResume, RoleCreatePhase,
+	} {
+		if !covered[role] {
+			t.Errorf("the reachable-variant table names no %v launch", role)
+		}
+	}
+}

--- a/actions/tmux_mode.go
+++ b/actions/tmux_mode.go
@@ -302,8 +302,17 @@ func repoTmuxAgentLaunchWithExecutable(ctx AgentLaunchContext, lookPath lookPath
 	if command != agent.CommandCodex && command != agent.CommandClaude && command != agent.CommandCursor {
 		return RepoTmuxAgentSpec{}, errors.New("tmux launch mode supports only CLI agents")
 	}
+	// The role is classified once here and read once below, by the validation
+	// that decides whether this launch may take the tracked route at all.
+	//
+	// The gate itself stays the marker rather than role.Tracked(): the marker is
+	// the launch's claim on the Flow lease, and the classifier deliberately
+	// names a phase-attached context a phase role even when it declared itself
+	// untracked. Such a launch has always taken the plain window here, and
+	// promoting it would hand it a lease it never asked for.
+	role := FlowLaunchRoleOf(ctx)
 	if ctx.FlowLaunchTracked {
-		if err := validateTrackedRepoTmuxRole(ctx); err != nil {
+		if err := validateTrackedRepoTmuxRole(ctx, role); err != nil {
 			return RepoTmuxAgentSpec{}, err
 		}
 	}
@@ -329,6 +338,7 @@ func repoTmuxAgentLaunchWithExecutable(ctx AgentLaunchContext, lookPath lookPath
 	sessionName := RepoAgentSessionName(sessionSource)
 	windowName := repoTmuxWindowName(ctx)
 	agentEnv := envWithoutKeys(cmd.Env, "TMUX", "ZELLIJ")
+	// Validated above, so the marker and role.Tracked() agree by here.
 	if ctx.FlowLaunchTracked {
 		canonicalRoot, err := flowlease.ResolveRoot(ctx.SessionStateRoot)
 		if err != nil {
@@ -451,16 +461,16 @@ func repoTmuxAgentLaunchWithExecutable(ctx AgentLaunchContext, lookPath lookPath
 	}, nil
 }
 
-func validateTrackedRepoTmuxRole(ctx AgentLaunchContext) error {
-	if !ctx.FlowLaunchTracked ||
-		strings.TrimSpace(ctx.FlowID) == "" ||
-		strings.TrimSpace(ctx.FlowPhaseID) == "" ||
+// validateTrackedRepoTmuxRole refuses every launch the tracked tmux route does
+// not serve. The role and its marker rows answer which launches those are; what
+// stays here is the transport and payload the role deliberately does not carry.
+// Headless never routes to tmux, an auto launch has no terminal to attach to
+// (F1), and a PR number belongs to autofix, which is not a tracked role.
+func validateTrackedRepoTmuxRole(ctx AgentLaunchContext, role FlowLaunchRole) error {
+	if !role.Tracked() ||
+		validateFlowLaunchRole(ctx, role) != nil ||
 		ctx.FlowAutoLaunch ||
 		ctx.Headless ||
-		ctx.FlowRepair ||
-		ctx.FlowAgent ||
-		ctx.FlowSavedSessionResume ||
-		ctx.FlowAutofix ||
 		ctx.FlowAutofixPRNumber != 0 {
 		return errors.New("invalid tracked Flow tmux launch role")
 	}

--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -207,11 +207,11 @@ deliberately treated alike.
 | `flowLaunchFailureUpdate` (`model/model_keys.go:3154`) | `actions.FlowLaunchRole.Tracked`, then `FlowPhaseTerminal`, `FlowPhaseKind` | V8/V10 (terminal resume: refuse) ‖ V11–V17 (no phase: refuse) ‖ plan-review kind (blocked) ‖ rest | manual/auto/create/non-terminal resume |
 | `tmuxRouteEligible` (`model/tmux_mode.go:63`) | `Headless`, `actions.FlowLaunchRoleOf`, `Command` | V3/V9/V10/V15 eligible ‖ rest | every embedded variant, for whichever of the two reasons |
 | `flowLaunchContextRequiresLifecycle` (`model/tmux_mode.go:329`) | `actions.IsFlowLaunchContext`, which reads all ten marker fields (`FlowID`, `FlowPhaseID`, `FlowPhaseKind`, plus the seven booleans; not `FlowAutofixPRNumber`) | Flow launches ‖ the four non-Flow literals and the two probes | all 17 variants alike; the two non-launch Flow-ID literals would also classify as Flow, but never reach it |
-| `actions.ShouldPrefillEmbeddedPrompt` (`actions/actions.go:1338`) | `Command`, `Embedded`, `Headless`, `ResumeSessionID`, `InitialPrompt`, `FlowID`, `FlowPhaseID`, `FlowLaunchTracked`, `FlowRepair`, `FlowAgent`, `FlowAutofix` | V1/V5 (prefill) ‖ V11/V13/V16 (untracked prefill arms) ‖ resume and headless and tmux (no prefill) | the three untracked arms are separate clauses with identical effect |
-| `actions.resumeSessionIDForContext` (`actions/actions.go:1450`) | `FlowSavedSessionResume` + 12 negated fields + `ResumeSessionID` | V17 ‖ everything else | asserts *one* variant; all others take the plain path |
-| `actions.validateTrackedRepoTmuxRole` (`actions/tmux_mode.go:454`) | `FlowLaunchTracked`, `FlowID`, `FlowPhaseID`, `FlowAutoLaunch`, `Headless`, `FlowRepair`, `FlowAgent`, `FlowSavedSessionResume`, `FlowAutofix`, `FlowAutofixPRNumber` | V3/V9/V10 accepted | manual and resume tmux launches are identical to it |
-| tracked lease branch (`actions/tmux_mode.go:332`) | `FlowLaunchTracked`, `SessionStateRoot`, `Executable`, `FlowID`, `FlowPhaseID`, `LaunchID` | V3/V9/V10 (leased window) ‖ V15 (plain window) | — |
-| `repoTmuxWindowName` / `repoTmuxLeasedWindowName` (`actions/tmux_mode.go:535`, `:549`) | `FlowPhaseKind`, `Command`, `LaunchID` | phase variants (kind-named) ‖ V15 (command-named) | manual vs resume |
+| `actions.ShouldPrefillEmbeddedPrompt` (`actions/actions.go:1441`) | `FlowLaunchRole.Prefills` + `validateFlowLaunchRole`, plus `Command`, `Embedded`, `Headless`, `ResumeSessionID`, `InitialPrompt` as transport and payload | V1/V5 (prefill) ‖ V11/V13/V16 (untracked prefill roles) ‖ resume and headless and tmux (no prefill) | the three untracked roles answer through one `Prefills` case list |
+| `actions.resumeSessionIDForContext` (`actions/actions.go:1553`) | `FlowSavedSessionResume` as the claim, `validateFlowLaunchRole(ctx, RoleSavedSessionResume)` for the markers, plus `Embedded`, `Headless`, `InitialPrompt`, `ResumeSessionID` | V17 ‖ everything else | asserts *one* variant; all others take the plain path |
+| `actions.validateTrackedRepoTmuxRole` (`actions/tmux_mode.go:464`) | `FlowLaunchRole.Tracked` + `validateFlowLaunchRole`, plus `FlowAutoLaunch`, `Headless`, `FlowAutofixPRNumber` | V3/V9/V10 accepted | manual and resume tmux launches are identical to it |
+| tracked lease branch (`actions/tmux_mode.go:341`) | `FlowLaunchTracked`, `SessionStateRoot`, `Executable`, `FlowID`, `FlowPhaseID`, `LaunchID` | V3/V9/V10 (leased window) ‖ V15 (plain window) | — |
+| `repoTmuxWindowName` / `repoTmuxLeasedWindowName` (`actions/tmux_mode.go:543`, `:557`) | `FlowPhaseKind`, `Command`, `LaunchID` | phase variants (kind-named) ‖ V15 (command-named) | manual vs resume |
 | `launchKind` (`model/flow_launch_pin.go:123`) | `FlowRepair`, `FlowAutofix`, `FlowAgent`, `FlowSavedSessionResume`, `ResumeSessionID` | repair ‖ autofix ‖ generic ‖ resume (V7–V10 **and** V17) ‖ phase | V1–V6 all report "phase" |
 | `registerLaunchControl` (`model/flow_launch_pin.go:102`) | `FlowID`, `LaunchID`, `FlowPhaseID` | phase-owning ‖ unowned (V11–V17) | — |
 | `reconcileInteractiveLaunchExitCmd` (`model/flow_launch_control.go:149`) | `FlowLaunchTracked`, `FlowID`, `FlowPhaseID`, `LaunchID` | V1–V10 ‖ rest | — |
@@ -239,6 +239,37 @@ differently than the old predicates — a repair context that also sets the agen
 or saved-resume marker is detachable, and a phase-attached context without
 `FlowLaunchTracked` takes the Flow lease — and `FlowLaunchRoleOf`'s doc comment
 names both.
+
+The four `actions`-side consumers read the same role
+(`approach-hyl.11`). `FlowLaunchRoleOf` answers *which* role a context names;
+`validateFlowLaunchRole` answers whether the context is a well-formed instance
+of it, from per-role marker rows transcribed from the "Marker fields" table of
+section 3. Between them they replace the four prefill predicates, the resume
+ladder's 13 conjuncts and the tmux ladder's 10. What stays beside the role at
+each call site is transport and payload the role deliberately does not carry:
+the three docked providers, `Embedded`/`Headless`, the prompt and the resumed
+session ID for the prefill and the resume, and `FlowAutoLaunch`,
+`Headless` and `FlowAutofixPRNumber` for the tmux route (F1's dead clause is
+still dead, and still explicit). Both tmux gates keep reading
+`FlowLaunchTracked` rather than `role.Tracked()`: the marker is the launch's
+*claim* on the Flow lease, and the classifier names a phase-attached context a
+phase role even when it declared itself untracked, so gating on the role would
+hand such a launch a lease it never asked for. The role decides whether the
+claim is well formed. `validateFlowLaunchRole` accepts any `Tracked()` role
+there, `RoleCreatePhase` included, because V7–V10 reach the tmux route as
+`RolePhaseResume` and naming `RoleTrackedPhase` alone would break them.
+
+Requiring well-formedness rather than the role alone is what keeps the
+migration behavior-preserving on the malformed shapes: a repair carrying phase
+markers, a phase-attached context that never set `FlowLaunchTracked`, and a
+repair that also sets the agent marker each name a role whose marker row they
+violate, so none of them prefills — which is what all four hand-written
+predicates answered by failing a conjunct. One shape does move: a repair or
+worktree agent whose `FlowID` is whitespace no longer prefills, because the role
+requires a Flow it can name where the old conjunct was an untrimmed
+`FlowID != ""`. No builder arm emits any of these. Their behavior at the seam,
+alongside all 17 reachable variants, the four non-Flow literals and the two
+probes, is pinned by `actions/flow_launch_role_seam_internal_test.go`.
 
 ### Field coverage check
 
@@ -271,20 +302,20 @@ headless (`model/tmux_mode.go:64`). Nothing states "auto ⇒ headless" as an
 invariant. Making auto launches interactive — a plausible future change — would
 turn every tmux-mode auto-advance into `invalid tracked Flow tmux launch role`.
 
-**F2 — closed on the model side by `approach-hyl.10`; the actions side is
-`approach-hyl.11`.** The eight model-side consumers no longer hand-write the
-role at all: they read `actions.FlowLaunchRoleOf`, whose precedence is stated
-once and tested against the builder. The three predicates below still live in
-`actions` and still disagree. The original finding, with its third predicate
-now historical:
-
-**The three hand-written role predicates disagree about which fields
-constitute a role.** `resumeSessionIDForContext` checks `FlowPhaseTerminal` and
-`InitialPrompt == ""`; `validateTrackedRepoTmuxRole` checks neither, but does
-check `FlowAutofixPRNumber != 0`; the autofix arm of
-`flowEmbeddedTerminalIdentity` used to check neither `FlowPhaseTerminal` nor
-`FlowAutoLaunch` — that arm is now the classifier's `RoleAutofix` case, so two
-of the three remain.
+**F2 — closed.** The model side closed with `approach-hyl.10` and the actions
+side with `approach-hyl.11`. Neither the eight model-side consumers nor the four
+actions-side ones hand-write the role any more: they read
+`actions.FlowLaunchRoleOf`, whose precedence is stated once and tested against
+the builder, and `actions.validateFlowLaunchRole`, whose per-role marker rows
+are section 3's table made executable. The original finding was that **the three
+hand-written role predicates disagreed about which fields constitute a role** —
+`resumeSessionIDForContext` checked `FlowPhaseTerminal` and
+`InitialPrompt == ""`, `validateTrackedRepoTmuxRole` checked neither but did
+check `FlowAutofixPRNumber != 0`, and the autofix arm of
+`flowEmbeddedTerminalIdentity` checked neither `FlowPhaseTerminal` nor
+`FlowAutoLaunch`. The marker half of that disagreement is now one answer; what
+each consumer still asks alone is transport and payload, which is a difference
+in what they need rather than a difference about what a role is.
 
 **F3 — `launchKind` classifies V17 and V7–V10 identically as `"resume"`**
 (`model/flow_launch_pin.go:132`), because it falls through on `ResumeSessionID`.


### PR DESCRIPTION
Four places in `actions` decided what a Flow launch is, and each one worked it out from scratch: four hand-written prefill predicates, a 13-conjunct ladder for saved-session resume, and a 10-conjunct ladder for the tracked tmux route. They did not agree on which fields constitute a role, so the same malformed launch context could read as a repair to one consumer and a phase launch to another.

All four now ask the classifier that `approach-hyl.10` put in place. `FlowLaunchRoleOf` answers which role a context names; the new `validateFlowLaunchRole` answers whether the context is a well-formed instance of that role, driven by per-role marker rows transcribed from the variant matrix — so `docs/flow-launch-variant-matrix.md` is now executable rather than prose. `FlowLaunchRole.Prefills` states which roles fill the embedded dock.

What stays beside the role at each call site is transport and payload the role deliberately does not carry: the docked providers and prompt for the prefill, `Embedded`/`Headless`/`InitialPrompt` for the resume, and `FlowAutoLaunch`/`Headless`/`FlowAutofixPRNumber` for the tmux route.

Both tmux gates keep reading `FlowLaunchTracked` rather than `role.Tracked()`. The marker is the launch's claim on the Flow lease, and the classifier names a phase-attached context a phase role even when it declared itself untracked — gating on the role would hand such a launch a lease it never asked for. The role decides whether the claim is well formed, and accepts any tracked role there because phase resume reaches tmux as V9/V10.

## Behavior

Requiring well-formedness rather than the role alone is what keeps this behavior-preserving on malformed shapes. A repair carrying phase markers, a phase-attached context missing the tracked marker, and a repair that also sets the agent marker each violate their role's marker row, so none prefills — which is exactly what the old predicates answered by failing a conjunct.

One unreachable shape moves: a repair or worktree agent whose Flow ID is whitespace no longer prefills. Provider argv and the exported `APPROACH_*` env are untouched.

## Verification

A new seam table drives all 17 reachable variants, the four non-Flow literals, the two routing probes, and eleven malformed marker combinations through all four consumers at once. `go test ./actions` passes.
