### PR TITLE
Route cached occupancy through advisory queries

### DIFF
--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -389,6 +389,16 @@ func (verdict Verdict) PhaseID() string { return verdict.phaseID }
 // refusal while HolderLeaseUnreadable remains the module decision.
 func (verdict Verdict) Err() error { return verdict.err }
 
+// Advisory is cached evidence that may only defer work. It deliberately has no
+// inverse operation: a caller can filter on Defer, but cannot turn a cache miss
+// into permission to mutate state.
+type Advisory struct {
+	verdict Verdict
+}
+
+// Defer reports whether cached evidence says the caller should wait.
+func (advisory Advisory) Defer() bool { return advisory.verdict.Occupied() }
+
 // FlowReader reads a Flow authoritatively.
 type FlowReader interface {
 	ReadFlow(flowID string) (flowstore.FlowRecord, error)
@@ -487,6 +497,12 @@ func Evaluate(sources Sources, query Query) Verdict {
 	return New(sources).Query(query)
 }
 
+// EvaluateAdvisory answers one cached advisory query against a short-lived
+// source set.
+func EvaluateAdvisory(sources Sources, query Query) Advisory {
+	return New(sources).Advise(query)
+}
+
 var (
 	// ErrInvalidQuery marks a programming error in a query. Query fails closed
 	// instead of panicking because it runs inside the TUI update loop.
@@ -496,9 +512,138 @@ var (
 	ErrMissingRuntime = errors.New("flowoccupancy: runtime source is required")
 	// ErrMissingLease marks a purpose that needs the cross-process lease adapter
 	// but received none.
-	ErrMissingLease        = errors.New("flowoccupancy: lease source is required")
+	ErrMissingLease = errors.New("flowoccupancy: lease source is required")
+	// ErrMissingFlowCache marks a cached purpose without its Flow mirror.
+	ErrMissingFlowCache = errors.New("flowoccupancy: cached Flow source is required")
+	// ErrMissingSessionCache marks a cached purpose without its session panes.
+	ErrMissingSessionCache = errors.New("flowoccupancy: cached session source is required")
 	errPendingSourceFamily = errors.New("flowoccupancy: a required source family is not implemented yet")
 )
+
+// Advise answers a cached query that may only defer its caller.
+func (occupancy Occupancy) Advise(query Query) Advisory {
+	flowID := strings.TrimSpace(query.FlowID)
+	if flowID == "" {
+		return Advisory{verdict: failedVerdict(fmt.Errorf("%w: Flow ID is required", ErrInvalidQuery))}
+	}
+	policy, ok := purposeRegistry[query.Purpose]
+	if !ok {
+		return Advisory{verdict: failedVerdict(fmt.Errorf("%w: purpose (%s, %s) is not registered", ErrInvalidQuery, query.Purpose.Role, query.Purpose.Stage))}
+	}
+	freshness, ok := resolveFreshness(query.Purpose.Stage, query.Freshness)
+	if !ok || freshness != FreshnessCached || !policy.freshness.allows(freshness) {
+		return Advisory{verdict: failedVerdict(fmt.Errorf("%w: purpose (%s, %s) is not a cached advisory query", ErrInvalidQuery, query.Purpose.Role, query.Purpose.Stage))}
+	}
+	if policy.sources&(readFlowStore|readSessionStore) != 0 || policy.probe != probeNone {
+		return Advisory{verdict: failedVerdict(fmt.Errorf("%w: cached advisory query requests an authoritative source", ErrInvalidQuery))}
+	}
+
+	lease := Free()
+	if policy.sources&readLease != 0 {
+		lease = queryLease(occupancy.sources.Lease, flowID)
+	}
+	runtime := Free()
+	if policy.sources&readRuntime != 0 {
+		if occupancy.sources.Runtime == nil {
+			return Advisory{verdict: failedVerdict(ErrMissingRuntime)}
+		}
+		runtime = queryRuntime(policy.runtime, occupancy.sources.Runtime, flowID)
+	}
+	flowCache := Free()
+	if policy.sources&readFlowCache != 0 {
+		if occupancy.sources.FlowCache == nil {
+			return Advisory{verdict: failedVerdict(ErrMissingFlowCache)}
+		}
+		flowCache = queryFlowCache(occupancy.sources.FlowCache, flowID, strings.TrimSpace(query.PhaseID), query.Purpose)
+	}
+	sessionCache := Free()
+	if policy.sources&readSessionCache != 0 {
+		if occupancy.sources.Cache == nil {
+			return Advisory{verdict: failedVerdict(ErrMissingSessionCache)}
+		}
+		sessionCache = querySessionCache(occupancy.sources.Cache, flowID)
+	}
+
+	return Advisory{verdict: chooseAdvisory(query.Purpose, lease, runtime, flowCache, sessionCache)}
+}
+
+func queryFlowCache(cache FlowCache, flowID, phaseID string, purpose Purpose) Verdict {
+	record, ok := cache.CachedFlow(flowID)
+	if !ok {
+		return Free()
+	}
+	if strings.TrimSpace(record.FlowID) != flowID {
+		return failedVerdict(fmt.Errorf("%w: cached Flow identity does not match %q", ErrInvalidQuery, flowID))
+	}
+	for _, phase := range record.Phases {
+		currentPhaseID := strings.TrimSpace(phase.PhaseID)
+		if phaseID != "" && currentPhaseID != phaseID {
+			continue
+		}
+		readPhaseSessions := purpose.Role == actions.RoleWorktreeAgent || phaseID != ""
+		if readPhaseSessions && phaseHasLiveSession(phase) {
+			return Verdict{holder: HolderPhaseSession, phaseID: currentPhaseID}
+		}
+		readRunningPhases := purpose.Stage != StageDrain || phaseID == ""
+		if readRunningPhases && phase.Status == flowstore.PhaseRunning {
+			return Verdict{holder: HolderRunningPhase, phaseID: currentPhaseID}
+		}
+	}
+	return Free()
+}
+
+func phaseHasLiveSession(phase flowstore.FlowPhase) bool {
+	launches := make(map[string]struct{}, len(phase.LaunchIDs))
+	for _, launchID := range phase.LaunchIDs {
+		if launchID = strings.TrimSpace(launchID); launchID != "" {
+			launches[launchID] = struct{}{}
+		}
+	}
+	for _, session := range phase.Sessions {
+		if strings.TrimSpace(session.SessionID) == "" {
+			continue
+		}
+		if _, ok := launches[strings.TrimSpace(session.LaunchID)]; !ok {
+			continue
+		}
+		if sessions.IsActive(session.Status, session.EndedAt) {
+			return true
+		}
+	}
+	return false
+}
+
+func querySessionCache(cache SessionCache, flowID string) Verdict {
+	for _, record := range cache.ActiveFlowSessions(flowID) {
+		if strings.TrimSpace(record.FlowID) == flowID && sessions.IsActive(record.Status, record.EndedAt) {
+			return Verdict{holder: HolderFlowSession}
+		}
+	}
+	return Free()
+}
+
+func chooseAdvisory(purpose Purpose, lease, runtime, flowCache, sessionCache Verdict) Verdict {
+	if lease.Occupied() {
+		return lease
+	}
+	if purpose.Role == actions.RoleWorktreeAgent {
+		if runtime.Occupied() {
+			return runtime
+		}
+		if sessionCache.Occupied() {
+			return sessionCache
+		}
+		return flowCache
+	}
+	switch runtime.Holder() {
+	case HolderRepairAttempt, HolderPhaseResumeAttempt, HolderPhaseAttempt, HolderOtherAttempt:
+		return runtime
+	}
+	if flowCache.Occupied() {
+		return flowCache
+	}
+	return runtime
+}
 
 // Query answers one occupancy question. A query whose purpose is not Valid
 // yields an occupied fail-closed verdict rather than a free one.

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -3,9 +3,209 @@ package flowoccupancy
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/sessions"
 )
+
+type flowCacheFixture struct {
+	record flowstore.FlowRecord
+	found  bool
+	calls  int
+}
+
+func (cache *flowCacheFixture) CachedFlow(flowID string) (flowstore.FlowRecord, bool) {
+	cache.calls++
+	if cache.record.FlowID != flowID {
+		return flowstore.FlowRecord{}, false
+	}
+	return cache.record, cache.found
+}
+
+func TestAdvisoryCachedRunningPhaseDefers(t *testing.T) {
+	cache := &flowCacheFixture{
+		found: true,
+		record: flowstore.FlowRecord{
+			FlowID: "flow-1",
+			Phases: []flowstore.FlowPhase{{PhaseID: "implementation", Status: flowstore.PhaseRunning}},
+		},
+	}
+	advice := New(Sources{
+		FlowCache: cache,
+		Lease:     &leaseFixture{t: t, wantFlowID: "flow-1"},
+		Runtime:   runtimeFixture{},
+	}).Advise(Query{
+		FlowID: "flow-1",
+		Purpose: Purpose{
+			Role:  actions.RoleTrackedPhase,
+			Stage: StageDrain,
+		},
+	})
+	if !advice.Defer() {
+		t.Fatal("Defer() = false, want cached running phase to defer")
+	}
+	if advice.verdict.Holder() != HolderRunningPhase || advice.verdict.PhaseID() != "implementation" {
+		t.Fatalf("advice = (%v, %q), want running phase implementation", advice.verdict.Holder(), advice.verdict.PhaseID())
+	}
+	if advice.verdict.Err() != nil {
+		t.Fatalf("Err() = %v, want nil", advice.verdict.Err())
+	}
+	if cache.calls != 1 {
+		t.Fatalf("CachedFlow calls = %d, want 1", cache.calls)
+	}
+}
+
+type sessionCacheFixture struct {
+	records    []sessions.SessionRecord
+	wantFlowID string
+	calls      int
+}
+
+func (cache *sessionCacheFixture) ActiveFlowSessions(flowID string) []sessions.SessionRecord {
+	cache.calls++
+	if flowID != cache.wantFlowID {
+		panic("unexpected Flow ID")
+	}
+	return cache.records
+}
+
+type panicFlowReader struct{}
+
+func (panicFlowReader) ReadFlow(string) (flowstore.FlowRecord, error) {
+	panic("advisory query reached Flow store")
+}
+
+type panicSessionStore struct{}
+
+func (panicSessionStore) ListFlowSessions(string) ([]sessions.SessionRecord, error) {
+	panic("advisory query reached session store")
+}
+
+type panicAgentProbe struct{}
+
+func (panicAgentProbe) FlowAgentRunning(flowstore.FlowRecord, string) bool {
+	panic("advisory query reached tmux probe")
+}
+
+func (panicAgentProbe) AutofixAgentRunning(flowstore.FlowRecord, string) bool {
+	panic("advisory query reached tmux probe")
+}
+
+func TestAdvisoryCachedEvidence(t *testing.T) {
+	ended := time.Now()
+	phaseWithSession := flowstore.FlowPhase{
+		PhaseID:   "implementation",
+		LaunchIDs: []string{" launch-1 "},
+		Sessions:  []flowstore.Session{{SessionID: "session-1", LaunchID: "launch-1", Status: "active"}},
+	}
+	tests := []struct {
+		name       string
+		purpose    Purpose
+		phaseID    string
+		flow       flowstore.FlowRecord
+		sessions   []sessions.SessionRecord
+		runtime    runtimeFixture
+		wantHolder Holder
+		wantPhase  string
+	}{
+		{
+			name:       "drain phase session is launch scoped",
+			purpose:    Purpose{Role: actions.RoleTrackedPhase, Stage: StageDrain},
+			phaseID:    "implementation",
+			flow:       flowstore.FlowRecord{FlowID: "flow-1", Phases: []flowstore.FlowPhase{phaseWithSession}},
+			wantHolder: HolderPhaseSession,
+			wantPhase:  "implementation",
+		},
+		{
+			name:    "drain ignores unmatched phase session",
+			purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: StageDrain},
+			phaseID: "implementation",
+			flow: flowstore.FlowRecord{FlowID: "flow-1", Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation", LaunchIDs: []string{"launch-other"},
+				Sessions: []flowstore.Session{{SessionID: "session-1", LaunchID: "launch-1", Status: "active"}},
+			}}},
+		},
+		{
+			name:    "drain ignores ended phase session",
+			purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: StageDrain},
+			phaseID: "implementation",
+			flow: flowstore.FlowRecord{FlowID: "flow-1", Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation", LaunchIDs: []string{"launch-1"},
+				Sessions: []flowstore.Session{{SessionID: "session-1", LaunchID: "launch-1", Status: "ended", EndedAt: ended}},
+			}}},
+		},
+		{
+			name:       "drain attempt outranks cached running phase and terminal",
+			purpose:    Purpose{Role: actions.RoleTrackedPhase, Stage: StageDrain},
+			flow:       flowstore.FlowRecord{FlowID: "flow-1", Phases: []flowstore.FlowPhase{{PhaseID: "implementation", Status: flowstore.PhaseRunning}}},
+			runtime:    runtimeFixture{attempts: map[string]actions.FlowLaunchRole{"flow-1": actions.RoleTrackedPhase}, flows: map[string]bool{"flow-1": true}},
+			wantHolder: HolderPhaseAttempt,
+		},
+		{
+			name:       "worktree footer reads whole Flow session mirror",
+			purpose:    Purpose{Role: actions.RoleWorktreeAgent, Stage: StageFooter},
+			flow:       flowstore.FlowRecord{FlowID: "flow-1"},
+			sessions:   []sessions.SessionRecord{{FlowID: " flow-1 ", SessionID: "session-1", Status: "active"}},
+			wantHolder: HolderFlowSession,
+		},
+		{
+			name:       "worktree runtime holder outranks both cached families",
+			purpose:    Purpose{Role: actions.RoleWorktreeAgent, Stage: StageFooter},
+			flow:       flowstore.FlowRecord{FlowID: "flow-1", Phases: []flowstore.FlowPhase{phaseWithSession}},
+			sessions:   []sessions.SessionRecord{{FlowID: "flow-1", SessionID: "session-1", Status: "active"}},
+			runtime:    runtimeFixture{flows: map[string]bool{"flow-1": true}},
+			wantHolder: HolderFlowTerminal,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			flowCache := &flowCacheFixture{record: tc.flow, found: true}
+			sessionCache := &sessionCacheFixture{records: tc.sessions, wantFlowID: "flow-1"}
+			advice := EvaluateAdvisory(Sources{
+				Flows: panicFlowReader{}, FlowCache: flowCache,
+				Sessions: panicSessionStore{}, Cache: sessionCache,
+				Lease: &leaseFixture{t: t, wantFlowID: "flow-1"}, Runtime: tc.runtime,
+				Probe: panicAgentProbe{},
+			}, Query{FlowID: " flow-1 ", Purpose: tc.purpose, PhaseID: tc.phaseID})
+			if advice.verdict.Holder() != tc.wantHolder || advice.verdict.PhaseID() != tc.wantPhase {
+				t.Fatalf("advice = (%v, %q), want (%v, %q)", advice.verdict.Holder(), advice.verdict.PhaseID(), tc.wantHolder, tc.wantPhase)
+			}
+			if advice.Defer() != (tc.wantHolder != HolderNone) {
+				t.Fatalf("Defer() = %v, want %v", advice.Defer(), tc.wantHolder != HolderNone)
+			}
+			if tc.purpose.Role == actions.RoleTrackedPhase && sessionCache.calls != 0 {
+				t.Fatalf("session cache calls = %d, want drain to skip the whole-Flow session mirror", sessionCache.calls)
+			}
+		})
+	}
+}
+
+func TestAdvisoryFailsClosedForInvalidQueriesAndMissingCaches(t *testing.T) {
+	tests := []struct {
+		name    string
+		sources Sources
+		query   Query
+		wantErr error
+	}{
+		{name: "blank Flow ID", query: Query{Purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: StageDrain}}, wantErr: ErrInvalidQuery},
+		{name: "authoritative purpose", query: Query{FlowID: "flow-1", Purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: StageAuthoritative}}, wantErr: ErrInvalidQuery},
+		{name: "missing Flow cache", sources: Sources{Lease: &leaseFixture{}, Runtime: runtimeFixture{}}, query: Query{FlowID: "flow-1", Purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: StageDrain}}, wantErr: ErrMissingFlowCache},
+		{name: "missing session cache", sources: Sources{FlowCache: &flowCacheFixture{record: flowstore.FlowRecord{FlowID: "flow-1"}, found: true}, Lease: &leaseFixture{}, Runtime: runtimeFixture{}}, query: Query{FlowID: "flow-1", Purpose: Purpose{Role: actions.RoleWorktreeAgent, Stage: StageFooter}}, wantErr: ErrMissingSessionCache},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			advice := EvaluateAdvisory(tc.sources, tc.query)
+			if !advice.Defer() {
+				t.Fatal("Defer() = false, want fail-closed deferral")
+			}
+			if !errors.Is(advice.verdict.Err(), tc.wantErr) {
+				t.Fatalf("Err() = %v, want errors.Is(_, %v)", advice.verdict.Err(), tc.wantErr)
+			}
+		})
+	}
+}
 
 func TestPurposeValidRegistry(t *testing.T) {
 	validStages := map[actions.FlowLaunchRole][]Stage{

--- a/model/flow_launch_adapters.go
+++ b/model/flow_launch_adapters.go
@@ -85,6 +85,40 @@ func (runtime flowOccupancyRuntime) RepairDrainPending(flowID string) bool {
 	return runtime.model.hasPendingRepairAutoDrainMarker(flowID)
 }
 
+type flowOccupancyFlowCache struct {
+	record flowstore.FlowRecord
+}
+
+var _ flowoccupancy.FlowCache = flowOccupancyFlowCache{}
+
+func (cache flowOccupancyFlowCache) CachedFlow(flowID string) (flowstore.FlowRecord, bool) {
+	flowID = strings.TrimSpace(flowID)
+	return cache.record, flowID != "" && strings.TrimSpace(cache.record.FlowID) == flowID
+}
+
+type flowOccupancySessionCache struct {
+	flowSessions     []sessions.SessionRecord
+	worktreeSessions []sessions.SessionRecord
+}
+
+var _ flowoccupancy.SessionCache = flowOccupancySessionCache{}
+
+func (cache flowOccupancySessionCache) ActiveFlowSessions(flowID string) []sessions.SessionRecord {
+	flowID = strings.TrimSpace(flowID)
+	if flowID == "" {
+		return nil
+	}
+	var active []sessions.SessionRecord
+	for _, records := range [][]sessions.SessionRecord{cache.flowSessions, cache.worktreeSessions} {
+		for _, record := range records {
+			if strings.TrimSpace(record.FlowID) == flowID && sessions.IsActive(record.Status, record.EndedAt) {
+				active = append(active, record)
+			}
+		}
+	}
+	return active
+}
+
 func flowLaunchRole(kind flowLaunchKind) actions.FlowLaunchRole {
 	switch kind {
 	case flowLaunchKindManualPhase, flowLaunchKindAutoPhase:
@@ -154,6 +188,47 @@ func (m Model) repairOccupancy(flowID string, stage flowoccupancy.Stage) flowocc
 		Purpose: flowoccupancy.Purpose{
 			Role:  actions.RoleRepair,
 			Stage: stage,
+		},
+	})
+}
+
+func (m Model) trackedPhaseDrainAdvice(record flowstore.FlowRecord, phaseID string) flowoccupancy.Advisory {
+	return flowoccupancy.EvaluateAdvisory(flowoccupancy.Sources{
+		FlowCache: flowOccupancyFlowCache{record: record},
+		Lease: flowOccupancyLeaseInspector{
+			root:     m.sessionStateRoot,
+			injected: m.leaseInspectInjected,
+			inspect:  m.inspectFlowLease,
+		},
+		Runtime: flowOccupancyRuntime{model: m},
+	}, flowoccupancy.Query{
+		FlowID: record.FlowID,
+		Purpose: flowoccupancy.Purpose{
+			Role:  actions.RoleTrackedPhase,
+			Stage: flowoccupancy.StageDrain,
+		},
+		PhaseID: phaseID,
+	})
+}
+
+func (m Model) worktreeAgentFooterAdvice(record flowstore.FlowRecord) flowoccupancy.Advisory {
+	return flowoccupancy.EvaluateAdvisory(flowoccupancy.Sources{
+		FlowCache: flowOccupancyFlowCache{record: record},
+		Cache: flowOccupancySessionCache{
+			flowSessions:     m.sessions.Items(),
+			worktreeSessions: m.worktreeSessions.Items(),
+		},
+		Lease: flowOccupancyLeaseInspector{
+			root:     m.sessionStateRoot,
+			injected: m.leaseInspectInjected,
+			inspect:  m.inspectFlowLease,
+		},
+		Runtime: flowOccupancyRuntime{model: m},
+	}, flowoccupancy.Query{
+		FlowID: record.FlowID,
+		Purpose: flowoccupancy.Purpose{
+			Role:  actions.RoleWorktreeAgent,
+			Stage: flowoccupancy.StageFooter,
 		},
 	})
 }

--- a/model/flow_launch_generic_agent.go
+++ b/model/flow_launch_generic_agent.go
@@ -36,10 +36,7 @@ func (m Model) selectedFlowWorktreeAgentReady() bool {
 	if !ok || !genericWorktreeAgentFlowEligible(record) {
 		return false
 	}
-	if m.flowLaunchAdmissionOccupied(record.FlowID) || m.hasKnownActiveFlowSession(record.FlowID) {
-		return false
-	}
-	return genericFlowRuntimeOccupancyReason(record) == ""
+	return !m.worktreeAgentFooterAdvice(record).Defer()
 }
 
 func (m Model) hasKnownActiveFlowSession(flowID string) bool {

--- a/model/flow_phase_launch.go
+++ b/model/flow_phase_launch.go
@@ -742,7 +742,7 @@ func (m Model) prepareAutoAdvanceDrainLaunches(records []flowstore.FlowRecord) (
 		// long as the session stays live. The mirrored sessions the poll
 		// already carries answer the common case for free. Deferral is silent
 		// and leaves the drain armed, exactly as the lifecycle's retry does.
-		if phaseHasMatchingLiveSession(phase) {
+		if m.trackedPhaseDrainAdvice(record, phase.PhaseID).Defer() {
 			continue
 		}
 		next, cmd, admitted := m.requestFlowLaunch(flowLaunchIntent{
@@ -764,20 +764,7 @@ func (m Model) prepareAutoAdvanceDrainLaunches(records []flowstore.FlowRecord) (
 }
 
 func (m Model) flowAutoAdvanceOccupied(record flowstore.FlowRecord) bool {
-	if occupied, err := m.trackedFlowLeaseOccupied(record.FlowID); err != nil || occupied {
-		return true
-	}
-	// A pending repair is a lifecycle attempt now, so attempt occupancy covers
-	// it without a second signal.
-	if m.flowLaunchAttemptOccupied(record.FlowID) {
-		return true
-	}
-	for _, phase := range record.Phases {
-		if phase.Status == flowstore.PhaseRunning {
-			return true
-		}
-	}
-	return m.hasFlowEmbeddedTerminalForFlow(record.FlowID)
+	return m.trackedPhaseDrainAdvice(record, "").Defer()
 }
 
 func (m Model) hasFlowEmbeddedTerminalForFlow(flowID string) bool {


### PR DESCRIPTION
The AutoMode drain filter and worktree-agent footer rebuilt cached occupancy rules inside the model. That left snapshot precedence outside the shared occupancy package and created another place for those rules to diverge.

This change adds a defer-only Advisory result to flowoccupancy and routes both cached consumers through it. A cached miss cannot authorize a mutation. The package also gets Flow and session cache adapters, launch-scoped phase-session matching, and fail-closed validation for invalid cached queries. The drain keeps its no-session-store-walk behavior for stalled polls, its arm and disarm ordering, and its silent deferral. The footer behavior is unchanged.

Validation:
- make fmt-check
- make test
- make build
- git diff --check origin/main...HEAD