### PR TITLE
refactor: centralize authoritative Flow occupancy reads

### DIFF
--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/internal/artifacts"
 	"github.com/approachcontrol/approach/sessions"
 )
 
@@ -517,6 +518,10 @@ var (
 	ErrMissingFlowCache = errors.New("flowoccupancy: cached Flow source is required")
 	// ErrMissingSessionCache marks a cached purpose without its session panes.
 	ErrMissingSessionCache = errors.New("flowoccupancy: cached session source is required")
+	// ErrMissingFlowStore marks an authoritative purpose without its Flow reader.
+	ErrMissingFlowStore = errors.New("flowoccupancy: authoritative Flow source is required")
+	// ErrMissingSessionStore marks an authoritative purpose without its session reader.
+	ErrMissingSessionStore = errors.New("flowoccupancy: authoritative session source is required")
 	errPendingSourceFamily = errors.New("flowoccupancy: a required source family is not implemented yet")
 )
 
@@ -660,6 +665,9 @@ func (occupancy Occupancy) Query(query Query) Verdict {
 	if !ok || !policy.freshness.allows(freshness) {
 		return failedVerdict(fmt.Errorf("%w: freshness %d is unsupported for purpose (%s, %s)", ErrInvalidQuery, query.Freshness, query.Purpose.Role, query.Purpose.Stage))
 	}
+	if freshness == FreshnessAuthoritative && policy.sources&(readFlowStore|readSessionStore) != 0 {
+		return occupancy.queryAuthoritative(query, policy, flowID)
+	}
 	if policy.sources&^(readRuntime|readLease) != 0 || policy.probe != probeNone {
 		return failedVerdict(errPendingSourceFamily)
 	}
@@ -684,6 +692,73 @@ func (occupancy Occupancy) Query(query Query) Verdict {
 		leaseVerdict = queryLease(occupancy.sources.Lease, flowID)
 	}
 	return chooseVerdict(query.Purpose, leaseVerdict, runtimeVerdict)
+}
+
+func (occupancy Occupancy) queryAuthoritative(query Query, policy purposePolicy, flowID string) Verdict {
+	if query.Purpose.Role != actions.RoleTrackedPhase ||
+		(query.Purpose.Stage != StageAuthoritative && query.Purpose.Stage != StageAutoAdvance) {
+		return failedVerdict(errPendingSourceFamily)
+	}
+	if policy.sources&readFlowStore == 0 {
+		return failedVerdict(errPendingSourceFamily)
+	}
+	if occupancy.sources.Flows == nil {
+		return failedVerdict(ErrMissingFlowStore)
+	}
+	record, err := occupancy.sources.Flows.ReadFlow(flowID)
+	if err != nil {
+		return failedVerdict(err)
+	}
+	if record.FlowID != flowID {
+		return failedVerdict(fmt.Errorf("%w: authoritative Flow identity %q does not match %q", ErrInvalidQuery, record.FlowID, flowID))
+	}
+	if query.Purpose.Stage == StageAutoAdvance {
+		candidate := artifacts.NormalizePhaseID(query.PhaseID)
+		for _, phase := range record.Phases {
+			if phase.Status == flowstore.PhaseRunning && artifacts.NormalizePhaseID(phase.PhaseID) != candidate {
+				return Verdict{holder: HolderRunningPhase, phaseID: phase.PhaseID}
+			}
+		}
+	}
+	if occupancy.sources.Sessions == nil {
+		return failedVerdict(ErrMissingSessionStore)
+	}
+	records, err := occupancy.sources.Sessions.ListFlowSessions(flowID)
+	if err != nil {
+		return failedVerdict(err)
+	}
+	phaseID := query.PhaseID
+	for _, phase := range record.Phases {
+		if phase.PhaseID != phaseID {
+			continue
+		}
+		if phaseHasLiveSession(phase) || phaseHasLiveStoredSession(flowID, phase, records) {
+			return Verdict{holder: HolderPhaseSession, phaseID: phase.PhaseID}
+		}
+		break
+	}
+	return Free()
+}
+
+func phaseHasLiveStoredSession(flowID string, phase flowstore.FlowPhase, records []sessions.SessionRecord) bool {
+	launches := make(map[string]struct{}, len(phase.LaunchIDs))
+	for _, launchID := range phase.LaunchIDs {
+		if launchID = strings.TrimSpace(launchID); launchID != "" {
+			launches[launchID] = struct{}{}
+		}
+	}
+	for _, record := range records {
+		if record.FlowID != flowID || strings.TrimSpace(record.SessionID) == "" {
+			continue
+		}
+		if _, ok := launches[strings.TrimSpace(record.LaunchID)]; !ok {
+			continue
+		}
+		if sessions.IsActive(record.Status, record.EndedAt) {
+			return true
+		}
+	}
+	return false
 }
 
 func queryLease(inspector LeaseInspector, flowID string) Verdict {

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -83,6 +83,293 @@ func (panicSessionStore) ListFlowSessions(string) ([]sessions.SessionRecord, err
 	panic("advisory query reached session store")
 }
 
+type flowReaderFixture struct {
+	t          *testing.T
+	wantFlowID string
+	record     flowstore.FlowRecord
+	err        error
+	calls      int
+}
+
+func (reader *flowReaderFixture) ReadFlow(flowID string) (flowstore.FlowRecord, error) {
+	reader.calls++
+	if reader.wantFlowID != "" && flowID != reader.wantFlowID {
+		reader.t.Fatalf("ReadFlow() flow ID = %q, want %q", flowID, reader.wantFlowID)
+	}
+	return reader.record, reader.err
+}
+
+type sessionStoreFixture struct {
+	t          *testing.T
+	wantFlowID string
+	records    []sessions.SessionRecord
+	err        error
+	calls      int
+}
+
+func (store *sessionStoreFixture) ListFlowSessions(flowID string) ([]sessions.SessionRecord, error) {
+	store.calls++
+	if store.wantFlowID != "" && flowID != store.wantFlowID {
+		store.t.Fatalf("ListFlowSessions() flow ID = %q, want %q", flowID, store.wantFlowID)
+	}
+	return store.records, store.err
+}
+
+func TestTrackedPhaseAuthoritativeQueryFindsMirroredPhaseSession(t *testing.T) {
+	flows := &flowReaderFixture{
+		t:          t,
+		wantFlowID: "flow-exact",
+		record: flowstore.FlowRecord{
+			FlowID: "flow-exact",
+			Phases: []flowstore.FlowPhase{{
+				PhaseID:   "implementation",
+				LaunchIDs: []string{"launch-1"},
+				Sessions: []flowstore.Session{{
+					SessionID: "session-1",
+					LaunchID:  "launch-1",
+					Status:    "running",
+				}},
+			}},
+		},
+	}
+	store := &sessionStoreFixture{t: t, wantFlowID: "flow-exact"}
+
+	verdict := New(Sources{Flows: flows, Sessions: store}).Query(Query{
+		FlowID: " flow-exact ",
+		Purpose: Purpose{
+			Role:  actions.RoleTrackedPhase,
+			Stage: StageAuthoritative,
+		},
+		PhaseID: "implementation",
+	})
+
+	if verdict.Holder() != HolderPhaseSession || verdict.PhaseID() != "implementation" || verdict.Err() != nil {
+		t.Fatalf("verdict = (%v, %q, %v), want phase session on implementation", verdict.Holder(), verdict.PhaseID(), verdict.Err())
+	}
+	if flows.calls != 1 || store.calls != 1 {
+		t.Fatalf("source calls = (Flow %d, sessions %d), want (1, 1)", flows.calls, store.calls)
+	}
+}
+
+func TestAuthoritativePhaseSessionEvaluation(t *testing.T) {
+	ended := time.Now()
+	base := flowstore.FlowRecord{
+		FlowID: "flow-1",
+		Phases: []flowstore.FlowPhase{{
+			PhaseID:   "implementation",
+			Status:    flowstore.PhaseReady,
+			LaunchIDs: []string{" launch-1 "},
+		}},
+	}
+	tests := []struct {
+		name       string
+		mutateFlow func(*flowstore.FlowRecord)
+		records    []sessions.SessionRecord
+		wantHolder Holder
+	}{
+		{
+			name: "store-only live session",
+			records: []sessions.SessionRecord{{
+				FlowID: "flow-1", SessionID: "session-1", LaunchID: "launch-1", Status: "last_seen",
+			}},
+			wantHolder: HolderPhaseSession,
+		},
+		{
+			name: "prefix-like Flow ID does not match",
+			records: []sessions.SessionRecord{{
+				FlowID: "flow-10", SessionID: "session-1", LaunchID: "launch-1", Status: "running",
+			}},
+		},
+		{
+			name: "another launch does not match",
+			records: []sessions.SessionRecord{{
+				FlowID: "flow-1", SessionID: "session-1", LaunchID: "launch-other", Status: "running",
+			}},
+		},
+		{
+			name: "ended session does not match",
+			records: []sessions.SessionRecord{{
+				FlowID: "flow-1", SessionID: "session-1", LaunchID: "launch-1", Status: "ended", EndedAt: ended,
+			}},
+		},
+		{
+			name: "mirror and store union",
+			mutateFlow: func(record *flowstore.FlowRecord) {
+				record.Phases[0].Sessions = []flowstore.Session{{
+					SessionID: "session-1", LaunchID: "launch-1", Status: "running",
+				}}
+			},
+			records: []sessions.SessionRecord{{
+				FlowID: "flow-1", SessionID: "session-2", LaunchID: "launch-other", Status: "running",
+			}},
+			wantHolder: HolderPhaseSession,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			record := base
+			record.Phases = append([]flowstore.FlowPhase(nil), base.Phases...)
+			if tc.mutateFlow != nil {
+				tc.mutateFlow(&record)
+			}
+			flows := &flowReaderFixture{t: t, wantFlowID: "flow-1", record: record}
+			store := &sessionStoreFixture{t: t, wantFlowID: "flow-1", records: tc.records}
+			verdict := Evaluate(Sources{Flows: flows, Sessions: store}, Query{
+				FlowID: " flow-1 ",
+				Purpose: Purpose{
+					Role:  actions.RoleTrackedPhase,
+					Stage: StageAuthoritative,
+				},
+				PhaseID: "implementation",
+			})
+			if verdict.Holder() != tc.wantHolder {
+				t.Fatalf("Holder() = %v, want %v", verdict.Holder(), tc.wantHolder)
+			}
+			wantPhase := ""
+			if tc.wantHolder == HolderPhaseSession {
+				wantPhase = "implementation"
+			}
+			if verdict.PhaseID() != wantPhase || verdict.Err() != nil {
+				t.Fatalf("verdict = (%v, %q, %v)", verdict.Holder(), verdict.PhaseID(), verdict.Err())
+			}
+			if flows.calls != 1 || store.calls != 1 {
+				t.Fatalf("source calls = (Flow %d, sessions %d), want (1, 1)", flows.calls, store.calls)
+			}
+		})
+	}
+}
+
+func TestAutoAdvanceAuthoritativeRunningPhasePrecedesSession(t *testing.T) {
+	record := flowstore.FlowRecord{
+		FlowID: "flow-1",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "implementation", Status: flowstore.PhaseReady, LaunchIDs: []string{"launch-1"}},
+			{PhaseID: "review-loop", Status: flowstore.PhaseRunning},
+		},
+	}
+	flows := &flowReaderFixture{t: t, wantFlowID: "flow-1", record: record}
+	store := &sessionStoreFixture{
+		t: t, wantFlowID: "flow-1",
+		records: []sessions.SessionRecord{{
+			FlowID: "flow-1", SessionID: "session-1", LaunchID: "launch-1", Status: "running",
+		}},
+	}
+	verdict := Evaluate(Sources{Flows: flows, Sessions: store}, Query{
+		FlowID: "flow-1",
+		Purpose: Purpose{
+			Role:  actions.RoleTrackedPhase,
+			Stage: StageAutoAdvance,
+		},
+		Freshness: FreshnessAuthoritative,
+		PhaseID:   "implementation",
+	})
+	if verdict.Holder() != HolderRunningPhase || verdict.PhaseID() != "review-loop" || verdict.Err() != nil {
+		t.Fatalf("verdict = (%v, %q, %v), want running review-loop", verdict.Holder(), verdict.PhaseID(), verdict.Err())
+	}
+	if flows.calls != 1 || store.calls != 0 {
+		t.Fatalf("source calls = (Flow %d, sessions %d), want (1, 0)", flows.calls, store.calls)
+	}
+}
+
+func TestAutoAdvanceAuthoritativeExcludesNormalizedCandidatePhase(t *testing.T) {
+	flows := &flowReaderFixture{
+		t: t, wantFlowID: "flow-1",
+		record: flowstore.FlowRecord{
+			FlowID: "flow-1",
+			Phases: []flowstore.FlowPhase{{
+				PhaseID: "implementation", Status: flowstore.PhaseRunning,
+			}},
+		},
+	}
+	store := &sessionStoreFixture{t: t, wantFlowID: "flow-1"}
+	verdict := Evaluate(Sources{Flows: flows, Sessions: store}, Query{
+		FlowID: "flow-1",
+		Purpose: Purpose{
+			Role:  actions.RoleTrackedPhase,
+			Stage: StageAutoAdvance,
+		},
+		Freshness: FreshnessAuthoritative,
+		PhaseID:   "  Implementation  ",
+	})
+	if verdict.Occupied() || verdict.Err() != nil {
+		t.Fatalf("verdict = (%v, %q, %v), want the normalized candidate excluded", verdict.Holder(), verdict.PhaseID(), verdict.Err())
+	}
+	if flows.calls != 1 || store.calls != 1 {
+		t.Fatalf("source calls = (Flow %d, sessions %d), want (1, 1)", flows.calls, store.calls)
+	}
+}
+
+func TestAuthoritativeQueriesFailClosedAtSourceBoundary(t *testing.T) {
+	flowErr := errors.New("read Flow failed")
+	sessionErr := errors.New("list sessions failed")
+	baseRecord := flowstore.FlowRecord{FlowID: "flow-1"}
+	tests := []struct {
+		name       string
+		sources    func(*testing.T) (Sources, *flowReaderFixture, *sessionStoreFixture)
+		wantErr    error
+		wantFlows  int
+		wantStores int
+	}{
+		{
+			name: "missing Flow reader", wantErr: ErrMissingFlowStore,
+			sources: func(t *testing.T) (Sources, *flowReaderFixture, *sessionStoreFixture) {
+				store := &sessionStoreFixture{t: t}
+				return Sources{Sessions: store}, nil, store
+			},
+		},
+		{
+			name: "Flow read error", wantErr: flowErr, wantFlows: 1,
+			sources: func(t *testing.T) (Sources, *flowReaderFixture, *sessionStoreFixture) {
+				flows := &flowReaderFixture{t: t, err: flowErr}
+				store := &sessionStoreFixture{t: t}
+				return Sources{Flows: flows, Sessions: store}, flows, store
+			},
+		},
+		{
+			name: "wrong Flow identity", wantErr: ErrInvalidQuery, wantFlows: 1,
+			sources: func(t *testing.T) (Sources, *flowReaderFixture, *sessionStoreFixture) {
+				flows := &flowReaderFixture{t: t, record: flowstore.FlowRecord{FlowID: "flow-10"}}
+				store := &sessionStoreFixture{t: t}
+				return Sources{Flows: flows, Sessions: store}, flows, store
+			},
+		},
+		{
+			name: "missing session reader", wantErr: ErrMissingSessionStore, wantFlows: 1,
+			sources: func(t *testing.T) (Sources, *flowReaderFixture, *sessionStoreFixture) {
+				flows := &flowReaderFixture{t: t, record: baseRecord}
+				return Sources{Flows: flows}, flows, nil
+			},
+		},
+		{
+			name: "session read error", wantErr: sessionErr, wantFlows: 1, wantStores: 1,
+			sources: func(t *testing.T) (Sources, *flowReaderFixture, *sessionStoreFixture) {
+				flows := &flowReaderFixture{t: t, record: baseRecord}
+				store := &sessionStoreFixture{t: t, err: sessionErr}
+				return Sources{Flows: flows, Sessions: store}, flows, store
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sources, flows, store := tc.sources(t)
+			verdict := Evaluate(sources, Query{
+				FlowID:  "flow-1",
+				Purpose: Purpose{Role: actions.RoleTrackedPhase, Stage: StageAuthoritative},
+				PhaseID: "implementation",
+			})
+			if !verdict.Occupied() || !errors.Is(verdict.Err(), tc.wantErr) {
+				t.Fatalf("verdict = (%v, %v), want fail-closed errors.Is(_, %v)", verdict.Holder(), verdict.Err(), tc.wantErr)
+			}
+			if flows != nil && flows.calls != tc.wantFlows {
+				t.Fatalf("Flow calls = %d, want %d", flows.calls, tc.wantFlows)
+			}
+			if store != nil && store.calls != tc.wantStores {
+				t.Fatalf("session calls = %d, want %d", store.calls, tc.wantStores)
+			}
+		})
+	}
+}
+
 type panicAgentProbe struct{}
 
 func (panicAgentProbe) FlowAgentRunning(flowstore.FlowRecord, string) bool {

--- a/model/flow_launch_adapters.go
+++ b/model/flow_launch_adapters.go
@@ -101,6 +101,26 @@ type flowOccupancySessionCache struct {
 	worktreeSessions []sessions.SessionRecord
 }
 
+type flowOccupancyAuthoritativeFlow struct {
+	record flowstore.FlowRecord
+}
+
+var _ flowoccupancy.FlowReader = flowOccupancyAuthoritativeFlow{}
+
+func (source flowOccupancyAuthoritativeFlow) ReadFlow(string) (flowstore.FlowRecord, error) {
+	return source.record, nil
+}
+
+type flowOccupancyAuthoritativeSessions struct {
+	list func(string) ([]sessions.SessionRecord, error)
+}
+
+var _ flowoccupancy.SessionStore = flowOccupancyAuthoritativeSessions{}
+
+func (source flowOccupancyAuthoritativeSessions) ListFlowSessions(flowID string) ([]sessions.SessionRecord, error) {
+	return source.list(flowID)
+}
+
 var _ flowoccupancy.SessionCache = flowOccupancySessionCache{}
 
 func (cache flowOccupancySessionCache) ActiveFlowSessions(flowID string) []sessions.SessionRecord {
@@ -169,6 +189,27 @@ func (m Model) trackedPhaseOccupancy(flowID string, stage flowoccupancy.Stage) f
 			Role:  actions.RoleTrackedPhase,
 			Stage: stage,
 		},
+	})
+}
+
+func trackedPhaseAuthoritativeOccupancy(
+	seams flowLaunchSeams,
+	flowID string,
+	record flowstore.FlowRecord,
+	phaseID string,
+	stage flowoccupancy.Stage,
+) flowoccupancy.Verdict {
+	return flowoccupancy.Evaluate(flowoccupancy.Sources{
+		Flows:    flowOccupancyAuthoritativeFlow{record: record},
+		Sessions: flowOccupancyAuthoritativeSessions{list: seams.ListFlowSessions},
+	}, flowoccupancy.Query{
+		FlowID: flowID,
+		Purpose: flowoccupancy.Purpose{
+			Role:  actions.RoleTrackedPhase,
+			Stage: stage,
+		},
+		Freshness: flowoccupancy.FreshnessAuthoritative,
+		PhaseID:   phaseID,
 	})
 }
 
@@ -278,7 +319,6 @@ func newFlowLaunchSeams(
 		ReadFlow:    readFlow,
 		ReadSession: readSession,
 		ListFlowSessions: func(flowID string) ([]sessions.SessionRecord, error) {
-			flowID = strings.TrimSpace(flowID)
 			if flowID == "" || listSessions == nil {
 				return nil, nil
 			}
@@ -288,7 +328,7 @@ func newFlowLaunchSeams(
 			}
 			var out []sessions.SessionRecord
 			for _, record := range all {
-				if strings.TrimSpace(record.FlowID) == flowID {
+				if record.FlowID == flowID {
 					out = append(out, record)
 				}
 			}

--- a/model/flow_launch_lifecycle.go
+++ b/model/flow_launch_lifecycle.go
@@ -530,23 +530,6 @@ func flowLaunchCandidatePhase(kind flowLaunchKind, record flowstore.FlowRecord, 
 	return flowstore.FlowPhase{}, false
 }
 
-// flowRecordHasOtherRunningPhase is flowAutoAdvanceOccupied's running-phase
-// signal applied to the fresh record, minus the candidate itself. A running
-// candidate means another source took it, which is staleness rather than
-// occupancy, and the candidate check classifies that first.
-func flowRecordHasOtherRunningPhase(record flowstore.FlowRecord, phaseID string) bool {
-	candidate := artifacts.NormalizePhaseID(phaseID)
-	for _, phase := range record.Phases {
-		if phase.Status != flowstore.PhaseRunning {
-			continue
-		}
-		if artifacts.NormalizePhaseID(phase.PhaseID) != candidate {
-			return true
-		}
-	}
-	return false
-}
-
 // flowLaunchLauncher borrows the preflight and prepare steps through the
 // lifecycle's own seams. NewLaunchID is pinned to the admission token: a second
 // generated ID would make every LaunchID-keyed fence miss and strand the
@@ -605,16 +588,16 @@ func (m Model) flowLaunchReadCmd(intent flowLaunchIntent, token string, settings
 			event.Err = noLaunchableFlowPhaseStatus
 			return event
 		}
-		records, err := seams.ListFlowSessions(intent.FlowID)
-		if err != nil {
-			event.Err = err.Error()
+		occupancy := trackedPhaseAuthoritativeOccupancy(seams, intent.FlowID, record, phase.PhaseID, flowoccupancy.StageAuthoritative)
+		if occupancy.Err() != nil {
+			event.Err = occupancy.Err().Error()
 			return event
 		}
-		if flowLaunchPhaseSessionOccupied(phase, records) {
+		if occupancy.Holder() == flowoccupancy.HolderPhaseSession {
 			// The phase itself is launchable — admission and the candidate
 			// lookup both passed — so the refusal has to name the session, not
 			// the phase, and say how to clear it.
-			event.Err = flowLaunchPhaseSessionLiveStatus(phase.PhaseID)
+			event.Err = flowLaunchPhaseSessionLiveStatus(occupancy.PhaseID())
 			return event
 		}
 		prepared, err := launcher.preflight(flowPhaseLaunchRequest{
@@ -649,9 +632,7 @@ func (m Model) flowLaunchReadCmd(intent flowLaunchIntent, token string, settings
 }
 
 // autoFlowLaunchReadCmd is the authoritative read for AutoMode. The check order
-// is normative: two checks can both hold and they yield different outcomes, and
-// Preflight runs before the session list because it is in-memory while
-// ListFlowSessions scans the whole session store once per poll.
+// is normative: two checks can both hold and they yield different outcomes.
 func autoFlowLaunchReadCmd(seams flowLaunchSeams, launcher flowLaunchPreparation, intent flowLaunchIntent, token string) tea.Cmd {
 	return func() tea.Msg {
 		event := flowLaunchEventMsg{
@@ -684,7 +665,13 @@ func autoFlowLaunchReadCmd(seams flowLaunchSeams, launcher flowLaunchPreparation
 			event.Outcome = flowLaunchOutcomeStale
 			return event
 		}
-		if flowRecordHasOtherRunningPhase(record, phase.PhaseID) {
+		occupancy := trackedPhaseAuthoritativeOccupancy(seams, intent.FlowID, record, phase.PhaseID, flowoccupancy.StageAutoAdvance)
+		if occupancy.Err() != nil {
+			event.Outcome = flowLaunchOutcomeFailed
+			event.Err = occupancy.Err().Error()
+			return event
+		}
+		if occupancy.Holder() == flowoccupancy.HolderRunningPhase || occupancy.Holder() == flowoccupancy.HolderPhaseSession {
 			event.Outcome = flowLaunchOutcomeRetry
 			return event
 		}
@@ -697,18 +684,6 @@ func autoFlowLaunchReadCmd(seams flowLaunchSeams, launcher flowLaunchPreparation
 		if err != nil {
 			event.Outcome = flowLaunchOutcomeFailed
 			event.Err = err.Error()
-			return event
-		}
-		records, err := seams.ListFlowSessions(intent.FlowID)
-		if err != nil {
-			event.Outcome = flowLaunchOutcomeFailed
-			event.Err = err.Error()
-			return event
-		}
-		if flowLaunchPhaseSessionOccupied(phase, records) {
-			// The previous run of this phase is still alive. It clears on its
-			// own, so this re-arms rather than dropping the launch.
-			event.Outcome = flowLaunchOutcomeRetry
 			return event
 		}
 		// Last, and behind the session check, so a phase a live session already

--- a/model/flow_launch_lifecycle_internal_test.go
+++ b/model/flow_launch_lifecycle_internal_test.go
@@ -2237,6 +2237,11 @@ func TestFlowLaunchLiveSessionScope(t *testing.T) {
 			wantLaunch: true,
 		},
 		{
+			name:       "noncanonical Flow identity does not block",
+			stored:     []sessions.SessionRecord{{SessionID: "s-2", LaunchID: "launch-1", FlowID: " flow-1 ", Status: "running"}},
+			wantLaunch: true,
+		},
+		{
 			name:       "ended session does not block",
 			mirrored:   []flowstore.Session{{SessionID: "s-1", LaunchID: "launch-1", Status: "ended", EndedAt: time.Now()}},
 			stored:     []sessions.SessionRecord{{SessionID: "s-1", LaunchID: "launch-1", FlowID: "flow-1", Status: "ended", EndedAt: time.Now()}},

--- a/model/flow_occupancy_sources_internal_test.go
+++ b/model/flow_occupancy_sources_internal_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/internal/flowlease"
 	"github.com/approachcontrol/approach/sessions"
 )
@@ -528,40 +527,5 @@ func TestFlowLaunchAdmissionOccupiedTruthTable(t *testing.T) {
 				t.Fatal("a blank Flow ID is not admission occupancy")
 			}
 		})
-	}
-}
-
-// TestFlowRecordHasOtherRunningPhaseExcludesTheCandidate is S10 minus the
-// candidate: a running candidate is staleness, which the caller classifies
-// first, so only some other running phase counts.
-func TestFlowRecordHasOtherRunningPhaseExcludesTheCandidate(t *testing.T) {
-	record := occupancyFlowRecord()
-	record.Phases = []flowstore.FlowPhase{
-		{PhaseID: "plan", Status: flowstore.PhaseCompleted, Order: 1},
-		{PhaseID: "implementation", Status: flowstore.PhaseRunning, Order: 2},
-		{PhaseID: "review-loop", Status: flowstore.PhaseReady, Order: 3},
-	}
-	tests := []struct {
-		name      string
-		candidate string
-		want      bool
-	}{
-		{name: "the running phase is the candidate", candidate: "implementation"},
-		{name: "a different phase is the candidate", candidate: "review-loop", want: true},
-		{name: "no candidate at all", candidate: "", want: true},
-		// Phase IDs are normalized on both sides before comparison.
-		{name: "the candidate is spelled differently", candidate: "  Implementation  "},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := flowRecordHasOtherRunningPhase(record, tc.candidate); got != tc.want {
-				t.Fatalf("flowRecordHasOtherRunningPhase(%q) = %v, want %v", tc.candidate, got, tc.want)
-			}
-		})
-	}
-
-	none := occupancyFlowRecord()
-	if flowRecordHasOtherRunningPhase(none, "implementation") {
-		t.Fatal("a record with no running phase never has another one")
 	}
 }


### PR DESCRIPTION
The tracked manual and AutoMode read stages each reconstructed fresh Flow and session occupancy. That split let the two paths drift from the module that owns the occupancy decision.

This change adds the authoritative Flow and session query to flowoccupancy, with exact canonical Flow identity and launch-scoped active-session matching. The model now supplies the fresh Flow record and session-store adapter, then consumes the module verdict. Manual launch keeps its phase-named refusal, while AutoMode keeps its silent retry and running-phase precedence.

Verification:
- make fmt-check
- make test
- make build