### PR TITLE
refactor: centralize remaining flow occupancy

### DIFF
--- a/flowoccupancy/occupancy.go
+++ b/flowoccupancy/occupancy.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/internal/artifacts"
 	"github.com/approachcontrol/approach/sessions"
@@ -211,10 +212,10 @@ var purposeRegistry = map[Purpose]purposePolicy{
 	// Matrix section 2.2: prepare stages recheck under the reservation.
 	{Role: actions.RoleTrackedPhase, Stage: StageReserved}:       {sources: readLease, freshness: allowAuthoritative},
 	{Role: actions.RolePhaseResume, Stage: StageReserved}:        {sources: readLease, freshness: allowAuthoritative},
-	{Role: actions.RoleRepair, Stage: StageReserved}:             {sources: readLease, freshness: allowAuthoritative},
-	{Role: actions.RoleAutofix, Stage: StageReserved}:            {sources: readLease, freshness: allowAuthoritative},
+	{Role: actions.RoleRepair, Stage: StageReserved}:             {sources: readLease | readFlowStore | readSessionStore, freshness: allowAuthoritative},
+	{Role: actions.RoleAutofix, Stage: StageReserved}:            {sources: readLease | readFlowStore | readSessionStore, freshness: allowAuthoritative},
 	{Role: actions.RoleWorktreeAgent, Stage: StageReserved}:      {sources: readLease | readFlowStore | readSessionStore, freshness: allowAuthoritative},
-	{Role: actions.RoleSavedSessionResume, Stage: StageReserved}: {sources: readLease, freshness: allowAuthoritative},
+	{Role: actions.RoleSavedSessionResume, Stage: StageReserved}: {sources: readLease | readFlowStore | readSessionStore, freshness: allowAuthoritative},
 
 	// Matrix section 2.2 and section 4.2: every installed launch kind has a
 	// terminal-slot backstop.
@@ -399,6 +400,15 @@ type Advisory struct {
 
 // Defer reports whether cached evidence says the caller should wait.
 func (advisory Advisory) Defer() bool { return advisory.verdict.Occupied() }
+
+// Holder names the cached holder that caused the deferral.
+func (advisory Advisory) Holder() Holder { return advisory.verdict.Holder() }
+
+// PhaseID names the cached phase holder, when one was found.
+func (advisory Advisory) PhaseID() string { return advisory.verdict.PhaseID() }
+
+// Err reports a fail-closed cached-source failure.
+func (advisory Advisory) Err() error { return advisory.verdict.Err() }
 
 // FlowReader reads a Flow authoritatively.
 type FlowReader interface {
@@ -598,6 +608,10 @@ func queryFlowCache(cache FlowCache, flowID, phaseID string, purpose Purpose) Ve
 }
 
 func phaseHasLiveSession(phase flowstore.FlowPhase) bool {
+	return phaseHasLiveSessionExcept(phase, SessionIdentity{})
+}
+
+func phaseHasLiveSessionExcept(phase flowstore.FlowPhase, skip SessionIdentity) bool {
 	launches := make(map[string]struct{}, len(phase.LaunchIDs))
 	for _, launchID := range phase.LaunchIDs {
 		if launchID = strings.TrimSpace(launchID); launchID != "" {
@@ -605,7 +619,7 @@ func phaseHasLiveSession(phase flowstore.FlowPhase) bool {
 		}
 	}
 	for _, session := range phase.Sessions {
-		if strings.TrimSpace(session.SessionID) == "" {
+		if strings.TrimSpace(session.SessionID) == "" || skip.matches(session.Provider, session.SessionID) {
 			continue
 		}
 		if _, ok := launches[strings.TrimSpace(session.LaunchID)]; !ok {
@@ -695,9 +709,13 @@ func (occupancy Occupancy) Query(query Query) Verdict {
 }
 
 func (occupancy Occupancy) queryAuthoritative(query Query, policy purposePolicy, flowID string) Verdict {
-	if query.Purpose.Role != actions.RoleTrackedPhase ||
-		(query.Purpose.Stage != StageAuthoritative && query.Purpose.Stage != StageAutoAdvance) {
+	if query.Purpose.Stage != StageAuthoritative && query.Purpose.Stage != StageAutoAdvance && query.Purpose.Stage != StageReserved {
 		return failedVerdict(errPendingSourceFamily)
+	}
+	if query.Purpose.Stage == StageReserved && policy.sources&readLease != 0 {
+		if verdict := queryLease(occupancy.sources.Lease, flowID); verdict.Occupied() {
+			return verdict
+		}
 	}
 	if policy.sources&readFlowStore == 0 {
 		return failedVerdict(errPendingSourceFamily)
@@ -727,6 +745,72 @@ func (occupancy Occupancy) queryAuthoritative(query Query, policy purposePolicy,
 	if err != nil {
 		return failedVerdict(err)
 	}
+	if query.Purpose.Role == actions.RoleRepair {
+		for _, phase := range flowstore.OrderedPhases(record.Phases) {
+			if phaseHasLiveSession(phase) || phaseHasLiveStoredSession(flowID, phase, records) {
+				return Verdict{holder: HolderPhaseSession, phaseID: phase.PhaseID}
+			}
+		}
+		return Free()
+	}
+	if query.Purpose.Role == actions.RoleAutofix {
+		for _, phase := range record.Phases {
+			if flowstore.PhaseStatusTerminal(string(phase.Status)) {
+				continue
+			}
+			if phaseHasLiveSession(phase) || phaseHasLiveStoredSession(flowID, phase, records) {
+				return Verdict{holder: HolderPhaseSession, phaseID: phase.PhaseID}
+			}
+		}
+		return Free()
+	}
+	if query.Purpose.Role == actions.RoleWorktreeAgent {
+		for _, stored := range records {
+			if strings.TrimSpace(stored.FlowID) == flowID && sessions.IsActive(stored.Status, stored.EndedAt) {
+				return Verdict{holder: HolderFlowSession}
+			}
+		}
+		for _, phase := range record.Phases {
+			if phaseHasLiveSession(phase) || phaseHasLiveStoredSession(flowID, phase, records) {
+				return Verdict{holder: HolderPhaseSession, phaseID: phase.PhaseID}
+			}
+			if phase.Status == flowstore.PhaseRunning {
+				return Verdict{holder: HolderRunningPhase, phaseID: phase.PhaseID}
+			}
+		}
+		return Free()
+	}
+	if query.Purpose.Role == actions.RoleSavedSessionResume {
+		for _, phase := range record.Phases {
+			if phase.Status == flowstore.PhaseRunning {
+				return Verdict{holder: HolderRunningPhase, phaseID: phase.PhaseID}
+			}
+			if phaseHasLiveSession(phase) || phaseHasLiveStoredSession(flowID, phase, records) {
+				return Verdict{holder: HolderPhaseSession, phaseID: phase.PhaseID}
+			}
+		}
+		for _, stored := range records {
+			if strings.TrimSpace(stored.FlowID) == flowID && strings.TrimSpace(stored.SessionID) != "" && sessions.IsActive(stored.Status, stored.EndedAt) {
+				return Verdict{holder: HolderFlowSession}
+			}
+		}
+		return Free()
+	}
+	if query.Purpose.Role == actions.RolePhaseResume {
+		for _, phase := range record.Phases {
+			if phase.PhaseID != query.PhaseID {
+				continue
+			}
+			if phaseHasLiveSessionExcept(phase, query.SkipSession) || phaseHasLiveStoredSessionExcept(flowID, phase, records, query.SkipSession) {
+				return Verdict{holder: HolderPhaseSession, phaseID: phase.PhaseID}
+			}
+			break
+		}
+		return Free()
+	}
+	if query.Purpose.Role != actions.RoleTrackedPhase {
+		return failedVerdict(errPendingSourceFamily)
+	}
 	phaseID := query.PhaseID
 	for _, phase := range record.Phases {
 		if phase.PhaseID != phaseID {
@@ -741,6 +825,10 @@ func (occupancy Occupancy) queryAuthoritative(query Query, policy purposePolicy,
 }
 
 func phaseHasLiveStoredSession(flowID string, phase flowstore.FlowPhase, records []sessions.SessionRecord) bool {
+	return phaseHasLiveStoredSessionExcept(flowID, phase, records, SessionIdentity{})
+}
+
+func phaseHasLiveStoredSessionExcept(flowID string, phase flowstore.FlowPhase, records []sessions.SessionRecord, skip SessionIdentity) bool {
 	launches := make(map[string]struct{}, len(phase.LaunchIDs))
 	for _, launchID := range phase.LaunchIDs {
 		if launchID = strings.TrimSpace(launchID); launchID != "" {
@@ -748,7 +836,7 @@ func phaseHasLiveStoredSession(flowID string, phase flowstore.FlowPhase, records
 		}
 	}
 	for _, record := range records {
-		if record.FlowID != flowID || strings.TrimSpace(record.SessionID) == "" {
+		if record.FlowID != flowID || strings.TrimSpace(record.SessionID) == "" || skip.matches(string(record.Provider), record.SessionID) {
 			continue
 		}
 		if _, ok := launches[strings.TrimSpace(record.LaunchID)]; !ok {
@@ -759,6 +847,12 @@ func phaseHasLiveStoredSession(flowID string, phase flowstore.FlowPhase, records
 		}
 	}
 	return false
+}
+
+func (identity SessionIdentity) matches(provider, sessionID string) bool {
+	return strings.TrimSpace(identity.SessionID) != "" &&
+		agent.Normalize(provider) == agent.Normalize(identity.Provider) &&
+		sessionID == identity.SessionID
 }
 
 func queryLease(inspector LeaseInspector, flowID string) Verdict {

--- a/flowoccupancy/occupancy_internal_test.go
+++ b/flowoccupancy/occupancy_internal_test.go
@@ -239,6 +239,280 @@ func TestAuthoritativePhaseSessionEvaluation(t *testing.T) {
 	}
 }
 
+func TestRepairAuthoritativeOccupancy(t *testing.T) {
+	tests := []struct {
+		name       string
+		running    bool
+		live       bool
+		wantHolder Holder
+		wantPhase  string
+	}{
+		{name: "running phase is not occupancy"},
+		{name: "live phase session", live: true, wantHolder: HolderPhaseSession, wantPhase: "review"},
+		{name: "live phase session wins over running status", running: true, live: true, wantHolder: HolderPhaseSession, wantPhase: "review"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runningStatus := flowstore.PhaseReady
+			if tc.running {
+				runningStatus = flowstore.PhaseRunning
+			}
+			review := flowstore.FlowPhase{
+				PhaseID:   "review",
+				Status:    flowstore.PhaseReady,
+				LaunchIDs: []string{"launch-review"},
+			}
+			if tc.live {
+				review.Sessions = []flowstore.Session{{
+					SessionID: "session-review", LaunchID: "launch-review", Status: "running",
+				}}
+			}
+			record := flowstore.FlowRecord{
+				FlowID: "flow-1",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "implementation", Status: runningStatus},
+					review,
+				},
+			}
+			verdict := Evaluate(Sources{
+				Flows:    &flowReaderFixture{t: t, wantFlowID: "flow-1", record: record},
+				Sessions: &sessionStoreFixture{t: t, wantFlowID: "flow-1"},
+			}, Query{
+				FlowID:  "flow-1",
+				Purpose: Purpose{Role: actions.RoleRepair, Stage: StageAuthoritative},
+			})
+			if verdict.Holder() != tc.wantHolder || verdict.PhaseID() != tc.wantPhase || verdict.Err() != nil {
+				t.Fatalf("verdict = (%v, %q, %v), want (%v, %q, nil)", verdict.Holder(), verdict.PhaseID(), verdict.Err(), tc.wantHolder, tc.wantPhase)
+			}
+		})
+	}
+}
+
+func TestAutofixAuthoritativeOccupancy(t *testing.T) {
+	tests := []struct {
+		name       string
+		running    bool
+		live       bool
+		terminal   bool
+		wantHolder Holder
+		wantPhase  string
+	}{
+		{name: "running phase is not occupancy"},
+		{name: "live phase session", live: true, wantHolder: HolderPhaseSession, wantPhase: "review"},
+		{name: "live phase session wins over running status", running: true, live: true, wantHolder: HolderPhaseSession, wantPhase: "review"},
+		{name: "terminal phase session is not occupancy", live: true, terminal: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runningStatus := flowstore.PhaseReady
+			if tc.running {
+				runningStatus = flowstore.PhaseRunning
+			}
+			reviewStatus := flowstore.PhaseReady
+			if tc.terminal {
+				reviewStatus = flowstore.PhaseCompleted
+			}
+			review := flowstore.FlowPhase{
+				PhaseID:   "review",
+				Status:    reviewStatus,
+				LaunchIDs: []string{"launch-review"},
+			}
+			if tc.live {
+				review.Sessions = []flowstore.Session{{
+					SessionID: "session-review", LaunchID: "launch-review", Status: "running",
+				}}
+			}
+			record := flowstore.FlowRecord{
+				FlowID: "flow-1",
+				Phases: []flowstore.FlowPhase{
+					{PhaseID: "implementation", Status: runningStatus},
+					review,
+				},
+			}
+			verdict := Evaluate(Sources{
+				Flows:    &flowReaderFixture{t: t, wantFlowID: "flow-1", record: record},
+				Sessions: &sessionStoreFixture{t: t, wantFlowID: "flow-1"},
+			}, Query{
+				FlowID:  "flow-1",
+				Purpose: Purpose{Role: actions.RoleAutofix, Stage: StageAuthoritative},
+			})
+			if verdict.Holder() != tc.wantHolder || verdict.PhaseID() != tc.wantPhase || verdict.Err() != nil {
+				t.Fatalf("verdict = (%v, %q, %v), want (%v, %q, nil)", verdict.Holder(), verdict.PhaseID(), verdict.Err(), tc.wantHolder, tc.wantPhase)
+			}
+		})
+	}
+}
+
+func TestWorktreeAgentAuthoritativeOccupancy(t *testing.T) {
+	tests := []struct {
+		name        string
+		phaseStatus flowstore.PhaseStatus
+		phaseLive   bool
+		stored      []sessions.SessionRecord
+		wantHolder  Holder
+		wantPhase   string
+	}{
+		{name: "running phase", phaseStatus: flowstore.PhaseRunning, wantHolder: HolderRunningPhase, wantPhase: "implementation"},
+		{name: "live phase session", phaseStatus: flowstore.PhaseReady, phaseLive: true, wantHolder: HolderPhaseSession, wantPhase: "implementation"},
+		{name: "live phase session wins within running phase", phaseStatus: flowstore.PhaseRunning, phaseLive: true, wantHolder: HolderPhaseSession, wantPhase: "implementation"},
+		{
+			name: "exact Flow stored session wins",
+			stored: []sessions.SessionRecord{
+				{FlowID: "flow-10", SessionID: "prefix", Status: "running"},
+				{FlowID: "flow-1", SessionID: "exact", Status: "running"},
+			},
+			phaseStatus: flowstore.PhaseRunning,
+			phaseLive:   true,
+			wantHolder:  HolderFlowSession,
+		},
+		{name: "terminal phase session remains occupancy", phaseStatus: flowstore.PhaseCompleted, phaseLive: true, wantHolder: HolderPhaseSession, wantPhase: "implementation"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			phase := flowstore.FlowPhase{
+				PhaseID:   "implementation",
+				Status:    tc.phaseStatus,
+				LaunchIDs: []string{"launch-1"},
+			}
+			if tc.phaseLive {
+				phase.Sessions = []flowstore.Session{{SessionID: "phase-session", LaunchID: "launch-1", Status: "running"}}
+			}
+			record := flowstore.FlowRecord{FlowID: "flow-1", Phases: []flowstore.FlowPhase{phase}}
+			verdict := Evaluate(Sources{
+				Flows:    &flowReaderFixture{t: t, wantFlowID: "flow-1", record: record},
+				Sessions: &sessionStoreFixture{t: t, wantFlowID: "flow-1", records: tc.stored},
+			}, Query{
+				FlowID:  "flow-1",
+				Purpose: Purpose{Role: actions.RoleWorktreeAgent, Stage: StageAuthoritative},
+			})
+			if verdict.Holder() != tc.wantHolder || verdict.PhaseID() != tc.wantPhase || verdict.Err() != nil {
+				t.Fatalf("verdict = (%v, %q, %v), want (%v, %q, nil)", verdict.Holder(), verdict.PhaseID(), verdict.Err(), tc.wantHolder, tc.wantPhase)
+			}
+		})
+	}
+}
+
+func TestSavedSessionResumeAuthoritativeOccupancy(t *testing.T) {
+	tests := []struct {
+		name        string
+		phaseStatus flowstore.PhaseStatus
+		phaseLive   bool
+		stored      []sessions.SessionRecord
+		wantHolder  Holder
+		wantPhase   string
+	}{
+		{name: "running phase", phaseStatus: flowstore.PhaseRunning, wantHolder: HolderRunningPhase, wantPhase: "implementation"},
+		{name: "live phase session", phaseStatus: flowstore.PhaseReady, phaseLive: true, wantHolder: HolderPhaseSession, wantPhase: "implementation"},
+		{name: "running status wins within live phase", phaseStatus: flowstore.PhaseRunning, phaseLive: true, wantHolder: HolderRunningPhase, wantPhase: "implementation"},
+		{
+			name:        "active exact Flow stored session",
+			phaseStatus: flowstore.PhaseReady,
+			stored: []sessions.SessionRecord{
+				{FlowID: "flow-10", SessionID: "prefix", Status: "running"},
+				{FlowID: "flow-1", SessionID: "exact", Status: "running"},
+			},
+			wantHolder: HolderFlowSession,
+		},
+		{
+			name:        "phase occupancy precedes Flow stored session",
+			phaseStatus: flowstore.PhaseRunning,
+			stored:      []sessions.SessionRecord{{FlowID: "flow-1", SessionID: "exact", Status: "running"}},
+			wantHolder:  HolderRunningPhase,
+			wantPhase:   "implementation",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			phase := flowstore.FlowPhase{
+				PhaseID:   "implementation",
+				Status:    tc.phaseStatus,
+				LaunchIDs: []string{"launch-1"},
+			}
+			if tc.phaseLive {
+				phase.Sessions = []flowstore.Session{{SessionID: "phase-session", LaunchID: "launch-1", Status: "running"}}
+			}
+			record := flowstore.FlowRecord{FlowID: "flow-1", Phases: []flowstore.FlowPhase{phase}}
+			verdict := Evaluate(Sources{
+				Flows:    &flowReaderFixture{t: t, wantFlowID: "flow-1", record: record},
+				Sessions: &sessionStoreFixture{t: t, wantFlowID: "flow-1", records: tc.stored},
+			}, Query{
+				FlowID:  "flow-1",
+				Purpose: Purpose{Role: actions.RoleSavedSessionResume, Stage: StageAuthoritative},
+			})
+			if verdict.Holder() != tc.wantHolder || verdict.PhaseID() != tc.wantPhase || verdict.Err() != nil {
+				t.Fatalf("verdict = (%v, %q, %v), want (%v, %q, nil)", verdict.Holder(), verdict.PhaseID(), verdict.Err(), tc.wantHolder, tc.wantPhase)
+			}
+		})
+	}
+}
+
+func TestPhaseResumeAuthoritativeOccupancyRemainsPhaseScopedWithSessionExemption(t *testing.T) {
+	target := flowstore.Session{
+		Provider: "Codex", SessionID: "target", LaunchID: "launch-implementation", Status: "running",
+	}
+	record := flowstore.FlowRecord{
+		FlowID: "flow-1",
+		Phases: []flowstore.FlowPhase{
+			{
+				PhaseID:   "implementation",
+				LaunchIDs: []string{"launch-implementation"},
+				Sessions:  []flowstore.Session{target},
+			},
+			{
+				PhaseID:   "review",
+				LaunchIDs: []string{"launch-review"},
+				Sessions: []flowstore.Session{{
+					Provider: "claude", SessionID: "other-phase", LaunchID: "launch-review", Status: "running",
+				}},
+			},
+		},
+	}
+	query := Query{
+		FlowID:      "flow-1",
+		Purpose:     Purpose{Role: actions.RolePhaseResume, Stage: StageAuthoritative},
+		PhaseID:     "implementation",
+		SkipSession: SessionIdentity{Provider: "codex", SessionID: "target"},
+	}
+	evaluate := func(record flowstore.FlowRecord) Verdict {
+		return Evaluate(Sources{
+			Flows:    &flowReaderFixture{t: t, wantFlowID: "flow-1", record: record},
+			Sessions: &sessionStoreFixture{t: t, wantFlowID: "flow-1"},
+		}, query)
+	}
+	if verdict := evaluate(record); verdict.Occupied() || verdict.Err() != nil {
+		t.Fatalf("exempt target plus other-phase session verdict = (%v, %q, %v), want free", verdict.Holder(), verdict.PhaseID(), verdict.Err())
+	}
+	record.Phases[0].Sessions = append(record.Phases[0].Sessions, flowstore.Session{
+		Provider: "claude", SessionID: "competitor", LaunchID: "launch-implementation", Status: "running",
+	})
+	if verdict := evaluate(record); verdict.Holder() != HolderPhaseSession || verdict.PhaseID() != "implementation" || verdict.Err() != nil {
+		t.Fatalf("same-phase competitor verdict = (%v, %q, %v), want phase session on implementation", verdict.Holder(), verdict.PhaseID(), verdict.Err())
+	}
+}
+
+func TestReservedAuthoritativePurposesCheckLeaseBeforeStores(t *testing.T) {
+	for _, role := range []actions.FlowLaunchRole{
+		actions.RoleRepair,
+		actions.RoleAutofix,
+		actions.RoleWorktreeAgent,
+		actions.RoleSavedSessionResume,
+	} {
+		t.Run(role.String(), func(t *testing.T) {
+			verdict := Evaluate(Sources{
+				Lease:    &leaseFixture{t: t, wantFlowID: "flow-1", occupied: true},
+				Flows:    panicFlowReader{},
+				Sessions: panicSessionStore{},
+			}, Query{
+				FlowID:  "flow-1",
+				Purpose: Purpose{Role: role, Stage: StageReserved},
+			})
+			if verdict.Holder() != HolderPeerLease || verdict.Err() != nil {
+				t.Fatalf("verdict = (%v, %v), want peer lease", verdict.Holder(), verdict.Err())
+			}
+		})
+	}
+}
+
 func TestAutoAdvanceAuthoritativeRunningPhasePrecedesSession(t *testing.T) {
 	record := flowstore.FlowRecord{
 		FlowID: "flow-1",

--- a/model/flow_launch_adapters.go
+++ b/model/flow_launch_adapters.go
@@ -115,9 +115,21 @@ type flowOccupancyAuthoritativeSessions struct {
 	list func(string) ([]sessions.SessionRecord, error)
 }
 
+type flowOccupancyKnownLease struct {
+	occupied bool
+	err      error
+}
+
+func (lease flowOccupancyKnownLease) FlowLeaseOccupied(string) (bool, error) {
+	return lease.occupied, lease.err
+}
+
 var _ flowoccupancy.SessionStore = flowOccupancyAuthoritativeSessions{}
 
 func (source flowOccupancyAuthoritativeSessions) ListFlowSessions(flowID string) ([]sessions.SessionRecord, error) {
+	if source.list == nil {
+		return nil, fmt.Errorf("Flow session reader is unavailable")
+	}
 	return source.list(flowID)
 }
 
@@ -210,6 +222,66 @@ func trackedPhaseAuthoritativeOccupancy(
 		},
 		Freshness: flowoccupancy.FreshnessAuthoritative,
 		PhaseID:   phaseID,
+	})
+}
+
+func flowAuthoritativeOccupancy(
+	seams flowLaunchSeams,
+	flowID string,
+	record flowstore.FlowRecord,
+	role actions.FlowLaunchRole,
+) flowoccupancy.Verdict {
+	return flowoccupancy.Evaluate(flowoccupancy.Sources{
+		Flows:    flowOccupancyAuthoritativeFlow{record: record},
+		Sessions: flowOccupancyAuthoritativeSessions{list: seams.ListFlowSessions},
+	}, flowoccupancy.Query{
+		FlowID: flowID,
+		Purpose: flowoccupancy.Purpose{
+			Role:  role,
+			Stage: flowoccupancy.StageAuthoritative,
+		},
+	})
+}
+
+func (m Model) flowReservedOccupancy(
+	seams flowLaunchSeams,
+	flowID string,
+	record flowstore.FlowRecord,
+	role actions.FlowLaunchRole,
+) flowoccupancy.Verdict {
+	return flowoccupancy.Evaluate(flowoccupancy.Sources{
+		Flows:    flowOccupancyAuthoritativeFlow{record: record},
+		Sessions: flowOccupancyAuthoritativeSessions{list: seams.ListFlowSessions},
+		Lease: flowOccupancyLeaseInspector{
+			root:     m.sessionStateRoot,
+			injected: m.leaseInspectInjected,
+			inspect:  m.inspectFlowLease,
+		},
+	}, flowoccupancy.Query{
+		FlowID: flowID,
+		Purpose: flowoccupancy.Purpose{
+			Role:  role,
+			Stage: flowoccupancy.StageReserved,
+		},
+	})
+}
+
+func flowReservedOccupancyAfterFreeLease(
+	seams flowLaunchSeams,
+	flowID string,
+	record flowstore.FlowRecord,
+	role actions.FlowLaunchRole,
+) flowoccupancy.Verdict {
+	return flowoccupancy.Evaluate(flowoccupancy.Sources{
+		Flows:    flowOccupancyAuthoritativeFlow{record: record},
+		Sessions: flowOccupancyAuthoritativeSessions{list: seams.ListFlowSessions},
+		Lease:    flowOccupancyKnownLease{},
+	}, flowoccupancy.Query{
+		FlowID: flowID,
+		Purpose: flowoccupancy.Purpose{
+			Role:  role,
+			Stage: flowoccupancy.StageReserved,
+		},
 	})
 }
 

--- a/model/flow_launch_autofix.go
+++ b/model/flow_launch_autofix.go
@@ -5,9 +5,10 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
+	"github.com/approachcontrol/approach/flowoccupancy"
 	"github.com/approachcontrol/approach/flowstore"
-	"github.com/approachcontrol/approach/sessions"
 )
 
 // The autofix refusals. Each is new against
@@ -236,13 +237,8 @@ func autofixFlowLaunchReadCmd(seams flowLaunchSeams, intent flowLaunchIntent, to
 			event.Err = flowAutofixDriftStatus
 			return event
 		}
-		records, err := seams.ListFlowSessions(intent.FlowID)
-		if err != nil {
-			event.Err = err.Error()
-			return event
-		}
-		if flowRecordHasLivePhaseSession(record, records) {
-			event.Err = flowAutofixLiveSessionStatus
+		if verdict := flowAuthoritativeOccupancy(seams, intent.FlowID, record, actions.RoleAutofix); verdict.Occupied() {
+			event.Err = autofixAuthoritativeOccupancyStatus(intent.FlowID, record, verdict)
 			return event
 		}
 		repoPath := record.RepoPath
@@ -261,24 +257,26 @@ func autofixFlowLaunchReadCmd(seams flowLaunchSeams, intent flowLaunchIntent, to
 	}
 }
 
-// flowRecordHasLivePhaseSession applies the phase-scoped live-session rule
-// across every non-terminal phase of the record. It stays phase-scoped, and
+// autofixAuthoritativeOccupancyStatus keeps autofix's existing refusal text in
+// model. The module applies the phase-scoped live-session rule across every
+// non-terminal phase of the record. It stays phase-scoped, and
 // skips terminal phases, for the same reason flowLaunchPhaseSessionOccupied's
 // own doc comment gives: a wider rule would let one crashed agent make the Flow
 // permanently unlaunchable, and here that would be worse than elsewhere —
 // repair reports no obstruction for a merge-eligible Flow, so U would be dead
 // with no in-TUI recovery. A merge-eligible Flow has every predecessor
 // completed, so counting terminal phases would be exactly that wider rule.
-func flowRecordHasLivePhaseSession(record flowstore.FlowRecord, records []sessions.SessionRecord) bool {
-	for _, phase := range record.Phases {
-		if flowstore.PhaseStatusTerminal(string(phase.Status)) {
-			continue
-		}
-		if flowLaunchPhaseSessionOccupied(phase, records) {
-			return true
-		}
+func autofixAuthoritativeOccupancyStatus(flowID string, record flowstore.FlowRecord, verdict flowoccupancy.Verdict) string {
+	if strings.TrimSpace(record.FlowID) != flowID {
+		return flowAutofixDriftStatus
 	}
-	return false
+	if verdict.Err() != nil {
+		return verdict.Err().Error()
+	}
+	if verdict.Holder() == flowoccupancy.HolderPhaseSession {
+		return flowAutofixLiveSessionStatus
+	}
+	return flowAutofixDriftStatus
 }
 
 // autofixFlowLaunchPrepareCmd takes the cross-process launch/close
@@ -327,16 +325,6 @@ func (m Model) autofixFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flow
 		// advisory launch/close lock; losing it would block every later launch,
 		// close, repair, or resume on this Flow until it timed out.
 		event.Release = release
-		if occupied, inspectErr := m.trackedFlowLeaseOccupied(msg.FlowID); inspectErr != nil {
-			event.LeaseDeferred = true
-			event.LeaseSetupError = true
-			event.Err = flowLeaseSetupErrorStatus(inspectErr)
-			return event
-		} else if occupied {
-			event.LeaseDeferred = true
-			event.Err = flowLeaseOccupiedStatus
-			return event
-		}
 		record := msg.Record
 		headless := msg.Headless
 		repoPath := msg.RepoPath
@@ -345,10 +333,6 @@ func (m Model) autofixFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flow
 		// stage validated. flowLaunchPreparation.prepare guards its own refresh the
 		// same way.
 		if !reserved.UpdatedAt.IsZero() {
-			if !autofixFlowEligible(reserved) || reserved.PR.Number <= 0 {
-				event.Err = flowAutofixDriftStatus
-				return event
-			}
 			record = reserved
 			headless = reserved.Headless
 			if reservedRepoPath := strings.TrimSpace(reserved.RepoPath); reservedRepoPath != "" {
@@ -361,6 +345,24 @@ func (m Model) autofixFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flow
 			// The record's plan path verbatim, exactly as the read stage passes it
 			// through: this agent needs no plan body.
 			event.PlanPath = record.PlanPath
+		}
+		verdict := m.flowReservedOccupancy(m.launchSeams, msg.FlowID, record, actions.RoleAutofix)
+		if verdict.Holder() == flowoccupancy.HolderLeaseUnreadable {
+			event.LeaseDeferred = true
+			event.LeaseSetupError = true
+			event.Err = flowLeaseSetupErrorStatus(verdict.Err())
+			return event
+		} else if verdict.Holder() == flowoccupancy.HolderPeerLease {
+			event.LeaseDeferred = true
+			event.Err = flowLeaseOccupiedStatus
+			return event
+		} else if verdict.Occupied() {
+			event.Err = autofixAuthoritativeOccupancyStatus(msg.FlowID, record, verdict)
+			return event
+		}
+		if !autofixFlowEligible(record) || record.PR.Number <= 0 {
+			event.Err = flowAutofixDriftStatus
+			return event
 		}
 		// The read stage's repo path is submitted as a fallback rather than
 		// applied here: the builder owns the precedence between it and the record,

--- a/model/flow_launch_autofix_internal_test.go
+++ b/model/flow_launch_autofix_internal_test.go
@@ -879,6 +879,30 @@ func TestAutofixPrepareRechecksLeaseUnderReservation(t *testing.T) {
 	}
 }
 
+func TestAutofixPrepareRechecksLivePhaseSessionsUnderReservation(t *testing.T) {
+	record := autofixFlowRecord()
+	h := newManualLaunchHarness(t, record)
+	m, prepareCmd := h.stageAutofixLaunch(h.model())
+	h.record.Phases[len(h.record.Phases)-1].LaunchIDs = []string{"late-launch"}
+	h.sessionRecords = []sessions.SessionRecord{liveFlowSession(record.FlowID, "late-launch", "late-session")}
+
+	preparedMsg, ok := runCommandWithoutWaiting(prepareCmd)
+	if !ok {
+		t.Fatal("prepare did not settle")
+	}
+	m = h.drainMsg(m, preparedMsg, 0)
+
+	if len(h.launchContexts) != 0 || len(h.tmuxContexts) != 0 {
+		t.Fatalf("late phase session started autofix: embedded=%d tmux=%d", len(h.launchContexts), len(h.tmuxContexts))
+	}
+	if m.status.Text != flowAutofixLiveSessionStatus {
+		t.Fatalf("status = %q, want %q", m.status.Text, flowAutofixLiveSessionStatus)
+	}
+	if h.launchReservations != 1 || h.launchReleases != 1 {
+		t.Fatalf("reservations=%d releases=%d, want protected refusal and release", h.launchReservations, h.launchReleases)
+	}
+}
+
 // TestAutofixPrepareResolvesHeadlessFromTheReservation pins the reason
 // prepare uses the reservation's record rather than the read stage's: this kind
 // writes no phase, so that record is its only fresh read of the Flow before the

--- a/model/flow_launch_generic_agent.go
+++ b/model/flow_launch_generic_agent.go
@@ -6,7 +6,9 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
+	"github.com/approachcontrol/approach/flowoccupancy"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
 )
@@ -111,8 +113,13 @@ func (m Model) admitWorktreeAgentFlowLaunch(intent flowLaunchIntent) (Model, tea
 	if m.hasKnownActiveFlowSession(intent.FlowID) {
 		return m.setStatus(statusOther, flowWorktreeAgentSessionStatus), nil, false
 	}
-	if reason := genericFlowRuntimeOccupancyReason(record); reason != "" {
-		return m.setStatus(statusOther, reason), nil, false
+	if advice := m.worktreeAgentFooterAdvice(record); advice.Defer() {
+		switch advice.Holder() {
+		case flowoccupancy.HolderPhaseSession:
+			return m.setStatus(statusOther, fmt.Sprintf("an active persisted session on phase %s already occupies this Flow", advice.PhaseID())), nil, false
+		case flowoccupancy.HolderRunningPhase:
+			return m.setStatus(statusOther, fmt.Sprintf("a running phase %s already occupies this Flow", advice.PhaseID())), nil, false
+		}
 	}
 	token := strings.TrimSpace(m.launchSeams.newLaunchID())
 	if token == "" {
@@ -148,25 +155,23 @@ func genericWorktreeAgentFlowEligible(record flowstore.FlowRecord) bool {
 		!flowstore.PreparationLaunchBlocked(record)
 }
 
-func genericFlowRuntimeOccupancyReason(record flowstore.FlowRecord) string {
-	for _, phase := range record.Phases {
-		if phaseHasMatchingLiveSession(phase) {
-			return fmt.Sprintf("an active persisted session on phase %s already occupies this Flow", phase.PhaseID)
-		}
-		if phase.Status == flowstore.PhaseRunning {
-			return fmt.Sprintf("a running phase %s already occupies this Flow", phase.PhaseID)
-		}
+func worktreeAgentAuthoritativeOccupancyStatus(flowID string, record flowstore.FlowRecord, verdict flowoccupancy.Verdict) string {
+	if strings.TrimSpace(record.FlowID) != flowID {
+		return flowWorktreeAgentStaleStatus
 	}
-	return ""
-}
-
-func activeFlowSession(records []sessions.SessionRecord) bool {
-	for _, record := range records {
-		if sessions.IsActive(record.Status, record.EndedAt) {
-			return true
-		}
+	if verdict.Err() != nil {
+		return verdict.Err().Error()
 	}
-	return false
+	switch verdict.Holder() {
+	case flowoccupancy.HolderFlowSession:
+		return flowWorktreeAgentSessionStatus
+	case flowoccupancy.HolderPhaseSession:
+		return fmt.Sprintf("an active persisted session on phase %s already occupies this Flow", verdict.PhaseID())
+	case flowoccupancy.HolderRunningPhase:
+		return fmt.Sprintf("a running phase %s already occupies this Flow", verdict.PhaseID())
+	default:
+		return flowWorktreeAgentStaleStatus
+	}
 }
 
 func worktreeAgentFlowLaunchReadCmd(seams flowLaunchSeams, intent flowLaunchIntent, token string) tea.Cmd {
@@ -185,17 +190,8 @@ func worktreeAgentFlowLaunchReadCmd(seams flowLaunchSeams, intent flowLaunchInte
 			event.Err = flowWorktreeAgentPathStatus
 			return event
 		}
-		recordSessions, err := seams.ListFlowSessions(intent.FlowID)
-		if err != nil {
-			event.Err = err.Error()
-			return event
-		}
-		if activeFlowSession(recordSessions) {
-			event.Err = flowWorktreeAgentSessionStatus
-			return event
-		}
-		if reason := genericFlowRuntimeOccupancyReason(record); reason != "" {
-			event.Err = reason
+		if verdict := flowAuthoritativeOccupancy(seams, intent.FlowID, record, actions.RoleWorktreeAgent); verdict.Occupied() {
+			event.Err = worktreeAgentAuthoritativeOccupancyStatus(intent.FlowID, record, verdict)
 			return event
 		}
 		planPath := strings.TrimSpace(record.PlanPath)
@@ -238,31 +234,22 @@ func (m Model) worktreeAgentFlowLaunchPrepareCmd(msg flowLaunchEventMsg, setting
 			return event
 		}
 		event.Release = release
-		if occupied, inspectErr := m.trackedFlowLeaseOccupied(msg.FlowID); inspectErr != nil {
+		verdict := m.flowReservedOccupancy(seams, msg.FlowID, record, actions.RoleWorktreeAgent)
+		if verdict.Holder() == flowoccupancy.HolderLeaseUnreadable {
 			event.LeaseDeferred = true
 			event.LeaseSetupError = true
-			event.Err = flowLeaseSetupErrorStatus(inspectErr)
+			event.Err = flowLeaseSetupErrorStatus(verdict.Err())
 			return event
-		} else if occupied {
+		} else if verdict.Holder() == flowoccupancy.HolderPeerLease {
 			event.LeaseDeferred = true
 			event.Err = flowLeaseOccupiedStatus
+			return event
+		} else if verdict.Occupied() {
+			event.Err = worktreeAgentAuthoritativeOccupancyStatus(msg.FlowID, record, verdict)
 			return event
 		}
 		if record.FlowID != msg.FlowID || !genericWorktreeAgentFlowEligible(record) {
 			event.Err = flowWorktreeAgentStaleStatus
-			return event
-		}
-		recordSessions, err := seams.ListFlowSessions(msg.FlowID)
-		if err != nil {
-			event.Err = err.Error()
-			return event
-		}
-		if activeFlowSession(recordSessions) {
-			event.Err = flowWorktreeAgentSessionStatus
-			return event
-		}
-		if reason := genericFlowRuntimeOccupancyReason(record); reason != "" {
-			event.Err = reason
 			return event
 		}
 		if err := seams.inspectWorktreeDirectory(record.WorktreePath); err != nil {

--- a/model/flow_launch_repair.go
+++ b/model/flow_launch_repair.go
@@ -6,10 +6,10 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/approachcontrol/approach/actions"
 	"github.com/approachcontrol/approach/agent"
 	"github.com/approachcontrol/approach/flowoccupancy"
 	"github.com/approachcontrol/approach/flowstore"
-	"github.com/approachcontrol/approach/sessions"
 )
 
 // The repair refusals. Two of these are shared for the same load-bearing
@@ -245,16 +245,8 @@ func repairFlowLaunchReadCmd(seams flowLaunchSeams, intent flowLaunchIntent, tok
 			event.Err = flowRepairNotRepairableStatus
 			return event
 		}
-		records, err := seams.ListFlowSessions(intent.FlowID)
-		if err != nil {
-			event.Err = err.Error()
-			return event
-		}
-		if phase, occupied := flowRepairPhaseSessionOccupied(record, records); occupied {
-			// The intent's Flow ID, not the record's: admission stamped it, the
-			// read resolved this record from it, and it is the exact string
-			// `approach flow read --flow-id` already takes.
-			event.Err = flowRepairLiveSessionStatus(intent.FlowID, phase)
+		if verdict := flowAuthoritativeOccupancy(seams, intent.FlowID, record, actions.RoleRepair); verdict.Occupied() {
+			event.Err = flowRepairAuthoritativeOccupancyStatus(intent.FlowID, record, verdict)
 			return event
 		}
 		repoPath, worktreePath, ok := flowRepairLaunchPaths(record.RepoPath, record.WorktreePath, intent.FallbackRepoPath)
@@ -290,7 +282,9 @@ func repairFlowLaunchReadCmd(seams flowLaunchSeams, intent flowLaunchIntent, tok
 	}
 }
 
-// flowRepairPhaseSessionOccupied is repair's Flow-scoped occupancy rule: a live
+// flowRepairAuthoritativeOccupancyStatus translates repair's Flow-scoped
+// occupancy verdict without moving model-owned recovery instructions into the
+// occupancy module. A live
 // session whose launch ID belongs to any phase of this Flow refuses the repair.
 // The per-phase evidence is the same scoping a phase launch uses, but the
 // effect is Flow-wide on purpose — the repair prompt authorizes phase reset,
@@ -320,13 +314,19 @@ func repairFlowLaunchReadCmd(seams flowLaunchSeams, intent flowLaunchIntent, tok
 // because which CLI escape is even legal depends on it. Iteration follows the
 // record's own phase order so a Flow with two occupied phases reports the same
 // one every press.
-func flowRepairPhaseSessionOccupied(record flowstore.FlowRecord, records []sessions.SessionRecord) (flowstore.FlowPhase, bool) {
-	for _, phase := range flowstore.OrderedPhases(record.Phases) {
-		if flowLaunchPhaseSessionOccupied(phase, records) {
-			return phase, true
+func flowRepairAuthoritativeOccupancyStatus(flowID string, record flowstore.FlowRecord, verdict flowoccupancy.Verdict) string {
+	if strings.TrimSpace(record.FlowID) != flowID {
+		return flowRepairNotRepairableStatus
+	}
+	if verdict.Err() != nil {
+		return verdict.Err().Error()
+	}
+	if verdict.Holder() == flowoccupancy.HolderPhaseSession {
+		if phase, ok := flowPhaseByID(record, verdict.PhaseID()); ok {
+			return flowRepairLiveSessionStatus(flowID, phase)
 		}
 	}
-	return flowstore.FlowPhase{}, false
+	return flowRepairNotRepairableStatus
 }
 
 // repairFlowLaunchPrepareCmd takes the cross-process repair reservation and
@@ -337,14 +337,10 @@ func flowRepairPhaseSessionOccupied(record flowstore.FlowRecord, records []sessi
 // launch for" vs "launch an agent for") and that text reaches the user. The
 // wrapper prefix is preserved verbatim for the same reason.
 //
-// There is no phase write here and no second session listing. What a re-listing
-// would close is not the self-inflicted race the tracked kinds have — repair
-// never calls AddPhaseLaunchID, so it publishes no launch ID of its own to race
-// against. What stays open is a peer approach process starting a phase session
-// between the read stage's listing and this reservation, and a second listing
-// would only narrow that window, not close it: the reservation excludes
-// CloseFlow and other repairs, and was never a session fence. Resume accepts
-// the same window for the same reason.
+// There is no phase write here. The reserved occupancy query re-lists sessions
+// against the reservation's Flow record, closing the read-to-reserve window as
+// far as the existing session-store seam allows. The reservation is not itself
+// a session fence, so a peer can still publish after this final listing.
 func (m Model) repairFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flowLaunchAgentSettingsSnapshot) tea.Cmd {
 	reserve := m.reserveFlowRepairLaunch
 	if reserve == nil {
@@ -376,14 +372,18 @@ func (m Model) repairFlowLaunchPrepareCmd(msg flowLaunchEventMsg, settings flowL
 		// Handed over before the revalidation below can refuse, so the handler
 		// drops the advisory launch/close lock on every path out of here.
 		event.Release = release
-		if occupied, inspectErr := m.trackedFlowLeaseOccupied(msg.FlowID); inspectErr != nil {
+		verdict := m.flowReservedOccupancy(m.launchSeams, msg.FlowID, current, actions.RoleRepair)
+		if verdict.Holder() == flowoccupancy.HolderLeaseUnreadable {
 			event.LeaseDeferred = true
 			event.LeaseSetupError = true
-			event.Err = flowLeaseSetupErrorStatus(inspectErr)
+			event.Err = flowLeaseSetupErrorStatus(verdict.Err())
 			return event
-		} else if occupied {
+		} else if verdict.Holder() == flowoccupancy.HolderPeerLease {
 			event.LeaseDeferred = true
 			event.Err = flowLeaseOccupiedStatus
+			return event
+		} else if verdict.Occupied() {
+			event.Err = flowRepairAuthoritativeOccupancyStatus(msg.FlowID, current, verdict)
 			return event
 		}
 		if strings.TrimSpace(current.FlowID) != msg.FlowID {

--- a/model/flow_launch_repair_internal_test.go
+++ b/model/flow_launch_repair_internal_test.go
@@ -99,6 +99,42 @@ func TestFlowRepairPrepareRechecksLeaseUnderReservation(t *testing.T) {
 	}
 }
 
+func TestFlowRepairPrepareRechecksLivePhaseSessionsUnderReservation(t *testing.T) {
+	record := repairLaunchFlowRecord(t)
+	h := newManualLaunchHarness(t, record)
+	m := h.repairModel()
+	next, readCmd := m.handleRepairSelectedFlow()
+	m = next.(Model)
+	readMsg, ok := runCommandWithoutWaiting(readCmd)
+	if !ok {
+		t.Fatal("repair read did not settle")
+	}
+	next, prepareCmd := m.Update(readMsg)
+	m = next.(Model)
+
+	reserved := record
+	reserved.Phases = append([]flowstore.FlowPhase(nil), record.Phases...)
+	reserved.Phases[0].LaunchIDs = []string{"late-launch"}
+	h.repairReserved, h.repairReservedOK = reserved, true
+	h.sessionRecords = []sessions.SessionRecord{liveRepairSessionRecord(record.FlowID, "late-launch")}
+
+	preparedMsg, ok := runCommandWithoutWaiting(prepareCmd)
+	if !ok {
+		t.Fatal("repair prepare did not settle")
+	}
+	m = h.drainMsg(m, preparedMsg, 0)
+
+	if len(h.launchContexts) != 0 {
+		t.Fatalf("late phase session started repair: %#v", h.launchContexts)
+	}
+	if want := flowRepairLiveSessionStatus(record.FlowID, reserved.Phases[0]); m.status.Text != want {
+		t.Fatalf("status = %q, want %q", m.status.Text, want)
+	}
+	if h.repairReservations != 1 || h.repairReleases != 1 {
+		t.Fatalf("repair reservations=%d releases=%d, want protected refusal and release", h.repairReservations, h.repairReleases)
+	}
+}
+
 func TestFlowRepairAdmissionReportsHeldLease(t *testing.T) {
 	record := repairLaunchFlowRecord(t)
 	h := newManualLaunchHarness(t, record)

--- a/model/flow_launch_saved_session_resume.go
+++ b/model/flow_launch_saved_session_resume.go
@@ -6,6 +6,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowoccupancy"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
 )
@@ -167,13 +169,12 @@ func savedSessionFlowLaunchFlowReadCmd(seams flowLaunchSeams, token string, key 
 			event.Err = err.Error()
 			return event
 		}
-		recordSessions, err := seams.ListFlowSessions(flowID)
-		if err != nil {
+		if err := validateSavedSessionResumeFlowRecord(flowID, record); err != nil {
 			event.Err = err.Error()
 			return event
 		}
-		if err := validateSavedSessionResumeFlow(flowID, record, recordSessions); err != nil {
-			event.Err = err.Error()
+		if verdict := flowAuthoritativeOccupancy(seams, flowID, record, actions.RoleSavedSessionResume); verdict.Occupied() {
+			event.Err = savedSessionResumeAuthoritativeOccupancyStatus(verdict)
 			return event
 		}
 		event.Record = record
@@ -181,27 +182,30 @@ func savedSessionFlowLaunchFlowReadCmd(seams flowLaunchSeams, token string, key 
 	}
 }
 
-func validateSavedSessionResumeFlow(flowID string, record flowstore.FlowRecord, stored []sessions.SessionRecord) error {
+func validateSavedSessionResumeFlowRecord(flowID string, record flowstore.FlowRecord) error {
 	if record.FlowID != flowID {
 		return fmt.Errorf("saved session resume expected Flow %q but read %q", flowID, record.FlowID)
 	}
 	if flowstore.FlowClosed(record) {
 		return fmt.Errorf("Flow is closed; reopen it to resume this session")
 	}
-	for _, phase := range record.Phases {
-		if phase.Status == flowstore.PhaseRunning {
-			return fmt.Errorf("a running phase already occupies this Flow")
-		}
-		if phaseHasMatchingLiveSession(phase) {
-			return fmt.Errorf("an active phase session already occupies this Flow")
-		}
-	}
-	for _, saved := range stored {
-		if strings.TrimSpace(saved.SessionID) != "" && sessions.IsActive(saved.Status, saved.EndedAt) {
-			return fmt.Errorf("an active persisted session already occupies this Flow")
-		}
-	}
 	return nil
+}
+
+func savedSessionResumeAuthoritativeOccupancyStatus(verdict flowoccupancy.Verdict) string {
+	if verdict.Err() != nil {
+		return verdict.Err().Error()
+	}
+	switch verdict.Holder() {
+	case flowoccupancy.HolderRunningPhase:
+		return "a running phase already occupies this Flow"
+	case flowoccupancy.HolderPhaseSession:
+		return "an active phase session already occupies this Flow"
+	case flowoccupancy.HolderFlowSession:
+		return "an active persisted session already occupies this Flow"
+	default:
+		return savedSessionResumeFlowOccupiedStatus
+	}
 }
 
 func (m Model) savedSessionFlowLaunchPrepareCmd(
@@ -280,13 +284,12 @@ func (m Model) savedSessionFlowLaunchPrepareCmd(
 			event.Err = tmuxFlowLiveWindowRefusal
 			return event
 		}
-		stored, err := seams.ListFlowSessions(msg.FlowID)
-		if err != nil {
+		if err := validateSavedSessionResumeFlowRecord(msg.FlowID, record); err != nil {
 			event.Err = err.Error()
 			return event
 		}
-		if err := validateSavedSessionResumeFlow(msg.FlowID, record, stored); err != nil {
-			event.Err = err.Error()
+		if verdict := flowReservedOccupancyAfterFreeLease(seams, msg.FlowID, record, actions.RoleSavedSessionResume); verdict.Occupied() {
+			event.Err = savedSessionResumeAuthoritativeOccupancyStatus(verdict)
 			return event
 		}
 		event.Record = record

--- a/model/flow_launch_saved_session_resume_internal_test.go
+++ b/model/flow_launch_saved_session_resume_internal_test.go
@@ -443,6 +443,24 @@ func originName(origin flowLaunchOrigin) string {
 	}
 }
 
+func testValidateSavedSessionResumeFlow(flowID string, record flowstore.FlowRecord, stored []sessions.SessionRecord) error {
+	if err := validateSavedSessionResumeFlowRecord(flowID, record); err != nil {
+		return err
+	}
+	for i := range stored {
+		if stored[i].FlowID == "" {
+			stored[i].FlowID = flowID
+		}
+	}
+	verdict := flowAuthoritativeOccupancy(flowLaunchSeams{
+		ListFlowSessions: func(string) ([]sessions.SessionRecord, error) { return stored, nil },
+	}, flowID, record, actions.RoleSavedSessionResume)
+	if verdict.Occupied() {
+		return errors.New(savedSessionResumeAuthoritativeOccupancyStatus(verdict))
+	}
+	return nil
+}
+
 func TestValidateSavedSessionResumeFlowOccupancy(t *testing.T) {
 	ended := sessions.SessionRecord{SessionID: "ended", Status: "ended"}
 	closedAt := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
@@ -462,7 +480,7 @@ func TestValidateSavedSessionResumeFlowOccupancy(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateSavedSessionResumeFlow("flow-1", tc.record, tc.stored)
+			err := testValidateSavedSessionResumeFlow("flow-1", tc.record, tc.stored)
 			if (err == nil) != tc.wantOK {
 				t.Fatalf("validate error = %v, wantOK %v", err, tc.wantOK)
 			}
@@ -526,6 +544,40 @@ func TestSavedSessionResumeRevalidatesUnderReservation(t *testing.T) {
 	}
 	if m.flowLaunchAttemptOccupied("flow-1") || len(m.flowLaunchSessionOwners) != 0 {
 		t.Fatal("failed protected revalidation retained ownership")
+	}
+}
+
+func TestSavedSessionResumeRefusesFreshOccupancyUnderReservation(t *testing.T) {
+	session := sessions.SessionRecord{Provider: sessions.ProviderCodex, SessionID: "session-1", FlowID: "flow-1", WorktreePath: "/repo/worktree"}
+	open := flowstore.FlowRecord{FlowID: "flow-1", Status: flowstore.StatusInProgress}
+	occupied := open
+	occupied.Phases = []flowstore.FlowPhase{{PhaseID: "implementation", Status: flowstore.PhaseRunning}}
+	started := false
+	released := false
+	m := savedSessionLifecycleModel(Options{
+		ReadSession: func(sessions.Provider, string) (sessions.SessionRecord, error) { return session, nil },
+		ReadFlow:    func(string) (flowstore.FlowRecord, error) { return open, nil },
+		ListSessions: func(sessions.SessionFilter) ([]sessions.SessionRecord, error) {
+			return nil, nil
+		},
+		ReserveFlowLaunch: func(string) (flowstore.FlowRecord, func(), error) {
+			return occupied, func() { released = true }, nil
+		},
+		StartEmbeddedTerminal: func(actions.AgentLaunchContext, int, int) (EmbeddedTerminal, error) {
+			started = true
+			return internalFakeEmbeddedTerminal{state: "running"}, nil
+		},
+	})
+	m.launchSeams.NewLaunchID = func() string { return "token" }
+	m, cmd := m.routeSavedSessionResume(session, flowLaunchOriginSessionsPane)
+	m, cmd = m.handleFlowLaunchEvent(cmd().(flowLaunchEventMsg))
+	m, cmd = m.handleFlowLaunchEvent(cmd().(flowLaunchEventMsg))
+	m, cmd = m.handleFlowLaunchEvent(cmd().(flowLaunchEventMsg))
+	if cmd != nil || started || !released || m.status.Text != "a running phase already occupies this Flow" {
+		t.Fatalf("occupancy revalidation result: cmd=%v started=%v released=%v status=%q", cmd != nil, started, released, m.status.Text)
+	}
+	if m.flowLaunchAttemptOccupied("flow-1") || len(m.flowLaunchSessionOwners) != 0 {
+		t.Fatal("occupied protected revalidation retained ownership")
 	}
 }
 

--- a/model/flow_occupancy_sessions_internal_test.go
+++ b/model/flow_occupancy_sessions_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowoccupancy"
 	"github.com/approachcontrol/approach/flowstore"
 	"github.com/approachcontrol/approach/sessions"
 )
@@ -36,6 +38,38 @@ func storedSession(provider, sessionID, launchID, status string) sessions.Sessio
 		LaunchID:  launchID,
 		Status:    status,
 	}
+}
+
+func testAuthoritativeOccupancy(record flowstore.FlowRecord, records []sessions.SessionRecord, role actions.FlowLaunchRole) flowoccupancy.Verdict {
+	for i := range records {
+		if records[i].FlowID == "" {
+			records[i].FlowID = record.FlowID
+		}
+	}
+	return flowAuthoritativeOccupancy(flowLaunchSeams{
+		ListFlowSessions: func(string) ([]sessions.SessionRecord, error) { return records, nil },
+	}, record.FlowID, record, role)
+}
+
+func repairAuthoritativePhaseSession(record flowstore.FlowRecord, records []sessions.SessionRecord) (flowstore.FlowPhase, bool) {
+	verdict := testAuthoritativeOccupancy(record, records, actions.RoleRepair)
+	if verdict.Holder() != flowoccupancy.HolderPhaseSession {
+		return flowstore.FlowPhase{}, false
+	}
+	return flowPhaseByID(record, verdict.PhaseID())
+}
+
+func worktreeAgentRecordOccupancyReason(record flowstore.FlowRecord) string {
+	verdict := testAuthoritativeOccupancy(record, nil, actions.RoleWorktreeAgent)
+	if !verdict.Occupied() {
+		return ""
+	}
+	return worktreeAgentAuthoritativeOccupancyStatus(record.FlowID, record, verdict)
+}
+
+func testActiveFlowSession(records []sessions.SessionRecord) bool {
+	record := flowstore.FlowRecord{FlowID: "flow-1"}
+	return testAuthoritativeOccupancy(record, records, actions.RoleWorktreeAgent).Holder() == flowoccupancy.HolderFlowSession
 }
 
 // TestFlowLaunchPhaseSessionOccupiedUnionRule runs one table across both halves
@@ -308,7 +342,7 @@ func TestFlowRepairPhaseSessionOccupiedReportsTheFirstOrderedPhase(t *testing.T)
 			occupied("implementation", "", 2),
 			{PhaseID: "plan", Status: flowstore.PhaseCompleted, Order: 1},
 		}
-		phase, ok := flowRepairPhaseSessionOccupied(record, nil)
+		phase, ok := repairAuthoritativePhaseSession(record, nil)
 		if !ok {
 			t.Fatal("a Flow with two session-occupied phases is occupied")
 		}
@@ -326,7 +360,7 @@ func TestFlowRepairPhaseSessionOccupiedReportsTheFirstOrderedPhase(t *testing.T)
 			occupied("review-loop", "", 3),
 			occupied("plan-review", "plan", 2),
 		}
-		phase, ok := flowRepairPhaseSessionOccupied(record, nil)
+		phase, ok := repairAuthoritativePhaseSession(record, nil)
 		if !ok {
 			t.Fatal("a Flow with two session-occupied phases is occupied")
 		}
@@ -336,7 +370,7 @@ func TestFlowRepairPhaseSessionOccupiedReportsTheFirstOrderedPhase(t *testing.T)
 	})
 
 	t.Run("no session-attached phase is not occupancy", func(t *testing.T) {
-		if _, ok := flowRepairPhaseSessionOccupied(occupancyFlowRecord(), nil); ok {
+		if _, ok := repairAuthoritativePhaseSession(occupancyFlowRecord(), nil); ok {
 			t.Fatal("a Flow with no session-attached phase is not occupied")
 		}
 	})
@@ -357,10 +391,10 @@ func TestFlowRepairPhaseSessionOccupiedUnionsTheStoreListing(t *testing.T) {
 		storedSession(occupancySessionProvider, occupancyStoreSessionID, occupancyStoreLaunchID, "active"),
 	}
 
-	if _, ok := flowRepairPhaseSessionOccupied(record, nil); ok {
+	if _, ok := repairAuthoritativePhaseSession(record, nil); ok {
 		t.Fatal("the mirror alone shows nothing here")
 	}
-	phase, ok := flowRepairPhaseSessionOccupied(record, store)
+	phase, ok := repairAuthoritativePhaseSession(record, store)
 	if !ok || phase.PhaseID != "implementation" {
 		t.Fatalf("phase = %q, ok = %v, want the store listing to occupy the phase", phase.PhaseID, ok)
 	}
@@ -385,7 +419,7 @@ func TestGenericFlowRuntimeOccupancyReasonOrdersSessionBeforeRunning(t *testing.
 	}
 
 	t.Run("no occupancy reports nothing", func(t *testing.T) {
-		if reason := genericFlowRuntimeOccupancyReason(occupancyFlowRecord()); reason != "" {
+		if reason := worktreeAgentRecordOccupancyReason(occupancyFlowRecord()); reason != "" {
 			t.Fatalf("reason = %q, want empty", reason)
 		}
 	})
@@ -393,7 +427,7 @@ func TestGenericFlowRuntimeOccupancyReasonOrdersSessionBeforeRunning(t *testing.
 	t.Run("a running phase is named", func(t *testing.T) {
 		record := withOccupancyRunningPhase(occupancyFlowRecord())
 		want := "a running phase implementation already occupies this Flow"
-		if reason := genericFlowRuntimeOccupancyReason(record); reason != want {
+		if reason := worktreeAgentRecordOccupancyReason(record); reason != want {
 			t.Fatalf("reason = %q, want %q", reason, want)
 		}
 	})
@@ -402,7 +436,7 @@ func TestGenericFlowRuntimeOccupancyReasonOrdersSessionBeforeRunning(t *testing.
 		record := occupancyFlowRecord()
 		record.Phases = []flowstore.FlowPhase{sessionPhase("implementation", 1, flowstore.PhaseRunning)}
 		want := "an active persisted session on phase implementation already occupies this Flow"
-		if reason := genericFlowRuntimeOccupancyReason(record); reason != want {
+		if reason := worktreeAgentRecordOccupancyReason(record); reason != want {
 			t.Fatalf("reason = %q, want %q", reason, want)
 		}
 	})
@@ -416,7 +450,7 @@ func TestGenericFlowRuntimeOccupancyReasonOrdersSessionBeforeRunning(t *testing.
 			sessionPhase("implementation", 1, flowstore.PhaseReady),
 		}
 		want := "an active persisted session on phase review-loop already occupies this Flow"
-		if reason := genericFlowRuntimeOccupancyReason(record); reason != want {
+		if reason := worktreeAgentRecordOccupancyReason(record); reason != want {
 			t.Fatalf("reason = %q, want %q — the loop is not order-normalized", reason, want)
 		}
 	})
@@ -431,7 +465,7 @@ func TestGenericFlowRuntimeOccupancyReasonOrdersSessionBeforeRunning(t *testing.
 			sessionPhase("review-loop", 2, flowstore.PhaseReady),
 		}
 		want := fmt.Sprintf("a running phase %s already occupies this Flow", "implementation")
-		if reason := genericFlowRuntimeOccupancyReason(record); reason != want {
+		if reason := worktreeAgentRecordOccupancyReason(record); reason != want {
 			t.Fatalf("reason = %q, want %q", reason, want)
 		}
 	})
@@ -459,8 +493,8 @@ func TestActiveFlowSessionIsWholeFlowScoped(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := activeFlowSession(tc.records); got != tc.want {
-				t.Fatalf("activeFlowSession = %v, want %v", got, tc.want)
+			if got := testActiveFlowSession(tc.records); got != tc.want {
+				t.Fatalf("testActiveFlowSession = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/model/flow_occupancy_simultaneous_internal_test.go
+++ b/model/flow_occupancy_simultaneous_internal_test.go
@@ -52,7 +52,7 @@ func TestEverySourceHoldingAtOnceIsSeenByEveryComposite(t *testing.T) {
 	if !flowLaunchPhaseSessionOccupied(f.phase(), f.stored) {
 		t.Fatal("the phase-session union must hold")
 	}
-	if reason := genericFlowRuntimeOccupancyReason(f.record); reason == "" {
+	if reason := worktreeAgentRecordOccupancyReason(f.record); reason == "" {
 		t.Fatal("the worktree agent's persisted rung must hold")
 	}
 }


### PR DESCRIPTION
The remaining repair, autofix, worktree-agent, and saved-session-resume launch paths still made authoritative occupancy decisions in the model layer. That split ownership made their scope and precedence rules harder to compare and preserve.

This change moves those decisions into purpose-specific policies in `flowoccupancy` while keeping each launch kind's existing behavior. Repair remains Flow-scoped, phase resume keeps its phase scope and session exemption, autofix and worktree-agent terminal-phase rules stay intact, and saved-session resume continues to reject both running phases and active exact-Flow sessions at read and prepare time. The model layer still owns the existing refusal text.

Tests add per-kind coverage for running phases, live sessions, and both conditions together, plus focused lifecycle checks for refusal text and prepare-time revalidation.

Verification:
- `make fmt-check`
- `make test`
- `make build`