### PR TITLE
Derive install backstop from ownership policy

### DIFF
--- a/model/flow_launch_adapters.go
+++ b/model/flow_launch_adapters.go
@@ -172,6 +172,18 @@ func flowLaunchRole(kind flowLaunchKind) actions.FlowLaunchRole {
 	}
 }
 
+func (m Model) flowLaunchInstallOccupancy(kind flowLaunchKind, flowID string) flowownership.Verdict {
+	return flowownership.Evaluate(flowownership.Sources{
+		Runtime: flowOccupancyRuntime{model: m},
+	}, flowownership.Query{
+		FlowID: flowID,
+		Purpose: flowownership.Purpose{
+			Role:  flowLaunchRole(kind),
+			Stage: flowownership.StageInstall,
+		},
+	})
+}
+
 func (m Model) createFlowAdmissionOccupancy(flowID string) flowownership.Verdict {
 	return flowownership.New(flowownership.Sources{
 		Runtime: flowOccupancyRuntime{model: m},

--- a/model/flow_launch_lifecycle.go
+++ b/model/flow_launch_lifecycle.go
@@ -1271,54 +1271,28 @@ func flowLaunchTmuxRepoPath(ctx actions.AgentLaunchContext, fallbackRepoPath str
 }
 
 // flowLaunchEmbeddedBackstop is the last occupancy check before a slot is
-// allocated, and it is deliberately per kind. Admission makes every branch here
-// unreachable, but dropping the backstop would be a regression against a future
-// unguarded source.
-//
-// Every kind refuses an open repair terminal. Repair alone also refuses a
-// non-repair Flow terminal, because repair is Flow-scoped rather than phase-
-// scoped: any terminal on the Flow is a competing owner of the same record.
-// That broad disjunct is where consumePendingFlowRepairLaunch's pre-allocation
-// recheck went, and keeping it here is what stops the migration from quietly
-// narrowing repair's last line of defense.
-//
-// It is a superset of that recheck, not a transcription of it: the old one
-// tested hasFlowEmbeddedTerminalForFlow alone, so a repair slot with no live
-// terminal got past it. The two predicates overlap rather than nest — one
-// requires a live terminal, the other a repair slot — so repair needs both, and
-// adding the second is a fix. The same tightening reaches the footer through
-// flowLaunchAdmissionOccupied, which now withdraws R for a terminal-less repair
-// slot that previously left it advertised.
+// allocated. Admission makes every branch here unreachable, but dropping the
+// backstop would be a regression against a future unguarded source. StageInstall
+// owns which terminal-slot sources each role reads; this function only renders
+// the occupied verdict in the attempt kind's established wording.
 //
 // The wording comes from the attempt's own kind, never from the prefill-failure
 // re-reservation, which labels every source manualPhase.
 func (m Model) flowLaunchEmbeddedBackstop(kind flowLaunchKind, flowID string) (string, bool) {
-	if kind == flowLaunchKindCreatePhase {
-		if m.hasFlowEmbeddedTerminalForFlow(flowID) || m.hasFlowRepairEmbeddedTerminalForFlow(flowID) {
-			return "Flow creation launch canceled because a terminal is already open for this Flow", true
-		}
+	if !m.flowLaunchInstallOccupancy(kind, flowID).Occupied() {
 		return "", false
+	}
+	if kind == flowLaunchKindCreatePhase {
+		return "Flow creation launch canceled because a terminal is already open for this Flow", true
 	}
 	if kind == flowLaunchKindWorktreeAgent {
-		if m.hasFlowEmbeddedTerminalForFlow(flowID) || m.hasFlowRepairEmbeddedTerminalForFlow(flowID) {
-			return flowWorktreeAgentSlotStatus, true
-		}
-		return "", false
+		return flowWorktreeAgentSlotStatus, true
 	}
 	if kind == flowLaunchKindSavedSessionResume {
-		if m.hasFlowEmbeddedTerminalForFlow(flowID) {
-			return "Saved session resume canceled because an embedded terminal already occupies this Flow", true
-		}
-		return "", false
+		return "Saved session resume canceled because an embedded terminal already occupies this Flow", true
 	}
 	if kind == flowLaunchKindRepair {
-		if m.hasFlowRepairEmbeddedTerminalForFlow(flowID) || m.hasFlowEmbeddedTerminalForFlow(flowID) {
-			return flowRepairTerminalStatus, true
-		}
-		return "", false
-	}
-	if !m.hasFlowRepairEmbeddedTerminalForFlow(flowID) {
-		return "", false
+		return flowRepairTerminalStatus, true
 	}
 	if kind == flowLaunchKindPhaseResume {
 		return "Flow phase resume canceled because a repair terminal is already open for this Flow", true

--- a/model/flow_occupancy_ladders_internal_test.go
+++ b/model/flow_occupancy_ladders_internal_test.go
@@ -367,7 +367,24 @@ func TestFlowLaunchEmbeddedBackstopPerKind(t *testing.T) {
 			t.Run(kind.name+"/"+state.name, func(t *testing.T) {
 				f := newOccupancyFixture(t, state.sources...)
 				want := kind.refusal(state.s6, state.s7)
+				direct := flowownership.Evaluate(flowownership.Sources{
+					Runtime: flowOccupancyRuntime{model: f.m},
+				}, flowownership.Query{
+					FlowID: f.flowID(),
+					Purpose: flowownership.Purpose{
+						Role:  flowLaunchRole(kind.kind),
+						Stage: flowownership.StageInstall,
+					},
+				})
+				install := f.m.flowLaunchInstallOccupancy(kind.kind, f.flowID())
+				if install.Occupied() != direct.Occupied() || install.Holder() != direct.Holder() || install.Err() != direct.Err() {
+					t.Fatalf("install verdict = (%v, %s, %v), direct StageInstall verdict = (%v, %s, %v)",
+						install.Occupied(), install.Holder(), install.Err(), direct.Occupied(), direct.Holder(), direct.Err())
+				}
 				status, refused := f.m.flowLaunchEmbeddedBackstop(kind.kind, f.flowID())
+				if refused != direct.Occupied() {
+					t.Fatalf("backstop refused = %v, direct StageInstall occupied = %v", refused, direct.Occupied())
+				}
 				if refused != (want != "") {
 					t.Fatalf("refused = %v, want %v", refused, want != "")
 				}
@@ -376,5 +393,24 @@ func TestFlowLaunchEmbeddedBackstopPerKind(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestFlowLaunchEmbeddedBackstopFailsClosedForInvalidInstallQuery(t *testing.T) {
+	f := newOccupancyFixture(t)
+	tests := []struct {
+		name   string
+		kind   flowLaunchKind
+		flowID string
+	}{
+		{name: "unknown launch kind", kind: flowLaunchKind(255), flowID: f.flowID()},
+		{name: "blank Flow ID", kind: flowLaunchKindManualPhase},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, refused := f.m.flowLaunchEmbeddedBackstop(tc.kind, tc.flowID); !refused {
+				t.Fatal("invalid install query was not refused")
+			}
+		})
 	}
 }


### PR DESCRIPTION
The final embedded-terminal occupancy check had its own per-launch-kind predicates, separate from the module policy used during admission. That duplication could let admission and slot allocation drift apart.

This change routes the install backstop through `flowownership.StageInstall` using the same role mapping as admission, while preserving the existing refusal text for every launch kind. Repair keeps its broader rule for any Flow terminal, including a terminal-less repair slot.

Tests compare the adapter and backstop against a direct StageInstall query across every relevant slot state and verify that invalid install queries fail closed.

Validation:
- `make fmt-check`
- `make test`
- `make build`
- `git diff --check origin/main...HEAD`