### PR TITLE
Stop epic progression when an unreadable Flow blocks a child

### DIFF
--- a/model/epic_progression.go
+++ b/model/epic_progression.go
@@ -90,9 +90,10 @@ type epicProgressionAdvanceResultMsg struct {
 	disposition  epicProgressionAdvanceDisposition
 	// owned and childTitle are selection-only: the chosen child and its Bead
 	// title, carried to the create-then-launch intent that follows.
-	owned      epicProgressionOwnedSuccessor
-	childTitle string
-	status     string
+	owned       epicProgressionOwnedSuccessor
+	childTitle  string
+	degradation *flowstore.PartialListError
+	status      string
 }
 
 type epicProgressionHaltRequest struct {
@@ -185,11 +186,12 @@ func (m Model) advanceEpicProgressionCmd(request epicProgressionAdvanceRequest, 
 	setProgression := m.setEpicProgression
 	repoPath := filepath.Clean(baseline.RepoPath)
 	epicID := strings.TrimSpace(baseline.Bead.EpicID)
+	var degradation *flowstore.PartialListError
 	result := func(disposition epicProgressionAdvanceDisposition, status string) epicProgressionAdvanceResultMsg {
 		return epicProgressionAdvanceResultMsg{
 			request: request.Request, ownerToken: request.OwnerToken, epicKey: request.EpicKey,
 			repoPath: repoPath, epicID: epicID, sourceFlowID: request.SourceFlowID,
-			disposition: disposition, status: status,
+			disposition: disposition, degradation: degradation, status: status,
 		}
 	}
 	return func() tea.Msg {
@@ -231,7 +233,9 @@ func (m Model) advanceEpicProgressionCmd(request epicProgressionAdvanceRequest, 
 			return result(epicProgressionAdvanceRetryable, fmt.Sprintf("Could not list ready children for epic %s: %v", epicID, readyErr))
 		}
 		flows, flowsErr := listFlows(flowstore.FlowFilter{RepoPath: repoPath})
-		if flowsErr != nil {
+		if partial, ok := flowstore.AsPartialList(flowsErr); ok {
+			degradation = partial
+		} else if flowsErr != nil {
 			return result(epicProgressionAdvanceRetryable, fmt.Sprintf("Could not check existing child Flows for epic %s: %v", epicID, flowsErr))
 		}
 		direct := make(map[string]struct{}, len(children))
@@ -477,6 +481,9 @@ func (m Model) handleEpicProgressionAdvanceResult(msg epicProgressionAdvanceResu
 		m.flowPreparationMatches(flowPreparationEpicAdvance, msg.ownerToken)
 	if !current {
 		return m, nil
+	}
+	if msg.degradation != nil {
+		m = m.setFlowDegradation(ui.ModeFlows, msg.repoPath, msg.degradation)
 	}
 	if msg.disposition == epicProgressionAdvanceSelected {
 		// The advance is not over: it continues as one create-then-launch

--- a/model/epic_progression_advance_internal_test.go
+++ b/model/epic_progression_advance_internal_test.go
@@ -127,7 +127,9 @@ func TestEpicProgressionAdvanceUsesReadableFlowsFromPartialList(t *testing.T) {
 		agentConfig:      agentConfig{agentCommand: "codex"},
 	}
 
-	_, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
+	_, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{
+		Flows: []flowstore.FlowRecord{terminal}, Degradation: partial, Request: 1,
+	})
 	result := epicProgressionAdvanceMessage(t, cmd)
 	if result.disposition != epicProgressionAdvanceSelected || result.owned.ChildID != "epic.b" {
 		t.Fatalf("advance result = %#v, want readable linked child skipped and epic.b selected", result)

--- a/model/epic_progression_advance_internal_test.go
+++ b/model/epic_progression_advance_internal_test.go
@@ -97,6 +97,92 @@ func TestEpicProgressionAdvanceUsesReadyOrderAndSkipsExactLinkedChildren(t *test
 	}
 }
 
+func TestEpicProgressionAdvanceUsesReadableFlowsFromPartialList(t *testing.T) {
+	repo, epic := "/repo", "epic"
+	key := epicProgressionBaselineKey(repo, epic)
+	source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
+	terminal := cloneFlowRecord(source)
+	terminal.Status = flowstore.StatusCompleted
+	linked := progressionAdvanceFlow("linked-a", repo, "epic.a", epic, flowstore.StatusPending)
+	partial := testPartialList("unreadable-flow")
+
+	m := Model{
+		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
+			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
+		},
+		listChildrenBeads: func(string, string) ([]beadsquery.Bead, error) {
+			return []beadsquery.Bead{{ID: "epic.a"}, {ID: "epic.b"}}, nil
+		},
+		listReadyBeads: func(string) ([]beadsquery.Bead, error) {
+			return []beadsquery.Bead{{ID: "epic.a"}, {ID: "epic.b", Title: "B"}}, nil
+		},
+		listFlows: func(filter flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			if filter.RepoPath != repo {
+				t.Fatalf("listFlows filter = %#v, want repository scope %q", filter, repo)
+			}
+			return []flowstore.FlowRecord{terminal, linked}, partial
+		},
+		autoAdvanceState: autoAdvanceState{autoAdvanceInFlight: 1},
+		agentConfig:      agentConfig{agentCommand: "codex"},
+	}
+
+	_, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
+	result := epicProgressionAdvanceMessage(t, cmd)
+	if result.disposition != epicProgressionAdvanceSelected || result.owned.ChildID != "epic.b" {
+		t.Fatalf("advance result = %#v, want readable linked child skipped and epic.b selected", result)
+	}
+	if result.degradation != partial || result.degradation.Entries[0].FlowID != "unreadable-flow" {
+		t.Fatalf("advance degradation = %#v, want typed diagnostic %#v", result.degradation, partial)
+	}
+}
+
+func TestEpicProgressionAdvanceKeepsFatalFlowListFailureRetryable(t *testing.T) {
+	repo, epic := "/repo", "epic"
+	key := epicProgressionBaselineKey(repo, epic)
+	source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
+	terminal := cloneFlowRecord(source)
+	terminal.Status = flowstore.StatusCompleted
+	setCalls, haltCalls := 0, 0
+
+	m := Model{
+		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
+			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
+		},
+		listChildrenBeads: func(string, string) ([]beadsquery.Bead, error) {
+			return []beadsquery.Bead{{ID: "epic.a"}, {ID: "epic.b"}}, nil
+		},
+		listReadyBeads: func(string) ([]beadsquery.Bead, error) {
+			return []beadsquery.Bead{{ID: "epic.b"}}, nil
+		},
+		listFlows: func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) {
+			return nil, errors.New("database unavailable")
+		},
+		setEpicProgression: func(flowstore.EpicProgressionUpdate) (flowstore.EpicProgression, error) {
+			setCalls++
+			return flowstore.EpicProgression{}, nil
+		},
+		haltEpicProgression: func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
+			haltCalls++
+			return flowstore.EpicProgression{}, nil
+		},
+		autoAdvanceState: autoAdvanceState{autoAdvanceInFlight: 1},
+	}
+
+	_, cmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{terminal}, Request: 1})
+	result := epicProgressionAdvanceMessage(t, cmd)
+	if result.disposition != epicProgressionAdvanceRetryable || result.owned.ChildID != "" || result.degradation != nil {
+		t.Fatalf("advance result = %#v, want an undecorated retryable failure", result)
+	}
+	if !strings.Contains(result.status, "database unavailable") {
+		t.Fatalf("status = %q, want fatal list cause", result.status)
+	}
+	if setCalls != 0 || haltCalls != 0 {
+		t.Fatalf("fatal list failure set progression %d times and halted %d times", setCalls, haltCalls)
+	}
+}
+
 func TestEpicProgressionAdvanceSkipsAnEpicWhoseChildIsAlreadyInFlight(t *testing.T) {
 	repo, epic := "/repo", "epic"
 	key := epicProgressionBaselineKey(repo, epic)

--- a/model/epic_progression_launch_internal_test.go
+++ b/model/epic_progression_launch_internal_test.go
@@ -422,3 +422,65 @@ func TestProgressionCreateSurfacesBeadSlotRefusalAndHalts(t *testing.T) {
 		t.Fatalf("owned successors = %#v, want none; adopting the winner livelocks reconciliation", m.epicProgressionOwnedSuccessors)
 	}
 }
+
+func TestProgressionCreateUnreadableBeadRefusalHaltsAndStopsLaterPolls(t *testing.T) {
+	refusal := &flowstore.BeadFlowUnreadableError{
+		RepoPath: progressionLaunchRepo, BeadID: progressionLaunchChild,
+		FlowID: "20260823T210000Z-unreadable", Err: errors.New("unsupported schema version 9999"),
+	}
+	fixture, m := newProgressionLaunchFixture(t, flowstore.EpicProgressionSuccessorAccepted, nil)
+	h := fixture.harness
+	h.createErr = refusal
+
+	m, cmd := fixture.admit(t, m)
+	m = drainProgressionLaunch(t, m, cmd)
+
+	if fixture.halted != 1 || len(fixture.updates) != 1 {
+		t.Fatalf("unreadable refusal halted %d times: %#v", fixture.halted, fixture.updates)
+	}
+	halt := fixture.updates[0].Halt
+	if halt.ChildBeadID != progressionLaunchChild || halt.Status != flowstore.StatusBlocked ||
+		!strings.Contains(halt.Message, refusal.FlowID) {
+		t.Fatalf("halt tuple = %#v, want child %q and unreadable Flow %q", halt, progressionLaunchChild, refusal.FlowID)
+	}
+	if m.status.Text != refusal.Error() {
+		t.Fatalf("status = %q, want refusal %q", m.status.Text, refusal.Error())
+	}
+	for _, step := range h.order {
+		if step == "worktree" || step == "finalize" || strings.HasPrefix(step, "reconcile:") || strings.HasPrefix(step, "launch-id:") {
+			t.Fatalf("unreadable refusal produced a post-create side effect: %#v", h.order)
+		}
+	}
+	if len(h.contexts) != 0 || len(h.phaseUpdates) != 0 {
+		t.Fatalf("unreadable refusal launched or updated phases: contexts=%#v updates=%#v", h.contexts, h.phaseUpdates)
+	}
+	if m.activeEpicProgressionAdvance.Request != 0 || m.flowPreparationAdmission {
+		t.Fatalf("halt retained advance admission: active=%#v admission=%t", m.activeEpicProgressionAdvance, m.flowPreparationAdmission)
+	}
+	if _, tracked := m.epicProgressionBaselines[fixture.key]; tracked {
+		t.Fatalf("halt retained baseline: %#v", m.epicProgressionBaselines)
+	}
+	if len(m.epicProgressionBaselineMinimumRequests) != 0 || len(m.epicProgressionOwnedSuccessors) != 0 {
+		t.Fatalf("halt retained progression tracking: minimum=%#v owned=%#v",
+			m.epicProgressionBaselineMinimumRequests, m.epicProgressionOwnedSuccessors)
+	}
+
+	readCalls := 0
+	m.readEpicProgression = func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
+		readCalls++
+		return flowstore.EpicProgression{RepoPath: progressionLaunchRepo, EpicID: progressionLaunchEpic, Enabled: true}, true, nil
+	}
+	m.autoAdvanceInFlight = 1
+	later := cloneFlowRecord(fixture.source)
+	later.Status = flowstore.StatusCompleted
+	next, laterCmd := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{later}, Request: 1})
+	for _, msg := range immediateFlowRefreshMessages(laterCmd) {
+		if _, ok := msg.(epicProgressionAdvanceResultMsg); ok {
+			t.Fatal("later poll scheduled the durably halted epic again")
+		}
+	}
+	if readCalls != 0 || next.activeEpicProgressionAdvance.Request != 0 || next.flowPreparationAdmission {
+		t.Fatalf("later poll touched halted progression: reads=%d active=%#v admission=%t",
+			readCalls, next.activeEpicProgressionAdvance, next.flowPreparationAdmission)
+	}
+}

--- a/model/flow_advance_tick.go
+++ b/model/flow_advance_tick.go
@@ -89,12 +89,18 @@ func (m Model) handleAutoAdvanceResult(msg AutoAdvanceResultMsg) (Model, tea.Cmd
 	if msg.Request == 0 || msg.Request != m.autoAdvanceInFlight {
 		return m.finishAutoAdvanceFetch(msg.Request)
 	}
-	if msg.Err != "" || msg.Degradation != nil {
+	if msg.Err != "" {
 		return m.finishAutoAdvanceFetch(msg.Request)
 	}
 
 	previous := cloneFlowRecords(m.autoAdvanceSnapshot)
 	current := cloneFlowRecords(msg.Flows)
+	if msg.Degradation != nil {
+		var progressionCmd, tickCmd tea.Cmd
+		m, progressionCmd = m.prepareEpicProgressionAdvance(current, msg.Request)
+		m, tickCmd = m.finishAutoAdvanceFetch(msg.Request)
+		return m, batchNonNil(progressionCmd, tickCmd)
+	}
 
 	var cmds []tea.Cmd
 	var autoCmd tea.Cmd


### PR DESCRIPTION
An unreadable Flow row made epic auto-progression retry once per second forever. The partial list error prevented child selection, even though the store can still return the readable rows.

This change lets progression use those readable rows while retaining the typed degradation report. If the unreadable row owns the next Bead slot, the existing store guard rejects creation and progression records one terminal halt that names the Flow requiring repair. Runtime tracking is torn down, so later ticks do not reschedule the epic. Fatal list failures remain retryable.

Regression coverage proves both halves: selection continues from a partial list, and an unreadable Bead owner produces no create or launch side effects, persists one halt, and stays stopped.

Verification:
- `make fmt-check`
- `make test`
- `make build`