### PR TITLE
Fix autofix embedded terminal titles

### DIFF
--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -1037,8 +1037,9 @@ On a Flow row or an expanded phase row:
   `g`, so occupancy, the persisted `h` headless preference, tmux mode, and the
   current agent/model/effort all apply, and interactive embedded launches prefill
   the dock for you to send. Their dock tab/chip uses the display identity
-  `autofix pr <num>` without `#`, so PR 116 renders, for example,
-  `1 codex autofix pr 116 running`; the default agent prompt remains
+  `autofix`, so the provider-specific label renders as, for example,
+  `1 codex autofix running` or `1 claude autofix running`. The PR number stays
+  in the agent prompt, not the tab identity: the default prompt is
   `autofix pr #116` unless `[flow_prompts].autofix` overrides it. Headless and
   tmux launches send that rendered prompt on argv; interactive embedded launches
   prefill the dock with it. Headless launches retain the existing Flow identity

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -1037,12 +1037,13 @@ On a Flow row or an expanded phase row:
   `g`, so occupancy, the persisted `h` headless preference, tmux mode, and the
   current agent/model/effort all apply, and interactive embedded launches prefill
   the dock for you to send. Their dock tab/chip uses the display identity
-  `autofix pr <num>` without `#`, so PR 116 renders, for example,
-  `1 codex autofix pr 116 running`; the default agent prompt remains
+  `autofix`, so the provider-specific label renders as, for example,
+  `1 codex autofix running` or `1 claude autofix running`. The PR number stays
+  in the agent prompt, not the tab identity: the default prompt is
   `autofix pr #116` unless `[flow_prompts].autofix` overrides it. Headless and
   tmux launches send that rendered prompt on argv; interactive embedded launches
-  prefill the dock with it. Headless launches occupy a dock slot like
-  interactive ones and carry the same `autofix pr <num>` identity.
+  prefill the dock with it. Headless launches retain their existing
+  `autofix pr <num>` identity rather than using the interactive label.
 
   It is deliberately **phase-untracked**: it writes no phase state, marks no
   phase running, and attaches its session to no phase history, so an autofix run

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -1037,13 +1037,12 @@ On a Flow row or an expanded phase row:
   `g`, so occupancy, the persisted `h` headless preference, tmux mode, and the
   current agent/model/effort all apply, and interactive embedded launches prefill
   the dock for you to send. Their dock tab/chip uses the display identity
-  `autofix`, so the provider-specific label renders as, for example,
-  `1 codex autofix running` or `1 claude autofix running`. The PR number stays
-  in the agent prompt, not the tab identity: the default prompt is
+  `autofix pr <num>` without `#`, so PR 116 renders, for example,
+  `1 codex autofix pr 116 running`; the default agent prompt remains
   `autofix pr #116` unless `[flow_prompts].autofix` overrides it. Headless and
   tmux launches send that rendered prompt on argv; interactive embedded launches
-  prefill the dock with it. Headless launches retain the existing Flow identity
-  rather than using the interactive autofix label.
+  prefill the dock with it. Headless launches occupy a dock slot like
+  interactive ones and carry the same `autofix pr <num>` identity.
 
   It is deliberately **phase-untracked**: it writes no phase state, marks no
   phase running, and attaches its session to no phase history, so an autofix run

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -759,12 +759,11 @@ func flowEmbeddedTerminalIdentity(ctx actions.AgentLaunchContext) string {
 	case actions.RoleSavedSessionResume:
 		return "session " + shortSessionID(ctx.ResumeSessionID)
 	case actions.RoleAutofix:
-		// The PR number and the transport are payload rather than role, so they
-		// stay here: an autofix launch that carries no PR number, or that is not
-		// running in the dock, has no label of its own to offer and takes the
-		// generic ladder below.
+		// The PR number is prompt payload, not dock identity. An autofix launch
+		// that carries no PR number, or that is not running in the dock, has no
+		// label of its own to offer and takes the generic ladder below.
 		if ctx.FlowAutofixPRNumber > 0 && ctx.Embedded && !ctx.Headless {
-			return fmt.Sprintf("autofix pr %d", ctx.FlowAutofixPRNumber)
+			return "autofix"
 		}
 	}
 	for _, value := range []string{

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -759,11 +759,13 @@ func flowEmbeddedTerminalIdentity(ctx actions.AgentLaunchContext) string {
 	case actions.RoleSavedSessionResume:
 		return "session " + shortSessionID(ctx.ResumeSessionID)
 	case actions.RoleAutofix:
-		// The PR number is prompt payload, not dock identity. An autofix launch
-		// that carries no PR number, or that is not running in the dock, has no
-		// label of its own to offer and takes the generic ladder below.
-		if ctx.FlowAutofixPRNumber > 0 && ctx.Embedded && !ctx.Headless {
-			return "autofix"
+		// The PR number and the transport are payload rather than role, so they
+		// stay here: an autofix launch that carries no PR number, or that is not
+		// running in the dock, has no label of its own to offer and takes the
+		// generic ladder below. Headless launches occupy a dock slot like
+		// interactive ones, so they carry the same label.
+		if ctx.FlowAutofixPRNumber > 0 && ctx.Embedded {
+			return fmt.Sprintf("autofix pr %d", ctx.FlowAutofixPRNumber)
 		}
 	}
 	for _, value := range []string{

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -759,13 +759,13 @@ func flowEmbeddedTerminalIdentity(ctx actions.AgentLaunchContext) string {
 	case actions.RoleSavedSessionResume:
 		return "session " + shortSessionID(ctx.ResumeSessionID)
 	case actions.RoleAutofix:
-		// The PR number and the transport are payload rather than role, so they
-		// stay here: an autofix launch that carries no PR number, or that is not
-		// running in the dock, has no label of its own to offer and takes the
-		// generic ladder below. Headless launches occupy a dock slot like
-		// interactive ones, so they carry the same label.
+		// Interactive tabs show the stable autofix role while the prompt carries
+		// the PR number. Headless slots keep their existing PR-specific identity.
 		if ctx.FlowAutofixPRNumber > 0 && ctx.Embedded {
-			return fmt.Sprintf("autofix pr %d", ctx.FlowAutofixPRNumber)
+			if ctx.Headless {
+				return fmt.Sprintf("autofix pr %d", ctx.FlowAutofixPRNumber)
+			}
+			return "autofix"
 		}
 	}
 	for _, value := range []string{

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -248,7 +248,7 @@ func TestFlowEmbeddedTerminalIdentityAutofix(t *testing.T) {
 		mutate func(*actions.AgentLaunchContext)
 		want   string
 	}{
-		{name: "valid", want: "autofix"},
+		{name: "valid", want: "autofix pr 116"},
 		{name: "repair precedence", mutate: func(ctx *actions.AgentLaunchContext) {
 			ctx.FlowRepair = true
 		}, want: "repair"},
@@ -286,7 +286,7 @@ func TestFlowEmbeddedTerminalIdentityAutofix(t *testing.T) {
 		}, want: "flow-1"},
 		{name: "headless", mutate: func(ctx *actions.AgentLaunchContext) {
 			ctx.Headless = true
-		}, want: "flow-1"},
+		}, want: "autofix pr 116"},
 		{name: "tracked without phase", mutate: func(ctx *actions.AgentLaunchContext) {
 			ctx.FlowLaunchTracked = true
 		}, want: "flow-1"},

--- a/model/embedded_terminal_internal_test.go
+++ b/model/embedded_terminal_internal_test.go
@@ -248,7 +248,7 @@ func TestFlowEmbeddedTerminalIdentityAutofix(t *testing.T) {
 		mutate func(*actions.AgentLaunchContext)
 		want   string
 	}{
-		{name: "valid", want: "autofix pr 116"},
+		{name: "valid", want: "autofix"},
 		{name: "repair precedence", mutate: func(ctx *actions.AgentLaunchContext) {
 			ctx.FlowRepair = true
 		}, want: "repair"},

--- a/model/flow_launch_autofix_internal_test.go
+++ b/model/flow_launch_autofix_internal_test.go
@@ -640,11 +640,11 @@ func TestAutofixLaunchOpensOneUntrackedEmbeddedSlot(t *testing.T) {
 				t.Fatalf("embedded terminals = %#v, want exactly one slot", m.embeddedTerminals)
 			}
 			slot := m.embeddedTerminals[0]
-			if slot.Number != 1 || slot.Provider != tc.provider || slot.Identity != "autofix pr 116" ||
+			if slot.Number != 1 || slot.Provider != tc.provider || slot.Identity != "autofix" ||
 				slot.Terminal.State() != "running" || !slot.PrefillPending {
 				t.Fatalf("autofix terminal slot = %#v", slot)
 			}
-			wantLabel := "1 " + tc.provider + " autofix pr 116 running"
+			wantLabel := "1 " + tc.provider + " autofix running"
 			view := ansi.Strip(m.View())
 			if !strings.Contains(view, wantLabel) {
 				t.Fatalf("dock does not contain %q:\n%s", wantLabel, view)
@@ -688,7 +688,7 @@ func TestAutofixLaunchHonorsModelAndEffortAndHeadless(t *testing.T) {
 		t.Fatal("a headless Flow must launch its autofix agent headless")
 	}
 	if len(m.embeddedTerminals) != 1 || m.embeddedTerminals[0].Identity != "autofix pr 116" {
-		t.Fatalf("headless autofix slot = %#v, want the autofix identity", m.embeddedTerminals)
+		t.Fatalf("headless autofix slot = %#v, want the PR-specific autofix identity", m.embeddedTerminals)
 	}
 }
 
@@ -945,10 +945,10 @@ func TestAutofixPrepareUsesReservedPRNumber(t *testing.T) {
 		t.Fatalf("reserved PR launch metadata = number %d prompt %q, want 204 and %q",
 			ctx.FlowAutofixPRNumber, ctx.InitialPrompt, "autofix pr #204")
 	}
-	if len(m.embeddedTerminals) != 1 || m.embeddedTerminals[0].Identity != "autofix pr 204" {
+	if len(m.embeddedTerminals) != 1 || m.embeddedTerminals[0].Identity != "autofix" {
 		t.Fatalf("reserved PR terminal slot = %#v", m.embeddedTerminals)
 	}
-	wantLabel := "1 codex autofix pr 204 running"
+	wantLabel := "1 codex autofix running"
 	if view := ansi.Strip(m.View()); !strings.Contains(view, wantLabel) {
 		t.Fatalf("dock does not contain %q:\n%s", wantLabel, view)
 	}

--- a/model/flow_launch_autofix_internal_test.go
+++ b/model/flow_launch_autofix_internal_test.go
@@ -640,11 +640,11 @@ func TestAutofixLaunchOpensOneUntrackedEmbeddedSlot(t *testing.T) {
 				t.Fatalf("embedded terminals = %#v, want exactly one slot", m.embeddedTerminals)
 			}
 			slot := m.embeddedTerminals[0]
-			if slot.Number != 1 || slot.Provider != tc.provider || slot.Identity != "autofix pr 116" ||
+			if slot.Number != 1 || slot.Provider != tc.provider || slot.Identity != "autofix" ||
 				slot.Terminal.State() != "running" || !slot.PrefillPending {
 				t.Fatalf("autofix terminal slot = %#v", slot)
 			}
-			wantLabel := "1 " + tc.provider + " autofix pr 116 running"
+			wantLabel := "1 " + tc.provider + " autofix running"
 			view := ansi.Strip(m.View())
 			if !strings.Contains(view, wantLabel) {
 				t.Fatalf("dock does not contain %q:\n%s", wantLabel, view)
@@ -942,10 +942,10 @@ func TestAutofixPrepareUsesReservedPRNumber(t *testing.T) {
 		t.Fatalf("reserved PR launch metadata = number %d prompt %q, want 204 and %q",
 			ctx.FlowAutofixPRNumber, ctx.InitialPrompt, "autofix pr #204")
 	}
-	if len(m.embeddedTerminals) != 1 || m.embeddedTerminals[0].Identity != "autofix pr 204" {
+	if len(m.embeddedTerminals) != 1 || m.embeddedTerminals[0].Identity != "autofix" {
 		t.Fatalf("reserved PR terminal slot = %#v", m.embeddedTerminals)
 	}
-	wantLabel := "1 codex autofix pr 204 running"
+	wantLabel := "1 codex autofix running"
 	if view := ansi.Strip(m.View()); !strings.Contains(view, wantLabel) {
 		t.Fatalf("dock does not contain %q:\n%s", wantLabel, view)
 	}

--- a/model/flow_launch_autofix_internal_test.go
+++ b/model/flow_launch_autofix_internal_test.go
@@ -640,11 +640,11 @@ func TestAutofixLaunchOpensOneUntrackedEmbeddedSlot(t *testing.T) {
 				t.Fatalf("embedded terminals = %#v, want exactly one slot", m.embeddedTerminals)
 			}
 			slot := m.embeddedTerminals[0]
-			if slot.Number != 1 || slot.Provider != tc.provider || slot.Identity != "autofix" ||
+			if slot.Number != 1 || slot.Provider != tc.provider || slot.Identity != "autofix pr 116" ||
 				slot.Terminal.State() != "running" || !slot.PrefillPending {
 				t.Fatalf("autofix terminal slot = %#v", slot)
 			}
-			wantLabel := "1 " + tc.provider + " autofix running"
+			wantLabel := "1 " + tc.provider + " autofix pr 116 running"
 			view := ansi.Strip(m.View())
 			if !strings.Contains(view, wantLabel) {
 				t.Fatalf("dock does not contain %q:\n%s", wantLabel, view)
@@ -672,7 +672,7 @@ func TestAutofixLaunchHonorsModelAndEffortAndHeadless(t *testing.T) {
 	m := h.modelWith([]scanner.Repo{{Path: "/dev/alpha", DisplayName: "alpha"}}, opts)
 	m.claudeModel = "claude-opus-4-1"
 
-	h.autofix(m)
+	m = h.autofix(m)
 
 	if len(h.launchContexts) != 1 {
 		t.Fatalf("embedded launches = %#v, want exactly one", h.launchContexts)
@@ -686,6 +686,9 @@ func TestAutofixLaunchHonorsModelAndEffortAndHeadless(t *testing.T) {
 	}
 	if !ctx.Headless {
 		t.Fatal("a headless Flow must launch its autofix agent headless")
+	}
+	if len(m.embeddedTerminals) != 1 || m.embeddedTerminals[0].Identity != "autofix pr 116" {
+		t.Fatalf("headless autofix slot = %#v, want the autofix identity", m.embeddedTerminals)
 	}
 }
 
@@ -942,10 +945,10 @@ func TestAutofixPrepareUsesReservedPRNumber(t *testing.T) {
 		t.Fatalf("reserved PR launch metadata = number %d prompt %q, want 204 and %q",
 			ctx.FlowAutofixPRNumber, ctx.InitialPrompt, "autofix pr #204")
 	}
-	if len(m.embeddedTerminals) != 1 || m.embeddedTerminals[0].Identity != "autofix" {
+	if len(m.embeddedTerminals) != 1 || m.embeddedTerminals[0].Identity != "autofix pr 204" {
 		t.Fatalf("reserved PR terminal slot = %#v", m.embeddedTerminals)
 	}
-	wantLabel := "1 codex autofix running"
+	wantLabel := "1 codex autofix pr 204 running"
 	if view := ansi.Strip(m.View()); !strings.Contains(view, wantLabel) {
 		t.Fatalf("dock does not contain %q:\n%s", wantLabel, view)
 	}

--- a/model/flow_launch_role_matrix_internal_test.go
+++ b/model/flow_launch_role_matrix_internal_test.go
@@ -247,7 +247,7 @@ func TestFlowLaunchRoleMatrixConsumerDecisions(t *testing.T) {
 				LaunchID: "launch-1", Record: autofixRecord, PlanPath: autofixRecord.PlanPath,
 			},
 			want: flowLaunchRoleMatrixDecisions{
-				Identity:          "autofix pr 116",
+				Identity:          "autofix",
 				Detach:            embeddedTerminalDetachAllowed,
 				TmuxEligible:      true,
 				RequiresLifecycle: true,

--- a/model/flow_launch_role_matrix_internal_test.go
+++ b/model/flow_launch_role_matrix_internal_test.go
@@ -247,22 +247,22 @@ func TestFlowLaunchRoleMatrixConsumerDecisions(t *testing.T) {
 				LaunchID: "launch-1", Record: autofixRecord, PlanPath: autofixRecord.PlanPath,
 			},
 			want: flowLaunchRoleMatrixDecisions{
-				Identity:          "autofix",
+				Identity:          "autofix pr 116",
 				Detach:            embeddedTerminalDetachAllowed,
 				TmuxEligible:      true,
 				RequiresLifecycle: true,
 			},
 		},
 		{
-			// Headless autofix has no dock to label, so it takes the generic
-			// ladder and shows the Flow ID.
+			// Headless autofix occupies a dock slot like the interactive
+			// launch, so it carries the same label.
 			name: "V14 autofix embedded headless",
 			target: autofixTarget{
 				LaunchID: "launch-1", Record: headlessAutofixRecord,
 				PlanPath: headlessAutofixRecord.PlanPath,
 			},
 			want: flowLaunchRoleMatrixDecisions{
-				Identity:          "flow-1",
+				Identity:          "autofix pr 116",
 				Detach:            embeddedTerminalDetachAllowed,
 				RequiresLifecycle: true,
 			},

--- a/model/flow_launch_role_matrix_internal_test.go
+++ b/model/flow_launch_role_matrix_internal_test.go
@@ -247,15 +247,14 @@ func TestFlowLaunchRoleMatrixConsumerDecisions(t *testing.T) {
 				LaunchID: "launch-1", Record: autofixRecord, PlanPath: autofixRecord.PlanPath,
 			},
 			want: flowLaunchRoleMatrixDecisions{
-				Identity:          "autofix pr 116",
+				Identity:          "autofix",
 				Detach:            embeddedTerminalDetachAllowed,
 				TmuxEligible:      true,
 				RequiresLifecycle: true,
 			},
 		},
 		{
-			// Headless autofix occupies a dock slot like the interactive
-			// launch, so it carries the same label.
+			// Headless autofix keeps its existing PR-specific identity.
 			name: "V14 autofix embedded headless",
 			target: autofixTarget{
 				LaunchID: "launch-1", Record: headlessAutofixRecord,


### PR DESCRIPTION
Autofix sessions launched with `U` still put the PR number in the dock title. That made the title diverge from the intended provider-specific `<provider> autofix running` label.

This change gives interactive embedded autofix sessions the stable `autofix` identity while keeping the PR number in launch metadata and the agent prompt. Codex and Claude launch coverage now checks both the dock label and the unchanged PR-specific prompt. The TUI guide documents the split between those two values.

Validation:

- `go test ./model`
- `make fmt-check`
- `git diff --check origin/main...HEAD`
- Full `make test` and `make build` passed in the implementation phase before the no-conflict rebase.