### PR TITLE
Pin every way a Flow says "I'm busy" before moving any caller

### DIFF
--- a/model/flow_occupancy_admission_internal_test.go
+++ b/model/flow_occupancy_admission_internal_test.go
@@ -1,0 +1,490 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/approachcontrol/approach/flowstore"
+)
+
+// The composed admissions of §2.1, the previews and footers of §2.3, and the
+// AutoMode drain of §2.4. Each admission is cross-checked against the footer
+// predicate that advertises its key, because "what the footer advertises and
+// what the key accepts can never disagree" is asserted in production comments
+// but not everywhere in tests — and D4 records three places where they are
+// deliberately allowed to disagree.
+
+// TestManualPhaseAdmissionAndFooterAgree covers `g`. The headless rung is first
+// in both, so the footer withdraws for exactly the reasons admission refuses.
+func TestManualPhaseAdmissionAndFooterAgree(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []occupancySource
+		want    string
+	}{
+		{name: "unoccupied Flow admits", want: ""},
+		{name: "pending headless write", sources: []occupancySource{srcHeadlessWrite}, want: flowHeadlessWritePendingStatus},
+		{name: "held lease", sources: []occupancySource{srcLeaseHeld}, want: flowLeaseOccupiedStatus},
+		{name: "unreadable lease", sources: []occupancySource{srcLeaseError}, want: flowLeaseSetupErrorStatus(occupancyLeaseErr())},
+		// Every runtime holder collapses into one generic status: the manual
+		// admission never names which of the three is blocking.
+		{name: "competing attempt", sources: []occupancySource{srcAttemptRepair}, want: noLaunchableFlowPhaseStatus},
+		{name: "Flow terminal", sources: []occupancySource{srcFlowTerminal}, want: noLaunchableFlowPhaseStatus},
+		{name: "terminal-less repair slot", sources: []occupancySource{srcRepairSlot}, want: noLaunchableFlowPhaseStatus},
+		{
+			// The headless rung is checked before the lease, so it wins even
+			// though the lease is the more durable obstacle.
+			name:    "headless write over a held lease",
+			sources: []occupancySource{srcHeadlessWrite, srcLeaseHeld},
+			want:    flowHeadlessWritePendingStatus,
+		},
+		{
+			name:    "held lease over a runtime holder",
+			sources: []occupancySource{srcLeaseHeld, srcFlowTerminal},
+			want:    flowLeaseOccupiedStatus,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, tc.sources...)
+			wantAdmitted := tc.want == ""
+
+			if got := f.m.selectedFlowHasLaunchablePhase(); got != wantAdmitted {
+				t.Fatalf("selectedFlowHasLaunchablePhase = %v, want %v", got, wantAdmitted)
+			}
+			_, _, previewed := f.m.previewFlowLaunch(flowLaunchIntent{
+				Kind:   flowLaunchKindManualPhase,
+				FlowID: f.flowID(),
+			})
+			// previewFlowLaunch has no headless term of its own; the footer adds
+			// it. Everything else the footer refuses, the preview refuses too.
+			wantPreview := !f.m.flowLaunchAdmissionOccupied(f.flowID())
+			if previewed != wantPreview {
+				t.Fatalf("previewFlowLaunch ok = %v, want %v", previewed, wantPreview)
+			}
+			if wantPreview && !wantAdmitted && tc.want != flowHeadlessWritePendingStatus {
+				t.Fatal("the preview may only outrun the footer for a pending headless write")
+			}
+
+			next, cmd, admitted := f.m.requestFlowLaunch(flowLaunchIntent{
+				Kind:   flowLaunchKindManualPhase,
+				FlowID: f.flowID(),
+			})
+			if admitted != wantAdmitted || (cmd != nil) != wantAdmitted {
+				t.Fatalf("admitted = %v, cmd != nil = %v, want %v", admitted, cmd != nil, wantAdmitted)
+			}
+			if got := next.status.Text; got != tc.want {
+				t.Fatalf("status = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAutoPhaseAdmissionRefusesInSilence is D3. Silence is a behavior, not an
+// omission: the advance poll runs at 1 Hz and is view-independent, so a status
+// would be repainted every second over whatever the user is looking at. A test
+// that only checked the boolean would not catch a migration that started
+// rendering text.
+func TestAutoPhaseAdmissionRefusesInSilence(t *testing.T) {
+	sourceSets := [][]occupancySource{
+		{srcLeaseHeld},
+		{srcLeaseError},
+		{srcAttemptManualPhase},
+		{srcFlowTerminal},
+		{srcRepairSlot},
+		{srcLeaseHeld, srcFlowTerminal, srcAttemptRepair},
+	}
+	for _, sources := range sourceSets {
+		t.Run(occupancySourcesName(sources), func(t *testing.T) {
+			f := newOccupancyFixture(t, sources...)
+			// A status set before the refusal proves the refusal did not merely
+			// leave the field empty; it never touched it.
+			before := f.m.setStatus(statusOther, "user is looking at this")
+			next, cmd, admitted := before.requestFlowLaunch(flowLaunchIntent{
+				Kind:    flowLaunchKindAutoPhase,
+				FlowID:  f.flowID(),
+				PhaseID: f.phase().PhaseID,
+			})
+			if admitted || cmd != nil {
+				t.Fatalf("admitted = %v, cmd != nil = %v, want a refusal", admitted, cmd != nil)
+			}
+			if got := next.status.Text; got != "user is looking at this" {
+				t.Fatalf("status = %q, want the pre-existing status untouched", got)
+			}
+		})
+	}
+}
+
+// TestAutoPhaseAdmissionIgnoresTheHeadlessWrite pins the other half of the auto
+// admission's set: it reads flowLaunchAdmissionOccupied and nothing else, so a
+// pending headless write does not stop it, where it stops `g`.
+func TestAutoPhaseAdmissionIgnoresTheHeadlessWrite(t *testing.T) {
+	f := newOccupancyFixture(t, srcHeadlessWrite)
+	_, cmd, admitted := f.m.requestFlowLaunch(flowLaunchIntent{
+		Kind:    flowLaunchKindAutoPhase,
+		FlowID:  f.flowID(),
+		PhaseID: f.phase().PhaseID,
+	})
+	if !admitted || cmd == nil {
+		t.Fatalf("admitted = %v, cmd != nil = %v, want an admitted auto launch", admitted, cmd != nil)
+	}
+}
+
+// TestCreatePhaseAdmissionIgnoresTheLease is D2, the sharpest divergence in the
+// matrix: a held lease refuses every other existing-Flow route and does not
+// refuse a create, because creation allocates a brand-new Flow that remains
+// embedded and unleased.
+func TestCreatePhaseAdmissionIgnoresTheLease(t *testing.T) {
+	tests := []struct {
+		name        string
+		sources     []occupancySource
+		wantRefused bool
+	}{
+		{name: "held lease does not refuse a create", sources: []occupancySource{srcLeaseHeld}},
+		{name: "unreadable lease does not refuse a create", sources: []occupancySource{srcLeaseError}},
+		{name: "a competing attempt refuses", sources: []occupancySource{srcAttemptRepair}, wantRefused: true},
+		{name: "a Flow terminal refuses", sources: []occupancySource{srcFlowTerminal}, wantRefused: true},
+		{name: "a terminal-less repair slot refuses", sources: []occupancySource{srcRepairSlot}, wantRefused: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, tc.sources...)
+			create := flowLaunchCreateRequest{
+				Presentation: flowLaunchCreatePresentation{Origin: flowLaunchOriginNewFlow, Request: 1},
+				RepoPath:     f.record.RepoPath,
+			}
+			m := f.m
+			m.flowCreateReq.current = create.Presentation.Request
+
+			next, _ := m.handleCreateFlowAllocated(flowLaunchEventMsg{
+				Kind:   flowLaunchKindCreatePhase,
+				Token:  "create-token",
+				FlowID: f.flowID(),
+				Create: create,
+			})
+			reserved := next.flowLaunchAttemptKind(f.flowID()) == flowLaunchKindCreatePhase
+			if reserved == tc.wantRefused {
+				t.Fatalf("createPhase reserved = %v, want refused = %v", reserved, tc.wantRefused)
+			}
+			if tc.wantRefused && next.status.Text != noLaunchableFlowPhaseStatus {
+				t.Fatalf("status = %q, want %q", next.status.Text, noLaunchableFlowPhaseStatus)
+			}
+		})
+	}
+}
+
+// TestPhaseResumeAdmissionAndPreviewDisagreeByDesign is D4's first case. Resume
+// refuses a competing attempt and an open repair terminal in silence, and its
+// footer keeps advertising the key for both — withdrawing it would be a behavior
+// change the survey records rather than makes.
+func TestPhaseResumeAdmissionAndPreviewDisagreeByDesign(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []occupancySource
+		// wantStatus is "" for both an admitted resume and a silent refusal;
+		// wantAdmitted is what tells those apart.
+		wantAdmitted bool
+		wantStatus   string
+		wantPreview  bool
+	}{
+		{name: "unoccupied Flow", wantAdmitted: true, wantPreview: true},
+		{name: "held lease", sources: []occupancySource{srcLeaseHeld}, wantStatus: flowLeaseOccupiedStatus},
+		{
+			name:       "unreadable lease",
+			sources:    []occupancySource{srcLeaseError},
+			wantStatus: flowLeaseSetupErrorStatus(occupancyLeaseErr()),
+		},
+		{
+			// S6 ∧ ¬S7: the only runtime state resume names.
+			name:       "Flow terminal with no repair slot",
+			sources:    []occupancySource{srcFlowTerminal},
+			wantStatus: flowPhaseResumeTerminalStatus,
+		},
+		{
+			// A competing attempt refuses silently and the footer stays lit.
+			name:        "competing attempt",
+			sources:     []occupancySource{srcAttemptRepair},
+			wantPreview: true,
+		},
+		{
+			// So does a repair slot, whether or not it has a live terminal:
+			// the status is scoped to the non-repair case by the conjunction.
+			name:        "terminal-less repair slot",
+			sources:     []occupancySource{srcRepairSlot},
+			wantPreview: true,
+		},
+		{
+			name:        "repair slot with a live terminal",
+			sources:     []occupancySource{srcFlowTerminal, srcRepairSlot},
+			wantPreview: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, tc.sources...)
+			if got := f.m.previewPhaseResume(f.flowID()); got != tc.wantPreview {
+				t.Fatalf("previewPhaseResume = %v, want %v", got, tc.wantPreview)
+			}
+			next, cmd, admitted := f.m.requestFlowLaunch(flowLaunchIntent{
+				Kind:    flowLaunchKindPhaseResume,
+				FlowID:  f.flowID(),
+				PhaseID: f.phase().PhaseID,
+			})
+			if admitted != tc.wantAdmitted || (cmd != nil) != tc.wantAdmitted {
+				t.Fatalf("admitted = %v, cmd != nil = %v, want %v", admitted, cmd != nil, tc.wantAdmitted)
+			}
+			if got := next.status.Text; got != tc.wantStatus {
+				t.Fatalf("status = %q, want %q", got, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestPreviewPhaseResumeIsTrueForABlankFlowID pins the preview's short circuit:
+// with no Flow named there is nothing to be occupied, and the key stays lit.
+func TestPreviewPhaseResumeIsTrueForABlankFlowID(t *testing.T) {
+	f := newOccupancyFixture(t, srcLeaseHeld, srcFlowTerminal)
+	if !f.m.previewPhaseResume("   ") {
+		t.Fatal("previewPhaseResume answers true for a blank Flow ID regardless of what holds any Flow")
+	}
+}
+
+// TestRepairFooterAddsTheHeadlessTermToThePreview is D4's second case: repair's
+// footer occupancy set is wider than its preview's, because admission's
+// occupancy set has no headless notion and the composite is shared with kinds
+// that must not inherit one.
+func TestRepairFooterAddsTheHeadlessTermToThePreview(t *testing.T) {
+	tests := []struct {
+		name        string
+		sources     []occupancySource
+		wantPreview bool
+		wantFooter  bool
+		wantStatus  string
+	}{
+		{name: "unoccupied repairable Flow", wantPreview: true, wantFooter: true},
+		{
+			// The headless write is invisible to the preview and withdraws the
+			// footer, and admission refuses with the ladder's rank 5.
+			name:        "pending headless write",
+			sources:     []occupancySource{srcHeadlessWrite},
+			wantPreview: true,
+			wantStatus:  flowHeadlessWritePendingStatus,
+		},
+		{name: "held lease", sources: []occupancySource{srcLeaseHeld}, wantStatus: flowLeaseOccupiedStatus},
+		{name: "Flow terminal", sources: []occupancySource{srcFlowTerminal}, wantStatus: flowRepairTerminalStatus},
+		{name: "repair attempt", sources: []occupancySource{srcAttemptRepair}, wantStatus: flowRepairPendingStatus},
+	}
+	record := occupancyRepairFlowRecord()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixtureFor(t, record, tc.sources...)
+			if _, ok := f.m.previewRepairLaunch(f.m.repairFlowLaunchIntent("")); ok != tc.wantPreview {
+				t.Fatalf("previewRepairLaunch ok = %v, want %v", ok, tc.wantPreview)
+			}
+			if got := f.m.selectedFlowRepairReady(); got != tc.wantFooter {
+				t.Fatalf("selectedFlowRepairReady = %v, want %v", got, tc.wantFooter)
+			}
+			next, cmd, admitted := f.m.requestFlowLaunch(flowLaunchIntent{
+				Kind:   flowLaunchKindRepair,
+				FlowID: f.flowID(),
+			})
+			wantAdmitted := tc.wantStatus == ""
+			if admitted != wantAdmitted || (cmd != nil) != wantAdmitted {
+				t.Fatalf("admitted = %v, cmd != nil = %v, want %v", admitted, cmd != nil, wantAdmitted)
+			}
+			if got := next.status.Text; got != tc.wantStatus {
+				t.Fatalf("status = %q, want %q", got, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestAutofixFooterAddsTheHeadlessTermToTheComposite is D4's third case, the
+// same shape as repair's: the footer is the composite plus S14.
+func TestAutofixFooterAddsTheHeadlessTermToTheComposite(t *testing.T) {
+	record := autofixFlowRecord()
+
+	ready := newOccupancyFixtureFor(t, record)
+	if !ready.m.selectedFlowAutofixReady() {
+		t.Fatal("an unoccupied autofix-eligible Flow advertises U")
+	}
+	if ready.m.flowLaunchAdmissionOccupied(record.FlowID) {
+		t.Fatal("the baseline fixture must not be occupied")
+	}
+
+	headless := newOccupancyFixtureFor(t, record, srcHeadlessWrite)
+	if headless.m.flowLaunchAdmissionOccupied(record.FlowID) {
+		t.Fatal("a headless write is not part of admission's occupancy set")
+	}
+	if headless.m.selectedFlowAutofixReady() {
+		t.Fatal("the footer withdraws U for a pending headless write the composite cannot see")
+	}
+}
+
+// TestSelectedFlowWorktreeAgentReadyMatchesItsAdmission is the footer half of
+// §4.4. It is the only footer predicate that reads the session mirror, and the
+// only one whose occupancy set is exactly its admission's minus the sources
+// admission cannot answer from the Model.
+func TestSelectedFlowWorktreeAgentReadyMatchesItsAdmission(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []occupancySource
+		want    bool
+	}{
+		{name: "unoccupied Flow", want: true},
+		{name: "held lease", sources: []occupancySource{srcLeaseHeld}},
+		{name: "unreadable lease", sources: []occupancySource{srcLeaseError}},
+		{name: "competing attempt", sources: []occupancySource{srcAttemptManualPhase}},
+		{name: "Flow terminal", sources: []occupancySource{srcFlowTerminal}},
+		{name: "terminal-less repair slot", sources: []occupancySource{srcRepairSlot}},
+		{name: "session mirror", sources: []occupancySource{srcSessionMirror}},
+		{name: "running phase", sources: []occupancySource{srcRunningPhase}},
+		{name: "session-attached phase", sources: []occupancySource{srcPhaseSession}},
+		{
+			// The footer does not probe tmux — it shells out — so a live autofix
+			// window leaves the key advertised and the press refuses.
+			name:    "live autofix tmux window leaves the footer lit",
+			sources: []occupancySource{srcTmuxAutofixWindow},
+			want:    true,
+		},
+		{
+			// Nor does it read the headless write; only repair's and autofix's
+			// footers add that term.
+			name:    "pending headless write leaves the footer lit",
+			sources: []occupancySource{srcHeadlessWrite},
+			want:    true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, tc.sources...)
+			if got := f.m.selectedFlowWorktreeAgentReady(); got != tc.want {
+				t.Fatalf("selectedFlowWorktreeAgentReady = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFlowAutoAdvanceOccupiedReadsFourSourcesAndNotTheOthers is §2.4's drain
+// gate. The negatives are the point: it deliberately does not read the repair
+// slot and does not shell out to tmux, because a poll on a timer must not.
+func TestFlowAutoAdvanceOccupiedReadsFourSourcesAndNotTheOthers(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []occupancySource
+		want    bool
+	}{
+		{name: "unoccupied Flow"},
+		{name: "held lease", sources: []occupancySource{srcLeaseHeld}, want: true},
+		{name: "unreadable lease", sources: []occupancySource{srcLeaseError}, want: true},
+		{name: "lifecycle attempt", sources: []occupancySource{srcAttemptRepair}, want: true},
+		{name: "persisted running phase", sources: []occupancySource{srcRunningPhase}, want: true},
+		{name: "Flow terminal", sources: []occupancySource{srcFlowTerminal}, want: true},
+		// The explicit negatives.
+		{name: "a terminal-less repair slot does not occupy the drain", sources: []occupancySource{srcRepairSlot}},
+		{name: "a live autofix tmux window does not occupy the drain", sources: []occupancySource{srcTmuxAutofixWindow}},
+		{name: "a session-attached phase does not occupy the drain", sources: []occupancySource{srcPhaseSession}},
+		{name: "the session mirror does not occupy the drain", sources: []occupancySource{srcSessionMirror}},
+		{name: "a pending headless write does not occupy the drain", sources: []occupancySource{srcHeadlessWrite}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, tc.sources...)
+			if got := f.m.flowAutoAdvanceOccupied(f.record); got != tc.want {
+				t.Fatalf("flowAutoAdvanceOccupied = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAutoAdvanceDrainDefersSilentlyAndStaysArmed pins the drain's own
+// occupancy behavior: a deferral launches nothing, sets no status, and leaves
+// the drain armed for the next poll. The session pre-filter is asserted the same
+// way, because it is the reason a stalled phase does not cost a session-store
+// walk every second.
+func TestAutoAdvanceDrainDefersSilentlyAndStaysArmed(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []occupancySource
+	}{
+		{name: "occupied by the drain's own gate", sources: []occupancySource{srcFlowTerminal}},
+		{name: "deferred by the session pre-filter", sources: []occupancySource{srcPhaseSession}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, tc.sources...)
+			record := f.record
+			record.AutoMode = true
+
+			m := f.m.armAutoAdvanceDrain(record.FlowID).setStatus(statusOther, "user is looking at this")
+			next, cmd := m.prepareAutoAdvanceDrainLaunches([]flowstore.FlowRecord{record})
+			if cmd != nil {
+				t.Fatal("a deferred drain must start no work")
+			}
+			if got := next.status.Text; got != "user is looking at this" {
+				t.Fatalf("status = %q, want the pre-existing status untouched", got)
+			}
+			if !next.autoAdvanceDrainArmed(record.FlowID) {
+				t.Fatal("a deferral leaves the drain armed for the next poll")
+			}
+			if next.flowLaunchAttemptOccupied(record.FlowID) &&
+				next.flowLaunchAttemptKind(record.FlowID) == flowLaunchKindAutoPhase {
+				t.Fatal("a deferred drain must reserve nothing")
+			}
+		})
+	}
+}
+
+// TestAutoAdvanceDrainIsDisarmedByARepairSlotOrMarker is the arm/disarm half of
+// §2.4, and the one place S7 and S16 are read by the poll at all. The drain gate
+// ignores both; the arming pass does not.
+//
+// Every row installs a held lease as well, so the drain gate defers in all of
+// them. Without that the unoccupied row would disarm by launching, and the
+// arm/disarm decision this test is about would be unobservable.
+func TestAutoAdvanceDrainIsDisarmedByARepairSlotOrMarker(t *testing.T) {
+	tests := []struct {
+		name      string
+		sources   []occupancySource
+		wantArmed bool
+	}{
+		{name: "a deferred drain stays armed", wantArmed: true},
+		{name: "an open repair slot disarms", sources: []occupancySource{srcRepairSlot}},
+		{name: "an unconsumed repair outcome disarms", sources: []occupancySource{srcDrainMarker}},
+		{
+			// The arming pass reads S7 specifically, so a non-repair Flow
+			// terminal is not a reason to disarm.
+			name:      "a non-repair Flow terminal does not disarm",
+			sources:   []occupancySource{srcFlowTerminal},
+			wantArmed: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, append([]occupancySource{srcLeaseHeld}, tc.sources...)...)
+			record := f.record
+			record.AutoMode = true
+
+			m := f.m.armAutoAdvanceDrain(record.FlowID)
+			if !m.autoAdvanceDrainArmed(record.FlowID) {
+				t.Fatal("the drain should start armed")
+			}
+			flows := []flowstore.FlowRecord{record}
+			next, _, _ := m.prepareAutoFlowPhaseLaunch(flows, flows)
+			if got := next.autoAdvanceDrainArmed(record.FlowID); got != tc.wantArmed {
+				t.Fatalf("autoAdvanceDrainArmed = %v, want %v", got, tc.wantArmed)
+			}
+		})
+	}
+}
+
+// occupancySourcesName renders a source set for a subtest name.
+func occupancySourcesName(sources []occupancySource) string {
+	if len(sources) == 0 {
+		return "nothing"
+	}
+	name := sources[0].String()
+	for _, source := range sources[1:] {
+		name += "+" + source.String()
+	}
+	return name
+}

--- a/model/flow_occupancy_ladders_internal_test.go
+++ b/model/flow_occupancy_ladders_internal_test.go
@@ -1,0 +1,380 @@
+package model
+
+import (
+	"testing"
+)
+
+// The ordered refusals of docs/flow-occupancy-matrix.md §4. F2 records that four
+// ladders exist and none shares a table; these tests give each one a table, and
+// every rank is asserted both alone and against a lower rank installed at the
+// same time, because a ladder that only ever sees one source cannot be shown to
+// be ordered at all.
+
+// TestFlowRepairOccupancyRefusalLadder is §4.1. The lease sits above all five of
+// these ranks and is answered separately, so it does not appear here.
+func TestFlowRepairOccupancyRefusalLadder(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []occupancySource
+		want    string
+	}{
+		// Rank 1–3 key on the attempt's kind.
+		{name: "rank 1: repair attempt", sources: []occupancySource{srcAttemptRepair}, want: flowRepairPendingStatus},
+		{name: "rank 2: phase resume attempt", sources: []occupancySource{srcAttemptPhaseResume}, want: flowRepairResumePendingStatus},
+		{name: "rank 3: manual phase attempt", sources: []occupancySource{srcAttemptManualPhase}, want: flowRepairPhasePendingStatus},
+		{name: "rank 3: auto phase attempt", sources: []occupancySource{srcAttemptAutoPhase}, want: flowRepairPhasePendingStatus},
+		// Rank 4 is the fallback for every other attempt kind and for the slots.
+		{name: "rank 4: autofix attempt", sources: []occupancySource{srcAttemptAutofix}, want: flowRepairTerminalStatus},
+		{name: "rank 4: worktree agent attempt", sources: []occupancySource{srcAttemptWorktreeAgent}, want: flowRepairTerminalStatus},
+		{name: "rank 4: Flow terminal", sources: []occupancySource{srcFlowTerminal}, want: flowRepairTerminalStatus},
+		{name: "rank 4: terminal-less repair slot", sources: []occupancySource{srcRepairSlot}, want: flowRepairTerminalStatus},
+		{name: "rank 5: pending headless write", sources: []occupancySource{srcHeadlessWrite}, want: flowHeadlessWritePendingStatus},
+
+		// Precedence: each rank over a lower one installed simultaneously.
+		{
+			name:    "rank 1 over rank 4",
+			sources: []occupancySource{srcAttemptRepair, srcFlowTerminal, srcRepairSlot},
+			want:    flowRepairPendingStatus,
+		},
+		{
+			name:    "rank 2 over rank 4",
+			sources: []occupancySource{srcAttemptPhaseResume, srcFlowTerminal},
+			want:    flowRepairResumePendingStatus,
+		},
+		{
+			name:    "rank 3 over rank 4",
+			sources: []occupancySource{srcAttemptManualPhase, srcFlowTerminal},
+			want:    flowRepairPhasePendingStatus,
+		},
+		{
+			name:    "rank 4 over rank 5",
+			sources: []occupancySource{srcFlowTerminal, srcHeadlessWrite},
+			want:    flowRepairTerminalStatus,
+		},
+		{
+			name:    "rank 1 over every lower rank at once",
+			sources: []occupancySource{srcAttemptRepair, srcFlowTerminal, srcRepairSlot, srcHeadlessWrite},
+			want:    flowRepairPendingStatus,
+		},
+		{
+			// Rank 5 is a fallthrough, not a test. With nothing at all holding
+			// the Flow it still answers with the headless status, and that
+			// surprising fact is exactly what a migration would silently change.
+			name: "rank 5 is a fallthrough, so it answers even with nothing pending",
+			want: flowHeadlessWritePendingStatus,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, tc.sources...)
+			if got := f.m.flowRepairOccupancyRefusal(f.flowID()); got != tc.want {
+				t.Fatalf("flowRepairOccupancyRefusal = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAutofixOccupancyLadderPrecedence extends the existing single-source table
+// (autofixOccupancyCases) rather than restating it: those rows already pin every
+// rank alone, so this adds only the rows they lack — two sources at once, where
+// the order is the whole point.
+func TestAutofixOccupancyLadderPrecedence(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []occupancySource
+		want    string
+	}{
+		{
+			// The lease outranks the whole inline ladder, and it is answered
+			// typed so a peer race is not collapsed into the in-flight status.
+			name:    "lease over a repair attempt",
+			sources: []occupancySource{srcLeaseHeld, srcAttemptRepair},
+			want:    flowLeaseOccupiedStatus,
+		},
+		{
+			name:    "unreadable lease over a Flow terminal",
+			sources: []occupancySource{srcLeaseError, srcFlowTerminal},
+			want:    flowLeaseSetupErrorStatus(occupancyLeaseErr()),
+		},
+		{
+			name:    "repair attempt over a Flow terminal",
+			sources: []occupancySource{srcAttemptRepair, srcFlowTerminal},
+			want:    flowRepairPendingStatus,
+		},
+		{
+			// The literal is inline in production rather than a constant, so it
+			// is asserted as a literal: a copy edit there has to fail here.
+			name:    "phase resume attempt over a repair slot",
+			sources: []occupancySource{srcAttemptPhaseResume, srcRepairSlot},
+			want:    "A phase resume is already pending for this Flow",
+		},
+		{
+			// A manual attempt does not reach the terminal rung's name: the
+			// terminal is checked first, so the slot is what gets reported.
+			name:    "Flow terminal over a manual phase attempt",
+			sources: []occupancySource{srcFlowTerminal, srcAttemptManualPhase},
+			want:    flowAutofixTerminalStatus,
+		},
+		{
+			name:    "terminal-less repair slot still outranks the generic in-flight status",
+			sources: []occupancySource{srcRepairSlot, srcAttemptManualPhase},
+			want:    flowAutofixTerminalStatus,
+		},
+		{
+			name:    "a bare attempt reports the generic in-flight status",
+			sources: []occupancySource{srcAttemptManualPhase, srcHeadlessWrite},
+			want:    flowAutofixInFlightStatus,
+		},
+		{
+			// Unlike repair's rank 5, autofix's headless rung is a real test, so
+			// it is reached only when nothing durable holds the Flow.
+			name:    "headless write is last",
+			sources: []occupancySource{srcHeadlessWrite},
+			want:    flowHeadlessWritePendingStatus,
+		},
+	}
+	record := autofixFlowRecord()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixtureFor(t, record, tc.sources...)
+			next, cmd, admitted := f.m.requestFlowLaunch(flowLaunchIntent{
+				Kind:   flowLaunchKindAutofix,
+				FlowID: record.FlowID,
+			})
+			if admitted || cmd != nil {
+				t.Fatalf("admitted = %v, cmd != nil = %v, want a refusal that starts no work", admitted, cmd != nil)
+			}
+			if got := next.status.Text; got != tc.want {
+				t.Fatalf("status = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWorktreeAgentOccupancyLadder is §4.4, the only admission that reads every
+// source family. Each rank is asserted alone and then over the next one down.
+func TestWorktreeAgentOccupancyLadder(t *testing.T) {
+	const (
+		runningPhaseReason = "a running phase implementation already occupies this Flow"
+		phaseSessionReason = "an active persisted session on phase implementation already occupies this Flow"
+	)
+	tests := []struct {
+		name    string
+		sources []occupancySource
+		want    string
+	}{
+		{name: "rank 1: unreadable lease", sources: []occupancySource{srcLeaseError}, want: flowLeaseSetupErrorStatus(occupancyLeaseErr())},
+		{name: "rank 1: held lease", sources: []occupancySource{srcLeaseHeld}, want: flowLeaseOccupiedStatus},
+		{name: "rank 2: lifecycle attempt", sources: []occupancySource{srcAttemptManualPhase}, want: flowWorktreeAgentPendingStatus},
+		{name: "rank 3: live autofix tmux window", sources: []occupancySource{srcTmuxAutofixWindow}, want: flowWorktreeAgentPendingStatus},
+		{name: "rank 4: Flow terminal", sources: []occupancySource{srcFlowTerminal}, want: flowWorktreeAgentSlotStatus},
+		{name: "rank 4: terminal-less repair slot", sources: []occupancySource{srcRepairSlot}, want: flowWorktreeAgentSlotStatus},
+		{name: "rank 5: session mirror", sources: []occupancySource{srcSessionMirror}, want: flowWorktreeAgentSessionStatus},
+		{name: "rank 6: persisted running phase", sources: []occupancySource{srcRunningPhase}, want: runningPhaseReason},
+		{name: "rank 6: session-attached phase", sources: []occupancySource{srcPhaseSession}, want: phaseSessionReason},
+
+		{
+			name:    "rank 1 over rank 2",
+			sources: []occupancySource{srcLeaseHeld, srcAttemptManualPhase},
+			want:    flowLeaseOccupiedStatus,
+		},
+		{
+			name:    "rank 2 over rank 3",
+			sources: []occupancySource{srcAttemptManualPhase, srcTmuxAutofixWindow},
+			want:    flowWorktreeAgentPendingStatus,
+		},
+		{
+			// Ranks 2 and 3 answer with the same string, so the rung that
+			// separates them is asserted by installing the tmux window with a
+			// slot below it instead.
+			name:    "rank 3 over rank 4",
+			sources: []occupancySource{srcTmuxAutofixWindow, srcFlowTerminal},
+			want:    flowWorktreeAgentPendingStatus,
+		},
+		{
+			name:    "rank 4 over rank 5",
+			sources: []occupancySource{srcRepairSlot, srcSessionMirror},
+			want:    flowWorktreeAgentSlotStatus,
+		},
+		{
+			name:    "rank 5 over rank 6",
+			sources: []occupancySource{srcSessionMirror, srcRunningPhase},
+			want:    flowWorktreeAgentSessionStatus,
+		},
+		{
+			name:    "the whole ladder at once reports the lease",
+			sources: []occupancySource{srcLeaseHeld, srcAttemptManualPhase, srcFlowTerminal, srcSessionMirror, srcRunningPhase},
+			want:    flowLeaseOccupiedStatus,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, tc.sources...)
+			next, cmd, admitted := f.m.requestFlowLaunch(flowLaunchIntent{
+				Kind:   flowLaunchKindWorktreeAgent,
+				FlowID: f.flowID(),
+			})
+			if admitted || cmd != nil {
+				t.Fatalf("admitted = %v, cmd != nil = %v, want a refusal that starts no work", admitted, cmd != nil)
+			}
+			if got := next.status.Text; got != tc.want {
+				t.Fatalf("status = %q, want %q", got, tc.want)
+			}
+			// Whatever already held the Flow may still hold it; what must not
+			// exist is a worktree-agent attempt this refusal created.
+			if next.flowLaunchAttemptKind(f.flowID()) == flowLaunchKindWorktreeAgent {
+				t.Fatal("a refused admission must reserve nothing of its own")
+			}
+		})
+	}
+}
+
+// TestWorktreeAgentAdmissionAdmitsAnUnoccupiedFlow is the ladder's control row:
+// without it, every case above could pass because the fixture never admits.
+func TestWorktreeAgentAdmissionAdmitsAnUnoccupiedFlow(t *testing.T) {
+	f := newOccupancyFixture(t)
+	next, cmd, admitted := f.m.requestFlowLaunch(flowLaunchIntent{
+		Kind:   flowLaunchKindWorktreeAgent,
+		FlowID: f.flowID(),
+	})
+	if !admitted || cmd == nil {
+		t.Fatalf("admitted = %v, cmd != nil = %v, want an admitted launch", admitted, cmd != nil)
+	}
+	if got := next.status.Text; got != "" {
+		t.Fatalf("status = %q, want silence on an admitted launch", got)
+	}
+	if !next.flowLaunchAttemptOccupied(f.flowID()) {
+		t.Fatal("an admitted launch reserves the Flow")
+	}
+}
+
+// TestFlowLaunchEmbeddedBackstopPerKind is §4.2: seven kind groups over the four
+// (S6, S7) states. Admission makes every branch unreachable in production, and
+// the backstop is still tested directly, per its own comment — dropping it would
+// be a regression against a future unguarded source.
+func TestFlowLaunchEmbeddedBackstopPerKind(t *testing.T) {
+	const (
+		createPhaseText   = "Flow creation launch canceled because a terminal is already open for this Flow"
+		savedResumeText   = "Saved session resume canceled because an embedded terminal already occupies this Flow"
+		phaseResumeText   = "Flow phase resume canceled because a repair terminal is already open for this Flow"
+		manualLaunchText  = "Flow phase launch canceled because a repair terminal is already open for this Flow"
+		neitherSlotStates = "neither slot"
+	)
+	slotStates := []struct {
+		name    string
+		sources []occupancySource
+		// s6 and s7 name which predicate the state satisfies, which is what the
+		// per-kind expectations below are written against.
+		s6, s7 bool
+	}{
+		{name: neitherSlotStates},
+		{name: "Flow terminal only", sources: []occupancySource{srcFlowTerminal}, s6: true},
+		{name: "repair slot only", sources: []occupancySource{srcRepairSlot}, s7: true},
+		{name: "both slots", sources: []occupancySource{srcFlowTerminal, srcRepairSlot}, s6: true, s7: true},
+	}
+	kinds := []struct {
+		name string
+		kind flowLaunchKind
+		// refusal returns the expected text for a (S6, S7) state, or "" when the
+		// kind admits it.
+		refusal func(s6, s7 bool) string
+	}{
+		{
+			name: "createPhase reads both slots",
+			kind: flowLaunchKindCreatePhase,
+			refusal: func(s6, s7 bool) string {
+				if s6 || s7 {
+					return createPhaseText
+				}
+				return ""
+			},
+		},
+		{
+			name: "worktreeAgent reads both slots",
+			kind: flowLaunchKindWorktreeAgent,
+			refusal: func(s6, s7 bool) string {
+				if s6 || s7 {
+					return flowWorktreeAgentSlotStatus
+				}
+				return ""
+			},
+		},
+		{
+			// The one kind that reads S6 alone: a terminal-less repair slot gets
+			// past it, and that is current behavior.
+			name: "savedSessionResume reads S6 only",
+			kind: flowLaunchKindSavedSessionResume,
+			refusal: func(s6, _ bool) string {
+				if s6 {
+					return savedResumeText
+				}
+				return ""
+			},
+		},
+		{
+			name: "repair reads both slots",
+			kind: flowLaunchKindRepair,
+			refusal: func(s6, s7 bool) string {
+				if s6 || s7 {
+					return flowRepairTerminalStatus
+				}
+				return ""
+			},
+		},
+		{
+			name: "phaseResume reads S7 only",
+			kind: flowLaunchKindPhaseResume,
+			refusal: func(_, s7 bool) string {
+				if s7 {
+					return phaseResumeText
+				}
+				return ""
+			},
+		},
+		{
+			name: "autofix reads S7 only and names no phase",
+			kind: flowLaunchKindAutofix,
+			refusal: func(_, s7 bool) string {
+				if s7 {
+					return flowAutofixCanceledStatus
+				}
+				return ""
+			},
+		},
+		{
+			name: "manualPhase reads S7 only",
+			kind: flowLaunchKindManualPhase,
+			refusal: func(_, s7 bool) string {
+				if s7 {
+					return manualLaunchText
+				}
+				return ""
+			},
+		},
+		{
+			name: "autoPhase shares manualPhase's branch",
+			kind: flowLaunchKindAutoPhase,
+			refusal: func(_, s7 bool) string {
+				if s7 {
+					return manualLaunchText
+				}
+				return ""
+			},
+		},
+	}
+	for _, kind := range kinds {
+		for _, state := range slotStates {
+			t.Run(kind.name+"/"+state.name, func(t *testing.T) {
+				f := newOccupancyFixture(t, state.sources...)
+				want := kind.refusal(state.s6, state.s7)
+				status, refused := f.m.flowLaunchEmbeddedBackstop(kind.kind, f.flowID())
+				if refused != (want != "") {
+					t.Fatalf("refused = %v, want %v", refused, want != "")
+				}
+				if status != want {
+					t.Fatalf("status = %q, want %q", status, want)
+				}
+			})
+		}
+	}
+}

--- a/model/flow_occupancy_sessions_internal_test.go
+++ b/model/flow_occupancy_sessions_internal_test.go
@@ -1,0 +1,467 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/sessions"
+)
+
+// The S11 ∪ S13 phase-session rule and the four scopes consumers apply it at.
+// Both halves are scoped identically — only sessions whose launch ID belongs to
+// the phase count — because a wider rule would let one crashed agent make the
+// Flow permanently unlaunchable.
+
+// occupancySessionPhase builds the phase these tables run against: it owns one
+// launch ID and nothing else.
+func occupancySessionPhase() flowstore.FlowPhase {
+	return flowstore.FlowPhase{
+		PhaseID:   "implementation",
+		Title:     "Implementation",
+		Status:    flowstore.PhaseReady,
+		Order:     1,
+		LaunchIDs: []string{occupancyPhaseLaunchID},
+	}
+}
+
+func mirroredSession(provider, sessionID, launchID, status string) flowstore.Session {
+	return flowstore.Session{Provider: provider, SessionID: sessionID, LaunchID: launchID, Status: status}
+}
+
+func storedSession(provider, sessionID, launchID, status string) sessions.SessionRecord {
+	return sessions.SessionRecord{
+		Provider:  sessions.Provider(provider),
+		SessionID: sessionID,
+		LaunchID:  launchID,
+		Status:    status,
+	}
+}
+
+// TestFlowLaunchPhaseSessionOccupiedUnionRule runs one table across both halves
+// of the union: every row is asserted with the session in the phase mirror only,
+// in the store listing only, and in both. A rule that stopped reading one half
+// would fail exactly one of those three.
+func TestFlowLaunchPhaseSessionOccupiedUnionRule(t *testing.T) {
+	tests := []struct {
+		name      string
+		provider  string
+		sessionID string
+		launchID  string
+		status    string
+		want      bool
+	}{
+		{
+			name:      "live session on an owned launch",
+			provider:  occupancySessionProvider,
+			sessionID: occupancyPhaseSessionID,
+			launchID:  occupancyPhaseLaunchID,
+			status:    "active",
+			want:      true,
+		},
+		{
+			// Launch IDs are trimmed on both sides before the set lookup.
+			name:      "the launch ID is trimmed on the session",
+			provider:  occupancySessionProvider,
+			sessionID: occupancyPhaseSessionID,
+			launchID:  "  " + occupancyPhaseLaunchID + "  ",
+			status:    "active",
+			want:      true,
+		},
+		{
+			name:      "a launch the phase does not own is not occupancy",
+			provider:  occupancySessionProvider,
+			sessionID: occupancyPhaseSessionID,
+			launchID:  "someone-elses-launch",
+			status:    "active",
+		},
+		{
+			name:      "an unattributed session is not occupancy",
+			provider:  occupancySessionProvider,
+			sessionID: occupancyPhaseSessionID,
+			launchID:  "",
+			status:    "active",
+		},
+		{
+			// The ID-less session is skipped before the launch lookup, so this
+			// is an absence test rather than a comparison.
+			name:      "a session with no ID is not occupancy",
+			provider:  occupancySessionProvider,
+			sessionID: "   ",
+			launchID:  occupancyPhaseLaunchID,
+			status:    "active",
+		},
+		{
+			name:      "an ended session is not occupancy",
+			provider:  occupancySessionProvider,
+			sessionID: occupancyPhaseSessionID,
+			launchID:  occupancyPhaseLaunchID,
+			status:    "ended",
+		},
+		{
+			// Provider is not part of the occupancy rule at all; only the
+			// resume exemption reads it.
+			name:      "a foreign provider on an owned launch still occupies",
+			provider:  "claude",
+			sessionID: occupancyPhaseSessionID,
+			launchID:  occupancyPhaseLaunchID,
+			status:    "active",
+			want:      true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mirror := occupancySessionPhase()
+			mirror.Sessions = []flowstore.Session{mirroredSession(tc.provider, tc.sessionID, tc.launchID, tc.status)}
+			store := []sessions.SessionRecord{storedSession(tc.provider, tc.sessionID, tc.launchID, tc.status)}
+
+			if got := phaseHasMatchingLiveSession(mirror); got != tc.want {
+				t.Fatalf("phaseHasMatchingLiveSession (mirror half) = %v, want %v", got, tc.want)
+			}
+			if got := flowLaunchPhaseSessionOccupied(mirror, nil); got != tc.want {
+				t.Fatalf("occupied (mirror only) = %v, want %v", got, tc.want)
+			}
+			if got := flowLaunchPhaseSessionOccupied(occupancySessionPhase(), store); got != tc.want {
+				t.Fatalf("occupied (store only) = %v, want %v", got, tc.want)
+			}
+			if got := flowLaunchPhaseSessionOccupied(mirror, store); got != tc.want {
+				t.Fatalf("occupied (both halves) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFlowLaunchPhaseSessionOccupiedIgnoresABlankOwnedLaunch pins that a phase
+// whose launch list is entirely whitespace owns nothing, so no session can be
+// attributed to it.
+func TestFlowLaunchPhaseSessionOccupiedIgnoresABlankOwnedLaunch(t *testing.T) {
+	phase := occupancySessionPhase()
+	phase.LaunchIDs = []string{"   ", ""}
+	phase.Sessions = []flowstore.Session{mirroredSession(occupancySessionProvider, occupancyPhaseSessionID, "", "active")}
+	store := []sessions.SessionRecord{storedSession(occupancySessionProvider, occupancyStoreSessionID, "  ", "active")}
+
+	if flowLaunchPhaseSessionOccupied(phase, store) {
+		t.Fatal("a phase that owns no launch cannot be occupied by a session")
+	}
+}
+
+// TestFlowSessionIdentityMatches pins the exemption's comparison rule: providers
+// compare normalized, session IDs compare byte-exact, and the zero identity —
+// which every caller but resume passes — matches nothing.
+func TestFlowSessionIdentityMatches(t *testing.T) {
+	target := flowSessionIdentity{Provider: occupancySessionProvider, SessionID: occupancyPhaseSessionID}
+	tests := []struct {
+		name      string
+		id        flowSessionIdentity
+		provider  string
+		sessionID string
+		want      bool
+	}{
+		{name: "exact pair", id: target, provider: occupancySessionProvider, sessionID: occupancyPhaseSessionID, want: true},
+		{
+			name: "provider spelled differently still matches", id: target,
+			provider: "Codex", sessionID: occupancyPhaseSessionID, want: true,
+		},
+		{
+			// Two providers can hand out the same session ID, so exempting by ID
+			// alone would exempt a live competing agent.
+			name: "same session ID from another provider does not match", id: target,
+			provider: "claude", sessionID: occupancyPhaseSessionID,
+		},
+		{
+			// Session IDs are the identity both stores enforce byte-exact, so
+			// IDs differing only by whitespace are two distinct agents.
+			name: "session ID differing by whitespace does not match", id: target,
+			provider: occupancySessionProvider, sessionID: " " + occupancyPhaseSessionID,
+		},
+		{
+			name: "the zero identity matches nothing", id: flowSessionIdentity{},
+			provider: occupancySessionProvider, sessionID: occupancyPhaseSessionID,
+		},
+		{
+			name: "an identity with a whitespace-only ID matches nothing",
+			id:   flowSessionIdentity{Provider: occupancySessionProvider, SessionID: "  "},
+			// The same whitespace the identity carries, so only the blank-ID
+			// guard can be what refuses the match.
+			provider: occupancySessionProvider, sessionID: "  ",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.id.matches(tc.provider, tc.sessionID); got != tc.want {
+				t.Fatalf("matches(%q, %q) = %v, want %v", tc.provider, tc.sessionID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPhaseSessionOccupancyExemptionAppliesToBothHalves is D6. Resume is the
+// only caller that passes an identity, and the target session appears in the
+// store listing as well as in the phase's own mirror, so the exemption has to
+// reach both or resume would refuse itself.
+func TestPhaseSessionOccupancyExemptionAppliesToBothHalves(t *testing.T) {
+	tests := []struct {
+		name string
+		skip flowSessionIdentity
+		// wantOccupied is what the rule reports with the target session live in
+		// both halves and nothing else present.
+		wantOccupied bool
+	}{
+		{
+			name: "the exact target is exempt",
+			skip: flowSessionIdentity{Provider: occupancySessionProvider, SessionID: occupancyPhaseSessionID},
+		},
+		{
+			name: "a differently spelled provider is still the target",
+			skip: flowSessionIdentity{Provider: "CODEX", SessionID: occupancyPhaseSessionID},
+		},
+		{
+			name:         "the same session ID from another provider is not exempt",
+			skip:         flowSessionIdentity{Provider: "claude", SessionID: occupancyPhaseSessionID},
+			wantOccupied: true,
+		},
+		{
+			name:         "a whitespace-differing session ID is not exempt",
+			skip:         flowSessionIdentity{Provider: occupancySessionProvider, SessionID: occupancyPhaseSessionID + " "},
+			wantOccupied: true,
+		},
+		{
+			name:         "the zero identity exempts nothing",
+			skip:         flowSessionIdentity{},
+			wantOccupied: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			phase := occupancySessionPhase()
+			phase.Sessions = []flowstore.Session{
+				mirroredSession(occupancySessionProvider, occupancyPhaseSessionID, occupancyPhaseLaunchID, "active"),
+			}
+			store := []sessions.SessionRecord{
+				storedSession(occupancySessionProvider, occupancyPhaseSessionID, occupancyPhaseLaunchID, "active"),
+			}
+
+			if got := phaseHasMatchingLiveSessionExcept(phase, tc.skip); got != tc.wantOccupied {
+				t.Fatalf("mirror half = %v, want %v", got, tc.wantOccupied)
+			}
+			if got := flowLaunchPhaseSessionOccupiedExcept(occupancySessionPhase(), store, tc.skip); got != tc.wantOccupied {
+				t.Fatalf("store half = %v, want %v", got, tc.wantOccupied)
+			}
+			if got := flowLaunchPhaseSessionOccupiedExcept(phase, store, tc.skip); got != tc.wantOccupied {
+				t.Fatalf("union = %v, want %v", got, tc.wantOccupied)
+			}
+		})
+	}
+}
+
+// TestPhaseSessionExemptionStillCountsACompetingSession pins the other half of
+// D6: exempting resume's own target must not exempt a second live agent on the
+// same phase.
+func TestPhaseSessionExemptionStillCountsACompetingSession(t *testing.T) {
+	skip := flowSessionIdentity{Provider: occupancySessionProvider, SessionID: occupancyPhaseSessionID}
+	phase := occupancySessionPhase()
+	phase.Sessions = []flowstore.Session{
+		mirroredSession(occupancySessionProvider, occupancyPhaseSessionID, occupancyPhaseLaunchID, "active"),
+		mirroredSession("claude", "competing-session", occupancyPhaseLaunchID, "active"),
+	}
+	if !phaseHasMatchingLiveSessionExcept(phase, skip) {
+		t.Fatal("a competing live session on the same phase still occupies it")
+	}
+
+	store := []sessions.SessionRecord{
+		storedSession(occupancySessionProvider, occupancyPhaseSessionID, occupancyPhaseLaunchID, "active"),
+		storedSession("claude", "competing-session", occupancyPhaseLaunchID, "active"),
+	}
+	if !flowLaunchPhaseSessionOccupiedExcept(occupancySessionPhase(), store, skip) {
+		t.Fatal("a competing live record in the store still occupies the phase")
+	}
+}
+
+// TestFlowRepairPhaseSessionOccupiedReportsTheFirstOrderedPhase is repair's
+// scope: Flow-wide, and iterated through flowstore.OrderedPhases, because the
+// refusal names the phase and has to name the same one on every press.
+//
+// What "ordered" means here is worth pinning precisely, because it is not what
+// the name suggests: OrderedPhases is stable over top-level phases and only
+// groups children under their parent, so the Order field does not re-sort them.
+// A Flow with two occupied top-level phases therefore reports the one declared
+// first, whatever its Order says.
+func TestFlowRepairPhaseSessionOccupiedReportsTheFirstOrderedPhase(t *testing.T) {
+	occupied := func(phaseID, parentID string, order int) flowstore.FlowPhase {
+		phase := flowstore.FlowPhase{
+			PhaseID:       phaseID,
+			ParentPhaseID: parentID,
+			Status:        flowstore.PhaseReady,
+			Order:         order,
+			LaunchIDs:     []string{phaseID + "-launch"},
+		}
+		phase.Sessions = []flowstore.Session{
+			mirroredSession(occupancySessionProvider, phaseID+"-session", phaseID+"-launch", "active"),
+		}
+		return phase
+	}
+
+	t.Run("top-level phases keep their declared order", func(t *testing.T) {
+		record := occupancyFlowRecord()
+		record.Phases = []flowstore.FlowPhase{
+			occupied("review-loop", "", 3),
+			occupied("implementation", "", 2),
+			{PhaseID: "plan", Status: flowstore.PhaseCompleted, Order: 1},
+		}
+		phase, ok := flowRepairPhaseSessionOccupied(record, nil)
+		if !ok {
+			t.Fatal("a Flow with two session-occupied phases is occupied")
+		}
+		if phase.PhaseID != "review-loop" {
+			t.Fatalf("phase = %q, want the first declared phase — Order does not re-sort top-level phases", phase.PhaseID)
+		}
+	})
+
+	t.Run("a child is walked with its parent, not where it was declared", func(t *testing.T) {
+		record := occupancyFlowRecord()
+		// The child is declared last but belongs to the first phase, so
+		// OrderedPhases lifts it ahead of the second top-level phase.
+		record.Phases = []flowstore.FlowPhase{
+			{PhaseID: "plan", Status: flowstore.PhaseCompleted, Order: 1},
+			occupied("review-loop", "", 3),
+			occupied("plan-review", "plan", 2),
+		}
+		phase, ok := flowRepairPhaseSessionOccupied(record, nil)
+		if !ok {
+			t.Fatal("a Flow with two session-occupied phases is occupied")
+		}
+		if phase.PhaseID != "plan-review" {
+			t.Fatalf("phase = %q, want the child walked directly after its parent", phase.PhaseID)
+		}
+	})
+
+	t.Run("no session-attached phase is not occupancy", func(t *testing.T) {
+		if _, ok := flowRepairPhaseSessionOccupied(occupancyFlowRecord(), nil); ok {
+			t.Fatal("a Flow with no session-attached phase is not occupied")
+		}
+	})
+}
+
+// TestFlowRepairPhaseSessionOccupiedUnionsTheStoreListing pins that repair's
+// Flow-scoped rule carries the same union as the phase-scoped one: a live record
+// the mirror never saw still occupies the Flow.
+func TestFlowRepairPhaseSessionOccupiedUnionsTheStoreListing(t *testing.T) {
+	record := occupancyFlowRecord()
+	record.Phases = []flowstore.FlowPhase{{
+		PhaseID:   "implementation",
+		Status:    flowstore.PhaseReady,
+		Order:     1,
+		LaunchIDs: []string{occupancyStoreLaunchID},
+	}}
+	store := []sessions.SessionRecord{
+		storedSession(occupancySessionProvider, occupancyStoreSessionID, occupancyStoreLaunchID, "active"),
+	}
+
+	if _, ok := flowRepairPhaseSessionOccupied(record, nil); ok {
+		t.Fatal("the mirror alone shows nothing here")
+	}
+	phase, ok := flowRepairPhaseSessionOccupied(record, store)
+	if !ok || phase.PhaseID != "implementation" {
+		t.Fatalf("phase = %q, ok = %v, want the store listing to occupy the phase", phase.PhaseID, ok)
+	}
+}
+
+// TestGenericFlowRuntimeOccupancyReasonOrdersSessionBeforeRunning pins two facts
+// about the worktree agent's S10 ∨ S11 rung that a migration would silently
+// change: within one phase the session reason wins over the running reason, and
+// the loop walks record.Phases as declared rather than in phase order.
+func TestGenericFlowRuntimeOccupancyReasonOrdersSessionBeforeRunning(t *testing.T) {
+	sessionPhase := func(phaseID string, order int, status flowstore.PhaseStatus) flowstore.FlowPhase {
+		phase := flowstore.FlowPhase{
+			PhaseID:   phaseID,
+			Status:    status,
+			Order:     order,
+			LaunchIDs: []string{phaseID + "-launch"},
+		}
+		phase.Sessions = []flowstore.Session{
+			mirroredSession(occupancySessionProvider, phaseID+"-session", phaseID+"-launch", "active"),
+		}
+		return phase
+	}
+
+	t.Run("no occupancy reports nothing", func(t *testing.T) {
+		if reason := genericFlowRuntimeOccupancyReason(occupancyFlowRecord()); reason != "" {
+			t.Fatalf("reason = %q, want empty", reason)
+		}
+	})
+
+	t.Run("a running phase is named", func(t *testing.T) {
+		record := withOccupancyRunningPhase(occupancyFlowRecord())
+		want := "a running phase implementation already occupies this Flow"
+		if reason := genericFlowRuntimeOccupancyReason(record); reason != want {
+			t.Fatalf("reason = %q, want %q", reason, want)
+		}
+	})
+
+	t.Run("the session reason wins within one phase", func(t *testing.T) {
+		record := occupancyFlowRecord()
+		record.Phases = []flowstore.FlowPhase{sessionPhase("implementation", 1, flowstore.PhaseRunning)}
+		want := "an active persisted session on phase implementation already occupies this Flow"
+		if reason := genericFlowRuntimeOccupancyReason(record); reason != want {
+			t.Fatalf("reason = %q, want %q", reason, want)
+		}
+	})
+
+	t.Run("iteration follows the record's declared phase order", func(t *testing.T) {
+		record := occupancyFlowRecord()
+		// review-loop is declared first but ordered last. The rule walks the
+		// slice, so it is the phase that gets named.
+		record.Phases = []flowstore.FlowPhase{
+			sessionPhase("review-loop", 3, flowstore.PhaseReady),
+			sessionPhase("implementation", 1, flowstore.PhaseReady),
+		}
+		want := "an active persisted session on phase review-loop already occupies this Flow"
+		if reason := genericFlowRuntimeOccupancyReason(record); reason != want {
+			t.Fatalf("reason = %q, want %q — the loop is not order-normalized", reason, want)
+		}
+	})
+
+	t.Run("a later phase's session outranks an earlier phase's running status", func(t *testing.T) {
+		// Both reasons exist, in different phases. The earlier phase is reached
+		// first, so its running reason is the one reported — the session-first
+		// rule is per phase, not per record.
+		record := occupancyFlowRecord()
+		record.Phases = []flowstore.FlowPhase{
+			{PhaseID: "implementation", Status: flowstore.PhaseRunning, Order: 1},
+			sessionPhase("review-loop", 2, flowstore.PhaseReady),
+		}
+		want := fmt.Sprintf("a running phase %s already occupies this Flow", "implementation")
+		if reason := genericFlowRuntimeOccupancyReason(record); reason != want {
+			t.Fatalf("reason = %q, want %q", reason, want)
+		}
+	})
+}
+
+// TestActiveFlowSessionIsWholeFlowScoped pins S13's whole-Flow variant, which
+// the worktree agent and create both read: it counts any live record in the
+// listing, with no launch-ID attribution at all.
+func TestActiveFlowSessionIsWholeFlowScoped(t *testing.T) {
+	tests := []struct {
+		name    string
+		records []sessions.SessionRecord
+		want    bool
+	}{
+		{name: "no records"},
+		{
+			name:    "a live record with no launch attribution still counts",
+			records: []sessions.SessionRecord{storedSession(occupancySessionProvider, occupancyStoreSessionID, "", "active")},
+			want:    true,
+		},
+		{
+			name:    "an ended record does not count",
+			records: []sessions.SessionRecord{storedSession(occupancySessionProvider, occupancyStoreSessionID, "", "ended")},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := activeFlowSession(tc.records); got != tc.want {
+				t.Fatalf("activeFlowSession = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/model/flow_occupancy_sessions_internal_test.go
+++ b/model/flow_occupancy_sessions_internal_test.go
@@ -421,7 +421,7 @@ func TestGenericFlowRuntimeOccupancyReasonOrdersSessionBeforeRunning(t *testing.
 		}
 	})
 
-	t.Run("a later phase's session outranks an earlier phase's running status", func(t *testing.T) {
+	t.Run("an earlier phase's running status outranks a later phase's session", func(t *testing.T) {
 		// Both reasons exist, in different phases. The earlier phase is reached
 		// first, so its running reason is the one reported — the session-first
 		// rule is per phase, not per record.

--- a/model/flow_occupancy_simultaneous_internal_test.go
+++ b/model/flow_occupancy_simultaneous_internal_test.go
@@ -1,0 +1,238 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/approachcontrol/approach/flowstore"
+)
+
+// The acceptance criterion this suite is most likely to miss: sources holding
+// the Flow at the same time, not one at a time. Every table above installs at
+// most two; these install four and five, and record what each consumer reports
+// for the identical state.
+
+// occupancyAllFiveSources is the state the bead names: a cross-process lease, an
+// in-process attempt, a retained terminal slot, a persisted running phase, and a
+// live session on that phase.
+func occupancyAllFiveSources() []occupancySource {
+	return []occupancySource{srcLeaseHeld, srcAttemptManualPhase, srcFlowTerminal, srcRunningPhase, srcPhaseSession}
+}
+
+// occupancyFourInProcessSources is the same state with the lease released. The
+// lease outranks everything in four of the ladders, so dropping it is what makes
+// the lower rungs — and their disagreements — observable.
+func occupancyFourInProcessSources() []occupancySource {
+	return []occupancySource{srcAttemptManualPhase, srcFlowTerminal, srcRunningPhase, srcPhaseSession}
+}
+
+// occupancyRepairComparableSources is the same set minus the phase session,
+// which is the one source repair cannot be compared on: a matched live session
+// makes the record un-repairable outright, so repair answers with silence rather
+// than with a rung of its ladder. TestRepairRefusesALiveSessionFlowInSilence
+// pins that separately.
+func occupancyRepairComparableSources() []occupancySource {
+	return []occupancySource{srcAttemptManualPhase, srcFlowTerminal, srcRunningPhase}
+}
+
+// TestEverySourceHoldingAtOnceIsSeenByEveryComposite proves the fixture really
+// installed all five, through the composites rather than through the installers.
+func TestEverySourceHoldingAtOnceIsSeenByEveryComposite(t *testing.T) {
+	f := newOccupancyFixture(t, occupancyAllFiveSources()...)
+
+	if !f.m.flowLaunchAdmissionOccupied(f.flowID()) {
+		t.Fatal("admission occupancy must hold")
+	}
+	if !f.m.flowLaunchRuntimeOccupied(f.flowID()) {
+		t.Fatal("runtime occupancy must hold")
+	}
+	if !f.m.flowAutoAdvanceOccupied(f.record) {
+		t.Fatal("the drain gate must hold")
+	}
+	if !flowLaunchPhaseSessionOccupied(f.phase(), f.stored) {
+		t.Fatal("the phase-session union must hold")
+	}
+	if reason := genericFlowRuntimeOccupancyReason(f.record); reason == "" {
+		t.Fatal("the worktree agent's persisted rung must hold")
+	}
+}
+
+// TestSimultaneousSourcesReportPerConsumerStatuses is the matrix. Each row is one
+// consumer's answer to the identical Model state, and the rows are meant to be
+// read side by side: they are what F2's "four ladders, no shared table" costs.
+func TestSimultaneousSourcesReportPerConsumerStatuses(t *testing.T) {
+	t.Run("with the lease held, every loud consumer names the lease", func(t *testing.T) {
+		sources := occupancyAllFiveSources()
+		f := newOccupancyFixture(t, sources...)
+
+		if got := statusFromRefusedLaunch(t, f, flowLaunchKindManualPhase); got != flowLeaseOccupiedStatus {
+			t.Fatalf("manual phase status = %q, want %q", got, flowLeaseOccupiedStatus)
+		}
+		if got := statusFromRefusedLaunch(t, f, flowLaunchKindPhaseResume); got != flowLeaseOccupiedStatus {
+			t.Fatalf("phase resume status = %q, want %q", got, flowLeaseOccupiedStatus)
+		}
+		if got := statusFromRefusedLaunch(t, f, flowLaunchKindWorktreeAgent); got != flowLeaseOccupiedStatus {
+			t.Fatalf("worktree agent status = %q, want %q", got, flowLeaseOccupiedStatus)
+		}
+		if got := statusFromRefusedAutofix(t, sources); got != flowLeaseOccupiedStatus {
+			t.Fatalf("autofix status = %q, want %q", got, flowLeaseOccupiedStatus)
+		}
+		if got := statusFromRefusedRepair(t, occupancyRepairComparableSources(), srcLeaseHeld); got != flowLeaseOccupiedStatus {
+			t.Fatalf("repair status = %q, want %q", got, flowLeaseOccupiedStatus)
+		}
+		// The auto admission stays silent through all five, exactly as it does
+		// through one.
+		if got := statusFromRefusedLaunch(t, f, flowLaunchKindAutoPhase); got != "" {
+			t.Fatalf("auto phase status = %q, want silence", got)
+		}
+		// The lease is ranked above repair's five-rung ladder and answered
+		// separately, so the ladder itself still reports its own rank 3.
+		if got := f.m.flowRepairOccupancyRefusal(f.flowID()); got != flowRepairPhasePendingStatus {
+			t.Fatalf("repair ladder = %q, want %q", got, flowRepairPhasePendingStatus)
+		}
+	})
+
+	t.Run("without the lease, repair and autofix disagree about the same state", func(t *testing.T) {
+		sources := occupancyFourInProcessSources()
+
+		// The identical state — a manual phase attempt plus a retained Flow
+		// terminal — is reported by repair as a competing *attempt* and by
+		// autofix as a competing *terminal*. Both hold simultaneously; the two
+		// ladders simply rank them in opposite orders. ADR 0003 Q2 keeps this
+		// divergence, and this row is what pins it.
+		comparable := occupancyRepairComparableSources()
+		if got := statusFromRefusedRepair(t, comparable); got != flowRepairPhasePendingStatus {
+			t.Fatalf("repair status = %q, want %q", got, flowRepairPhasePendingStatus)
+		}
+		if got := statusFromRefusedAutofix(t, comparable); got != flowAutofixTerminalStatus {
+			t.Fatalf("autofix status = %q, want %q", got, flowAutofixTerminalStatus)
+		}
+
+		f := newOccupancyFixture(t, sources...)
+		// Manual collapses all four into one generic status; it names nothing.
+		if got := statusFromRefusedLaunch(t, f, flowLaunchKindManualPhase); got != noLaunchableFlowPhaseStatus {
+			t.Fatalf("manual phase status = %q, want %q", got, noLaunchableFlowPhaseStatus)
+		}
+		// Resume names the terminal, because the terminal is not a repair slot.
+		if got := statusFromRefusedLaunch(t, f, flowLaunchKindPhaseResume); got != flowPhaseResumeTerminalStatus {
+			t.Fatalf("phase resume status = %q, want %q", got, flowPhaseResumeTerminalStatus)
+		}
+		// The worktree agent stops at its attempt rung, two rungs above the
+		// slot rung the same state also satisfies.
+		if got := statusFromRefusedLaunch(t, f, flowLaunchKindWorktreeAgent); got != flowWorktreeAgentPendingStatus {
+			t.Fatalf("worktree agent status = %q, want %q", got, flowWorktreeAgentPendingStatus)
+		}
+		if got := statusFromRefusedLaunch(t, f, flowLaunchKindAutoPhase); got != "" {
+			t.Fatalf("auto phase status = %q, want silence", got)
+		}
+	})
+}
+
+// TestRepairRefusesALiveSessionFlowInSilence is why repair drops out of the
+// four-source comparison above. A matched live session is treated as active work
+// even when the persisted phase already says blocked, so the record stops being
+// repairable at all — and an un-repairable selection refuses silently, before
+// any rung of the occupancy ladder is consulted.
+func TestRepairRefusesALiveSessionFlowInSilence(t *testing.T) {
+	f := newOccupancyFixtureFor(t, occupancyRepairFlowRecord(), srcPhaseSession, srcFlowTerminal)
+
+	if _, repairable := flowRepairObstructionForRecord(f.record); repairable {
+		t.Fatal("a live session on a blocked phase makes the record un-repairable")
+	}
+	before := f.m.setStatus(statusOther, "user is looking at this")
+	next, cmd, admitted := before.requestFlowLaunch(flowLaunchIntent{
+		Kind:   flowLaunchKindRepair,
+		FlowID: f.flowID(),
+	})
+	if admitted || cmd != nil {
+		t.Fatalf("admitted = %v, cmd != nil = %v, want a refusal", admitted, cmd != nil)
+	}
+	if got := next.status.Text; got != "user is looking at this" {
+		t.Fatalf("status = %q, want the pre-existing status untouched", got)
+	}
+	if f.m.selectedFlowRepairReady() {
+		t.Fatal("R must not be advertised for an un-repairable Flow")
+	}
+}
+
+// TestSimultaneousSourcesWithdrawEveryFooter is the display half of the matrix:
+// with four sources holding, no key is advertised anywhere.
+func TestSimultaneousSourcesWithdrawEveryFooter(t *testing.T) {
+	f := newOccupancyFixture(t, occupancyFourInProcessSources()...)
+	if f.m.selectedFlowHasLaunchablePhase() {
+		t.Fatal("g must not be advertised")
+	}
+	if f.m.previewPhaseResume(f.flowID()) {
+		t.Fatal("the resume footer must withdraw for a non-repair Flow terminal")
+	}
+	if f.m.selectedFlowWorktreeAgentReady() {
+		t.Fatal("the worktree agent footer must withdraw")
+	}
+	if newOccupancyFixtureFor(t, autofixFlowRecord(), occupancyFourInProcessSources()...).m.selectedFlowAutofixReady() {
+		t.Fatal("U must not be advertised")
+	}
+	if newOccupancyFixtureFor(t, occupancyRepairFlowRecord(), occupancyFourInProcessSources()...).m.selectedFlowRepairReady() {
+		t.Fatal("R must not be advertised")
+	}
+}
+
+// TestSimultaneousSourcesRefuseTheInstallBackstopPerKind runs the last line of
+// defense against the same four-source state. Both slot predicates hold here, so
+// every kind refuses — including savedSessionResume, which reads S6 alone.
+func TestSimultaneousSourcesRefuseTheInstallBackstopPerKind(t *testing.T) {
+	f := newOccupancyFixture(t, append(occupancyFourInProcessSources(), srcRepairSlot)...)
+	kinds := []flowLaunchKind{
+		flowLaunchKindManualPhase,
+		flowLaunchKindCreatePhase,
+		flowLaunchKindAutoPhase,
+		flowLaunchKindPhaseResume,
+		flowLaunchKindRepair,
+		flowLaunchKindAutofix,
+		flowLaunchKindWorktreeAgent,
+		flowLaunchKindSavedSessionResume,
+	}
+	for _, kind := range kinds {
+		status, refused := f.m.flowLaunchEmbeddedBackstop(kind, f.flowID())
+		if !refused || status == "" {
+			t.Fatalf("kind %v: refused = %v, status = %q, want a refusal with text", kind, refused, status)
+		}
+	}
+}
+
+// statusFromRefusedLaunch drives one admission through the lifecycle's only
+// entry point and returns the status it left behind, failing if it admitted.
+func statusFromRefusedLaunch(t *testing.T, f occupancyFixture, kind flowLaunchKind) string {
+	t.Helper()
+	next, cmd, admitted := f.m.requestFlowLaunch(flowLaunchIntent{
+		Kind:    kind,
+		FlowID:  f.flowID(),
+		PhaseID: f.phase().PhaseID,
+	})
+	if admitted || cmd != nil {
+		t.Fatalf("kind %v: admitted = %v, cmd != nil = %v, want a refusal", kind, admitted, cmd != nil)
+	}
+	return next.status.Text
+}
+
+// statusFromRefusedAutofix and statusFromRefusedRepair rebuild the fixture on
+// the record their kind requires: autofix needs a fully completed Flow with an
+// open PR, and repair needs a gated one with no launchable phase, so neither can
+// share the launchable record the other tables use.
+func statusFromRefusedAutofix(t *testing.T, sources []occupancySource, extra ...occupancySource) string {
+	t.Helper()
+	return statusFromRefusedKindOnRecord(t, autofixFlowRecord(), flowLaunchKindAutofix, append(append([]occupancySource(nil), sources...), extra...))
+}
+
+func statusFromRefusedRepair(t *testing.T, sources []occupancySource, extra ...occupancySource) string {
+	t.Helper()
+	return statusFromRefusedKindOnRecord(t, occupancyRepairFlowRecord(), flowLaunchKindRepair, append(append([]occupancySource(nil), sources...), extra...))
+}
+
+func statusFromRefusedKindOnRecord(t *testing.T, record flowstore.FlowRecord, kind flowLaunchKind, sources []occupancySource) string {
+	t.Helper()
+	f := newOccupancyFixtureFor(t, record, sources...)
+	next, cmd, admitted := f.m.requestFlowLaunch(flowLaunchIntent{Kind: kind, FlowID: f.flowID()})
+	if admitted || cmd != nil {
+		t.Fatalf("kind %v: admitted = %v, cmd != nil = %v, want a refusal", kind, admitted, cmd != nil)
+	}
+	return next.status.Text
+}

--- a/model/flow_occupancy_sources_internal_test.go
+++ b/model/flow_occupancy_sources_internal_test.go
@@ -1,0 +1,508 @@
+package model
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/internal/flowlease"
+	"github.com/approachcontrol/approach/sessions"
+)
+
+// One table per leaf source predicate from docs/flow-occupancy-matrix.md §1.
+// These assert current behavior, including the parts that read as surprising:
+// lease-read failure is occupancy everywhere (S2 is fail-closed), and a blank
+// Flow ID is not occupancy in any of the trimmed predicates.
+
+// TestTrackedFlowLeaseOccupiedSources covers S1 and S2. Five of the six
+// non-Free outcomes are error paths, and admission treats every one of them as
+// occupancy, so the error cases are the load-bearing rows here.
+func TestTrackedFlowLeaseOccupiedSources(t *testing.T) {
+	inspectErr := errors.New("unsafe flow-leases directory")
+	tests := []struct {
+		name string
+		// mutate rewrites the lease seam and its preconditions on the built
+		// Model, which is the only place sessionStateRoot and the injection flag
+		// can be varied without a second Options build.
+		mutate       func(Model) Model
+		flowID       string
+		wantOccupied bool
+		wantErr      string
+	}{
+		{
+			name:   "free lease is not occupancy",
+			mutate: func(m Model) Model { return m },
+			flowID: "flow-1",
+		},
+		{
+			name: "held lease is occupancy",
+			mutate: func(m Model) Model {
+				m.inspectFlowLease = func(string, string) (flowlease.LeaseState, error) { return flowlease.Held, nil }
+				return m
+			},
+			flowID:       "flow-1",
+			wantOccupied: true,
+		},
+		{
+			name: "inspector error is reported, not swallowed",
+			mutate: func(m Model) Model {
+				m.inspectFlowLease = func(string, string) (flowlease.LeaseState, error) { return 0, inspectErr }
+				return m
+			},
+			flowID:  "flow-1",
+			wantErr: inspectErr.Error(),
+		},
+		{
+			name: "nil inspector fails closed",
+			mutate: func(m Model) Model {
+				m.inspectFlowLease = nil
+				return m
+			},
+			flowID:  "flow-1",
+			wantErr: "Flow lease inspector is unavailable",
+		},
+		{
+			// The injected inspector owns its own root contract, so a blank root
+			// is not an error when a test or embedder supplied the inspector.
+			name: "blank artifact root is tolerated for an injected inspector",
+			mutate: func(m Model) Model {
+				m.sessionStateRoot = ""
+				return m
+			},
+			flowID: "flow-1",
+		},
+		{
+			name: "blank artifact root fails closed for the production inspector",
+			mutate: func(m Model) Model {
+				m.sessionStateRoot = ""
+				m.leaseInspectInjected = false
+				return m
+			},
+			flowID:  "flow-1",
+			wantErr: "Flow lease artifact root is unavailable",
+		},
+		{
+			name: "an unrecognized lease state fails closed",
+			mutate: func(m Model) Model {
+				m.inspectFlowLease = func(string, string) (flowlease.LeaseState, error) {
+					return flowlease.LeaseState(99), nil
+				}
+				return m
+			},
+			flowID:  "flow-1",
+			wantErr: "invalid Flow lease state 99",
+		},
+		{
+			// A blank Flow ID short-circuits before every check above, including
+			// the ones that would otherwise fail closed.
+			name: "blank Flow ID is neither occupancy nor an error",
+			mutate: func(m Model) Model {
+				m.inspectFlowLease = nil
+				return m
+			},
+			flowID: "   ",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t)
+			occupied, err := tc.mutate(f.m).trackedFlowLeaseOccupied(tc.flowID)
+			if occupied != tc.wantOccupied {
+				t.Fatalf("occupied = %v, want %v", occupied, tc.wantOccupied)
+			}
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("err = %v, want nil", err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("err = nil, want %q", tc.wantErr)
+			case tc.wantErr != "" && err.Error() != tc.wantErr:
+				t.Fatalf("err = %q, want %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestFlowLeaseSetupErrorStatusWrapsTheInspectionError pins the one refusal
+// string that is not a constant: it is a prefix plus the wrapped error text.
+func TestFlowLeaseSetupErrorStatusWrapsTheInspectionError(t *testing.T) {
+	const prefix = "Flow phase launch deferred because tracked tmux occupancy could not be inspected: "
+	got := flowLeaseSetupErrorStatus(occupancyLeaseErr())
+	if !strings.HasPrefix(got, prefix) {
+		t.Fatalf("status = %q, want prefix %q", got, prefix)
+	}
+	if got != prefix+occupancyLeaseErrText {
+		t.Fatalf("status = %q, want the wrapped error appended verbatim", got)
+	}
+}
+
+// TestFlowLaunchAttemptOccupancySources covers S3 and its companion S4. Matching
+// is on the exact canonical Flow ID, which is the contract that stops
+// prefix-like IDs from colliding.
+func TestFlowLaunchAttemptOccupancySources(t *testing.T) {
+	tests := []struct {
+		name         string
+		sources      []occupancySource
+		query        string
+		wantOccupied bool
+		wantKind     flowLaunchKind
+	}{
+		{name: "no attempt", query: "flow-1"},
+		{
+			name:         "manual phase attempt",
+			sources:      []occupancySource{srcAttemptManualPhase},
+			query:        "flow-1",
+			wantOccupied: true,
+			wantKind:     flowLaunchKindManualPhase,
+		},
+		{
+			name:         "repair attempt",
+			sources:      []occupancySource{srcAttemptRepair},
+			query:        "flow-1",
+			wantOccupied: true,
+			wantKind:     flowLaunchKindRepair,
+		},
+		{
+			// Surrounding whitespace on the query is trimmed before the lookup,
+			// so the same attempt still answers.
+			name:         "whitespace around the query still matches",
+			sources:      []occupancySource{srcAttemptRepair},
+			query:        "  flow-1  ",
+			wantOccupied: true,
+			wantKind:     flowLaunchKindRepair,
+		},
+		{
+			name:    "blank Flow ID is not occupancy",
+			sources: []occupancySource{srcAttemptRepair},
+			query:   "   ",
+		},
+		{
+			// The stated contract: an ID that merely has the held one as a
+			// prefix is a different Flow.
+			name:    "prefix-like Flow ID does not collide",
+			sources: []occupancySource{srcAttemptRepair},
+			query:   "flow-11",
+		},
+		{
+			name:    "a different Flow ID does not collide",
+			sources: []occupancySource{srcAttemptRepair},
+			query:   "flow-2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, tc.sources...)
+			if got := f.m.flowLaunchAttemptOccupied(tc.query); got != tc.wantOccupied {
+				t.Fatalf("flowLaunchAttemptOccupied(%q) = %v, want %v", tc.query, got, tc.wantOccupied)
+			}
+			if got := f.m.flowLaunchAttemptKind(tc.query); got != tc.wantKind {
+				t.Fatalf("flowLaunchAttemptKind(%q) = %v, want %v", tc.query, got, tc.wantKind)
+			}
+		})
+	}
+}
+
+// TestFlowLaunchAttemptKindIsZeroForATokenlessAttempt pins the other way an
+// attempt entry fails to count: the map holds it, but its token is blank, so
+// every lookup treats the Flow as unheld.
+func TestFlowLaunchAttemptKindIsZeroForATokenlessAttempt(t *testing.T) {
+	f := newOccupancyFixture(t)
+	m := f.m
+	m.flowLaunchAttempts = map[string]flowLaunchAttempt{
+		f.flowID(): {Kind: flowLaunchKindRepair, FlowID: f.flowID(), State: flowLaunchStateReading},
+	}
+	if m.flowLaunchAttemptOccupied(f.flowID()) {
+		t.Fatal("an attempt with no token must not occupy the Flow")
+	}
+	if got := m.flowLaunchAttemptKind(f.flowID()); got != 0 {
+		t.Fatalf("flowLaunchAttemptKind = %v, want the zero kind", got)
+	}
+}
+
+// TestFlowEmbeddedTerminalPredicatesOverlapRatherThanNest is F3 made into data.
+// One table over the four (Terminal != nil × FlowRepair) combinations, asserting
+// both predicates on every row, because previewPhaseResume's `∧¬` depends on the
+// overlap being exactly this shape.
+func TestFlowEmbeddedTerminalPredicatesOverlapRatherThanNest(t *testing.T) {
+	tests := []struct {
+		name       string
+		terminal   bool
+		repair     bool
+		wantFlow   bool
+		wantRepair bool
+	}{
+		{name: "no slot at all"},
+		{name: "live terminal, not repair", terminal: true, wantFlow: true},
+		{name: "repair slot with no terminal", repair: true, wantRepair: true},
+		{name: "repair slot with a live terminal", terminal: true, repair: true, wantFlow: true, wantRepair: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t)
+			m := f.m
+			if tc.terminal || tc.repair {
+				slot := embeddedTerminalSlot{
+					Scope:      embeddedTerminalScopeFlow,
+					FlowID:     f.flowID(),
+					FlowRepair: tc.repair,
+				}
+				if tc.terminal {
+					slot.Terminal = flowPhaseLaunchTestTerminal{state: "running"}
+				}
+				m.embeddedTerminals = append(m.embeddedTerminals, slot)
+			}
+			if got := m.hasFlowEmbeddedTerminalForFlow(f.flowID()); got != tc.wantFlow {
+				t.Fatalf("hasFlowEmbeddedTerminalForFlow = %v, want %v", got, tc.wantFlow)
+			}
+			if got := m.hasFlowRepairEmbeddedTerminalForFlow(f.flowID()); got != tc.wantRepair {
+				t.Fatalf("hasFlowRepairEmbeddedTerminalForFlow = %v, want %v", got, tc.wantRepair)
+			}
+		})
+	}
+}
+
+// TestFlowEmbeddedTerminalPredicatesScopeAndTrimming pins the two ways a slot
+// can exist and still not answer: a non-Flow scope, and a Flow ID that is not
+// the one asked about. The two predicates diverge on trimming, and that
+// divergence is current behavior rather than a decision either way.
+func TestFlowEmbeddedTerminalPredicatesScopeAndTrimming(t *testing.T) {
+	f := newOccupancyFixture(t, srcFlowTerminal, srcRepairSlot)
+
+	if f.m.hasFlowEmbeddedTerminalForFlow("flow-2") || f.m.hasFlowRepairEmbeddedTerminalForFlow("flow-2") {
+		t.Fatal("a slot on one Flow must not answer for another")
+	}
+	if f.m.hasFlowEmbeddedTerminalForFlow("  ") || f.m.hasFlowRepairEmbeddedTerminalForFlow("  ") {
+		t.Fatal("a blank Flow ID is not occupancy")
+	}
+	// hasFlowRepairEmbeddedTerminalForFlow trims its argument; the broad
+	// predicate compares it as given. Both are asserted so a migration that
+	// unified them has to do so deliberately.
+	if f.m.hasFlowEmbeddedTerminalForFlow("  flow-1  ") {
+		t.Fatal("hasFlowEmbeddedTerminalForFlow compares the Flow ID as given")
+	}
+	if !f.m.hasFlowRepairEmbeddedTerminalForFlow("  flow-1  ") {
+		t.Fatal("hasFlowRepairEmbeddedTerminalForFlow trims before comparing")
+	}
+
+	scoped := newOccupancyFixture(t)
+	m := scoped.m
+	m.embeddedTerminals = append(m.embeddedTerminals, embeddedTerminalSlot{
+		Scope:      embeddedTerminalScopeSession,
+		FlowID:     scoped.flowID(),
+		FlowRepair: true,
+		Terminal:   flowPhaseLaunchTestTerminal{state: "running"},
+	})
+	if m.hasFlowEmbeddedTerminalForFlow(scoped.flowID()) || m.hasFlowRepairEmbeddedTerminalForFlow(scoped.flowID()) {
+		t.Fatal("a session-scoped slot must not occupy the Flow")
+	}
+}
+
+// TestFlowHeadlessWritePendingComparesTheFlowIDUntrimmed is S14, and it is the
+// odd one out: pendingFlowHeadlessWriteIndex compares the raw string where every
+// neighbouring predicate trims first. Pinned deliberately.
+func TestFlowHeadlessWritePendingComparesTheFlowIDUntrimmed(t *testing.T) {
+	f := newOccupancyFixture(t, srcHeadlessWrite)
+
+	if !f.m.flowHeadlessWritePending(f.flowID()) {
+		t.Fatal("an in-flight headless write should be pending for its own Flow")
+	}
+	if f.m.flowHeadlessWritePending("  " + f.flowID() + "  ") {
+		t.Fatal("flowHeadlessWritePending compares the Flow ID untrimmed")
+	}
+	if f.m.flowHeadlessWritePending("flow-2") {
+		t.Fatal("a write on one Flow must not be pending for another")
+	}
+	if f.m.flowHeadlessWritePending("") {
+		t.Fatal("no write is enqueued under a blank Flow ID")
+	}
+	// markFlowHeadlessWritePending refuses a blank Flow ID outright, so the
+	// untrimmed comparison can never be reached through an empty key.
+	if newOccupancyFixture(t).m.markFlowHeadlessWritePending(pendingFlowHeadlessWrite{}).flowHeadlessWritePending("") {
+		t.Fatal("a blank-Flow pending write must not be recorded at all")
+	}
+}
+
+// TestHasKnownActiveFlowSessionReadsBothMirrors is S12. It is the only source
+// the worktree agent reads and nothing else does, and it unions the Flow session
+// pane with the worktree session pane.
+func TestHasKnownActiveFlowSessionReadsBothMirrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(occupancyFixture, Model) Model
+		query string
+		want  bool
+	}{
+		{name: "empty mirrors", build: func(_ occupancyFixture, m Model) Model { return m }, query: "flow-1"},
+		{
+			name: "active session in the Flow mirror",
+			build: func(f occupancyFixture, m Model) Model {
+				return m.withOccupancySessionMirror(f.flowID())
+			},
+			query: "flow-1",
+			want:  true,
+		},
+		{
+			name: "active session in the worktree mirror",
+			build: func(f occupancyFixture, m Model) Model {
+				m.worktreeSessions = m.worktreeSessions.SetItems([]sessions.SessionRecord{{
+					FlowID: f.flowID(), Status: "active",
+				}})
+				return m
+			},
+			query: "flow-1",
+			want:  true,
+		},
+		{
+			// The mirror's own Flow ID is trimmed before comparison, unlike S14.
+			name: "the mirrored Flow ID is trimmed before comparison",
+			build: func(f occupancyFixture, m Model) Model {
+				m.sessions = m.sessions.SetItems([]sessions.SessionRecord{{
+					FlowID: "  " + f.flowID() + "  ", Status: "active",
+				}})
+				return m
+			},
+			query: "flow-1",
+			want:  true,
+		},
+		{
+			name: "ended session is not occupancy",
+			build: func(f occupancyFixture, m Model) Model {
+				m.sessions = m.sessions.SetItems([]sessions.SessionRecord{{
+					FlowID: f.flowID(), Status: "ended",
+				}})
+				return m
+			},
+			query: "flow-1",
+		},
+		{
+			name: "another Flow's active session is not occupancy",
+			build: func(_ occupancyFixture, m Model) Model {
+				m.sessions = m.sessions.SetItems([]sessions.SessionRecord{{FlowID: "flow-2", Status: "active"}})
+				return m
+			},
+			query: "flow-1",
+		},
+		{
+			name: "blank Flow ID is not occupancy",
+			build: func(f occupancyFixture, m Model) Model {
+				return m.withOccupancySessionMirror(f.flowID())
+			},
+			query: "  ",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t)
+			if got := tc.build(f, f.m).hasKnownActiveFlowSession(tc.query); got != tc.want {
+				t.Fatalf("hasKnownActiveFlowSession(%q) = %v, want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFlowLaunchRuntimeOccupiedTruthTable is the S3 ∨ S6 ∨ S7 composite, over
+// every combination of its three disjuncts.
+func TestFlowLaunchRuntimeOccupiedTruthTable(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []occupancySource
+		want    bool
+	}{
+		{name: "nothing holds the Flow"},
+		{name: "attempt only", sources: []occupancySource{srcAttemptManualPhase}, want: true},
+		{name: "Flow terminal only", sources: []occupancySource{srcFlowTerminal}, want: true},
+		{name: "repair slot only", sources: []occupancySource{srcRepairSlot}, want: true},
+		{name: "attempt and terminal", sources: []occupancySource{srcAttemptManualPhase, srcFlowTerminal}, want: true},
+		{name: "terminal and repair slot", sources: []occupancySource{srcFlowTerminal, srcRepairSlot}, want: true},
+		{name: "all three", sources: []occupancySource{srcAttemptRepair, srcFlowTerminal, srcRepairSlot}, want: true},
+		// The lease is not a runtime term; this is the whole of D2.
+		{name: "held lease is not runtime occupancy", sources: []occupancySource{srcLeaseHeld}},
+		{name: "lease error is not runtime occupancy", sources: []occupancySource{srcLeaseError}},
+		{name: "headless write is not runtime occupancy", sources: []occupancySource{srcHeadlessWrite}},
+		{name: "running phase is not runtime occupancy", sources: []occupancySource{srcRunningPhase}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, tc.sources...)
+			if got := f.m.flowLaunchRuntimeOccupied(f.flowID()); got != tc.want {
+				t.Fatalf("flowLaunchRuntimeOccupied = %v, want %v", got, tc.want)
+			}
+			if f.m.flowLaunchRuntimeOccupied("  ") {
+				t.Fatal("a blank Flow ID is not runtime occupancy")
+			}
+		})
+	}
+}
+
+// TestFlowLaunchAdmissionOccupiedTruthTable is S2 ∨ S1 ∨ runtime. Both lease
+// outcomes collapse into the same boolean here — that collapse is D1, and it is
+// why five admissions read the lease typed instead.
+func TestFlowLaunchAdmissionOccupiedTruthTable(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources []occupancySource
+		want    bool
+	}{
+		{name: "nothing holds the Flow"},
+		{name: "held lease", sources: []occupancySource{srcLeaseHeld}, want: true},
+		{name: "unreadable lease", sources: []occupancySource{srcLeaseError}, want: true},
+		{name: "runtime attempt", sources: []occupancySource{srcAttemptAutofix}, want: true},
+		{name: "runtime terminal", sources: []occupancySource{srcFlowTerminal}, want: true},
+		{name: "runtime repair slot", sources: []occupancySource{srcRepairSlot}, want: true},
+		{name: "lease and runtime together", sources: []occupancySource{srcLeaseHeld, srcFlowTerminal}, want: true},
+		// Neither the headless write nor the persisted record is part of the
+		// composite; every consumer that wants them adds them itself.
+		{name: "headless write alone", sources: []occupancySource{srcHeadlessWrite}},
+		{name: "running phase alone", sources: []occupancySource{srcRunningPhase}},
+		{name: "phase session alone", sources: []occupancySource{srcPhaseSession}},
+		{name: "session mirror alone", sources: []occupancySource{srcSessionMirror}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newOccupancyFixture(t, tc.sources...)
+			if got := f.m.flowLaunchAdmissionOccupied(f.flowID()); got != tc.want {
+				t.Fatalf("flowLaunchAdmissionOccupied = %v, want %v", got, tc.want)
+			}
+			// A blank Flow ID returns before the lease is inspected, so even a
+			// fail-closed inspector cannot make it occupancy.
+			if f.m.flowLaunchAdmissionOccupied("   ") {
+				t.Fatal("a blank Flow ID is not admission occupancy")
+			}
+		})
+	}
+}
+
+// TestFlowRecordHasOtherRunningPhaseExcludesTheCandidate is S10 minus the
+// candidate: a running candidate is staleness, which the caller classifies
+// first, so only some other running phase counts.
+func TestFlowRecordHasOtherRunningPhaseExcludesTheCandidate(t *testing.T) {
+	record := occupancyFlowRecord()
+	record.Phases = []flowstore.FlowPhase{
+		{PhaseID: "plan", Status: flowstore.PhaseCompleted, Order: 1},
+		{PhaseID: "implementation", Status: flowstore.PhaseRunning, Order: 2},
+		{PhaseID: "review-loop", Status: flowstore.PhaseReady, Order: 3},
+	}
+	tests := []struct {
+		name      string
+		candidate string
+		want      bool
+	}{
+		{name: "the running phase is the candidate", candidate: "implementation"},
+		{name: "a different phase is the candidate", candidate: "review-loop", want: true},
+		{name: "no candidate at all", candidate: "", want: true},
+		// Phase IDs are normalized on both sides before comparison.
+		{name: "the candidate is spelled differently", candidate: "  Implementation  "},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := flowRecordHasOtherRunningPhase(record, tc.candidate); got != tc.want {
+				t.Fatalf("flowRecordHasOtherRunningPhase(%q) = %v, want %v", tc.candidate, got, tc.want)
+			}
+		})
+	}
+
+	none := occupancyFlowRecord()
+	if flowRecordHasOtherRunningPhase(none, "implementation") {
+		t.Fatal("a record with no running phase never has another one")
+	}
+}

--- a/model/flow_occupancy_support_internal_test.go
+++ b/model/flow_occupancy_support_internal_test.go
@@ -1,0 +1,445 @@
+package model
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/approachcontrol/approach/config"
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/internal/flowlease"
+	"github.com/approachcontrol/approach/scanner"
+	"github.com/approachcontrol/approach/sessions"
+)
+
+// This file is the harness for approach-x0r.2's characterization suite. The
+// suite pins today's Flow occupancy behavior — including the parts that look
+// wrong — so every later slice of approach-x0r is provably behavior-preserving.
+// docs/flow-occupancy-matrix.md is the frozen survey these tests are keyed to;
+// its S-numbers appear throughout.
+//
+// The one design constraint that matters: the acceptance criterion the suite is
+// most likely to miss is "simultaneous sources, not one at a time". Every source
+// therefore has exactly one installer, so a case naming three sources composes
+// three installers in one line and costs no more to write than a single-source
+// case.
+
+// occupancySource names one of the survey's representations of "something is
+// already working in this Flow". The attempt sources are split by kind because
+// the ordered ladders (§4.1, §4.3) rank on the kind, not on the attempt.
+type occupancySource int
+
+const (
+	srcLeaseHeld occupancySource = iota + 1
+	srcLeaseError
+	srcAttemptManualPhase
+	srcAttemptAutoPhase
+	srcAttemptPhaseResume
+	srcAttemptRepair
+	srcAttemptAutofix
+	srcAttemptWorktreeAgent
+	srcFlowTerminal
+	srcRepairSlot
+	srcRunningPhase
+	srcPhaseSession
+	srcSessionMirror
+	srcStoreSession
+	srcHeadlessWrite
+	srcTmuxAutofixWindow
+	srcDrainMarker
+)
+
+func (source occupancySource) String() string {
+	switch source {
+	case srcLeaseHeld:
+		return "leaseHeld"
+	case srcLeaseError:
+		return "leaseError"
+	case srcAttemptManualPhase:
+		return "attemptManualPhase"
+	case srcAttemptAutoPhase:
+		return "attemptAutoPhase"
+	case srcAttemptPhaseResume:
+		return "attemptPhaseResume"
+	case srcAttemptRepair:
+		return "attemptRepair"
+	case srcAttemptAutofix:
+		return "attemptAutofix"
+	case srcAttemptWorktreeAgent:
+		return "attemptWorktreeAgent"
+	case srcFlowTerminal:
+		return "flowTerminal"
+	case srcRepairSlot:
+		return "repairSlot"
+	case srcRunningPhase:
+		return "runningPhase"
+	case srcPhaseSession:
+		return "phaseSession"
+	case srcSessionMirror:
+		return "sessionMirror"
+	case srcStoreSession:
+		return "storeSession"
+	case srcHeadlessWrite:
+		return "headlessWrite"
+	case srcTmuxAutofixWindow:
+		return "tmuxAutofixWindow"
+	case srcDrainMarker:
+		return "drainMarker"
+	default:
+		return "unknown"
+	}
+}
+
+// The fixed identifiers the installers write. Tests assert against these rather
+// than re-deriving them, so a case that installs a source and a case that
+// asserts on it cannot drift apart.
+const (
+	occupancyLeaseErrText      = "flow-leases directory is unsafe"
+	occupancyPhaseLaunchID     = "phase-launch-1"
+	occupancyStoreLaunchID     = "store-launch-1"
+	occupancyAutofixTmuxLaunch = "autofix-tmux-1"
+	occupancySessionProvider   = "codex"
+	occupancyPhaseSessionID    = "phase-session-1"
+	occupancyStoreSessionID    = "store-session-1"
+)
+
+func occupancyLeaseErr() error {
+	return errors.New(occupancyLeaseErrText)
+}
+
+// occupancyFixture holds everything a case needs to interrogate one Flow: the
+// Model with the sources installed, the record the sources were installed
+// against, and the authoritative session listing the store-scoped predicates
+// take as an argument rather than reading from the Model.
+type occupancyFixture struct {
+	t *testing.T
+	h *manualLaunchHarness
+
+	m      Model
+	record flowstore.FlowRecord
+	stored []sessions.SessionRecord
+}
+
+// occupancyFlowRecord is the launchable Flow: one ready implementation phase,
+// which is what `g` and the manual admission need. It is deliberately not
+// repairable — a Flow with a launchable phase never is (flow_repair.go:43-47) —
+// so repair cases use occupancyRepairFlowRecord instead.
+func occupancyFlowRecord() flowstore.FlowRecord {
+	return flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		Title:        "Flow one",
+		RepoPath:     "/dev/alpha",
+		WorktreePath: "/dev/alpha",
+		Branch:       "flow/one",
+		Commit:       "abc123",
+		Status:       flowstore.StatusInProgress,
+		UpdatedAt:    time.Now(),
+		Phases: []flowstore.FlowPhase{{
+			PhaseID: "implementation",
+			Title:   "Implementation",
+			Kind:    flowstore.KindImplementation,
+			Status:  flowstore.PhaseReady,
+			Order:   1,
+		}},
+	}
+}
+
+// occupancyRepairFlowRecord is the repairable Flow: a blocked phase with no
+// launchable successor, which is the shape flowRepairObstructionForRecord
+// admits.
+func occupancyRepairFlowRecord() flowstore.FlowRecord {
+	record := occupancyFlowRecord()
+	record.Phases = []flowstore.FlowPhase{{
+		PhaseID: "implementation",
+		Title:   "Implementation",
+		Kind:    flowstore.KindImplementation,
+		Status:  flowstore.PhaseBlocked,
+		Outcome: flowstore.OutcomeBlocked,
+		Notes:   "persisted metadata is inconsistent",
+		Order:   1,
+	}}
+	return record
+}
+
+func newOccupancyFixture(t *testing.T, sources ...occupancySource) occupancyFixture {
+	t.Helper()
+	return newOccupancyFixtureFor(t, occupancyFlowRecord(), sources...)
+}
+
+// newOccupancyFixtureFor installs every named source against one record. The
+// two-stage shape is forced by the Model's construction: the tmux launch
+// backend is read out of Options when the Model is built, while every other
+// source is either a closure the seam calls per probe or a plain Model field.
+//
+// The record is selected in the Flows pane because cachedFlowRecord and
+// cachedGenericWorktreeAgentRecord both resolve through the selection.
+func newOccupancyFixtureFor(t *testing.T, record flowstore.FlowRecord, sources ...occupancySource) occupancyFixture {
+	t.Helper()
+	f := occupancyFixture{t: t, record: record}
+	f.h = newManualLaunchHarness(t, record)
+	// A usable inspector reporting Free is the unoccupied baseline; the lease
+	// sources below replace its answer rather than its existence.
+	f.h.leaseState = flowlease.Free
+
+	for _, source := range sources {
+		f.configure(source)
+	}
+	// The record may have been rewritten by a record-shaped source, and both the
+	// pane and the read seam have to see the same one.
+	f.h.record = f.record
+	f.m = f.h.modelWith([]scanner.Repo{{Path: f.record.RepoPath, DisplayName: "alpha"}}, f.h.options())
+	for _, source := range sources {
+		f.m = f.install(source, f.m)
+	}
+	f.h.sessionRecords = f.stored
+	return f
+}
+
+// configure applies the half of a source that has to exist before the Model is
+// built, and rewrites the record for the sources that are properties of it.
+func (f *occupancyFixture) configure(source occupancySource) {
+	switch source {
+	case srcLeaseHeld:
+		f.h.leaseState = flowlease.Held
+	case srcLeaseError:
+		f.h.leaseErr = occupancyLeaseErr()
+	case srcRunningPhase:
+		f.record = withOccupancyRunningPhase(f.record)
+	case srcPhaseSession:
+		f.record = withOccupancyPhaseSession(f.record)
+	case srcStoreSession:
+		f.record = withOccupancyStoreLaunchID(f.record)
+		f.stored = append(f.stored, occupancyStoreSessionRecord(f.record.FlowID))
+	case srcTmuxAutofixWindow:
+		f.h.launchBackend = config.LaunchBackendTmux
+		f.h.tmuxAvailable = true
+		f.h.tmuxWindowLiveLaunchID = occupancyAutofixTmuxLaunch
+	}
+}
+
+// install applies the Model-shaped half of a source. Every installer reuses the
+// production writer for its state — reserveFlowLaunchAttempt rather than a raw
+// map write, withFlowAutofixTmuxLaunch rather than a registry poke — so a case
+// can never install a state the code itself cannot produce.
+func (f occupancyFixture) install(source occupancySource, m Model) Model {
+	f.t.Helper()
+	switch source {
+	case srcAttemptManualPhase:
+		return f.reserve(m, flowLaunchKindManualPhase)
+	case srcAttemptAutoPhase:
+		return f.reserve(m, flowLaunchKindAutoPhase)
+	case srcAttemptPhaseResume:
+		return f.reserve(m, flowLaunchKindPhaseResume)
+	case srcAttemptRepair:
+		return f.reserve(m, flowLaunchKindRepair)
+	case srcAttemptAutofix:
+		return f.reserve(m, flowLaunchKindAutofix)
+	case srcAttemptWorktreeAgent:
+		return f.reserve(m, flowLaunchKindWorktreeAgent)
+	case srcFlowTerminal:
+		m.embeddedTerminals = append(m.embeddedTerminals, embeddedTerminalSlot{
+			Scope:    embeddedTerminalScopeFlow,
+			FlowID:   f.record.FlowID,
+			Terminal: flowPhaseLaunchTestTerminal{state: "running"},
+		})
+		return m
+	case srcRepairSlot:
+		// Terminal stays nil on purpose: S6 and S7 overlap rather than nest, and
+		// a terminal-less repair slot is the state that tells them apart.
+		m.embeddedTerminals = append(m.embeddedTerminals, embeddedTerminalSlot{
+			Scope:      embeddedTerminalScopeFlow,
+			FlowID:     f.record.FlowID,
+			FlowRepair: true,
+		})
+		return m
+	case srcSessionMirror:
+		return m.withOccupancySessionMirror(f.record.FlowID)
+	case srcHeadlessWrite:
+		return m.markFlowHeadlessWritePending(pendingFlowHeadlessWrite{
+			flowID:   f.record.FlowID,
+			repoPath: f.record.RepoPath,
+			enabled:  true,
+		})
+	case srcTmuxAutofixWindow:
+		return m.withFlowAutofixTmuxLaunch(f.record.FlowID, occupancyAutofixTmuxLaunch)
+	case srcDrainMarker:
+		return m.setRepairAutoDrainMarker(f.record.FlowID, true)
+	}
+	return m
+}
+
+func (f occupancyFixture) reserve(m Model, kind flowLaunchKind) Model {
+	f.t.Helper()
+	next, ok := m.reserveFlowLaunchAttempt(flowLaunchAttempt{
+		Token:   "occupancy-token",
+		Kind:    kind,
+		FlowID:  f.record.FlowID,
+		PhaseID: f.record.Phases[0].PhaseID,
+	}, flowLaunchStateReading)
+	if !ok {
+		f.t.Fatalf("reserving a %v attempt should succeed on an unreserved Flow", kind)
+	}
+	return next
+}
+
+// phase is the record's first phase, which is the one every phase-scoped
+// installer writes to.
+func (f occupancyFixture) phase() flowstore.FlowPhase {
+	return f.record.Phases[0]
+}
+
+// flowID is the exact persisted ID the installers keyed on.
+func (f occupancyFixture) flowID() string {
+	return f.record.FlowID
+}
+
+func withOccupancyRunningPhase(record flowstore.FlowRecord) flowstore.FlowRecord {
+	phases := append([]flowstore.FlowPhase(nil), record.Phases...)
+	phases[0].Status = flowstore.PhaseRunning
+	record.Phases = phases
+	return record
+}
+
+// withOccupancyPhaseSession installs S11: a live session in the phase's own
+// mirror whose launch ID the phase owns. Both halves are required — an
+// unmatched launch ID is skipped by phaseHasMatchingLiveSessionExcept.
+func withOccupancyPhaseSession(record flowstore.FlowRecord) flowstore.FlowRecord {
+	phases := append([]flowstore.FlowPhase(nil), record.Phases...)
+	phases[0].LaunchIDs = append(append([]string(nil), phases[0].LaunchIDs...), occupancyPhaseLaunchID)
+	phases[0].Sessions = append(append([]flowstore.Session(nil), phases[0].Sessions...), flowstore.Session{
+		Provider:  occupancySessionProvider,
+		SessionID: occupancyPhaseSessionID,
+		LaunchID:  occupancyPhaseLaunchID,
+		Status:    "active",
+	})
+	record.Phases = phases
+	return record
+}
+
+// withOccupancyStoreLaunchID gives the phase the launch ID the store-listing
+// source's session claims, which is what scopes S13 to this phase.
+func withOccupancyStoreLaunchID(record flowstore.FlowRecord) flowstore.FlowRecord {
+	phases := append([]flowstore.FlowPhase(nil), record.Phases...)
+	phases[0].LaunchIDs = append(append([]string(nil), phases[0].LaunchIDs...), occupancyStoreLaunchID)
+	record.Phases = phases
+	return record
+}
+
+func occupancyStoreSessionRecord(flowID string) sessions.SessionRecord {
+	return sessions.SessionRecord{
+		Provider:  occupancySessionProvider,
+		SessionID: occupancyStoreSessionID,
+		LaunchID:  occupancyStoreLaunchID,
+		FlowID:    flowID,
+		Status:    "active",
+	}
+}
+
+// withOccupancySessionMirror installs S12, the display mirror the worktree
+// agent is the only family to read.
+func (m Model) withOccupancySessionMirror(flowID string) Model {
+	m.sessions = m.sessions.SetItems([]sessions.SessionRecord{{
+		Provider:  occupancySessionProvider,
+		SessionID: "mirror-session-1",
+		FlowID:    flowID,
+		Status:    "active",
+	}})
+	return m
+}
+
+// TestOccupancyFixtureInstallersDriveTheirOwnLeaf proves every installer in
+// isolation. Without this, a later table asserting "three sources at once" could
+// pass because one of the three never installed anything.
+func TestOccupancyFixtureInstallersDriveTheirOwnLeaf(t *testing.T) {
+	tests := []struct {
+		source occupancySource
+		// leaf is the single predicate this installer exists to flip.
+		leaf func(occupancyFixture) bool
+	}{
+		{srcLeaseHeld, func(f occupancyFixture) bool {
+			occupied, err := f.m.trackedFlowLeaseOccupied(f.flowID())
+			return occupied && err == nil
+		}},
+		{srcLeaseError, func(f occupancyFixture) bool {
+			_, err := f.m.trackedFlowLeaseOccupied(f.flowID())
+			return err != nil
+		}},
+		{srcAttemptManualPhase, func(f occupancyFixture) bool {
+			return f.m.flowLaunchAttemptKind(f.flowID()) == flowLaunchKindManualPhase
+		}},
+		{srcAttemptAutoPhase, func(f occupancyFixture) bool {
+			return f.m.flowLaunchAttemptKind(f.flowID()) == flowLaunchKindAutoPhase
+		}},
+		{srcAttemptPhaseResume, func(f occupancyFixture) bool {
+			return f.m.flowLaunchAttemptKind(f.flowID()) == flowLaunchKindPhaseResume
+		}},
+		{srcAttemptRepair, func(f occupancyFixture) bool {
+			return f.m.flowLaunchAttemptKind(f.flowID()) == flowLaunchKindRepair
+		}},
+		{srcAttemptAutofix, func(f occupancyFixture) bool {
+			return f.m.flowLaunchAttemptKind(f.flowID()) == flowLaunchKindAutofix
+		}},
+		{srcAttemptWorktreeAgent, func(f occupancyFixture) bool {
+			return f.m.flowLaunchAttemptKind(f.flowID()) == flowLaunchKindWorktreeAgent
+		}},
+		{srcFlowTerminal, func(f occupancyFixture) bool {
+			return f.m.hasFlowEmbeddedTerminalForFlow(f.flowID())
+		}},
+		{srcRepairSlot, func(f occupancyFixture) bool {
+			return f.m.hasFlowRepairEmbeddedTerminalForFlow(f.flowID())
+		}},
+		{srcRunningPhase, func(f occupancyFixture) bool {
+			return f.phase().Status == flowstore.PhaseRunning
+		}},
+		{srcPhaseSession, func(f occupancyFixture) bool {
+			return phaseHasMatchingLiveSession(f.phase())
+		}},
+		{srcSessionMirror, func(f occupancyFixture) bool {
+			return f.m.hasKnownActiveFlowSession(f.flowID())
+		}},
+		{srcStoreSession, func(f occupancyFixture) bool {
+			return flowLaunchPhaseSessionOccupied(f.phase(), f.stored)
+		}},
+		{srcHeadlessWrite, func(f occupancyFixture) bool {
+			return f.m.flowHeadlessWritePending(f.flowID())
+		}},
+		{srcTmuxAutofixWindow, func(f occupancyFixture) bool {
+			return f.m.tmuxAutofixAgentStillRunning(f.record, f.record.RepoPath)
+		}},
+		{srcDrainMarker, func(f occupancyFixture) bool {
+			return f.m.hasPendingRepairAutoDrainMarker(f.flowID())
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.source.String(), func(t *testing.T) {
+			if tc.leaf(newOccupancyFixture(t)) {
+				t.Fatal("the baseline fixture must not already satisfy this leaf")
+			}
+			if !tc.leaf(newOccupancyFixture(t, tc.source)) {
+				t.Fatalf("installing %v must flip its own leaf predicate", tc.source)
+			}
+		})
+	}
+}
+
+// TestOccupancyFixtureComposesSimultaneousSources is the harness's stopping
+// condition: the five-source state the bead calls out has to cost one line.
+func TestOccupancyFixtureComposesSimultaneousSources(t *testing.T) {
+	f := newOccupancyFixture(t, srcLeaseHeld, srcAttemptManualPhase, srcFlowTerminal, srcRunningPhase, srcPhaseSession)
+
+	if occupied, err := f.m.trackedFlowLeaseOccupied(f.flowID()); err != nil || !occupied {
+		t.Fatalf("lease occupied = %v, err = %v, want true and nil", occupied, err)
+	}
+	if !f.m.flowLaunchAttemptOccupied(f.flowID()) {
+		t.Fatal("the attempt map should hold the Flow")
+	}
+	if !f.m.hasFlowEmbeddedTerminalForFlow(f.flowID()) {
+		t.Fatal("the Flow terminal slot should be installed")
+	}
+	if f.phase().Status != flowstore.PhaseRunning {
+		t.Fatal("the record's phase should be running")
+	}
+	if !phaseHasMatchingLiveSession(f.phase()) {
+		t.Fatal("the phase should carry a live mirrored session")
+	}
+}


### PR DESCRIPTION
`approach-x0r` concentrates Flow occupancy into one deep module. Every later
slice of the epic moves a call site, and there is currently no suite that says
what the sixteen sources answer today — so "behavior-preserving" would be a
claim rather than a check. ADR 0003 states outright that these tests come first.

This is `approach-x0r.2`: characterization tests only. No production file is
modified by this PR.

## What the suite pins

Six new files under `model/`, keyed to `docs/flow-occupancy-matrix.md`:

- **`flow_occupancy_support_internal_test.go`** — the harness. One installer per
  source, so a case naming five simultaneous sources costs one line rather than
  a page. Every installer reuses the production writer for its state
  (`reserveFlowLaunchAttempt`, `withFlowAutofixTmuxLaunch`, `Options.InspectFlowLease`)
  so a case can never install a state the code itself cannot reach, and each
  installer is proved in isolation against the leaf it targets.
- **`flow_occupancy_sources_internal_test.go`** — one table per leaf predicate
  (S1–S14), including the five lease outcomes that are all occupancy, and the
  four-row S6/S7 overlap table that `previewPhaseResume`'s `∧¬` depends on.
- **`flow_occupancy_sessions_internal_test.go`** — the S11 ∪ S13 union run
  three ways per row (mirror only, store only, both), the resume exemption
  across both halves, and the phase-ordering facts repair and the worktree
  agent each rely on.
- **`flow_occupancy_ladders_internal_test.go`** — the four ordered refusals of
  §4, each rank asserted alone *and* against a lower rank held simultaneously,
  plus the install backstop's seven kind groups over four slot states.
- **`flow_occupancy_admission_internal_test.go`** — composed admissions
  cross-checked against the footer predicates that advertise their keys,
  including D4's three deliberate disagreements and D2's create-phase lease
  divergence. Silent refusals are asserted as *silent* (status unchanged), not
  merely as `admitted == false`.
- **`flow_occupancy_simultaneous_internal_test.go`** — lease + attempt + slot +
  running phase + live session all holding at once, and the row that matters
  most: repair names the competing *attempt* where autofix names the
  *terminal*, for the identical Model state.

## Behaviors pinned on purpose rather than fixed

These read as wrong and are current behavior. A later slice that changes any of
them has to do so deliberately:

- Repair's ladder rank 5 is a *fallthrough*, so `flowRepairOccupancyRefusal`
  returns `flowHeadlessWritePendingStatus` even when nothing at all holds the
  Flow and no headless write is pending.
- The install backstop is unreachable in production — admission covers every
  branch — and is still tested directly, per its own comment.
- `flowHeadlessWritePending` compares the Flow ID **untrimmed** where its
  neighbouring predicates all trim.
- A matched live session makes a blocked Flow un-repairable outright, so repair
  answers with silence rather than with a rung of its ladder.

Two facts turned out differently from how the plan described them, and the
tests record what the code actually does: `flowstore.OrderedPhases` is stable
over top-level phases (it groups children under parents rather than sorting by
`Order`), and `hasFlowEmbeddedTerminalForFlow` compares the Flow ID as given
while `hasFlowRepairEmbeddedTerminalForFlow` trims it.

## Verification

`make fmt-check`, `make test`, and `make build` all pass. `go test ./model -run
Occupancy -count=2` passes, so the new tables carry no order dependence with the
existing ones sharing the package. `git diff --name-only origin/main...HEAD`
lists only `*_test.go` files under `model/`.
