### PR TITLE
feat(actions): add Ghostty GUI terminal alias

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -2264,6 +2264,9 @@ func parseTerminalPreference(source, terminal string, lookPath lookPathFunc) ter
 }
 
 func normalizeMacOSGUIAppAlias(value string) (string, bool) {
+	if value == "Ghostty" || value == "Ghostty.app" {
+		return "Ghostty", true
+	}
 	switch strings.ToLower(value) {
 	case "terminal", "terminal.app":
 		return "Terminal", true
@@ -2284,6 +2287,9 @@ func terminalLaunchFromPreference(goos, path string, lookPath lookPathFunc, pref
 		}
 		if command != nil {
 			if !commandExists("osascript", lookPath) {
+				if pref.app == "Ghostty" {
+					return TerminalLaunchSpec{}, ghosttyAppleScriptDependencyError("launch agent")
+				}
 				return TerminalLaunchSpec{}, fmt.Errorf("cannot launch agent: osascript is required to run a command in %s", pref.app)
 			}
 			return TerminalLaunchSpec{
@@ -2294,8 +2300,11 @@ func terminalLaunchFromPreference(goos, path string, lookPath lookPathFunc, pref
 		if pref.app == "Terminal" && !commandExists("open", lookPath) {
 			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch terminal: open is required to open Terminal")
 		}
-		if pref.app == "iTerm" && !commandExists("osascript", lookPath) {
-			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch terminal: osascript is required to open iTerm")
+		if pref.app != "Terminal" && !commandExists("osascript", lookPath) {
+			if pref.app == "Ghostty" {
+				return TerminalLaunchSpec{}, ghosttyAppleScriptDependencyError("launch terminal")
+			}
+			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch terminal: osascript is required to open %s", pref.app)
 		}
 		return TerminalLaunchSpec{Cmd: macOSTerminalOpenCommand(pref.app, path)}, nil
 	case terminalPreferenceUnsupportedGUIApp:
@@ -2330,6 +2339,9 @@ func detachedTerminalLaunchFromPreference(goos, cwd string, lookPath lookPathFun
 			return TerminalLaunchSpec{}, missingTerminalCommandError(pref)
 		}
 		if !commandExists("osascript", lookPath) {
+			if pref.app == "Ghostty" {
+				return TerminalLaunchSpec{}, ghosttyAppleScriptDependencyError("launch detached terminal handoff")
+			}
 			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch detached terminal handoff: osascript is required to run a command in %s", pref.app)
 		}
 		return TerminalLaunchSpec{Cmd: macOSTerminalScriptCommand(pref.app, detachedTerminalShellCommand(shellCommand, cwd))}, nil
@@ -2373,6 +2385,9 @@ func macOSScriptLaunch(path string, lookPath lookPathFunc, pref terminalPreferen
 		return TerminalLaunchSpec{Cmd: macOSTerminalScriptCommand("Terminal", shellCommand), Detached: detached}, nil
 	case terminalPreferenceGUIApp:
 		if !commandExists("osascript", lookPath) {
+			if pref.app == "Ghostty" {
+				return TerminalLaunchSpec{}, ghosttyAppleScriptDependencyError("launch agent")
+			}
 			return TerminalLaunchSpec{}, fmt.Errorf("cannot launch agent: osascript is required to run a command in %s", pref.app)
 		}
 		return TerminalLaunchSpec{Cmd: macOSTerminalScriptCommand(pref.app, shellCommand), Detached: detached}, nil
@@ -2408,6 +2423,10 @@ func missingTerminalCommandError(pref terminalPreference) error {
 		return fmt.Errorf("TERMINAL is set to %q, but that command was not found", pref.raw)
 	}
 	return fmt.Errorf("%s is set to %q, but that command was not found", pref.source, pref.raw)
+}
+
+func ghosttyAppleScriptDependencyError(action string) error {
+	return fmt.Errorf("cannot %s: osascript and macOS Automation permission are required to control Ghostty; configure command = %q to use the CLI fallback", action, "ghostty")
 }
 
 // resolveShell returns a runnable shell path. It accepts shell only if it is a
@@ -2671,8 +2690,8 @@ func commandExists(name string, lookPath lookPathFunc) bool {
 }
 
 func macOSTerminalOpenCommand(app, path string) *exec.Cmd {
-	if app == "iTerm" {
-		return macOSTerminalScriptCommand("iTerm", "cd "+shellQuote(path)+" && exec ${SHELL:-/bin/sh}")
+	if app == "iTerm" || app == "Ghostty" {
+		return macOSTerminalScriptCommand(app, "cd "+shellQuote(path)+" && exec ${SHELL:-/bin/sh}")
 	}
 	return exec.Command("open", "-a", "Terminal", path)
 }
@@ -2692,6 +2711,18 @@ func macOSTerminalScriptCommand(app, shellCommand string) *exec.Cmd {
 			"-e", `activate`,
 			"-e", `set newWindow to (create window with default profile)`,
 			"-e", fmt.Sprintf(`tell current session of newWindow to write text %q`, shellCommand),
+			"-e", `end tell`,
+		)
+	}
+	if app == "Ghostty" {
+		return exec.Command(
+			"osascript",
+			"-e", `tell application "Ghostty"`,
+			"-e", `activate`,
+			"-e", `set newWindow to new window`,
+			"-e", `set targetTerminal to focused terminal of selected tab of newWindow`,
+			"-e", fmt.Sprintf(`input text %q to targetTerminal`, shellCommand),
+			"-e", `send key "enter" to targetTerminal`,
 			"-e", `end tell`,
 		)
 	}

--- a/actions/actions_select_test.go
+++ b/actions/actions_select_test.go
@@ -341,6 +341,71 @@ func TestTerminalLaunchWithOptions_DarwinConfiguredITermOpensWorktree(t *testing
 	}
 }
 
+func TestTerminalLaunchWithOptions_DarwinConfiguredGhosttyAliasesOpenNewWindow(t *testing.T) {
+	for _, alias := range []string{"Ghostty", "Ghostty.app"} {
+		t.Run(alias, func(t *testing.T) {
+			launch, err := terminalLaunchWithOptions("/repo/work tree's", "darwin", fakeGetenv(nil), fakeLookPath("osascript"), nil, LaunchOptions{
+				TerminalCommand: alias,
+			})
+			if err != nil {
+				t.Fatalf("terminalLaunchWithOptions returned error: %v", err)
+			}
+			if launch.Cmd.Args[0] != "osascript" {
+				t.Fatalf("expected Ghostty AppleScript transport, got %#v", launch.Cmd.Args)
+			}
+
+			joined := strings.Join(launch.Cmd.Args, "\n")
+			for _, want := range []string{
+				`tell application "Ghostty"`,
+				"activate",
+				"set newWindow to new window",
+				"set targetTerminal to focused terminal of selected tab of newWindow",
+				"input text",
+				`send key "enter" to targetTerminal`,
+			} {
+				if !strings.Contains(joined, want) {
+					t.Fatalf("expected Ghostty launch args to contain %q, got %#v", want, launch.Cmd.Args)
+				}
+			}
+			if strings.Contains(joined, "front window") {
+				t.Fatalf("Ghostty launch should not address an existing user terminal: %#v", launch.Cmd.Args)
+			}
+
+			const prefix = `input text `
+			const suffix = ` to targetTerminal`
+			var inputText string
+			for _, arg := range launch.Cmd.Args {
+				if strings.HasPrefix(arg, prefix) && strings.HasSuffix(arg, suffix) {
+					inputText = strings.TrimSuffix(strings.TrimPrefix(arg, prefix), suffix)
+				}
+			}
+			inner, err := strconv.Unquote(inputText)
+			if err != nil {
+				t.Fatalf("input-text payload is not a valid quoted string: %q", inputText)
+			}
+			want := "cd " + shellQuote("/repo/work tree's") + " && exec ${SHELL:-/bin/sh}"
+			if inner != want {
+				t.Fatalf("input-text payload = %q, want %q", inner, want)
+			}
+		})
+	}
+}
+
+func TestTerminalLaunchWithOptions_LowercaseGhosttyRemainsCLICommand(t *testing.T) {
+	launch, err := terminalLaunchWithOptions("/repo", "darwin", fakeGetenv(nil), fakeLookPath("ghostty"), nil, LaunchOptions{
+		TerminalCommand: "ghostty",
+	})
+	if err != nil {
+		t.Fatalf("terminalLaunchWithOptions returned error: %v", err)
+	}
+	if !reflect.DeepEqual(launch.Cmd.Args, []string{"ghostty"}) {
+		t.Fatalf("lowercase ghostty should use the CLI transport, got %#v", launch.Cmd.Args)
+	}
+	if launch.Cmd.Dir != "/repo" {
+		t.Fatalf("lowercase ghostty launch dir = %q, want /repo", launch.Cmd.Dir)
+	}
+}
+
 func TestTerminalLaunchWithOptions_DarwinTerminalAppNormalizesToFallback(t *testing.T) {
 	launch, err := terminalLaunchWithOptions("/repo", "darwin", fakeGetenv(nil), fakeLookPath("open"), nil, LaunchOptions{
 		TerminalCommand: "Terminal.app",
@@ -614,6 +679,75 @@ func TestDetachedTerminalLaunch_ITermOsascriptEscapesTargetShellCommand(t *testi
 	}
 	if strings.Contains(strings.Join(launch.Cmd.Args, "\n"), "current session of current window") {
 		t.Fatalf("iTerm handoff should not write into the user's current session: %#v", launch.Cmd.Args)
+	}
+}
+
+func TestDetachedTerminalLaunch_GhosttyOsascriptEscapesTargetShellCommand(t *testing.T) {
+	const target = `env -u TMUX tmux -L "sock"; do shell script "touch /tmp/PWNED"; echo '$HOME' \ attach-session -t agent`
+	const cwd = `/repo/work tree's`
+	launch, err := detachedTerminalLaunch(target, cwd, "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{
+		TerminalCommand: "Ghostty.app",
+	})
+	if err != nil {
+		t.Fatalf("detachedTerminalLaunch returned error: %v", err)
+	}
+	if launch.Cmd.Args[0] != "osascript" {
+		t.Fatalf("expected osascript transport, got %#v", launch.Cmd.Args)
+	}
+
+	const prefix = `input text `
+	const suffix = ` to targetTerminal`
+	var inputText string
+	for _, arg := range launch.Cmd.Args {
+		if strings.HasPrefix(arg, prefix) && strings.HasSuffix(arg, suffix) {
+			inputText = strings.TrimSuffix(strings.TrimPrefix(arg, prefix), suffix)
+		}
+	}
+	if inputText == "" {
+		t.Fatalf("no Ghostty input-text argument found in %#v", launch.Cmd.Args)
+	}
+	inner, err := strconv.Unquote(inputText)
+	if err != nil {
+		t.Fatalf("input-text payload is not a valid quoted string: %q", inputText)
+	}
+	want := "cd " + shellQuote(cwd) + " && " + target
+	if inner != want {
+		t.Fatalf("input-text payload = %q, want exact handoff command %q", inner, want)
+	}
+	joined := strings.Join(launch.Cmd.Args, "\n")
+	for _, want := range []string{"set newWindow to new window", "set targetTerminal to focused terminal of selected tab of newWindow", `send key "enter" to targetTerminal`} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected Ghostty handoff args to contain %q, got %#v", want, launch.Cmd.Args)
+		}
+	}
+	if strings.Contains(joined, "front window") {
+		t.Fatalf("Ghostty handoff should not address an existing user terminal: %#v", launch.Cmd.Args)
+	}
+}
+
+func TestGhosttyGUILaunchesReportMissingOsascriptFallback(t *testing.T) {
+	tests := map[string]func() error{
+		"worktree": func() error {
+			_, err := terminalLaunchWithOptions("/repo", "darwin", fakeGetenv(nil), fakeLookPath(), nil, LaunchOptions{TerminalCommand: "Ghostty"})
+			return err
+		},
+		"handoff": func() error {
+			_, err := detachedTerminalLaunch("tmux attach-session -t agent", "/repo", "darwin", fakeGetenv(nil), fakeLookPath(), LaunchOptions{TerminalCommand: "Ghostty.app"})
+			return err
+		},
+	}
+	for name, run := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := run()
+			if err == nil {
+				t.Fatal("expected missing osascript error")
+			}
+			for _, want := range []string{"osascript", "macOS Automation", `command = "ghostty"`} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want %q", err.Error(), want)
+				}
+			}
+		})
 	}
 }
 

--- a/actions/agent_launch_internal_test.go
+++ b/actions/agent_launch_internal_test.go
@@ -183,6 +183,81 @@ func TestAgentLaunchWithOptions_DarwinConfiguredITermRunsGeneratedScript(t *test
 	requireScriptContains(t, agentLaunchScript(t), "Read the plan and begin implementation.")
 }
 
+func TestAgentLaunchWithOptions_DarwinConfiguredGhosttyRunsGeneratedScript(t *testing.T) {
+	putAgentOnPath(t, "codex")
+	ctx := planAgentContext()
+	const prompt = `"; do shell script "touch /tmp/PWNED"; echo "`
+	ctx.InitialPrompt = prompt
+	launch, err := agentLaunchWithOptions(ctx, "darwin", fakeGetenv(nil), fakeLookPath("osascript"), LaunchOptions{
+		TerminalCommand: "Ghostty.app",
+	})
+	if err != nil {
+		t.Fatalf("agentLaunchWithOptions returned error: %v", err)
+	}
+	if launch.Interactive {
+		t.Fatal("Ghostty agent launch should be detached")
+	}
+	if !launch.Detached {
+		t.Fatal("Ghostty agent launch should be marked detached")
+	}
+	if launch.Cleanup == nil {
+		t.Fatal("expected cleanup to be wired")
+	}
+	if launch.Cmd.Args[0] != "osascript" {
+		t.Fatalf("expected Ghostty AppleScript transport, got %#v", launch.Cmd.Args)
+	}
+
+	joined := strings.Join(launch.Cmd.Args, "\n")
+	for _, want := range []string{
+		`tell application "Ghostty"`,
+		"activate",
+		"set newWindow to new window",
+		"set targetTerminal to focused terminal of selected tab of newWindow",
+		`send key "enter" to targetTerminal`,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected Ghostty agent args to contain %q, got %#v", want, launch.Cmd.Args)
+		}
+	}
+	for _, unwanted := range []string{prompt, "APPROACH_PLAN_ID", "codex --config", "front window"} {
+		if strings.Contains(joined, unwanted) {
+			t.Fatalf("agent details or existing-window target leaked into AppleScript args: %q in %#v", unwanted, launch.Cmd.Args)
+		}
+	}
+
+	const prefix = `input text `
+	const suffix = ` to targetTerminal`
+	var inputText string
+	for _, arg := range launch.Cmd.Args {
+		if strings.HasPrefix(arg, prefix) && strings.HasSuffix(arg, suffix) {
+			inputText = strings.TrimSuffix(strings.TrimPrefix(arg, prefix), suffix)
+		}
+	}
+	inner, err := strconv.Unquote(inputText)
+	if err != nil {
+		t.Fatalf("input-text payload is not a valid quoted string: %q", inputText)
+	}
+	if !strings.HasPrefix(inner, "exec sh '") || !strings.Contains(inner, "approach-agent-") {
+		t.Fatalf("Ghostty input payload should run only the generated agent script, got %q", inner)
+	}
+	requireScriptContains(t, agentLaunchScript(t), `'`+prompt+`'`)
+}
+
+func TestAgentLaunchWithOptions_GhosttyReportsMissingOsascriptFallback(t *testing.T) {
+	putAgentOnPath(t, "codex")
+	_, err := agentLaunchWithOptions(planAgentContext(), "darwin", fakeGetenv(nil), fakeLookPath(), LaunchOptions{
+		TerminalCommand: "Ghostty",
+	})
+	if err == nil {
+		t.Fatal("expected missing osascript error")
+	}
+	for _, want := range []string{"osascript", "macOS Automation", `command = "ghostty"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want %q", err.Error(), want)
+		}
+	}
+}
+
 func TestAgentLaunch_TerminalEnvRunsAgentWithDashE(t *testing.T) {
 	putAgentOnPath(t, "codex")
 	env := fakeGetenv(map[string]string{"TERMINAL": "alacritty"})

--- a/docs/config.md
+++ b/docs/config.md
@@ -202,9 +202,10 @@ command = "iTerm"
 ```
 
 On macOS, supported GUI aliases are `Terminal`, `Terminal.app`, `iTerm`,
-`iTerm.app`, `iTerm2`, and `iTerm2.app`. Terminal aliases use the built-in
-Terminal transport. iTerm aliases use AppleScript so both plain worktree
-terminals and detached agent scripts open in iTerm.
+`iTerm.app`, `iTerm2`, `iTerm2.app`, `Ghostty`, and `Ghostty.app`. Terminal
+aliases use the built-in Terminal transport. iTerm and Ghostty aliases use
+AppleScript so plain worktree terminals, agent launches, and detach handoff
+open a new window in the running app.
 
 Other command values are treated as whitespace-separated CLI terminal commands
 when the first field exists on `PATH`; configured arguments are preserved as
@@ -215,14 +216,18 @@ an unsupported GUI app name can open a plain worktree terminal with
 handoff. Use a supported GUI alias or a CLI terminal command for agent launches
 and embedded detach handoff.
 
-Ghostty works through the CLI command path because it accepts `-e`:
-`command = "ghostty"` covers plain worktree terminals, agent launches, and
-detach handoff. The `ghostty` binary must be on `PATH` (the macOS app bundle
-ships it at `Ghostty.app/Contents/MacOS/ghostty`). On macOS each launch starts
-a separate Ghostty app instance rather than a window in the running one.
-Ghostty accepts any of its config keys as flags, so
+The `Ghostty` and `Ghostty.app` GUI aliases require Ghostty 1.3 or newer and
+`osascript`. macOS asks once for Automation permission when Approach first
+controls Ghostty. If Ghostty has `macos-applescript = false`, configure the
+lowercase CLI form, `command = "ghostty"`, instead.
+
+Lowercase `ghostty` stays on the CLI command path because it accepts `-e`.
+This form requires the `ghostty` binary on `PATH`; the macOS app bundle ships it
+at `Ghostty.app/Contents/MacOS/ghostty`. It starts a separate Ghostty app
+instance on macOS rather than adding a window to the running app. Ghostty
+accepts its config keys as flags, so
 `command = "ghostty --wait-after-command=true"` keeps windows open after a
-launched agent exits instead of closing before the output can be read.
+launched agent exits. The GUI aliases do not accept CLI arguments.
 
 ### `[clipboard]`
 


### PR DESCRIPTION
Ghostty users currently have to launch through the lowercase CLI transport on macOS, which starts a separate app instance instead of opening a terminal in the running app.

This adds exact Ghostty and Ghostty.app GUI aliases backed by Ghostty 1.3 AppleScript support. Worktree terminals, generated agent launches, and embedded detach handoff now open a new window in the running Ghostty app. The lowercase ghostty command remains on the existing CLI -e path.

The AppleScript payload uses the existing shell and Go quoting helpers, reports a clear osascript dependency error, and points users to the lowercase CLI fallback when scripting is unavailable or disabled. The configuration reference now documents the aliases, version requirement, Automation permission, and fallback behavior.

## Verification

- make fmt-check
- make test
- make build
- macOS smoke checks recorded in the completed implementation phase for worktree, agent, and detach launch shapes