### PR TITLE
Add OSC 52 clipboard fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ make clean   # Remove bin/
 
 - Go 1.26+
 - Git 2.15+ (worktree support)
-- macOS clipboard: `pbcopy` (included with macOS)
-- Linux clipboard: install one of `wl-copy`, `xclip`, or `xsel`
+- Clipboard: native commands are preferred in the default `auto` mode. macOS
+  includes `pbcopy`; Linux can use `wl-copy`, `xclip`, or `xsel`. If none is
+  installed, Approach falls back to OSC 52.
+- OSC 52 clipboard fallback requires support from the hosting terminal and
+  permission for clipboard writes. tmux also needs clipboard writes and
+  passthrough enabled. See [clipboard configuration](docs/config.md#clipboard).
 - Linux terminal launch: set `TERMINAL` to your terminal emulator; when no tmux/Zellij/`TERMINAL` launch is available, Approach falls back to launching `$SHELL` in the worktree directory

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -2,10 +2,12 @@ package actions
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"io"
 	"net/url"
 	"os"
 	"os/exec"
@@ -35,6 +37,28 @@ type envVar struct {
 
 type lookPathFunc func(string) (string, error)
 type getenvFunc func(string) string
+
+const (
+	ClipboardMethodAuto   = "auto"
+	ClipboardMethodSystem = "system"
+	ClipboardMethodOSC52  = "osc52"
+
+	DefaultOSC52MaxPayloadBytes = 100_000
+)
+
+// ClipboardOptions selects the clipboard transport and bounds encoded OSC 52 payloads.
+type ClipboardOptions struct {
+	Method               string
+	OSC52MaxPayloadBytes int
+}
+
+type clipboardDeps struct {
+	goos         string
+	lookPath     lookPathFunc
+	getenv       getenvFunc
+	runSystem    func(commandSpec, string) error
+	openTerminal func() (io.WriteCloser, error)
+}
 
 // CommandRunner executes a command and returns stdout, stderr, and the command error.
 type CommandRunner interface {
@@ -1014,15 +1038,87 @@ func DropStash(repoPath string, index int) error {
 	return runGit(repoPath, "stash", "drop", ref)
 }
 
-// CopyToClipboard copies text to the system clipboard.
+// CopyToClipboard copies text using the native clipboard when available and
+// otherwise falls back to OSC 52.
 func CopyToClipboard(text string) error {
-	spec, err := selectClipboardCommand(runtime.GOOS, exec.LookPath)
+	return CopyToClipboardWithOptions(text, ClipboardOptions{
+		Method:               ClipboardMethodAuto,
+		OSC52MaxPayloadBytes: DefaultOSC52MaxPayloadBytes,
+	})
+}
+
+// CopyToClipboardWithOptions copies text using the configured clipboard transport.
+func CopyToClipboardWithOptions(text string, opts ClipboardOptions) error {
+	return copyToClipboardWithOptions(text, opts, clipboardDeps{
+		goos:     runtime.GOOS,
+		lookPath: exec.LookPath,
+		getenv:   os.Getenv,
+		runSystem: func(spec commandSpec, text string) error {
+			cmd := exec.Command(spec.name, spec.args...)
+			cmd.Stdin = strings.NewReader(text)
+			return cmd.Run()
+		},
+		openTerminal: func() (io.WriteCloser, error) {
+			return os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+		},
+	})
+}
+
+func copyToClipboardWithOptions(text string, opts ClipboardOptions, deps clipboardDeps) error {
+	method := opts.Method
+	if method == "" {
+		method = ClipboardMethodAuto
+	}
+	if method == ClipboardMethodSystem || method == ClipboardMethodAuto {
+		spec, err := selectClipboardCommand(deps.goos, deps.lookPath)
+		if err == nil {
+			if err := deps.runSystem(spec, text); err != nil {
+				return fmt.Errorf("run clipboard command %s: %w", spec.name, err)
+			}
+			return nil
+		}
+		if method == ClipboardMethodSystem {
+			return err
+		}
+	}
+	if method != ClipboardMethodOSC52 && method != ClipboardMethodAuto {
+		return fmt.Errorf("unknown clipboard method %q", opts.Method)
+	}
+
+	sequence, err := buildOSC52Sequence(text, opts.OSC52MaxPayloadBytes, deps.getenv("TMUX") != "")
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(spec.name, spec.args...)
-	cmd.Stdin = strings.NewReader(text)
-	return cmd.Run()
+	terminal, err := deps.openTerminal()
+	if err != nil {
+		return fmt.Errorf("open controlling terminal for OSC 52: %w", err)
+	}
+	n, writeErr := terminal.Write(sequence)
+	if writeErr == nil && n != len(sequence) {
+		writeErr = io.ErrShortWrite
+	}
+	closeErr := terminal.Close()
+	if writeErr != nil {
+		writeErr = fmt.Errorf("write OSC 52 sequence to controlling terminal: %w", writeErr)
+	}
+	if closeErr != nil {
+		closeErr = fmt.Errorf("close controlling terminal after OSC 52 write: %w", closeErr)
+	}
+	return errors.Join(writeErr, closeErr)
+}
+
+func buildOSC52Sequence(text string, maxPayloadBytes int, tmux bool) ([]byte, error) {
+	payload := base64.StdEncoding.EncodeToString([]byte(text))
+	if maxPayloadBytes > 0 && len(payload) > maxPayloadBytes {
+		return nil, fmt.Errorf("OSC 52 encoded payload is %d bytes, limit is %d bytes", len(payload), maxPayloadBytes)
+	}
+
+	sequence := "\x1b]52;c;" + payload + "\x1b\\"
+	if !tmux {
+		return []byte(sequence), nil
+	}
+	sequence = strings.ReplaceAll(sequence, "\x1b", "\x1b\x1b")
+	return []byte("\x1bPtmux;" + sequence + "\x1b\\"), nil
 }
 
 // OpenURL opens an absolute http(s) URL in the system browser.

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -2036,6 +2036,9 @@ func TestTerminalLaunch_TmuxRequiresInteractiveTTY(t *testing.T) {
 }
 
 func TestCopyToClipboard(t *testing.T) {
+	if os.Getenv("TEST_CLIPBOARD") == "" {
+		t.Skip("skipping: set TEST_CLIPBOARD=1 to run the native clipboard smoke test")
+	}
 	if _, err := exec.LookPath("pbcopy"); err != nil {
 		t.Skip("pbcopy not available")
 	}

--- a/actions/clipboard_test.go
+++ b/actions/clipboard_test.go
@@ -1,0 +1,266 @@
+package actions
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+type recordingWriteCloser struct {
+	bytes.Buffer
+	closeErr error
+}
+
+func (w *recordingWriteCloser) Close() error { return w.closeErr }
+
+func TestBuildOSC52Sequence(t *testing.T) {
+	text := "copy 雪"
+	payload := base64.StdEncoding.EncodeToString([]byte(text))
+
+	tests := []struct {
+		name string
+		tmux bool
+		want string
+	}{
+		{
+			name: "plain terminal",
+			want: "\x1b]52;c;" + payload + "\x1b\\",
+		},
+		{
+			name: "tmux passthrough",
+			tmux: true,
+			want: "\x1bPtmux;\x1b\x1b]52;c;" + payload + "\x1b\x1b\\\x1b\\",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildOSC52Sequence(text, 100_000, tt.tmux)
+			if err != nil {
+				t.Fatalf("buildOSC52Sequence returned error: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("sequence = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCopyToClipboardWithOptions_ForcedOSC52BypassesSystemClipboard(t *testing.T) {
+	terminal := &recordingWriteCloser{}
+	lookedUp := false
+	deps := clipboardDeps{
+		goos: "linux",
+		lookPath: func(string) (string, error) {
+			lookedUp = true
+			return "", errors.New("unexpected lookup")
+		},
+		getenv: func(string) string { return "" },
+		runSystem: func(commandSpec, string) error {
+			t.Fatal("system clipboard command should not run")
+			return nil
+		},
+		openTerminal: func() (io.WriteCloser, error) { return terminal, nil },
+	}
+
+	err := copyToClipboardWithOptions("hello", ClipboardOptions{
+		Method:               ClipboardMethodOSC52,
+		OSC52MaxPayloadBytes: 100_000,
+	}, deps)
+	if err != nil {
+		t.Fatalf("copyToClipboardWithOptions returned error: %v", err)
+	}
+	if lookedUp {
+		t.Fatal("forced OSC 52 should bypass clipboard command lookup")
+	}
+	want, err := buildOSC52Sequence("hello", 100_000, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(terminal.Bytes(), want) {
+		t.Fatalf("terminal write = %q, want %q", terminal.Bytes(), want)
+	}
+}
+
+func TestCopyToClipboardWithOptions_SelectsTransport(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		available    []string
+		runErr       error
+		wantSystem   string
+		wantTerminal bool
+		wantError    string
+	}{
+		{
+			name:       "auto prefers native command",
+			method:     ClipboardMethodAuto,
+			available:  []string{"wl-copy", "xclip"},
+			wantSystem: "wl-copy",
+		},
+		{
+			name:       "system uses native command",
+			method:     ClipboardMethodSystem,
+			available:  []string{"xsel"},
+			wantSystem: "xsel",
+		},
+		{
+			name:         "auto falls back when commands are unavailable",
+			method:       ClipboardMethodAuto,
+			wantTerminal: true,
+		},
+		{
+			name:      "auto reports native execution failure",
+			method:    ClipboardMethodAuto,
+			available: []string{"xclip"},
+			runErr:    errors.New("exit status 1"),
+			wantError: "run clipboard command xclip",
+		},
+		{
+			name:      "system requires a native command",
+			method:    ClipboardMethodSystem,
+			wantError: "wl-copy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			terminal := &recordingWriteCloser{}
+			var ranSystem string
+			openedTerminal := false
+			deps := clipboardDeps{
+				goos:     "linux",
+				lookPath: fakeLookPath(tt.available...),
+				getenv:   func(string) string { return "" },
+				runSystem: func(spec commandSpec, text string) error {
+					ranSystem = spec.name
+					if text != "hello" {
+						t.Fatalf("system clipboard input = %q, want hello", text)
+					}
+					return tt.runErr
+				},
+				openTerminal: func() (io.WriteCloser, error) {
+					openedTerminal = true
+					return terminal, nil
+				},
+			}
+
+			err := copyToClipboardWithOptions("hello", ClipboardOptions{
+				Method:               tt.method,
+				OSC52MaxPayloadBytes: 100_000,
+			}, deps)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("error = %v, want text %q", err, tt.wantError)
+				}
+			} else if err != nil {
+				t.Fatalf("copyToClipboardWithOptions returned error: %v", err)
+			}
+			if ranSystem != tt.wantSystem && !(tt.runErr != nil && ranSystem == "xclip") {
+				t.Fatalf("system command = %q, want %q", ranSystem, tt.wantSystem)
+			}
+			if openedTerminal != tt.wantTerminal {
+				t.Fatalf("opened terminal = %v, want %v", openedTerminal, tt.wantTerminal)
+			}
+		})
+	}
+}
+
+func TestBuildOSC52SequencePayloadLimit(t *testing.T) {
+	text := "abc"
+	encodedSize := base64.StdEncoding.EncodedLen(len(text))
+
+	if _, err := buildOSC52Sequence(text, encodedSize, false); err != nil {
+		t.Fatalf("payload at boundary returned error: %v", err)
+	}
+	if _, err := buildOSC52Sequence(text, 0, false); err != nil {
+		t.Fatalf("unlimited payload returned error: %v", err)
+	}
+	_, err := buildOSC52Sequence(text, encodedSize-1, false)
+	if err == nil {
+		t.Fatal("oversized payload should fail")
+	}
+	for _, want := range []string{"4 bytes", "limit is 3 bytes"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want text %q", err, want)
+		}
+	}
+}
+
+func TestCopyToClipboardWithOptions_RejectsOversizedPayloadBeforeTerminalWrite(t *testing.T) {
+	openedTerminal := false
+	deps := clipboardDeps{
+		goos:     "linux",
+		lookPath: fakeLookPath(),
+		getenv:   func(string) string { return "" },
+		runSystem: func(commandSpec, string) error {
+			t.Fatal("system command should not run")
+			return nil
+		},
+		openTerminal: func() (io.WriteCloser, error) {
+			openedTerminal = true
+			return &recordingWriteCloser{}, nil
+		},
+	}
+
+	err := copyToClipboardWithOptions("abc", ClipboardOptions{
+		Method:               ClipboardMethodOSC52,
+		OSC52MaxPayloadBytes: 3,
+	}, deps)
+	if err == nil || !strings.Contains(err.Error(), "4 bytes") {
+		t.Fatalf("error = %v, want encoded payload size", err)
+	}
+	if openedTerminal {
+		t.Fatal("oversized payload should fail before opening the terminal")
+	}
+}
+
+type failingWriteCloser struct {
+	n        int
+	writeErr error
+	closeErr error
+}
+
+func (w failingWriteCloser) Write([]byte) (int, error) { return w.n, w.writeErr }
+func (w failingWriteCloser) Close() error              { return w.closeErr }
+
+func TestCopyToClipboardWithOptions_ReportsTerminalFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		openErr   error
+		writer    io.WriteCloser
+		wantError string
+	}{
+		{name: "open", openErr: errors.New("no tty"), wantError: "open controlling terminal"},
+		{name: "short write", writer: failingWriteCloser{n: 1}, wantError: "short write"},
+		{name: "write", writer: failingWriteCloser{writeErr: errors.New("broken pipe")}, wantError: "broken pipe"},
+		{name: "close", writer: failingWriteCloser{closeErr: errors.New("close failed")}, wantError: "close failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deps := clipboardDeps{
+				goos:     "linux",
+				lookPath: fakeLookPath(),
+				getenv:   func(string) string { return "" },
+				runSystem: func(commandSpec, string) error {
+					t.Fatal("system command should not run")
+					return nil
+				},
+				openTerminal: func() (io.WriteCloser, error) {
+					return tt.writer, tt.openErr
+				},
+			}
+			err := copyToClipboardWithOptions("hello", ClipboardOptions{
+				Method:               ClipboardMethodOSC52,
+				OSC52MaxPayloadBytes: 100_000,
+			}, deps)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("error = %v, want text %q", err, tt.wantError)
+			}
+		})
+	}
+}

--- a/cmd/approach/main.go
+++ b/cmd/approach/main.go
@@ -629,6 +629,12 @@ func modelOptionsFromConfig(cfg config.Config, scanRepos func() ([]scanner.Repo,
 		ListFlows:        flowStore.List,
 		FlowStore:        flowStore,
 		ReadPlan:         planStore.ReadPlan,
+		CopyToClipboard: func(text string) error {
+			return actions.CopyToClipboardWithOptions(text, actions.ClipboardOptions{
+				Method:               cfg.Clipboard.Method,
+				OSC52MaxPayloadBytes: cfg.Clipboard.OSC52MaxPayloadBytes,
+			})
+		},
 		LaunchTerminal: func(path string) (actions.TerminalLaunchSpec, error) {
 			return actions.TerminalLaunchWithOptions(path, launchOpts)
 		},

--- a/cmd/approach/main_test.go
+++ b/cmd/approach/main_test.go
@@ -474,6 +474,29 @@ func TestModelOptionsFromConfigPassesReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestModelOptionsFromConfigPassesClipboardOptions(t *testing.T) {
+	sessionStore, planStore, flowStore := testArtifactStores(t)
+	opts := modelOptionsFromConfig(config.Config{
+		Clipboard: config.ClipboardConfig{
+			Method:               config.ClipboardMethodOSC52,
+			OSC52MaxPayloadBytes: 3,
+		},
+	}, nil, sessionStore, planStore, flowStore)
+
+	if opts.CopyToClipboard == nil {
+		t.Fatal("CopyToClipboard should be wired")
+	}
+	err := opts.CopyToClipboard("abc")
+	if err == nil {
+		t.Fatal("configured OSC 52 payload cap should reject the copy")
+	}
+	for _, want := range []string{"4 bytes", "limit is 3 bytes"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("CopyToClipboard error = %q, want text %q", err, want)
+		}
+	}
+}
+
 func TestModelOptionsFromConfigPassesFlowPreset(t *testing.T) {
 	sessionStore, planStore, flowStore := testArtifactStores(t)
 	preset := flowstore.Preset{

--- a/config/clipboard_test.go
+++ b/config/clipboard_test.go
@@ -1,0 +1,53 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/approachcontrol/approach/config"
+)
+
+func TestLoadFromClipboardConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantMethod string
+		wantLimit  int
+		wantError  string
+	}{
+		{name: "omitted defaults", wantMethod: config.ClipboardMethodAuto, wantLimit: 100_000},
+		{name: "auto", body: "[clipboard]\nmethod = \"auto\"\n", wantMethod: config.ClipboardMethodAuto, wantLimit: 100_000},
+		{name: "system normalized", body: "[clipboard]\nmethod = \"  SYSTEM  \"\n", wantMethod: config.ClipboardMethodSystem, wantLimit: 100_000},
+		{name: "osc52", body: "[clipboard]\nmethod = \"osc52\"\n", wantMethod: config.ClipboardMethodOSC52, wantLimit: 100_000},
+		{name: "zero is unlimited", body: "[clipboard]\nosc52_max_payload_bytes = 0\n", wantMethod: config.ClipboardMethodAuto, wantLimit: 0},
+		{name: "custom limit", body: "[clipboard]\nosc52_max_payload_bytes = 4096\n", wantMethod: config.ClipboardMethodAuto, wantLimit: 4096},
+		{name: "invalid method", body: "[clipboard]\nmethod = \"terminal\"\n", wantError: "clipboard.method"},
+		{name: "negative limit", body: "[clipboard]\nosc52_max_payload_bytes = -1\n", wantError: "clipboard.osc52_max_payload_bytes must be >= 0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if tt.body != "" {
+				if err := os.WriteFile(path, []byte(tt.body), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			cfg, err := config.LoadFrom(path)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("LoadFrom error = %v, want text %q", err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadFrom returned error: %v", err)
+			}
+			if cfg.Clipboard.Method != tt.wantMethod || cfg.Clipboard.OSC52MaxPayloadBytes != tt.wantLimit {
+				t.Fatalf("clipboard config = %#v, want method %q limit %d", cfg.Clipboard, tt.wantMethod, tt.wantLimit)
+			}
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,21 @@ type Config struct {
 	Flow        FlowConfig       `toml:"flow"`
 	Sessions    SessionsConfig   `toml:"sessions"`
 	Bootstrap   BootstrapConfig  `toml:"bootstrap"`
+	Clipboard   ClipboardConfig  `toml:"clipboard"`
+}
+
+const (
+	ClipboardMethodAuto   = "auto"
+	ClipboardMethodSystem = "system"
+	ClipboardMethodOSC52  = "osc52"
+
+	DefaultOSC52MaxPayloadBytes = 100_000
+)
+
+// ClipboardConfig selects clipboard transport and limits encoded OSC 52 payloads.
+type ClipboardConfig struct {
+	Method               string `toml:"method"`
+	OSC52MaxPayloadBytes int    `toml:"osc52_max_payload_bytes"`
 }
 
 // ScanConfig configures repository discovery.
@@ -261,6 +276,15 @@ func parseConfigData(path string, data []byte, opts loadOptions) (Config, error)
 	}
 	cfg.Launch.Backend = backend
 
+	method, err := normalizeClipboardMethod(cfg.Clipboard.Method)
+	if err != nil {
+		return Config{}, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	cfg.Clipboard.Method = method
+	if cfg.Clipboard.OSC52MaxPayloadBytes < 0 {
+		return Config{}, fmt.Errorf("parse config %s: clipboard.osc52_max_payload_bytes must be >= 0", path)
+	}
+
 	if cfg.Sessions.Root != "" {
 		root, err := expandHome(cfg.Sessions.Root, opts.homeDir)
 		if err != nil {
@@ -284,7 +308,26 @@ func parseConfigData(path string, data []byte, opts loadOptions) (Config, error)
 }
 
 func defaultConfig() Config {
-	return Config{Launch: LaunchConfig{Backend: LaunchBackendEmbedded}}
+	return Config{
+		Launch: LaunchConfig{Backend: LaunchBackendEmbedded},
+		Clipboard: ClipboardConfig{
+			Method:               ClipboardMethodAuto,
+			OSC52MaxPayloadBytes: DefaultOSC52MaxPayloadBytes,
+		},
+	}
+}
+
+func normalizeClipboardMethod(value string) (string, error) {
+	switch method := strings.ToLower(strings.TrimSpace(value)); method {
+	case "", ClipboardMethodAuto:
+		return ClipboardMethodAuto, nil
+	case ClipboardMethodSystem:
+		return ClipboardMethodSystem, nil
+	case ClipboardMethodOSC52:
+		return ClipboardMethodOSC52, nil
+	default:
+		return "", fmt.Errorf("clipboard.method %q must be %q, %q, or %q", value, ClipboardMethodAuto, ClipboardMethodSystem, ClipboardMethodOSC52)
+	}
 }
 
 // normalizeLaunchBackend lowercases and validates [launch].backend. An unknown

--- a/docs/config.md
+++ b/docs/config.md
@@ -26,6 +26,8 @@ exist:
 | Scan root | `WORKTREE_ROOT` | `[scan].root` | `~/dev` |
 | Plan editor command | `[editor].command` | `EDITOR` | unset |
 | Terminal command | `TERMINAL` | `[terminal].command` | platform fallback |
+| Clipboard method | none | `[clipboard].method` | `auto` |
+| OSC 52 encoded payload limit | none | `[clipboard].osc52_max_payload_bytes` | `100000` bytes |
 | Coding agent | none | `[agent].command` | unset |
 | Agent launch backend | none | `[launch].backend` | `embedded` |
 | Agent model | none | `[agent].codex_model` / `[agent].claude_model` | provider default |
@@ -59,6 +61,10 @@ command = "code"
 
 [terminal]
 command = "wezterm start"
+
+[clipboard]
+method = "auto"
+osc52_max_payload_bytes = 100000
 
 [provider]
 name = "github"
@@ -217,6 +223,27 @@ a separate Ghostty app instance rather than a window in the running one.
 Ghostty accepts any of its config keys as flags, so
 `command = "ghostty --wait-after-command=true"` keeps windows open after a
 launched agent exits instead of closing before the output can be read.
+
+### `[clipboard]`
+
+Controls how copy actions write to the clipboard.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `method` | string | `auto` tries the platform clipboard command first and uses OSC 52 only when no supported command is installed. `system` requires a platform command. `osc52` writes directly to the controlling terminal. Values are case-insensitive and surrounding whitespace is ignored. |
+| `osc52_max_payload_bytes` | integer | Maximum Base64-encoded OSC 52 payload size. The default is `100000`. `0` removes the limit. Negative values fail startup. Oversized copies fail without truncation or a partial terminal write. |
+
+On macOS, the system method uses `pbcopy`. On Linux it tries `wl-copy`, then
+`xclip`, then `xsel`. If Approach finds a native command but that command fails,
+`auto` reports the failure instead of switching transports.
+
+OSC 52 asks the terminal hosting Approach to set its clipboard. The terminal
+must support OSC 52 and permit clipboard writes in its security settings. Over
+SSH, that means the local hosting terminal, not the remote machine. Inside tmux,
+Approach emits tmux's passthrough form. Configure tmux to permit passthrough and
+clipboard writes, for example with `set -g allow-passthrough on` and
+`set -g set-clipboard on`. Approach sends one complete clipboard update and
+never splits or truncates the copied text.
 
 ### `[provider]`
 


### PR DESCRIPTION
`CopyToClipboard` currently fails in SSH and headless environments when no native clipboard command is installed. This change adds an OSC 52 write path so the hosting terminal can receive clipboard contents without changing existing copy call sites.

Native clipboard commands remain the first choice in the default `auto` mode. Users can force `system` or `osc52` through the new `[clipboard]` config section. OSC 52 writes use the controlling terminal, enforce a configurable encoded-payload limit, and wrap the sequence for tmux passthrough when needed.

Tests cover transport selection, exact OSC 52 and tmux framing, payload boundaries, Unicode input, config validation, and wiring into the application model.

Validation:

- `go test ./actions ./config ./cmd/approach`
- `make fmt-check`
- `go test -short ./...`
- `make test`
- `make build`
