### PR TITLE
Move repair occupancy verdicts into the occupancy module

### DIFF
--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -188,8 +188,9 @@ var purposeRegistry = map[Purpose]purposePolicy{
 	{Role: actions.RoleCreatePhase, Stage: StageAdmission}: {sources: readRuntime, runtime: readAdmissionRuntime, freshness: allowAuthoritative},
 	// Matrix section 2.1: phase-resume admission and its keypress probe.
 	{Role: actions.RolePhaseResume, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime, probe: probeAutofixAgent, freshness: allowAuthoritative},
-	// Matrix section 2.1: repair admission and its whole-Flow agent probe.
-	{Role: actions.RoleRepair, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, probe: probeFlowAgent, freshness: allowAuthoritative},
+	// Matrix section 2.1: repair admission. The whole-Flow tmux probe remains a
+	// separate keypress check because it shells out and is not part of admission.
+	{Role: actions.RoleRepair, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, freshness: allowAuthoritative},
 	// Matrix section 2.1: autofix admission and its whole-Flow agent probe.
 	{Role: actions.RoleAutofix, Stage: StageAdmission}: {sources: readRuntime | readLease, runtime: readAdmissionRuntime | readHeadlessWrite, probe: probeFlowAgent, freshness: allowAuthoritative},
 	// Matrix section 2.1: worktree-agent admission reads every source family.

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -216,6 +216,76 @@ func TestTrackedPhaseLeaseAndRuntimePrecedence(t *testing.T) {
 	})
 }
 
+func TestRepairPurposeHolderPrecedence(t *testing.T) {
+	leaseErr := errors.New("unsafe flow-leases directory")
+	tests := []struct {
+		name          string
+		leaseOccupied bool
+		leaseErr      error
+		runtime       runtimeFixture
+		wantPreview   Holder
+		wantAdmission Holder
+		wantFooter    Holder
+	}{
+		{name: "free"},
+		{name: "repair attempt", runtime: runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleRepair}}, wantPreview: HolderRepairAttempt, wantAdmission: HolderRepairAttempt, wantFooter: HolderRepairAttempt},
+		{name: "phase resume attempt", runtime: runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RolePhaseResume}}, wantPreview: HolderPhaseResumeAttempt, wantAdmission: HolderPhaseResumeAttempt, wantFooter: HolderPhaseResumeAttempt},
+		{name: "phase attempt", runtime: runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleTrackedPhase}}, wantPreview: HolderPhaseAttempt, wantAdmission: HolderPhaseAttempt, wantFooter: HolderPhaseAttempt},
+		{name: "other attempt", runtime: runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleAutofix}}, wantPreview: HolderOtherAttempt, wantAdmission: HolderOtherAttempt, wantFooter: HolderOtherAttempt},
+		{name: "Flow terminal", runtime: runtimeFixture{flows: map[string]bool{"flow-1": true}}, wantPreview: HolderFlowTerminal, wantAdmission: HolderFlowTerminal, wantFooter: HolderFlowTerminal},
+		{name: "terminal-less repair slot", runtime: runtimeFixture{repairs: map[string]bool{"flow-1": true}}, wantPreview: HolderRepairTerminal, wantAdmission: HolderRepairTerminal, wantFooter: HolderRepairTerminal},
+		{name: "headless write", runtime: runtimeFixture{headless: map[string]bool{"flow-1": true}}, wantAdmission: HolderHeadlessWrite, wantFooter: HolderHeadlessWrite},
+		{
+			name:          "repair attempt wins every runtime source",
+			runtime:       runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleRepair}, flows: map[string]bool{"flow-1": true}, repairs: map[string]bool{"flow-1": true}, headless: map[string]bool{"flow-1": true}},
+			wantPreview:   HolderRepairAttempt,
+			wantAdmission: HolderRepairAttempt,
+			wantFooter:    HolderRepairAttempt,
+		},
+		{
+			name:          "held lease wins every runtime source",
+			leaseOccupied: true,
+			runtime:       runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleRepair}, flows: map[string]bool{"flow-1": true}, repairs: map[string]bool{"flow-1": true}, headless: map[string]bool{"flow-1": true}},
+			wantPreview:   HolderPeerLease,
+			wantAdmission: HolderPeerLease,
+			wantFooter:    HolderPeerLease,
+		},
+		{
+			name:          "unreadable lease wins every runtime source",
+			leaseErr:      leaseErr,
+			runtime:       runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleRepair}, flows: map[string]bool{"flow-1": true}, repairs: map[string]bool{"flow-1": true}, headless: map[string]bool{"flow-1": true}},
+			wantPreview:   HolderLeaseUnreadable,
+			wantAdmission: HolderLeaseUnreadable,
+			wantFooter:    HolderLeaseUnreadable,
+		},
+	}
+	for _, tc := range tests {
+		for _, stage := range []struct {
+			name  string
+			stage Stage
+			want  Holder
+		}{
+			{name: "preview", stage: StagePreview, want: tc.wantPreview},
+			{name: "admission", stage: StageAdmission, want: tc.wantAdmission},
+			{name: "footer", stage: StageFooter, want: tc.wantFooter},
+		} {
+			t.Run(tc.name+"/"+stage.name, func(t *testing.T) {
+				lease := &leaseFixture{occupied: tc.leaseOccupied, err: tc.leaseErr, t: t, wantFlowID: "flow-1"}
+				verdict := New(Sources{Lease: lease, Runtime: tc.runtime}).Query(Query{
+					FlowID:  "flow-1",
+					Purpose: Purpose{Role: actions.RoleRepair, Stage: stage.stage},
+				})
+				if verdict.Holder() != stage.want {
+					t.Fatalf("Holder() = %v, want %v", verdict.Holder(), stage.want)
+				}
+				if !errors.Is(verdict.Err(), tc.leaseErr) {
+					t.Fatalf("Err() = %v, want errors.Is(_, %v)", verdict.Err(), tc.leaseErr)
+				}
+			})
+		}
+	}
+}
+
 func (runtime runtimeFixture) AttemptHolder(flowID string) (actions.FlowLaunchRole, bool) {
 	role, ok := runtime.attempts[flowID]
 	return role, ok

--- a/model/flow_launch_adapters.go
+++ b/model/flow_launch_adapters.go
@@ -138,6 +138,26 @@ func (m Model) trackedPhaseOccupancy(flowID string, stage flowoccupancy.Stage) f
 	})
 }
 
+func (m Model) repairOccupancy(flowID string, stage flowoccupancy.Stage) flowoccupancy.Verdict {
+	if strings.TrimSpace(flowID) == "" {
+		return flowoccupancy.Free()
+	}
+	return flowoccupancy.Evaluate(flowoccupancy.Sources{
+		Lease: flowOccupancyLeaseInspector{
+			root:     m.sessionStateRoot,
+			injected: m.leaseInspectInjected,
+			inspect:  m.inspectFlowLease,
+		},
+		Runtime: flowOccupancyRuntime{model: m},
+	}, flowoccupancy.Query{
+		FlowID: flowID,
+		Purpose: flowoccupancy.Purpose{
+			Role:  actions.RoleRepair,
+			Stage: stage,
+		},
+	})
+}
+
 // flowLaunchSeams is the authoritative boundary the launch lifecycle reads and
 // writes through. It is built once in NewWithOptions and stored on the Model so
 // the lifecycle never reaches for a pane snapshot or a package-level store.

--- a/model/flow_launch_repair.go
+++ b/model/flow_launch_repair.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/approachcontrol/approach/agent"
+	"github.com/approachcontrol/approach/flowoccupancy"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
 )
@@ -136,7 +137,7 @@ func (m Model) cachedRepairTarget(intent flowLaunchIntent) (flowstore.FlowRecord
 // their conjunction.
 func (m Model) previewRepairLaunch(intent flowLaunchIntent) (flowstore.FlowRecord, bool) {
 	record, ok := m.cachedRepairTarget(intent)
-	if !ok || m.flowLaunchAdmissionOccupied(record.FlowID) {
+	if !ok || m.repairOccupancy(record.FlowID, flowoccupancy.StagePreview).Occupied() {
 		return flowstore.FlowRecord{}, false
 	}
 	return record, true
@@ -154,15 +155,8 @@ func (m Model) admitRepairFlowLaunch(intent flowLaunchIntent) (Model, tea.Cmd, b
 	}
 	flowID := strings.TrimSpace(record.FlowID)
 	intent.FlowID = flowID
-	leaseOccupied, leaseErr := m.trackedFlowLeaseOccupied(flowID)
-	if leaseErr != nil {
-		return m.setStatus(statusOther, flowLeaseSetupErrorStatus(leaseErr)), nil, false
-	}
-	if leaseOccupied {
-		return m.setStatus(statusOther, flowLeaseOccupiedStatus), nil, false
-	}
-	if m.flowLaunchRuntimeOccupied(flowID) || m.flowHeadlessWritePending(flowID) {
-		return m.setStatus(statusOther, m.flowRepairOccupancyRefusal(flowID)), nil, false
+	if verdict := m.repairOccupancy(flowID, flowoccupancy.StageAdmission); verdict.Occupied() {
+		return m.setStatus(statusOther, flowRepairOccupancyStatus(verdict)), nil, false
 	}
 	token := strings.TrimSpace(m.launchSeams.newLaunchID())
 	if token == "" {
@@ -195,26 +189,32 @@ func (m Model) admitRepairFlowLaunch(intent flowLaunchIntent) (Model, tea.Cmd, b
 	return m, m.flowLaunchReadCmd(intent, token, settings), true
 }
 
-// flowRepairOccupancyRefusal names what is holding the Flow in this exact
-// order: repair attempt, phase-resume attempt, manual/auto phase attempt,
-// actual terminal or other-attempt fallback, then pending headless write.
-func (m Model) flowRepairOccupancyRefusal(flowID string) string {
-	switch m.flowLaunchAttemptKind(flowID) {
-	case flowLaunchKindRepair:
+func flowRepairOccupancyStatus(verdict flowoccupancy.Verdict) string {
+	switch verdict.Holder() {
+	case flowoccupancy.HolderLeaseUnreadable:
+		return flowLeaseSetupErrorStatus(verdict.Err())
+	case flowoccupancy.HolderPeerLease:
+		return flowLeaseOccupiedStatus
+	case flowoccupancy.HolderRepairAttempt:
 		return flowRepairPendingStatus
-	case flowLaunchKindPhaseResume:
+	case flowoccupancy.HolderPhaseResumeAttempt:
 		return flowRepairResumePendingStatus
-	case flowLaunchKindManualPhase, flowLaunchKindAutoPhase:
+	case flowoccupancy.HolderPhaseAttempt:
 		return flowRepairPhasePendingStatus
-	}
-	if m.hasFlowEmbeddedTerminalForFlow(flowID) ||
-		m.hasFlowRepairEmbeddedTerminalForFlow(flowID) ||
-		m.flowLaunchAttemptOccupied(flowID) {
+	case flowoccupancy.HolderOtherAttempt,
+		flowoccupancy.HolderFlowTerminal,
+		flowoccupancy.HolderRepairTerminal:
+		return flowRepairTerminalStatus
+	case flowoccupancy.HolderHeadlessWrite:
+		return flowHeadlessWritePendingStatus
+	case flowoccupancy.HolderNone:
+		if verdict.Err() != nil {
+			return flowLeaseSetupErrorStatus(verdict.Err())
+		}
+		return ""
+	default:
 		return flowRepairTerminalStatus
 	}
-	// Repair reads the persisted headless preference asynchronously, so it must
-	// wait for an in-flight toggle exactly as a phase launch does.
-	return flowHeadlessWritePendingStatus
 }
 
 // repairFlowLaunchReadCmd is the authoritative read for a repair. It does not

--- a/model/flow_occupancy_admission_internal_test.go
+++ b/model/flow_occupancy_admission_internal_test.go
@@ -336,9 +336,8 @@ func TestPreviewPhaseResumeIsTrueForABlankFlowID(t *testing.T) {
 }
 
 // TestRepairFooterAddsTheHeadlessTermToThePreview is D4's second case: repair's
-// footer occupancy set is wider than its preview's, because admission's
-// occupancy set has no headless notion and the composite is shared with kinds
-// that must not inherit one.
+// footer occupancy set is wider than its preview's. Repair admission includes
+// the headless term, while StagePreview deliberately does not.
 func TestRepairFooterAddsTheHeadlessTermToThePreview(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -356,9 +355,17 @@ func TestRepairFooterAddsTheHeadlessTermToThePreview(t *testing.T) {
 			wantPreview: true,
 			wantStatus:  flowHeadlessWritePendingStatus,
 		},
+		{name: "unreadable lease", sources: []occupancySource{srcLeaseError}, wantStatus: flowLeaseSetupErrorStatus(occupancyLeaseErr())},
 		{name: "held lease", sources: []occupancySource{srcLeaseHeld}, wantStatus: flowLeaseOccupiedStatus},
+		{name: "phase resume attempt", sources: []occupancySource{srcAttemptPhaseResume}, wantStatus: flowRepairResumePendingStatus},
+		{name: "manual phase attempt", sources: []occupancySource{srcAttemptManualPhase}, wantStatus: flowRepairPhasePendingStatus},
+		{name: "auto phase attempt", sources: []occupancySource{srcAttemptAutoPhase}, wantStatus: flowRepairPhasePendingStatus},
+		{name: "other attempt", sources: []occupancySource{srcAttemptAutofix}, wantStatus: flowRepairTerminalStatus},
 		{name: "Flow terminal", sources: []occupancySource{srcFlowTerminal}, wantStatus: flowRepairTerminalStatus},
+		{name: "terminal-less repair slot", sources: []occupancySource{srcRepairSlot}, wantStatus: flowRepairTerminalStatus},
 		{name: "repair attempt", sources: []occupancySource{srcAttemptRepair}, wantStatus: flowRepairPendingStatus},
+		{name: "repair attempt wins all runtime sources", sources: []occupancySource{srcAttemptRepair, srcFlowTerminal, srcRepairSlot, srcHeadlessWrite}, wantStatus: flowRepairPendingStatus},
+		{name: "lease wins all runtime sources", sources: []occupancySource{srcLeaseHeld, srcAttemptRepair, srcFlowTerminal, srcRepairSlot, srcHeadlessWrite}, wantStatus: flowLeaseOccupiedStatus},
 	}
 	record := occupancyRepairFlowRecord()
 	for _, tc := range tests {

--- a/model/flow_occupancy_ladders_internal_test.go
+++ b/model/flow_occupancy_ladders_internal_test.go
@@ -2,6 +2,8 @@ package model
 
 import (
 	"testing"
+
+	"github.com/approachcontrol/approach/flowoccupancy"
 )
 
 // The ordered refusals of docs/flow-occupancy-matrix.md §4. F2 records that four
@@ -10,14 +12,17 @@ import (
 // same time, because a ladder that only ever sees one source cannot be shown to
 // be ordered at all.
 
-// TestFlowRepairOccupancyRefusalLadder is §4.1. The lease sits above all five of
-// these ranks and is answered separately, so it does not appear here.
+// TestFlowRepairOccupancyRefusalLadder is §4.1. It exercises the module verdict
+// and the model-owned rendering together so neither side can silently reorder
+// or rename a refusal.
 func TestFlowRepairOccupancyRefusalLadder(t *testing.T) {
 	tests := []struct {
 		name    string
 		sources []occupancySource
 		want    string
 	}{
+		{name: "lease unreadable above the runtime ladder", sources: []occupancySource{srcLeaseError, srcAttemptRepair}, want: flowLeaseSetupErrorStatus(occupancyLeaseErr())},
+		{name: "held lease above the runtime ladder", sources: []occupancySource{srcLeaseHeld, srcAttemptRepair}, want: flowLeaseOccupiedStatus},
 		// Rank 1–3 key on the attempt's kind.
 		{name: "rank 1: repair attempt", sources: []occupancySource{srcAttemptRepair}, want: flowRepairPendingStatus},
 		{name: "rank 2: phase resume attempt", sources: []occupancySource{srcAttemptPhaseResume}, want: flowRepairResumePendingStatus},
@@ -56,19 +61,14 @@ func TestFlowRepairOccupancyRefusalLadder(t *testing.T) {
 			sources: []occupancySource{srcAttemptRepair, srcFlowTerminal, srcRepairSlot, srcHeadlessWrite},
 			want:    flowRepairPendingStatus,
 		},
-		{
-			// Rank 5 is a fallthrough, not a test. With nothing at all holding
-			// the Flow it still answers with the headless status, and that
-			// surprising fact is exactly what a migration would silently change.
-			name: "rank 5 is a fallthrough, so it answers even with nothing pending",
-			want: flowHeadlessWritePendingStatus,
-		},
+		{name: "free Flow has no refusal"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			f := newOccupancyFixture(t, tc.sources...)
-			if got := f.m.flowRepairOccupancyRefusal(f.flowID()); got != tc.want {
-				t.Fatalf("flowRepairOccupancyRefusal = %q, want %q", got, tc.want)
+			verdict := f.m.repairOccupancy(f.flowID(), flowoccupancy.StageAdmission)
+			if got := flowRepairOccupancyStatus(verdict); got != tc.want {
+				t.Fatalf("flowRepairOccupancyStatus = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/model/flow_occupancy_simultaneous_internal_test.go
+++ b/model/flow_occupancy_simultaneous_internal_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"testing"
 
+	"github.com/approachcontrol/approach/flowoccupancy"
 	"github.com/approachcontrol/approach/flowstore"
 )
 
@@ -84,10 +85,11 @@ func TestSimultaneousSourcesReportPerConsumerStatuses(t *testing.T) {
 		if got := statusFromRefusedLaunch(t, f, flowLaunchKindAutoPhase); got != "" {
 			t.Fatalf("auto phase status = %q, want silence", got)
 		}
-		// The lease is ranked above repair's five-rung ladder and answered
-		// separately, so the ladder itself still reports its own rank 3.
-		if got := f.m.flowRepairOccupancyRefusal(f.flowID()); got != flowRepairPhasePendingStatus {
-			t.Fatalf("repair ladder = %q, want %q", got, flowRepairPhasePendingStatus)
+		// The module owns the lease and runtime ordering together, so the named
+		// verdict reports the lease above repair's runtime ladder.
+		verdict := f.m.repairOccupancy(f.flowID(), flowoccupancy.StageAdmission)
+		if got := flowRepairOccupancyStatus(verdict); got != flowLeaseOccupiedStatus {
+			t.Fatalf("repair ladder = %q, want %q", got, flowLeaseOccupiedStatus)
 		}
 	})
 

--- a/model/flow_repair.go
+++ b/model/flow_repair.go
@@ -146,10 +146,9 @@ func phaseHasMatchingLiveSessionExcept(phase flowstore.FlowPhase, skip flowSessi
 // falls back to selectedFlow(), which is the selection semantics this predicate
 // has always had.
 //
-// The headless term stays outside the preview because admission's occupancy set
-// has no headless notion and flowLaunchAdmissionOccupied is shared with kinds
-// that must not inherit one. Dropping it here would re-advertise R during an
-// in-flight headless write, which admission still refuses.
+// The headless term stays outside StagePreview so other preview consumers do
+// not inherit repair's transient holder. StageAdmission includes it for repair,
+// and this explicit check keeps the footer aligned without changing preview.
 func (m Model) selectedFlowRepairReady() bool {
 	record, ok := m.previewRepairLaunch(m.repairFlowLaunchIntent(""))
 	return ok && !m.flowHeadlessWritePending(record.FlowID)

--- a/model/flow_repair_internal_test.go
+++ b/model/flow_repair_internal_test.go
@@ -234,10 +234,9 @@ func TestSelectedFlowRepairReadyUsesBothFlowSurfacesAndTerminalOccupancy(t *test
 		if repairSlot.selectedFlowRepairReady() {
 			t.Fatalf("selectedFlowRepairReady() = true in mode %v with a terminal-less repair slot", mode)
 		}
-		// The headless term lives outside the preview boundary, because
-		// admission's occupancy set has no headless notion and is shared with
-		// kinds that must not inherit one. The footer still has to withdraw for
-		// exactly as long as admission refuses.
+		// The headless term lives outside the preview boundary. Repair admission
+		// includes it, and the footer still has to withdraw for exactly as long
+		// as admission refuses.
 		pendingHeadless := m.markFlowHeadlessWritePending(pendingFlowHeadlessWrite{
 			flowID:   record.FlowID,
 			repoPath: record.RepoPath,


### PR DESCRIPTION
Repair admission and preview code still reconstructed holder precedence from launch-attempt kinds and slot maps. That left repair occupancy policy split between the model and the shared occupancy package.

This change gives `flowoccupancy` a named holder verdict with the existing precedence, adapts repair admission and preview rendering to consume it, and keeps pending headless writes outside the shared occupancy set. The refusal strings and terminal-less repair-slot behavior remain unchanged.

Tests cover each holder independently, simultaneous holders, the full precedence ladder, repair admission, preview behavior, and footer withdrawal.

Validation:
- `make fmt-check`
- `make test`
- `make build`