### PR TITLE
Route manual Flow launch through lease occupancy

### DIFF
--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -383,10 +383,9 @@ func (verdict Verdict) Holder() Holder { return verdict.holder }
 // and the refusal names it. Blank otherwise.
 func (verdict Verdict) PhaseID() string { return verdict.phaseID }
 
-// Err reports a source failure that was not itself occupancy. A lease that
-// could not be read is HolderLeaseUnreadable rather than an error, because
-// fail-closed occupancy is the answer; a Flow store or session store read that
-// failed has no safe answer and surfaces here.
+// Err reports the source failure behind a fail-closed answer. Lease inspection
+// failures retain their original error so presentation code can explain the
+// refusal while HolderLeaseUnreadable remains the module decision.
 func (verdict Verdict) Err() error { return verdict.err }
 
 // FlowReader reads a Flow authoritatively.
@@ -478,13 +477,22 @@ func New(sources Sources) Occupancy {
 	return Occupancy{sources: sources}
 }
 
+// Evaluate answers one query against a short-lived source set. It is the
+// compact form for callers that do not retain an Occupancy between queries.
+func Evaluate(sources Sources, query Query) Verdict {
+	return New(sources).Query(query)
+}
+
 var (
 	// ErrInvalidQuery marks a programming error in a query. Query fails closed
 	// instead of panicking because it runs inside the TUI update loop.
 	ErrInvalidQuery = errors.New("flowoccupancy: invalid query")
 	// ErrMissingRuntime marks a purpose that needs the in-process adapter but
 	// received none.
-	ErrMissingRuntime      = errors.New("flowoccupancy: runtime source is required")
+	ErrMissingRuntime = errors.New("flowoccupancy: runtime source is required")
+	// ErrMissingLease marks a purpose that needs the cross-process lease adapter
+	// but received none.
+	ErrMissingLease        = errors.New("flowoccupancy: lease source is required")
 	errPendingSourceFamily = errors.New("flowoccupancy: a required source family is not implemented yet")
 )
 
@@ -503,16 +511,56 @@ func (occupancy Occupancy) Query(query Query) Verdict {
 	if !ok || !policy.freshness.allows(freshness) {
 		return failedVerdict(fmt.Errorf("%w: freshness %d is unsupported for purpose (%s, %s)", ErrInvalidQuery, query.Freshness, query.Purpose.Role, query.Purpose.Stage))
 	}
-	if policy.sources&readRuntime == 0 {
+	if policy.sources&^(readRuntime|readLease) != 0 || policy.probe != probeNone {
 		return failedVerdict(errPendingSourceFamily)
 	}
-	if policy.sources&^readRuntime != 0 || policy.probe != probeNone {
-		return failedVerdict(errPendingSourceFamily)
+
+	runtimeVerdict := Free()
+	if policy.sources&readRuntime != 0 {
+		if occupancy.sources.Runtime == nil {
+			return failedVerdict(ErrMissingRuntime)
+		}
+		if query.Purpose.Role == actions.RoleTrackedPhase && query.Purpose.Stage == StageFooter &&
+			policy.runtime&readHeadlessWrite != 0 && occupancy.sources.Runtime.HeadlessWritePending(flowID) {
+			runtimeVerdict = Verdict{holder: HolderHeadlessWrite}
+		} else {
+			runtimeVerdict = queryRuntime(policy.runtime, occupancy.sources.Runtime, flowID)
+		}
 	}
-	if occupancy.sources.Runtime == nil {
-		return failedVerdict(ErrMissingRuntime)
+	leaseVerdict := Free()
+	if policy.sources&readLease != 0 {
+		leaseVerdict = queryLease(occupancy.sources.Lease, flowID)
 	}
-	return queryRuntime(policy.runtime, occupancy.sources.Runtime, flowID)
+	return chooseVerdict(query.Purpose, leaseVerdict, runtimeVerdict)
+}
+
+func queryLease(inspector LeaseInspector, flowID string) Verdict {
+	if inspector == nil {
+		return Verdict{holder: HolderLeaseUnreadable, err: ErrMissingLease}
+	}
+	occupied, err := inspector.FlowLeaseOccupied(flowID)
+	if err != nil {
+		return Verdict{holder: HolderLeaseUnreadable, err: err}
+	}
+	if occupied {
+		return Verdict{holder: HolderPeerLease}
+	}
+	return Free()
+}
+
+// chooseVerdict owns purpose ordering independently of adapter call order.
+// Tracked-phase footers include the transient headless write and rank it above
+// the lease. Preview excludes that source through its runtime permission. In
+// both cases a lease outranks attempts and terminal slots.
+func chooseVerdict(purpose Purpose, lease, runtime Verdict) Verdict {
+	if purpose.Role == actions.RoleTrackedPhase && purpose.Stage == StageFooter &&
+		runtime.Holder() == HolderHeadlessWrite {
+		return runtime
+	}
+	if lease.Occupied() {
+		return lease
+	}
+	return runtime
 }
 
 func queryRuntime(permission runtimePermission, runtime Runtime, flowID string) Verdict {

--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -424,6 +424,9 @@ type Runtime interface {
 	// HasFlowTerminal reports a retained Flow terminal slot with a live
 	// terminal.
 	HasFlowTerminal(flowID string) bool
+	// HasNonRepairFlowTerminal reports a retained live Flow terminal that is
+	// not itself a repair slot.
+	HasNonRepairFlowTerminal(flowID string) bool
 	// HasRepairTerminal reports a retained repair slot. It overlaps
 	// HasFlowTerminal rather than nesting inside it: one requires a live
 	// terminal, the other a repair slot.
@@ -523,6 +526,9 @@ func (occupancy Occupancy) Query(query Query) Verdict {
 		if query.Purpose.Role == actions.RoleTrackedPhase && query.Purpose.Stage == StageFooter &&
 			policy.runtime&readHeadlessWrite != 0 && occupancy.sources.Runtime.HeadlessWritePending(flowID) {
 			runtimeVerdict = Verdict{holder: HolderHeadlessWrite}
+		} else if query.Purpose.Role == actions.RoleTrackedPhase && query.Purpose.Stage == StageFooter &&
+			policy.runtime&readFlowTerminal != 0 && occupancy.sources.Runtime.HasNonRepairFlowTerminal(flowID) {
+			runtimeVerdict = Verdict{holder: HolderFlowTerminal}
 		} else {
 			runtimeVerdict = queryRuntime(policy.runtime, occupancy.sources.Runtime, flowID)
 		}

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -95,6 +95,111 @@ type runtimeFixture struct {
 	repairDrains map[string]bool
 }
 
+type leaseFixture struct {
+	wantFlowID string
+	occupied   bool
+	err        error
+	calls      int
+	t          *testing.T
+}
+
+func (lease *leaseFixture) FlowLeaseOccupied(flowID string) (bool, error) {
+	lease.calls++
+	if lease.wantFlowID != "" && flowID != lease.wantFlowID {
+		lease.t.Fatalf("FlowLeaseOccupied() flow ID = %q, want %q", flowID, lease.wantFlowID)
+	}
+	return lease.occupied, lease.err
+}
+
+func TestQueryAnswersFromLeaseSource(t *testing.T) {
+	inspectErr := errors.New("unsafe flow-leases directory")
+	tests := []struct {
+		name       string
+		lease      *leaseFixture
+		wantHolder Holder
+		wantErr    error
+	}{
+		{name: "free", lease: &leaseFixture{}, wantHolder: HolderNone},
+		{name: "held", lease: &leaseFixture{occupied: true}, wantHolder: HolderPeerLease},
+		{name: "inspection error", lease: &leaseFixture{err: inspectErr}, wantHolder: HolderLeaseUnreadable, wantErr: inspectErr},
+		{name: "missing adapter", wantHolder: HolderLeaseUnreadable, wantErr: ErrMissingLease},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.lease != nil {
+				tc.lease.t = t
+				tc.lease.wantFlowID = "flow-exact"
+			}
+			sources := Sources{Runtime: runtimeFixture{}}
+			if tc.lease != nil {
+				sources.Lease = tc.lease
+			}
+			verdict := New(sources).Query(Query{
+				FlowID:  " flow-exact ",
+				Purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: StagePreview},
+			})
+			if verdict.Holder() != tc.wantHolder {
+				t.Fatalf("Holder() = %v, want %v", verdict.Holder(), tc.wantHolder)
+			}
+			if !errors.Is(verdict.Err(), tc.wantErr) {
+				t.Fatalf("Err() = %v, want errors.Is(_, %v)", verdict.Err(), tc.wantErr)
+			}
+			if tc.lease != nil && tc.lease.calls != 1 {
+				t.Fatalf("lease calls = %d, want 1", tc.lease.calls)
+			}
+		})
+	}
+}
+
+func TestTrackedPhaseLeaseAndRuntimePrecedence(t *testing.T) {
+	tests := []struct {
+		name       string
+		stage      Stage
+		runtime    runtimeFixture
+		wantHolder Holder
+	}{
+		{
+			name:       "preview lease outranks attempt and terminal",
+			stage:      StagePreview,
+			runtime:    runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleRepair}, flows: map[string]bool{"flow-1": true}},
+			wantHolder: HolderPeerLease,
+		},
+		{
+			name:       "footer headless write outranks lease",
+			stage:      StageFooter,
+			runtime:    runtimeFixture{headless: map[string]bool{"flow-1": true}},
+			wantHolder: HolderHeadlessWrite,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			verdict := New(Sources{
+				Lease:   &leaseFixture{occupied: true, t: t, wantFlowID: "flow-1"},
+				Runtime: tc.runtime,
+			}).Query(Query{
+				FlowID:  "flow-1",
+				Purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: tc.stage},
+			})
+			if verdict.Holder() != tc.wantHolder {
+				t.Fatalf("Holder() = %v, want %v", verdict.Holder(), tc.wantHolder)
+			}
+		})
+	}
+
+	t.Run("footer headless write outranks unreadable lease", func(t *testing.T) {
+		verdict := New(Sources{
+			Lease:   &leaseFixture{err: errors.New("lease unreadable"), t: t, wantFlowID: "flow-1"},
+			Runtime: runtimeFixture{headless: map[string]bool{"flow-1": true}},
+		}).Query(Query{
+			FlowID:  "flow-1",
+			Purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: StageFooter},
+		})
+		if verdict.Holder() != HolderHeadlessWrite || verdict.Err() != nil {
+			t.Fatalf("verdict = (%v, %v), want headless write with nil error", verdict.Holder(), verdict.Err())
+		}
+	})
+}
+
 func (runtime runtimeFixture) AttemptHolder(flowID string) (actions.FlowLaunchRole, bool) {
 	role, ok := runtime.attempts[flowID]
 	return role, ok

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -88,11 +88,12 @@ func TestQueryRejectsInvalidInputsAndMissingRuntime(t *testing.T) {
 }
 
 type runtimeFixture struct {
-	attempts     map[string]actions.FlowLaunchRole
-	flows        map[string]bool
-	repairs      map[string]bool
-	headless     map[string]bool
-	repairDrains map[string]bool
+	attempts       map[string]actions.FlowLaunchRole
+	flows          map[string]bool
+	nonRepairFlows map[string]bool
+	repairs        map[string]bool
+	headless       map[string]bool
+	repairDrains   map[string]bool
 }
 
 type leaseFixture struct {
@@ -153,28 +154,43 @@ func TestQueryAnswersFromLeaseSource(t *testing.T) {
 
 func TestTrackedPhaseLeaseAndRuntimePrecedence(t *testing.T) {
 	tests := []struct {
-		name       string
-		stage      Stage
-		runtime    runtimeFixture
-		wantHolder Holder
+		name          string
+		stage         Stage
+		leaseOccupied bool
+		runtime       runtimeFixture
+		wantHolder    Holder
 	}{
 		{
-			name:       "preview lease outranks attempt and terminal",
-			stage:      StagePreview,
-			runtime:    runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleRepair}, flows: map[string]bool{"flow-1": true}},
-			wantHolder: HolderPeerLease,
+			name:          "preview lease outranks attempt and terminal",
+			stage:         StagePreview,
+			leaseOccupied: true,
+			runtime:       runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleRepair}, flows: map[string]bool{"flow-1": true}},
+			wantHolder:    HolderPeerLease,
 		},
 		{
-			name:       "footer headless write outranks lease",
+			name:          "footer headless write outranks lease",
+			stage:         StageFooter,
+			leaseOccupied: true,
+			runtime:       runtimeFixture{headless: map[string]bool{"flow-1": true}},
+			wantHolder:    HolderHeadlessWrite,
+		},
+		{
+			name:       "footer Flow terminal outranks attempt",
 			stage:      StageFooter,
-			runtime:    runtimeFixture{headless: map[string]bool{"flow-1": true}},
-			wantHolder: HolderHeadlessWrite,
+			runtime:    runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleRepair}, flows: map[string]bool{"flow-1": true}},
+			wantHolder: HolderFlowTerminal,
+		},
+		{
+			name:       "footer non-repair Flow terminal outranks attempt and repair slot",
+			stage:      StageFooter,
+			runtime:    runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleTrackedPhase}, flows: map[string]bool{"flow-1": true}, nonRepairFlows: map[string]bool{"flow-1": true}, repairs: map[string]bool{"flow-1": true}},
+			wantHolder: HolderFlowTerminal,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			verdict := New(Sources{
-				Lease:   &leaseFixture{occupied: true, t: t, wantFlowID: "flow-1"},
+				Lease:   &leaseFixture{occupied: tc.leaseOccupied, t: t, wantFlowID: "flow-1"},
 				Runtime: tc.runtime,
 			}).Query(Query{
 				FlowID:  "flow-1",
@@ -205,7 +221,13 @@ func (runtime runtimeFixture) AttemptHolder(flowID string) (actions.FlowLaunchRo
 	return role, ok
 }
 
-func (runtime runtimeFixture) HasFlowTerminal(flowID string) bool   { return runtime.flows[flowID] }
+func (runtime runtimeFixture) HasFlowTerminal(flowID string) bool { return runtime.flows[flowID] }
+func (runtime runtimeFixture) HasNonRepairFlowTerminal(flowID string) bool {
+	if runtime.nonRepairFlows != nil {
+		return runtime.nonRepairFlows[flowID]
+	}
+	return runtime.flows[flowID] && !runtime.repairs[flowID]
+}
 func (runtime runtimeFixture) HasRepairTerminal(flowID string) bool { return runtime.repairs[flowID] }
 func (runtime runtimeFixture) HeadlessWritePending(flowID string) bool {
 	return runtime.headless[flowID]

--- a/model/flow_launch_adapters.go
+++ b/model/flow_launch_adapters.go
@@ -8,8 +8,41 @@ import (
 	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/flowoccupancy"
 	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/internal/flowlease"
 	"github.com/approachcontrol/approach/sessions"
 )
+
+// flowOccupancyLeaseInspector adapts the model's preserved injection seam to
+// the occupancy module. Production inspection requires the shared artifact
+// root; injected inspectors own their own root contract.
+type flowOccupancyLeaseInspector struct {
+	root     string
+	injected bool
+	inspect  func(root, flowID string) (flowlease.LeaseState, error)
+}
+
+var _ flowoccupancy.LeaseInspector = flowOccupancyLeaseInspector{}
+
+func (adapter flowOccupancyLeaseInspector) FlowLeaseOccupied(flowID string) (bool, error) {
+	if strings.TrimSpace(adapter.root) == "" && !adapter.injected {
+		return false, fmt.Errorf("Flow lease artifact root is unavailable")
+	}
+	if adapter.inspect == nil {
+		return false, fmt.Errorf("Flow lease inspector is unavailable")
+	}
+	state, err := adapter.inspect(adapter.root, flowID)
+	if err != nil {
+		return false, err
+	}
+	switch state {
+	case flowlease.Free:
+		return false, nil
+	case flowlease.Held:
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid Flow lease state %d", state)
+	}
+}
 
 // flowOccupancyRuntime keeps the occupancy package on the lifecycle's existing
 // model-side seams without exposing the Model's maps or terminal slots.
@@ -72,6 +105,26 @@ func (m Model) createFlowAdmissionOccupancy(flowID string) flowoccupancy.Verdict
 		Purpose: flowoccupancy.Purpose{
 			Role:  actions.RoleCreatePhase,
 			Stage: flowoccupancy.StageAdmission,
+		},
+	})
+}
+
+func (m Model) trackedPhaseOccupancy(flowID string, stage flowoccupancy.Stage) flowoccupancy.Verdict {
+	if strings.TrimSpace(flowID) == "" {
+		return flowoccupancy.Free()
+	}
+	return flowoccupancy.Evaluate(flowoccupancy.Sources{
+		Lease: flowOccupancyLeaseInspector{
+			root:     m.sessionStateRoot,
+			injected: m.leaseInspectInjected,
+			inspect:  m.inspectFlowLease,
+		},
+		Runtime: flowOccupancyRuntime{model: m},
+	}, flowoccupancy.Query{
+		FlowID: flowID,
+		Purpose: flowoccupancy.Purpose{
+			Role:  actions.RoleTrackedPhase,
+			Stage: stage,
 		},
 	})
 }

--- a/model/flow_launch_adapters.go
+++ b/model/flow_launch_adapters.go
@@ -64,6 +64,15 @@ func (runtime flowOccupancyRuntime) HasFlowTerminal(flowID string) bool {
 	return runtime.model.hasFlowEmbeddedTerminalForFlow(flowID)
 }
 
+func (runtime flowOccupancyRuntime) HasNonRepairFlowTerminal(flowID string) bool {
+	for _, slot := range runtime.model.embeddedTerminals {
+		if slot.Scope == embeddedTerminalScopeFlow && slot.FlowID == flowID && slot.Terminal != nil && !slot.FlowRepair {
+			return true
+		}
+	}
+	return false
+}
+
 func (runtime flowOccupancyRuntime) HasRepairTerminal(flowID string) bool {
 	return runtime.model.hasFlowRepairEmbeddedTerminalForFlow(flowID)
 }

--- a/model/flow_launch_lifecycle.go
+++ b/model/flow_launch_lifecycle.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
+	"github.com/approachcontrol/approach/flowoccupancy"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/internal/artifacts"
 	"github.com/approachcontrol/approach/internal/controlplane"
-	"github.com/approachcontrol/approach/internal/flowlease"
 	"github.com/approachcontrol/approach/sessions"
 	"github.com/approachcontrol/approach/ui"
 )
@@ -285,29 +285,27 @@ func (m Model) requestFlowLaunch(intent flowLaunchIntent) (Model, tea.Cmd, bool)
 func (m Model) admitManualFlowLaunch(intent flowLaunchIntent) (Model, tea.Cmd, bool) {
 	flowID := strings.TrimSpace(intent.FlowID)
 	intent.FlowID = flowID
-	if flowID != "" && m.flowHeadlessWritePending(flowID) {
-		return m.setStatus(statusOther, flowHeadlessWritePendingStatus), nil, false
-	}
 	if flowID == "" {
 		return m.setStatus(statusOther, noLaunchableFlowPhaseStatus), nil, false
 	}
-	if occupied, err := m.trackedFlowLeaseOccupied(flowID); err != nil {
-		return m.setStatus(statusOther, flowLeaseSetupErrorStatus(err)), nil, false
-	} else if occupied {
+	occupancy := m.trackedPhaseOccupancy(flowID, flowoccupancy.StageFooter)
+	switch occupancy.Holder() {
+	case flowoccupancy.HolderHeadlessWrite:
+		return m.setStatus(statusOther, flowHeadlessWritePendingStatus), nil, false
+	case flowoccupancy.HolderLeaseUnreadable:
+		return m.setStatus(statusOther, flowLeaseSetupErrorStatus(occupancy.Err())), nil, false
+	case flowoccupancy.HolderPeerLease:
 		return m.setStatus(statusOther, flowLeaseOccupiedStatus), nil, false
 	}
-	// The typed lease check above owns the actionable cross-process result.
-	// Repeating it through previewFlowLaunch would collapse a peer race into the
-	// generic no-phase status; only in-process occupancy belongs in this second
-	// synchronous check. The launch reservation performs the next lease check.
 	record, phase, ok := m.cachedFlowLaunchTarget(intent)
 	if !ok {
 		return m.setStatus(statusOther, noLaunchableFlowPhaseStatus), nil, false
 	}
-	if status, occupied := m.retainedFlowTerminalLaunchStatus(record.FlowID); occupied {
+	if occupancy.Holder() == flowoccupancy.HolderFlowTerminal {
+		status, _ := m.retainedFlowTerminalLaunchStatus(record.FlowID)
 		return m.setStatus(statusOther, status), nil, false
 	}
-	if m.flowLaunchRuntimeOccupied(record.FlowID) {
+	if occupancy.Occupied() {
 		return m.setStatus(statusOther, noLaunchableFlowPhaseStatus), nil, false
 	}
 	token := strings.TrimSpace(m.launchSeams.newLaunchID())
@@ -429,8 +427,7 @@ func (m Model) flowLaunchAdmissionOccupied(flowID string) bool {
 	if flowID == "" {
 		return false
 	}
-	leaseOccupied, leaseErr := m.trackedFlowLeaseOccupied(flowID)
-	return leaseErr != nil || leaseOccupied || m.flowLaunchRuntimeOccupied(flowID)
+	return m.trackedPhaseOccupancy(flowID, flowoccupancy.StagePreview).Occupied()
 }
 
 // flowLaunchRuntimeOccupied is the in-process ownership half of admission.
@@ -458,28 +455,11 @@ func (m Model) trackedFlowLeaseOccupied(flowID string) (bool, error) {
 	if flowID == "" {
 		return false, nil
 	}
-	// An injected inspector owns its own root contract; tests and embedders may
-	// deliberately provide a root-independent implementation. The production
-	// inspector never receives a blank root, so tracked admission fails before
-	// mutation when shared launch state is unavailable.
-	if strings.TrimSpace(m.sessionStateRoot) == "" && !m.leaseInspectInjected {
-		return false, fmt.Errorf("Flow lease artifact root is unavailable")
-	}
-	if m.inspectFlowLease == nil {
-		return false, fmt.Errorf("Flow lease inspector is unavailable")
-	}
-	state, err := m.inspectFlowLease(m.sessionStateRoot, flowID)
-	if err != nil {
-		return false, err
-	}
-	switch state {
-	case flowlease.Free:
-		return false, nil
-	case flowlease.Held:
-		return true, nil
-	default:
-		return false, fmt.Errorf("invalid Flow lease state %d", state)
-	}
+	return (flowOccupancyLeaseInspector{
+		root:     m.sessionStateRoot,
+		injected: m.leaseInspectInjected,
+		inspect:  m.inspectFlowLease,
+	}).FlowLeaseOccupied(flowID)
 }
 
 func (m Model) cachedFlowRecord(flowID string) (flowstore.FlowRecord, bool) {

--- a/model/flow_occupancy_admission_internal_test.go
+++ b/model/flow_occupancy_admission_internal_test.go
@@ -28,6 +28,8 @@ func TestManualPhaseAdmissionAndFooterAgree(t *testing.T) {
 		{name: "unreadable lease", sources: []occupancySource{srcLeaseError}, want: flowLeaseSetupErrorStatus(occupancyLeaseErr())},
 		{name: "competing attempt", sources: []occupancySource{srcAttemptRepair}, want: noLaunchableFlowPhaseStatus},
 		{name: "Flow terminal", sources: []occupancySource{srcFlowTerminal}, want: `Close, detach, or dismiss Flow terminal "flow" before launching this Flow`},
+		{name: "Flow terminal over a competing attempt", sources: []occupancySource{srcAttemptManualPhase, srcFlowTerminal}, want: `Close, detach, or dismiss Flow terminal "flow" before launching this Flow`},
+		{name: "Flow terminal over an attempt and repair slot", sources: []occupancySource{srcAttemptManualPhase, srcFlowTerminal, srcRepairSlot}, want: `Close, detach, or dismiss Flow terminal "flow" before launching this Flow`},
 		{name: "terminal-less repair slot", sources: []occupancySource{srcRepairSlot}, want: noLaunchableFlowPhaseStatus},
 		{
 			// The headless rung is checked before the lease, so it wins even

--- a/model/flow_occupancy_admission_internal_test.go
+++ b/model/flow_occupancy_admission_internal_test.go
@@ -37,6 +37,11 @@ func TestManualPhaseAdmissionAndFooterAgree(t *testing.T) {
 			want:    flowHeadlessWritePendingStatus,
 		},
 		{
+			name:    "headless write over an unreadable lease",
+			sources: []occupancySource{srcHeadlessWrite, srcLeaseError},
+			want:    flowHeadlessWritePendingStatus,
+		},
+		{
 			name:    "held lease over a runtime holder",
 			sources: []occupancySource{srcLeaseHeld, srcFlowTerminal},
 			want:    flowLeaseOccupiedStatus,
@@ -75,6 +80,19 @@ func TestManualPhaseAdmissionAndFooterAgree(t *testing.T) {
 				t.Fatalf("status = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestManualPhasePreviewAndFooterNeverProbeTmux(t *testing.T) {
+	f := newOccupancyFixture(t, srcTmuxAutofixWindow)
+	if !f.m.selectedFlowHasLaunchablePhase() {
+		t.Fatal("tmux-only source withdrew the manual phase footer")
+	}
+	if _, _, ok := f.m.previewFlowLaunch(flowLaunchIntent{Kind: flowLaunchKindManualPhase, FlowID: f.flowID()}); !ok {
+		t.Fatal("tmux-only source refused the manual phase preview")
+	}
+	if len(f.h.tmuxWindowProbes) != 0 {
+		t.Fatalf("preview or footer invoked tmux probes: %#v", f.h.tmuxWindowProbes)
 	}
 }
 

--- a/model/flow_occupancy_admission_internal_test.go
+++ b/model/flow_occupancy_admission_internal_test.go
@@ -96,6 +96,16 @@ func TestManualPhasePreviewAndFooterNeverProbeTmux(t *testing.T) {
 	}
 }
 
+func TestManualPhaseFooterSkipsLeaseForUnlaunchableFlow(t *testing.T) {
+	f := newOccupancyFixtureFor(t, occupancyRepairFlowRecord())
+	if f.m.selectedFlowHasLaunchablePhase() {
+		t.Fatal("blocked Flow advertised a manual phase launch")
+	}
+	if f.h.leaseInspections != 0 {
+		t.Fatalf("lease inspections = %d, want 0", f.h.leaseInspections)
+	}
+}
+
 func TestManualPhaseAdmissionNamesRetainedTerminalAndAdmitsAfterRelease(t *testing.T) {
 	f := newOccupancyFixture(t, srcFlowTerminal)
 	f.m.embeddedTerminals[0].Identity = "implementation"

--- a/model/flow_occupancy_sources_internal_test.go
+++ b/model/flow_occupancy_sources_internal_test.go
@@ -123,6 +123,65 @@ func TestTrackedFlowLeaseOccupiedSources(t *testing.T) {
 	}
 }
 
+func TestFlowOccupancyLeaseInspectorPreservesRootContractAndFlowID(t *testing.T) {
+	tests := []struct {
+		name     string
+		adapter  flowOccupancyLeaseInspector
+		wantHeld bool
+		wantErr  string
+	}{
+		{
+			name: "production inspector receives the configured root and exact Flow ID",
+			adapter: flowOccupancyLeaseInspector{
+				root: "/state/root",
+				inspect: func(root, flowID string) (flowlease.LeaseState, error) {
+					if root != "/state/root" || flowID != "flow-1" {
+						t.Fatalf("inspect args = (%q, %q), want (%q, %q)", root, flowID, "/state/root", "flow-1")
+					}
+					return flowlease.Held, nil
+				},
+			},
+			wantHeld: true,
+		},
+		{
+			name: "blank production root fails closed before inspection",
+			adapter: flowOccupancyLeaseInspector{
+				inspect: func(string, string) (flowlease.LeaseState, error) {
+					t.Fatal("production inspector called with a blank root")
+					return flowlease.Free, nil
+				},
+			},
+			wantErr: "Flow lease artifact root is unavailable",
+		},
+		{
+			name: "injected inspector may ignore a blank root",
+			adapter: flowOccupancyLeaseInspector{
+				injected: true,
+				inspect: func(root, flowID string) (flowlease.LeaseState, error) {
+					if root != "" || flowID != "flow-1" {
+						t.Fatalf("inspect args = (%q, %q), want (%q, %q)", root, flowID, "", "flow-1")
+					}
+					return flowlease.Free, nil
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			held, err := tc.adapter.FlowLeaseOccupied("flow-1")
+			if held != tc.wantHeld {
+				t.Fatalf("held = %v, want %v", held, tc.wantHeld)
+			}
+			if tc.wantErr == "" && err != nil {
+				t.Fatalf("err = %v, want nil", err)
+			}
+			if tc.wantErr != "" && (err == nil || err.Error() != tc.wantErr) {
+				t.Fatalf("err = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestFlowLeaseSetupErrorStatusWrapsTheInspectionError pins the one refusal
 // string that is not a constant: it is a prefix plus the wrapped error text.
 func TestFlowLeaseSetupErrorStatusWrapsTheInspectionError(t *testing.T) {

--- a/model/model.go
+++ b/model/model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/approachcontrol/approach/beadsmutate"
 	"github.com/approachcontrol/approach/beadsquery"
 	"github.com/approachcontrol/approach/config"
+	"github.com/approachcontrol/approach/flowoccupancy"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/gitquery"
 	"github.com/approachcontrol/approach/internal/artifacts"
@@ -2707,12 +2708,10 @@ func (m Model) selectedFlowHasLaunchablePhase() bool {
 	if !ok {
 		return false
 	}
-	// An in-flight headless write makes admission refuse, so the footer has to
-	// stop advertising for as long as it is outstanding.
-	if m.flowHeadlessWritePending(record.FlowID) {
+	if m.trackedPhaseOccupancy(record.FlowID, flowoccupancy.StageFooter).Occupied() {
 		return false
 	}
-	_, _, ok = m.previewFlowLaunch(flowLaunchIntent{
+	_, _, ok = m.cachedFlowLaunchTarget(flowLaunchIntent{
 		Kind:   flowLaunchKindManualPhase,
 		FlowID: record.FlowID,
 	})

--- a/model/model.go
+++ b/model/model.go
@@ -2708,14 +2708,14 @@ func (m Model) selectedFlowHasLaunchablePhase() bool {
 	if !ok {
 		return false
 	}
-	if m.trackedPhaseOccupancy(record.FlowID, flowoccupancy.StageFooter).Occupied() {
-		return false
-	}
 	_, _, ok = m.cachedFlowLaunchTarget(flowLaunchIntent{
 		Kind:   flowLaunchKindManualPhase,
 		FlowID: record.FlowID,
 	})
-	return ok
+	if !ok {
+		return false
+	}
+	return !m.trackedPhaseOccupancy(record.FlowID, flowoccupancy.StageFooter).Occupied()
 }
 
 // withFlowAutofixTmuxLaunch appends an autofix tmux launch to the


### PR DESCRIPTION
Manual Flow launch admission and its footer preview could derive cross-process lease occupancy through separate paths, which left room for their answers to diverge.

This change moves tracked Flow lease inspection into the flowoccupancy module and routes both manual launch admission and footer preview through the same module verdicts. It preserves the existing lease refusal text and precedence, keeps blank production roots fail-closed, retains the injected inspector seam, and avoids lease inspection when a Flow has no launchable phase.

Verification:

- make fmt-check
- go test ./flowoccupancy ./model
- make test
- make build