### PR TITLE
Route Plan Now admission through the occupancy module

### DIFF
--- a/docs/adr/0003-flow-occupancy-deep-module.md
+++ b/docs/adr/0003-flow-occupancy-deep-module.md
@@ -92,17 +92,19 @@ of them.
 
 | Stage | Consumers | Constraint |
 | --- | --- | --- |
-| `StagePreview` | matrix §2.3 | Runs per frame. Cached only. |
+| `StagePreview` | matrix §2.3 launch previews | Cached only. Omits terms added only by the footer. |
+| `StageFooter` | matrix §2.3 footer predicates | Runs per frame. Cached only. |
 | `StageAdmission` | matrix §2.1, keypress rows | Runs on a keypress. In-process sources plus the lease; no session-store walk. |
 | `StageAutoAdvance` | matrix §2.1 "Auto phase", §2.2 "AutoMode read" | The AutoMode advance poll. Never reads S14, refuses in silence, and its read adds S10-minus-the-candidate. |
 | `StageAuthoritative` | matrix §2.2 read stages | Runs in a `tea.Cmd`. Full store access. |
 | `StageReserved` | matrix §2.2 prepare stages | Runs under the cross-process reservation. Re-checks the lease. |
 | `StageInstall` | `flowLaunchEmbeddedBackstop` | Last check before a slot is allocated. Slot sources only. |
-| `StageDrain` | matrix §2.4 | Runs at 1 Hz. Cached only, and must never shell out. |
+| `StageDrain` | matrix §2.4 drain gate and session pre-filter | Runs at 1 Hz. Cached only, and must never shell out. |
+| `StageDrainControl` | matrix §2.4 arm/disarm pass | Applies repair-slot and repair-marker state without widening the drain gate. |
 
-One non-launch purpose does not fit the role axis and gets `RoleNone` with its
-own stage: `StageSessionRelease` (matrix §2.5,
-`model/flow_session_release.go:115`).
+The non-launch session-release consumers use `RoleNone`: `StageFooter` for its
+cached affordance and `StageSessionRelease` for the authoritative gesture
+(matrix §2.5, `model/flow_session_release.go:88,115`).
 
 The quit deferral (`model/embedded_terminal.go:920,942`) is deliberately *not*
 a purpose, even though matrix §2.5 lists it. It reads S5 alone, and D5 keeps S5
@@ -166,15 +168,16 @@ The rule, stated once so it stops living in comments:
 > The tmux window probe is read only at `StageAdmission` and
 > `StageAuthoritative`, because it forks a subprocess
 > (`model/tmux_mode.go:425-427`). Every other stage — including the AutoMode
-> poll's `StageAutoAdvance` and `StageDrain` — never consults it.
+> poll's `StageAutoAdvance`, `StageDrain`, and `StageDrainControl` — never
+> consults it.
 
-### D4 — `Verdict` exposes a named `Holder` and a `Reason`, never the sources
+### D4 — `Verdict` exposes policy results, never sources or presentation text
 
 ```
 Verdict.Occupied() bool
 Verdict.Holder()   Holder
-Verdict.Reason()   string
 Verdict.PhaseID()  string
+Verdict.Err()      error
 ```
 
 `Holder` is a closed enum over matrix §1, collapsed to what consumers actually
@@ -203,14 +206,8 @@ path "re-reserves while the slot it is about to dismiss is still installed"
 transient, with per-purpose overrides for repair, autofix, and the install
 backstop. Three overrides in one table beats four ladders in four files.
 
-`Reason()` is likewise a table keyed by `(Purpose, Holder)`. The same holder
-gets different text per role by design — `flowRepairTerminalStatus`,
-`flowAutofixTerminalStatus`, `flowWorktreeAgentSlotStatus`, and
-`flowPhaseResumeTerminalStatus` are four strings for one slot — so the strings
-move into `flowoccupancy` with the table. Callers that refuse in silence (auto
-phase, create, phase resume: matrix D3) simply do not read `Reason()`; loudness
-stays the caller's decision, because it is a presentation concern and the poll's
-1 Hz repaint is the reason for it.
+Presentation text stays in `model`, as confirmed by Q3 below. The module owns
+which holder wins and returns the phase identity needed by model's copy table.
 
 ### D5 — six adapter interfaces, one per source family
 
@@ -242,11 +239,14 @@ exists to hide. See decision request Q4.
 
 | Consumer | After |
 | --- | --- |
-| Each admission | one `Occupancy.Query` call; refuse on `Occupied()`, render `Reason()` or stay silent per role |
-| `previewFlowLaunch`, `previewRepairLaunch`, `previewPhaseResume`, the three footer predicates | one `StagePreview` query, conjoined with the existing launchability half, which is unchanged |
+| Each admission | one `Occupancy.Query` call; refuse on `Occupied()`, render model-owned text or stay silent per role |
+| `previewFlowLaunch`, `previewRepairLaunch` | one `StagePreview` query, conjoined with the existing launchability half |
+| Footer predicates, including phase resume | one `StageFooter` query, preserving footer-only terms |
 | `flowAutoAdvanceOccupied` and the drain's session pre-filter | one `StageDrain` query |
+| Drain arm/disarm repair checks | one `StageDrainControl` query |
+| Session release gesture | one authoritative `StageSessionRelease` query after its `RoleNone` footer check |
 | `flowRepairOccupancyRefusal` | deleted; the ladder is the repair rows of the priority and reason tables |
-| `flowLaunchEmbeddedBackstop` | one `StageInstall` query per kind; the per-kind strings move into the reason table |
+| `flowLaunchEmbeddedBackstop` | one `StageInstall` query per kind; model keeps the per-kind strings |
 | `flowLaunchAdmissionOccupied`, `flowLaunchRuntimeOccupied` | deleted once the last caller migrates |
 | `flowLaunchPhaseSessionOccupied(Except)`, `phaseHasMatchingLiveSession(Except)` | move into `flowoccupancy` as the phase-session rule; the resume exemption becomes a `Query` field |
 | tmux keypress probes | unchanged in placement, but reached through `AgentProbe` so the module can refuse to call them at the wrong stage |
@@ -255,15 +255,14 @@ exists to hide. See decision request Q4.
 
 - The four ladders of matrix F2 become one table, and `approach-x0r.11` can
   assert that no new one appears.
-- The C3 rule becomes checkable: a `StagePreview` query that reached
-  `ListFlowSessions` is a bug the module can catch, not a review comment.
+- The C3 rule becomes checkable: a `StagePreview` or `StageFooter` query that
+  reached `ListFlowSessions` is a bug the module can catch, not a review comment.
 - Behavior is preserved exactly, including the per-purpose ordering differences
   D4 names. `approach-x0r.2` pins that with characterization tests *before* any
   caller moves; this ADR is written on the assumption that those tests exist
   first.
-- The user-facing strings move out of `model/`. That is a large, mechanical, and
-  reviewable diff, and it is the point: today's four vocabularies for one holder
-  are only visible once they sit in one table.
+- User-facing strings stay in one exhaustive table in `model/`; the module owns
+  holder selection and ordering.
 - `flowoccupancy` will import `actions`, `flowstore`, and `sessions`, and
   nothing else in this repo. Any future need to import `model` means the
   boundary was drawn wrong.
@@ -306,20 +305,20 @@ than guessing a destination name now.
 ### Q1 - `Purpose` as a `(Role, Stage)` pair: **confirmed, with a `Valid()` registry**
 
 The pair stands. The axes are sparse and irregular rather than orthogonal:
-`StageSessionRelease` admits only `RoleNone`, and `StageAutoAdvance` and
-`StageDrain` admit only `RoleTrackedPhase`. That is a real argument for a flat
-enum and the ADR did not make it against itself.
+`StageSessionRelease` admits only `RoleNone`; `StageAutoAdvance`, `StageDrain`,
+and `StageDrainControl` admit only `RoleTrackedPhase`. That is a real argument
+for a flat enum and the ADR did not make it against itself.
 
 The pair wins anyway, on a stronger ground than D2 gives. The rule most worth
-making machine-checkable is C3, "no `StagePreview` query ever reaches
+making machine-checkable is C3, "no cached rendering query ever reaches
 `ListFlowSessions`". That is expressible only if `Stage` is a value the module
 can quantify over. Flatten it and C3 goes back to being a review comment, which
 is what `approach-x0r.11` exists to end.
 
 Phantom combinations are closed by the `Purpose.Valid()` table rather than by the
-type system. That table becomes the single registry of real consumers, roughly
-25 rows, each `(Role, Stage)` annotated with its matrix section 2 citation, and
-each carrying the source set that purpose may read. An invalid purpose yields a
+type system. That table becomes the single registry of real consumer policies,
+each `(Role, Stage)` annotated with its matrix section 2 citation and carrying
+the source set that purpose may read. An invalid purpose yields a
 fail-closed occupied verdict with `Err`, never a panic: a TUI must not crash on a
 programming error. `approach-x0r.11` asserts the registry both ways, so a
 consumer without a purpose and a purpose without a caller are both build

--- a/flowoccupancy/doc.go
+++ b/flowoccupancy/doc.go
@@ -10,11 +10,12 @@
 // # The contract
 //
 // A caller states its Flow, its purpose, and how fresh an answer it needs, and
-// gets back a verdict that names the holder and, when the caller renders
-// refusals, the exact text to show. Callers never see the underlying
-// representations — not the lease, not the attempt map, not the terminal slots,
-// not the session mirror. Adding a new source is a change inside this package;
-// today it is a change at every call site that could have read it.
+// gets back a verdict that names the holder, the occupied phase when relevant,
+// and any source error. Model owns user-visible refusal text so each migrated
+// caller can preserve its existing wording. Callers never see the underlying
+// representations such as the lease, attempt map, terminal slots, or session
+// mirror. Adding a new source is a change inside this package instead of every
+// call site that could have read it.
 //
 // Purpose is a (Role, Stage) pair. Role is actions.FlowLaunchRole, reused from
 // ADR 0002, and selects the vocabulary and the refusal order. Stage names the
@@ -51,11 +52,10 @@
 //
 // # Status
 //
-// This is the interface skeleton landed by approach-x0r.1. Every method body
-// is a stub; the implementation is approach-x0r.3, behind the characterization
-// tests approach-x0r.2 writes first. Query fails closed until then: it reports
-// occupancy with ErrUnimplemented, so a caller migrated early breaks loudly
-// rather than being told the Flow is free. No caller in model/ has been
-// migrated, no existing predicate has been deleted, and no behavior has
-// changed.
+// The in-process runtime source family is implemented. It classifies launch
+// attempts, Flow terminals, repair slots, pending headless writes, and repair
+// drain markers according to the purpose registry. Creation-time Plan Now is
+// the first migrated caller and asks the runtime-only create-admission purpose.
+// Purposes that require a later source family still fail closed with an error;
+// the lease, store, cache, session, and tmux-probe slices remain pending.
 package flowoccupancy

--- a/flowoccupancy/doc.go
+++ b/flowoccupancy/doc.go
@@ -21,14 +21,16 @@
 // ADR 0002, and selects the vocabulary and the refusal order. Stage names the
 // consumer class and selects the source set:
 //
-//	StagePreview         renders per frame; cached sources only
+//	StagePreview         answers a launch preview from cached sources
+//	StageFooter          renders an affordance with footer-only occupancy
 //	StageAdmission       runs on a keypress; in-process sources plus the lease
 //	StageAutoAdvance     the AutoMode advance poll's admission and read
 //	StageAuthoritative   runs in a command; full store access
 //	StageReserved        runs under the cross-process reservation
 //	StageInstall         the last check before a terminal slot is allocated
-//	StageDrain           runs at 1 Hz; cached only, and never forks a subprocess
-//	StageSessionRelease  the non-launch release gesture
+//	StageDrain           gates an AutoMode launch at 1 Hz
+//	StageDrainControl    applies repair state to drain arm and disarm
+//	StageSessionRelease  runs the authoritative non-launch release gesture
 //
 // # The freshness rule
 //
@@ -40,9 +42,8 @@
 // they are the state rather than a mirror of it, and are read at every
 // freshness. A lease that cannot be read is occupancy under every purpose, in
 // both directions, fail-closed. The tmux window probe forks a subprocess and is
-// therefore consulted only at StageAdmission and StageAuthoritative — never at
-// any other stage, and in particular never from the AutoMode poll path
-// (StageAutoAdvance, StageDrain).
+// therefore consulted only at StageAdmission and StageAuthoritative, never from
+// the cached rendering or AutoMode poll stages.
 //
 // # What this package must never do
 //

--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -145,6 +145,7 @@ const (
 	readAttempt runtimePermission = 1 << iota
 	readFlowTerminal
 	readRepairTerminal
+	readFlowTerminalWithoutRepair
 	readHeadlessWrite
 	readRepairDrain
 )
@@ -177,8 +178,8 @@ var purposeRegistry = map[Purpose]purposePolicy{
 	{Role: actions.RolePhaseResume, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime, probe: probeAutofixAgent, freshness: allowAuthoritative},
 	// Matrix section 2.1: repair admission and its whole-Flow agent probe.
 	{Role: actions.RoleRepair, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, probe: probeFlowAgent, freshness: allowAuthoritative},
-	// Matrix section 2.1: autofix admission and its registry-only agent probe.
-	{Role: actions.RoleAutofix, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, probe: probeAutofixAgent, freshness: allowAuthoritative},
+	// Matrix section 2.1: autofix admission and its whole-Flow agent probe.
+	{Role: actions.RoleAutofix, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, probe: probeFlowAgent, freshness: allowAuthoritative},
 	// Matrix section 2.1: worktree-agent admission reads every source family.
 	{Role: actions.RoleWorktreeAgent, Stage: StageAdmission}: {sources: readRuntime | readLease | readFlowCache | readSessionCache, runtime: readAdmissionRuntime, probe: probeAutofixAgent, freshness: allowAuthoritative},
 	// Matrix section 2.1: saved-session resume admits after resolving its Flow.
@@ -213,7 +214,7 @@ var purposeRegistry = map[Purpose]purposePolicy{
 
 	// Matrix section 2.3: footer and preview consumers use mirrors only.
 	{Role: actions.RoleTrackedPhase, Stage: StagePreview}:  {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
-	{Role: actions.RolePhaseResume, Stage: StagePreview}:   {sources: readRuntime | readLease, runtime: readFlowTerminal | readRepairTerminal, freshness: allowCached},
+	{Role: actions.RolePhaseResume, Stage: StagePreview}:   {sources: readRuntime | readLease, runtime: readFlowTerminalWithoutRepair, freshness: allowCached},
 	{Role: actions.RoleRepair, Stage: StagePreview}:        {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
 	{Role: actions.RoleAutofix, Stage: StagePreview}:       {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
 	{Role: actions.RoleWorktreeAgent, Stage: StagePreview}: {sources: readRuntime | readLease | readFlowCache | readSessionCache, runtime: readAdmissionRuntime, freshness: allowCached},
@@ -491,24 +492,31 @@ func (occupancy Occupancy) Query(query Query) Verdict {
 	if occupancy.sources.Runtime == nil {
 		return failedVerdict(ErrMissingRuntime)
 	}
+	return queryRuntime(policy.runtime, occupancy.sources.Runtime, flowID)
+}
 
-	if policy.runtime&readAttempt != 0 {
-		if role, occupied := occupancy.sources.Runtime.AttemptHolder(flowID); occupied {
+func queryRuntime(permission runtimePermission, runtime Runtime, flowID string) Verdict {
+	if permission&readAttempt != 0 {
+		if role, occupied := runtime.AttemptHolder(flowID); occupied {
 			return Verdict{holder: attemptHolder(role)}
 		}
 	}
-	// A repair slot and a live Flow terminal deliberately overlap. Prefer the
-	// more specific repair holder so the result stays deterministic.
-	if policy.runtime&readRepairTerminal != 0 && occupancy.sources.Runtime.HasRepairTerminal(flowID) {
-		return Verdict{holder: HolderRepairTerminal}
-	}
-	if policy.runtime&readFlowTerminal != 0 && occupancy.sources.Runtime.HasFlowTerminal(flowID) {
+	if permission&readFlowTerminalWithoutRepair != 0 &&
+		runtime.HasFlowTerminal(flowID) && !runtime.HasRepairTerminal(flowID) {
 		return Verdict{holder: HolderFlowTerminal}
 	}
-	if policy.runtime&readRepairDrain != 0 && occupancy.sources.Runtime.RepairDrainPending(flowID) {
+	// A repair slot and a live Flow terminal deliberately overlap. Prefer the
+	// more specific repair holder so the result stays deterministic.
+	if permission&readRepairTerminal != 0 && runtime.HasRepairTerminal(flowID) {
+		return Verdict{holder: HolderRepairTerminal}
+	}
+	if permission&readFlowTerminal != 0 && runtime.HasFlowTerminal(flowID) {
+		return Verdict{holder: HolderFlowTerminal}
+	}
+	if permission&readRepairDrain != 0 && runtime.RepairDrainPending(flowID) {
 		return Verdict{holder: HolderRepairDrain}
 	}
-	if policy.runtime&readHeadlessWrite != 0 && occupancy.sources.Runtime.HeadlessWritePending(flowID) {
+	if permission&readHeadlessWrite != 0 && runtime.HeadlessWritePending(flowID) {
 		return Verdict{holder: HolderHeadlessWrite}
 	}
 	return Free()

--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -2,6 +2,8 @@ package flowoccupancy
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/flowstore"
@@ -114,8 +116,114 @@ type Purpose struct {
 // the handoff-pending check quit defers on is a process-wide policy rather than
 // a per-Flow question, so it stays in model. See ADR 0003 D5.
 func (purpose Purpose) Valid() bool {
-	// implemented in approach-x0r.3
-	return false
+	_, ok := purposeRegistry[purpose]
+	return ok
+}
+
+type sourcePermission uint16
+
+const (
+	readRuntime sourcePermission = 1 << iota
+	readLease
+	readFlowCache
+	readFlowStore
+	readSessionCache
+	readSessionStore
+)
+
+type probeChoice uint8
+
+const (
+	probeNone probeChoice = iota
+	probeAutofixAgent
+	probeFlowAgent
+)
+
+type runtimePermission uint8
+
+const (
+	readAttempt runtimePermission = 1 << iota
+	readFlowTerminal
+	readRepairTerminal
+	readHeadlessWrite
+	readRepairDrain
+)
+
+const readAdmissionRuntime = readAttempt | readFlowTerminal | readRepairTerminal
+
+type freshnessPermission uint8
+
+const (
+	allowCached freshnessPermission = 1 << iota
+	allowAuthoritative
+)
+
+type purposePolicy struct {
+	sources   sourcePermission
+	runtime   runtimePermission
+	probe     probeChoice
+	freshness freshnessPermission
+}
+
+// purposeRegistry is the executable transcription of the consumers in
+// docs/flow-occupancy-matrix.md section 2. A row records every source family a
+// purpose may eventually read, including families implemented by later slices.
+var purposeRegistry = map[Purpose]purposePolicy{
+	// Matrix section 2.1: manual phase admission and its g-key tmux probe.
+	{Role: actions.RoleTrackedPhase, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, probe: probeAutofixAgent, freshness: allowAuthoritative},
+	// Matrix section 2.1: creation-time Plan Now admission is runtime-only.
+	{Role: actions.RoleCreatePhase, Stage: StageAdmission}: {sources: readRuntime, runtime: readAdmissionRuntime, freshness: allowAuthoritative},
+	// Matrix section 2.1: phase-resume admission and its keypress probe.
+	{Role: actions.RolePhaseResume, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime, probe: probeAutofixAgent, freshness: allowAuthoritative},
+	// Matrix section 2.1: repair admission and its whole-Flow agent probe.
+	{Role: actions.RoleRepair, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, probe: probeFlowAgent, freshness: allowAuthoritative},
+	// Matrix section 2.1: autofix admission and its registry-only agent probe.
+	{Role: actions.RoleAutofix, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, probe: probeAutofixAgent, freshness: allowAuthoritative},
+	// Matrix section 2.1: worktree-agent admission reads every source family.
+	{Role: actions.RoleWorktreeAgent, Stage: StageAdmission}: {sources: readRuntime | readLease | readFlowCache | readSessionCache, runtime: readAdmissionRuntime, probe: probeAutofixAgent, freshness: allowAuthoritative},
+	// Matrix section 2.1: saved-session resume admits after resolving its Flow.
+	{Role: actions.RoleSavedSessionResume, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime, freshness: allowAuthoritative},
+
+	// Matrix section 2.2: authoritative lifecycle reads.
+	{Role: actions.RoleTrackedPhase, Stage: StageAuthoritative}:       {sources: readFlowStore | readSessionStore, freshness: allowAuthoritative},
+	{Role: actions.RoleCreatePhase, Stage: StageAuthoritative}:        {sources: readSessionStore, freshness: allowAuthoritative},
+	{Role: actions.RolePhaseResume, Stage: StageAuthoritative}:        {sources: readFlowStore | readSessionStore, freshness: allowAuthoritative},
+	{Role: actions.RoleRepair, Stage: StageAuthoritative}:             {sources: readFlowStore | readSessionStore, freshness: allowAuthoritative},
+	{Role: actions.RoleAutofix, Stage: StageAuthoritative}:            {sources: readFlowStore | readSessionStore, freshness: allowAuthoritative},
+	{Role: actions.RoleWorktreeAgent, Stage: StageAuthoritative}:      {sources: readFlowStore | readSessionStore, freshness: allowAuthoritative},
+	{Role: actions.RoleSavedSessionResume, Stage: StageAuthoritative}: {sources: readFlowStore | readSessionStore, freshness: allowAuthoritative},
+
+	// Matrix section 2.2: prepare stages recheck under the reservation.
+	{Role: actions.RoleTrackedPhase, Stage: StageReserved}:       {sources: readLease, freshness: allowAuthoritative},
+	{Role: actions.RolePhaseResume, Stage: StageReserved}:        {sources: readLease, freshness: allowAuthoritative},
+	{Role: actions.RoleRepair, Stage: StageReserved}:             {sources: readLease, freshness: allowAuthoritative},
+	{Role: actions.RoleAutofix, Stage: StageReserved}:            {sources: readLease, freshness: allowAuthoritative},
+	{Role: actions.RoleWorktreeAgent, Stage: StageReserved}:      {sources: readLease | readFlowStore | readSessionStore, freshness: allowAuthoritative},
+	{Role: actions.RoleSavedSessionResume, Stage: StageReserved}: {sources: readLease, freshness: allowAuthoritative},
+
+	// Matrix section 2.2 and section 4.2: every installed launch kind has a
+	// terminal-slot backstop.
+	{Role: actions.RoleTrackedPhase, Stage: StageInstall}:       {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
+	{Role: actions.RoleCreatePhase, Stage: StageInstall}:        {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
+	{Role: actions.RolePhaseResume, Stage: StageInstall}:        {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
+	{Role: actions.RoleRepair, Stage: StageInstall}:             {sources: readRuntime, runtime: readFlowTerminal, freshness: allowAuthoritative},
+	{Role: actions.RoleAutofix, Stage: StageInstall}:            {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
+	{Role: actions.RoleWorktreeAgent, Stage: StageInstall}:      {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
+	{Role: actions.RoleSavedSessionResume, Stage: StageInstall}: {sources: readRuntime, runtime: readFlowTerminal, freshness: allowAuthoritative},
+
+	// Matrix section 2.3: footer and preview consumers use mirrors only.
+	{Role: actions.RoleTrackedPhase, Stage: StagePreview}:  {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
+	{Role: actions.RolePhaseResume, Stage: StagePreview}:   {sources: readRuntime | readLease, runtime: readFlowTerminal | readRepairTerminal, freshness: allowCached},
+	{Role: actions.RoleRepair, Stage: StagePreview}:        {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
+	{Role: actions.RoleAutofix, Stage: StagePreview}:       {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
+	{Role: actions.RoleWorktreeAgent, Stage: StagePreview}: {sources: readRuntime | readLease | readFlowCache | readSessionCache, runtime: readAdmissionRuntime, freshness: allowCached},
+
+	// Matrix sections 2.1 and 2.2: AutoMode has cached and authoritative halves.
+	{Role: actions.RoleTrackedPhase, Stage: StageAutoAdvance}: {sources: readRuntime | readLease | readFlowStore | readSessionStore, runtime: readAdmissionRuntime, freshness: allowCached | allowAuthoritative},
+	// Matrix section 2.4: the 1 Hz drain reads runtime state and mirrors only.
+	{Role: actions.RoleTrackedPhase, Stage: StageDrain}: {sources: readRuntime | readLease | readFlowCache | readSessionCache, runtime: readAttempt | readFlowTerminal | readRepairTerminal | readRepairDrain, freshness: allowCached},
+	// Matrix section 2.5: release preview and keypress share one non-launch purpose.
+	{Role: actions.RoleNone, Stage: StageSessionRelease}: {sources: readRuntime | readSessionCache | readSessionStore, runtime: readAttempt | readHeadlessWrite, freshness: allowCached | allowAuthoritative},
 }
 
 // SessionIdentity exempts one provider session from the session-occupancy rule.
@@ -245,7 +353,7 @@ type Verdict struct {
 }
 
 // Occupied reports whether anything holds the Flow for this purpose.
-func (verdict Verdict) Occupied() bool { return verdict.holder != HolderNone }
+func (verdict Verdict) Occupied() bool { return verdict.holder != HolderNone || verdict.err != nil }
 
 // Holder names what holds it, or HolderNone.
 func (verdict Verdict) Holder() Holder { return verdict.holder }
@@ -349,17 +457,107 @@ func New(sources Sources) Occupancy {
 	return Occupancy{sources: sources}
 }
 
-// ErrUnimplemented is the error every Query carries until approach-x0r.3 lands
-// the source reads. It exists so a caller migrated ahead of the implementation
-// fails loudly instead of being told the Flow is free.
-var ErrUnimplemented = errors.New("flowoccupancy: Query is not implemented yet")
+var (
+	// ErrInvalidQuery marks a programming error in a query. Query fails closed
+	// instead of panicking because it runs inside the TUI update loop.
+	ErrInvalidQuery = errors.New("flowoccupancy: invalid query")
+	// ErrMissingRuntime marks a purpose that needs the in-process adapter but
+	// received none.
+	ErrMissingRuntime      = errors.New("flowoccupancy: runtime source is required")
+	errPendingSourceFamily = errors.New("flowoccupancy: a required source family is not implemented yet")
+)
 
 // Query answers one occupancy question. A query whose purpose is not Valid
 // yields an occupied fail-closed verdict rather than a free one.
 func (occupancy Occupancy) Query(query Query) Verdict {
-	// implemented in approach-x0r.3. Until then every purpose is invalid, so the
-	// fail-closed branch above is the whole behavior: occupied, with an error.
-	return Verdict{holder: HolderLeaseUnreadable, err: ErrUnimplemented}
+	flowID := strings.TrimSpace(query.FlowID)
+	if flowID == "" {
+		return failedVerdict(fmt.Errorf("%w: Flow ID is required", ErrInvalidQuery))
+	}
+	policy, ok := purposeRegistry[query.Purpose]
+	if !ok {
+		return failedVerdict(fmt.Errorf("%w: purpose (%s, %s) is not registered", ErrInvalidQuery, query.Purpose.Role, query.Purpose.Stage))
+	}
+	freshness, ok := resolveFreshness(query.Purpose.Stage, query.Freshness)
+	if !ok || !policy.freshness.allows(freshness) {
+		return failedVerdict(fmt.Errorf("%w: freshness %d is unsupported for purpose (%s, %s)", ErrInvalidQuery, query.Freshness, query.Purpose.Role, query.Purpose.Stage))
+	}
+	if policy.sources&readRuntime == 0 {
+		return failedVerdict(errPendingSourceFamily)
+	}
+	if policy.sources&^readRuntime != 0 || policy.probe != probeNone {
+		return failedVerdict(errPendingSourceFamily)
+	}
+	if occupancy.sources.Runtime == nil {
+		return failedVerdict(ErrMissingRuntime)
+	}
+
+	if policy.runtime&readAttempt != 0 {
+		if role, occupied := occupancy.sources.Runtime.AttemptHolder(flowID); occupied {
+			return Verdict{holder: attemptHolder(role)}
+		}
+	}
+	// A repair slot and a live Flow terminal deliberately overlap. Prefer the
+	// more specific repair holder so the result stays deterministic.
+	if policy.runtime&readRepairTerminal != 0 && occupancy.sources.Runtime.HasRepairTerminal(flowID) {
+		return Verdict{holder: HolderRepairTerminal}
+	}
+	if policy.runtime&readFlowTerminal != 0 && occupancy.sources.Runtime.HasFlowTerminal(flowID) {
+		return Verdict{holder: HolderFlowTerminal}
+	}
+	if policy.runtime&readRepairDrain != 0 && occupancy.sources.Runtime.RepairDrainPending(flowID) {
+		return Verdict{holder: HolderRepairDrain}
+	}
+	if policy.runtime&readHeadlessWrite != 0 && occupancy.sources.Runtime.HeadlessWritePending(flowID) {
+		return Verdict{holder: HolderHeadlessWrite}
+	}
+	return Free()
+}
+
+func failedVerdict(err error) Verdict {
+	return Verdict{err: err}
+}
+
+func resolveFreshness(stage Stage, freshness Freshness) (Freshness, bool) {
+	switch freshness {
+	case FreshnessCached, FreshnessAuthoritative:
+		return freshness, true
+	case FreshnessDefault:
+		switch stage {
+		case StagePreview, StageAutoAdvance, StageDrain, StageSessionRelease:
+			return FreshnessCached, true
+		case StageAdmission, StageAuthoritative, StageReserved, StageInstall:
+			return FreshnessAuthoritative, true
+		default:
+			return FreshnessDefault, false
+		}
+	default:
+		return FreshnessDefault, false
+	}
+}
+
+func (permission freshnessPermission) allows(freshness Freshness) bool {
+	switch freshness {
+	case FreshnessCached:
+		return permission&allowCached != 0
+	case FreshnessAuthoritative:
+		return permission&allowAuthoritative != 0
+	default:
+		return false
+	}
+}
+
+func attemptHolder(role actions.FlowLaunchRole) Holder {
+	switch role {
+	case actions.RoleRepair:
+		return HolderRepairAttempt
+	case actions.RolePhaseResume:
+		return HolderPhaseResumeAttempt
+	case actions.RoleTrackedPhase, actions.RoleCreatePhase:
+		return HolderPhaseAttempt
+	default:
+		return HolderOtherAttempt
+	}
 }
 
 // Free is the verdict for an unoccupied Flow. It exists so callers and tests

--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -203,11 +203,11 @@ var purposeRegistry = map[Purpose]purposePolicy{
 
 	// Matrix section 2.2 and section 4.2: every installed launch kind has a
 	// terminal-slot backstop.
-	{Role: actions.RoleTrackedPhase, Stage: StageInstall}:       {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
+	{Role: actions.RoleTrackedPhase, Stage: StageInstall}:       {sources: readRuntime, runtime: readRepairTerminal, freshness: allowAuthoritative},
 	{Role: actions.RoleCreatePhase, Stage: StageInstall}:        {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
-	{Role: actions.RolePhaseResume, Stage: StageInstall}:        {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
-	{Role: actions.RoleRepair, Stage: StageInstall}:             {sources: readRuntime, runtime: readFlowTerminal, freshness: allowAuthoritative},
-	{Role: actions.RoleAutofix, Stage: StageInstall}:            {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
+	{Role: actions.RolePhaseResume, Stage: StageInstall}:        {sources: readRuntime, runtime: readRepairTerminal, freshness: allowAuthoritative},
+	{Role: actions.RoleRepair, Stage: StageInstall}:             {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
+	{Role: actions.RoleAutofix, Stage: StageInstall}:            {sources: readRuntime, runtime: readRepairTerminal, freshness: allowAuthoritative},
 	{Role: actions.RoleWorktreeAgent, Stage: StageInstall}:      {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
 	{Role: actions.RoleSavedSessionResume, Stage: StageInstall}: {sources: readRuntime, runtime: readFlowTerminal, freshness: allowAuthoritative},
 

--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -19,9 +19,13 @@ const (
 	// StageUnknown is the zero value and is never a legal query. A caller that
 	// forgot its stage must not silently get the cheapest answer.
 	StageUnknown Stage = iota
-	// StagePreview renders a footer affordance or a preview, every frame.
-	// Cached sources only: no store walk, no subprocess.
+	// StagePreview answers a launch preview from cached sources only. Footer-only
+	// occupancy belongs to StageFooter.
 	StagePreview
+	// StageFooter renders a footer affordance every frame. It is separate from
+	// StagePreview because some footers add occupancy that their launch preview
+	// deliberately ignores.
+	StageFooter
 	// StageAdmission decides a keypress admission. In-process sources plus a
 	// lease inspect; still no session-store walk.
 	StageAdmission
@@ -44,6 +48,10 @@ const (
 	// StageDrain runs at 1 Hz from the AutoMode poll. Cached only, and it must
 	// never fork a subprocess.
 	StageDrain
+	// StageDrainControl decides whether repair state disarms the AutoMode drain.
+	// It stays separate from StageDrain's launch gate because repair state does
+	// not occupy that gate.
+	StageDrainControl
 	// StageSessionRelease is the non-launch release gesture, which asks about
 	// the launch lifecycle rather than about a launch of its own.
 	StageSessionRelease
@@ -54,6 +62,8 @@ func (stage Stage) String() string {
 	switch stage {
 	case StagePreview:
 		return "preview"
+	case StageFooter:
+		return "footer"
 	case StageAdmission:
 		return "admission"
 	case StageAutoAdvance:
@@ -66,6 +76,8 @@ func (stage Stage) String() string {
 		return "install"
 	case StageDrain:
 		return "drain"
+	case StageDrainControl:
+		return "drainControl"
 	case StageSessionRelease:
 		return "sessionRelease"
 	default:
@@ -101,7 +113,7 @@ type Purpose struct {
 }
 
 // Valid reports whether this purpose names a consumer that exists. It is backed
-// by the purpose registry: roughly 25 rows, one per real consumer in
+// by the purpose registry: one row per real consumer policy in
 // docs/flow-occupancy-matrix.md section 2, each carrying the source set that
 // purpose may read and the probe method, if any, it may call.
 //
@@ -111,10 +123,10 @@ type Purpose struct {
 // error. approach-x0r.11 asserts the registry both ways, so a consumer with no
 // purpose and a purpose with no caller are both build failures.
 //
-// StageSessionRelease, the one non-launch stage, carries actions.RoleNone;
-// every other stage requires a real role. There is deliberately no quit stage:
-// the handoff-pending check quit defers on is a process-wide policy rather than
-// a per-Flow question, so it stays in model. See ADR 0003 D5.
+// The session-release footer and gesture carry actions.RoleNone; every launch
+// purpose requires a real role. There is deliberately no quit stage: the
+// handoff-pending check quit defers on is a process-wide policy rather than a
+// per-Flow question, so it stays in model. See ADR 0003 D5.
 func (purpose Purpose) Valid() bool {
 	_, ok := purposeRegistry[purpose]
 	return ok
@@ -212,19 +224,27 @@ var purposeRegistry = map[Purpose]purposePolicy{
 	{Role: actions.RoleWorktreeAgent, Stage: StageInstall}:      {sources: readRuntime, runtime: readFlowTerminal | readRepairTerminal, freshness: allowAuthoritative},
 	{Role: actions.RoleSavedSessionResume, Stage: StageInstall}: {sources: readRuntime, runtime: readFlowTerminal, freshness: allowAuthoritative},
 
-	// Matrix section 2.3: footer and preview consumers use mirrors only.
-	{Role: actions.RoleTrackedPhase, Stage: StagePreview}:  {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
-	{Role: actions.RolePhaseResume, Stage: StagePreview}:   {sources: readRuntime | readLease, runtime: readFlowTerminalWithoutRepair, freshness: allowCached},
-	{Role: actions.RoleRepair, Stage: StagePreview}:        {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
-	{Role: actions.RoleAutofix, Stage: StagePreview}:       {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
-	{Role: actions.RoleWorktreeAgent, Stage: StagePreview}: {sources: readRuntime | readLease | readFlowCache | readSessionCache, runtime: readAdmissionRuntime, freshness: allowCached},
+	// Matrix section 2.3: launch previews omit footer-only occupancy terms.
+	{Role: actions.RoleTrackedPhase, Stage: StagePreview}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime, freshness: allowCached},
+	{Role: actions.RoleRepair, Stage: StagePreview}:       {sources: readRuntime | readLease, runtime: readAdmissionRuntime, freshness: allowCached},
+	// Matrix section 2.3: rendered affordances use mirrors only. Tracked phase
+	// and repair add the headless-write term their launch previews omit.
+	{Role: actions.RoleTrackedPhase, Stage: StageFooter}:  {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
+	{Role: actions.RolePhaseResume, Stage: StageFooter}:   {sources: readRuntime | readLease, runtime: readFlowTerminalWithoutRepair, freshness: allowCached},
+	{Role: actions.RoleRepair, Stage: StageFooter}:        {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
+	{Role: actions.RoleAutofix, Stage: StageFooter}:       {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowCached},
+	{Role: actions.RoleWorktreeAgent, Stage: StageFooter}: {sources: readRuntime | readLease | readFlowCache | readSessionCache, runtime: readAdmissionRuntime, freshness: allowCached},
+	{Role: actions.RoleNone, Stage: StageFooter}:          {sources: readFlowCache, freshness: allowCached},
 
 	// Matrix sections 2.1 and 2.2: AutoMode has cached and authoritative halves.
 	{Role: actions.RoleTrackedPhase, Stage: StageAutoAdvance}: {sources: readRuntime | readLease | readFlowStore | readSessionStore, runtime: readAdmissionRuntime, freshness: allowCached | allowAuthoritative},
-	// Matrix section 2.4: the 1 Hz drain reads runtime state and mirrors only.
-	{Role: actions.RoleTrackedPhase, Stage: StageDrain}: {sources: readRuntime | readLease | readFlowCache | readSessionCache, runtime: readAttempt | readFlowTerminal | readRepairTerminal | readRepairDrain, freshness: allowCached},
-	// Matrix section 2.5: release preview and keypress share one non-launch purpose.
-	{Role: actions.RoleNone, Stage: StageSessionRelease}: {sources: readRuntime | readSessionCache | readSessionStore, runtime: readAttempt | readHeadlessWrite, freshness: allowCached | allowAuthoritative},
+	// Matrix section 2.4: the 1 Hz drain gate reads runtime state and its cached
+	// Flow record. Repair state belongs to the separate arm/disarm consumer.
+	{Role: actions.RoleTrackedPhase, Stage: StageDrain}:        {sources: readRuntime | readLease | readFlowCache, runtime: readAttempt | readFlowTerminal, freshness: allowCached},
+	{Role: actions.RoleTrackedPhase, Stage: StageDrainControl}: {sources: readRuntime, runtime: readRepairTerminal | readRepairDrain, freshness: allowCached},
+	// Matrix section 2.5: the release gesture adds launch-lifecycle and
+	// authoritative session checks to the footer's cached Flow check.
+	{Role: actions.RoleNone, Stage: StageSessionRelease}: {sources: readRuntime | readFlowCache | readSessionStore, runtime: readAttempt | readHeadlessWrite, freshness: allowAuthoritative},
 }
 
 // SessionIdentity exempts one provider session from the session-occupancy rule.
@@ -422,11 +442,11 @@ type Runtime interface {
 //
 // The two methods are not one method with a flag. FlowAgentRunning unions the
 // record's phase launch IDs with the autofix registry and serves repair;
-// AutofixAgentRunning is the registry half alone and serves the g keypress, the
-// resume keypress, and autofix. Widening the keystroke probes to every phase of
-// the record would newly refuse g for a finished agent whose window the user
-// merely left open (model/tmux_mode.go:435-438), so collapsing them is a
-// behavior change, not a simplification.
+// AutofixAgentRunning is the registry half alone and serves tracked-phase,
+// phase-resume, and worktree-agent admission. Widening those probes to every
+// phase of the record would newly refuse a tracked launch for a finished agent
+// whose window the user merely left open (model/tmux_mode.go:435-438), so
+// collapsing them is a behavior change, not a simplification.
 //
 // Both take the record and a fallback repo path because both must locate the
 // worktree, and a flow ID alone cannot without a store read.
@@ -532,9 +552,9 @@ func resolveFreshness(stage Stage, freshness Freshness) (Freshness, bool) {
 		return freshness, true
 	case FreshnessDefault:
 		switch stage {
-		case StagePreview, StageAutoAdvance, StageDrain, StageSessionRelease:
+		case StagePreview, StageFooter, StageAutoAdvance, StageDrain, StageDrainControl:
 			return FreshnessCached, true
-		case StageAdmission, StageAuthoritative, StageReserved, StageInstall:
+		case StageAdmission, StageAuthoritative, StageReserved, StageInstall, StageSessionRelease:
 			return FreshnessAuthoritative, true
 		default:
 			return FreshnessDefault, false

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -141,6 +141,48 @@ func TestQueryAnswersFromInProcessRuntime(t *testing.T) {
 	}
 }
 
+func TestStageInstallReadsPerRoleTerminalSources(t *testing.T) {
+	tests := []struct {
+		name       string
+		role       actions.FlowLaunchRole
+		flow       bool
+		repair     bool
+		wantHolder Holder
+	}{
+		{name: "tracked phase ignores Flow terminal", role: actions.RoleTrackedPhase, flow: true, wantHolder: HolderNone},
+		{name: "tracked phase reads repair terminal", role: actions.RoleTrackedPhase, repair: true, wantHolder: HolderRepairTerminal},
+		{name: "create phase reads Flow terminal", role: actions.RoleCreatePhase, flow: true, wantHolder: HolderFlowTerminal},
+		{name: "create phase reads repair terminal", role: actions.RoleCreatePhase, repair: true, wantHolder: HolderRepairTerminal},
+		{name: "phase resume ignores Flow terminal", role: actions.RolePhaseResume, flow: true, wantHolder: HolderNone},
+		{name: "phase resume reads repair terminal", role: actions.RolePhaseResume, repair: true, wantHolder: HolderRepairTerminal},
+		{name: "repair reads Flow terminal", role: actions.RoleRepair, flow: true, wantHolder: HolderFlowTerminal},
+		{name: "repair reads repair terminal", role: actions.RoleRepair, repair: true, wantHolder: HolderRepairTerminal},
+		{name: "autofix ignores Flow terminal", role: actions.RoleAutofix, flow: true, wantHolder: HolderNone},
+		{name: "autofix reads repair terminal", role: actions.RoleAutofix, repair: true, wantHolder: HolderRepairTerminal},
+		{name: "worktree agent reads Flow terminal", role: actions.RoleWorktreeAgent, flow: true, wantHolder: HolderFlowTerminal},
+		{name: "worktree agent reads repair terminal", role: actions.RoleWorktreeAgent, repair: true, wantHolder: HolderRepairTerminal},
+		{name: "saved-session resume reads Flow terminal", role: actions.RoleSavedSessionResume, flow: true, wantHolder: HolderFlowTerminal},
+		{name: "saved-session resume ignores repair terminal", role: actions.RoleSavedSessionResume, repair: true, wantHolder: HolderNone},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			verdict := New(Sources{Runtime: runtimeFixture{
+				flows:   map[string]bool{"flow-1": tc.flow},
+				repairs: map[string]bool{"flow-1": tc.repair},
+			}}).Query(Query{
+				FlowID:  "flow-1",
+				Purpose: Purpose{Role: tc.role, Stage: StageInstall},
+			})
+			if verdict.Holder() != tc.wantHolder {
+				t.Fatalf("Holder() = %v, want %v", verdict.Holder(), tc.wantHolder)
+			}
+			if verdict.Err() != nil {
+				t.Fatalf("Err() = %v, want nil", verdict.Err())
+			}
+		})
+	}
+}
+
 // Free() stays the way callers and tests express "nothing holds it", and must
 // not drift into occupancy alongside the fail-closed stub.
 func TestFreeIsNotOccupied(t *testing.T) {

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -183,6 +183,39 @@ func TestStageInstallReadsPerRoleTerminalSources(t *testing.T) {
 	}
 }
 
+func TestAutofixAdmissionUsesWholeFlowAgentProbe(t *testing.T) {
+	policy := purposeRegistry[Purpose{Role: actions.RoleAutofix, Stage: StageAdmission}]
+	if policy.probe != probeFlowAgent {
+		t.Fatalf("probe = %v, want whole-Flow agent probe %v", policy.probe, probeFlowAgent)
+	}
+}
+
+func TestPhaseResumePreviewPreservesRepairSlotException(t *testing.T) {
+	policy := purposeRegistry[Purpose{Role: actions.RolePhaseResume, Stage: StagePreview}]
+	tests := []struct {
+		name       string
+		flow       bool
+		repair     bool
+		wantHolder Holder
+	}{
+		{name: "neither", wantHolder: HolderNone},
+		{name: "Flow terminal only", flow: true, wantHolder: HolderFlowTerminal},
+		{name: "repair slot only", repair: true, wantHolder: HolderNone},
+		{name: "overlapping Flow terminal and repair slot", flow: true, repair: true, wantHolder: HolderNone},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			verdict := queryRuntime(policy.runtime, runtimeFixture{
+				flows:   map[string]bool{"flow-1": tc.flow},
+				repairs: map[string]bool{"flow-1": tc.repair},
+			}, "flow-1")
+			if verdict.Holder() != tc.wantHolder {
+				t.Fatalf("Holder() = %v, want %v", verdict.Holder(), tc.wantHolder)
+			}
+		})
+	}
+}
+
 // Free() stays the way callers and tests express "nothing holds it", and must
 // not drift into occupancy alongside the fail-closed stub.
 func TestFreeIsNotOccupied(t *testing.T) {

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestPurposeValidRegistry(t *testing.T) {
 	validStages := map[actions.FlowLaunchRole][]Stage{
-		actions.RoleNone:               {StageSessionRelease},
-		actions.RoleTrackedPhase:       {StagePreview, StageAdmission, StageAutoAdvance, StageAuthoritative, StageReserved, StageInstall, StageDrain},
+		actions.RoleNone:               {StageFooter, StageSessionRelease},
+		actions.RoleTrackedPhase:       {StagePreview, StageFooter, StageAdmission, StageAutoAdvance, StageAuthoritative, StageReserved, StageInstall, StageDrain, StageDrainControl},
 		actions.RoleCreatePhase:        {StageAdmission, StageAuthoritative, StageInstall},
-		actions.RolePhaseResume:        {StagePreview, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
-		actions.RoleRepair:             {StagePreview, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
-		actions.RoleAutofix:            {StagePreview, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
-		actions.RoleWorktreeAgent:      {StagePreview, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
+		actions.RolePhaseResume:        {StageFooter, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
+		actions.RoleRepair:             {StagePreview, StageFooter, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
+		actions.RoleAutofix:            {StageFooter, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
+		actions.RoleWorktreeAgent:      {StageFooter, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
 		actions.RoleSavedSessionResume: {StageAdmission, StageAuthoritative, StageReserved, StageInstall},
 	}
 	want := make(map[Purpose]bool)
@@ -88,9 +88,11 @@ func TestQueryRejectsInvalidInputsAndMissingRuntime(t *testing.T) {
 }
 
 type runtimeFixture struct {
-	attempts map[string]actions.FlowLaunchRole
-	flows    map[string]bool
-	repairs  map[string]bool
+	attempts     map[string]actions.FlowLaunchRole
+	flows        map[string]bool
+	repairs      map[string]bool
+	headless     map[string]bool
+	repairDrains map[string]bool
 }
 
 func (runtime runtimeFixture) AttemptHolder(flowID string) (actions.FlowLaunchRole, bool) {
@@ -100,8 +102,12 @@ func (runtime runtimeFixture) AttemptHolder(flowID string) (actions.FlowLaunchRo
 
 func (runtime runtimeFixture) HasFlowTerminal(flowID string) bool   { return runtime.flows[flowID] }
 func (runtime runtimeFixture) HasRepairTerminal(flowID string) bool { return runtime.repairs[flowID] }
-func (runtime runtimeFixture) HeadlessWritePending(string) bool     { return false }
-func (runtime runtimeFixture) RepairDrainPending(string) bool       { return false }
+func (runtime runtimeFixture) HeadlessWritePending(flowID string) bool {
+	return runtime.headless[flowID]
+}
+func (runtime runtimeFixture) RepairDrainPending(flowID string) bool {
+	return runtime.repairDrains[flowID]
+}
 
 func TestQueryAnswersFromInProcessRuntime(t *testing.T) {
 	tests := []struct {
@@ -191,7 +197,7 @@ func TestAutofixAdmissionUsesWholeFlowAgentProbe(t *testing.T) {
 }
 
 func TestPhaseResumePreviewPreservesRepairSlotException(t *testing.T) {
-	policy := purposeRegistry[Purpose{Role: actions.RolePhaseResume, Stage: StagePreview}]
+	policy := purposeRegistry[Purpose{Role: actions.RolePhaseResume, Stage: StageFooter}]
 	tests := []struct {
 		name       string
 		flow       bool
@@ -213,6 +219,66 @@ func TestPhaseResumePreviewPreservesRepairSlotException(t *testing.T) {
 				t.Fatalf("Holder() = %v, want %v", verdict.Holder(), tc.wantHolder)
 			}
 		})
+	}
+}
+
+func TestPreviewAndFooterKeepHeadlessWritePoliciesSeparate(t *testing.T) {
+	for _, role := range []actions.FlowLaunchRole{actions.RoleTrackedPhase, actions.RoleRepair} {
+		runtime := runtimeFixture{headless: map[string]bool{"flow-1": true}}
+		preview := purposeRegistry[Purpose{Role: role, Stage: StagePreview}]
+		if verdict := queryRuntime(preview.runtime, runtime, "flow-1"); verdict.Holder() != HolderNone {
+			t.Errorf("%s preview holder = %v, want none", role, verdict.Holder())
+		}
+		footer := purposeRegistry[Purpose{Role: role, Stage: StageFooter}]
+		if verdict := queryRuntime(footer.runtime, runtime, "flow-1"); verdict.Holder() != HolderHeadlessWrite {
+			t.Errorf("%s footer holder = %v, want %v", role, verdict.Holder(), HolderHeadlessWrite)
+		}
+	}
+}
+
+func TestDrainGateAndControlKeepRepairStateSeparate(t *testing.T) {
+	gate := purposeRegistry[Purpose{Role: actions.RoleTrackedPhase, Stage: StageDrain}]
+	control := purposeRegistry[Purpose{Role: actions.RoleTrackedPhase, Stage: StageDrainControl}]
+	tests := []struct {
+		name        string
+		runtime     runtimeFixture
+		wantGate    Holder
+		wantControl Holder
+	}{
+		{name: "Flow terminal gates", runtime: runtimeFixture{flows: map[string]bool{"flow-1": true}}, wantGate: HolderFlowTerminal},
+		{name: "repair slot controls", runtime: runtimeFixture{repairs: map[string]bool{"flow-1": true}}, wantControl: HolderRepairTerminal},
+		{name: "repair marker controls", runtime: runtimeFixture{repairDrains: map[string]bool{"flow-1": true}}, wantControl: HolderRepairDrain},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if verdict := queryRuntime(gate.runtime, tc.runtime, "flow-1"); verdict.Holder() != tc.wantGate {
+				t.Errorf("gate holder = %v, want %v", verdict.Holder(), tc.wantGate)
+			}
+			if verdict := queryRuntime(control.runtime, tc.runtime, "flow-1"); verdict.Holder() != tc.wantControl {
+				t.Errorf("control holder = %v, want %v", verdict.Holder(), tc.wantControl)
+			}
+		})
+	}
+	if gate.sources&readSessionCache != 0 {
+		t.Fatal("drain gate reads the session mirror, want cached Flow record only")
+	}
+}
+
+func TestSessionReleaseFooterAndGestureKeepSourcesSeparate(t *testing.T) {
+	footer := purposeRegistry[Purpose{Role: actions.RoleNone, Stage: StageFooter}]
+	if footer.sources != readFlowCache || footer.runtime != 0 {
+		t.Fatalf("footer policy = {sources:%v runtime:%v}, want cached Flow only", footer.sources, footer.runtime)
+	}
+	gesture := purposeRegistry[Purpose{Role: actions.RoleNone, Stage: StageSessionRelease}]
+	wantSources := readRuntime | readFlowCache | readSessionStore
+	if gesture.sources != wantSources {
+		t.Fatalf("gesture sources = %v, want %v", gesture.sources, wantSources)
+	}
+	if gesture.runtime != readAttempt|readHeadlessWrite {
+		t.Fatalf("gesture runtime = %v, want attempt and headless-write sources", gesture.runtime)
+	}
+	if freshness, ok := resolveFreshness(StageSessionRelease, FreshnessDefault); !ok || freshness != FreshnessAuthoritative {
+		t.Fatalf("default freshness = (%v, %v), want (%v, true)", freshness, ok, FreshnessAuthoritative)
 	}
 }
 

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -7,19 +7,137 @@ import (
 	"github.com/approachcontrol/approach/actions"
 )
 
-// The skeleton must never report a Flow free. Until approach-x0r.3 reads the
-// sources, a caller migrated early has to fail closed and fail loudly.
-func TestQueryFailsClosedWhileUnimplemented(t *testing.T) {
-	verdict := New(Sources{}).Query(Query{
-		FlowID:  "flow-1",
-		Purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: StageAdmission},
-	})
-
-	if !verdict.Occupied() {
-		t.Fatalf("Occupied() = false, want true while Query is unimplemented")
+func TestPurposeValidRegistry(t *testing.T) {
+	validStages := map[actions.FlowLaunchRole][]Stage{
+		actions.RoleNone:               {StageSessionRelease},
+		actions.RoleTrackedPhase:       {StagePreview, StageAdmission, StageAutoAdvance, StageAuthoritative, StageReserved, StageInstall, StageDrain},
+		actions.RoleCreatePhase:        {StageAdmission, StageAuthoritative, StageInstall},
+		actions.RolePhaseResume:        {StagePreview, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
+		actions.RoleRepair:             {StagePreview, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
+		actions.RoleAutofix:            {StagePreview, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
+		actions.RoleWorktreeAgent:      {StagePreview, StageAdmission, StageAuthoritative, StageReserved, StageInstall},
+		actions.RoleSavedSessionResume: {StageAdmission, StageAuthoritative, StageReserved, StageInstall},
 	}
-	if !errors.Is(verdict.Err(), ErrUnimplemented) {
-		t.Fatalf("Err() = %v, want ErrUnimplemented", verdict.Err())
+	want := make(map[Purpose]bool)
+	for role, stages := range validStages {
+		for _, stage := range stages {
+			want[Purpose{Role: role, Stage: stage}] = true
+		}
+	}
+	roles := []actions.FlowLaunchRole{
+		actions.RoleNone, actions.RoleTrackedPhase, actions.RolePhaseResume,
+		actions.RoleRepair, actions.RoleAutofix, actions.RoleWorktreeAgent,
+		actions.RoleSavedSessionResume, actions.RoleCreatePhase,
+	}
+	for _, role := range roles {
+		for stage := StageUnknown; stage <= StageSessionRelease; stage++ {
+			purpose := Purpose{Role: role, Stage: stage}
+			if got := purpose.Valid(); got != want[purpose] {
+				t.Errorf("Purpose{%s, %s}.Valid() = %v, want %v", role, stage, got, want[purpose])
+			}
+		}
+	}
+	if len(purposeRegistry) != len(want) {
+		t.Fatalf("purpose registry has %d rows, want %d", len(purposeRegistry), len(want))
+	}
+}
+
+func TestQueryRejectsInvalidInputsAndMissingRuntime(t *testing.T) {
+	tests := []struct {
+		name  string
+		query Query
+		want  error
+	}{
+		{
+			name:  "blank Flow ID",
+			query: Query{FlowID: "   ", Purpose: Purpose{Role: actions.RoleCreatePhase, Stage: StageAdmission}},
+			want:  ErrInvalidQuery,
+		},
+		{
+			name:  "phantom purpose",
+			query: Query{FlowID: "flow-1", Purpose: Purpose{Role: actions.RoleAutofix, Stage: StageDrain}},
+			want:  ErrInvalidQuery,
+		},
+		{
+			name:  "unsupported freshness",
+			query: Query{FlowID: "flow-1", Purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: StagePreview}, Freshness: FreshnessAuthoritative},
+			want:  ErrInvalidQuery,
+		},
+		{
+			name:  "unknown freshness",
+			query: Query{FlowID: "flow-1", Purpose: Purpose{Role: actions.RoleCreatePhase, Stage: StageAdmission}, Freshness: FreshnessAuthoritative + 1},
+			want:  ErrInvalidQuery,
+		},
+		{
+			name:  "required runtime adapter missing",
+			query: Query{FlowID: "flow-1", Purpose: Purpose{Role: actions.RoleCreatePhase, Stage: StageAdmission}},
+			want:  ErrMissingRuntime,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			verdict := New(Sources{}).Query(tc.query)
+			if !verdict.Occupied() {
+				t.Fatal("Occupied() = false, want fail-closed occupancy")
+			}
+			if !errors.Is(verdict.Err(), tc.want) {
+				t.Fatalf("Err() = %v, want errors.Is(_, %v)", verdict.Err(), tc.want)
+			}
+		})
+	}
+}
+
+type runtimeFixture struct {
+	attempts map[string]actions.FlowLaunchRole
+	flows    map[string]bool
+	repairs  map[string]bool
+}
+
+func (runtime runtimeFixture) AttemptHolder(flowID string) (actions.FlowLaunchRole, bool) {
+	role, ok := runtime.attempts[flowID]
+	return role, ok
+}
+
+func (runtime runtimeFixture) HasFlowTerminal(flowID string) bool   { return runtime.flows[flowID] }
+func (runtime runtimeFixture) HasRepairTerminal(flowID string) bool { return runtime.repairs[flowID] }
+func (runtime runtimeFixture) HeadlessWritePending(string) bool     { return false }
+func (runtime runtimeFixture) RepairDrainPending(string) bool       { return false }
+
+func TestQueryAnswersFromInProcessRuntime(t *testing.T) {
+	tests := []struct {
+		name    string
+		runtime runtimeFixture
+		flowID  string
+		want    Holder
+	}{
+		{name: "free", runtime: runtimeFixture{}, flowID: "flow-1", want: HolderNone},
+		{name: "exact Flow ID only", runtime: runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-10": actions.RoleRepair}}, flowID: "flow-1", want: HolderNone},
+		{name: "repair attempt", runtime: runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleRepair}}, flowID: "flow-1", want: HolderRepairAttempt},
+		{name: "phase resume attempt", runtime: runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RolePhaseResume}}, flowID: "flow-1", want: HolderPhaseResumeAttempt},
+		{name: "tracked phase attempt", runtime: runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleTrackedPhase}}, flowID: "flow-1", want: HolderPhaseAttempt},
+		{name: "create phase attempt", runtime: runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleCreatePhase}}, flowID: "flow-1", want: HolderPhaseAttempt},
+		{name: "other attempt", runtime: runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleAutofix}}, flowID: "flow-1", want: HolderOtherAttempt},
+		{name: "Flow terminal", runtime: runtimeFixture{flows: map[string]bool{"flow-1": true}}, flowID: "flow-1", want: HolderFlowTerminal},
+		{name: "repair slot", runtime: runtimeFixture{repairs: map[string]bool{"flow-1": true}}, flowID: "flow-1", want: HolderRepairTerminal},
+		{name: "repair slot with live terminal", runtime: runtimeFixture{flows: map[string]bool{"flow-1": true}, repairs: map[string]bool{"flow-1": true}}, flowID: "flow-1", want: HolderRepairTerminal},
+		{name: "attempt wins simultaneous sources", runtime: runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleRepair}, flows: map[string]bool{"flow-1": true}, repairs: map[string]bool{"flow-1": true}}, flowID: "flow-1", want: HolderRepairAttempt},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			verdict := New(Sources{Runtime: tc.runtime}).Query(Query{
+				FlowID:  tc.flowID,
+				Purpose: Purpose{Role: actions.RoleCreatePhase, Stage: StageAdmission},
+			})
+			if verdict.Holder() != tc.want {
+				t.Fatalf("Holder() = %v, want %v", verdict.Holder(), tc.want)
+			}
+			if verdict.Occupied() != (tc.want != HolderNone) {
+				t.Fatalf("Occupied() = %v, want %v", verdict.Occupied(), tc.want != HolderNone)
+			}
+			if verdict.Err() != nil {
+				t.Fatalf("Err() = %v, want nil", verdict.Err())
+			}
+		})
 	}
 }
 

--- a/model/flow_launch_adapters.go
+++ b/model/flow_launch_adapters.go
@@ -6,9 +6,75 @@ import (
 	"strings"
 
 	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowoccupancy"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
 )
+
+// flowOccupancyRuntime keeps the occupancy package on the lifecycle's existing
+// model-side seams without exposing the Model's maps or terminal slots.
+type flowOccupancyRuntime struct {
+	model Model
+}
+
+var _ flowoccupancy.Runtime = flowOccupancyRuntime{}
+
+func (runtime flowOccupancyRuntime) AttemptHolder(flowID string) (actions.FlowLaunchRole, bool) {
+	attempt, ok := runtime.model.flowLaunchAttempt(flowID)
+	if !ok {
+		return actions.RoleNone, false
+	}
+	return flowLaunchRole(attempt.Kind), true
+}
+
+func (runtime flowOccupancyRuntime) HasFlowTerminal(flowID string) bool {
+	return runtime.model.hasFlowEmbeddedTerminalForFlow(flowID)
+}
+
+func (runtime flowOccupancyRuntime) HasRepairTerminal(flowID string) bool {
+	return runtime.model.hasFlowRepairEmbeddedTerminalForFlow(flowID)
+}
+
+func (runtime flowOccupancyRuntime) HeadlessWritePending(flowID string) bool {
+	return runtime.model.flowHeadlessWritePending(flowID)
+}
+
+func (runtime flowOccupancyRuntime) RepairDrainPending(flowID string) bool {
+	return runtime.model.hasPendingRepairAutoDrainMarker(flowID)
+}
+
+func flowLaunchRole(kind flowLaunchKind) actions.FlowLaunchRole {
+	switch kind {
+	case flowLaunchKindManualPhase, flowLaunchKindAutoPhase:
+		return actions.RoleTrackedPhase
+	case flowLaunchKindCreatePhase:
+		return actions.RoleCreatePhase
+	case flowLaunchKindPhaseResume:
+		return actions.RolePhaseResume
+	case flowLaunchKindRepair:
+		return actions.RoleRepair
+	case flowLaunchKindAutofix:
+		return actions.RoleAutofix
+	case flowLaunchKindWorktreeAgent:
+		return actions.RoleWorktreeAgent
+	case flowLaunchKindSavedSessionResume:
+		return actions.RoleSavedSessionResume
+	default:
+		return actions.RoleNone
+	}
+}
+
+func (m Model) createFlowAdmissionOccupancy(flowID string) flowoccupancy.Verdict {
+	return flowoccupancy.New(flowoccupancy.Sources{
+		Runtime: flowOccupancyRuntime{model: m},
+	}).Query(flowoccupancy.Query{
+		FlowID: flowID,
+		Purpose: flowoccupancy.Purpose{
+			Role:  actions.RoleCreatePhase,
+			Stage: flowoccupancy.StageAdmission,
+		},
+	})
+}
 
 // flowLaunchSeams is the authoritative boundary the launch lifecycle reads and
 // writes through. It is built once in NewWithOptions and stored on the Model so

--- a/model/flow_launch_create.go
+++ b/model/flow_launch_create.go
@@ -421,7 +421,7 @@ func (m Model) handleCreateFlowAllocated(msg flowLaunchEventMsg) (Model, tea.Cmd
 	if !artifacts.IsSafeID(msg.FlowID) {
 		return m.refuseCreateFlowLaunch(msg.Create, fmt.Sprintf("Flow ID allocation returned invalid ID %q", msg.FlowID))
 	}
-	if m.flowLaunchRuntimeOccupied(msg.FlowID) {
+	if m.createFlowAdmissionOccupancy(msg.FlowID).Occupied() {
 		return m.refuseCreateFlowLaunch(msg.Create, noLaunchableFlowPhaseStatus)
 	}
 	attempt := flowLaunchAttempt{

--- a/model/flow_occupancy_admission_internal_test.go
+++ b/model/flow_occupancy_admission_internal_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"testing"
 
+	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/flowstore"
 )
 
@@ -152,7 +153,7 @@ func TestCreatePhaseAdmissionIgnoresTheLease(t *testing.T) {
 				Presentation: flowLaunchCreatePresentation{Origin: flowLaunchOriginNewFlow, Request: 1},
 				RepoPath:     f.record.RepoPath,
 			}
-			m := f.m
+			m := f.m.setStatus(statusOther, "leave this status alone")
 			m.flowCreateReq.current = create.Presentation.Request
 
 			next, _ := m.handleCreateFlowAllocated(flowLaunchEventMsg{
@@ -165,8 +166,46 @@ func TestCreatePhaseAdmissionIgnoresTheLease(t *testing.T) {
 			if reserved == tc.wantRefused {
 				t.Fatalf("createPhase reserved = %v, want refused = %v", reserved, tc.wantRefused)
 			}
-			if tc.wantRefused && next.status.Text != noLaunchableFlowPhaseStatus {
-				t.Fatalf("status = %q, want %q", next.status.Text, noLaunchableFlowPhaseStatus)
+			if tc.wantRefused {
+				if next.status.Text != noLaunchableFlowPhaseStatus {
+					t.Fatalf("status = %q, want %q", next.status.Text, noLaunchableFlowPhaseStatus)
+				}
+				return
+			}
+			attempt, ok := next.flowLaunchAttempt(f.flowID())
+			if !ok || attempt.State != flowLaunchStateCreateSessionReading {
+				t.Fatalf("attempt = %#v, ok = %v, want createSessionReading reservation", attempt, ok)
+			}
+			if next.status.Text != "leave this status alone" {
+				t.Fatalf("status = %q, want the pre-existing status untouched", next.status.Text)
+			}
+		})
+	}
+}
+
+func TestFlowOccupancyRuntimeClassifiesEveryLaunchKind(t *testing.T) {
+	tests := []struct {
+		kind flowLaunchKind
+		want actions.FlowLaunchRole
+	}{
+		{kind: flowLaunchKindManualPhase, want: actions.RoleTrackedPhase},
+		{kind: flowLaunchKindAutoPhase, want: actions.RoleTrackedPhase},
+		{kind: flowLaunchKindCreatePhase, want: actions.RoleCreatePhase},
+		{kind: flowLaunchKindPhaseResume, want: actions.RolePhaseResume},
+		{kind: flowLaunchKindRepair, want: actions.RoleRepair},
+		{kind: flowLaunchKindAutofix, want: actions.RoleAutofix},
+		{kind: flowLaunchKindWorktreeAgent, want: actions.RoleWorktreeAgent},
+		{kind: flowLaunchKindSavedSessionResume, want: actions.RoleSavedSessionResume},
+	}
+	for _, tc := range tests {
+		t.Run(tc.want.String(), func(t *testing.T) {
+			m := newOccupancyFixture(t).m
+			m.flowLaunchAttempts = map[string]flowLaunchAttempt{
+				"flow-1": {Token: "token", Kind: tc.kind, FlowID: "flow-1"},
+			}
+			role, ok := (flowOccupancyRuntime{model: m}).AttemptHolder("flow-1")
+			if !ok || role != tc.want {
+				t.Fatalf("AttemptHolder() = (%v, %v), want (%v, true)", role, ok, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Plan Now creation admission currently reads the attempt map and embedded terminal slots directly. That keeps occupancy policy inside the model and makes each new caller responsible for knowing the runtime representations.

This change adds the first complete `flowoccupancy` slice and routes creation-time Plan Now admission through it. The module now has a validated purpose registry, fail-closed invalid-purpose handling, in-process runtime source classification, and model adapters for attempts and terminal slots. Existing refusal behavior and text remain unchanged. The ADR and package documentation now describe the implemented boundary and source policies.

Verification:
- `make fmt-check`
- `make test`
- `make build`
- `git diff --check origin/main...HEAD`
