### PR TITLE
fix(flowstore): make schema validation order-independent

### DIFF
--- a/cmd/approach/flow.go
+++ b/cmd/approach/flow.go
@@ -1709,7 +1709,8 @@ func runFlowRequest(deps runDeps, stateRoot string, req launchcontrol.Request, r
 	if req.PhaseID == "" {
 		req.PhaseID = control.phaseID
 	}
-	if control.launchID != "" && control.phaseID != "" && strings.TrimSpace(req.FlowID) == strings.TrimSpace(control.flowID) {
+	if control.launchID != "" && control.phaseID != "" && control.servesRoot(stateRoot) &&
+		strings.TrimSpace(req.FlowID) == strings.TrimSpace(control.flowID) {
 		req.OwnerPhaseID = control.phaseID
 	}
 	if class == launchcontrol.ClassDirect || control.endpoint == "" ||

--- a/cmd/approach/flow_control_test.go
+++ b/cmd/approach/flow_control_test.go
@@ -216,6 +216,50 @@ func TestFlowLeavesWithAnotherStateRootBypassTheEndpoint(t *testing.T) {
 	}
 }
 
+func TestFlowLeavesWithAnotherStateRootDoNotInheritLaunchOwnership(t *testing.T) {
+	controllerRoot := t.TempDir()
+	repoPath := filepath.Join(controllerRoot, "repo")
+	created := mustRunFlow(t, []string{"approach", "flow", "create", "--title", "Proxied", "--instructions", "x", "--repo-path", repoPath, "--json", "--state-root", controllerRoot})
+	recordLaunch(t, controllerRoot, created.FlowID, "plan", "launch-1")
+	_, endpoint := controllerFor(t, controllerRoot, created.FlowID, "plan", "launch-1")
+
+	scratch := t.TempDir()
+	scratchStore, err := flowstore.NewStore(flowstore.StoreOptions{Root: scratch})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := scratchStore.Create(flowstore.FlowRecord{
+		FlowID:       created.FlowID,
+		Title:        "Scratch",
+		Instructions: "x",
+		RepoPath:     filepath.Join(scratch, "repo"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := scratchStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	getenv := controlEnv(controllerRoot, endpoint.Path, endpoint.Token, "launch-1", created.FlowID, "plan")
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"approach", "flow", "phase", "set", "--flow-id", created.FlowID, "--phase-id", "plan", "--status", "completed", "--summary", "scratch only", "--state-root", scratch}, noScanDeps(t, runDeps{stdout: &stdout, stderr: &stderr, getenv: getenv})); err != nil {
+		t.Fatalf("scratch write: %v (%s)", err, stderr.String())
+	}
+
+	scratchRecord := mustRunFlow(t, []string{"approach", "flow", "read", "--flow-id", created.FlowID, "--state-root", scratch})
+	if phase := phaseByID(scratchRecord, "plan"); phase.Status != flowstore.PhaseCompleted || phase.Summary != "scratch only" {
+		t.Fatalf("scratch phase = %#v", phase)
+	}
+	liveRecord := mustRunFlow(t, []string{"approach", "flow", "read", "--flow-id", created.FlowID, "--state-root", controllerRoot})
+	if phase := phaseByID(liveRecord, "plan"); phase.Status != flowstore.PhaseRunning || phase.Summary != "" {
+		t.Fatalf("live phase = %#v", phase)
+	}
+	log, _ := launchcontrol.OpenLog(controllerRoot, "launch-1")
+	if requests, _ := log.Requests(); len(requests) != 0 {
+		t.Fatalf("scratch write was logged against the launch: %#v", requests)
+	}
+}
+
 func TestReplayableWriteFallsBackToLoggedDirectOpenWhenEndpointUnreachable(t *testing.T) {
 	root := t.TempDir()
 	repoPath := filepath.Join(root, "repo")

--- a/flowstore/backend_sqlite.go
+++ b/flowstore/backend_sqlite.go
@@ -727,6 +727,10 @@ func validateSQLiteSchemaObjects(db *sql.DB, version int64) error {
 	if err := rows.Close(); err != nil {
 		return fmt.Errorf("close flow database schema object rows: %w", err)
 	}
+	return validateSQLiteSchemaObjectSet(objects, version)
+}
+
+func validateSQLiteSchemaObjectSet(objects []string, version int64) error {
 	want := []string{
 		"index:idx_flows_repo_updated:flows",
 		"index:idx_flows_status_updated:flows",
@@ -756,8 +760,10 @@ func validateSQLiteSchemaObjects(db *sql.DB, version int64) error {
 				}
 			}
 		}
-		sort.Strings(want)
 	}
+	objects = append([]string(nil), objects...)
+	sort.Strings(objects)
+	sort.Strings(want)
 	if !equalStrings(objects, want) {
 		return fmt.Errorf("flow database has incompatible schema objects: got %v, want %v", objects, want)
 	}

--- a/flowstore/schema_objects_internal_test.go
+++ b/flowstore/schema_objects_internal_test.go
@@ -1,0 +1,83 @@
+package flowstore
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestSQLiteSchemaObjectsAcceptEquivalentObjectsInAnyOrder(t *testing.T) {
+	objectsByVersion := map[int64][]string{
+		1: {
+			"index:idx_flows_repo_updated:flows",
+			"index:idx_flows_status_updated:flows",
+			"index:idx_flows_updated:flows",
+			"table:flows:flows",
+		},
+		2: {
+			"index:idx_flows_repo_updated:flows",
+			"index:idx_flows_status_updated:flows",
+			"index:idx_flows_updated:flows",
+			"table:flows:flows",
+			"trigger:guard_linked_flow_record_update:flows",
+		},
+	}
+	objectsByVersion[3] = append(slices.Clone(objectsByVersion[2]),
+		"table:epic_progressions:epic_progressions",
+		"trigger:guard_prepared_flow_record_update:flows",
+	)
+	objectsByVersion[4] = append(slices.Clone(objectsByVersion[3]),
+		"trigger:guard_epic_progression_done_insert:epic_progressions",
+		"trigger:guard_epic_progression_done_record_update:epic_progressions",
+	)
+	objectsByVersion[5] = append(slices.Clone(objectsByVersion[4]),
+		"trigger:guard_progression_claim_record_update:flows",
+	)
+	objectsByVersion[6] = append(slices.Clone(objectsByVersion[5]),
+		"trigger:guard_preparation_nonce_update:flows",
+	)
+	objectsByVersion[7] = append(slices.Clone(objectsByVersion[6]),
+		"trigger:guard_recovered_launch_state_update:flows",
+	)
+
+	for version := int64(1); version <= databaseSchemaVersion; version++ {
+		objects := slices.Clone(objectsByVersion[version])
+		slices.Reverse(objects)
+		if err := validateSQLiteSchemaObjectSet(objects, version); err != nil {
+			t.Errorf("validateSQLiteSchemaObjectSet(version %d) error = %v, want nil for equivalent objects in reverse order", version, err)
+		}
+	}
+}
+
+func TestSQLiteSchemaObjectsRequireAnExactSet(t *testing.T) {
+	objects := []string{
+		"trigger:guard_recovered_launch_state_update:flows",
+		"trigger:guard_preparation_nonce_update:flows",
+		"trigger:guard_progression_claim_record_update:flows",
+		"trigger:guard_prepared_flow_record_update:flows",
+		"trigger:guard_linked_flow_record_update:flows",
+		"trigger:guard_epic_progression_done_record_update:epic_progressions",
+		"trigger:guard_epic_progression_done_insert:epic_progressions",
+		"table:flows:flows",
+		"table:epic_progressions:epic_progressions",
+		"index:idx_flows_updated:flows",
+		"index:idx_flows_status_updated:flows",
+		"index:idx_flows_repo_updated:flows",
+	}
+
+	for _, tt := range []struct {
+		name    string
+		objects []string
+	}{
+		{name: "missing", objects: slices.Clone(objects[1:])},
+		{name: "extra", objects: append(slices.Clone(objects), "table:unexpected:unexpected")},
+		{name: "changed", objects: append(slices.Clone(objects[1:]), "trigger:changed:flows")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSQLiteSchemaObjectSet(tt.objects, databaseSchemaVersion)
+			if err == nil || !strings.Contains(err.Error(), "incompatible schema objects") {
+				t.Fatalf("validateSQLiteSchemaObjectSet() error = %v, want incompatible schema objects", err)
+			}
+		})
+	}
+}

--- a/internal/launchcontrol/replay.go
+++ b/internal/launchcontrol/replay.go
@@ -174,7 +174,7 @@ func (c *Controller) replayLocked(log *Log) (ReplayResult, error) {
 			continue
 		}
 		if live.Status == comparison {
-			req := requestFromEnvelope(env)
+			req := requestFromEnvelope(env, phaseID)
 			resp, err := Execute(c.store, req)
 			if err != nil {
 				return result, err
@@ -264,10 +264,14 @@ func savedResponsePhaseState(env RequestEnvelope, phaseID string, resp Response)
 		return env.Observed, nil
 	}
 	var action PhaseActionResult
-	if err := json.Unmarshal(resp.Result, &action); err == nil &&
-		artifacts.NormalizePhaseID(action.UpdatedPhase.PhaseID) == artifacts.NormalizePhaseID(phaseID) &&
-		action.UpdatedPhase.Status != "" {
-		return ObservedPhase{Status: string(action.UpdatedPhase.Status), UpdatedAt: action.UpdatedPhase.UpdatedAt}, nil
+	if err := json.Unmarshal(resp.Result, &action); err == nil {
+		if artifacts.NormalizePhaseID(action.UpdatedPhase.PhaseID) == artifacts.NormalizePhaseID(phaseID) &&
+			action.UpdatedPhase.Status != "" {
+			return ObservedPhase{Status: string(action.UpdatedPhase.Status), UpdatedAt: action.UpdatedPhase.UpdatedAt}, nil
+		}
+		if phase, ok := PhaseByID(action.Flow, phaseID); ok {
+			return ObservedPhase{Status: string(phase.Status), UpdatedAt: phase.UpdatedAt}, nil
+		}
 	}
 	var record flowstore.FlowRecord
 	if err := json.Unmarshal(resp.Result, &record); err == nil {
@@ -304,10 +308,9 @@ func (c *Controller) demote(log *Log, flowID, launchID, reason string, update fl
 	return resp, nil
 }
 
-func requestFromEnvelope(env RequestEnvelope) Request {
-	ownerPhaseID := ""
-	if !env.Unowned {
-		ownerPhaseID = env.PhaseID
+func requestFromEnvelope(env RequestEnvelope, ownerPhaseID string) Request {
+	if env.Unowned {
+		ownerPhaseID = ""
 	}
 	return Request{
 		SchemaVersion: ProtocolSchemaVersion,
@@ -315,7 +318,7 @@ func requestFromEnvelope(env RequestEnvelope) Request {
 		LaunchID:      env.LaunchID,
 		FlowID:        env.FlowID,
 		PhaseID:       env.PhaseID,
-		OwnerPhaseID:  ownerPhaseID,
+		OwnerPhaseID:  artifacts.NormalizePhaseID(ownerPhaseID),
 		Verb:          env.Verb,
 		Payload:       env.Payload,
 	}
@@ -342,6 +345,13 @@ func intendedStatus(env RequestEnvelope) string {
 // a false negative only re-executes an idempotent request while a false
 // positive loses a write for good.
 func targetReached(record flowstore.FlowRecord, phase flowstore.FlowPhase, env RequestEnvelope) bool {
+	if artifacts.NormalizePhaseID(env.PhaseID) != "" {
+		if target, ok := PhaseByID(record, env.PhaseID); ok {
+			phase = target
+		} else if !FlowLevel(env.Verb) {
+			return false
+		}
+	}
 	fieldsMatch := func(outcome, notes, summary string) bool {
 		if outcome != "" && phase.Outcome != outcome {
 			return false

--- a/internal/launchcontrol/replay_test.go
+++ b/internal/launchcontrol/replay_test.go
@@ -282,6 +282,85 @@ func TestReplayAppliesSpooledBatchInOrderRegardlessOfObservedTimestamps(t *testi
 	}
 }
 
+func TestReplayCrossPhaseRequestUsesLaunchOwnerPhaseFence(t *testing.T) {
+	store, root := newTestStore(t)
+	created := createFlow(t, store, "Cross-phase replay")
+	completePhase(t, store, created.FlowID, "plan", "")
+	completePhase(t, store, created.FlowID, "plan-review", flowstore.OutcomeApproved)
+	launchWithBaseline(t, store, root, created.FlowID, "implementation", "launch-1")
+
+	req := mustRequest(t, VerbPhaseSet, created.FlowID, "plan-review", "launch-1", PhaseSetPayload{
+		Status: string(flowstore.PhaseCompleted), Outcome: flowstore.OutcomeApproved, Notes: "cross-phase",
+	})
+	spool(t, root, req)
+
+	report := newTestController(t, store, root).Sweep()
+	if report.Replayed != 1 {
+		t.Fatalf("sweep = %#v", report)
+	}
+	phase := phaseOf(t, store, created.FlowID, "plan-review")
+	if phase.Status != flowstore.PhaseCompleted || phase.Notes != "cross-phase" {
+		t.Fatalf("target phase = %#v", phase)
+	}
+}
+
+func TestReplayCrossPhaseRequestChecksTargetPhaseState(t *testing.T) {
+	store, root := newTestStore(t)
+	created := createFlow(t, store, "Cross-phase target state")
+	completePhase(t, store, created.FlowID, "plan", "")
+	completePhase(t, store, created.FlowID, "plan-review", flowstore.OutcomeApproved)
+	launchWithBaseline(t, store, root, created.FlowID, "implementation", "launch-1")
+
+	req := mustRequest(t, VerbPhaseSet, created.FlowID, "plan-review", "launch-1", PhaseSetPayload{
+		Status: string(flowstore.PhaseRunning),
+	})
+	spool(t, root, req)
+
+	report := newTestController(t, store, root).Sweep()
+	if report.Replayed != 1 {
+		t.Fatalf("sweep = %#v", report)
+	}
+	phase := phaseOf(t, store, created.FlowID, "plan-review")
+	if phase.Status != flowstore.PhaseRunning {
+		t.Fatalf("target phase = %#v", phase)
+	}
+}
+
+func TestReplayCrossPhaseSavedResponseReadsLaunchOwnerFromFlow(t *testing.T) {
+	store, root := newTestStore(t)
+	created := createFlow(t, store, "Cross-phase saved response")
+	completePhase(t, store, created.FlowID, "plan", "")
+	completePhase(t, store, created.FlowID, "plan-review", flowstore.OutcomeApproved)
+	launchWithBaseline(t, store, root, created.FlowID, "implementation", "launch-1")
+
+	original := applyMarkerHook
+	applyMarkerHook = func() error { return errors.New("crash before applied.json") }
+	t.Cleanup(func() { applyMarkerHook = original })
+	req := mustRequest(t, VerbPhaseComplete, created.FlowID, "plan-review", "launch-1", PhaseActionPayload{
+		Outcome: flowstore.OutcomeApproved, Summary: "cross-phase",
+	})
+	log, _ := OpenLog(root, "launch-1")
+	unlock, _ := log.Lock(time.Second)
+	_, err := ApplyLogged(store, log, req, mustEnvelope(t, req, WrittenByController), time.Now())
+	unlock()
+	applyMarkerHook = original
+	if err == nil || !strings.Contains(err.Error(), "crash before applied.json") {
+		t.Fatalf("ApplyLogged error = %v", err)
+	}
+
+	report := newTestController(t, store, root).Sweep()
+	if report.Replayed != 1 {
+		t.Fatalf("sweep = %#v", report)
+	}
+	if pending, err := log.Pending(); err != nil || len(pending) != 0 {
+		t.Fatalf("pending = %#v, %v", pending, err)
+	}
+	applied, ok, err := log.Applied()
+	if err != nil || !ok || applied.Status != string(flowstore.PhaseRunning) {
+		t.Fatalf("applied = %#v, %v, %v", applied, ok, err)
+	}
+}
+
 func TestReplayRejectsBatchWhenPhaseRelaunchedUnderNewerLaunch(t *testing.T) {
 	store, root := newTestStore(t)
 	created := createFlow(t, store, "Newer Launch")


### PR DESCRIPTION
SQLite schema validation sorted only the expected object list, so a valid database could fail validation when `sqlite_master` returned the same objects in a different order.

This change sorts copies of both the observed and expected lists before comparing them. The regression tests reverse every supported schema version and retain coverage for missing, extra, and changed objects.

Autoreview also found two launch-control ownership bugs in the same branch. Replay now keeps the launch owner phase when a request targets another phase, and Flow control routes alternate state roots through their own launch-control server. Tests cover cross-phase responses, replay, and state-root isolation.

Verification:

- `make fmt-check`
- `make test`
- `make build`
