### PR TITLE
docs(flow): retain agent as the canonical phase term

### DIFF
--- a/docs/flow-phases.md
+++ b/docs/flow-phases.md
@@ -640,6 +640,14 @@ readiness, or linked plan. An identical replacement preserves timestamps.
 
 ## Compatibility and migration
 
+`agent` is the canonical Flow term for a phase's coding-agent selector. The
+Flow JSON field, `approach flow phase agent set --agent`, the TUI, and the
+`APPROACH_AGENT` launch context all use it. Session ingestion and external
+issue or PR metadata use `provider` for separate concepts, while `command`
+describes the configured executable used to launch the selected agent. Existing
+Flow records remain authoritative; no `provider` or `command` alias, record
+migration, or schema-version change is planned.
+
 - The persisted schema gains three optional phase fields (`agent`, `model`,
   `reasoning_effort`); `schema_version` stays `1`, `closed` is an additive
   status, and no existing status strings were removed or renamed. Records


### PR DESCRIPTION
Flow phase settings already persist and expose `agent`, but nearby code uses `provider` and `command` for different concepts. Without an explicit rationale, future work could treat the naming difference as unfinished cleanup and introduce an unnecessary persisted-schema migration.

This documents `agent` as the canonical term for the Flow JSON field, CLI, TUI, and launch context. It also distinguishes session and external-service `provider` metadata from the configured executable `command`, and records that no alias, migration, or schema-version change is planned.

Validation:
- `git diff --check origin/main...HEAD`
- `make fmt-check`
- prior Flow autoreview passed with no actionable findings