### PR TITLE
Fail the build when a Flow launch context is built outside the seam

### DIFF
--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -282,6 +282,12 @@ type flowSeamContextShapes struct {
 	// aliases are the qualified names declared as an alias of the launch
 	// context anywhere in the scan set.
 	aliases map[string]bool
+	// embeds is qualified owner type -> what it embeds anonymously, either
+	// the launch context itself (under flowSeamEmbeddedContext) or another
+	// qualified type. Go promotes an embedded context's fields, so
+	// `type wrapper struct{ actions.AgentLaunchContext }` makes
+	// `w.FlowID = "f"` a marker write on a launch context.
+	embeds map[string]map[string]bool
 }
 
 // flowSeamScope pairs the scan-set-wide shapes with the file the expressions
@@ -296,6 +302,7 @@ func newFlowSeamContextShapes() flowSeamContextShapes {
 		fields:  make(map[string]map[string]flowSeamKind),
 		results: make(map[string]map[int]flowSeamKind),
 		aliases: make(map[string]bool),
+		embeds:  make(map[string]map[string]bool),
 	}
 }
 
@@ -321,6 +328,39 @@ func (s flowSeamContextShapes) merge(other flowSeamContextShapes) {
 	for alias := range other.aliases {
 		s.aliases[alias] = true
 	}
+	for owner, embedded := range other.embeds {
+		if s.embeds[owner] == nil {
+			s.embeds[owner] = make(map[string]bool)
+		}
+		for name := range embedded {
+			s.embeds[owner][name] = true
+		}
+	}
+}
+
+// flowSeamEmbeddedContext is the embeds entry for a struct that embeds the
+// launch context itself rather than another named type.
+const flowSeamEmbeddedContext = "<launch context>"
+
+// promotesContext reports whether owner has the launch context's fields
+// promoted into it, directly or through a chain of embedded types.
+func (s flowSeamContextShapes) promotesContext(owner string, seen map[string]bool) bool {
+	if owner == "" || seen[owner] {
+		return false
+	}
+	seen[owner] = true
+	for embedded := range s.embeds[owner] {
+		if embedded == flowSeamEmbeddedContext || s.promotesContext(embedded, seen) {
+			return true
+		}
+	}
+	return false
+}
+
+// holdsContext reports whether a marker write on a value of this kind writes a
+// launch context: the value is one, or embeds one and has its fields promoted.
+func (scope flowSeamScope) holdsContext(kind flowSeamKind) bool {
+	return kind.context || scope.shapes.promotesContext(kind.named, make(map[string]bool))
 }
 
 func (s flowSeamContextShapes) contextFieldCount() int {
@@ -347,6 +387,22 @@ func (s flowSeamContextShapes) resultKinds(call *ast.CallExpr) map[int]flowSeamK
 	return nil
 }
 
+// flowSeamEmbeddedName is the field name Go gives an anonymous field: the base
+// name of its type.
+func flowSeamEmbeddedName(expr ast.Expr) string {
+	switch typ := expr.(type) {
+	case *ast.ParenExpr:
+		return flowSeamEmbeddedName(typ.X)
+	case *ast.StarExpr:
+		return flowSeamEmbeddedName(typ.X)
+	case *ast.Ident:
+		return typ.Name
+	case *ast.SelectorExpr:
+		return typ.Sel.Name
+	}
+	return ""
+}
+
 func flowSeamContextShapesOf(dir string, file *ast.File, aliases map[string]bool) flowSeamContextShapes {
 	shapes := newFlowSeamContextShapes()
 	for alias := range aliases {
@@ -366,11 +422,32 @@ func flowSeamContextShapesOf(dir string, file *ast.File, aliases map[string]bool
 				if !kind.known() {
 					continue
 				}
+				names := make([]string, 0, len(field.Names))
 				for _, name := range field.Names {
+					names = append(names, name.Name)
+				}
+				if len(names) == 0 {
+					// An embedded field is named after its type, and its own
+					// fields are promoted into the embedding struct.
+					embeddedName := flowSeamEmbeddedName(field.Type)
+					if embeddedName == "" {
+						continue
+					}
+					names = append(names, embeddedName)
+					if shapes.embeds[owner] == nil {
+						shapes.embeds[owner] = make(map[string]bool)
+					}
+					if kind.context {
+						shapes.embeds[owner][flowSeamEmbeddedContext] = true
+					} else if kind.named != "" {
+						shapes.embeds[owner][kind.named] = true
+					}
+				}
+				for _, name := range names {
 					if shapes.fields[owner] == nil {
 						shapes.fields[owner] = make(map[string]flowSeamKind)
 					}
-					shapes.fields[owner][name.Name] = kind
+					shapes.fields[owner][name] = kind
 				}
 			}
 		case *ast.FuncDecl:
@@ -639,7 +716,7 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers m
 				if !ok || !markers[selector.Sel.Name] {
 					continue
 				}
-				if flowSeamExprKind(selector.X, locals, scope).context {
+				if scope.holdsContext(flowSeamExprKind(selector.X, locals, scope)) {
 					record(selector.Sel.Name)
 				}
 			}
@@ -1097,6 +1174,58 @@ func unrelatedSharedOwnerName(e envelope) {
 type envelope struct {
 	Context actions.AgentLaunchContext
 }`}},
+			want: []string{},
+		},
+		"marker assigned on a promoted embedded launch context": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type wrapper struct {
+	actions.AgentLaunchContext
+}
+
+func viaEmbedding(w wrapper) {
+	w.FlowID = "f"
+}`,
+			want: []string{"viaEmbedding.FlowID"},
+		},
+		"marker assigned through a chain of embedded launch contexts": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type outerWrapper struct {
+	wrapper
+}
+
+func viaEmbeddingChain(o outerWrapper) {
+	o.FlowRepair = true
+}`,
+			neighbors: []flowSeamNeighbor{{source: `package model
+type wrapper struct {
+	actions.AgentLaunchContext
+}`}},
+			want: []string{"viaEmbeddingChain.FlowRepair"},
+		},
+		"marker assigned on the named embedded field": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type wrapper struct {
+	actions.AgentLaunchContext
+}
+
+func viaEmbeddedFieldName(w wrapper) {
+	w.AgentLaunchContext.FlowAgent = true
+}`,
+			want: []string{"viaEmbeddedFieldName.FlowAgent"},
+		},
+		"marker-named field on a struct embedding something else": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type plainWrapper struct {
+	otherpkg.Thing
+}
+
+func unrelatedEmbedding(w plainWrapper) {
+	w.FlowID = "f"
+}`,
 			want: []string{},
 		},
 		"marker assigned through a slice element": {

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -88,12 +88,73 @@ func flowSeamLaunchContextLit(expr ast.Expr) *ast.CompositeLit {
 	return nil
 }
 
+// flowSeamContextFieldNames collects every struct field in file whose declared
+// type is an AgentLaunchContext. A marker written through such a field —
+// `msg.LaunchContext.FlowRepair = true` — builds Flow launch identity just as
+// surely as a write to a local, so the detector needs the field names to tell
+// those apart from a same-named field on an unrelated struct.
+func flowSeamContextFieldNames(file *ast.File) map[string]bool {
+	fields := make(map[string]bool)
+	ast.Inspect(file, func(n ast.Node) bool {
+		structType, ok := n.(*ast.StructType)
+		if !ok || structType.Fields == nil {
+			return true
+		}
+		for _, field := range structType.Fields.List {
+			if !flowSeamIsLaunchContextType(field.Type) {
+				continue
+			}
+			for _, name := range field.Names {
+				fields[name.Name] = true
+			}
+		}
+		return true
+	})
+	return fields
+}
+
+// flowSeamLaunchContextExpr reports whether expr provably yields a launch
+// context: a literal, a name already known to hold one, or a read of a struct
+// field declared as one, through any number of parentheses, address-of, and
+// dereference wrappers.
+func flowSeamLaunchContextExpr(expr ast.Expr, names, fields map[string]bool) bool {
+	if flowSeamLaunchContextLit(expr) != nil {
+		return true
+	}
+	switch expr := expr.(type) {
+	case *ast.ParenExpr:
+		return flowSeamLaunchContextExpr(expr.X, names, fields)
+	case *ast.StarExpr:
+		return flowSeamLaunchContextExpr(expr.X, names, fields)
+	case *ast.UnaryExpr:
+		if expr.Op == token.AND {
+			return flowSeamLaunchContextExpr(expr.X, names, fields)
+		}
+	case *ast.Ident:
+		return names[expr.Name]
+	case *ast.SelectorExpr:
+		return fields[expr.Sel.Name]
+	}
+	return false
+}
+
 // flowSeamLaunchContextNames collects every identifier in node that is
 // provably an AgentLaunchContext: parameters and results of the function and
-// of any closure inside it, `var` declarations, and `:=` bindings of a launch
-// context literal.
-func flowSeamLaunchContextNames(node ast.Node) map[string]bool {
+// of any closure inside it, `var` declarations, and bindings of a launch
+// context literal, of another such name, or of a launch context struct field.
+// Aliases chain, so the walk repeats until it stops learning names.
+func flowSeamLaunchContextNames(node ast.Node, fields map[string]bool) map[string]bool {
 	names := make(map[string]bool)
+	for {
+		before := len(names)
+		flowSeamCollectLaunchContextNames(node, names, fields)
+		if len(names) == before {
+			return names
+		}
+	}
+}
+
+func flowSeamCollectLaunchContextNames(node ast.Node, names, fields map[string]bool) {
 	addFields := func(fields *ast.FieldList) {
 		if fields == nil {
 			return
@@ -127,13 +188,13 @@ func flowSeamLaunchContextNames(node ast.Node) map[string]bool {
 				}
 			}
 			for index, value := range n.Values {
-				if flowSeamLaunchContextLit(value) != nil && index < len(n.Names) {
+				if index < len(n.Names) && flowSeamLaunchContextExpr(value, names, fields) {
 					names[n.Names[index].Name] = true
 				}
 			}
 		case *ast.AssignStmt:
 			for index, value := range n.Rhs {
-				if index >= len(n.Lhs) || flowSeamLaunchContextLit(value) == nil {
+				if index >= len(n.Lhs) || !flowSeamLaunchContextExpr(value, names, fields) {
 					continue
 				}
 				if ident, ok := n.Lhs[index].(*ast.Ident); ok {
@@ -143,14 +204,13 @@ func flowSeamLaunchContextNames(node ast.Node) map[string]bool {
 		}
 		return true
 	})
-	return names
 }
 
 // flowSeamNodeViolations reports marker fields set within one declaration:
 // keys on a launch context literal, and assignments to a marker field of a
 // name that is provably a launch context.
-func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers map[string]bool) []flowSeamViolation {
-	locals := flowSeamLaunchContextNames(node)
+func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers, fields map[string]bool) []flowSeamViolation {
+	locals := flowSeamLaunchContextNames(node, fields)
 	var violations []flowSeamViolation
 	record := func(field string) {
 		violations = append(violations, flowSeamViolation{Dir: dir, File: file, Func: function, Field: field})
@@ -177,8 +237,7 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers m
 				if !ok || !markers[selector.Sel.Name] {
 					continue
 				}
-				base, ok := selector.X.(*ast.Ident)
-				if ok && locals[base.Name] {
+				if flowSeamLaunchContextExpr(selector.X, locals, fields) {
 					record(selector.Sel.Name)
 				}
 			}
@@ -191,7 +250,7 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers m
 // flowSeamViolations reports every marker field set on a launch context in one
 // file, attributed to its enclosing top-level function. The launch module
 // itself is exempt.
-func flowSeamViolations(dir, name string, file *ast.File, markers map[string]bool) []flowSeamViolation {
+func flowSeamViolations(dir, name string, file *ast.File, markers, fields map[string]bool) []flowSeamViolation {
 	if dir == "model" && name == flowSeamLaunchContextExemptFile {
 		return nil
 	}
@@ -199,7 +258,7 @@ func flowSeamViolations(dir, name string, file *ast.File, markers map[string]boo
 	for _, declaration := range file.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
 		if !ok {
-			violations = append(violations, flowSeamNodeViolations(dir, name, "", declaration, markers)...)
+			violations = append(violations, flowSeamNodeViolations(dir, name, "", declaration, markers, fields)...)
 			continue
 		}
 		if function.Body == nil {
@@ -211,7 +270,7 @@ func flowSeamViolations(dir, name string, file *ast.File, markers map[string]boo
 				label = receiver + "." + label
 			}
 		}
-		violations = append(violations, flowSeamNodeViolations(dir, name, label, function, markers)...)
+		violations = append(violations, flowSeamNodeViolations(dir, name, label, function, markers, fields)...)
 	}
 	return violations
 }
@@ -262,7 +321,7 @@ func flowSeamViolationsForSource(t *testing.T, dir, name, source string) []strin
 	if err != nil {
 		t.Fatalf("parse %s: %v", name, err)
 	}
-	found := flowSeamViolations(dir, name, file, flowSeamMarkerFields())
+	found := flowSeamViolations(dir, name, file, flowSeamMarkerFields(), flowSeamContextFieldNames(file))
 	reported := make([]string, 0, len(found))
 	for _, violation := range found {
 		reported = append(reported, violation.Func+"."+violation.Field)
@@ -353,6 +412,60 @@ func build() AgentLaunchContext {
 var seed = actions.AgentLaunchContext{FlowAutofix: true}`,
 			want: []string{".FlowAutofix"},
 		},
+		"marker assigned through an alias of a launch context": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func aliased(ctx actions.AgentLaunchContext) {
+	alias := ctx
+	alias.FlowRepair = true
+}`,
+			want: []string{"aliased.FlowRepair"},
+		},
+		"marker assigned through a launch context struct field": {
+			dir: "model", name: "messages.go",
+			source: `package model
+type launchMsg struct {
+	LaunchContext actions.AgentLaunchContext
+}
+
+func nested(msg launchMsg) {
+	msg.LaunchContext.FlowPhaseKind = "review"
+}`,
+			want: []string{"nested.FlowPhaseKind"},
+		},
+		"marker assigned through a pointer dereference": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func deref(ctx *actions.AgentLaunchContext) {
+	(*ctx).FlowLaunchTracked = true
+}`,
+			want: []string{"deref.FlowLaunchTracked"},
+		},
+		"marker assigned on an alias of a launch context field": {
+			dir: "model", name: "messages.go",
+			source: `package model
+type launchMsg struct {
+	LaunchContext actions.AgentLaunchContext
+}
+
+func copied(msg launchMsg) {
+	ctx := msg.LaunchContext
+	ctx.FlowID = "f"
+}`,
+			want: []string{"copied.FlowID"},
+		},
+		"same-named field on an unrelated nested struct": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type decoy struct {
+	LaunchContext otherpkg.Context
+}
+
+func unrelatedNested(d decoy) {
+	d.LaunchContext.FlowID = "f"
+}`,
+			want: []string{},
+		},
 		"builder-wrapped literal is still inspected": {
 			dir: "model", name: "ready_bead_slice.go",
 			source: `package model
@@ -409,6 +522,17 @@ func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
 	fset := token.NewFileSet()
 	matched := make(map[flowSeamAllowance]bool)
 	var offenders []string
+
+	// Two passes: the struct fields that hold a launch context are declared in
+	// one file and written through in another, so the whole scan set has to be
+	// parsed before any of it can be judged.
+	type flowSeamSourceFile struct {
+		dir  string
+		name string
+		file *ast.File
+	}
+	var sources []flowSeamSourceFile
+	fields := make(map[string]bool)
 	for _, dir := range sortedKeys(flowSeamScanDirs()) {
 		path := flowSeamScanDirs()[dir]
 		entries, err := os.ReadDir(path)
@@ -424,14 +548,23 @@ func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parse %s/%s: %v", dir, name, err)
 			}
-			for _, violation := range flowSeamViolations(dir, name, file, markers) {
-				allowance := flowSeamAllowance{Dir: violation.Dir, File: violation.File, Func: violation.Func}
-				if _, allowed := flowSeamAllowList[allowance]; allowed {
-					matched[allowance] = true
-					continue
-				}
-				offenders = append(offenders, violation.String())
+			sources = append(sources, flowSeamSourceFile{dir: dir, name: name, file: file})
+			for field := range flowSeamContextFieldNames(file) {
+				fields[field] = true
 			}
+		}
+	}
+	if len(fields) == 0 {
+		t.Fatal("no struct field of type actions.AgentLaunchContext found; the nested-field half of the seam rule is scanning nothing")
+	}
+	for _, source := range sources {
+		for _, violation := range flowSeamViolations(source.dir, source.name, source.file, markers, fields) {
+			allowance := flowSeamAllowance{Dir: violation.Dir, File: violation.File, Func: violation.Func}
+			if _, allowed := flowSeamAllowList[allowance]; allowed {
+				matched[allowance] = true
+				continue
+			}
+			offenders = append(offenders, violation.String())
 		}
 	}
 	sort.Strings(offenders)

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -641,7 +641,14 @@ func flowSeamExprKindRaw(expr ast.Expr, locals *flowSeamLocals, scope flowSeamSc
 			return flowSeamKind{context: true}
 		}
 	case *ast.CallExpr:
-		return scope.shapes.resultKinds(expr)[0]
+		if kind, ok := scope.shapes.resultKinds(expr)[0]; ok {
+			return kind
+		}
+		// A conversion is spelled like a call: `localContext(base)` yields
+		// whatever localContext was defined as.
+		if len(expr.Args) == 1 {
+			return flowSeamTypeKind(expr.Fun, scope.file)
+		}
 	}
 	return flowSeamKind{}
 }
@@ -1135,6 +1142,18 @@ func viaHelperCollection() {
 	contexts[0].FlowRepair = true
 }`,
 			want: []string{"viaHelperCollection.FlowRepair"},
+		},
+		"marker assigned on a converted launch context": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type localContext actions.AgentLaunchContext
+
+func viaConversion(base actions.AgentLaunchContext) actions.AgentLaunchContext {
+	ctx := localContext(base)
+	ctx.FlowRepair = true
+	return actions.AgentLaunchContext(ctx)
+}`,
+			want: []string{"viaConversion.FlowRepair"},
 		},
 		"marker assigned on a helper-returned embedding wrapper": {
 			dir: "model", name: "keys.go",

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -849,6 +849,17 @@ func flowSeamViolations(dir, name string, file *ast.File, markers map[string]boo
 	return violations
 }
 
+// The rule guards the Flow* markers and not ResumeSessionID or PlanPhaseID,
+// the two fields FlowLaunchRoleOf also reads. Those two discriminate only
+// among the phase roles, which the ladder reaches only once FlowID and
+// FlowPhaseID are both set — and both of those are guarded markers. So no code
+// outside the launch module can name a phase role with them; it could only
+// re-point a context the builder already built, which is the mutation class
+// flowLaunchContextRequiresLifecycle and the Flow reservation refuse at
+// runtime. Guarding them here instead would fail the two legitimate non-Flow
+// launches that set them — saved-session resume and plans-mode implement,
+// neither of which touches a Flow — and buying that with standing allow-list
+// exemptions would cost more of the rule than it adds.
 func flowSeamMarkerFields() map[string]bool {
 	markers := make(map[string]bool)
 	structType := reflect.TypeOf(actions.AgentLaunchContext{})

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -272,12 +272,13 @@ type flowSeamContextShapes struct {
 	// `LaunchContext` field from either failing the guard or hiding a real
 	// violation.
 	fields map[string]map[string]flowSeamKind
-	// results maps a function name to the indices of its results that are
-	// launch contexts, so `ctx := makeContext(); ctx.FlowRepair = true` is
-	// caught the same way a literal binding is. Receivers and packages are
-	// ignored here: a call is resolved by name only, and conflating two
-	// same-named functions only makes the seam rule stricter.
-	results map[string]map[int]bool
+	// results maps a function name to what each of its results holds, so
+	// `ctx := makeContext(); ctx.FlowRepair = true` is caught the same way a
+	// literal binding is, and a helper handing back a slice or map of contexts
+	// is followed into its elements. Receivers and packages are ignored here:
+	// a call is resolved by name only, and conflating two same-named functions
+	// only makes the seam rule stricter.
+	results map[string]map[int]flowSeamKind
 	// aliases are the qualified names declared as an alias of the launch
 	// context anywhere in the scan set.
 	aliases map[string]bool
@@ -293,7 +294,7 @@ type flowSeamScope struct {
 func newFlowSeamContextShapes() flowSeamContextShapes {
 	return flowSeamContextShapes{
 		fields:  make(map[string]map[string]flowSeamKind),
-		results: make(map[string]map[int]bool),
+		results: make(map[string]map[int]flowSeamKind),
 		aliases: make(map[string]bool),
 	}
 }
@@ -307,12 +308,14 @@ func (s flowSeamContextShapes) merge(other flowSeamContextShapes) {
 			s.fields[owner][name] = kind
 		}
 	}
-	for name, indices := range other.results {
+	for name, kinds := range other.results {
 		if s.results[name] == nil {
-			s.results[name] = make(map[int]bool)
+			s.results[name] = make(map[int]flowSeamKind)
 		}
-		for index := range indices {
-			s.results[name][index] = true
+		for index, kind := range kinds {
+			if flowSeamKindRank(kind) > flowSeamKindRank(s.results[name][index]) {
+				s.results[name][index] = kind
+			}
 		}
 	}
 	for alias := range other.aliases {
@@ -332,9 +335,9 @@ func (s flowSeamContextShapes) contextFieldCount() int {
 	return count
 }
 
-// resultIndices reports which results of the called function are launch
-// contexts, for a call whose callee is a plain name or a method selector.
-func (s flowSeamContextShapes) resultIndices(call *ast.CallExpr) map[int]bool {
+// resultKinds reports what each result of the called function holds, for a
+// call whose callee is a plain name or a method selector.
+func (s flowSeamContextShapes) resultKinds(call *ast.CallExpr) map[int]flowSeamKind {
 	switch fn := call.Fun.(type) {
 	case *ast.Ident:
 		return s.results[fn.Name]
@@ -374,22 +377,23 @@ func flowSeamContextShapesOf(dir string, file *ast.File, aliases map[string]bool
 			if n.Type == nil || n.Type.Results == nil {
 				return true
 			}
-			indices := make(map[int]bool)
+			kinds := make(map[int]flowSeamKind)
 			position := 0
 			for _, result := range n.Type.Results.List {
 				count := len(result.Names)
 				if count == 0 {
 					count = 1
 				}
-				if flowSeamIsLaunchContextType(result.Type, scope) {
+				kind := flowSeamTypeKind(result.Type, scope)
+				if kind.context || kind.collection {
 					for offset := 0; offset < count; offset++ {
-						indices[position+offset] = true
+						kinds[position+offset] = kind
 					}
 				}
 				position += count
 			}
-			if len(indices) > 0 {
-				shapes.results[n.Name.Name] = indices
+			if len(kinds) > 0 {
+				shapes.results[n.Name.Name] = kinds
 			}
 		}
 		return true
@@ -480,9 +484,7 @@ func flowSeamExprKind(expr ast.Expr, locals *flowSeamLocals, scope flowSeamScope
 			return flowSeamKind{context: true}
 		}
 	case *ast.CallExpr:
-		if scope.shapes.resultIndices(expr)[0] {
-			return flowSeamKind{context: true}
-		}
+		return scope.shapes.resultKinds(expr)[0]
 	}
 	return flowSeamKind{}
 }
@@ -503,9 +505,9 @@ func flowSeamLaunchContextNames(node ast.Node, scope flowSeamScope) *flowSeamLoc
 	}
 }
 
-// flowSeamBindCallResults records the names on the left of a single-call
-// assignment whose matching result is a launch context, covering the
-// multi-result `ctx, decision, err := build()` shape as well as the single one.
+// flowSeamBindCallResults records what the names on the left of a single-call
+// assignment hold, covering the multi-result `ctx, decision, err := build()`
+// shape as well as the single one.
 func flowSeamBindCallResults(lhs, rhs []ast.Expr, locals *flowSeamLocals, scope flowSeamScope) {
 	if len(rhs) != 1 {
 		return
@@ -514,13 +516,10 @@ func flowSeamBindCallResults(lhs, rhs []ast.Expr, locals *flowSeamLocals, scope 
 	if !ok {
 		return
 	}
-	indices := scope.shapes.resultIndices(call)
+	kinds := scope.shapes.resultKinds(call)
 	for index, target := range lhs {
-		if !indices[index] {
-			continue
-		}
 		if ident, ok := target.(*ast.Ident); ok {
-			locals.learn(ident.Name, flowSeamKind{context: true})
+			locals.learn(ident.Name, kinds[index])
 		}
 	}
 }
@@ -965,6 +964,19 @@ func viaHelper() {
 	ctx.FlowRepair = true
 }`,
 			want: []string{"viaHelper.FlowRepair"},
+		},
+		"marker assigned through a helper-returned collection": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func makeContexts() []actions.AgentLaunchContext {
+	return nil
+}
+
+func viaHelperCollection() {
+	contexts := makeContexts()
+	contexts[0].FlowRepair = true
+}`,
+			want: []string{"viaHelperCollection.FlowRepair"},
 		},
 		"marker assigned on a multi-result helper context": {
 			dir: "model", name: "keys.go",

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -758,13 +758,22 @@ func flowSeamCollectLaunchContextNames(node ast.Node, locals *flowSeamLocals, sc
 	})
 }
 
+// flowSeamPositionalLiteral is what an unkeyed launch context literal is
+// reported as, since it sets marker fields without naming any.
+const flowSeamPositionalLiteral = "(positional literal)"
+
 // flowSeamLiteralMarkers records every marker field keyed in one launch
-// context literal.
+// context literal, and reports an unkeyed literal outright.
 func flowSeamLiteralMarkers(lit *ast.CompositeLit, markers map[string]bool, record func(string)) {
 	for _, element := range lit.Elts {
 		pair, ok := element.(*ast.KeyValueExpr)
 		if !ok {
-			continue
+			// An unkeyed literal fills the fields by position, markers
+			// included, and names none of them. There is no legitimate reason
+			// to spell a launch context that way, so the literal itself is the
+			// violation.
+			record(flowSeamPositionalLiteral)
+			return
 		}
 		if key, ok := pair.Key.(*ast.Ident); ok && markers[key.Name] {
 			record(key.Name)
@@ -776,6 +785,15 @@ func flowSeamLiteralMarkers(lit *ast.CompositeLit, markers map[string]bool, reco
 // keys on a launch context literal, including the elided element literals of a
 // slice or map of contexts, and assignments to a marker field of any
 // expression that provably yields a launch context.
+// flowSeamRoleDiscriminators are the two non-marker fields FlowLaunchRoleOf
+// reads. Writing one into a fresh context is how the legitimate non-Flow
+// launches are built, so only a mutation counts: re-pointing a context that
+// already exists is how a tracked phase silently becomes a phase resume, and
+// every runtime check downstream accepts the result as well-formed.
+func flowSeamRoleDiscriminators() map[string]bool {
+	return map[string]bool{"ResumeSessionID": true, "PlanPhaseID": true}
+}
+
 func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers map[string]bool, scope flowSeamScope) []flowSeamViolation {
 	locals := flowSeamLaunchContextNames(node, scope)
 	var violations []flowSeamViolation
@@ -805,9 +823,10 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers m
 				}
 			}
 		case *ast.AssignStmt:
+			mutated := flowSeamRoleDiscriminators()
 			for _, target := range n.Lhs {
 				selector, ok := target.(*ast.SelectorExpr)
-				if !ok || !markers[selector.Sel.Name] {
+				if !ok || !(markers[selector.Sel.Name] || mutated[selector.Sel.Name]) {
 					continue
 				}
 				if scope.holdsContext(flowSeamExprKind(selector.X, locals, scope)) {
@@ -849,17 +868,12 @@ func flowSeamViolations(dir, name string, file *ast.File, markers map[string]boo
 	return violations
 }
 
-// The rule guards the Flow* markers and not ResumeSessionID or PlanPhaseID,
-// the two fields FlowLaunchRoleOf also reads. Those two discriminate only
-// among the phase roles, which the ladder reaches only once FlowID and
-// FlowPhaseID are both set — and both of those are guarded markers. So no code
-// outside the launch module can name a phase role with them; it could only
-// re-point a context the builder already built, which is the mutation class
-// flowLaunchContextRequiresLifecycle and the Flow reservation refuse at
-// runtime. Guarding them here instead would fail the two legitimate non-Flow
-// launches that set them — saved-session resume and plans-mode implement,
-// neither of which touches a Flow — and buying that with standing allow-list
-// exemptions would cost more of the rule than it adds.
+// flowSeamMarkerFields derives the guarded marker set from the struct itself.
+// The other two fields FlowLaunchRoleOf reads, ResumeSessionID and
+// PlanPhaseID, are guarded separately by flowSeamRoleDiscriminators: they name
+// a role only alongside a marker, so writing one into a fresh context builds
+// the legitimate non-Flow launches, and only mutating one on a context that
+// already exists re-points a role.
 func flowSeamMarkerFields() map[string]bool {
 	markers := make(map[string]bool)
 	structType := reflect.TypeOf(actions.AgentLaunchContext{})
@@ -1177,6 +1191,30 @@ func viaMake() {
 	contexts[0].FlowID = "f"
 }`,
 			want: []string{"viaMake.FlowID"},
+		},
+		"unkeyed launch context literal": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func positional() {
+	_ = actions.AgentLaunchContext{"cmd", "launch"}
+}`,
+			want: []string{"positional.(positional literal)"},
+		},
+		"role discriminator mutated on an existing context": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func repoint(ctx actions.AgentLaunchContext) {
+	ctx.ResumeSessionID = "session"
+}`,
+			want: []string{"repoint.ResumeSessionID"},
+		},
+		"role discriminator keyed in a literal": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func fresh() {
+	_ = actions.AgentLaunchContext{ResumeSessionID: "session"}
+}`,
+			want: []string{},
 		},
 		"marker assigned on a converted launch context": {
 			dir: "model", name: "keys.go",
@@ -1516,25 +1554,32 @@ func slice() {
 // flowSeamAllowance names a function outside the launch module that may set
 // Flow markers on a launch context.
 type flowSeamAllowance struct {
-	Dir  string
-	File string
-	Func string
+	Dir   string
+	File  string
+	Func  string
+	Field string
 }
 
-// flowSeamAllowList is keyed by function rather than by file:line so that an
-// unrelated edit above the literal does not re-pin the guard. Each of these
-// addresses a launch record that already exists; neither starts a process, so
-// neither is a launch the role builder could have built.
+// flowSeamAllowList is keyed by function and field rather than by file:line, so
+// that an unrelated edit above the literal does not re-pin the guard and an
+// allowance for one field does not quietly cover the rest. The two Flow-marked
+// entries address a launch record that already exists; neither starts a
+// process, so neither is a launch the role builder could have built. The
+// plans-mode entry sets a role discriminator on a context with no Flow marker
+// on it, so there is no Flow role for it to change.
 //
-// The four remaining out-of-module AgentLaunchContext constructors — the
-// Ready-Bead `S` slice, plans-mode implement, worktree `a`, and non-Flow
-// session resume — need no entry: they set no Flow marker at all, which is
-// exactly what keeps flowLaunchContextRequiresLifecycle false for them. An
-// allow-list entry there would be dead configuration granting a standing
-// exemption, so the stale-entry check below would rightly fail on it.
+// The other out-of-module AgentLaunchContext constructors — the Ready-Bead `S`
+// slice, worktree `a`, and non-Flow session resume — need no entry: they set no
+// guarded field at all, which is exactly what keeps
+// flowLaunchContextRequiresLifecycle false for them. An allow-list entry there
+// would be dead configuration granting a standing exemption, so the
+// stale-entry check below would rightly fail on it.
 var flowSeamAllowList = map[flowSeamAllowance]string{
-	{Dir: "model", File: "flow_launch_lifecycle.go", Func: "Model.blockAutoFlowLaunchPhase"}:   "Synthesizes a failure context addressing the launch attempt that already failed; there is no process to start.",
-	{Dir: "model", File: "flow_session_release.go", Func: "Model.releaseFlowPhaseSessionsCmd"}: "Finalizes the hook records of launches that already ran and are being released.",
+	{Dir: "model", File: "flow_launch_lifecycle.go", Func: "Model.blockAutoFlowLaunchPhase", Field: "FlowID"}:        "Synthesizes a failure context addressing the launch attempt that already failed; there is no process to start.",
+	{Dir: "model", File: "flow_launch_lifecycle.go", Func: "Model.blockAutoFlowLaunchPhase", Field: "FlowPhaseID"}:   "Synthesizes a failure context addressing the launch attempt that already failed; there is no process to start.",
+	{Dir: "model", File: "flow_session_release.go", Func: "Model.releaseFlowPhaseSessionsCmd", Field: "FlowID"}:      "Finalizes the hook records of launches that already ran and are being released.",
+	{Dir: "model", File: "flow_session_release.go", Func: "Model.releaseFlowPhaseSessionsCmd", Field: "FlowPhaseID"}: "Finalizes the hook records of launches that already ran and are being released.",
+	{Dir: "model", File: "model_keys.go", Func: "Model.planLaunchContext", Field: "PlanPhaseID"}:                     "Fills in the selected phase of a plans-mode launch that carries no Flow marker, so it names no Flow role to change.",
 }
 
 // flowSeamScanRoot is the repository root, reached from the model package.
@@ -1641,7 +1686,7 @@ func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
 	}
 	for _, source := range sources {
 		for _, violation := range flowSeamViolations(source.dir, source.name, source.file, markers, shapes) {
-			allowance := flowSeamAllowance{Dir: violation.Dir, File: violation.File, Func: violation.Func}
+			allowance := flowSeamAllowance{Dir: violation.Dir, File: violation.File, Func: violation.Func, Field: violation.Field}
 			if _, allowed := flowSeamAllowList[allowance]; allowed {
 				matched[allowance] = true
 				continue
@@ -1658,8 +1703,8 @@ func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
 	}
 	for allowance := range flowSeamAllowList {
 		if !matched[allowance] {
-			t.Errorf("stale Flow seam allow-list entry: %s/%s %s sets no Flow marker; delete the entry",
-				allowance.Dir, allowance.File, allowance.Func)
+			t.Errorf("stale Flow seam allow-list entry: %s/%s %s never sets %s; delete the entry",
+				allowance.Dir, allowance.File, allowance.Func, allowance.Field)
 		}
 	}
 }

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -282,6 +282,11 @@ type flowSeamContextShapes struct {
 	// aliases are the qualified names declared as an alias of the launch
 	// context anywhere in the scan set.
 	aliases map[string]bool
+	// underlying is qualified named type -> what defining it actually made,
+	// for `type launchContexts []actions.AgentLaunchContext` and friends. A
+	// defined type has the launch context's fields, so a marker write through
+	// one is a marker write.
+	underlying map[string]flowSeamKind
 	// embeds is qualified owner type -> what it embeds anonymously, either
 	// the launch context itself (under flowSeamEmbeddedContext) or another
 	// qualified type. Go promotes an embedded context's fields, so
@@ -303,6 +308,8 @@ func newFlowSeamContextShapes() flowSeamContextShapes {
 		results: make(map[string]map[int]flowSeamKind),
 		aliases: make(map[string]bool),
 		embeds:  make(map[string]map[string]bool),
+
+		underlying: make(map[string]flowSeamKind),
 	}
 }
 
@@ -327,6 +334,11 @@ func (s flowSeamContextShapes) merge(other flowSeamContextShapes) {
 	}
 	for alias := range other.aliases {
 		s.aliases[alias] = true
+	}
+	for named, kind := range other.underlying {
+		if flowSeamKindRank(kind) > flowSeamKindRank(s.underlying[named]) {
+			s.underlying[named] = kind
+		}
 	}
 	for owner, embedded := range other.embeds {
 		if s.embeds[owner] == nil {
@@ -357,10 +369,33 @@ func (s flowSeamContextShapes) promotesContext(owner string, seen map[string]boo
 	return false
 }
 
+// resolveKind follows a named type to what defining it actually made, so
+// `type launchContexts []actions.AgentLaunchContext` reads as a collection
+// wherever one of its values appears.
+func (scope flowSeamScope) resolveKind(kind flowSeamKind) flowSeamKind {
+	seen := make(map[string]bool)
+	for kind.named != "" && !kind.context && !kind.collection {
+		if seen[kind.named] {
+			break
+		}
+		seen[kind.named] = true
+		resolved, ok := scope.shapes.underlying[kind.named]
+		if !ok {
+			break
+		}
+		kind = resolved
+	}
+	return kind
+}
+
 // holdsContext reports whether a marker write on a value of this kind writes a
-// launch context: the value is one, or embeds one and has its fields promoted.
+// launch context: the value is one, was defined as one, or embeds one and has
+// its fields promoted.
 func (scope flowSeamScope) holdsContext(kind flowSeamKind) bool {
-	return kind.context || scope.shapes.promotesContext(kind.named, make(map[string]bool))
+	if scope.resolveKind(kind).context {
+		return true
+	}
+	return scope.shapes.promotesContext(kind.named, make(map[string]bool))
 }
 
 func (s flowSeamContextShapes) contextFieldCount() int {
@@ -412,6 +447,11 @@ func flowSeamContextShapesOf(dir string, file *ast.File, aliases map[string]bool
 	ast.Inspect(file, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.TypeSpec:
+			if !n.Assign.IsValid() {
+				if kind := flowSeamTypeKind(n.Type, scope); kind.context || kind.collection {
+					shapes.underlying[flowSeamQualify(dir, n.Name.Name)] = kind
+				}
+			}
 			structType, ok := n.Type.(*ast.StructType)
 			if !ok || structType.Fields == nil {
 				return true
@@ -534,6 +574,10 @@ func flowSeamKindRank(kind flowSeamKind) int {
 // parentheses, address-of, and dereference. It reads syntax, not types, so an
 // expression it cannot place comes back unknown rather than guessed at.
 func flowSeamExprKind(expr ast.Expr, locals *flowSeamLocals, scope flowSeamScope) flowSeamKind {
+	return scope.resolveKind(flowSeamExprKindRaw(expr, locals, scope))
+}
+
+func flowSeamExprKindRaw(expr ast.Expr, locals *flowSeamLocals, scope flowSeamScope) flowSeamKind {
 	if flowSeamLaunchContextLit(expr, scope.file) != nil {
 		return flowSeamKind{context: true}
 	}
@@ -692,11 +736,12 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers m
 	ast.Inspect(node, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.CompositeLit:
-			if flowSeamIsLaunchContextType(n.Type, scope.file) {
+			kind := scope.resolveKind(flowSeamTypeKind(n.Type, scope.file))
+			if kind.context {
 				flowSeamLiteralMarkers(n, markers, record)
 				return true
 			}
-			if !flowSeamTypeKind(n.Type, scope.file).collection {
+			if !kind.collection {
 				return true
 			}
 			// `[]actions.AgentLaunchContext{{FlowRepair: true}}`: the element
@@ -1175,6 +1220,36 @@ type envelope struct {
 	Context actions.AgentLaunchContext
 }`}},
 			want: []string{},
+		},
+		"marker assigned through a named collection type": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type launchContexts []actions.AgentLaunchContext
+
+func viaNamedCollection(xs launchContexts) {
+	xs[0].FlowRepair = true
+}`,
+			want: []string{"viaNamedCollection.FlowRepair"},
+		},
+		"marker keyed in a named collection literal": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type launchContexts []actions.AgentLaunchContext
+
+func inNamedCollectionLiteral() {
+	_ = launchContexts{{FlowAgent: true}}
+}`,
+			want: []string{"inNamedCollectionLiteral.FlowAgent"},
+		},
+		"marker assigned on a defined launch context type": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type definedContext actions.AgentLaunchContext
+
+func viaDefinedType(ctx definedContext) {
+	ctx.FlowPhaseTerminal = true
+}`,
+			want: []string{"viaDefinedType.FlowPhaseTerminal"},
 		},
 		"marker assigned on a promoted embedded launch context": {
 			dir: "model", name: "keys.go",

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -51,41 +51,134 @@ func (v flowSeamViolation) String() string {
 	return fmt.Sprintf("%s/%s: %s sets %s", v.Dir, v.File, where, v.Field)
 }
 
-// flowSeamActionsImportPath is the package the launch context type lives in.
-const flowSeamActionsImportPath = "github.com/approachcontrol/approach/actions"
+// flowSeamModulePath is this repository's module path, and
+// flowSeamActionsImportPath the package the launch context type lives in.
+const (
+	flowSeamModulePath         = "github.com/approachcontrol/approach"
+	flowSeamActionsImportPath  = flowSeamModulePath + "/actions"
+	flowSeamLaunchContextIdent = "AgentLaunchContext"
+)
 
-// flowSeamActionsNames is every identifier that names the actions package in
-// file: whatever its import declares it as, since `import act ".../actions"`
-// spells the same type `act.AgentLaunchContext`. The unaliased name is always
-// included so a source fragment without imports still reads normally.
-func flowSeamActionsNames(file *ast.File) map[string]bool {
-	names := map[string]bool{"actions": true}
-	for _, imported := range file.Imports {
-		path, err := strconv.Unquote(imported.Path.Value)
-		if err != nil || path != flowSeamActionsImportPath {
-			continue
-		}
-		if imported.Name != nil && imported.Name.Name != "_" && imported.Name.Name != "." {
-			names[imported.Name.Name] = true
-		}
-	}
-	return names
+// flowSeamFile is everything about one file that a type expression in it has
+// to be read against.
+type flowSeamFile struct {
+	// dir is the file's package directory, relative to the repository root.
+	// It qualifies every named type the file declares or spells, so two
+	// packages that happen to share a struct name stay distinct.
+	dir string
+	// pkgs are the identifiers that name the actions package here, since
+	// `import act ".../actions"` spells the same type `act.AgentLaunchContext`.
+	pkgs map[string]bool
+	// imports maps a package identifier to the repository directory it refers
+	// to, for imports of this module, so `msgs.Envelope` qualifies too.
+	imports map[string]string
+	// aliases are the qualified names of declared aliases of the launch
+	// context — `type launchContext = actions.AgentLaunchContext` — which are
+	// that exact type and so must classify as one. Collected across the whole
+	// scan set, since an alias is declared in one file and used in another.
+	aliases map[string]bool
 }
 
-// flowSeamIsLaunchContextType matches the two syntactic spellings of the type:
-// a qualified actions.AgentLaunchContext under whatever name the file imports
-// the actions package as, and the bare ident from inside actions itself.
-func flowSeamIsLaunchContextType(expr ast.Expr, pkgs map[string]bool) bool {
+// flowSeamQualify names a type by the package directory that declares it.
+func flowSeamQualify(dir, name string) string {
+	if dir == "" || name == "" {
+		return ""
+	}
+	return dir + "." + name
+}
+
+// flowSeamDirForImportPath maps an import path of this module to the
+// repository directory it lives in, and returns "" for anything external.
+func flowSeamDirForImportPath(path string) string {
+	if path == flowSeamModulePath {
+		return "."
+	}
+	if !strings.HasPrefix(path, flowSeamModulePath+"/") {
+		return ""
+	}
+	return strings.TrimPrefix(path, flowSeamModulePath+"/")
+}
+
+// flowSeamFileScope reads a file's import declarations: which identifiers name
+// the actions package, and which name some other package of this module. The
+// unaliased "actions" is always accepted so a source fragment without imports
+// still reads normally.
+func flowSeamFileScope(dir string, file *ast.File, aliases map[string]bool) flowSeamFile {
+	scope := flowSeamFile{
+		dir:     dir,
+		pkgs:    map[string]bool{"actions": true},
+		imports: make(map[string]string),
+		aliases: aliases,
+	}
+	if scope.aliases == nil {
+		scope.aliases = make(map[string]bool)
+	}
+	for _, imported := range file.Imports {
+		path, err := strconv.Unquote(imported.Path.Value)
+		if err != nil {
+			continue
+		}
+		name := ""
+		if imported.Name != nil {
+			name = imported.Name.Name
+		}
+		if name == "_" || name == "." {
+			continue
+		}
+		if name == "" {
+			name = filepath.Base(path)
+		}
+		if path == flowSeamActionsImportPath {
+			scope.pkgs[name] = true
+		}
+		if importedDir := flowSeamDirForImportPath(path); importedDir != "" {
+			scope.imports[name] = importedDir
+		}
+	}
+	return scope
+}
+
+// flowSeamIsLaunchContextType matches every spelling of the type: the bare
+// ident from inside actions itself, a qualified name under whatever the file
+// imports the actions package as, and any declared alias of either.
+func flowSeamIsLaunchContextType(expr ast.Expr, file flowSeamFile) bool {
 	switch typ := expr.(type) {
-	case *ast.Ident:
-		return typ.Name == "AgentLaunchContext"
+	case *ast.ParenExpr:
+		return flowSeamIsLaunchContextType(typ.X, file)
 	case *ast.StarExpr:
-		return flowSeamIsLaunchContextType(typ.X, pkgs)
+		return flowSeamIsLaunchContextType(typ.X, file)
+	case *ast.Ident:
+		return typ.Name == flowSeamLaunchContextIdent || file.aliases[flowSeamQualify(file.dir, typ.Name)]
 	case *ast.SelectorExpr:
 		pkg, ok := typ.X.(*ast.Ident)
-		return ok && pkgs[pkg.Name] && typ.Sel.Name == "AgentLaunchContext"
+		if !ok {
+			return false
+		}
+		if file.pkgs[pkg.Name] && typ.Sel.Name == flowSeamLaunchContextIdent {
+			return true
+		}
+		return file.aliases[flowSeamQualify(file.imports[pkg.Name], typ.Sel.Name)]
 	}
 	return false
+}
+
+// flowSeamAliasNames collects the qualified names this file declares as an
+// alias of the launch context. Aliases can chain, so the caller repeats the
+// pass until it stops learning names.
+func flowSeamAliasNames(dir string, file *ast.File, known map[string]bool) map[string]bool {
+	scope := flowSeamFileScope(dir, file, known)
+	found := make(map[string]bool)
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.TypeSpec)
+		if !ok || !spec.Assign.IsValid() {
+			return true
+		}
+		if flowSeamIsLaunchContextType(spec.Type, scope) {
+			found[flowSeamQualify(dir, spec.Name.Name)] = true
+		}
+		return true
+	})
+	return found
 }
 
 // flowSeamLaunchContextLit unwraps the expressions that still yield a launch
@@ -93,20 +186,20 @@ func flowSeamIsLaunchContextType(expr ast.Expr, pkgs map[string]bool) bool {
 // roles wrap their literals in. Anything else returns nil, because an
 // assignment target has to be *provably* a launch context before a marker
 // write on it counts as a violation.
-func flowSeamLaunchContextLit(expr ast.Expr, pkgs map[string]bool) *ast.CompositeLit {
+func flowSeamLaunchContextLit(expr ast.Expr, file flowSeamFile) *ast.CompositeLit {
 	switch expr := expr.(type) {
 	case *ast.ParenExpr:
-		return flowSeamLaunchContextLit(expr.X, pkgs)
+		return flowSeamLaunchContextLit(expr.X, file)
 	case *ast.UnaryExpr:
 		if expr.Op == token.AND {
-			return flowSeamLaunchContextLit(expr.X, pkgs)
+			return flowSeamLaunchContextLit(expr.X, file)
 		}
 	case *ast.CallExpr:
 		if fn, ok := expr.Fun.(*ast.Ident); ok && fn.Name == "applyLaunchStamp" && len(expr.Args) > 0 {
-			return flowSeamLaunchContextLit(expr.Args[0], pkgs)
+			return flowSeamLaunchContextLit(expr.Args[0], file)
 		}
 	case *ast.CompositeLit:
-		if flowSeamIsLaunchContextType(expr.Type, pkgs) {
+		if flowSeamIsLaunchContextType(expr.Type, file) {
 			return expr
 		}
 	}
@@ -115,8 +208,9 @@ func flowSeamLaunchContextLit(expr ast.Expr, pkgs map[string]bool) *ast.Composit
 
 // flowSeamKind is what an expression was found to yield: a launch context, a
 // slice or map of them, and/or a value of a named type declared in this
-// repository. The named type is what lets a field read be judged by its owner
-// rather than by field name alone.
+// repository, qualified by the package that declares it. The named type is
+// what lets a field read be judged by its owner rather than by field name
+// alone.
 type flowSeamKind struct {
 	context    bool
 	collection bool
@@ -128,33 +222,33 @@ func (k flowSeamKind) known() bool {
 }
 
 // flowSeamTypeKind classifies a type expression: an AgentLaunchContext, a
-// slice/array/map/variadic of them, or a named type of this package.
-func flowSeamTypeKind(expr ast.Expr, pkgs map[string]bool) flowSeamKind {
+// slice/array/map/variadic of them, or a named type of this repository.
+func flowSeamTypeKind(expr ast.Expr, file flowSeamFile) flowSeamKind {
+	if flowSeamIsLaunchContextType(expr, file) {
+		return flowSeamKind{context: true}
+	}
 	switch typ := expr.(type) {
 	case *ast.ParenExpr:
-		return flowSeamTypeKind(typ.X, pkgs)
+		return flowSeamTypeKind(typ.X, file)
 	case *ast.StarExpr:
-		return flowSeamTypeKind(typ.X, pkgs)
+		return flowSeamTypeKind(typ.X, file)
 	case *ast.Ellipsis:
-		if flowSeamIsLaunchContextType(typ.Elt, pkgs) {
+		if flowSeamIsLaunchContextType(typ.Elt, file) {
 			return flowSeamKind{collection: true}
 		}
 	case *ast.ArrayType:
-		if flowSeamIsLaunchContextType(typ.Elt, pkgs) {
+		if flowSeamIsLaunchContextType(typ.Elt, file) {
 			return flowSeamKind{collection: true}
 		}
 	case *ast.MapType:
-		if flowSeamIsLaunchContextType(typ.Value, pkgs) {
+		if flowSeamIsLaunchContextType(typ.Value, file) {
 			return flowSeamKind{collection: true}
 		}
 	case *ast.Ident:
-		if typ.Name == "AgentLaunchContext" {
-			return flowSeamKind{context: true}
-		}
-		return flowSeamKind{named: typ.Name}
+		return flowSeamKind{named: flowSeamQualify(file.dir, typ.Name)}
 	case *ast.SelectorExpr:
-		if flowSeamIsLaunchContextType(typ, pkgs) {
-			return flowSeamKind{context: true}
+		if pkg, ok := typ.X.(*ast.Ident); ok {
+			return flowSeamKind{named: flowSeamQualify(file.imports[pkg.Name], typ.Sel.Name)}
 		}
 	}
 	return flowSeamKind{}
@@ -165,24 +259,28 @@ func flowSeamTypeKind(expr ast.Expr, pkgs map[string]bool) flowSeamKind {
 // context, and which functions hand one back. Both are declared in one file
 // and used in another, so they are merged across every scanned file first.
 type flowSeamContextShapes struct {
-	// fields is owner type name -> field name -> what that field holds, so a
-	// write through one — `msg.LaunchContext.FlowRepair = true` — is judged by
-	// the struct it belongs to. Keying by owner is what keeps an unrelated
-	// struct that happens to declare a `LaunchContext` field of some other
-	// type from failing the guard.
+	// fields is qualified owner type -> field name -> what that field holds,
+	// so a write through one — `msg.LaunchContext.FlowRepair = true` — is
+	// judged by the struct it belongs to. Qualifying the owner by package is
+	// what keeps an unrelated struct that happens to share a name and a
+	// `LaunchContext` field from either failing the guard or hiding a real
+	// violation.
 	fields map[string]map[string]flowSeamKind
 	// results maps a function name to the indices of its results that are
 	// launch contexts, so `ctx := makeContext(); ctx.FlowRepair = true` is
-	// caught the same way a literal binding is. Receivers are ignored: two
-	// functions sharing a name is rare, and conflating them only makes the
-	// seam rule stricter.
+	// caught the same way a literal binding is. Receivers and packages are
+	// ignored here: a call is resolved by name only, and conflating two
+	// same-named functions only makes the seam rule stricter.
 	results map[string]map[int]bool
+	// aliases are the qualified names declared as an alias of the launch
+	// context anywhere in the scan set.
+	aliases map[string]bool
 }
 
-// flowSeamScope pairs the scan-set-wide shapes with the one thing that is
-// per-file: which identifiers name the actions package here.
+// flowSeamScope pairs the scan-set-wide shapes with the file the expressions
+// being judged were written in.
 type flowSeamScope struct {
-	pkgs   map[string]bool
+	file   flowSeamFile
 	shapes flowSeamContextShapes
 }
 
@@ -190,6 +288,7 @@ func newFlowSeamContextShapes() flowSeamContextShapes {
 	return flowSeamContextShapes{
 		fields:  make(map[string]map[string]flowSeamKind),
 		results: make(map[string]map[int]bool),
+		aliases: make(map[string]bool),
 	}
 }
 
@@ -209,6 +308,9 @@ func (s flowSeamContextShapes) merge(other flowSeamContextShapes) {
 		for index := range indices {
 			s.results[name][index] = true
 		}
+	}
+	for alias := range other.aliases {
+		s.aliases[alias] = true
 	}
 }
 
@@ -236,9 +338,12 @@ func (s flowSeamContextShapes) resultIndices(call *ast.CallExpr) map[int]bool {
 	return nil
 }
 
-func flowSeamContextShapesOf(file *ast.File) flowSeamContextShapes {
+func flowSeamContextShapesOf(dir string, file *ast.File, aliases map[string]bool) flowSeamContextShapes {
 	shapes := newFlowSeamContextShapes()
-	pkgs := flowSeamActionsNames(file)
+	for alias := range aliases {
+		shapes.aliases[alias] = true
+	}
+	scope := flowSeamFileScope(dir, file, aliases)
 	ast.Inspect(file, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.TypeSpec:
@@ -246,16 +351,17 @@ func flowSeamContextShapesOf(file *ast.File) flowSeamContextShapes {
 			if !ok || structType.Fields == nil {
 				return true
 			}
+			owner := flowSeamQualify(dir, n.Name.Name)
 			for _, field := range structType.Fields.List {
-				kind := flowSeamTypeKind(field.Type, pkgs)
+				kind := flowSeamTypeKind(field.Type, scope)
 				if !kind.known() {
 					continue
 				}
 				for _, name := range field.Names {
-					if shapes.fields[n.Name.Name] == nil {
-						shapes.fields[n.Name.Name] = make(map[string]flowSeamKind)
+					if shapes.fields[owner] == nil {
+						shapes.fields[owner] = make(map[string]flowSeamKind)
 					}
-					shapes.fields[n.Name.Name][name.Name] = kind
+					shapes.fields[owner][name.Name] = kind
 				}
 			}
 		case *ast.FuncDecl:
@@ -269,7 +375,7 @@ func flowSeamContextShapesOf(file *ast.File) flowSeamContextShapes {
 				if count == 0 {
 					count = 1
 				}
-				if flowSeamIsLaunchContextType(result.Type, pkgs) {
+				if flowSeamIsLaunchContextType(result.Type, scope) {
 					for offset := 0; offset < count; offset++ {
 						indices[position+offset] = true
 					}
@@ -341,7 +447,7 @@ func flowSeamKindRank(kind flowSeamKind) int {
 // parentheses, address-of, and dereference. It reads syntax, not types, so an
 // expression it cannot place comes back unknown rather than guessed at.
 func flowSeamExprKind(expr ast.Expr, locals *flowSeamLocals, scope flowSeamScope) flowSeamKind {
-	if flowSeamLaunchContextLit(expr, scope.pkgs) != nil {
+	if flowSeamLaunchContextLit(expr, scope.file) != nil {
 		return flowSeamKind{context: true}
 	}
 	switch expr := expr.(type) {
@@ -354,7 +460,7 @@ func flowSeamExprKind(expr ast.Expr, locals *flowSeamLocals, scope flowSeamScope
 			return flowSeamExprKind(expr.X, locals, scope)
 		}
 	case *ast.CompositeLit:
-		return flowSeamTypeKind(expr.Type, scope.pkgs)
+		return flowSeamTypeKind(expr.Type, scope.file)
 	case *ast.Ident:
 		return locals.kind(expr.Name)
 	case *ast.SelectorExpr:
@@ -419,7 +525,7 @@ func flowSeamCollectLaunchContextNames(node ast.Node, locals *flowSeamLocals, sc
 			return
 		}
 		for _, field := range fields.List {
-			kind := flowSeamTypeKind(field.Type, scope.pkgs)
+			kind := flowSeamTypeKind(field.Type, scope.file)
 			for _, name := range field.Names {
 				locals.learn(name.Name, kind)
 			}
@@ -441,7 +547,7 @@ func flowSeamCollectLaunchContextNames(node ast.Node, locals *flowSeamLocals, sc
 			addFuncType(n.Type)
 		case *ast.ValueSpec:
 			if n.Type != nil {
-				kind := flowSeamTypeKind(n.Type, scope.pkgs)
+				kind := flowSeamTypeKind(n.Type, scope.file)
 				for _, name := range n.Names {
 					locals.learn(name.Name, kind)
 				}
@@ -504,11 +610,11 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers m
 	ast.Inspect(node, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.CompositeLit:
-			if flowSeamIsLaunchContextType(n.Type, scope.pkgs) {
+			if flowSeamIsLaunchContextType(n.Type, scope.file) {
 				flowSeamLiteralMarkers(n, markers, record)
 				return true
 			}
-			if !flowSeamTypeKind(n.Type, scope.pkgs).collection {
+			if !flowSeamTypeKind(n.Type, scope.file).collection {
 				return true
 			}
 			// `[]actions.AgentLaunchContext{{FlowRepair: true}}`: the element
@@ -545,7 +651,7 @@ func flowSeamViolations(dir, name string, file *ast.File, markers map[string]boo
 	if dir == "model" && name == flowSeamLaunchContextExemptFile {
 		return nil
 	}
-	scope := flowSeamScope{pkgs: flowSeamActionsNames(file), shapes: shapes}
+	scope := flowSeamScope{file: flowSeamFileScope(dir, file, shapes.aliases), shapes: shapes}
 	var violations []flowSeamViolation
 	for _, declaration := range file.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
@@ -606,27 +712,73 @@ func TestFlowLaunchMarkerFieldsAreExactlyTheEleven(t *testing.T) {
 	}
 }
 
+// flowSeamParsedFile is one parsed source in the scan set, with the package
+// directory that qualifies the names it declares.
+type flowSeamParsedFile struct {
+	dir  string
+	name string
+	file *ast.File
+}
+
+// flowSeamShapesOf reads the whole scan set: aliases of the launch context
+// first, repeated until aliases of aliases stop appearing, then the struct
+// fields and helper results those aliases let it recognize.
+func flowSeamShapesOf(sources []flowSeamParsedFile) flowSeamContextShapes {
+	aliases := make(map[string]bool)
+	for {
+		learned := 0
+		for _, source := range sources {
+			for alias := range flowSeamAliasNames(source.dir, source.file, aliases) {
+				if !aliases[alias] {
+					aliases[alias] = true
+					learned++
+				}
+			}
+		}
+		if learned == 0 {
+			break
+		}
+	}
+	shapes := newFlowSeamContextShapes()
+	for _, source := range sources {
+		shapes.merge(flowSeamContextShapesOf(source.dir, source.file, aliases))
+	}
+	return shapes
+}
+
 // flowSeamViolationsForSource judges source the way the repository scan does:
 // shapes merged from source and from every neighbor, then violations read off
 // source alone. Neighbors matter because a field declared in one file is
 // written through in another, and because a name shared with a real launch
 // context field must not turn an unrelated struct into a violation.
-func flowSeamViolationsForSource(t *testing.T, dir, name, source string, neighbors ...string) []string {
+// flowSeamNeighbor is another file in the scan set, in whatever package
+// directory it belongs to.
+type flowSeamNeighbor struct {
+	dir    string
+	source string
+}
+
+func flowSeamViolationsForSource(t *testing.T, dir, name, source string, neighbors ...flowSeamNeighbor) []string {
 	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, name, source, 0)
 	if err != nil {
 		t.Fatalf("parse %s: %v", name, err)
 	}
-	shapes := newFlowSeamContextShapes()
-	shapes.merge(flowSeamContextShapesOf(file))
+	sources := []flowSeamParsedFile{{dir: dir, name: name, file: file}}
 	for index, neighbor := range neighbors {
-		parsed, err := parser.ParseFile(fset, fmt.Sprintf("neighbor%d.go", index), neighbor, 0)
+		neighborName := fmt.Sprintf("neighbor%d.go", index)
+		parsed, err := parser.ParseFile(fset, neighborName, neighbor.source, 0)
 		if err != nil {
 			t.Fatalf("parse neighbor %d: %v", index, err)
 		}
-		shapes.merge(flowSeamContextShapesOf(parsed))
+		neighborDir := neighbor.dir
+		if neighborDir == "" {
+			neighborDir = dir
+		}
+		sources = append(sources, flowSeamParsedFile{dir: neighborDir, name: neighborName, file: parsed})
 	}
+	shapes := flowSeamShapesOf(sources)
 	found := flowSeamViolations(dir, name, file, flowSeamMarkerFields(), shapes)
 	reported := make([]string, 0, len(found))
 	for _, violation := range found {
@@ -641,7 +793,7 @@ func TestFlowSeamDetectorFindsOutOfModuleMarkers(t *testing.T) {
 		dir       string
 		name      string
 		source    string
-		neighbors []string
+		neighbors []flowSeamNeighbor
 		want      []string
 	}{
 		"marker literal outside the launch module": {
@@ -859,10 +1011,62 @@ type decoy struct {
 func unrelatedOwner(d decoy) {
 	d.LaunchContext.FlowID = "f"
 }`,
-			neighbors: []string{`package model
+			neighbors: []flowSeamNeighbor{{source: `package model
 type launchMsg struct {
 	LaunchContext actions.AgentLaunchContext
-}`},
+}`}},
+			want: []string{},
+		},
+		"marker assigned on an alias of the launch context": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func viaAlias(ctx launchContext) {
+	ctx.FlowRepair = true
+}`,
+			neighbors: []flowSeamNeighbor{{source: `package model
+type launchContext = actions.AgentLaunchContext`}},
+			want: []string{"viaAlias.FlowRepair"},
+		},
+		"marker keyed in a literal of an aliased launch context": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type launchContext = actions.AgentLaunchContext
+
+func inAliasLiteral() {
+	_ = launchContext{FlowAutoLaunch: true}
+}`,
+			want: []string{"inAliasLiteral.FlowAutoLaunch"},
+		},
+		"owner name shared with another package still reports": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type envelope struct {
+	Context actions.AgentLaunchContext
+}
+
+func viaSharedOwnerName(e envelope) {
+	e.Context.FlowID = "f"
+}`,
+			neighbors: []flowSeamNeighbor{{dir: "actions", source: `package actions
+type envelope struct {
+	Context string
+}`}},
+			want: []string{"viaSharedOwnerName.FlowID"},
+		},
+		"owner name shared with another package stays unrelated": {
+			dir: "actions", name: "actions.go",
+			source: `package actions
+type envelope struct {
+	Context otherpkg.Context
+}
+
+func unrelatedSharedOwnerName(e envelope) {
+	e.Context.FlowID = "f"
+}`,
+			neighbors: []flowSeamNeighbor{{dir: "model", source: `package model
+type envelope struct {
+	Context actions.AgentLaunchContext
+}`}},
 			want: []string{},
 		},
 		"marker assigned through a slice element": {
@@ -906,10 +1110,10 @@ func viaRange(contexts []actions.AgentLaunchContext) {
 func viaFieldSlice(batch launchBatch) {
 	batch.Contexts[0].FlowID = "f"
 }`,
-			neighbors: []string{`package model
+			neighbors: []flowSeamNeighbor{{source: `package model
 type launchBatch struct {
 	Contexts []actions.AgentLaunchContext
-}`},
+}`}},
 			want: []string{"viaFieldSlice.FlowID"},
 		},
 		"builder-wrapped literal is still inspected": {
@@ -1029,13 +1233,7 @@ func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
 	// Two passes: the struct fields and helper results that carry a launch
 	// context are declared in one file and used in another, so the whole scan
 	// set has to be parsed before any of it can be judged.
-	type flowSeamSourceFile struct {
-		dir  string
-		name string
-		file *ast.File
-	}
-	var sources []flowSeamSourceFile
-	shapes := newFlowSeamContextShapes()
+	var sources []flowSeamParsedFile
 	scanned := flowSeamScanFiles(t)
 	if len(scanned) == 0 {
 		t.Fatalf("no Go files found under %s; the seam rule is scanning nothing", flowSeamScanRoot)
@@ -1045,9 +1243,9 @@ func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parse %s: %v", source.Path, err)
 		}
-		sources = append(sources, flowSeamSourceFile{dir: source.Dir, name: source.Name, file: file})
-		shapes.merge(flowSeamContextShapesOf(file))
+		sources = append(sources, flowSeamParsedFile{dir: source.Dir, name: source.Name, file: file})
 	}
+	shapes := flowSeamShapesOf(sources)
 	beyondTheLaunchPackages := false
 	for _, source := range scanned {
 		if source.Dir != "model" && source.Dir != "actions" {

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -221,10 +221,14 @@ type flowSeamKind struct {
 	context    bool
 	collection bool
 	named      string
+	// element is the qualified named type a slice or map holds, for
+	// `type wrapped []Base`, where whether this is a collection of contexts
+	// is only answerable once Base itself has been resolved.
+	element string
 }
 
 func (k flowSeamKind) known() bool {
-	return k.context || k.collection || k.named != ""
+	return k.context || k.collection || k.named != "" || k.element != ""
 }
 
 // flowSeamTypeKind classifies a type expression: an AgentLaunchContext, a
@@ -239,23 +243,29 @@ func flowSeamTypeKind(expr ast.Expr, file flowSeamFile) flowSeamKind {
 	case *ast.StarExpr:
 		return flowSeamTypeKind(typ.X, file)
 	case *ast.Ellipsis:
-		if flowSeamIsLaunchContextType(typ.Elt, file) {
-			return flowSeamKind{collection: true}
-		}
+		return flowSeamElementKind(typ.Elt, file)
 	case *ast.ArrayType:
-		if flowSeamIsLaunchContextType(typ.Elt, file) {
-			return flowSeamKind{collection: true}
-		}
+		return flowSeamElementKind(typ.Elt, file)
 	case *ast.MapType:
-		if flowSeamIsLaunchContextType(typ.Value, file) {
-			return flowSeamKind{collection: true}
-		}
+		return flowSeamElementKind(typ.Value, file)
 	case *ast.Ident:
 		return flowSeamKind{named: flowSeamQualify(file.dir, typ.Name)}
 	case *ast.SelectorExpr:
 		if pkg, ok := typ.X.(*ast.Ident); ok {
 			return flowSeamKind{named: flowSeamQualify(file.imports[pkg.Name], typ.Sel.Name)}
 		}
+	}
+	return flowSeamKind{}
+}
+
+// flowSeamElementKind classifies what a slice, array, or map holds: contexts
+// outright, or a named type that only the collected definitions can resolve.
+func flowSeamElementKind(expr ast.Expr, file flowSeamFile) flowSeamKind {
+	if flowSeamIsLaunchContextType(expr, file) {
+		return flowSeamKind{collection: true}
+	}
+	if element := flowSeamTypeKind(expr, file); element.named != "" {
+		return flowSeamKind{element: element.named}
 	}
 	return flowSeamKind{}
 }
@@ -373,19 +383,44 @@ func (s flowSeamContextShapes) promotesContext(owner string, seen map[string]boo
 // `type launchContexts []actions.AgentLaunchContext` reads as a collection
 // wherever one of its values appears.
 func (scope flowSeamScope) resolveKind(kind flowSeamKind) flowSeamKind {
-	seen := make(map[string]bool)
-	for kind.named != "" && !kind.context && !kind.collection {
-		if seen[kind.named] {
-			break
+	return scope.resolveKindSeen(kind, make(map[string]bool))
+}
+
+func (scope flowSeamScope) resolveKindSeen(kind flowSeamKind, seen map[string]bool) flowSeamKind {
+	for {
+		switch {
+		case kind.context, kind.collection:
+			return kind
+		case kind.element != "":
+			element := scope.resolveNamed(kind.element, seen)
+			if element.context {
+				return flowSeamKind{collection: true}
+			}
+			return kind
+		case kind.named != "" && !seen[kind.named]:
+			seen[kind.named] = true
+			resolved, ok := scope.shapes.underlying[kind.named]
+			if !ok {
+				return kind
+			}
+			kind = resolved
+		default:
+			return kind
 		}
-		seen[kind.named] = true
-		resolved, ok := scope.shapes.underlying[kind.named]
-		if !ok {
-			break
-		}
-		kind = resolved
 	}
-	return kind
+}
+
+// resolveNamed follows a qualified named type to what defining it made.
+func (scope flowSeamScope) resolveNamed(name string, seen map[string]bool) flowSeamKind {
+	if seen[name] {
+		return flowSeamKind{}
+	}
+	seen[name] = true
+	resolved, ok := scope.shapes.underlying[name]
+	if !ok {
+		return flowSeamKind{}
+	}
+	return scope.resolveKindSeen(resolved, seen)
 }
 
 // holdsContext reports whether a marker write on a value of this kind writes a
@@ -448,7 +483,7 @@ func flowSeamContextShapesOf(dir string, file *ast.File, aliases map[string]bool
 		switch n := n.(type) {
 		case *ast.TypeSpec:
 			if !n.Assign.IsValid() {
-				if kind := flowSeamTypeKind(n.Type, scope); kind.context || kind.collection {
+				if kind := flowSeamTypeKind(n.Type, scope); kind.known() {
 					shapes.underlying[flowSeamQualify(dir, n.Name.Name)] = kind
 				}
 			}
@@ -562,7 +597,7 @@ func flowSeamKindRank(kind flowSeamKind) int {
 		return 3
 	case kind.collection:
 		return 2
-	case kind.named != "":
+	case kind.named != "", kind.element != "":
 		return 1
 	}
 	return 0
@@ -1250,6 +1285,42 @@ func viaDefinedType(ctx definedContext) {
 	ctx.FlowPhaseTerminal = true
 }`,
 			want: []string{"viaDefinedType.FlowPhaseTerminal"},
+		},
+		"marker assigned through a chain of defined context types": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type base actions.AgentLaunchContext
+
+type wrapped base
+
+func viaDefinedChain(ctx wrapped) {
+	ctx.FlowRepair = true
+}`,
+			want: []string{"viaDefinedChain.FlowRepair"},
+		},
+		"marker assigned through a collection of defined context types": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type base actions.AgentLaunchContext
+
+type bases []base
+
+func viaDefinedCollection(xs bases) {
+	xs[0].FlowID = "f"
+}`,
+			want: []string{"viaDefinedCollection.FlowID"},
+		},
+		"collection of an unrelated named type stays unrelated": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type thing struct{}
+
+type things []thing
+
+func unrelatedCollection(xs things) {
+	xs[0].FlowID = "f"
+}`,
+			want: []string{},
 		},
 		"marker assigned on a promoted embedded launch context": {
 			dir: "model", name: "keys.go",

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -282,7 +282,8 @@ type flowSeamContextShapes struct {
 	// `LaunchContext` field from either failing the guard or hiding a real
 	// violation.
 	fields map[string]map[string]flowSeamKind
-	// results maps a function name to what each of its results holds, so
+	// results maps a function name to what each of its results holds, named
+	// types included so a helper handing back a wrapper resolves like one, so
 	// `ctx := makeContext(); ctx.FlowRepair = true` is caught the same way a
 	// literal binding is, and a helper handing back a slice or map of contexts
 	// is followed into its elements. Receivers and packages are ignored here:
@@ -537,7 +538,7 @@ func flowSeamContextShapesOf(dir string, file *ast.File, aliases map[string]bool
 					count = 1
 				}
 				kind := flowSeamTypeKind(result.Type, scope)
-				if kind.context || kind.collection {
+				if kind.known() {
 					for offset := 0; offset < count; offset++ {
 						kinds[position+offset] = kind
 					}
@@ -1134,6 +1135,23 @@ func viaHelperCollection() {
 	contexts[0].FlowRepair = true
 }`,
 			want: []string{"viaHelperCollection.FlowRepair"},
+		},
+		"marker assigned on a helper-returned embedding wrapper": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type holder struct {
+	actions.AgentLaunchContext
+}
+
+func makeHolder() holder {
+	return holder{}
+}
+
+func viaHelperWrapper() {
+	h := makeHolder()
+	h.FlowID = "f"
+}`,
+			want: []string{"viaHelperWrapper.FlowID"},
 		},
 		"marker assigned on a multi-result helper context": {
 			dir: "model", name: "keys.go",

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -22,11 +22,12 @@ import (
 // property of the repository's shape, not of any single call, so it is checked
 // by scanning source rather than by exercising behavior.
 //
-// The scan follows a context through aliases, struct fields, and helper
-// results, but it reads syntax rather than types, so
-// flowLaunchContextRequiresLifecycle stays the runtime backstop for whatever
-// it still cannot see (contexts inside slices, maps, or interface values). This
-// test is the earlier, louder half of the same guard.
+// The scan follows a context through aliases, struct fields of a known owner,
+// helper results, and slice and map elements, but it reads syntax rather than
+// types, so flowLaunchContextRequiresLifecycle stays the runtime backstop for
+// whatever it still cannot see: a context reached through an interface value,
+// through a function value, or through a base whose type the file never
+// spells. This test is the earlier, louder half of the same guard.
 
 // flowSeamLaunchContextExemptFile is the launch module itself — the one file
 // allowed to construct Flow-marked launch contexts.
@@ -112,15 +113,64 @@ func flowSeamLaunchContextLit(expr ast.Expr, pkgs map[string]bool) *ast.Composit
 	return nil
 }
 
-// flowSeamContextShapes is what a file has to be read for before any marker
-// write in it can be judged: the struct fields that hold a launch context, and
-// the functions that hand one back. Both are declared in one file and used in
-// another, so they are merged across the whole scan set first.
+// flowSeamKind is what an expression was found to yield: a launch context, a
+// slice or map of them, and/or a value of a named type declared in this
+// repository. The named type is what lets a field read be judged by its owner
+// rather than by field name alone.
+type flowSeamKind struct {
+	context    bool
+	collection bool
+	named      string
+}
+
+func (k flowSeamKind) known() bool {
+	return k.context || k.collection || k.named != ""
+}
+
+// flowSeamTypeKind classifies a type expression: an AgentLaunchContext, a
+// slice/array/map/variadic of them, or a named type of this package.
+func flowSeamTypeKind(expr ast.Expr, pkgs map[string]bool) flowSeamKind {
+	switch typ := expr.(type) {
+	case *ast.ParenExpr:
+		return flowSeamTypeKind(typ.X, pkgs)
+	case *ast.StarExpr:
+		return flowSeamTypeKind(typ.X, pkgs)
+	case *ast.Ellipsis:
+		if flowSeamIsLaunchContextType(typ.Elt, pkgs) {
+			return flowSeamKind{collection: true}
+		}
+	case *ast.ArrayType:
+		if flowSeamIsLaunchContextType(typ.Elt, pkgs) {
+			return flowSeamKind{collection: true}
+		}
+	case *ast.MapType:
+		if flowSeamIsLaunchContextType(typ.Value, pkgs) {
+			return flowSeamKind{collection: true}
+		}
+	case *ast.Ident:
+		if typ.Name == "AgentLaunchContext" {
+			return flowSeamKind{context: true}
+		}
+		return flowSeamKind{named: typ.Name}
+	case *ast.SelectorExpr:
+		if flowSeamIsLaunchContextType(typ, pkgs) {
+			return flowSeamKind{context: true}
+		}
+	}
+	return flowSeamKind{}
+}
+
+// flowSeamContextShapes is what the scan set has to be read for before any
+// marker write in it can be judged: which field of which struct holds a launch
+// context, and which functions hand one back. Both are declared in one file
+// and used in another, so they are merged across every scanned file first.
 type flowSeamContextShapes struct {
-	// fields are struct field names declared as an AgentLaunchContext, so a
-	// write through one — `msg.LaunchContext.FlowRepair = true` — is told
-	// apart from a same-named field on an unrelated struct.
-	fields map[string]bool
+	// fields is owner type name -> field name -> what that field holds, so a
+	// write through one — `msg.LaunchContext.FlowRepair = true` — is judged by
+	// the struct it belongs to. Keying by owner is what keeps an unrelated
+	// struct that happens to declare a `LaunchContext` field of some other
+	// type from failing the guard.
+	fields map[string]map[string]flowSeamKind
 	// results maps a function name to the indices of its results that are
 	// launch contexts, so `ctx := makeContext(); ctx.FlowRepair = true` is
 	// caught the same way a literal binding is. Receivers are ignored: two
@@ -138,14 +188,19 @@ type flowSeamScope struct {
 
 func newFlowSeamContextShapes() flowSeamContextShapes {
 	return flowSeamContextShapes{
-		fields:  make(map[string]bool),
+		fields:  make(map[string]map[string]flowSeamKind),
 		results: make(map[string]map[int]bool),
 	}
 }
 
 func (s flowSeamContextShapes) merge(other flowSeamContextShapes) {
-	for field := range other.fields {
-		s.fields[field] = true
+	for owner, fields := range other.fields {
+		if s.fields[owner] == nil {
+			s.fields[owner] = make(map[string]flowSeamKind)
+		}
+		for name, kind := range fields {
+			s.fields[owner][name] = kind
+		}
 	}
 	for name, indices := range other.results {
 		if s.results[name] == nil {
@@ -155,6 +210,18 @@ func (s flowSeamContextShapes) merge(other flowSeamContextShapes) {
 			s.results[name][index] = true
 		}
 	}
+}
+
+func (s flowSeamContextShapes) contextFieldCount() int {
+	count := 0
+	for _, fields := range s.fields {
+		for _, kind := range fields {
+			if kind.context {
+				count++
+			}
+		}
+	}
+	return count
 }
 
 // resultIndices reports which results of the called function are launch
@@ -174,16 +241,21 @@ func flowSeamContextShapesOf(file *ast.File) flowSeamContextShapes {
 	pkgs := flowSeamActionsNames(file)
 	ast.Inspect(file, func(n ast.Node) bool {
 		switch n := n.(type) {
-		case *ast.StructType:
-			if n.Fields == nil {
+		case *ast.TypeSpec:
+			structType, ok := n.Type.(*ast.StructType)
+			if !ok || structType.Fields == nil {
 				return true
 			}
-			for _, field := range n.Fields.List {
-				if !flowSeamIsLaunchContextType(field.Type, pkgs) {
+			for _, field := range structType.Fields.List {
+				kind := flowSeamTypeKind(field.Type, pkgs)
+				if !kind.known() {
 					continue
 				}
 				for _, name := range field.Names {
-					shapes.fields[name.Name] = true
+					if shapes.fields[n.Name.Name] == nil {
+						shapes.fields[n.Name.Name] = make(map[string]flowSeamKind)
+					}
+					shapes.fields[n.Name.Name][name.Name] = kind
 				}
 			}
 		case *ast.FuncDecl:
@@ -213,46 +285,71 @@ func flowSeamContextShapesOf(file *ast.File) flowSeamContextShapes {
 	return shapes
 }
 
-// flowSeamLaunchContextExpr reports whether expr provably yields a launch
-// context: a literal, a name already known to hold one, or a read of a struct
-// field declared as one, through any number of parentheses, address-of, and
-// dereference wrappers.
-func flowSeamLaunchContextExpr(expr ast.Expr, names map[string]bool, scope flowSeamScope) bool {
+// flowSeamLocals is what one declaration's names were found to hold.
+type flowSeamLocals map[string]flowSeamKind
+
+func (l flowSeamLocals) learn(name string, kind flowSeamKind) {
+	if name == "" || name == "_" || !kind.known() {
+		return
+	}
+	if existing, ok := l[name]; ok && existing == kind {
+		return
+	}
+	l[name] = kind
+}
+
+// flowSeamExprKind resolves what an expression yields. It follows the shapes a
+// launch context actually travels through in this repository — names, struct
+// fields of a known owner, helper results, slice and map elements — through
+// parentheses, address-of, and dereference. It reads syntax, not types, so an
+// expression it cannot place comes back unknown rather than guessed at.
+func flowSeamExprKind(expr ast.Expr, locals flowSeamLocals, scope flowSeamScope) flowSeamKind {
 	if flowSeamLaunchContextLit(expr, scope.pkgs) != nil {
-		return true
+		return flowSeamKind{context: true}
 	}
 	switch expr := expr.(type) {
 	case *ast.ParenExpr:
-		return flowSeamLaunchContextExpr(expr.X, names, scope)
+		return flowSeamExprKind(expr.X, locals, scope)
 	case *ast.StarExpr:
-		return flowSeamLaunchContextExpr(expr.X, names, scope)
+		return flowSeamExprKind(expr.X, locals, scope)
 	case *ast.UnaryExpr:
 		if expr.Op == token.AND {
-			return flowSeamLaunchContextExpr(expr.X, names, scope)
+			return flowSeamExprKind(expr.X, locals, scope)
 		}
+	case *ast.CompositeLit:
+		return flowSeamTypeKind(expr.Type, scope.pkgs)
 	case *ast.Ident:
-		return names[expr.Name]
+		return locals[expr.Name]
 	case *ast.SelectorExpr:
-		return scope.shapes.fields[expr.Sel.Name]
+		owner := flowSeamExprKind(expr.X, locals, scope).named
+		if owner == "" {
+			return flowSeamKind{}
+		}
+		return scope.shapes.fields[owner][expr.Sel.Name]
+	case *ast.IndexExpr:
+		if flowSeamExprKind(expr.X, locals, scope).collection {
+			return flowSeamKind{context: true}
+		}
 	case *ast.CallExpr:
-		return scope.shapes.resultIndices(expr)[0]
+		if scope.shapes.resultIndices(expr)[0] {
+			return flowSeamKind{context: true}
+		}
 	}
-	return false
+	return flowSeamKind{}
 }
 
-// flowSeamLaunchContextNames collects every identifier in node that is
-// provably an AgentLaunchContext: parameters and results of the function and
-// of any closure inside it, `var` declarations, and bindings of a launch
-// context literal, of another such name, of a launch context struct field, or
-// of a result of a function that returns one. Aliases chain, so the walk
-// repeats until it stops learning names.
-func flowSeamLaunchContextNames(node ast.Node, scope flowSeamScope) map[string]bool {
-	names := make(map[string]bool)
+// flowSeamLaunchContextNames collects what every name in node holds:
+// parameters and results of the function and of any closure inside it, `var`
+// declarations, and bindings of a literal, of another such name, of a struct
+// field, of a helper result, or of a slice or map element. Bindings chain, so
+// the walk repeats until it stops learning names.
+func flowSeamLaunchContextNames(node ast.Node, scope flowSeamScope) flowSeamLocals {
+	locals := make(flowSeamLocals)
 	for {
-		before := len(names)
-		flowSeamCollectLaunchContextNames(node, names, scope)
-		if len(names) == before {
-			return names
+		before := len(locals)
+		flowSeamCollectLaunchContextNames(node, locals, scope)
+		if len(locals) == before {
+			return locals
 		}
 	}
 }
@@ -260,7 +357,7 @@ func flowSeamLaunchContextNames(node ast.Node, scope flowSeamScope) map[string]b
 // flowSeamBindCallResults records the names on the left of a single-call
 // assignment whose matching result is a launch context, covering the
 // multi-result `ctx, decision, err := build()` shape as well as the single one.
-func flowSeamBindCallResults(lhs, rhs []ast.Expr, names map[string]bool, scope flowSeamScope) {
+func flowSeamBindCallResults(lhs, rhs []ast.Expr, locals flowSeamLocals, scope flowSeamScope) {
 	if len(rhs) != 1 {
 		return
 	}
@@ -274,22 +371,20 @@ func flowSeamBindCallResults(lhs, rhs []ast.Expr, names map[string]bool, scope f
 			continue
 		}
 		if ident, ok := target.(*ast.Ident); ok {
-			names[ident.Name] = true
+			locals.learn(ident.Name, flowSeamKind{context: true})
 		}
 	}
 }
 
-func flowSeamCollectLaunchContextNames(node ast.Node, names map[string]bool, scope flowSeamScope) {
+func flowSeamCollectLaunchContextNames(node ast.Node, locals flowSeamLocals, scope flowSeamScope) {
 	addFields := func(fields *ast.FieldList) {
 		if fields == nil {
 			return
 		}
 		for _, field := range fields.List {
-			if !flowSeamIsLaunchContextType(field.Type, scope.pkgs) {
-				continue
-			}
+			kind := flowSeamTypeKind(field.Type, scope.pkgs)
 			for _, name := range field.Names {
-				names[name.Name] = true
+				locals.learn(name.Name, kind)
 			}
 		}
 	}
@@ -304,42 +399,65 @@ func flowSeamCollectLaunchContextNames(node ast.Node, names map[string]bool, sco
 		switch n := n.(type) {
 		case *ast.FuncDecl:
 			addFuncType(n.Type)
+			addFields(n.Recv)
 		case *ast.FuncLit:
 			addFuncType(n.Type)
 		case *ast.ValueSpec:
-			if flowSeamIsLaunchContextType(n.Type, scope.pkgs) {
+			if n.Type != nil {
+				kind := flowSeamTypeKind(n.Type, scope.pkgs)
 				for _, name := range n.Names {
-					names[name.Name] = true
+					locals.learn(name.Name, kind)
 				}
 			}
 			for index, value := range n.Values {
-				if index < len(n.Names) && flowSeamLaunchContextExpr(value, names, scope) {
-					names[n.Names[index].Name] = true
+				if index < len(n.Names) {
+					locals.learn(n.Names[index].Name, flowSeamExprKind(value, locals, scope))
 				}
 			}
 			specNames := make([]ast.Expr, 0, len(n.Names))
 			for _, name := range n.Names {
 				specNames = append(specNames, name)
 			}
-			flowSeamBindCallResults(specNames, n.Values, names, scope)
+			flowSeamBindCallResults(specNames, n.Values, locals, scope)
 		case *ast.AssignStmt:
 			for index, value := range n.Rhs {
-				if index >= len(n.Lhs) || !flowSeamLaunchContextExpr(value, names, scope) {
+				if index >= len(n.Lhs) {
 					continue
 				}
 				if ident, ok := n.Lhs[index].(*ast.Ident); ok {
-					names[ident.Name] = true
+					locals.learn(ident.Name, flowSeamExprKind(value, locals, scope))
 				}
 			}
-			flowSeamBindCallResults(n.Lhs, n.Rhs, names, scope)
+			flowSeamBindCallResults(n.Lhs, n.Rhs, locals, scope)
+		case *ast.RangeStmt:
+			if flowSeamExprKind(n.X, locals, scope).collection {
+				if ident, ok := n.Value.(*ast.Ident); ok {
+					locals.learn(ident.Name, flowSeamKind{context: true})
+				}
+			}
 		}
 		return true
 	})
 }
 
+// flowSeamLiteralMarkers records every marker field keyed in one launch
+// context literal.
+func flowSeamLiteralMarkers(lit *ast.CompositeLit, markers map[string]bool, record func(string)) {
+	for _, element := range lit.Elts {
+		pair, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		if key, ok := pair.Key.(*ast.Ident); ok && markers[key.Name] {
+			record(key.Name)
+		}
+	}
+}
+
 // flowSeamNodeViolations reports marker fields set within one declaration:
-// keys on a launch context literal, and assignments to a marker field of a
-// name that is provably a launch context.
+// keys on a launch context literal, including the elided element literals of a
+// slice or map of contexts, and assignments to a marker field of any
+// expression that provably yields a launch context.
 func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers map[string]bool, scope flowSeamScope) []flowSeamViolation {
 	locals := flowSeamLaunchContextNames(node, scope)
 	var violations []flowSeamViolation
@@ -349,17 +467,22 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers m
 	ast.Inspect(node, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.CompositeLit:
-			if !flowSeamIsLaunchContextType(n.Type, scope.pkgs) {
+			if flowSeamIsLaunchContextType(n.Type, scope.pkgs) {
+				flowSeamLiteralMarkers(n, markers, record)
 				return true
 			}
+			if !flowSeamTypeKind(n.Type, scope.pkgs).collection {
+				return true
+			}
+			// `[]actions.AgentLaunchContext{{FlowRepair: true}}`: the element
+			// literals leave the type elided, so they are only recognizable
+			// from the collection that holds them.
 			for _, element := range n.Elts {
-				pair, ok := element.(*ast.KeyValueExpr)
-				if !ok {
-					continue
+				if pair, ok := element.(*ast.KeyValueExpr); ok {
+					element = pair.Value
 				}
-				key, ok := pair.Key.(*ast.Ident)
-				if ok && markers[key.Name] {
-					record(key.Name)
+				if lit, ok := element.(*ast.CompositeLit); ok && lit.Type == nil {
+					flowSeamLiteralMarkers(lit, markers, record)
 				}
 			}
 		case *ast.AssignStmt:
@@ -368,7 +491,7 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers m
 				if !ok || !markers[selector.Sel.Name] {
 					continue
 				}
-				if flowSeamLaunchContextExpr(selector.X, locals, scope) {
+				if flowSeamExprKind(selector.X, locals, scope).context {
 					record(selector.Sel.Name)
 				}
 			}
@@ -446,14 +569,28 @@ func TestFlowLaunchMarkerFieldsAreExactlyTheEleven(t *testing.T) {
 	}
 }
 
-func flowSeamViolationsForSource(t *testing.T, dir, name, source string) []string {
+// flowSeamViolationsForSource judges source the way the repository scan does:
+// shapes merged from source and from every neighbor, then violations read off
+// source alone. Neighbors matter because a field declared in one file is
+// written through in another, and because a name shared with a real launch
+// context field must not turn an unrelated struct into a violation.
+func flowSeamViolationsForSource(t *testing.T, dir, name, source string, neighbors ...string) []string {
 	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, name, source, 0)
 	if err != nil {
 		t.Fatalf("parse %s: %v", name, err)
 	}
-	found := flowSeamViolations(dir, name, file, flowSeamMarkerFields(), flowSeamContextShapesOf(file))
+	shapes := newFlowSeamContextShapes()
+	shapes.merge(flowSeamContextShapesOf(file))
+	for index, neighbor := range neighbors {
+		parsed, err := parser.ParseFile(fset, fmt.Sprintf("neighbor%d.go", index), neighbor, 0)
+		if err != nil {
+			t.Fatalf("parse neighbor %d: %v", index, err)
+		}
+		shapes.merge(flowSeamContextShapesOf(parsed))
+	}
+	found := flowSeamViolations(dir, name, file, flowSeamMarkerFields(), shapes)
 	reported := make([]string, 0, len(found))
 	for _, violation := range found {
 		reported = append(reported, violation.Func+"."+violation.Field)
@@ -464,10 +601,11 @@ func flowSeamViolationsForSource(t *testing.T, dir, name, source string) []strin
 
 func TestFlowSeamDetectorFindsOutOfModuleMarkers(t *testing.T) {
 	tests := map[string]struct {
-		dir    string
-		name   string
-		source string
-		want   []string
+		dir       string
+		name      string
+		source    string
+		neighbors []string
+		want      []string
 	}{
 		"marker literal outside the launch module": {
 			dir: "model", name: "keys.go",
@@ -660,6 +798,69 @@ func unrelatedNested(d decoy) {
 }`,
 			want: []string{},
 		},
+		"unrelated struct sharing a real launch context field name": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type decoy struct {
+	LaunchContext otherpkg.Context
+}
+
+func unrelatedOwner(d decoy) {
+	d.LaunchContext.FlowID = "f"
+}`,
+			neighbors: []string{`package model
+type launchMsg struct {
+	LaunchContext actions.AgentLaunchContext
+}`},
+			want: []string{},
+		},
+		"marker assigned through a slice element": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func viaSlice() {
+	contexts := []actions.AgentLaunchContext{{}}
+	contexts[0].FlowRepair = true
+}`,
+			want: []string{"viaSlice.FlowRepair"},
+		},
+		"marker keyed in a slice element literal": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func inSliceLiteral() {
+	_ = []actions.AgentLaunchContext{{FlowAgent: true}}
+}`,
+			want: []string{"inSliceLiteral.FlowAgent"},
+		},
+		"marker assigned through a map element": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func viaMap(contexts map[string]actions.AgentLaunchContext) {
+	contexts["a"].FlowPhaseID = "p"
+}`,
+			want: []string{"viaMap.FlowPhaseID"},
+		},
+		"marker assigned on a range value": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func viaRange(contexts []actions.AgentLaunchContext) {
+	for _, ctx := range contexts {
+		ctx.FlowAutofixPRNumber = 1
+	}
+}`,
+			want: []string{"viaRange.FlowAutofixPRNumber"},
+		},
+		"marker assigned through a struct field holding launch contexts": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func viaFieldSlice(batch launchBatch) {
+	batch.Contexts[0].FlowID = "f"
+}`,
+			neighbors: []string{`package model
+type launchBatch struct {
+	Contexts []actions.AgentLaunchContext
+}`},
+			want: []string{"viaFieldSlice.FlowID"},
+		},
 		"builder-wrapped literal is still inspected": {
 			dir: "model", name: "ready_bead_slice.go",
 			source: `package model
@@ -672,7 +873,7 @@ func slice() {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := flowSeamViolationsForSource(t, test.dir, test.name, test.source)
+			got := flowSeamViolationsForSource(t, test.dir, test.name, test.source, test.neighbors...)
 			if strings.Join(got, ",") != strings.Join(test.want, ",") {
 				t.Fatalf("violations = %v, want %v", got, test.want)
 			}
@@ -746,7 +947,7 @@ func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
 			shapes.merge(flowSeamContextShapesOf(file))
 		}
 	}
-	if len(shapes.fields) == 0 {
+	if shapes.contextFieldCount() == 0 {
 		t.Fatal("no struct field of type actions.AgentLaunchContext found; the nested-field half of the seam rule is scanning nothing")
 	}
 	if len(shapes.results) == 0 {

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -139,8 +139,9 @@ func flowSeamFileScope(dir string, file *ast.File, aliases map[string]bool) flow
 }
 
 // flowSeamIsLaunchContextType matches every spelling of the type: the bare
-// ident from inside actions itself, a qualified name under whatever the file
-// imports the actions package as, and any declared alias of either.
+// ident inside the actions package itself, a qualified name under whatever the
+// file imports the actions package as, and any declared alias of either. A
+// package that declares its own type of the same name is not this type.
 func flowSeamIsLaunchContextType(expr ast.Expr, file flowSeamFile) bool {
 	switch typ := expr.(type) {
 	case *ast.ParenExpr:
@@ -148,7 +149,12 @@ func flowSeamIsLaunchContextType(expr ast.Expr, file flowSeamFile) bool {
 	case *ast.StarExpr:
 		return flowSeamIsLaunchContextType(typ.X, file)
 	case *ast.Ident:
-		return typ.Name == flowSeamLaunchContextIdent || file.aliases[flowSeamQualify(file.dir, typ.Name)]
+		// The bare spelling is the type only inside actions itself; elsewhere
+		// a package-local type of the same name is somebody else's.
+		if typ.Name == flowSeamLaunchContextIdent && file.dir == "actions" {
+			return true
+		}
+		return file.aliases[flowSeamQualify(file.dir, typ.Name)]
 	case *ast.SelectorExpr:
 		pkg, ok := typ.X.(*ast.Ident)
 		if !ok {
@@ -864,6 +870,18 @@ func build() AgentLaunchContext {
 	return AgentLaunchContext{FlowSavedSessionResume: true}
 }`,
 			want: []string{"build.FlowSavedSessionResume"},
+		},
+		"unrelated package declaring its own launch context name": {
+			dir: "flowoccupancy", name: "occupancy.go",
+			source: `package flowoccupancy
+type AgentLaunchContext struct {
+	FlowID string
+}
+
+func local() {
+	_ = AgentLaunchContext{FlowID: "f"}
+}`,
+			want: []string{},
 		},
 		"marker literal at package level": {
 			dir: "model", name: "keys.go",

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -5,7 +5,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -285,17 +285,54 @@ func flowSeamContextShapesOf(file *ast.File) flowSeamContextShapes {
 	return shapes
 }
 
-// flowSeamLocals is what one declaration's names were found to hold.
-type flowSeamLocals map[string]flowSeamKind
+// flowSeamLocals is what one declaration's names were found to hold. It is one
+// flat namespace rather than a stack of lexical scopes: a name that ever holds
+// a launch context anywhere in the declaration keeps that classification, so a
+// closure that shadows `ctx` with something else cannot hide the outer marker
+// write. The cost is that the reverse shadowing reports a write the compiler
+// would bind elsewhere — loud and rare, and the kind of thing a human reads
+// once, where the silent miss is the failure that matters.
+type flowSeamLocals struct {
+	kinds   map[string]flowSeamKind
+	changed bool
+}
 
-func (l flowSeamLocals) learn(name string, kind flowSeamKind) {
+func newFlowSeamLocals() *flowSeamLocals {
+	return &flowSeamLocals{kinds: make(map[string]flowSeamKind)}
+}
+
+func (l *flowSeamLocals) kind(name string) flowSeamKind {
+	return l.kinds[name]
+}
+
+func (l *flowSeamLocals) learn(name string, kind flowSeamKind) {
 	if name == "" || name == "_" || !kind.known() {
 		return
 	}
-	if existing, ok := l[name]; ok && existing == kind {
+	// Learning only ever moves a name up the rank, never sideways or down.
+	// That is what keeps a shadowing binding from trading a launch context
+	// away, and what makes the repeated walk terminate.
+	existing := l.kinds[name]
+	if flowSeamKindRank(kind) <= flowSeamKindRank(existing) {
 		return
 	}
-	l[name] = kind
+	l.kinds[name] = kind
+	l.changed = true
+}
+
+// flowSeamKindRank orders what a name can be found to hold, most specific
+// last: a launch context outranks a collection of them, which outranks a
+// value of some named type.
+func flowSeamKindRank(kind flowSeamKind) int {
+	switch {
+	case kind.context:
+		return 3
+	case kind.collection:
+		return 2
+	case kind.named != "":
+		return 1
+	}
+	return 0
 }
 
 // flowSeamExprKind resolves what an expression yields. It follows the shapes a
@@ -303,7 +340,7 @@ func (l flowSeamLocals) learn(name string, kind flowSeamKind) {
 // fields of a known owner, helper results, slice and map elements — through
 // parentheses, address-of, and dereference. It reads syntax, not types, so an
 // expression it cannot place comes back unknown rather than guessed at.
-func flowSeamExprKind(expr ast.Expr, locals flowSeamLocals, scope flowSeamScope) flowSeamKind {
+func flowSeamExprKind(expr ast.Expr, locals *flowSeamLocals, scope flowSeamScope) flowSeamKind {
 	if flowSeamLaunchContextLit(expr, scope.pkgs) != nil {
 		return flowSeamKind{context: true}
 	}
@@ -319,7 +356,7 @@ func flowSeamExprKind(expr ast.Expr, locals flowSeamLocals, scope flowSeamScope)
 	case *ast.CompositeLit:
 		return flowSeamTypeKind(expr.Type, scope.pkgs)
 	case *ast.Ident:
-		return locals[expr.Name]
+		return locals.kind(expr.Name)
 	case *ast.SelectorExpr:
 		owner := flowSeamExprKind(expr.X, locals, scope).named
 		if owner == "" {
@@ -343,12 +380,12 @@ func flowSeamExprKind(expr ast.Expr, locals flowSeamLocals, scope flowSeamScope)
 // declarations, and bindings of a literal, of another such name, of a struct
 // field, of a helper result, or of a slice or map element. Bindings chain, so
 // the walk repeats until it stops learning names.
-func flowSeamLaunchContextNames(node ast.Node, scope flowSeamScope) flowSeamLocals {
-	locals := make(flowSeamLocals)
+func flowSeamLaunchContextNames(node ast.Node, scope flowSeamScope) *flowSeamLocals {
+	locals := newFlowSeamLocals()
 	for {
-		before := len(locals)
+		locals.changed = false
 		flowSeamCollectLaunchContextNames(node, locals, scope)
-		if len(locals) == before {
+		if !locals.changed {
 			return locals
 		}
 	}
@@ -357,7 +394,7 @@ func flowSeamLaunchContextNames(node ast.Node, scope flowSeamScope) flowSeamLoca
 // flowSeamBindCallResults records the names on the left of a single-call
 // assignment whose matching result is a launch context, covering the
 // multi-result `ctx, decision, err := build()` shape as well as the single one.
-func flowSeamBindCallResults(lhs, rhs []ast.Expr, locals flowSeamLocals, scope flowSeamScope) {
+func flowSeamBindCallResults(lhs, rhs []ast.Expr, locals *flowSeamLocals, scope flowSeamScope) {
 	if len(rhs) != 1 {
 		return
 	}
@@ -376,7 +413,7 @@ func flowSeamBindCallResults(lhs, rhs []ast.Expr, locals flowSeamLocals, scope f
 	}
 }
 
-func flowSeamCollectLaunchContextNames(node ast.Node, locals flowSeamLocals, scope flowSeamScope) {
+func flowSeamCollectLaunchContextNames(node ast.Node, locals *flowSeamLocals, scope flowSeamScope) {
 	addFields := func(fields *ast.FieldList) {
 		if fields == nil {
 			return
@@ -798,6 +835,20 @@ func unrelatedNested(d decoy) {
 }`,
 			want: []string{},
 		},
+		"closure shadowing does not hide the outer marker write": {
+			dir: "model", name: "keys.go",
+			source: `package model
+type decoy struct{}
+
+func shadowed(ctx actions.AgentLaunchContext) func() {
+	ctx.FlowRepair = true
+	return func() {
+		ctx := decoy{}
+		_ = ctx
+	}
+}`,
+			want: []string{"shadowed.FlowRepair"},
+		},
 		"unrelated struct sharing a real launch context field name": {
 			dir: "model", name: "keys.go",
 			source: `package model
@@ -905,8 +956,65 @@ var flowSeamAllowList = map[flowSeamAllowance]string{
 	{Dir: "model", File: "flow_session_release.go", Func: "Model.releaseFlowPhaseSessionsCmd"}: "Finalizes the hook records of launches that already ran and are being released.",
 }
 
-func flowSeamScanDirs() map[string]string {
-	return map[string]string{"model": ".", "actions": "../actions"}
+// flowSeamScanRoot is the repository root, reached from the model package.
+const flowSeamScanRoot = ".."
+
+// flowSeamSkippedDirs are directories with no Go of ours in them. `web` is the
+// separate Next.js deployable; the rest are tool and dependency output.
+var flowSeamSkippedDirs = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"vendor":       true,
+	"web":          true,
+}
+
+// flowSeamGoFile is one non-test Go file in the scan set, named the way a
+// violation reports it: package directory relative to the repository root,
+// plus file name.
+type flowSeamGoFile struct {
+	Dir  string
+	Name string
+	Path string
+}
+
+// flowSeamScanFiles walks every non-test Go file in the repository.
+// AgentLaunchContext is exported, so any package can build one; scanning only
+// the two packages that happen to do so today would let the next one in.
+func flowSeamScanFiles(t *testing.T) []flowSeamGoFile {
+	t.Helper()
+	var files []flowSeamGoFile
+	err := filepath.WalkDir(flowSeamScanRoot, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		name := entry.Name()
+		if entry.IsDir() {
+			if path != flowSeamScanRoot && (strings.HasPrefix(name, ".") || flowSeamSkippedDirs[name]) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		dir := filepath.ToSlash(filepath.Dir(path))
+		dir = strings.TrimPrefix(strings.TrimPrefix(dir, flowSeamScanRoot), "/")
+		if dir == "" {
+			dir = "."
+		}
+		files = append(files, flowSeamGoFile{Dir: dir, Name: name, Path: path})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", flowSeamScanRoot, err)
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].Dir != files[j].Dir {
+			return files[i].Dir < files[j].Dir
+		}
+		return files[i].Name < files[j].Name
+	})
+	return files
 }
 
 // TestFlowLaunchContextLiteralsStayInsideTheLaunchModule is the enforcement:
@@ -928,24 +1036,27 @@ func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
 	}
 	var sources []flowSeamSourceFile
 	shapes := newFlowSeamContextShapes()
-	for _, dir := range sortedKeys(flowSeamScanDirs()) {
-		path := flowSeamScanDirs()[dir]
-		entries, err := os.ReadDir(path)
+	scanned := flowSeamScanFiles(t)
+	if len(scanned) == 0 {
+		t.Fatalf("no Go files found under %s; the seam rule is scanning nothing", flowSeamScanRoot)
+	}
+	for _, source := range scanned {
+		file, err := parser.ParseFile(fset, source.Path, nil, 0)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("parse %s: %v", source.Path, err)
 		}
-		for _, entry := range entries {
-			name := entry.Name()
-			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-				continue
-			}
-			file, err := parser.ParseFile(fset, filepath.Join(path, name), nil, 0)
-			if err != nil {
-				t.Fatalf("parse %s/%s: %v", dir, name, err)
-			}
-			sources = append(sources, flowSeamSourceFile{dir: dir, name: name, file: file})
-			shapes.merge(flowSeamContextShapesOf(file))
+		sources = append(sources, flowSeamSourceFile{dir: source.Dir, name: source.Name, file: file})
+		shapes.merge(flowSeamContextShapesOf(file))
+	}
+	beyondTheLaunchPackages := false
+	for _, source := range scanned {
+		if source.Dir != "model" && source.Dir != "actions" {
+			beyondTheLaunchPackages = true
+			break
 		}
+	}
+	if !beyondTheLaunchPackages {
+		t.Fatal("the scan found nothing outside model/ and actions/; AgentLaunchContext is exported, so the walk has to reach every package")
 	}
 	if shapes.contextFieldCount() == 0 {
 		t.Fatal("no struct field of type actions.AgentLaunchContext found; the nested-field half of the seam rule is scanning nothing")
@@ -976,15 +1087,6 @@ func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
 				allowance.Dir, allowance.File, allowance.Func)
 		}
 	}
-}
-
-func sortedKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for key := range m {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
 }
 
 // TestFlowLaunchLifecycleBackstopStaysWired keeps the runtime half of the

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -644,6 +644,12 @@ func flowSeamExprKindRaw(expr ast.Expr, locals *flowSeamLocals, scope flowSeamSc
 		if kind, ok := scope.shapes.resultKinds(expr)[0]; ok {
 			return kind
 		}
+		// The allocating builtins take the type itself as their first
+		// argument: `new(actions.AgentLaunchContext)` and
+		// `make([]actions.AgentLaunchContext, n)`.
+		if fn, ok := expr.Fun.(*ast.Ident); ok && (fn.Name == "new" || fn.Name == "make") && len(expr.Args) > 0 {
+			return flowSeamTypeKind(expr.Args[0], scope.file)
+		}
 		// A conversion is spelled like a call: `localContext(base)` yields
 		// whatever localContext was defined as.
 		if len(expr.Args) == 1 {
@@ -1142,6 +1148,24 @@ func viaHelperCollection() {
 	contexts[0].FlowRepair = true
 }`,
 			want: []string{"viaHelperCollection.FlowRepair"},
+		},
+		"marker assigned on a context allocated with new": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func viaNew() {
+	ctx := new(actions.AgentLaunchContext)
+	ctx.FlowRepair = true
+}`,
+			want: []string{"viaNew.FlowRepair"},
+		},
+		"marker assigned on a context slice allocated with make": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func viaMake() {
+	contexts := make([]actions.AgentLaunchContext, 1)
+	contexts[0].FlowID = "f"
+}`,
+			want: []string{"viaMake.FlowID"},
 		},
 		"marker assigned on a converted launch context": {
 			dir: "model", name: "keys.go",

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -1,0 +1,473 @@
+package model
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/approachcontrol/approach/actions"
+)
+
+// The Flow launch seam is a deep module: every Flow launch context is built by
+// the role builder in model/flow_launch_context.go, so the eleven Flow marker
+// fields on actions.AgentLaunchContext are set in exactly one place. That is a
+// property of the repository's shape, not of any single call, so it is checked
+// by scanning source rather than by exercising behavior.
+//
+// flowLaunchContextRequiresLifecycle stays the runtime backstop for whatever a
+// syntactic rule cannot see (aliased imports, contexts threaded through
+// helpers). This test is the earlier, louder half of the same guard.
+
+// flowSeamLaunchContextExemptFile is the launch module itself — the one file
+// allowed to construct Flow-marked launch contexts.
+const flowSeamLaunchContextExemptFile = "flow_launch_context.go"
+
+// flowSeamViolation is one marker field set on a launch context outside the
+// launch module. Func is the enclosing top-level function, receiver-qualified,
+// or empty for a package-level declaration.
+type flowSeamViolation struct {
+	Dir   string
+	File  string
+	Func  string
+	Field string
+}
+
+func (v flowSeamViolation) String() string {
+	where := v.Func
+	if where == "" {
+		where = "(package level)"
+	}
+	return fmt.Sprintf("%s/%s: %s sets %s", v.Dir, v.File, where, v.Field)
+}
+
+// flowSeamIsLaunchContextType matches the two syntactic spellings of the type:
+// actions.AgentLaunchContext from model, and the bare ident from inside
+// actions itself.
+func flowSeamIsLaunchContextType(expr ast.Expr) bool {
+	switch typ := expr.(type) {
+	case *ast.Ident:
+		return typ.Name == "AgentLaunchContext"
+	case *ast.StarExpr:
+		return flowSeamIsLaunchContextType(typ.X)
+	case *ast.SelectorExpr:
+		pkg, ok := typ.X.(*ast.Ident)
+		return ok && pkg.Name == "actions" && typ.Sel.Name == "AgentLaunchContext"
+	}
+	return false
+}
+
+// flowSeamLaunchContextLit unwraps the expressions that still yield a launch
+// context: parentheses, an address-of, and applyLaunchStamp, which the builder
+// roles wrap their literals in. Anything else returns nil, because an
+// assignment target has to be *provably* a launch context before a marker
+// write on it counts as a violation.
+func flowSeamLaunchContextLit(expr ast.Expr) *ast.CompositeLit {
+	switch expr := expr.(type) {
+	case *ast.ParenExpr:
+		return flowSeamLaunchContextLit(expr.X)
+	case *ast.UnaryExpr:
+		if expr.Op == token.AND {
+			return flowSeamLaunchContextLit(expr.X)
+		}
+	case *ast.CallExpr:
+		if fn, ok := expr.Fun.(*ast.Ident); ok && fn.Name == "applyLaunchStamp" && len(expr.Args) > 0 {
+			return flowSeamLaunchContextLit(expr.Args[0])
+		}
+	case *ast.CompositeLit:
+		if flowSeamIsLaunchContextType(expr.Type) {
+			return expr
+		}
+	}
+	return nil
+}
+
+// flowSeamLaunchContextNames collects every identifier in node that is
+// provably an AgentLaunchContext: parameters and results of the function and
+// of any closure inside it, `var` declarations, and `:=` bindings of a launch
+// context literal.
+func flowSeamLaunchContextNames(node ast.Node) map[string]bool {
+	names := make(map[string]bool)
+	addFields := func(fields *ast.FieldList) {
+		if fields == nil {
+			return
+		}
+		for _, field := range fields.List {
+			if !flowSeamIsLaunchContextType(field.Type) {
+				continue
+			}
+			for _, name := range field.Names {
+				names[name.Name] = true
+			}
+		}
+	}
+	addFuncType := func(typ *ast.FuncType) {
+		if typ == nil {
+			return
+		}
+		addFields(typ.Params)
+		addFields(typ.Results)
+	}
+	ast.Inspect(node, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.FuncDecl:
+			addFuncType(n.Type)
+		case *ast.FuncLit:
+			addFuncType(n.Type)
+		case *ast.ValueSpec:
+			if flowSeamIsLaunchContextType(n.Type) {
+				for _, name := range n.Names {
+					names[name.Name] = true
+				}
+			}
+			for index, value := range n.Values {
+				if flowSeamLaunchContextLit(value) != nil && index < len(n.Names) {
+					names[n.Names[index].Name] = true
+				}
+			}
+		case *ast.AssignStmt:
+			for index, value := range n.Rhs {
+				if index >= len(n.Lhs) || flowSeamLaunchContextLit(value) == nil {
+					continue
+				}
+				if ident, ok := n.Lhs[index].(*ast.Ident); ok {
+					names[ident.Name] = true
+				}
+			}
+		}
+		return true
+	})
+	return names
+}
+
+// flowSeamNodeViolations reports marker fields set within one declaration:
+// keys on a launch context literal, and assignments to a marker field of a
+// name that is provably a launch context.
+func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers map[string]bool) []flowSeamViolation {
+	locals := flowSeamLaunchContextNames(node)
+	var violations []flowSeamViolation
+	record := func(field string) {
+		violations = append(violations, flowSeamViolation{Dir: dir, File: file, Func: function, Field: field})
+	}
+	ast.Inspect(node, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.CompositeLit:
+			if !flowSeamIsLaunchContextType(n.Type) {
+				return true
+			}
+			for _, element := range n.Elts {
+				pair, ok := element.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := pair.Key.(*ast.Ident)
+				if ok && markers[key.Name] {
+					record(key.Name)
+				}
+			}
+		case *ast.AssignStmt:
+			for _, target := range n.Lhs {
+				selector, ok := target.(*ast.SelectorExpr)
+				if !ok || !markers[selector.Sel.Name] {
+					continue
+				}
+				base, ok := selector.X.(*ast.Ident)
+				if ok && locals[base.Name] {
+					record(selector.Sel.Name)
+				}
+			}
+		}
+		return true
+	})
+	return violations
+}
+
+// flowSeamViolations reports every marker field set on a launch context in one
+// file, attributed to its enclosing top-level function. The launch module
+// itself is exempt.
+func flowSeamViolations(dir, name string, file *ast.File, markers map[string]bool) []flowSeamViolation {
+	if dir == "model" && name == flowSeamLaunchContextExemptFile {
+		return nil
+	}
+	var violations []flowSeamViolation
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok {
+			violations = append(violations, flowSeamNodeViolations(dir, name, "", declaration, markers)...)
+			continue
+		}
+		if function.Body == nil {
+			continue
+		}
+		label := function.Name.Name
+		if function.Recv != nil && len(function.Recv.List) == 1 {
+			if receiver := flowLaunchReceiverName(function.Recv.List[0].Type); receiver != "" {
+				label = receiver + "." + label
+			}
+		}
+		violations = append(violations, flowSeamNodeViolations(dir, name, label, function, markers)...)
+	}
+	return violations
+}
+
+func flowSeamMarkerFields() map[string]bool {
+	markers := make(map[string]bool)
+	structType := reflect.TypeOf(actions.AgentLaunchContext{})
+	for index := 0; index < structType.NumField(); index++ {
+		if name := structType.Field(index).Name; strings.HasPrefix(name, "Flow") {
+			markers[name] = true
+		}
+	}
+	return markers
+}
+
+// TestFlowLaunchMarkerFieldsAreExactlyTheEleven pins the derived marker set
+// against the fields ADR 0002 names. Adding a twelfth Flow* field extends the
+// seam rule automatically; renaming one fails here rather than silently
+// shrinking the rule.
+func TestFlowLaunchMarkerFieldsAreExactlyTheEleven(t *testing.T) {
+	expected := []string{
+		"FlowAgent",
+		"FlowAutoLaunch",
+		"FlowAutofix",
+		"FlowAutofixPRNumber",
+		"FlowID",
+		"FlowLaunchTracked",
+		"FlowPhaseID",
+		"FlowPhaseKind",
+		"FlowPhaseTerminal",
+		"FlowRepair",
+		"FlowSavedSessionResume",
+	}
+	derived := make([]string, 0, len(expected))
+	for name := range flowSeamMarkerFields() {
+		derived = append(derived, name)
+	}
+	sort.Strings(derived)
+	if strings.Join(derived, ",") != strings.Join(expected, ",") {
+		t.Fatalf("Flow marker fields changed:\n got %v\nwant %v", derived, expected)
+	}
+}
+
+func flowSeamViolationsForSource(t *testing.T, dir, name, source string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, name, source, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", name, err)
+	}
+	found := flowSeamViolations(dir, name, file, flowSeamMarkerFields())
+	reported := make([]string, 0, len(found))
+	for _, violation := range found {
+		reported = append(reported, violation.Func+"."+violation.Field)
+	}
+	sort.Strings(reported)
+	return reported
+}
+
+func TestFlowSeamDetectorFindsOutOfModuleMarkers(t *testing.T) {
+	tests := map[string]struct {
+		dir    string
+		name   string
+		source string
+		want   []string
+	}{
+		"marker literal outside the launch module": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func (m Model) start() {
+	ctx := actions.AgentLaunchContext{LaunchID: "l", FlowRepair: true}
+	_ = ctx
+}`,
+			want: []string{"Model.start.FlowRepair"},
+		},
+		"marker literal inside the launch module": {
+			dir: "model", name: flowSeamLaunchContextExemptFile,
+			source: `package model
+func build() {
+	_ = actions.AgentLaunchContext{FlowID: "f", FlowPhaseID: "p"}
+}`,
+			want: []string{},
+		},
+		"launch context without a marker": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func plain() {
+	_ = actions.AgentLaunchContext{LaunchID: "l", Command: "sh"}
+}`,
+			want: []string{},
+		},
+		"marker literal inside a closure": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func (m Model) outer() tea.Cmd {
+	return func() tea.Msg {
+		return actions.AgentLaunchContext{FlowAgent: true}
+	}
+}`,
+			want: []string{"Model.outer.FlowAgent"},
+		},
+		"marker assigned after the literal": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func later() {
+	ctx := actions.AgentLaunchContext{LaunchID: "l"}
+	ctx.FlowAutoLaunch = true
+}`,
+			want: []string{"later.FlowAutoLaunch"},
+		},
+		"marker assigned on a launch context parameter": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func stamp(ctx actions.AgentLaunchContext) {
+	ctx.FlowPhaseTerminal = true
+}`,
+			want: []string{"stamp.FlowPhaseTerminal"},
+		},
+		"same-named field on an unrelated struct": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func unrelated() {
+	attempt := flowLaunchAttempt{}
+	attempt.FlowID = "f"
+}`,
+			want: []string{},
+		},
+		"bare ident literal used inside actions": {
+			dir: "actions", name: "actions.go",
+			source: `package actions
+func build() AgentLaunchContext {
+	return AgentLaunchContext{FlowSavedSessionResume: true}
+}`,
+			want: []string{"build.FlowSavedSessionResume"},
+		},
+		"marker literal at package level": {
+			dir: "model", name: "keys.go",
+			source: `package model
+var seed = actions.AgentLaunchContext{FlowAutofix: true}`,
+			want: []string{".FlowAutofix"},
+		},
+		"builder-wrapped literal is still inspected": {
+			dir: "model", name: "ready_bead_slice.go",
+			source: `package model
+func slice() {
+	ctx := applyLaunchStamp(actions.AgentLaunchContext{LaunchID: "l"})
+	ctx.FlowID = "f"
+}`,
+			want: []string{"slice.FlowID"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := flowSeamViolationsForSource(t, test.dir, test.name, test.source)
+			if strings.Join(got, ",") != strings.Join(test.want, ",") {
+				t.Fatalf("violations = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+// flowSeamAllowance names a function outside the launch module that may set
+// Flow markers on a launch context.
+type flowSeamAllowance struct {
+	Dir  string
+	File string
+	Func string
+}
+
+// flowSeamAllowList is keyed by function rather than by file:line so that an
+// unrelated edit above the literal does not re-pin the guard. Each of these
+// addresses a launch record that already exists; neither starts a process, so
+// neither is a launch the role builder could have built.
+//
+// The four remaining out-of-module AgentLaunchContext constructors — the
+// Ready-Bead `S` slice, plans-mode implement, worktree `a`, and non-Flow
+// session resume — need no entry: they set no Flow marker at all, which is
+// exactly what keeps flowLaunchContextRequiresLifecycle false for them. An
+// allow-list entry there would be dead configuration granting a standing
+// exemption, so the stale-entry check below would rightly fail on it.
+var flowSeamAllowList = map[flowSeamAllowance]string{
+	{Dir: "model", File: "flow_launch_lifecycle.go", Func: "Model.blockAutoFlowLaunchPhase"}:   "Synthesizes a failure context addressing the launch attempt that already failed; there is no process to start.",
+	{Dir: "model", File: "flow_session_release.go", Func: "Model.releaseFlowPhaseSessionsCmd"}: "Finalizes the hook records of launches that already ran and are being released.",
+}
+
+func flowSeamScanDirs() map[string]string {
+	return map[string]string{"model": ".", "actions": "../actions"}
+}
+
+// TestFlowLaunchContextLiteralsStayInsideTheLaunchModule is the enforcement:
+// no Flow marker is set on a launch context outside
+// model/flow_launch_context.go, save for the two allow-listed finalizers.
+func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
+	markers := flowSeamMarkerFields()
+	fset := token.NewFileSet()
+	matched := make(map[flowSeamAllowance]bool)
+	var offenders []string
+	for _, dir := range sortedKeys(flowSeamScanDirs()) {
+		path := flowSeamScanDirs()[dir]
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			file, err := parser.ParseFile(fset, filepath.Join(path, name), nil, 0)
+			if err != nil {
+				t.Fatalf("parse %s/%s: %v", dir, name, err)
+			}
+			for _, violation := range flowSeamViolations(dir, name, file, markers) {
+				allowance := flowSeamAllowance{Dir: violation.Dir, File: violation.File, Func: violation.Func}
+				if _, allowed := flowSeamAllowList[allowance]; allowed {
+					matched[allowance] = true
+					continue
+				}
+				offenders = append(offenders, violation.String())
+			}
+		}
+	}
+	sort.Strings(offenders)
+	for _, offender := range offenders {
+		t.Errorf("Flow launch context built outside the launch module: %s", offender)
+	}
+	if len(offenders) > 0 {
+		t.Log("build Flow launch contexts through the role builder in model/" + flowSeamLaunchContextExemptFile)
+	}
+	for allowance := range flowSeamAllowList {
+		if !matched[allowance] {
+			t.Errorf("stale Flow seam allow-list entry: %s/%s %s sets no Flow marker; delete the entry",
+				allowance.Dir, allowance.File, allowance.Func)
+		}
+	}
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestFlowLaunchLifecycleBackstopStaysWired keeps the runtime half of the
+// guard from being deleted once the static half exists: launchAgentForBackend
+// must still refuse a marker-bearing context that reaches it anyway.
+func TestFlowLaunchLifecycleBackstopStaysWired(t *testing.T) {
+	contracts := parseFlowLaunchFunctionContracts(t, false)
+	contract, ok := contracts[modelFlowLaunchFunction("launchAgentForBackend")]
+	if !ok {
+		t.Fatal("Model.launchAgentForBackend is gone; the Flow launch runtime backstop lost its home")
+	}
+	if !contract.calls["flowLaunchContextRequiresLifecycle"] {
+		t.Fatal("Model.launchAgentForBackend no longer calls flowLaunchContextRequiresLifecycle; the static seam test is not a substitute for the runtime refusal")
+	}
+}

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -21,9 +21,11 @@ import (
 // property of the repository's shape, not of any single call, so it is checked
 // by scanning source rather than by exercising behavior.
 //
-// flowLaunchContextRequiresLifecycle stays the runtime backstop for whatever a
-// syntactic rule cannot see (aliased imports, contexts threaded through
-// helpers). This test is the earlier, louder half of the same guard.
+// The scan follows a context through aliases, struct fields, and helper
+// results, but it reads syntax rather than types, so
+// flowLaunchContextRequiresLifecycle stays the runtime backstop for whatever
+// it still cannot see (aliased imports, contexts inside slices or maps). This
+// test is the earlier, louder half of the same guard.
 
 // flowSeamLaunchContextExemptFile is the launch module itself — the one file
 // allowed to construct Flow-marked launch contexts.
@@ -88,52 +90,122 @@ func flowSeamLaunchContextLit(expr ast.Expr) *ast.CompositeLit {
 	return nil
 }
 
-// flowSeamContextFieldNames collects every struct field in file whose declared
-// type is an AgentLaunchContext. A marker written through such a field —
-// `msg.LaunchContext.FlowRepair = true` — builds Flow launch identity just as
-// surely as a write to a local, so the detector needs the field names to tell
-// those apart from a same-named field on an unrelated struct.
-func flowSeamContextFieldNames(file *ast.File) map[string]bool {
-	fields := make(map[string]bool)
-	ast.Inspect(file, func(n ast.Node) bool {
-		structType, ok := n.(*ast.StructType)
-		if !ok || structType.Fields == nil {
-			return true
+// flowSeamContextShapes is what a file has to be read for before any marker
+// write in it can be judged: the struct fields that hold a launch context, and
+// the functions that hand one back. Both are declared in one file and used in
+// another, so they are merged across the whole scan set first.
+type flowSeamContextShapes struct {
+	// fields are struct field names declared as an AgentLaunchContext, so a
+	// write through one — `msg.LaunchContext.FlowRepair = true` — is told
+	// apart from a same-named field on an unrelated struct.
+	fields map[string]bool
+	// results maps a function name to the indices of its results that are
+	// launch contexts, so `ctx := makeContext(); ctx.FlowRepair = true` is
+	// caught the same way a literal binding is. Receivers are ignored: two
+	// functions sharing a name is rare, and conflating them only makes the
+	// seam rule stricter.
+	results map[string]map[int]bool
+}
+
+func newFlowSeamContextShapes() flowSeamContextShapes {
+	return flowSeamContextShapes{
+		fields:  make(map[string]bool),
+		results: make(map[string]map[int]bool),
+	}
+}
+
+func (s flowSeamContextShapes) merge(other flowSeamContextShapes) {
+	for field := range other.fields {
+		s.fields[field] = true
+	}
+	for name, indices := range other.results {
+		if s.results[name] == nil {
+			s.results[name] = make(map[int]bool)
 		}
-		for _, field := range structType.Fields.List {
-			if !flowSeamIsLaunchContextType(field.Type) {
-				continue
+		for index := range indices {
+			s.results[name][index] = true
+		}
+	}
+}
+
+// resultIndices reports which results of the called function are launch
+// contexts, for a call whose callee is a plain name or a method selector.
+func (s flowSeamContextShapes) resultIndices(call *ast.CallExpr) map[int]bool {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return s.results[fn.Name]
+	case *ast.SelectorExpr:
+		return s.results[fn.Sel.Name]
+	}
+	return nil
+}
+
+func flowSeamContextShapesOf(file *ast.File) flowSeamContextShapes {
+	shapes := newFlowSeamContextShapes()
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.StructType:
+			if n.Fields == nil {
+				return true
 			}
-			for _, name := range field.Names {
-				fields[name.Name] = true
+			for _, field := range n.Fields.List {
+				if !flowSeamIsLaunchContextType(field.Type) {
+					continue
+				}
+				for _, name := range field.Names {
+					shapes.fields[name.Name] = true
+				}
+			}
+		case *ast.FuncDecl:
+			if n.Type == nil || n.Type.Results == nil {
+				return true
+			}
+			indices := make(map[int]bool)
+			position := 0
+			for _, result := range n.Type.Results.List {
+				count := len(result.Names)
+				if count == 0 {
+					count = 1
+				}
+				if flowSeamIsLaunchContextType(result.Type) {
+					for offset := 0; offset < count; offset++ {
+						indices[position+offset] = true
+					}
+				}
+				position += count
+			}
+			if len(indices) > 0 {
+				shapes.results[n.Name.Name] = indices
 			}
 		}
 		return true
 	})
-	return fields
+	return shapes
 }
 
 // flowSeamLaunchContextExpr reports whether expr provably yields a launch
 // context: a literal, a name already known to hold one, or a read of a struct
 // field declared as one, through any number of parentheses, address-of, and
 // dereference wrappers.
-func flowSeamLaunchContextExpr(expr ast.Expr, names, fields map[string]bool) bool {
+func flowSeamLaunchContextExpr(expr ast.Expr, names map[string]bool, shapes flowSeamContextShapes) bool {
 	if flowSeamLaunchContextLit(expr) != nil {
 		return true
 	}
 	switch expr := expr.(type) {
 	case *ast.ParenExpr:
-		return flowSeamLaunchContextExpr(expr.X, names, fields)
+		return flowSeamLaunchContextExpr(expr.X, names, shapes)
 	case *ast.StarExpr:
-		return flowSeamLaunchContextExpr(expr.X, names, fields)
+		return flowSeamLaunchContextExpr(expr.X, names, shapes)
 	case *ast.UnaryExpr:
 		if expr.Op == token.AND {
-			return flowSeamLaunchContextExpr(expr.X, names, fields)
+			return flowSeamLaunchContextExpr(expr.X, names, shapes)
 		}
 	case *ast.Ident:
 		return names[expr.Name]
 	case *ast.SelectorExpr:
-		return fields[expr.Sel.Name]
+		return shapes.fields[expr.Sel.Name]
+	case *ast.CallExpr:
+		return shapes.resultIndices(expr)[0]
 	}
 	return false
 }
@@ -141,20 +213,43 @@ func flowSeamLaunchContextExpr(expr ast.Expr, names, fields map[string]bool) boo
 // flowSeamLaunchContextNames collects every identifier in node that is
 // provably an AgentLaunchContext: parameters and results of the function and
 // of any closure inside it, `var` declarations, and bindings of a launch
-// context literal, of another such name, or of a launch context struct field.
-// Aliases chain, so the walk repeats until it stops learning names.
-func flowSeamLaunchContextNames(node ast.Node, fields map[string]bool) map[string]bool {
+// context literal, of another such name, of a launch context struct field, or
+// of a result of a function that returns one. Aliases chain, so the walk
+// repeats until it stops learning names.
+func flowSeamLaunchContextNames(node ast.Node, shapes flowSeamContextShapes) map[string]bool {
 	names := make(map[string]bool)
 	for {
 		before := len(names)
-		flowSeamCollectLaunchContextNames(node, names, fields)
+		flowSeamCollectLaunchContextNames(node, names, shapes)
 		if len(names) == before {
 			return names
 		}
 	}
 }
 
-func flowSeamCollectLaunchContextNames(node ast.Node, names, fields map[string]bool) {
+// flowSeamBindCallResults records the names on the left of a single-call
+// assignment whose matching result is a launch context, covering the
+// multi-result `ctx, decision, err := build()` shape as well as the single one.
+func flowSeamBindCallResults(lhs, rhs []ast.Expr, names map[string]bool, shapes flowSeamContextShapes) {
+	if len(rhs) != 1 {
+		return
+	}
+	call, ok := rhs[0].(*ast.CallExpr)
+	if !ok {
+		return
+	}
+	indices := shapes.resultIndices(call)
+	for index, target := range lhs {
+		if !indices[index] {
+			continue
+		}
+		if ident, ok := target.(*ast.Ident); ok {
+			names[ident.Name] = true
+		}
+	}
+}
+
+func flowSeamCollectLaunchContextNames(node ast.Node, names map[string]bool, shapes flowSeamContextShapes) {
 	addFields := func(fields *ast.FieldList) {
 		if fields == nil {
 			return
@@ -188,19 +283,25 @@ func flowSeamCollectLaunchContextNames(node ast.Node, names, fields map[string]b
 				}
 			}
 			for index, value := range n.Values {
-				if index < len(n.Names) && flowSeamLaunchContextExpr(value, names, fields) {
+				if index < len(n.Names) && flowSeamLaunchContextExpr(value, names, shapes) {
 					names[n.Names[index].Name] = true
 				}
 			}
+			specNames := make([]ast.Expr, 0, len(n.Names))
+			for _, name := range n.Names {
+				specNames = append(specNames, name)
+			}
+			flowSeamBindCallResults(specNames, n.Values, names, shapes)
 		case *ast.AssignStmt:
 			for index, value := range n.Rhs {
-				if index >= len(n.Lhs) || !flowSeamLaunchContextExpr(value, names, fields) {
+				if index >= len(n.Lhs) || !flowSeamLaunchContextExpr(value, names, shapes) {
 					continue
 				}
 				if ident, ok := n.Lhs[index].(*ast.Ident); ok {
 					names[ident.Name] = true
 				}
 			}
+			flowSeamBindCallResults(n.Lhs, n.Rhs, names, shapes)
 		}
 		return true
 	})
@@ -209,8 +310,8 @@ func flowSeamCollectLaunchContextNames(node ast.Node, names, fields map[string]b
 // flowSeamNodeViolations reports marker fields set within one declaration:
 // keys on a launch context literal, and assignments to a marker field of a
 // name that is provably a launch context.
-func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers, fields map[string]bool) []flowSeamViolation {
-	locals := flowSeamLaunchContextNames(node, fields)
+func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers map[string]bool, shapes flowSeamContextShapes) []flowSeamViolation {
+	locals := flowSeamLaunchContextNames(node, shapes)
 	var violations []flowSeamViolation
 	record := func(field string) {
 		violations = append(violations, flowSeamViolation{Dir: dir, File: file, Func: function, Field: field})
@@ -237,7 +338,7 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers, 
 				if !ok || !markers[selector.Sel.Name] {
 					continue
 				}
-				if flowSeamLaunchContextExpr(selector.X, locals, fields) {
+				if flowSeamLaunchContextExpr(selector.X, locals, shapes) {
 					record(selector.Sel.Name)
 				}
 			}
@@ -250,7 +351,7 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers, 
 // flowSeamViolations reports every marker field set on a launch context in one
 // file, attributed to its enclosing top-level function. The launch module
 // itself is exempt.
-func flowSeamViolations(dir, name string, file *ast.File, markers, fields map[string]bool) []flowSeamViolation {
+func flowSeamViolations(dir, name string, file *ast.File, markers map[string]bool, shapes flowSeamContextShapes) []flowSeamViolation {
 	if dir == "model" && name == flowSeamLaunchContextExemptFile {
 		return nil
 	}
@@ -258,7 +359,7 @@ func flowSeamViolations(dir, name string, file *ast.File, markers, fields map[st
 	for _, declaration := range file.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
 		if !ok {
-			violations = append(violations, flowSeamNodeViolations(dir, name, "", declaration, markers, fields)...)
+			violations = append(violations, flowSeamNodeViolations(dir, name, "", declaration, markers, shapes)...)
 			continue
 		}
 		if function.Body == nil {
@@ -270,7 +371,7 @@ func flowSeamViolations(dir, name string, file *ast.File, markers, fields map[st
 				label = receiver + "." + label
 			}
 		}
-		violations = append(violations, flowSeamNodeViolations(dir, name, label, function, markers, fields)...)
+		violations = append(violations, flowSeamNodeViolations(dir, name, label, function, markers, shapes)...)
 	}
 	return violations
 }
@@ -321,7 +422,7 @@ func flowSeamViolationsForSource(t *testing.T, dir, name, source string) []strin
 	if err != nil {
 		t.Fatalf("parse %s: %v", name, err)
 	}
-	found := flowSeamViolations(dir, name, file, flowSeamMarkerFields(), flowSeamContextFieldNames(file))
+	found := flowSeamViolations(dir, name, file, flowSeamMarkerFields(), flowSeamContextShapesOf(file))
 	reported := make([]string, 0, len(found))
 	for _, violation := range found {
 		reported = append(reported, violation.Func+"."+violation.Field)
@@ -454,6 +555,46 @@ func copied(msg launchMsg) {
 }`,
 			want: []string{"copied.FlowID"},
 		},
+		"marker assigned on a helper-returned launch context": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func makeContext() actions.AgentLaunchContext {
+	return actions.AgentLaunchContext{LaunchID: "l"}
+}
+
+func viaHelper() {
+	ctx := makeContext()
+	ctx.FlowRepair = true
+}`,
+			want: []string{"viaHelper.FlowRepair"},
+		},
+		"marker assigned on a multi-result helper context": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func buildContext() (flowLaunchRouteDecision, actions.AgentLaunchContext, error) {
+	return flowLaunchRouteDecision{}, actions.AgentLaunchContext{}, nil
+}
+
+func viaMultiResult() {
+	decision, ctx, err := buildContext()
+	_, _ = decision, err
+	ctx.FlowAgent = true
+}`,
+			want: []string{"viaMultiResult.FlowAgent"},
+		},
+		"marker assigned on a result of a helper returning something else": {
+			dir: "model", name: "keys.go",
+			source: `package model
+func makeAttempt() flowLaunchAttempt {
+	return flowLaunchAttempt{}
+}
+
+func viaOtherHelper() {
+	attempt := makeAttempt()
+	attempt.FlowID = "f"
+}`,
+			want: []string{},
+		},
 		"same-named field on an unrelated nested struct": {
 			dir: "model", name: "keys.go",
 			source: `package model
@@ -523,16 +664,16 @@ func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
 	matched := make(map[flowSeamAllowance]bool)
 	var offenders []string
 
-	// Two passes: the struct fields that hold a launch context are declared in
-	// one file and written through in another, so the whole scan set has to be
-	// parsed before any of it can be judged.
+	// Two passes: the struct fields and helper results that carry a launch
+	// context are declared in one file and used in another, so the whole scan
+	// set has to be parsed before any of it can be judged.
 	type flowSeamSourceFile struct {
 		dir  string
 		name string
 		file *ast.File
 	}
 	var sources []flowSeamSourceFile
-	fields := make(map[string]bool)
+	shapes := newFlowSeamContextShapes()
 	for _, dir := range sortedKeys(flowSeamScanDirs()) {
 		path := flowSeamScanDirs()[dir]
 		entries, err := os.ReadDir(path)
@@ -549,16 +690,17 @@ func TestFlowLaunchContextLiteralsStayInsideTheLaunchModule(t *testing.T) {
 				t.Fatalf("parse %s/%s: %v", dir, name, err)
 			}
 			sources = append(sources, flowSeamSourceFile{dir: dir, name: name, file: file})
-			for field := range flowSeamContextFieldNames(file) {
-				fields[field] = true
-			}
+			shapes.merge(flowSeamContextShapesOf(file))
 		}
 	}
-	if len(fields) == 0 {
+	if len(shapes.fields) == 0 {
 		t.Fatal("no struct field of type actions.AgentLaunchContext found; the nested-field half of the seam rule is scanning nothing")
 	}
+	if len(shapes.results) == 0 {
+		t.Fatal("no function returning an actions.AgentLaunchContext found; the helper-result half of the seam rule is scanning nothing")
+	}
 	for _, source := range sources {
-		for _, violation := range flowSeamViolations(source.dir, source.name, source.file, markers, fields) {
+		for _, violation := range flowSeamViolations(source.dir, source.name, source.file, markers, shapes) {
 			allowance := flowSeamAllowance{Dir: violation.Dir, File: violation.File, Func: violation.Func}
 			if _, allowed := flowSeamAllowList[allowance]; allowed {
 				matched[allowance] = true

--- a/model/flow_launch_seam_test.go
+++ b/model/flow_launch_seam_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -24,7 +25,7 @@ import (
 // The scan follows a context through aliases, struct fields, and helper
 // results, but it reads syntax rather than types, so
 // flowLaunchContextRequiresLifecycle stays the runtime backstop for whatever
-// it still cannot see (aliased imports, contexts inside slices or maps). This
+// it still cannot see (contexts inside slices, maps, or interface values). This
 // test is the earlier, louder half of the same guard.
 
 // flowSeamLaunchContextExemptFile is the launch module itself — the one file
@@ -49,18 +50,39 @@ func (v flowSeamViolation) String() string {
 	return fmt.Sprintf("%s/%s: %s sets %s", v.Dir, v.File, where, v.Field)
 }
 
+// flowSeamActionsImportPath is the package the launch context type lives in.
+const flowSeamActionsImportPath = "github.com/approachcontrol/approach/actions"
+
+// flowSeamActionsNames is every identifier that names the actions package in
+// file: whatever its import declares it as, since `import act ".../actions"`
+// spells the same type `act.AgentLaunchContext`. The unaliased name is always
+// included so a source fragment without imports still reads normally.
+func flowSeamActionsNames(file *ast.File) map[string]bool {
+	names := map[string]bool{"actions": true}
+	for _, imported := range file.Imports {
+		path, err := strconv.Unquote(imported.Path.Value)
+		if err != nil || path != flowSeamActionsImportPath {
+			continue
+		}
+		if imported.Name != nil && imported.Name.Name != "_" && imported.Name.Name != "." {
+			names[imported.Name.Name] = true
+		}
+	}
+	return names
+}
+
 // flowSeamIsLaunchContextType matches the two syntactic spellings of the type:
-// actions.AgentLaunchContext from model, and the bare ident from inside
-// actions itself.
-func flowSeamIsLaunchContextType(expr ast.Expr) bool {
+// a qualified actions.AgentLaunchContext under whatever name the file imports
+// the actions package as, and the bare ident from inside actions itself.
+func flowSeamIsLaunchContextType(expr ast.Expr, pkgs map[string]bool) bool {
 	switch typ := expr.(type) {
 	case *ast.Ident:
 		return typ.Name == "AgentLaunchContext"
 	case *ast.StarExpr:
-		return flowSeamIsLaunchContextType(typ.X)
+		return flowSeamIsLaunchContextType(typ.X, pkgs)
 	case *ast.SelectorExpr:
 		pkg, ok := typ.X.(*ast.Ident)
-		return ok && pkg.Name == "actions" && typ.Sel.Name == "AgentLaunchContext"
+		return ok && pkgs[pkg.Name] && typ.Sel.Name == "AgentLaunchContext"
 	}
 	return false
 }
@@ -70,20 +92,20 @@ func flowSeamIsLaunchContextType(expr ast.Expr) bool {
 // roles wrap their literals in. Anything else returns nil, because an
 // assignment target has to be *provably* a launch context before a marker
 // write on it counts as a violation.
-func flowSeamLaunchContextLit(expr ast.Expr) *ast.CompositeLit {
+func flowSeamLaunchContextLit(expr ast.Expr, pkgs map[string]bool) *ast.CompositeLit {
 	switch expr := expr.(type) {
 	case *ast.ParenExpr:
-		return flowSeamLaunchContextLit(expr.X)
+		return flowSeamLaunchContextLit(expr.X, pkgs)
 	case *ast.UnaryExpr:
 		if expr.Op == token.AND {
-			return flowSeamLaunchContextLit(expr.X)
+			return flowSeamLaunchContextLit(expr.X, pkgs)
 		}
 	case *ast.CallExpr:
 		if fn, ok := expr.Fun.(*ast.Ident); ok && fn.Name == "applyLaunchStamp" && len(expr.Args) > 0 {
-			return flowSeamLaunchContextLit(expr.Args[0])
+			return flowSeamLaunchContextLit(expr.Args[0], pkgs)
 		}
 	case *ast.CompositeLit:
-		if flowSeamIsLaunchContextType(expr.Type) {
+		if flowSeamIsLaunchContextType(expr.Type, pkgs) {
 			return expr
 		}
 	}
@@ -105,6 +127,13 @@ type flowSeamContextShapes struct {
 	// functions sharing a name is rare, and conflating them only makes the
 	// seam rule stricter.
 	results map[string]map[int]bool
+}
+
+// flowSeamScope pairs the scan-set-wide shapes with the one thing that is
+// per-file: which identifiers name the actions package here.
+type flowSeamScope struct {
+	pkgs   map[string]bool
+	shapes flowSeamContextShapes
 }
 
 func newFlowSeamContextShapes() flowSeamContextShapes {
@@ -142,6 +171,7 @@ func (s flowSeamContextShapes) resultIndices(call *ast.CallExpr) map[int]bool {
 
 func flowSeamContextShapesOf(file *ast.File) flowSeamContextShapes {
 	shapes := newFlowSeamContextShapes()
+	pkgs := flowSeamActionsNames(file)
 	ast.Inspect(file, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.StructType:
@@ -149,7 +179,7 @@ func flowSeamContextShapesOf(file *ast.File) flowSeamContextShapes {
 				return true
 			}
 			for _, field := range n.Fields.List {
-				if !flowSeamIsLaunchContextType(field.Type) {
+				if !flowSeamIsLaunchContextType(field.Type, pkgs) {
 					continue
 				}
 				for _, name := range field.Names {
@@ -167,7 +197,7 @@ func flowSeamContextShapesOf(file *ast.File) flowSeamContextShapes {
 				if count == 0 {
 					count = 1
 				}
-				if flowSeamIsLaunchContextType(result.Type) {
+				if flowSeamIsLaunchContextType(result.Type, pkgs) {
 					for offset := 0; offset < count; offset++ {
 						indices[position+offset] = true
 					}
@@ -187,25 +217,25 @@ func flowSeamContextShapesOf(file *ast.File) flowSeamContextShapes {
 // context: a literal, a name already known to hold one, or a read of a struct
 // field declared as one, through any number of parentheses, address-of, and
 // dereference wrappers.
-func flowSeamLaunchContextExpr(expr ast.Expr, names map[string]bool, shapes flowSeamContextShapes) bool {
-	if flowSeamLaunchContextLit(expr) != nil {
+func flowSeamLaunchContextExpr(expr ast.Expr, names map[string]bool, scope flowSeamScope) bool {
+	if flowSeamLaunchContextLit(expr, scope.pkgs) != nil {
 		return true
 	}
 	switch expr := expr.(type) {
 	case *ast.ParenExpr:
-		return flowSeamLaunchContextExpr(expr.X, names, shapes)
+		return flowSeamLaunchContextExpr(expr.X, names, scope)
 	case *ast.StarExpr:
-		return flowSeamLaunchContextExpr(expr.X, names, shapes)
+		return flowSeamLaunchContextExpr(expr.X, names, scope)
 	case *ast.UnaryExpr:
 		if expr.Op == token.AND {
-			return flowSeamLaunchContextExpr(expr.X, names, shapes)
+			return flowSeamLaunchContextExpr(expr.X, names, scope)
 		}
 	case *ast.Ident:
 		return names[expr.Name]
 	case *ast.SelectorExpr:
-		return shapes.fields[expr.Sel.Name]
+		return scope.shapes.fields[expr.Sel.Name]
 	case *ast.CallExpr:
-		return shapes.resultIndices(expr)[0]
+		return scope.shapes.resultIndices(expr)[0]
 	}
 	return false
 }
@@ -216,11 +246,11 @@ func flowSeamLaunchContextExpr(expr ast.Expr, names map[string]bool, shapes flow
 // context literal, of another such name, of a launch context struct field, or
 // of a result of a function that returns one. Aliases chain, so the walk
 // repeats until it stops learning names.
-func flowSeamLaunchContextNames(node ast.Node, shapes flowSeamContextShapes) map[string]bool {
+func flowSeamLaunchContextNames(node ast.Node, scope flowSeamScope) map[string]bool {
 	names := make(map[string]bool)
 	for {
 		before := len(names)
-		flowSeamCollectLaunchContextNames(node, names, shapes)
+		flowSeamCollectLaunchContextNames(node, names, scope)
 		if len(names) == before {
 			return names
 		}
@@ -230,7 +260,7 @@ func flowSeamLaunchContextNames(node ast.Node, shapes flowSeamContextShapes) map
 // flowSeamBindCallResults records the names on the left of a single-call
 // assignment whose matching result is a launch context, covering the
 // multi-result `ctx, decision, err := build()` shape as well as the single one.
-func flowSeamBindCallResults(lhs, rhs []ast.Expr, names map[string]bool, shapes flowSeamContextShapes) {
+func flowSeamBindCallResults(lhs, rhs []ast.Expr, names map[string]bool, scope flowSeamScope) {
 	if len(rhs) != 1 {
 		return
 	}
@@ -238,7 +268,7 @@ func flowSeamBindCallResults(lhs, rhs []ast.Expr, names map[string]bool, shapes 
 	if !ok {
 		return
 	}
-	indices := shapes.resultIndices(call)
+	indices := scope.shapes.resultIndices(call)
 	for index, target := range lhs {
 		if !indices[index] {
 			continue
@@ -249,13 +279,13 @@ func flowSeamBindCallResults(lhs, rhs []ast.Expr, names map[string]bool, shapes 
 	}
 }
 
-func flowSeamCollectLaunchContextNames(node ast.Node, names map[string]bool, shapes flowSeamContextShapes) {
+func flowSeamCollectLaunchContextNames(node ast.Node, names map[string]bool, scope flowSeamScope) {
 	addFields := func(fields *ast.FieldList) {
 		if fields == nil {
 			return
 		}
 		for _, field := range fields.List {
-			if !flowSeamIsLaunchContextType(field.Type) {
+			if !flowSeamIsLaunchContextType(field.Type, scope.pkgs) {
 				continue
 			}
 			for _, name := range field.Names {
@@ -277,13 +307,13 @@ func flowSeamCollectLaunchContextNames(node ast.Node, names map[string]bool, sha
 		case *ast.FuncLit:
 			addFuncType(n.Type)
 		case *ast.ValueSpec:
-			if flowSeamIsLaunchContextType(n.Type) {
+			if flowSeamIsLaunchContextType(n.Type, scope.pkgs) {
 				for _, name := range n.Names {
 					names[name.Name] = true
 				}
 			}
 			for index, value := range n.Values {
-				if index < len(n.Names) && flowSeamLaunchContextExpr(value, names, shapes) {
+				if index < len(n.Names) && flowSeamLaunchContextExpr(value, names, scope) {
 					names[n.Names[index].Name] = true
 				}
 			}
@@ -291,17 +321,17 @@ func flowSeamCollectLaunchContextNames(node ast.Node, names map[string]bool, sha
 			for _, name := range n.Names {
 				specNames = append(specNames, name)
 			}
-			flowSeamBindCallResults(specNames, n.Values, names, shapes)
+			flowSeamBindCallResults(specNames, n.Values, names, scope)
 		case *ast.AssignStmt:
 			for index, value := range n.Rhs {
-				if index >= len(n.Lhs) || !flowSeamLaunchContextExpr(value, names, shapes) {
+				if index >= len(n.Lhs) || !flowSeamLaunchContextExpr(value, names, scope) {
 					continue
 				}
 				if ident, ok := n.Lhs[index].(*ast.Ident); ok {
 					names[ident.Name] = true
 				}
 			}
-			flowSeamBindCallResults(n.Lhs, n.Rhs, names, shapes)
+			flowSeamBindCallResults(n.Lhs, n.Rhs, names, scope)
 		}
 		return true
 	})
@@ -310,8 +340,8 @@ func flowSeamCollectLaunchContextNames(node ast.Node, names map[string]bool, sha
 // flowSeamNodeViolations reports marker fields set within one declaration:
 // keys on a launch context literal, and assignments to a marker field of a
 // name that is provably a launch context.
-func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers map[string]bool, shapes flowSeamContextShapes) []flowSeamViolation {
-	locals := flowSeamLaunchContextNames(node, shapes)
+func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers map[string]bool, scope flowSeamScope) []flowSeamViolation {
+	locals := flowSeamLaunchContextNames(node, scope)
 	var violations []flowSeamViolation
 	record := func(field string) {
 		violations = append(violations, flowSeamViolation{Dir: dir, File: file, Func: function, Field: field})
@@ -319,7 +349,7 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers m
 	ast.Inspect(node, func(n ast.Node) bool {
 		switch n := n.(type) {
 		case *ast.CompositeLit:
-			if !flowSeamIsLaunchContextType(n.Type) {
+			if !flowSeamIsLaunchContextType(n.Type, scope.pkgs) {
 				return true
 			}
 			for _, element := range n.Elts {
@@ -338,7 +368,7 @@ func flowSeamNodeViolations(dir, file, function string, node ast.Node, markers m
 				if !ok || !markers[selector.Sel.Name] {
 					continue
 				}
-				if flowSeamLaunchContextExpr(selector.X, locals, shapes) {
+				if flowSeamLaunchContextExpr(selector.X, locals, scope) {
 					record(selector.Sel.Name)
 				}
 			}
@@ -355,11 +385,12 @@ func flowSeamViolations(dir, name string, file *ast.File, markers map[string]boo
 	if dir == "model" && name == flowSeamLaunchContextExemptFile {
 		return nil
 	}
+	scope := flowSeamScope{pkgs: flowSeamActionsNames(file), shapes: shapes}
 	var violations []flowSeamViolation
 	for _, declaration := range file.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
 		if !ok {
-			violations = append(violations, flowSeamNodeViolations(dir, name, "", declaration, markers, shapes)...)
+			violations = append(violations, flowSeamNodeViolations(dir, name, "", declaration, markers, scope)...)
 			continue
 		}
 		if function.Body == nil {
@@ -371,7 +402,7 @@ func flowSeamViolations(dir, name string, file *ast.File, markers map[string]boo
 				label = receiver + "." + label
 			}
 		}
-		violations = append(violations, flowSeamNodeViolations(dir, name, label, function, markers, shapes)...)
+		violations = append(violations, flowSeamNodeViolations(dir, name, label, function, markers, scope)...)
 	}
 	return violations
 }
@@ -554,6 +585,28 @@ func copied(msg launchMsg) {
 	ctx.FlowID = "f"
 }`,
 			want: []string{"copied.FlowID"},
+		},
+		"marker literal behind an aliased actions import": {
+			dir: "model", name: "keys.go",
+			source: `package model
+
+import act "github.com/approachcontrol/approach/actions"
+
+func aliasedImport() {
+	_ = act.AgentLaunchContext{FlowRepair: true}
+}`,
+			want: []string{"aliasedImport.FlowRepair"},
+		},
+		"same-named type from an unrelated package": {
+			dir: "model", name: "keys.go",
+			source: `package model
+
+import act "github.com/elsewhere/other"
+
+func unrelatedPackage() {
+	_ = act.AgentLaunchContext{FlowRepair: true}
+}`,
+			want: []string{},
 		},
 		"marker assigned on a helper-returned launch context": {
 			dir: "model", name: "keys.go",


### PR DESCRIPTION
## The problem

`approach-hyl.9`–`.11` finished migrating all seven Flow roles behind the launch-context role builder in `model/flow_launch_context.go`. Nothing stops an eighth from being hand-rolled at a call site tomorrow. The only guard today is `flowLaunchContextRequiresLifecycle`, which fires at runtime once the launch is already in flight — it refuses correctly, but it tells you at the wrong moment, and a reviewer has to walk the call path to know it will fire at all.

The seam is a property of the repository's shape, so it should be checked by reading the repository.

## The change

New `model/flow_launch_seam_test.go`. No production code changes.

`TestFlowLaunchContextLiteralsStayInsideTheLaunchModule` scans every non-test file in `model/` and `actions/` and fails on any Flow marker field set on an `AgentLaunchContext` outside `model/flow_launch_context.go`. It catches both syntactic spellings of the hole:

- a marker key on a composite literal — `actions.AgentLaunchContext{...}` from `model`, bare `AgentLaunchContext{...}` from inside `actions`, including inside a closure or a package-level `var`;
- an assignment `ctx.FlowRepair = true` where `ctx` is *provably* an `AgentLaunchContext` — a parameter, a result, a `var`, or a `:=` of a launch-context literal (including one wrapped in `applyLaunchStamp`). Anything not provably a launch context is ignored, so a same-named field on `flowLaunchAttempt` is not a false positive.

The marker set is derived by reflection over the struct rather than hand-written, and `TestFlowLaunchMarkerFieldsAreExactlyTheEleven` pins it against the eleven `Flow*` fields ADR 0002 names. A twelfth field is covered automatically; a rename fails loudly instead of silently shrinking the rule.

`TestFlowLaunchLifecycleBackstopStaysWired` asserts `Model.launchAgentForBackend` still calls `flowLaunchContextRequiresLifecycle`, so the runtime net cannot be deleted on the strength of the static one. It reuses the contract parser already in `flow_launch_boundary_test.go`.

## Allow-list

Two entries, each carrying its rationale, for the literals that address a launch record which already exists rather than constructing one:

| Function | Why it is not a launch |
|---|---|
| `Model.blockAutoFlowLaunchPhase` | Synthesizes a failure context for the attempt that already failed; there is no process to start. |
| `Model.releaseFlowPhaseSessionsCmd` | Finalizes hook records of launches that already ran and are being released. |

Two deliberate deviations from the bead text, both flagged in the approved plan:

- **Keyed by file + enclosing function, not `file:line`.** Line numbers shift on any unrelated edit in those files, which turns the guard into a maintenance tax and trains people to re-pin it. There is one literal per function, so this is equally precise and stable. An allow-list entry that matches nothing is itself a test failure, so the list cannot rot.
- **The four non-Flow constructors get no entry.** The bead lists Ready-Bead `S`, plans-mode implement, worktree `a`, and non-Flow session resume as allow-list members. They set no marker at all — which is exactly what keeps `flowLaunchContextRequiresLifecycle` false for them — so an entry would be dead configuration granting a standing exemption, and the stale-entry check would rightly fail on it. They are named in a comment explaining why instead.

## Verification

The detector is driven by ten table tests over synthetic source, so "fails when a violation is introduced" is a permanent assertion, not a one-off. As an additional sanity check I injected a real `FlowRepair: true` into `model/model_keys.go` and an `AgentLaunchContext{FlowAgent: true}` into `actions/actions.go`; the scan reported both, across both packages and both spellings, and was reverted. Temporarily adding a bogus allow-list entry produced the expected stale-entry failure.

Full gate: `make fmt-check`, `go vet ./model ./actions`, `make build`, and `make test` all pass.