### PR TITLE
Unify tracked Flow launch routing

### DIFF
--- a/docs/flow-launch-variant-matrix.md
+++ b/docs/flow-launch-variant-matrix.md
@@ -111,9 +111,8 @@ V1–V4 were the last route-deciding arm to move. The tracked-phase builder
 resolves the reservation-vs-requested headless rule and *then* decides the
 route against the finished context, which is what keeps the
 `any kind × tmux × headless` pruning rule true by construction rather than by
-call-site ordering. `prepare` now maps the builder's route onto
-`flowPhaseLaunchRoute`, and an unmapped route is an error rather than a silent
-embedded default.
+call-site ordering. `prepare` carries the builder's `flowLaunchRoute` directly
+to lifecycle dispatch, whose final route switch rejects unsupported values.
 
 V5–V6 moved last. Their arm returns a constant embedded route like the repair,
 worktree-agent and saved-session-resume arms, so the `createPhase × tmux`
@@ -121,8 +120,7 @@ pruning rule now holds by construction rather than by a missing call site, and
 the create call site takes the builder's route instead of assigning
 `flowLaunchRouteEmbedded` itself. Its tracked-ness moved too: `FlowLaunchTracked`
 and `Embedded` are now set in the arm rather than stamped at install, so no Flow
-context is rewritten between prepare and the terminal open (see F4). Unifying
-`flowLaunchRoute` with `flowPhaseLaunchRoute` remains the standing follow-up.
+context is rewritten between prepare and the terminal open (see F4).
 
 ## 3. Field values, with the pipeline point that sets them
 

--- a/model/flow_launch_lifecycle.go
+++ b/model/flow_launch_lifecycle.go
@@ -819,14 +819,7 @@ func (m Model) flowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flowLaunchA
 		}
 		event.Context = result.Context
 		event.FallbackNote = result.FallbackNote
-		switch result.Route {
-		case flowPhaseLaunchEmbedded:
-			event.Route = flowLaunchRouteEmbedded
-		case flowPhaseLaunchTmux:
-			event.Route = flowLaunchRouteTmux
-		default:
-			event.Err = fmt.Sprintf("unsupported flow phase launch route %d", result.Route)
-		}
+		event.Route = result.Route
 		return event
 	}
 }

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -15,15 +15,6 @@ import (
 	"github.com/approachcontrol/approach/ui"
 )
 
-type flowPhaseLaunchRoute int
-
-const (
-	flowPhaseLaunchEmbedded flowPhaseLaunchRoute = iota + 1
-	// flowPhaseLaunchTmux runs the agent as a window in the repo's tmux
-	// session. It is external-style: nothing in the TUI owns the process.
-	flowPhaseLaunchTmux
-)
-
 type flowPhaseLaunchRequest struct {
 	Record     flowstore.FlowRecord
 	Phase      flowstore.FlowPhase
@@ -45,7 +36,7 @@ type flowPhaseLaunchPreparedRequest struct {
 
 type flowPhaseLaunchResult struct {
 	Context actions.AgentLaunchContext
-	Route   flowPhaseLaunchRoute
+	Route   flowLaunchRoute
 	Skipped bool
 	// FallbackNote is set only when the tmux route was eligible and the
 	// availability probe failed. Choosing the embedded backend, and the
@@ -385,26 +376,7 @@ func (l flowLaunchPreparation) prepare(req flowPhaseLaunchPreparedRequest) (flow
 	if err != nil {
 		return flowPhaseLaunchResult{}, err
 	}
-	route, err := flowPhaseLaunchRouteFor(decision.Route)
-	if err != nil {
-		return flowPhaseLaunchResult{}, err
-	}
-	return flowPhaseLaunchResult{Context: ctx, Route: route, FallbackNote: decision.FallbackNote}, nil
-}
-
-// flowPhaseLaunchRouteFor maps the builder's route onto the phase launch's own
-// enum. An unmapped route is an error rather than a silent embedded default: a
-// routing bug that fell through to embedded would launch a wrong-but-plausible
-// agent instead of announcing itself.
-func flowPhaseLaunchRouteFor(route flowLaunchRoute) (flowPhaseLaunchRoute, error) {
-	switch route {
-	case flowLaunchRouteEmbedded:
-		return flowPhaseLaunchEmbedded, nil
-	case flowLaunchRouteTmux:
-		return flowPhaseLaunchTmux, nil
-	default:
-		return 0, fmt.Errorf("unroutable flow phase launch: route %d", route)
-	}
+	return flowPhaseLaunchResult{Context: ctx, Route: decision.Route, FallbackNote: decision.FallbackNote}, nil
 }
 
 func (l flowLaunchPreparation) readPlan(planID string) (string, error) {


### PR DESCRIPTION
Tracked Flow phase preparation carried a second route enum that duplicated the route already chosen by `newFlowLaunchContext`. This left an adapter and a second translation switch between the builder and final lifecycle dispatch.

This change carries `flowLaunchRoute` through `flowPhaseLaunchResult` directly. It removes `flowPhaseLaunchRoute`, `flowPhaseLaunchRouteFor`, and the lifecycle conversion while keeping unsupported-route validation at the final dispatch boundary. The launch variant matrix now reflects the single shared route type.

Verification:
- `make fmt-check`
- `make test`
- `make build`