### PR TITLE
Keep Flow agents alive for tracked work

### DIFF
--- a/agent-skills/approach-flow/references/active-phase.md
+++ b/agent-skills/approach-flow/references/active-phase.md
@@ -42,6 +42,15 @@ If a plan is linked, read it using the launch default:
 Use the phase's persisted semantic kind rather than assuming its ID is one of
 the default names.
 
+## Settle tracked work before responding
+
+Before any final response, wait for all spawned background or delegated work
+to finish and consume every result. Do not record phase completion while such
+work is still running. If work cannot finish safely, stop it and persist an
+honest non-complete outcome with useful notes: use `needs-attention` for
+unfinished actionable work and `block` only for a genuine external blocker.
+Plan persistence remains separate from Flow phase completion.
+
 ## Record the outcome
 
 Commands default both IDs from the launch:

--- a/agent-skills/unified_skill_test.go
+++ b/agent-skills/unified_skill_test.go
@@ -73,6 +73,18 @@ func TestApproachFlowHasCanonicalInterfaceMetadata(t *testing.T) {
 	})
 }
 
+func TestApproachFlowActivePhaseDrainsTrackedWorkBeforeFinalResponse(t *testing.T) {
+	activePhase := readFile(t, filepath.Join(repoRoot(t), "agent-skills", "approach-flow", "references", "active-phase.md"))
+	requireContainsAll(t, "active phase pending-work contract", activePhase, []string{
+		"Before any final response",
+		"spawned background or delegated work",
+		"consume every result",
+		"stop",
+		"needs-attention",
+		"block",
+	})
+}
+
 func repoRoot(t *testing.T) string {
 	t.Helper()
 	_, file, _, ok := runtime.Caller(0)

--- a/docs/agent-sessions.md
+++ b/docs/agent-sessions.md
@@ -225,6 +225,13 @@ socket path, reloads registrations from `launch.json`, replays every pending
 request exactly once — under the latest-launch gate, so a launch that no
 longer owns its phase never writes — and only then listens.
 
+The agent and launch controller cover different failure boundaries. The agent
+must wait for all spawned background or delegated work before its final
+response, consume every result, and persist the phase outcome last. If it
+cannot finish work safely, it stops that work and records `needs_attention` or
+`blocked` with useful notes. This keeps a normal headless turn alive until its
+tracked work settles.
+
 Reconciliation demotes a phase only on positive exit evidence: an embedded
 terminal's exit, an interactive launch handing the TTY back, the lease
 runner's `exit.json`, or a Claude session record the store says ended more
@@ -237,6 +244,9 @@ and Cursor records say `ended` after every turn, so they are never exit
 evidence either: a Codex or Cursor launch that exits without a result is
 demoted only by its embedded terminal's exit or the lease runner's
 `exit.json`.
+That exit record and the resulting `phase_result_missing` transition are
+diagnostic evidence when teardown still prevents a phase result or session
+capture. They are not a substitute for the agent awaiting its background work.
 The write is `needs_attention` with the reason as the outcome
 (`phase_result_missing` or `phase_result_stale`); on a plan-review kind it is
 `blocked`/`blocked` with the reason leading the notes, the convention that

--- a/docs/config.md
+++ b/docs/config.md
@@ -307,11 +307,15 @@ launch yet.
 
 Optional templates for Flow phase launch prompts and the `U` autofix launcher.
 Blank or omitted keys use the built-in prompt for that key. Unknown placeholders
-remain literal. Approach appends `After completing this phase goal, mark this
-Flow phase done with approach-flow.` to both built-in phase prompts and
-configured phase templates unless the template already ends with that exact
-standalone instruction. The `autofix` key is not a phase prompt and never
-receives that suffix.
+remain literal. Approach appends a two-line suffix to both built-in phase
+prompts and configured phase templates: `Before your final response, wait for
+every spawned background or delegated task to finish and consume its result;
+if any cannot finish safely, stop it and persist needs_attention or blocked
+with useful notes.` followed by `After completing this phase goal, mark this
+Flow phase done with approach-flow.` A template already ending with that exact
+pair is left alone; a template ending with only the phase-done instruction has
+that line replaced with the full pair. The `autofix` key is not a phase prompt
+and never receives that suffix.
 
 The `f2` prompt-template picker also manages these Flow prompt keys. Saving a
 blank or whitespace-only template with `ctrl+s` resets that key by removing the
@@ -791,12 +795,15 @@ use the `commit` skill, Review Loop to use the review-loop workflow with goal
 `review-and-revise` and `commit` when revisions are made, PR Creation to use
 the `ship` skill, and Autoreview to use `ship` when fixes require commits or
 pushes. All Flow phase launch prompts also end with:
+`Before your final response, wait for every spawned background or delegated
+task to finish and consume its result; if any cannot finish safely, stop it
+and persist needs_attention or blocked with useful notes.` followed by
 `After completing this phase goal, mark this Flow phase done with approach-flow.`
 Autoreview launch prompts include the PR target metadata but leave detailed
 completion, needs-attention, blocked, and restart mechanics to the high-level
 Flow phase commands.
 Override `[flow_prompts]` keys to customize those phase templates; Approach still
-appends the common phase-done instruction to custom templates.
+appends the common pending-work and phase-done instructions to custom templates.
 
 The PR Creation phase should record structured PR metadata with
 `approach flow pr set` after a pull request exists. The command currently supports

--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -57,6 +57,14 @@ source of truth. Setting `ready` is rejected with "readiness is derived"; the
 CLI rejects unknown statuses with the valid list, and the store rejects them as
 `invalid phase status`.
 
+Every generated phase prompt, including prompts built from `[flow_prompts]`
+templates, ends with the same lifecycle rule. Before its final response, the
+agent waits for all spawned background or delegated work and consumes every
+result. If work cannot finish safely, the agent stops it and records
+`needs_attention` with useful notes for unfinished actionable work, or
+`blocked` for a genuine external blocker. The phase-result write comes after
+that drain, so `completed` never claims success while tracked work is running.
+
 ## Canonical transition table
 
 | From \ To | running | needs_attention | completed | blocked | skipped |

--- a/model/export_test.go
+++ b/model/export_test.go
@@ -166,6 +166,10 @@ func FlowPhaseDoneInstructionForTest() string {
 	return flowPhaseDoneInstruction
 }
 
+func FlowPendingWorkInstructionForTest() string {
+	return flowPendingWorkInstruction
+}
+
 func FlowPlanPromptForTest(record flowstore.FlowRecord, templates FlowPromptTemplates) string {
 	return flowPlanPrompt(record, flowstore.FlowPhase{PhaseID: flowPlanPhaseID, Title: "Plan", Kind: flowstore.KindPlan}, templates, "")
 }

--- a/model/flow_prompt_completion_test.go
+++ b/model/flow_prompt_completion_test.go
@@ -9,6 +9,90 @@ import (
 	"github.com/approachcontrol/approach/model"
 )
 
+const flowPendingWorkInstruction = "Before your final response, wait for every spawned background or delegated task to finish and consume its result; if any cannot finish safely, stop it and persist needs_attention or blocked with useful notes."
+
+func TestEveryFlowPromptEndsWithPendingWorkThenPhaseCompletion(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID:       "flow-1",
+		Instructions: "Do not leave similar background work running at turn end.",
+		PlanPath:     "/state/plans/plan-1/plan.md",
+		WorktreePath: "/dev/alpha-worktrees/flow-lifecycle",
+		Branch:       "flow/lifecycle",
+		Commit:       "abc123",
+	}
+	phases := []flowstore.FlowPhase{
+		{PhaseID: "plan", Kind: flowstore.KindPlan, Title: "Plan"},
+		{PhaseID: "plan-review", Kind: flowstore.KindPlanReview, Title: "Plan Review"},
+		{PhaseID: "implementation", Kind: flowstore.KindImplementation, Title: "Implementation"},
+		{PhaseID: "review-loop", Kind: flowstore.KindReviewLoop, Title: "Review Loop"},
+		{PhaseID: "pr-creation", Kind: flowstore.KindPRCreation, Title: "PR Creation"},
+		{PhaseID: "autoreview", Kind: flowstore.KindAutoreview, Title: "Autoreview"},
+		{PhaseID: "merge", Kind: flowstore.KindMerge, Title: "Merge"},
+		{PhaseID: "qa-check", Title: "QA Check"},
+	}
+
+	for _, phase := range phases {
+		t.Run(string(flowstore.SemanticKind(phase))+"/built-in", func(t *testing.T) {
+			var prompt string
+			if flowstore.SemanticKind(phase) == flowstore.KindPlan {
+				prompt = model.FlowPlanPromptForTest(record, model.FlowPromptTemplates{})
+			} else {
+				prompt = model.FlowPhasePromptForTest(record, phase, record.PlanPath, "The plan mentions waiting for child work.", model.FlowPromptTemplates{})
+			}
+			assertFlowLifecycleSuffix(t, prompt)
+		})
+
+		t.Run(string(flowstore.SemanticKind(phase))+"/configured", func(t *testing.T) {
+			template := "Custom {phase_id} workflow."
+			templates := flowPromptTemplateForKind(flowstore.SemanticKind(phase), template)
+			var prompt string
+			if flowstore.SemanticKind(phase) == flowstore.KindPlan {
+				prompt = model.FlowPlanPromptForTest(record, templates)
+			} else {
+				prompt = model.FlowPhasePromptForTest(record, phase, record.PlanPath, "", templates)
+			}
+			assertFlowLifecycleSuffix(t, prompt)
+		})
+	}
+}
+
+func flowPromptTemplateForKind(kind flowstore.PhaseKind, template string) model.FlowPromptTemplates {
+	switch kind {
+	case flowstore.KindPlan:
+		return model.FlowPromptTemplates{Plan: template}
+	case flowstore.KindPlanReview:
+		return model.FlowPromptTemplates{PlanReview: template}
+	case flowstore.KindImplementation:
+		return model.FlowPromptTemplates{Implementation: template}
+	case flowstore.KindReviewLoop:
+		return model.FlowPromptTemplates{ReviewLoop: template}
+	case flowstore.KindPRCreation:
+		return model.FlowPromptTemplates{PRCreation: template}
+	case flowstore.KindAutoreview:
+		return model.FlowPromptTemplates{Autoreview: template}
+	case flowstore.KindMerge:
+		return model.FlowPromptTemplates{Merge: template}
+	default:
+		return model.FlowPromptTemplates{Generic: template}
+	}
+}
+
+func assertFlowLifecycleSuffix(t *testing.T, prompt string) {
+	t.Helper()
+	if got := strings.Count(prompt, flowPendingWorkInstruction); got != 1 {
+		t.Fatalf("pending-work instruction count = %d, want 1\n%s", got, prompt)
+	}
+	var lines []string
+	for _, line := range strings.Split(strings.TrimRight(prompt, " \t\r\n"), "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	if len(lines) < 2 || lines[len(lines)-2] != flowPendingWorkInstruction || lines[len(lines)-1] != model.FlowPhaseDoneInstructionForTest() {
+		t.Fatalf("prompt must end with pending-work then completion instructions:\n%s", prompt)
+	}
+}
+
 func TestFlowPlanPromptAppendsPhaseDoneInstruction(t *testing.T) {
 	record := flowstore.FlowRecord{
 		Instructions: "Build the thing",
@@ -23,6 +107,7 @@ func TestFlowPlanPromptAppendsPhaseDoneInstruction(t *testing.T) {
 		"Create and persist the plan with \"${APPROACH_EXECUTABLE:-${APPROACH_BIN:-approach}}\" plan save, link it back with \"${APPROACH_EXECUTABLE:-${APPROACH_BIN:-approach}}\" flow plan set, then report Flow persistence failures explicitly before ending.",
 		"If the task references a GitHub issue, link it with \"${APPROACH_EXECUTABLE:-${APPROACH_BIN:-approach}}\" flow issue set using the issue number and URL; when only #N is given, derive the URL from an unambiguous GitHub origin remote or note the ambiguity instead of guessing.",
 		"",
+		model.FlowPendingWorkInstructionForTest(),
 		model.FlowPhaseDoneInstructionForTest(),
 	}, "\n")
 	if got := model.FlowPlanPromptForTest(record, model.FlowPromptTemplates{}); got != want {
@@ -130,7 +215,7 @@ func TestFlowPromptTemplatesAppendPhaseDoneInstruction(t *testing.T) {
 			want = strings.ReplaceAll(want, "{issue_provider}", record.Issue.Provider)
 			want = strings.ReplaceAll(want, "{issue_number}", "123")
 			want = strings.ReplaceAll(want, "{issue_url}", record.Issue.URL)
-			want += "\n\n" + model.FlowPhaseDoneInstructionForTest()
+			want += "\n\n" + model.FlowPendingWorkInstructionForTest() + "\n" + model.FlowPhaseDoneInstructionForTest()
 			if got != want {
 				t.Fatalf("templated prompt = %q, want %q", got, want)
 			}
@@ -260,6 +345,36 @@ func TestFlowPromptPhaseDoneInstructionDuplicateGuard(t *testing.T) {
 			t.Fatalf("prompt should append completion instruction when only rendered placeholder ends with it:\n%s", got)
 		}
 		assertFinalFlowDoneInstruction(t, got)
+	})
+}
+
+func TestFlowPromptPendingWorkInstructionDuplicateGuard(t *testing.T) {
+	pending := model.FlowPendingWorkInstructionForTest()
+	done := model.FlowPhaseDoneInstructionForTest()
+	record := flowstore.FlowRecord{FlowID: "flow-1"}
+	phase := flowstore.FlowPhase{PhaseID: "review-loop", Title: "Review Loop"}
+
+	t.Run("exact lifecycle suffix remains singular", func(t *testing.T) {
+		template := "Review {flow_id}\n\n" + pending + "\n" + done + "\n"
+		got := model.FlowPhasePromptForTest(record, phase, "", "", model.FlowPromptTemplates{ReviewLoop: template})
+		assertFlowLifecycleSuffix(t, got)
+	})
+
+	t.Run("exact pending line gains completion only", func(t *testing.T) {
+		template := "Review {flow_id}\n\n" + pending + "\n"
+		got := model.FlowPhasePromptForTest(record, phase, "", "", model.FlowPromptTemplates{ReviewLoop: template})
+		assertFlowLifecycleSuffix(t, got)
+	})
+
+	t.Run("earlier occurrence still appends final pending line", func(t *testing.T) {
+		template := pending + "\n\nContinue {phase_id}."
+		got := model.FlowPhasePromptForTest(record, phase, "", "", model.FlowPromptTemplates{ReviewLoop: template})
+		if strings.Count(got, pending) != 2 {
+			t.Fatalf("prompt should append pending-work instruction after an earlier occurrence:\n%s", got)
+		}
+		if lastNonEmptyLine(got) != done {
+			t.Fatalf("completion instruction must remain last:\n%s", got)
+		}
 	})
 }
 
@@ -483,5 +598,5 @@ func lastNonEmptyLine(text string) string {
 }
 
 func appendFlowDoneInstructionForTest(prompt string) string {
-	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + model.FlowPhaseDoneInstructionForTest()
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + model.FlowPendingWorkInstructionForTest() + "\n" + model.FlowPhaseDoneInstructionForTest()
 }

--- a/model/flow_prompts.go
+++ b/model/flow_prompts.go
@@ -10,7 +10,10 @@ import (
 	"github.com/approachcontrol/approach/flowstore"
 )
 
-const flowPhaseDoneInstruction = "After completing this phase goal, mark this Flow phase done with approach-flow."
+const (
+	flowPendingWorkInstruction = "Before your final response, wait for every spawned background or delegated task to finish and consume its result; if any cannot finish safely, stop it and persist needs_attention or blocked with useful notes."
+	flowPhaseDoneInstruction   = "After completing this phase goal, mark this Flow phase done with approach-flow."
+)
 
 // FlowPromptTemplates stores optional launch prompt templates for Flow phases
 // and the U autofix launcher. Unknown placeholders are left literal so users
@@ -104,24 +107,55 @@ func prNumberPlaceholder(number int) string {
 	return strconv.Itoa(number)
 }
 
-func ensureFlowPhaseDoneInstruction(prompt, guardSource string) string {
+func ensureFlowPhaseWorkflowSuffix(prompt, guardSource string) string {
 	guard := guardSource
 	if strings.TrimSpace(guard) == "" {
 		guard = prompt
 	}
-	if lastNonEmptyPromptLine(guard) == flowPhaseDoneInstruction {
+	guardLines := nonEmptyPromptLines(guard)
+	if hasExactPromptSuffix(guardLines, flowPendingWorkInstruction, flowPhaseDoneInstruction) {
 		return strings.TrimRight(prompt, " \t\r\n")
 	}
-	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + flowPhaseDoneInstruction
+	if hasExactPromptSuffix(guardLines, flowPhaseDoneInstruction) {
+		prompt = removeExactFinalPromptLine(prompt, flowPhaseDoneInstruction)
+	} else if hasExactPromptSuffix(guardLines, flowPendingWorkInstruction) {
+		return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + flowPhaseDoneInstruction
+	}
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + flowPendingWorkInstruction + "\n" + flowPhaseDoneInstruction
 }
 
-func lastNonEmptyPromptLine(text string) string {
+func nonEmptyPromptLines(text string) []string {
 	lines := strings.Split(text, "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := strings.TrimSuffix(lines[i], "\r")
+	nonEmpty := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSuffix(line, "\r")
 		if strings.TrimSpace(line) != "" {
-			return line
+			nonEmpty = append(nonEmpty, line)
 		}
+	}
+	return nonEmpty
+}
+
+func hasExactPromptSuffix(lines []string, suffix ...string) bool {
+	if len(lines) < len(suffix) {
+		return false
+	}
+	start := len(lines) - len(suffix)
+	for i := range suffix {
+		if lines[start+i] != suffix[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func removeExactFinalPromptLine(prompt, line string) string {
+	trimmed := strings.TrimRight(prompt, " \t\r\n")
+	if !hasExactPromptSuffix(nonEmptyPromptLines(trimmed), line) {
+		return trimmed
+	}
+	if newline := strings.LastIndex(trimmed, "\n"); newline >= 0 {
+		return strings.TrimRight(trimmed[:newline], " \t\r\n")
 	}
 	return ""
 }
@@ -180,7 +214,7 @@ func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, pla
 	bin := flowPromptBinary(binary)
 	if template := templates.templateForPhase(phase); strings.TrimSpace(template) != "" {
 		prompt := renderFlowPromptTemplate(template, record, phase, planPath, planBody, bin)
-		return ensureFlowPhaseDoneInstruction(prompt, template)
+		return ensureFlowPhaseWorkflowSuffix(prompt, template)
 	}
 	var prompt string
 	switch flowstore.SemanticKind(phase) {
@@ -201,7 +235,7 @@ func flowPhasePrompt(record flowstore.FlowRecord, phase flowstore.FlowPhase, pla
 	default:
 		prompt = flowGenericPhasePrompt(record, phase, planPath, planBody, bin)
 	}
-	return ensureFlowPhaseDoneInstruction(prompt, "")
+	return ensureFlowPhaseWorkflowSuffix(prompt, "")
 }
 
 func flowPhasePromptNeedsPlanBody(phase flowstore.FlowPhase) bool {

--- a/model/flow_start.go
+++ b/model/flow_start.go
@@ -722,7 +722,7 @@ func flowPlanPrompt(flow flowstore.FlowRecord, phase flowstore.FlowPhase, templa
 	bin := flowPromptBinary(binary)
 	if strings.TrimSpace(templates.Plan) != "" {
 		prompt := renderFlowPromptTemplate(templates.Plan, flow, phase, flow.PlanPath, "", bin)
-		return ensureFlowPhaseDoneInstruction(prompt, templates.Plan)
+		return ensureFlowPhaseWorkflowSuffix(prompt, templates.Plan)
 	}
 	var b strings.Builder
 	b.WriteString("Use the approach-flow skill for this launch.\n\n")
@@ -730,5 +730,5 @@ func flowPlanPrompt(flow flowstore.FlowRecord, phase flowstore.FlowPhase, templa
 	b.WriteString("\nProduce a plan only; do not start coding in this phase.")
 	b.WriteString("\nCreate and persist the plan with " + bin + " plan save, link it back with " + bin + " flow plan set, then report Flow persistence failures explicitly before ending.")
 	b.WriteString("\nIf the task references a GitHub issue, link it with " + bin + " flow issue set using the issue number and URL; when only #N is given, derive the URL from an unambiguous GitHub origin remote or note the ambiguity instead of guessing.")
-	return ensureFlowPhaseDoneInstruction(b.String(), "")
+	return ensureFlowPhaseWorkflowSuffix(b.String(), "")
 }


### PR DESCRIPTION
A headless Flow agent can end its provider turn while delegated or background work is still running. That tears down the process tree before the result is consumed and can leave the phase without a useful completion record.

This change adds one mandatory pending-work gate to every built-in and configured Flow prompt. Agents must wait for spawned work, consume its result, or stop it and persist an honest non-complete phase outcome before replying. The canonical approach-flow skill and Flow/session documentation now carry the same contract. Existing launch-control exit evidence remains the fallback when a provider still exits without a phase result.

Tests cover every semantic phase and configured prompt template, verify the gate appears once, and require it to precede phase completion. The canonical skill contract is tested as well.

Validation:
- make fmt-check
- make test
- make build