### PR TITLE
fix(epic): fence progression writes by activation

### DIFF
--- a/flowstore/epic_progression.go
+++ b/flowstore/epic_progression.go
@@ -874,5 +874,9 @@ func boolToSQLite(value bool) int {
 }
 
 func epicProgressionMutationTime(record EpicProgression, candidate time.Time) time.Time {
-	return monotonicMutationTime(candidate, record.CreatedAt, record.UpdatedAt)
+	stamp := monotonicMutationTime(candidate, record.CreatedAt, record.UpdatedAt)
+	if !record.UpdatedAt.IsZero() && !stamp.After(record.UpdatedAt) {
+		stamp = record.UpdatedAt.UTC().Add(time.Nanosecond)
+	}
+	return stamp
 }

--- a/flowstore/epic_progression.go
+++ b/flowstore/epic_progression.go
@@ -17,6 +17,10 @@ const epicProgressionSchemaVersion = 1
 
 var errPreparedEpicProgressionCommitUnknown = errors.New("prepared epic progression commit outcome is unknown")
 
+// ErrEpicProgressionActivationChanged reports that a progression edge was
+// observed under an activation other than the one currently stored.
+var ErrEpicProgressionActivationChanged = errors.New("epic progression activation changed")
+
 // IsPreparedEpicProgressionCommitUnknown reports that an atomic enable reached
 // commit but SQLite could not confirm whether that commit became durable.
 func IsPreparedEpicProgressionCommitUnknown(err error) bool {
@@ -52,16 +56,18 @@ type EpicProgression struct {
 // done and halt; explicit normal off clears done and retains a sticky halt;
 // done may be newly established only from authoritative active state.
 type EpicProgressionUpdate struct {
-	Key     EpicProgressionKey
-	Enabled bool
-	Done    bool
+	Key                EpicProgressionKey
+	Enabled            bool
+	Done               bool
+	ExpectedActivation time.Time
 }
 
 // EpicProgressionHaltUpdate records why progression stopped. Only authoritative
 // active state may halt, and the first halt tuple is the one that sticks.
 type EpicProgressionHaltUpdate struct {
-	Key  EpicProgressionKey
-	Halt EpicProgressionHalt
+	Key                EpicProgressionKey
+	Halt               EpicProgressionHalt
+	ExpectedActivation time.Time
 }
 
 // PreparedEpicProgressionUpdate binds enablement to one exact prepared child
@@ -87,9 +93,10 @@ const (
 // EpicProgressionSuccessorUpdate names the exact prepared Flow that sequential
 // progression owns. Callers hold its launch/close reservation while reconciling.
 type EpicProgressionSuccessorUpdate struct {
-	FlowID string
-	Key    EpicProgressionKey
-	Bead   BeadLink
+	FlowID             string
+	Key                EpicProgressionKey
+	Bead               BeadLink
+	ExpectedActivation time.Time
 }
 
 // EpicProgressionSuccessorResult returns the records observed in the same
@@ -140,6 +147,12 @@ func (s *Store) SetEpicProgression(update EpicProgressionUpdate) (EpicProgressio
 		return EpicProgression{}, err
 	}
 	update.Key = key
+	if update.Done {
+		update.ExpectedActivation, err = normalizeEpicProgressionActivation(update.ExpectedActivation)
+		if err != nil {
+			return EpicProgression{}, err
+		}
+	}
 	backend, ok := s.backend.(epicProgressionBackend)
 	if !ok {
 		return EpicProgression{}, errors.New("flow backend does not support epic progression")
@@ -156,6 +169,10 @@ func (s *Store) HaltEpicProgression(update EpicProgressionHaltUpdate) (EpicProgr
 		return EpicProgression{}, err
 	}
 	update.Key = key
+	update.ExpectedActivation, err = normalizeEpicProgressionActivation(update.ExpectedActivation)
+	if err != nil {
+		return EpicProgression{}, err
+	}
 	if err := validateEpicProgressionHalt(update.Halt); err != nil {
 		return EpicProgression{}, err
 	}
@@ -288,6 +305,10 @@ func (s *Store) ReconcileEpicProgressionSuccessor(update EpicProgressionSuccesso
 	if update.Bead.EpicID != key.EpicID {
 		return retryable(fmt.Errorf("sequential epic progression key epic %q does not match Flow link epic %q", key.EpicID, update.Bead.EpicID))
 	}
+	update.ExpectedActivation, err = normalizeEpicProgressionActivation(update.ExpectedActivation)
+	if err != nil {
+		return retryable(err)
+	}
 	backend, ok := s.backend.(*sqliteBackend)
 	if !ok {
 		return retryable(errors.New("flow backend does not support atomic sequential epic progression reconciliation"))
@@ -306,7 +327,7 @@ func (s *Store) ReconcileEpicProgressionSuccessor(update EpicProgressionSuccesso
 		return retryable(err)
 	}
 	result := EpicProgressionSuccessorResult{Progression: progression}
-	if !found || !progression.Enabled || progression.Done || progression.Halt != nil {
+	if !found || !progression.Enabled || progression.Done || progression.Halt != nil || !progression.UpdatedAt.Equal(update.ExpectedActivation) {
 		result.Outcome = EpicProgressionSuccessorInactive
 	} else {
 		stored, flowFound, readErr := queryStoredFlow(tx.QueryRow(
@@ -348,6 +369,21 @@ func normalizeEpicProgressionKey(key EpicProgressionKey) (EpicProgressionKey, er
 		return EpicProgressionKey{}, errors.New("epic progression epic id is required")
 	}
 	return EpicProgressionKey{RepoPath: filepath.Clean(repoPath), EpicID: epicID}, nil
+}
+
+func normalizeEpicProgressionActivation(value time.Time) (time.Time, error) {
+	if value.IsZero() {
+		return time.Time{}, errors.New("epic progression expected activation is required")
+	}
+	encoded, err := formatStorageTime(value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("epic progression expected activation is invalid: %w", err)
+	}
+	parsed, err := parseCanonicalStorageTime(encoded)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("epic progression expected activation is invalid: %w", err)
+	}
+	return parsed, nil
 }
 
 func validateEpicProgression(record EpicProgression) error {
@@ -642,8 +678,17 @@ func (b *sqliteBackend) setEpicProgression(update EpicProgressionUpdate, now fun
 		}
 		if update.Done {
 			halt = nil
+			if current.Done {
+				if err := tx.Commit(); err != nil {
+					return EpicProgression{}, fmt.Errorf("commit epic progression update %q/%q: %w", update.Key.RepoPath, update.Key.EpicID, err)
+				}
+				return current, nil
+			}
 			if !current.Done && (!current.Enabled || current.Halt != nil) {
 				return EpicProgression{}, fmt.Errorf("epic progression %q/%q can only become done from active state", update.Key.RepoPath, update.Key.EpicID)
+			}
+			if !current.UpdatedAt.Equal(update.ExpectedActivation) {
+				return EpicProgression{}, fmt.Errorf("%w for %q/%q", ErrEpicProgressionActivationChanged, update.Key.RepoPath, update.Key.EpicID)
 			}
 		}
 		if current.Enabled == update.Enabled && current.Done == update.Done && current.Halt == halt {
@@ -715,17 +760,15 @@ func (b *sqliteBackend) haltEpicProgression(update EpicProgressionHaltUpdate, no
 		}
 		return current, nil
 	}
-	// This checks that progression is active, not that it is the same activation
-	// whose tracked child produced update.Halt: another process that disabled and
-	// re-enabled the epic can still be halted by a stale observation. The advance
-	// edge carries the identical exposure and predates this one, so fencing needs
-	// a shared activation generation across both — tracked in approach-d93.
 	if !current.Enabled || current.Done {
 		state := "off"
 		if current.Done {
 			state = "done"
 		}
 		return EpicProgression{}, fmt.Errorf("epic progression %q/%q is %s; only active progression can halt", update.Key.RepoPath, update.Key.EpicID, state)
+	}
+	if !current.UpdatedAt.Equal(update.ExpectedActivation) {
+		return EpicProgression{}, fmt.Errorf("%w for %q/%q", ErrEpicProgressionActivationChanged, update.Key.RepoPath, update.Key.EpicID)
 	}
 	halt := update.Halt
 	current.Enabled = false

--- a/flowstore/epic_progression_internal_test.go
+++ b/flowstore/epic_progression_internal_test.go
@@ -2,12 +2,88 @@ package flowstore
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestEpicProgressionObservedActivationFencesEveryProgressionEdge(t *testing.T) {
+	now := time.Date(2026, 8, 25, 14, 0, 0, 0, time.UTC)
+	store, err := NewStore(StoreOptions{Root: t.TempDir(), Now: func() time.Time { return now }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	repo := filepath.Join(t.TempDir(), "repo")
+	key := EpicProgressionKey{RepoPath: repo, EpicID: "epic"}
+	activationA, err := store.SetEpicProgression(EpicProgressionUpdate{Key: key, Enabled: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Minute)
+	if _, err := store.SetEpicProgression(EpicProgressionUpdate{Key: key}); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Minute)
+	activationB, err := store.SetEpicProgression(EpicProgressionUpdate{Key: key, Enabled: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if activationB.UpdatedAt.Equal(activationA.UpdatedAt) {
+		t.Fatal("disable and re-enable retained the activation timestamp")
+	}
+
+	link := BeadLink{ID: "epic.2", EpicID: key.EpicID}
+	flow, finalizer, err := store.CreatePreparation(FlowRecord{
+		FlowID: "prepared", RepoPath: repo, Title: "Prepared", Instructions: "Test.", Bead: link,
+	}, CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SetStartMetadata(StartMetadataUpdate{
+		FlowID: flow.FlowID, WorktreePath: filepath.Join(t.TempDir(), "worktree"), Branch: "flow/prepared",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := finalizer.Finalize(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	assertActivationBUntouched := func(op string) {
+		t.Helper()
+		got, found, readErr := store.ReadEpicProgression(key)
+		if readErr != nil || !found || !reflect.DeepEqual(got, activationB) {
+			t.Fatalf("%s changed activation B: got %#v, found %t, err %v; want %#v", op, got, found, readErr, activationB)
+		}
+	}
+
+	halt := EpicProgressionHalt{ChildBeadID: "epic.1", Status: StatusBlocked, Message: "stale child blocked"}
+	if _, err := store.HaltEpicProgression(EpicProgressionHaltUpdate{
+		Key: key, Halt: halt, ExpectedActivation: activationA.UpdatedAt,
+	}); !errors.Is(err, ErrEpicProgressionActivationChanged) {
+		t.Fatalf("stale halt error = %v, want activation changed", err)
+	}
+	assertActivationBUntouched("stale halt")
+
+	if _, err := store.SetEpicProgression(EpicProgressionUpdate{
+		Key: key, Done: true, ExpectedActivation: activationA.UpdatedAt,
+	}); !errors.Is(err, ErrEpicProgressionActivationChanged) {
+		t.Fatalf("stale completion error = %v, want activation changed", err)
+	}
+	assertActivationBUntouched("stale completion")
+
+	result, err := store.ReconcileEpicProgressionSuccessor(EpicProgressionSuccessorUpdate{
+		FlowID: flow.FlowID, Key: key, Bead: link, ExpectedActivation: activationA.UpdatedAt,
+	})
+	if err != nil || result.Outcome != EpicProgressionSuccessorInactive {
+		t.Fatalf("stale successor result = %#v, err %v; want inactive", result, err)
+	}
+	assertActivationBUntouched("stale successor reconciliation")
+}
 
 func TestEpicProgressionCodecRejectsInvalidHaltStates(t *testing.T) {
 	stamp := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
@@ -130,7 +206,7 @@ func TestEpicProgressionSerializedWriterOrdersDoneAndManualOff(t *testing.T) {
 			}
 			resultCh := make(chan writeResult, 1)
 			go func() {
-				progression, err := second.SetEpicProgression(EpicProgressionUpdate{Key: key, Done: tt.queuedDone})
+				progression, err := second.SetEpicProgression(EpicProgressionUpdate{Key: key, Done: tt.queuedDone, ExpectedActivation: active.UpdatedAt})
 				resultCh <- writeResult{progression: progression, err: err}
 			}()
 			<-started
@@ -172,7 +248,7 @@ func TestEpicProgressionDoneRejectsAuthoritativeHaltAndSuccessorTreatsDoneInacti
 	if _, err := backend.db.Exec("INSERT INTO epic_progressions(repo_path, epic_id, enabled, updated_at, record) VALUES(?, ?, 0, ?, ?)", key.RepoPath, key.EpicID, updatedAt, data); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.SetEpicProgression(EpicProgressionUpdate{Key: key, Done: true}); err == nil {
+	if _, err := store.SetEpicProgression(EpicProgressionUpdate{Key: key, Done: true, ExpectedActivation: halted.UpdatedAt}); err == nil {
 		t.Fatal("halted -> done succeeded")
 	}
 	got, found, err := store.ReadEpicProgression(key)
@@ -184,12 +260,12 @@ func TestEpicProgressionDoneRejectsAuthoritativeHaltAndSuccessorTreatsDoneInacti
 	if err != nil || !active.Enabled || active.Done || active.Halt != nil {
 		t.Fatalf("enable halted = %#v, err %v", active, err)
 	}
-	done, err := store.SetEpicProgression(EpicProgressionUpdate{Key: key, Done: true})
+	done, err := store.SetEpicProgression(EpicProgressionUpdate{Key: key, Done: true, ExpectedActivation: active.UpdatedAt})
 	if err != nil || !done.Done {
 		t.Fatalf("active -> done = %#v, err %v", done, err)
 	}
 	result, err := store.ReconcileEpicProgressionSuccessor(EpicProgressionSuccessorUpdate{
-		FlowID: "absent-flow", Key: key, Bead: BeadLink{ID: "epic.2", EpicID: key.EpicID},
+		FlowID: "absent-flow", Key: key, Bead: BeadLink{ID: "epic.2", EpicID: key.EpicID}, ExpectedActivation: done.UpdatedAt,
 	})
 	if err != nil || result.Outcome != EpicProgressionSuccessorInactive || !result.Progression.Done {
 		t.Fatalf("done successor reconciliation = %#v, err %v", result, err)
@@ -282,7 +358,7 @@ func TestReconcileEpicProgressionSuccessorHaltedPrecedesFlowState(t *testing.T) 
 
 	for _, flowID := range []string{"absent", flow.FlowID} {
 		result, err := store.ReconcileEpicProgressionSuccessor(EpicProgressionSuccessorUpdate{
-			FlowID: flowID, Key: key, Bead: link,
+			FlowID: flowID, Key: key, Bead: link, ExpectedActivation: halted.UpdatedAt,
 		})
 		if err != nil || result.Outcome != EpicProgressionSuccessorInactive {
 			t.Fatalf("flow %q result = %#v, err %v; want inactive", flowID, result, err)
@@ -384,12 +460,13 @@ func TestHaltEpicProgressionWritesDisabledProjectionAndStaysInactive(t *testing.
 		t.Fatal(err)
 	}
 
-	if _, err := store.SetEpicProgression(EpicProgressionUpdate{Key: key, Enabled: true}); err != nil {
+	active, err := store.SetEpicProgression(EpicProgressionUpdate{Key: key, Enabled: true})
+	if err != nil {
 		t.Fatal(err)
 	}
 	now = now.Add(time.Minute)
 	halt := EpicProgressionHalt{ChildBeadID: "epic.1", Status: StatusNeedsAttention, Message: "child Flow flow-1 halted auto-progression"}
-	halted, err := store.HaltEpicProgression(EpicProgressionHaltUpdate{Key: key, Halt: halt})
+	halted, err := store.HaltEpicProgression(EpicProgressionHaltUpdate{Key: key, Halt: halt, ExpectedActivation: active.UpdatedAt})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +482,7 @@ func TestHaltEpicProgressionWritesDisabledProjectionAndStaysInactive(t *testing.
 		t.Fatalf("enabled projection after halt = %d, want 0", enabled)
 	}
 
-	result, err := store.ReconcileEpicProgressionSuccessor(EpicProgressionSuccessorUpdate{FlowID: flow.FlowID, Key: key, Bead: link})
+	result, err := store.ReconcileEpicProgressionSuccessor(EpicProgressionSuccessorUpdate{FlowID: flow.FlowID, Key: key, Bead: link, ExpectedActivation: halted.UpdatedAt})
 	if err != nil || result.Outcome != EpicProgressionSuccessorInactive {
 		t.Fatalf("halted successor reconciliation = %#v, err %v; want inactive", result, err)
 	}

--- a/flowstore/epic_progression_internal_test.go
+++ b/flowstore/epic_progression_internal_test.go
@@ -24,11 +24,9 @@ func TestEpicProgressionObservedActivationFencesEveryProgressionEdge(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	now = now.Add(time.Minute)
 	if _, err := store.SetEpicProgression(EpicProgressionUpdate{Key: key}); err != nil {
 		t.Fatal(err)
 	}
-	now = now.Add(time.Minute)
 	activationB, err := store.SetEpicProgression(EpicProgressionUpdate{Key: key, Enabled: true})
 	if err != nil {
 		t.Fatal(err)

--- a/flowstore/epic_progression_test.go
+++ b/flowstore/epic_progression_test.go
@@ -33,7 +33,8 @@ func TestReconcileEpicProgressionSuccessorClassifiesAuthoritativeState(t *testin
 			repo := filepath.Join(t.TempDir(), "repo")
 			key := flowstore.EpicProgressionKey{RepoPath: repo, EpicID: "epic"}
 			link := flowstore.BeadLink{ID: "epic.2", EpicID: "epic"}
-			if _, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Enabled: true}); err != nil {
+			active, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Enabled: true})
+			if err != nil {
 				t.Fatal(err)
 			}
 			flowID := "successor"
@@ -76,7 +77,7 @@ func TestReconcileEpicProgressionSuccessorClassifiesAuthoritativeState(t *testin
 			}
 
 			result, err := store.ReconcileEpicProgressionSuccessor(flowstore.EpicProgressionSuccessorUpdate{
-				FlowID: flowID, Key: key, Bead: link,
+				FlowID: flowID, Key: key, Bead: link, ExpectedActivation: active.UpdatedAt,
 			})
 			if err != nil {
 				t.Fatalf("ReconcileEpicProgressionSuccessor() error = %v", err)
@@ -155,7 +156,7 @@ func TestReconcileEpicProgressionSuccessorInactivePrecedesEveryFlowCondition(t *
 				// The inactive progression read must win over every simultaneous
 				// authoritative Flow condition above.
 				result, err := store.ReconcileEpicProgressionSuccessor(flowstore.EpicProgressionSuccessorUpdate{
-					FlowID: flowID, Key: key, Bead: link,
+					FlowID: flowID, Key: key, Bead: link, ExpectedActivation: time.Date(2026, 8, 25, 1, 0, 0, 0, time.UTC),
 				})
 				if err != nil || result.Outcome != flowstore.EpicProgressionSuccessorInactive {
 					t.Fatalf("result = %#v, err %v; want inactive", result, err)
@@ -251,12 +252,13 @@ func TestEpicProgressionDoneTransitionsRequireAuthoritativeActiveState(t *testin
 				}
 			}
 			if initial == "halted" {
-				if _, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Enabled: true}); err != nil {
+				active, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Enabled: true})
+				if err != nil {
 					t.Fatal(err)
 				}
 				if _, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: flowstore.EpicProgressionHalt{
 					ChildBeadID: "epic.1", Status: flowstore.StatusBlocked, Message: "child Flow flow-1 halted auto-progression",
-				}}); err != nil {
+				}, ExpectedActivation: active.UpdatedAt}); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -264,7 +266,7 @@ func TestEpicProgressionDoneTransitionsRequireAuthoritativeActiveState(t *testin
 			if readErr != nil {
 				t.Fatal(readErr)
 			}
-			if _, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Done: true}); err == nil {
+			if _, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Done: true, ExpectedActivation: time.Date(2026, 8, 25, 1, 0, 0, 0, time.UTC)}); err == nil {
 				t.Fatalf("SetEpicProgression(done) from %s succeeded", initial)
 			}
 			after, foundAfter, readErr := store.ReadEpicProgression(key)
@@ -284,11 +286,11 @@ func TestEpicProgressionDoneTransitionsRequireAuthoritativeActiveState(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	done, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Done: true})
+	done, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Done: true, ExpectedActivation: active.UpdatedAt})
 	if err != nil || done.Enabled || !done.Done || done.Halt != nil {
 		t.Fatalf("active -> done = %#v, err %v", done, err)
 	}
-	redundant, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Done: true})
+	redundant, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Done: true, ExpectedActivation: active.UpdatedAt})
 	if err != nil || !redundant.UpdatedAt.Equal(done.UpdatedAt) {
 		t.Fatalf("done -> done = %#v, err %v", redundant, err)
 	}
@@ -482,7 +484,7 @@ func TestHaltEpicProgressionRequiresAuthoritativeActiveState(t *testing.T) {
 		Message:     "child Flow flow-1 halted auto-progression",
 	}
 
-	if _, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: halt}); err == nil {
+	if _, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: halt, ExpectedActivation: now}); err == nil {
 		t.Fatal("HaltEpicProgression(missing row) succeeded")
 	}
 	if _, found, err := store.ReadEpicProgression(key); err != nil || found {
@@ -494,7 +496,7 @@ func TestHaltEpicProgressionRequiresAuthoritativeActiveState(t *testing.T) {
 		t.Fatal(err)
 	}
 	now = now.Add(time.Minute)
-	if _, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: halt}); err == nil {
+	if _, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: halt, ExpectedActivation: off.UpdatedAt}); err == nil {
 		t.Fatal("HaltEpicProgression(normal off) succeeded")
 	}
 	if got, found, err := store.ReadEpicProgression(key); err != nil || !found || got != off {
@@ -507,7 +509,7 @@ func TestHaltEpicProgressionRequiresAuthoritativeActiveState(t *testing.T) {
 		t.Fatal(err)
 	}
 	now = now.Add(time.Minute)
-	halted, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: halt})
+	halted, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: halt, ExpectedActivation: active.UpdatedAt})
 	if err != nil {
 		t.Fatalf("HaltEpicProgression(active) error = %v", err)
 	}
@@ -527,7 +529,7 @@ func TestHaltEpicProgressionRequiresAuthoritativeActiveState(t *testing.T) {
 
 	now = now.Add(time.Minute)
 	later := flowstore.EpicProgressionHalt{ChildBeadID: "epic.2", Status: flowstore.StatusClosed, Message: "a later cause"}
-	sticky, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: later})
+	sticky, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: later, ExpectedActivation: active.UpdatedAt})
 	if err != nil {
 		t.Fatalf("HaltEpicProgression(already halted) error = %v", err)
 	}
@@ -536,15 +538,16 @@ func TestHaltEpicProgressionRequiresAuthoritativeActiveState(t *testing.T) {
 	}
 
 	now = now.Add(time.Minute)
-	if _, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Enabled: true}); err != nil {
+	activeAgain, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Enabled: true})
+	if err != nil {
 		t.Fatal(err)
 	}
-	done, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Done: true})
+	done, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Done: true, ExpectedActivation: activeAgain.UpdatedAt})
 	if err != nil {
 		t.Fatal(err)
 	}
 	now = now.Add(time.Minute)
-	if _, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: halt}); err == nil {
+	if _, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: halt, ExpectedActivation: done.UpdatedAt}); err == nil {
 		t.Fatal("HaltEpicProgression(done) succeeded")
 	}
 	if got, found, err := store.ReadEpicProgression(key); err != nil || !found || got != done {
@@ -576,12 +579,54 @@ func TestHaltEpicProgressionRejectsNonCanonicalHaltTuples(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, err = store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: tt.halt})
+			_, err = store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: tt.halt, ExpectedActivation: active.UpdatedAt})
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("HaltEpicProgression(%#v) error = %v, want %q", tt.halt, err, tt.want)
 			}
 			if got, found, err := store.ReadEpicProgression(key); err != nil || !found || got != active {
 				t.Fatalf("row after rejected halt = %#v, found %t, err %v; want %#v", got, found, err, active)
+			}
+		})
+	}
+}
+
+func TestEpicProgressionObservedEdgesRequireValidExpectedActivation(t *testing.T) {
+	store, err := flowstore.NewStore(flowstore.StoreOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	key := flowstore.EpicProgressionKey{RepoPath: filepath.Join(t.TempDir(), "repo"), EpicID: "epic"}
+	halt := flowstore.EpicProgressionHalt{ChildBeadID: "epic.1", Status: flowstore.StatusBlocked, Message: "blocked"}
+	invalid := time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, tt := range []struct {
+		name string
+		run  func() error
+		want string
+	}{
+		{name: "completion missing", run: func() error {
+			_, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Done: true})
+			return err
+		}, want: "required"},
+		{name: "completion malformed", run: func() error {
+			_, err := store.SetEpicProgression(flowstore.EpicProgressionUpdate{Key: key, Done: true, ExpectedActivation: invalid})
+			return err
+		}, want: "invalid"},
+		{name: "halt missing", run: func() error {
+			_, err := store.HaltEpicProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: halt})
+			return err
+		}, want: "required"},
+		{name: "successor missing", run: func() error {
+			_, err := store.ReconcileEpicProgressionSuccessor(flowstore.EpicProgressionSuccessorUpdate{
+				FlowID: "prepared", Key: key, Bead: flowstore.BeadLink{ID: "epic.2", EpicID: key.EpicID},
+			})
+			return err
+		}, want: "required"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.run(); err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
 			}
 		})
 	}

--- a/flowstore/epic_progression_test.go
+++ b/flowstore/epic_progression_test.go
@@ -410,7 +410,7 @@ func TestEnableEpicProgressionRefusesIncompleteClosedAndRunningFlows(t *testing.
 	}
 }
 
-func TestEpicProgressionUpdatesClampRegressingClock(t *testing.T) {
+func TestEpicProgressionUpdatesAdvanceAcrossRegressingClock(t *testing.T) {
 	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
 	repo := filepath.Join(t.TempDir(), "repo")
 	store, err := flowstore.NewStore(flowstore.StoreOptions{
@@ -455,8 +455,8 @@ func TestEpicProgressionUpdatesClampRegressingClock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if disabled.UpdatedAt.Before(enabled.UpdatedAt) {
-		t.Fatalf("disabled updated_at regressed from %s to %s", enabled.UpdatedAt, disabled.UpdatedAt)
+	if !disabled.UpdatedAt.After(enabled.UpdatedAt) {
+		t.Fatalf("disabled updated_at = %s, want after %s", disabled.UpdatedAt, enabled.UpdatedAt)
 	}
 	now = now.Add(-time.Minute)
 	atomicallyEnabled, _, err := store.EnableEpicProgressionForPreparedFlow(flowstore.PreparedEpicProgressionUpdate{
@@ -465,8 +465,8 @@ func TestEpicProgressionUpdatesClampRegressingClock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if atomicallyEnabled.UpdatedAt.Before(disabled.UpdatedAt) {
-		t.Fatalf("atomic enable updated_at regressed from %s to %s", disabled.UpdatedAt, atomicallyEnabled.UpdatedAt)
+	if !atomicallyEnabled.UpdatedAt.After(disabled.UpdatedAt) {
+		t.Fatalf("atomic enable updated_at = %s, want after %s", atomicallyEnabled.UpdatedAt, disabled.UpdatedAt)
 	}
 }
 

--- a/model/epic_progression.go
+++ b/model/epic_progression.go
@@ -1,9 +1,11 @@
 package model
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -58,6 +60,11 @@ type epicProgressionOwnedSuccessor struct {
 	FlowID       string
 }
 
+type epicProgressionBaseline struct {
+	flowstore.FlowRecord
+	Activation time.Time
+}
+
 type epicProgressionAdvanceRequest struct {
 	Request      uint64
 	OwnerToken   uint64
@@ -87,6 +94,7 @@ type epicProgressionAdvanceResultMsg struct {
 	repoPath     string
 	epicID       string
 	sourceFlowID string
+	activation   time.Time
 	disposition  epicProgressionAdvanceDisposition
 	// owned and childTitle are selection-only: the chosen child and its Bead
 	// title, carried to the create-then-launch intent that follows.
@@ -156,7 +164,7 @@ func (m Model) releaseFlowPreparation(kind flowPreparationKind, token uint64) Mo
 	return m
 }
 
-func (m Model) startEpicProgressionAdvance(epicKey string, baseline, observed flowstore.FlowRecord) (Model, tea.Cmd) {
+func (m Model) startEpicProgressionAdvance(epicKey string, baseline epicProgressionBaseline, observed flowstore.FlowRecord) (Model, tea.Cmd) {
 	var ownerToken uint64
 	var admitted bool
 	m, ownerToken, admitted = m.acquireFlowPreparation(flowPreparationEpicAdvance)
@@ -177,7 +185,7 @@ func (m Model) startEpicProgressionAdvance(epicKey string, baseline, observed fl
 // successor reconciliation and its first phase — belongs to the create-phase
 // launch pipeline the selection is handed to, so the whole advance is one
 // admitted launch attempt rather than a preparation plus a later start.
-func (m Model) advanceEpicProgressionCmd(request epicProgressionAdvanceRequest, baseline, observed flowstore.FlowRecord) tea.Cmd {
+func (m Model) advanceEpicProgressionCmd(request epicProgressionAdvanceRequest, baseline epicProgressionBaseline, observed flowstore.FlowRecord) tea.Cmd {
 	readProgression := m.readEpicProgression
 	closeBead := m.closeBead
 	listChildren := m.listChildrenBeads
@@ -190,7 +198,7 @@ func (m Model) advanceEpicProgressionCmd(request epicProgressionAdvanceRequest, 
 	result := func(disposition epicProgressionAdvanceDisposition, status string) epicProgressionAdvanceResultMsg {
 		return epicProgressionAdvanceResultMsg{
 			request: request.Request, ownerToken: request.OwnerToken, epicKey: request.EpicKey,
-			repoPath: repoPath, epicID: epicID, sourceFlowID: request.SourceFlowID,
+			repoPath: repoPath, epicID: epicID, sourceFlowID: request.SourceFlowID, activation: baseline.Activation,
 			disposition: disposition, degradation: degradation, status: status,
 		}
 	}
@@ -200,7 +208,8 @@ func (m Model) advanceEpicProgressionCmd(request epicProgressionAdvanceRequest, 
 		if err != nil {
 			return result(epicProgressionAdvanceRetryable, fmt.Sprintf("Could not confirm auto-progression state for epic %s: %v", epicID, err))
 		}
-		if !found || !progression.Enabled || progression.Done || progression.Halt != nil {
+		if !found || !progression.Enabled || progression.Done || progression.Halt != nil ||
+			(!progression.UpdatedAt.IsZero() && !progression.UpdatedAt.Equal(baseline.Activation)) {
 			return result(epicProgressionAdvanceInactive, fmt.Sprintf("Auto-progression for epic %s is no longer active", epicID))
 		}
 
@@ -302,9 +311,12 @@ func (m Model) advanceEpicProgressionCmd(request epicProgressionAdvanceRequest, 
 			if intersection > 0 && linked == intersection {
 				status = fmt.Sprintf("Auto-progression complete for epic %s; every ready child already has a Flow", epicID)
 			}
-			_, doneErr := setProgression(flowstore.EpicProgressionUpdate{Key: key, Enabled: false, Done: true})
+			_, doneErr := setProgression(flowstore.EpicProgressionUpdate{Key: key, Enabled: false, Done: true, ExpectedActivation: baseline.Activation})
 			if doneErr == nil {
 				return result(epicProgressionAdvanceExhausted, status)
+			}
+			if errors.Is(doneErr, flowstore.ErrEpicProgressionActivationChanged) {
+				return result(epicProgressionAdvanceInactive, fmt.Sprintf("Auto-progression for epic %s is no longer active", epicID))
 			}
 			authoritative, stillFound, readErr := readProgression(key)
 			if readErr != nil {
@@ -351,7 +363,7 @@ func progressionMergedChildClose(observed flowstore.FlowRecord) (string, string,
 	return beadID, reason, true
 }
 
-func (m Model) startEpicProgressionHalt(epicKey string, baseline, observed flowstore.FlowRecord) (Model, tea.Cmd) {
+func (m Model) startEpicProgressionHalt(epicKey string, baseline epicProgressionBaseline, observed flowstore.FlowRecord) (Model, tea.Cmd) {
 	var ownerToken uint64
 	var admitted bool
 	m, ownerToken, admitted = m.acquireFlowPreparation(flowPreparationEpicHalt)
@@ -371,13 +383,13 @@ func (m Model) startEpicProgressionHalt(epicKey string, baseline, observed flows
 		Status:      epicProgressionResolvedStatus(observed),
 		Message:     fmt.Sprintf("child Flow %s halted auto-progression", strings.TrimSpace(observed.FlowID)),
 	}
-	return m, m.haltEpicProgressionCauseCmd(request, filepath.Clean(observed.RepoPath), strings.TrimSpace(observed.Bead.EpicID), halt)
+	return m, m.haltEpicProgressionCauseCmd(request, filepath.Clean(observed.RepoPath), strings.TrimSpace(observed.Bead.EpicID), baseline.Activation, halt)
 }
 
 // haltEpicProgressionCauseCmd persists one already-composed halt tuple. Both
 // halt edges — a failed child and a child that could not launch at all — share
 // it, so neither can invent its own announcement or its own retry rules.
-func (m Model) haltEpicProgressionCauseCmd(request epicProgressionHaltRequest, repoPath, epicID string, halt flowstore.EpicProgressionHalt) tea.Cmd {
+func (m Model) haltEpicProgressionCauseCmd(request epicProgressionHaltRequest, repoPath, epicID string, activation time.Time, halt flowstore.EpicProgressionHalt) tea.Cmd {
 	haltProgression := m.haltEpicProgression
 	readProgression := m.readEpicProgression
 	result := func(disposition epicProgressionHaltDisposition, status string) epicProgressionHaltResultMsg {
@@ -389,7 +401,7 @@ func (m Model) haltEpicProgressionCauseCmd(request epicProgressionHaltRequest, r
 	}
 	return func() tea.Msg {
 		key := flowstore.EpicProgressionKey{RepoPath: repoPath, EpicID: epicID}
-		persisted, err := haltProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: halt})
+		persisted, err := haltProgression(flowstore.EpicProgressionHaltUpdate{Key: key, Halt: halt, ExpectedActivation: activation})
 		if err == nil {
 			// Halt is sticky, so an already-halted row keeps its first cause and
 			// this attempt's tuple is discarded. Announce what the store retained,
@@ -399,6 +411,9 @@ func (m Model) haltEpicProgressionCauseCmd(request epicProgressionHaltRequest, r
 				cause = *persisted.Halt
 			}
 			return result(epicProgressionHaltPersisted, epicProgressionHaltStatus(epicID, cause))
+		}
+		if errors.Is(err, flowstore.ErrEpicProgressionActivationChanged) {
+			return result(epicProgressionHaltInactive, fmt.Sprintf("Auto-progression for epic %s is no longer active", epicID))
 		}
 		authoritative, found, readErr := readProgression(key)
 		if readErr != nil {
@@ -410,7 +425,7 @@ func (m Model) haltEpicProgressionCauseCmd(request epicProgressionHaltRequest, r
 			// tuple rather than the generic inactive line.
 			return result(epicProgressionHaltPersisted, epicProgressionHaltStatus(epicID, *authoritative.Halt))
 		}
-		if found && authoritative.Enabled && !authoritative.Done {
+		if found && authoritative.Enabled && !authoritative.Done && authoritative.UpdatedAt.Equal(activation) {
 			return result(epicProgressionHaltRetryable, fmt.Sprintf("Could not halt auto-progression for epic %s: %v", epicID, err))
 		}
 		return result(epicProgressionHaltInactive, fmt.Sprintf("Auto-progression for epic %s is no longer active", epicID))
@@ -990,12 +1005,12 @@ func (m Model) handleEpicProgressionToggleResult(msg epicProgressionToggleResult
 		switch msg.baselineDisposition {
 		case epicProgressionBaselineReplace:
 			if m.epicProgressionBaselines == nil {
-				m.epicProgressionBaselines = make(map[string]flowstore.FlowRecord)
+				m.epicProgressionBaselines = make(map[string]epicProgressionBaseline)
 			}
 			if m.epicProgressionBaselineMinimumRequests == nil {
 				m.epicProgressionBaselineMinimumRequests = make(map[string]uint64)
 			}
-			m.epicProgressionBaselines[key] = msg.flow
+			m.epicProgressionBaselines[key] = epicProgressionBaseline{FlowRecord: msg.flow, Activation: msg.progression.UpdatedAt}
 			m.epicProgressionBaselineMinimumRequests[key] = m.autoAdvanceRequestSeq + 1
 			delete(m.epicProgressionOwnedSuccessors, key)
 		case epicProgressionBaselineRemove:

--- a/model/epic_progression_advance_internal_test.go
+++ b/model/epic_progression_advance_internal_test.go
@@ -54,7 +54,7 @@ func TestEpicProgressionAdvanceUsesReadyOrderAndSkipsExactLinkedChildren(t *test
 	linked := progressionAdvanceFlow("linked-a", repo, "epic.a", epic, flowstore.StatusCompleted)
 	beadQueries := 0
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -107,7 +107,7 @@ func TestEpicProgressionAdvanceUsesReadableFlowsFromPartialList(t *testing.T) {
 	partial := testPartialList("unreadable-flow")
 
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -148,7 +148,7 @@ func TestEpicProgressionAdvanceKeepsFatalFlowListFailureRetryable(t *testing.T) 
 	setCalls, haltCalls := 0, 0
 
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -192,7 +192,7 @@ func TestEpicProgressionAdvanceSkipsAnEpicWhoseChildIsAlreadyInFlight(t *testing
 	terminal := cloneFlowRecord(source)
 	terminal.Status = flowstore.StatusCompleted
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		epicProgressionOwnedSuccessors: map[string]epicProgressionOwnedSuccessor{
 			key: {SourceFlowID: source.FlowID, ChildID: "epic.b", FlowID: "flow-b"},
 		},
@@ -225,9 +225,9 @@ func TestEpicProgressionAdvanceRotatesRetryingEpics(t *testing.T) {
 	secondTerminal.Status = flowstore.StatusCompleted
 
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{
-			firstKey:  firstSource,
-			secondKey: secondSource,
+		epicProgressionBaselines: map[string]epicProgressionBaseline{
+			firstKey:  progressionBaselineForTest(firstSource),
+			secondKey: progressionBaselineForTest(secondSource),
 		},
 		readEpicProgression: func(key flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{}, false, errors.New("store unavailable for " + key.EpicID)
@@ -273,10 +273,13 @@ func TestEpicProgressionRuntimeBaselineLifecycle(t *testing.T) {
 	})
 
 	t.Run("non terminal observation refreshes exact baseline", func(t *testing.T) {
-		m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source}, autoAdvanceState: autoAdvanceState{autoAdvanceInFlight: 1}}
+		m := Model{epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)}, autoAdvanceState: autoAdvanceState{autoAdvanceInFlight: 1}}
 		next, _ := updateFlowRefreshTest(m, AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{nonSuccess}, Request: 1})
 		if next.epicProgressionBaselines[key].Title != "refreshed" {
 			t.Fatalf("baseline = %#v", next.epicProgressionBaselines[key])
+		}
+		if got, want := next.epicProgressionBaselines[key].Activation, progressionBaselineForTest(source).Activation; !got.Equal(want) {
+			t.Fatalf("activation changed from %s to %s during refresh", want, got)
 		}
 	})
 
@@ -289,7 +292,7 @@ func TestEpicProgressionRuntimeBaselineLifecycle(t *testing.T) {
 		{name: "missing tracked flow", msg: AutoAdvanceResultMsg{Flows: nil, Request: 1}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source}, autoAdvanceState: autoAdvanceState{autoAdvanceInFlight: 1}}
+			m := Model{epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)}, autoAdvanceState: autoAdvanceState{autoAdvanceInFlight: 1}}
 			next, _ := updateFlowRefreshTest(m, tt.msg)
 			if next.epicProgressionBaselines[key].FlowID != source.FlowID {
 				t.Fatalf("baseline changed: %#v", next.epicProgressionBaselines)
@@ -315,11 +318,12 @@ func TestEpicProgressionAdvanceChecksAuthoritativeStateBeforeSideEffects(t *test
 		{name: "disabled", found: true, progression: flowstore.EpicProgression{RepoPath: repo, EpicID: epic}},
 		{name: "done", found: true, progression: flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Done: true}},
 		{name: "halted", found: true, progression: flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Halt: &flowstore.EpicProgressionHalt{ChildBeadID: "epic.a", Status: flowstore.StatusBlocked, Message: "halted"}}},
+		{name: "new activation", found: true, progression: flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true, UpdatedAt: progressionBaselineForTest(source).Activation.Add(time.Minute)}},
 		{name: "unreadable", err: errors.New("corrupt row"), wantBaseline: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			sideEffects := 0
-			m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+			m := Model{epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 				readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 					return tt.progression, tt.found, tt.err
 				},
@@ -365,10 +369,11 @@ func TestEpicProgressionExhaustionReconciliationMatrix(t *testing.T) {
 		{name: "write error reread halted", setErr: errors.New("write"), readFound: true, readHalt: true, wantStatus: "no longer active"},
 		{name: "write error reread enabled", setErr: errors.New("write"), readFound: true, readEnabled: true, wantBaseline: true, wantStatus: "Could not disable"},
 		{name: "write error reread error", setErr: errors.New("write"), readErr: errors.New("read"), wantStatus: "Could not confirm"},
+		{name: "stale activation", setErr: flowstore.ErrEpicProgressionActivationChanged, wantStatus: "no longer active"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			reads := 0
-			m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+			m := Model{epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 				readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 					reads++
 					if reads == 1 {
@@ -384,7 +389,7 @@ func TestEpicProgressionExhaustionReconciliationMatrix(t *testing.T) {
 				listReadyBeads:    func(string) ([]beadsquery.Bead, error) { return nil, nil },
 				listFlows:         func(flowstore.FlowFilter) ([]flowstore.FlowRecord, error) { return nil, nil },
 				setEpicProgression: func(update flowstore.EpicProgressionUpdate) (flowstore.EpicProgression, error) {
-					if update.Enabled || !update.Done {
+					if update.Enabled || !update.Done || !update.ExpectedActivation.Equal(progressionBaselineForTest(source).Activation) {
 						t.Fatalf("exhaustion update = %#v, want enabled=false done=true", update)
 					}
 					return flowstore.EpicProgression{RepoPath: repo, EpicID: epic}, tt.setErr
@@ -407,7 +412,7 @@ func TestEpicProgressionPreparationAdmissionIsSingleFlightAndStaleResultFenced(t
 	source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
 	terminal := cloneFlowRecord(source)
 	terminal.Status = flowstore.StatusCompleted
-	m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+	m := Model{epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -471,7 +476,7 @@ func TestEpicProgressionSelectionScopeDoesNotSuppressOtherRepositoryLink(t *test
 	source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
 	terminal := cloneFlowRecord(source)
 	terminal.Status = flowstore.StatusCompleted
-	m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+	m := Model{epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -505,7 +510,7 @@ func TestEpicProgressionExhaustionReportsAllReadyChildrenAlreadyLinked(t *testin
 	terminal := cloneFlowRecord(source)
 	terminal.Status = flowstore.StatusCompleted
 	linked := progressionAdvanceFlow("flow-b", repo, "epic.b", epic, flowstore.StatusPending)
-	m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+	m := Model{epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -624,7 +629,7 @@ func TestEpicProgressionSelectionMatchesBeadSlotGuard(t *testing.T) {
 			terminal := cloneFlowRecord(source)
 			terminal.Status = flowstore.StatusCompleted
 			existing := tt.existing()
-			m := Model{epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+			m := Model{epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 				readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 					return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 				},
@@ -686,7 +691,7 @@ func TestEpicProgressionBeadSlotRefusalConvergesAcrossPasses(t *testing.T) {
 	}
 	passes := []pass{}
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -751,7 +756,7 @@ func TestEpicProgressionAdvanceClosesMergedChildBeadBeforeReadyQuery(t *testing.
 	// whole point: a close that lands after the query selects nothing.
 	ready := []beadsquery.Bead{}
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -802,7 +807,7 @@ func TestEpicProgressionAdvanceDoesNotCloseUnmergedChildBead(t *testing.T) {
 
 	closes := 0
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},
@@ -840,7 +845,7 @@ func TestEpicProgressionAdvanceCloseFailureIsRetryable(t *testing.T) {
 	queries := 0
 	setProgressionCalls := 0
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true}, true, nil
 		},

--- a/model/epic_progression_halt_internal_test.go
+++ b/model/epic_progression_halt_internal_test.go
@@ -99,7 +99,7 @@ func TestEpicProgressionFailureTerminalHaltsAndDropsTracking(t *testing.T) {
 			var updates []flowstore.EpicProgressionHaltUpdate
 			sideEffects := 0
 			m := Model{
-				epicProgressionBaselines:               map[string]flowstore.FlowRecord{key: source},
+				epicProgressionBaselines:               map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 				epicProgressionBaselineMinimumRequests: map[string]uint64{key: 1},
 				epicProgressionOwnedSuccessors: map[string]epicProgressionOwnedSuccessor{
 					key: {SourceFlowID: source.FlowID, ChildID: "epic.b", FlowID: "flow-b"},
@@ -138,7 +138,8 @@ func TestEpicProgressionFailureTerminalHaltsAndDropsTracking(t *testing.T) {
 				Status:      tt.want,
 				Message:     "child Flow flow-a halted auto-progression",
 			}
-			if len(updates) != 1 || updates[0].Key != (flowstore.EpicProgressionKey{RepoPath: repo, EpicID: epic}) || updates[0].Halt != wantHalt {
+			wantActivation := progressionBaselineForTest(source).Activation
+			if len(updates) != 1 || updates[0].Key != (flowstore.EpicProgressionKey{RepoPath: repo, EpicID: epic}) || updates[0].Halt != wantHalt || !updates[0].ExpectedActivation.Equal(wantActivation) {
 				t.Fatalf("halt updates = %#v, want one %#v", updates, wantHalt)
 			}
 
@@ -218,7 +219,7 @@ func TestEpicProgressionSuccessAndNonTerminalObservationsDoNotHalt(t *testing.T)
 			source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
 			observed := tt.observed(cloneFlowRecord(source))
 			m := Model{
-				epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+				epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 				haltEpicProgression: func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 					t.Fatal("non-failure observation halted progression")
 					return flowstore.EpicProgression{}, nil
@@ -272,6 +273,12 @@ func TestEpicProgressionHaltPersistenceFailureUsesAuthoritativeState(t *testing.
 			wantBaseline:    true,
 		},
 		{
+			name:            "new activation",
+			progression:     flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Enabled: true, UpdatedAt: time.Date(2026, 8, 25, 13, 0, 0, 0, time.UTC)},
+			found:           true,
+			wantDisposition: epicProgressionHaltInactive,
+		},
+		{
 			name:            "unreadable",
 			readErr:         errors.New("corrupt row"),
 			wantDisposition: epicProgressionHaltRetryable,
@@ -299,11 +306,15 @@ func TestEpicProgressionHaltPersistenceFailureUsesAuthoritativeState(t *testing.
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
+			baseline := progressionBaselineForTest(source)
+			if tt.name == "still active" {
+				tt.progression.UpdatedAt = baseline.Activation
+			}
 			observed := cloneFlowRecord(source)
 			observed.Status = flowstore.StatusBlocked
 			halts := 0
 			m := Model{
-				epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+				epicProgressionBaselines: map[string]epicProgressionBaseline{key: baseline},
 				haltEpicProgression: func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 					halts++
 					return flowstore.EpicProgression{}, errors.New("write failed")
@@ -339,6 +350,40 @@ func TestEpicProgressionHaltPersistenceFailureUsesAuthoritativeState(t *testing.
 	}
 }
 
+func TestEpicProgressionHaltActivationMismatchStopsWithoutAdoptingFreshState(t *testing.T) {
+	repo, epic := "/repo", "epic"
+	key := epicProgressionBaselineKey(repo, epic)
+	source := progressionAdvanceFlow("flow-a", repo, "epic.a", epic, flowstore.StatusPending)
+	baseline := progressionBaselineForTest(source)
+	reads := 0
+	m := Model{
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: baseline},
+		haltEpicProgression: func(update flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
+			if !update.ExpectedActivation.Equal(baseline.Activation) {
+				t.Fatalf("expected activation = %s, want %s", update.ExpectedActivation, baseline.Activation)
+			}
+			return flowstore.EpicProgression{}, flowstore.ErrEpicProgressionActivationChanged
+		},
+		readEpicProgression: func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
+			reads++
+			return flowstore.EpicProgression{Enabled: true, UpdatedAt: baseline.Activation.Add(time.Minute)}, true, nil
+		},
+	}
+	request := epicProgressionHaltRequest{Request: 1, EpicKey: key, SourceFlowID: source.FlowID}
+	m.activeEpicProgressionHalt = request
+	m.flowPreparationAdmission = true
+	msg := epicProgressionHaltMessage(t, m.haltEpicProgressionCauseCmd(request, repo, epic, baseline.Activation, flowstore.EpicProgressionHalt{
+		ChildBeadID: "epic.a", Status: flowstore.StatusBlocked, Message: "blocked",
+	}))
+	if msg.disposition != epicProgressionHaltInactive || reads != 0 {
+		t.Fatalf("stale halt = disposition %v, reads %d; want inactive without readback", msg.disposition, reads)
+	}
+	next, _ := updateFlowRefreshTest(m, msg)
+	if _, tracked := next.epicProgressionBaselines[key]; tracked {
+		t.Fatalf("stale halt retained old baseline: %#v", next.epicProgressionBaselines)
+	}
+}
+
 // TestEpicProgressionHaltSharesPreparationAdmissionAndRotates covers Design 4:
 // the halt cannot interleave with an in-flight advance, and a halt that keeps
 // failing cannot starve the other tracked epics.
@@ -357,7 +402,7 @@ func TestEpicProgressionHaltSharesPreparationAdmissionAndRotates(t *testing.T) {
 
 	t.Run("held admission defers without losing the edge", func(t *testing.T) {
 		m := Model{
-			epicProgressionBaselines: map[string]flowstore.FlowRecord{firstKey: firstSource},
+			epicProgressionBaselines: map[string]epicProgressionBaseline{firstKey: progressionBaselineForTest(firstSource)},
 			flowPreparationAdmission: true,
 			flowPreparationSeq:       7,
 			flowPreparationOwner:     flowPreparationOwner{Kind: flowPreparationEpicAdvance, Token: 7},
@@ -384,8 +429,8 @@ func TestEpicProgressionHaltSharesPreparationAdmissionAndRotates(t *testing.T) {
 
 	t.Run("failing halt rotates to the next tracked epic", func(t *testing.T) {
 		m := Model{
-			epicProgressionBaselines: map[string]flowstore.FlowRecord{
-				firstKey: firstSource, secondKey: secondSource,
+			epicProgressionBaselines: map[string]epicProgressionBaseline{
+				firstKey: progressionBaselineForTest(firstSource), secondKey: progressionBaselineForTest(secondSource),
 			},
 			haltEpicProgression: func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 				return flowstore.EpicProgression{}, errors.New("write failed")
@@ -418,7 +463,7 @@ func TestEpicProgressionStaleHaltResultIsFencedAndReleasesAdmission(t *testing.T
 	blocked := cloneFlowRecord(source)
 	blocked.Status = flowstore.StatusBlocked
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		haltEpicProgression: func(update flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 			halt := update.Halt
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Halt: &halt}, nil
@@ -627,7 +672,7 @@ func TestEpicProgressionHaltAnnouncesTheRetainedCause(t *testing.T) {
 		Message:     "child Flow flow-z halted auto-progression",
 	}
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		haltEpicProgression: func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 			first := retained
 			return flowstore.EpicProgression{RepoPath: repo, EpicID: epic, Halt: &first}, nil
@@ -661,7 +706,7 @@ func TestEpicProgressionHaltWriteErrorReportsADurableHalt(t *testing.T) {
 		Message:     "child Flow flow-z halted auto-progression",
 	}
 	m := Model{
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: source},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(source)},
 		haltEpicProgression: func(flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 			return flowstore.EpicProgression{}, errors.New("commit failed")
 		},

--- a/model/epic_progression_internal_test.go
+++ b/model/epic_progression_internal_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/approachcontrol/approach/ui"
 )
 
+func progressionBaselineForTest(flow flowstore.FlowRecord) epicProgressionBaseline {
+	activation := flow.UpdatedAt
+	if activation.IsZero() {
+		activation = time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	}
+	return epicProgressionBaseline{FlowRecord: flow, Activation: activation}
+}
+
 func TestEpicProgressionRetryRelevantIgnoresConsumedSuccessfulMarkers(t *testing.T) {
 	stamp := time.Date(2026, 8, 14, 16, 0, 0, 0, time.UTC)
 	base := flowstore.FlowRecord{FlowID: "flow-1", Status: flowstore.StatusPending, PreparedAt: &stamp, ProgressionClaim: true}
@@ -109,7 +117,7 @@ func TestEpicProgressionToggleReconcilesRuntimeBaselineBeforeReservationRelease(
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			baselines := map[string]flowstore.FlowRecord{key: oldFlow}
+			baselines := map[string]epicProgressionBaseline{key: progressionBaselineForTest(oldFlow)}
 			owned := map[string]epicProgressionOwnedSuccessor{key: {SourceFlowID: oldFlow.FlowID, ChildID: "epic.2", FlowID: "owned-flow"}}
 			m := Model{
 				beadExpansion:                  beadExpansionSnapshot{target: beadExpansionTarget{token: 99}},
@@ -152,7 +160,7 @@ func TestDisableEpicProgressionConfirmedActivePreservesRuntimeBaseline(t *testin
 		readEpicProgression: func(key flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 			return flowstore.EpicProgression{RepoPath: key.RepoPath, EpicID: key.EpicID, Enabled: true}, true, nil
 		},
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: baseline},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(baseline)},
 		epicProgressionOwnedSuccessors: map[string]epicProgressionOwnedSuccessor{
 			key: {SourceFlowID: baseline.FlowID, ChildID: "epic.2", FlowID: "owned-flow"},
 		},
@@ -322,7 +330,7 @@ func TestStaleEpicProgressionToggleOwnerCannotMutateNewerRuntimeState(t *testing
 	m := Model{
 		flowPreparationAdmission: true,
 		flowPreparationOwner:     flowPreparationOwner{Kind: flowPreparationEpicToggle, Token: 2},
-		epicProgressionBaselines: map[string]flowstore.FlowRecord{key: baseline},
+		epicProgressionBaselines: map[string]epicProgressionBaseline{key: progressionBaselineForTest(baseline)},
 		epicProgressionOwnedSuccessors: map[string]epicProgressionOwnedSuccessor{
 			key: owned,
 		},

--- a/model/epic_progression_launch.go
+++ b/model/epic_progression_launch.go
@@ -90,7 +90,7 @@ func (m Model) applyEpicProgressionSuccessor(attempt flowLaunchAttempt, msg flow
 	switch msg.Successor.Outcome {
 	case flowstore.EpicProgressionSuccessorAccepted:
 		if m.epicProgressionBaselines == nil {
-			m.epicProgressionBaselines = make(map[string]flowstore.FlowRecord)
+			m.epicProgressionBaselines = make(map[string]epicProgressionBaseline)
 		}
 		if m.epicProgressionBaselineMinimumRequests == nil {
 			m.epicProgressionBaselineMinimumRequests = make(map[string]uint64)
@@ -99,7 +99,7 @@ func (m Model) applyEpicProgressionSuccessor(attempt flowLaunchAttempt, msg flow
 		// prepared and pending. Installing it here rather than after the launch
 		// keeps the advance edge level-triggered on a record that exists, and a
 		// launch that then fails tears this baseline down through the halt.
-		m.epicProgressionBaselines[key] = cloneFlowRecord(msg.Record)
+		m.epicProgressionBaselines[key] = epicProgressionBaseline{FlowRecord: cloneFlowRecord(msg.Record), Activation: msg.Successor.Progression.UpdatedAt}
 		m.epicProgressionBaselineMinimumRequests[key] = m.autoAdvanceRequestSeq + 1
 		delete(m.epicProgressionOwnedSuccessors, key)
 		return m, nil, false
@@ -160,7 +160,7 @@ func (m Model) failEpicProgressionCreate(create flowLaunchCreateRequest, flowID,
 		Status:      flowstore.StatusBlocked,
 		Message:     epicProgressionLaunchFailureMessage(flowID, cause),
 	}
-	return m, m.haltEpicProgressionCauseCmd(request, repoPath, epicID, halt)
+	return m, m.haltEpicProgressionCauseCmd(request, repoPath, epicID, baseline.Activation, halt)
 }
 
 // epicProgressionLaunchFailureMessage is rendered verbatim beside the child by
@@ -185,11 +185,12 @@ func (m Model) requestEpicProgressionChildLaunch(msg epicProgressionAdvanceResul
 	childID := strings.TrimSpace(msg.owned.ChildID)
 	settings := snapshotFlowLaunchAgentSettings(m.flowLaunchLauncher(""))
 	create := flowLaunchCreateRequest{
-		Presentation: flowLaunchCreatePresentation{Origin: flowLaunchOriginEpicProgression, Request: msg.request},
-		RepoPath:     msg.repoPath,
-		Title:        childID + ": " + strings.TrimSpace(msg.childTitle),
-		Instructions: epicProgressionChildInstructions(childID),
-		Bead:         flowstore.BeadLink{ID: childID, EpicID: msg.epicID},
+		Presentation:   flowLaunchCreatePresentation{Origin: flowLaunchOriginEpicProgression, Request: msg.request},
+		RepoPath:       msg.repoPath,
+		EpicActivation: msg.activation,
+		Title:          childID + ": " + strings.TrimSpace(msg.childTitle),
+		Instructions:   epicProgressionChildInstructions(childID),
+		Bead:           flowstore.BeadLink{ID: childID, EpicID: msg.epicID},
 		// Progression children are unattended by construction: nothing focuses
 		// their terminal and no one types into it, so the record is written
 		// headless and its phases run with AutoMode, which the store enables on

--- a/model/epic_progression_launch_internal_test.go
+++ b/model/epic_progression_launch_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -38,10 +39,12 @@ func newProgressionLaunchFixture(t *testing.T, outcome flowstore.EpicProgression
 		source:  progressionAdvanceFlow("flow-source", progressionLaunchRepo, "epic.a", progressionLaunchEpic, flowstore.StatusCompleted),
 	}
 	m := h.model(t)
+	confirmedActivation := time.Date(2026, 8, 25, 15, 0, 0, 0, time.UTC)
 	m.launchSeams.ReconcileEpicSuccessor = func(update flowstore.EpicProgressionSuccessorUpdate) (flowstore.EpicProgressionSuccessorResult, error) {
 		h.order = append(h.order, "reconcile:"+update.FlowID)
 		if update.FlowID != h.record.FlowID || update.Bead != h.record.Bead ||
-			update.Key != (flowstore.EpicProgressionKey{RepoPath: progressionLaunchRepo, EpicID: progressionLaunchEpic}) {
+			update.Key != (flowstore.EpicProgressionKey{RepoPath: progressionLaunchRepo, EpicID: progressionLaunchEpic}) ||
+			!update.ExpectedActivation.Equal(progressionBaselineForTest(fixture.source).Activation) {
 			t.Fatalf("successor reconciliation = %#v", update)
 		}
 		if h.record.PreparedAt == nil {
@@ -50,7 +53,7 @@ func newProgressionLaunchFixture(t *testing.T, outcome flowstore.EpicProgression
 		if reconcileErr != nil {
 			return flowstore.EpicProgressionSuccessorResult{Outcome: flowstore.EpicProgressionSuccessorRetryable}, reconcileErr
 		}
-		return flowstore.EpicProgressionSuccessorResult{Outcome: outcome, Flow: h.record}, nil
+		return flowstore.EpicProgressionSuccessorResult{Outcome: outcome, Flow: h.record, Progression: flowstore.EpicProgression{UpdatedAt: confirmedActivation}}, nil
 	}
 	m.haltEpicProgression = func(update flowstore.EpicProgressionHaltUpdate) (flowstore.EpicProgression, error) {
 		fixture.halted++
@@ -61,7 +64,7 @@ func newProgressionLaunchFixture(t *testing.T, outcome flowstore.EpicProgression
 	m.readEpicProgression = func(flowstore.EpicProgressionKey) (flowstore.EpicProgression, bool, error) {
 		return flowstore.EpicProgression{RepoPath: progressionLaunchRepo, EpicID: progressionLaunchEpic, Enabled: true}, true, nil
 	}
-	m.epicProgressionBaselines = map[string]flowstore.FlowRecord{fixture.key: fixture.source}
+	m.epicProgressionBaselines = map[string]epicProgressionBaseline{fixture.key: progressionBaselineForTest(fixture.source)}
 	m.epicProgressionBaselineMinimumRequests = map[string]uint64{}
 	m.epicProgressionOwnedSuccessors = map[string]epicProgressionOwnedSuccessor{}
 
@@ -87,6 +90,7 @@ func (f *progressionLaunchFixture) admit(t *testing.T, m Model) (Model, tea.Cmd)
 		},
 		RepoPath: progressionLaunchRepo, Title: "New Flow", Instructions: "Write the plan.",
 		Bead: f.harness.record.Bead, BaseRef: "main", Headless: true,
+		EpicActivation: m.epicProgressionBaselines[f.key].Activation,
 	}
 	settings := snapshotFlowLaunchAgentSettings(m.flowLaunchLauncher(""))
 	next, cmd, admitted := m.requestFlowLaunch(flowLaunchIntent{
@@ -157,7 +161,7 @@ func TestProgressionCreateLaunchesTheFirstPhaseAndOwnsItsSuccessor(t *testing.T)
 	if reconcileAt, launchAt := strings.Index(joined, "reconcile:"), strings.Index(joined, "launch-id:"); reconcileAt < 0 || launchAt < 0 || reconcileAt > launchAt {
 		t.Fatalf("order = %#v, want reconciliation before the first phase is made running", h.order)
 	}
-	if got := m.epicProgressionBaselines[fixture.key]; got.FlowID != h.record.FlowID {
+	if got := m.epicProgressionBaselines[fixture.key]; got.FlowID != h.record.FlowID || !got.Activation.Equal(time.Date(2026, 8, 25, 15, 0, 0, 0, time.UTC)) {
 		t.Fatalf("baseline = %#v, want the accepted child", got)
 	}
 	if got := m.epicProgressionBaselineMinimumRequests[fixture.key]; got != m.autoAdvanceRequestSeq+1 {

--- a/model/flow_advance_tick.go
+++ b/model/flow_advance_tick.go
@@ -174,7 +174,7 @@ func (m Model) prepareEpicProgressionAdvance(current []flowstore.FlowRecord, req
 		// this design already accepts.
 		switch {
 		case epicProgressionSuccessTerminal(observed):
-			if epicProgressionSuccessTerminal(baseline) {
+			if epicProgressionSuccessTerminal(baseline.FlowRecord) {
 				continue
 			}
 			if owned, ok := m.epicProgressionOwnedSuccessors[key]; ok && owned.SourceFlowID == baseline.FlowID {
@@ -192,7 +192,7 @@ func (m Model) prepareEpicProgressionAdvance(current []flowstore.FlowRecord, req
 				return m, cmd
 			}
 		case epicProgressionFailureTerminal(observed):
-			if epicProgressionFailureTerminal(baseline) {
+			if epicProgressionFailureTerminal(baseline.FlowRecord) {
 				continue
 			}
 			// The halt tuple is composed from the observed record, never from
@@ -205,7 +205,8 @@ func (m Model) prepareEpicProgressionAdvance(current []flowstore.FlowRecord, req
 				return m, cmd
 			}
 		default:
-			m.epicProgressionBaselines[key] = cloneFlowRecord(observed)
+			baseline.FlowRecord = cloneFlowRecord(observed)
+			m.epicProgressionBaselines[key] = baseline
 		}
 	}
 	return m, nil

--- a/model/flow_launch_create.go
+++ b/model/flow_launch_create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -28,13 +29,14 @@ type flowLaunchCreatePresentation struct {
 // Presentation and RepoPath together are its source-aware presentation fence;
 // the remaining fields are immutable request-time snapshots.
 type flowLaunchCreateRequest struct {
-	Presentation flowLaunchCreatePresentation
-	RepoPath     string
-	Title        string
-	Instructions string
-	Bead         flowstore.BeadLink
-	BaseRef      string
-	Headless     bool
+	Presentation   flowLaunchCreatePresentation
+	RepoPath       string
+	Title          string
+	Instructions   string
+	Bead           flowstore.BeadLink
+	BaseRef        string
+	Headless       bool
+	EpicActivation time.Time
 }
 
 // flowLaunchCreateRequestedMsg keeps the form thin: it carries intent and the
@@ -691,9 +693,10 @@ func reconcileCreatedEpicSuccessor(seams flowLaunchSeams, attempt flowLaunchAtte
 	}
 	create := attempt.Create
 	result, err := seams.ReconcileEpicSuccessor(flowstore.EpicProgressionSuccessorUpdate{
-		FlowID: attempt.FlowID,
-		Key:    flowstore.EpicProgressionKey{RepoPath: create.RepoPath, EpicID: create.Bead.EpicID},
-		Bead:   create.Bead,
+		FlowID:             attempt.FlowID,
+		Key:                flowstore.EpicProgressionKey{RepoPath: create.RepoPath, EpicID: create.Bead.EpicID},
+		Bead:               create.Bead,
+		ExpectedActivation: create.EpicActivation,
 	})
 	if err != nil {
 		return result, err.Error()

--- a/model/model.go
+++ b/model/model.go
@@ -223,7 +223,7 @@ type Model struct {
 	tmuxAttachHint          bool
 	embeddedTerminalState
 	autoAdvanceState
-	epicProgressionBaselines map[string]flowstore.FlowRecord
+	epicProgressionBaselines map[string]epicProgressionBaseline
 
 	epicProgressionBaselineMinimumRequests map[string]uint64
 


### PR DESCRIPTION
A stale TUI process can retain an epic child baseline after another process disables and re-enables the same epic. Its later halt, completion, or successor write can then mutate the new activation.

This change uses the progression row UpdatedAt value as the activation generation. Runtime baselines carry that generation into edge-derived writes, and the store compares it inside the transaction before changing the row. Disable and re-enable mutations now advance the generation monotonically, including when the clock is frozen or moves backward.

Regression coverage exercises stale halt, exhausted completion, and successor reconciliation, plus matching-generation behavior and frozen-clock reactivation.

Tests:
- make fmt-check
- make test
- make build