### PR TITLE
feat(tui): render OSC 8 hyperlinks

### DIFF
--- a/embeddedterm/terminal.go
+++ b/embeddedterm/terminal.go
@@ -1,11 +1,11 @@
 package embeddedterm
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -56,7 +56,10 @@ const (
 	finalOutputDrainTimeout = 200 * time.Millisecond
 	terminateWaitTimeout    = 2 * time.Second
 	maxPendingSequenceBytes = 16
+	maxPendingOSC8Bytes     = 64 * 1024
 )
+
+const osc8URIEscapeMarker = "__approach_osc8_escape__"
 
 var newEmulator = func(width, height int) (*vt.SafeEmulator, error) {
 	return vt.NewSafeEmulator(width, height), nil
@@ -328,6 +331,7 @@ func (t *Terminal) waitLoop() {
 func (t *Terminal) readLoop(ptmx *os.File, emu *vt.SafeEmulator) {
 	defer close(t.readDone)
 	filter := terminalQueryFilter{writer: ptmx}
+	hyperlinks := osc8InputFilter{}
 	buf := make([]byte, 4096)
 	for {
 		n, err := ptmx.Read(buf)
@@ -339,6 +343,7 @@ func (t *Terminal) readLoop(ptmx *os.File, emu *vt.SafeEmulator) {
 			if t.transform != nil {
 				filtered = t.transform.Transform(filtered, final)
 			}
+			filtered = hyperlinks.Filter(filtered, final)
 			if len(filtered) > 0 {
 				t.emuMu.Lock()
 				_, writeErr := emu.Write(filtered)
@@ -350,6 +355,107 @@ func (t *Terminal) readLoop(ptmx *os.File, emu *vt.SafeEmulator) {
 		}
 		if err != nil {
 			return
+		}
+	}
+}
+
+// osc8InputFilter works around x/vt's reversed hyperlink fields and its
+// unbounded semicolon split. It swaps the URI and parameter fields before the
+// emulator sees them, escaping URI semicolons with a reversible marker.
+type osc8InputFilter struct {
+	pending []byte
+}
+
+func (f *osc8InputFilter) Filter(p []byte, final bool) []byte {
+	const prefix = "\x1b]8;"
+	data := append(append([]byte(nil), f.pending...), p...)
+	f.pending = nil
+	out := make([]byte, 0, len(data))
+
+	for len(data) > 0 {
+		start := bytes.Index(data, []byte(prefix))
+		if start < 0 {
+			keep := 0
+			if !final {
+				keep = osc8PrefixSuffixLen(data, []byte(prefix))
+			}
+			out = append(out, data[:len(data)-keep]...)
+			f.pending = append(f.pending, data[len(data)-keep:]...)
+			break
+		}
+		out = append(out, data[:start]...)
+		data = data[start:]
+		end, terminatorLen := oscTerminator(data[len(prefix):])
+		if end < 0 {
+			if !final && len(data) <= maxPendingOSC8Bytes {
+				f.pending = append(f.pending, data...)
+			} else {
+				out = append(out, data...)
+			}
+			break
+		}
+		end += len(prefix)
+		params, uri, ok := strings.Cut(string(data[len(prefix):end]), ";")
+		if !ok {
+			out = append(out, data[:end+terminatorLen]...)
+		} else {
+			out = append(out, prefix...)
+			out = append(out, encodeOSC8URI(uri)...)
+			out = append(out, ';')
+			out = append(out, params...)
+			out = append(out, data[end:end+terminatorLen]...)
+		}
+		data = data[end+terminatorLen:]
+	}
+	return out
+}
+
+func osc8PrefixSuffixLen(data, prefix []byte) int {
+	limit := min(len(data), len(prefix)-1)
+	for length := limit; length > 0; length-- {
+		if bytes.Equal(data[len(data)-length:], prefix[:length]) {
+			return length
+		}
+	}
+	return 0
+}
+
+func oscTerminator(data []byte) (int, int) {
+	bel := bytes.IndexByte(data, '\a')
+	st := bytes.Index(data, []byte("\x1b\\"))
+	switch {
+	case bel >= 0 && (st < 0 || bel < st):
+		return bel, 1
+	case st >= 0:
+		return st, 2
+	default:
+		return -1, 0
+	}
+}
+
+func encodeOSC8URI(uri string) string {
+	uri = strings.ReplaceAll(uri, osc8URIEscapeMarker, osc8URIEscapeMarker+"m")
+	return strings.ReplaceAll(uri, ";", osc8URIEscapeMarker+"s")
+}
+
+func decodeOSC8URI(uri string) string {
+	var out strings.Builder
+	for {
+		before, after, ok := strings.Cut(uri, osc8URIEscapeMarker)
+		out.WriteString(before)
+		if !ok {
+			return out.String()
+		}
+		switch {
+		case strings.HasPrefix(after, "s"):
+			out.WriteByte(';')
+			uri = after[1:]
+		case strings.HasPrefix(after, "m"):
+			out.WriteString(osc8URIEscapeMarker)
+			uri = after[1:]
+		default:
+			out.WriteString(osc8URIEscapeMarker)
+			uri = after
 		}
 	}
 }
@@ -405,7 +511,7 @@ func (t *Terminal) trySnapshotRows() []string {
 	rows := make([]string, 0, emu.ScrollbackLen()+emu.Height())
 	if scrollback := emu.Scrollback(); scrollback != nil {
 		for _, line := range scrollback.Lines() {
-			rows = append(rows, line.Render())
+			rows = append(rows, normalizeRenderedHyperlinkLine(line.Render()))
 		}
 	}
 	rows = append(rows, splitTerminalRows(emu.Render())...)
@@ -456,9 +562,8 @@ func splitTerminalRows(rendered string) []string {
 	return rows
 }
 
-// x/vt currently stores OSC 8 parameters and URIs in reversed fields. Its
-// renderer therefore emits a URI in the parameter slot. Repair that known
-// shape while leaving already-correct OSC 8 sequences alone.
+// x/vt renders the reversible URI escape used by osc8InputFilter. Restore the
+// exact child-provided target before exposing rendered rows to the host.
 func normalizeRenderedHyperlinks(rendered string) string {
 	const prefix = "\x1b]8;"
 	var out strings.Builder
@@ -478,17 +583,39 @@ func normalizeRenderedHyperlinks(rendered string) string {
 		sequence := rendered[:end+1]
 		payload := rendered[len(prefix):end]
 		params, uri, ok := strings.Cut(payload, ";")
-		if ok && looksLikeHyperlinkURI(params) && !looksLikeHyperlinkURI(uri) {
-			sequence = prefix + uri + ";" + params + "\a"
+		if ok {
+			sequence = prefix + params + ";" + decodeOSC8URI(uri) + "\a"
 		}
 		out.WriteString(sequence)
 		rendered = rendered[end+1:]
 	}
 }
 
-func looksLikeHyperlinkURI(value string) bool {
-	parsed, err := url.Parse(value)
-	return err == nil && parsed.Scheme != ""
+func normalizeRenderedHyperlinkLine(rendered string) string {
+	rendered = normalizeRenderedHyperlinks(rendered)
+	const prefix = "\x1b]8;"
+	open := false
+	remaining := rendered
+	for {
+		start := strings.Index(remaining, prefix)
+		if start < 0 {
+			break
+		}
+		remaining = remaining[start+len(prefix):]
+		end := strings.IndexByte(remaining, '\a')
+		if end < 0 {
+			break
+		}
+		_, uri, ok := strings.Cut(remaining[:end], ";")
+		if ok {
+			open = uri != ""
+		}
+		remaining = remaining[end+1:]
+	}
+	if open {
+		rendered += ansi.ResetHyperlink()
+	}
+	return rendered
 }
 
 func trimBlankTerminalRows(rows []string) []string {

--- a/embeddedterm/terminal.go
+++ b/embeddedterm/terminal.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -447,11 +448,47 @@ func fitTerminalLine(line string, width int) string {
 }
 
 func splitTerminalRows(rendered string) []string {
+	rendered = normalizeRenderedHyperlinks(rendered)
 	rows := strings.Split(rendered, "\n")
 	if len(rows) > 0 && rows[len(rows)-1] == "" {
 		rows = rows[:len(rows)-1]
 	}
 	return rows
+}
+
+// x/vt currently stores OSC 8 parameters and URIs in reversed fields. Its
+// renderer therefore emits a URI in the parameter slot. Repair that known
+// shape while leaving already-correct OSC 8 sequences alone.
+func normalizeRenderedHyperlinks(rendered string) string {
+	const prefix = "\x1b]8;"
+	var out strings.Builder
+	for {
+		start := strings.Index(rendered, prefix)
+		if start < 0 {
+			out.WriteString(rendered)
+			return out.String()
+		}
+		out.WriteString(rendered[:start])
+		rendered = rendered[start:]
+		end := strings.IndexByte(rendered, '\a')
+		if end < 0 {
+			out.WriteString(rendered)
+			return out.String()
+		}
+		sequence := rendered[:end+1]
+		payload := rendered[len(prefix):end]
+		params, uri, ok := strings.Cut(payload, ";")
+		if ok && looksLikeHyperlinkURI(params) && !looksLikeHyperlinkURI(uri) {
+			sequence = prefix + uri + ";" + params + "\a"
+		}
+		out.WriteString(sequence)
+		rendered = rendered[end+1:]
+	}
+}
+
+func looksLikeHyperlinkURI(value string) bool {
+	parsed, err := url.Parse(value)
+	return err == nil && parsed.Scheme != ""
 }
 
 func trimBlankTerminalRows(rows []string) []string {

--- a/embeddedterm/terminal_test.go
+++ b/embeddedterm/terminal_test.go
@@ -334,6 +334,84 @@ func TestTerminalPreservesHyperlinksInVisibleLines(t *testing.T) {
 	}
 }
 
+func TestTerminalPreservesHyperlinksInSavedScrollback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pty tests require a Unix-like platform")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	const target = "https://example.com/pull/8"
+	term, err := NewManager().Start(ctx, StartRequest{
+		Command: "sh",
+		Args:    []string{"-c", "printf '\033]8;;https://example.com/pull/8\aold-link\033]8;;\a\\none\\ntwo\\nthree\\n'"},
+		Width:   20,
+		Height:  2,
+	})
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	defer term.Close()
+	if err := term.Wait(ctx); err != nil {
+		t.Fatalf("Wait returned error: %v", err)
+	}
+
+	got := strings.Join(term.VisibleLines(20, 6), "\n")
+	if !strings.Contains(got, ansi.SetHyperlink(target)) {
+		t.Fatalf("saved scrollback dropped hyperlink: %q", got)
+	}
+	if !strings.Contains(got, ansi.ResetHyperlink()) {
+		t.Fatalf("saved scrollback did not close hyperlink: %q", got)
+	}
+}
+
+func TestTerminalPreservesHyperlinkWithSemicolonURI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pty tests require a Unix-like platform")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	const target = "https://example.com/__approach_osc8_escape__/a;b?x=1;y=2"
+	term, err := NewManager().Start(ctx, StartRequest{
+		Command: "sh",
+		Args:    []string{"-c", "printf '\033]8;;https://example.com/__approach_osc8_escape__/a;b?x=1;y=2\alink\033]8;;\a'"},
+		Width:   40,
+		Height:  2,
+	})
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	defer term.Close()
+	if err := term.Wait(ctx); err != nil {
+		t.Fatalf("Wait returned error: %v", err)
+	}
+
+	got := strings.Join(term.VisibleLines(40, 2), "\n")
+	if !strings.Contains(got, ansi.SetHyperlink(target)) {
+		t.Fatalf("semicolon URI hyperlink was not preserved: %q", got)
+	}
+}
+
+func TestOSC8InputFilterHandlesChunkBoundaries(t *testing.T) {
+	const target = "https://example.com/a;b"
+	var filter osc8InputFilter
+	chunks := [][]byte{
+		[]byte("before\x1b"),
+		[]byte("]8;id=8;https://example.com/a"),
+		[]byte(";b\x1b"),
+		[]byte("\\link\x1b]8;;\aafter"),
+	}
+	var got []byte
+	for i, chunk := range chunks {
+		got = append(got, filter.Filter(chunk, i == len(chunks)-1)...)
+	}
+	want := "before\x1b]8;" + encodeOSC8URI(target) + ";id=8\x1b\\link\x1b]8;;\aafter"
+	if string(got) != want {
+		t.Fatalf("filtered OSC 8 stream = %q, want %q", string(got), want)
+	}
+}
+
 func TestTerminalVisibleLinesFitRequestedWidth(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("pty tests require a Unix-like platform")

--- a/embeddedterm/terminal_test.go
+++ b/embeddedterm/terminal_test.go
@@ -295,6 +295,45 @@ func TestTerminalPreservesANSIStyleInVisibleLines(t *testing.T) {
 	}
 }
 
+func TestTerminalPreservesHyperlinksInVisibleLines(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("pty tests require a Unix-like platform")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	const target = "https://example.com/pull/8"
+	term, err := NewManager().Start(ctx, StartRequest{
+		Command: "sh",
+		Args:    []string{"-c", "printf '\\033]8;;https://example.com/pull/8\\aabcdef\\033]8;;\\a next'"},
+		Width:   20,
+		Height:  3,
+	})
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	defer term.Close()
+	if err := term.Wait(ctx); err != nil {
+		t.Fatalf("Wait returned error: %v", err)
+	}
+
+	for _, width := range []int{20, 4} {
+		lines := term.VisibleLines(width, 3)
+		got := strings.Join(lines, "\n")
+		if !strings.Contains(got, ansi.SetHyperlink(target)) {
+			t.Fatalf("width %d dropped hyperlink: %q", width, got)
+		}
+		if !strings.Contains(got, ansi.ResetHyperlink()) {
+			t.Fatalf("width %d did not close hyperlink: %q", width, got)
+		}
+		for _, line := range lines {
+			if gotWidth := ansi.StringWidth(line); gotWidth != width {
+				t.Fatalf("line width = %d, want %d: %q", gotWidth, width, line)
+			}
+		}
+	}
+}
+
 func TestTerminalVisibleLinesFitRequestedWidth(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("pty tests require a Unix-like platform")

--- a/ui/bead_expansion.go
+++ b/ui/bead_expansion.go
@@ -71,21 +71,21 @@ func BeadVisualHeight(bead beadsquery.Bead, expansion BeadExpansion) int {
 	return height
 }
 
-func renderBeadsPane(beads []beadsquery.Bead, selected, scroll, width, height int, expansion BeadExpansion) []string {
+func renderBeadsPane(beads []beadsquery.Bead, selected, scroll, width, height int, expansion BeadExpansion, repoPath string) []string {
 	content := make([]string, 0, len(beads))
 	for i, bead := range beads {
-		content = append(content, expansionVisualLines(bead, i == selected, width, expansion)...)
+		content = append(content, expansionVisualLines(bead, i == selected, width, expansion, repoPath)...)
 	}
 	return scrollAndPad(content, scroll, height)
 }
 
-func expansionVisualLines(bead beadsquery.Bead, selected bool, width int, expansion BeadExpansion) []string {
+func expansionVisualLines(bead beadsquery.Bead, selected bool, width int, expansion BeadExpansion, repoPath string) []string {
 	own := selected && bead.ID == expansion.EpicID
 	markers := beadRowMarkers{
 		Auto:   own && expansion.ProgressionKnown && expansion.ProgressionEnabled,
 		Halted: own && strings.TrimSpace(expansion.ProgressionHaltDetail) != "",
 	}
-	lines := []string{renderBeadRow(bead, selected, width, markers)}
+	lines := []string{renderBeadRow(bead, selected, width, markers, repoPath)}
 	if expansion.EpicID == "" || bead.ID != expansion.EpicID {
 		return lines
 	}
@@ -112,7 +112,7 @@ func expansionVisualLines(bead beadsquery.Bead, selected bool, width int, expans
 			for _, child := range expansion.Children {
 				id := terminalSafeSingleLine(child.ID)
 				title := terminalSafeSingleLine(child.Title)
-				body := fmt.Sprintf("↳ %s  P%d  %s", id, child.Priority, title)
+				body := fmt.Sprintf("↳ %s  P%d  %s", hyperlink(id, beadHyperlinkTarget(repoPath, child.ID)), child.Priority, title)
 				marker := ""
 				if expansion.ReadinessKnown && expansion.ReadyIDs[child.ID] {
 					marker = "  [ready]"
@@ -136,11 +136,11 @@ func expansionVisualLines(bead beadsquery.Bead, selected bool, width int, expans
 	return lines
 }
 
-func renderBeadRow(bead beadsquery.Bead, selected bool, width int, markers beadRowMarkers) string {
+func renderBeadRow(bead beadsquery.Bead, selected bool, width int, markers beadRowMarkers, repoPath string) string {
 	id := terminalSafeSingleLine(bead.ID)
 	title := terminalSafeSingleLine(bead.Title)
 	assignee := terminalSafeSingleLine(bead.Assignee)
-	body := fmt.Sprintf("%s  P%d  %s", id, bead.Priority, title)
+	body := fmt.Sprintf("%s  P%d  %s", hyperlink(id, beadHyperlinkTarget(repoPath, bead.ID)), bead.Priority, title)
 	if assignee != "" {
 		body += "  " + assignee
 	}

--- a/ui/beads_test.go
+++ b/ui/beads_test.go
@@ -54,7 +54,7 @@ func TestRenderBeadsPaneMarksEpicsAndExpandsSelectedEpicReadyFirst(t *testing.T)
 		ReadyIDs:       map[string]bool{"bd-child-2": true},
 		ReadinessKnown: true,
 	}
-	lines := renderBeadsPane(beads, 0, 0, 80, 5, expansion)
+	lines := renderBeadsPane(beads, 0, 0, 80, 5, expansion, "")
 	plain := ansi.Strip(strings.Join(lines, "\n"))
 	for _, want := range []string{"bd-epic  P1  Parent  [epic]", "bd-child-2  P1  Ready  [ready]", "bd-child-1  P2  Neutral", "bd-task  P2  Ordinary"} {
 		if !strings.Contains(plain, want) {
@@ -78,7 +78,7 @@ func TestRenderBeadRowPreservesEpicMarkerAtNarrowWidths(t *testing.T) {
 		Assignee: "a-very-long-assignee", IssueType: "epic",
 	}
 	for _, selected := range []bool{false, true} {
-		line := renderBeadRow(epic, selected, width, beadRowMarkers{})
+		line := renderBeadRow(epic, selected, width, beadRowMarkers{}, "")
 		plain := ansi.Strip(line)
 		if !strings.Contains(plain, "[epic]") {
 			t.Fatalf("selected=%t narrow row lost epic marker: %q", selected, plain)
@@ -94,7 +94,7 @@ func TestRenderBeadRowPreservesEpicAndAutoMarkersAtMinimumWidth(t *testing.T) {
 
 	const width = 19 // selection prefix plus "  [epic]  [auto]"
 	epic := beadsquery.Bead{ID: "bd-epic", Priority: 1, Title: "A very long epic title", IssueType: "epic"}
-	line := renderBeadRow(epic, true, width, beadRowMarkers{Auto: true})
+	line := renderBeadRow(epic, true, width, beadRowMarkers{Auto: true}, "")
 	plain := ansi.Strip(line)
 	if !strings.Contains(plain, "[epic]  [auto]") {
 		t.Fatalf("minimum-width row lost persistent markers: %q", plain)
@@ -114,7 +114,7 @@ func TestRenderBeadsPaneShowsProgressionFailureWithoutHidingChildren(t *testing.
 		ReadinessKnown:    true,
 		ProgressionDetail: "database failed\n\x1b]8;;https://example.invalid\aunsafe",
 	}
-	lines := expansionVisualLines(epic, true, 60, expansion)
+	lines := expansionVisualLines(epic, true, 60, expansion, "")
 	plain := ansi.Strip(strings.Join(lines, "\n"))
 	if len(lines) != 3 || !strings.Contains(plain, "bd-child") || !strings.Contains(plain, "Auto-progression unavailable: database failed unsafe") {
 		t.Fatalf("progression warning/children render = %d lines:\n%s", len(lines), plain)
@@ -138,7 +138,7 @@ func TestRenderBeadsPanePreservesReadyMarkerAtNarrowWidths(t *testing.T) {
 		Children: []beadsquery.Bead{child}, ReadyIDs: map[string]bool{child.ID: true},
 		ReadinessKnown: true,
 	}
-	lines := expansionVisualLines(epic, true, width, expansion)
+	lines := expansionVisualLines(epic, true, width, expansion, "")
 	if len(lines) != 2 {
 		t.Fatalf("rendered lines = %d, want parent and child", len(lines))
 	}
@@ -161,7 +161,7 @@ func TestRenderBeadsPaneStylesSelectedExpansionLines(t *testing.T) {
 		Children: []beadsquery.Bead{{ID: "bd-child", Priority: 1, Title: "Child"}},
 		Detail:   "bd ready failed",
 	}
-	selectedLines := expansionVisualLines(epic, true, width, expansion)
+	selectedLines := expansionVisualLines(epic, true, width, expansion, "")
 	plainLines := []string{
 		"     ↳ bd-child  P1  Child",
 		"     Readiness unavailable: bd ready failed",
@@ -176,7 +176,7 @@ func TestRenderBeadsPaneStylesSelectedExpansionLines(t *testing.T) {
 		}
 	}
 
-	unfocusedLines := expansionVisualLines(epic, false, width, expansion)
+	unfocusedLines := expansionVisualLines(epic, false, width, expansion, "")
 	for i, want := range plainLines {
 		if got := unfocusedLines[i+1]; got != want {
 			t.Fatalf("unfocused expansion line %d = %q, want plain %q", i, got, want)
@@ -192,7 +192,7 @@ func TestRenderBeadsPaneEmptyChildrenStillShowsReadinessFailure(t *testing.T) {
 		EpicID: epic.ID, State: BeadExpansionLoaded,
 		Detail: "bd ready failed",
 	}
-	lines := expansionVisualLines(epic, true, 60, expansion)
+	lines := expansionVisualLines(epic, true, 60, expansion, "")
 	plain := ansi.Strip(strings.Join(lines, "\n"))
 	for _, want := range []string{"no direct children", "Readiness unavailable: bd ready failed"} {
 		if !strings.Contains(plain, want) {
@@ -230,7 +230,7 @@ func TestRenderBeadsPaneExpansionStatesAreBoundedAndSanitized(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			const width = 48
-			lines := renderBeadsPane([]beadsquery.Bead{epic}, 0, 0, width, 5, tt.expansion)
+			lines := renderBeadsPane([]beadsquery.Bead{epic}, 0, 0, width, 5, tt.expansion, "")
 			plain := ansi.Strip(strings.Join(lines, "\n"))
 			if !strings.Contains(plain, tt.want) {
 				t.Fatalf("render missing %q:\n%s", tt.want, plain)
@@ -241,7 +241,7 @@ func TestRenderBeadsPaneExpansionStatesAreBoundedAndSanitized(t *testing.T) {
 				}
 			}
 			for _, selected := range []bool{false, true} {
-				rendered := len(expansionVisualLines(epic, selected, width, tt.expansion))
+				rendered := len(expansionVisualLines(epic, selected, width, tt.expansion, ""))
 				if got := BeadVisualHeight(epic, tt.expansion); got != rendered {
 					t.Fatalf("selected=%t height = %d, rendered expansion lines = %d", selected, got, rendered)
 				}
@@ -259,7 +259,7 @@ func TestRenderBeadsPaneHaltedEpicReplacesAutoMarkerAndNamesTheCause(t *testing.
 		EpicID: epic.ID, State: BeadExpansionLoaded, ReadinessKnown: true,
 		ProgressionKnown: true, ProgressionHaltDetail: "bd-epic.1 is blocked",
 	}
-	lines := expansionVisualLines(epic, true, width, expansion)
+	lines := expansionVisualLines(epic, true, width, expansion, "")
 	plain := ansi.Strip(strings.Join(lines, "\n"))
 	if !strings.Contains(plain, "[epic]  [halted]") {
 		t.Fatalf("halted epic row missing marker:\n%s", plain)
@@ -273,7 +273,7 @@ func TestRenderBeadsPaneHaltedEpicReplacesAutoMarkerAndNamesTheCause(t *testing.
 
 	// Halted outranks auto: it is the state that wants the user's attention.
 	expansion.ProgressionEnabled = true
-	both := ansi.Strip(strings.Join(expansionVisualLines(epic, true, width, expansion), "\n"))
+	both := ansi.Strip(strings.Join(expansionVisualLines(epic, true, width, expansion, ""), "\n"))
 	if strings.Contains(both, "[auto]") || !strings.Contains(both, "[halted]") {
 		t.Fatalf("halted row showed the auto marker:\n%s", both)
 	}
@@ -281,7 +281,7 @@ func TestRenderBeadsPaneHaltedEpicReplacesAutoMarkerAndNamesTheCause(t *testing.
 	// The cause precedes a read failure when a projection carries both.
 	expansion.ProgressionEnabled = false
 	expansion.ProgressionDetail = "database failed"
-	ordered := ansi.Strip(strings.Join(expansionVisualLines(epic, true, width, expansion), "\n"))
+	ordered := ansi.Strip(strings.Join(expansionVisualLines(epic, true, width, expansion, ""), "\n"))
 	haltAt := strings.Index(ordered, "Auto-progression halted:")
 	unavailableAt := strings.Index(ordered, "Auto-progression unavailable:")
 	if haltAt < 0 || unavailableAt < 0 || haltAt > unavailableAt {
@@ -294,7 +294,7 @@ func TestRenderBeadsPaneHonorsVisualScrollOffset(t *testing.T) {
 
 	epic := beadsquery.Bead{ID: "bd-epic", Priority: 1, Title: "Parent", IssueType: "epic"}
 	expansion := BeadExpansion{EpicID: epic.ID, State: BeadExpansionLoaded, ReadinessKnown: true, Children: []beadsquery.Bead{{ID: "bd-child-1", Title: "One"}, {ID: "bd-child-2", Title: "Two"}}}
-	lines := renderBeadsPane([]beadsquery.Bead{epic, {ID: "bd-after", Title: "After"}}, -1, 2, 60, 2, expansion)
+	lines := renderBeadsPane([]beadsquery.Bead{epic, {ID: "bd-after", Title: "After"}}, -1, 2, 60, 2, expansion, "")
 	plain := ansi.Strip(strings.Join(lines, "\n"))
 	if strings.Contains(plain, "bd-epic") || strings.Contains(plain, "bd-child-1") || !strings.Contains(plain, "bd-child-2") || !strings.Contains(plain, "bd-after") {
 		t.Fatalf("visual scroll did not slice flattened expansion lines:\n%s", plain)

--- a/ui/hyperlink.go
+++ b/ui/hyperlink.go
@@ -1,0 +1,59 @@
+package ui
+
+import (
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// hyperlink wraps display text that has already been made terminal-safe.
+func hyperlink(label, target string) string {
+	if label == "" || target == "" {
+		return label
+	}
+	return ansi.SetHyperlink(target) + label + ansi.ResetHyperlink()
+}
+
+func hyperlinkColumn(label, target string, width int, style lipgloss.Style) string {
+	label = truncateToWidth(label, width)
+	cell := hyperlink(style.Render(label), target)
+	if padding := width - ansi.StringWidth(label); padding > 0 {
+		cell += style.Render(strings.Repeat(" ", padding))
+	}
+	return cell
+}
+
+func prHyperlinkTarget(raw string) string {
+	raw = strings.TrimSpace(raw)
+	target, err := url.Parse(raw)
+	if err != nil || target.Host == "" || (target.Scheme != "http" && target.Scheme != "https") {
+		return ""
+	}
+	return target.String()
+}
+
+func fileHyperlinkTarget(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" || !filepath.IsAbs(path) {
+		return ""
+	}
+	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(filepath.Clean(path))}).String()
+}
+
+// beadHyperlinkTarget keeps the repo qualification explicit and centralized.
+// The custom URI is intended for terminal handlers that know how to open a
+// Bead in its repository.
+func beadHyperlinkTarget(repoPath, beadID string) string {
+	repoPath = strings.TrimSpace(repoPath)
+	beadID = strings.TrimSpace(beadID)
+	if repoPath == "" || beadID == "" || !filepath.IsAbs(repoPath) {
+		return ""
+	}
+	query := url.Values{}
+	query.Set("id", beadID)
+	query.Set("repo", filepath.Clean(repoPath))
+	return "bead://open?" + query.Encode()
+}

--- a/ui/hyperlink.go
+++ b/ui/hyperlink.go
@@ -18,6 +18,7 @@ func hyperlink(label, target string) string {
 }
 
 func hyperlinkColumn(label, target string, width int, style lipgloss.Style) string {
+	label = terminalSafeSingleLine(label)
 	label = truncateToWidth(label, width)
 	cell := hyperlink(style.Render(label), target)
 	if padding := width - ansi.StringWidth(label); padding > 0 {
@@ -36,7 +37,6 @@ func prHyperlinkTarget(raw string) string {
 }
 
 func fileHyperlinkTarget(path string) string {
-	path = strings.TrimSpace(path)
 	if path == "" || !filepath.IsAbs(path) {
 		return ""
 	}
@@ -47,7 +47,6 @@ func fileHyperlinkTarget(path string) string {
 // The custom URI is intended for terminal handlers that know how to open a
 // Bead in its repository.
 func beadHyperlinkTarget(repoPath, beadID string) string {
-	repoPath = strings.TrimSpace(repoPath)
 	beadID = strings.TrimSpace(beadID)
 	if repoPath == "" || beadID == "" || !filepath.IsAbs(repoPath) {
 		return ""

--- a/ui/hyperlink.go
+++ b/ui/hyperlink.go
@@ -18,7 +18,7 @@ func hyperlink(label, target string) string {
 }
 
 func hyperlinkColumn(label, target string, width int, style lipgloss.Style) string {
-	label = terminalSafeSingleLine(label)
+	label = terminalSafeHyperlinkLabel(label)
 	label = truncateToWidth(label, width)
 	cell := hyperlink(style.Render(label), target)
 	if padding := width - ansi.StringWidth(label); padding > 0 {

--- a/ui/hyperlink_test.go
+++ b/ui/hyperlink_test.go
@@ -1,0 +1,205 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/approachcontrol/approach/beadsquery"
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/gitquery"
+	"github.com/approachcontrol/approach/scanner"
+	"github.com/approachcontrol/approach/sessions"
+)
+
+func TestHyperlink(t *testing.T) {
+	tests := []struct {
+		name   string
+		label  string
+		target string
+		want   string
+	}{
+		{name: "empty label", target: "https://example.com"},
+		{name: "empty target", label: "plain", want: "plain"},
+		{name: "unicode label", label: "PR 界", target: "https://example.com/pull/8", want: ansi.SetHyperlink("https://example.com/pull/8") + "PR 界" + ansi.ResetHyperlink()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hyperlink(tt.label, tt.target); got != tt.want {
+				t.Fatalf("hyperlink(%q, %q) = %q, want %q", tt.label, tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHyperlinkTargets(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "trusted PR", got: prHyperlinkTarget("https://github.com/approachcontrol/approach/pull/8?view=files#diff-a"), want: "https://github.com/approachcontrol/approach/pull/8?view=files#diff-a"},
+		{name: "reject non-HTTP PR", got: prHyperlinkTarget("javascript:alert(1)")},
+		{name: "reject relative PR", got: prHyperlinkTarget("github.com/approach/pull/8")},
+		{name: "absolute file", got: fileHyperlinkTarget("/tmp/space # percent%/界"), want: "file:///tmp/space%20%23%20percent%25/%E7%95%8C"},
+		{name: "reject relative file", got: fileHyperlinkTarget("relative/path")},
+		{name: "repo-qualified Bead", got: beadHyperlinkTarget("/tmp/repo #1", "approach-5e7/child"), want: "bead://open?id=approach-5e7%2Fchild&repo=%2Ftmp%2Frepo+%231"},
+		{name: "missing Bead repo", got: beadHyperlinkTarget("", "approach-5e7")},
+		{name: "missing Bead ID", got: beadHyperlinkTarget("/tmp/repo", "")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Fatalf("target = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHyperlinkClosesBeforeAdjacentTextAndHasZeroWidth(t *testing.T) {
+	label := "PR 界"
+	linked := hyperlink(label, "https://example.com/pull/8")
+	row := linked + "  next"
+	if !strings.Contains(row, label+ansi.ResetHyperlink()+"  next") {
+		t.Fatalf("link does not close before adjacent text: %q", row)
+	}
+	if got := ansi.Strip(row); got != label+"  next" {
+		t.Fatalf("stripped row = %q", got)
+	}
+	if got, want := ansi.StringWidth(row), ansi.StringWidth(label+"  next"); got != want {
+		t.Fatalf("row width = %d, want %d", got, want)
+	}
+}
+
+func TestHyperlinkColumnClosesBeforePadding(t *testing.T) {
+	const target = "https://example.com/pull/8"
+	cell := hyperlinkColumn("#8", target, 8, lipgloss.NewStyle())
+	if !strings.Contains(cell, "#8"+ansi.ResetHyperlink()+strings.Repeat(" ", 6)) {
+		t.Fatalf("column link includes padding: %q", cell)
+	}
+	if got := ansi.StringWidth(cell); got != 8 {
+		t.Fatalf("column width = %d, want 8", got)
+	}
+}
+
+func TestRenderFlowHyperlinksPreserveTextAndWidth(t *testing.T) {
+	const (
+		repoPath     = "/tmp/approach repo"
+		worktreePath = "/tmp/approach worktrees/feature"
+		prURL        = "https://github.com/approachcontrol/approach/pull/88"
+	)
+	record := flowstore.FlowRecord{
+		FlowID: "flow-1", Title: "Linked Flow", Status: flowstore.StatusInProgress,
+		RepoPath: repoPath, WorktreePath: worktreePath, Branch: "feature/links",
+		PR: flowstore.PullRequest{Number: 88, URL: prURL},
+	}
+	for _, selected := range []int{-1, 0} {
+		rows := renderFlowPane([]flowstore.FlowRecord{record}, selected, 0, 240, 3, "", "", nil, true, map[string]string{repoPath: "approach"})
+		row := rows[1]
+		for _, target := range []string{fileHyperlinkTarget(repoPath), fileHyperlinkTarget(worktreePath), prURL} {
+			if !strings.Contains(row, ansi.SetHyperlink(target)) {
+				t.Fatalf("selected=%d row missing target %q: %q", selected, target, row)
+			}
+		}
+		plain := ansi.Strip(row)
+		for _, label := range []string{"approach", "feature/links", "#88", "Linked Flow"} {
+			if !strings.Contains(plain, label) {
+				t.Fatalf("selected=%d stripped row missing %q: %q", selected, label, plain)
+			}
+		}
+		if got := ansi.StringWidth(row); got > 240 {
+			t.Fatalf("selected=%d width = %d, want <= 240", selected, got)
+		}
+	}
+
+	linked := renderFlowPane([]flowstore.FlowRecord{record}, -1, 0, 108, 3, "", "", nil, false, nil)[1]
+	baseline := record
+	baseline.PR.URL = ""
+	plain := renderFlowPane([]flowstore.FlowRecord{baseline}, -1, 0, 108, 3, "", "", nil, false, nil)[1]
+	if got, want := ansi.Strip(linked), ansi.Strip(plain); got != want {
+		t.Fatalf("truncation changed visible text: got %q want %q", got, want)
+	}
+	if ansi.StringWidth(linked) != ansi.StringWidth(plain) || ansi.StringWidth(linked) > 108 {
+		t.Fatalf("truncated linked width = %d, plain width = %d", ansi.StringWidth(linked), ansi.StringWidth(plain))
+	}
+	start := strings.Index(linked, ansi.SetHyperlink(prURL))
+	if start < 0 || !strings.Contains(linked[start:], ansi.ResetHyperlink()) {
+		t.Fatalf("truncated PR link is not explicitly closed: %q", linked)
+	}
+}
+
+func TestRenderAuthoritativePathAndBeadTargets(t *testing.T) {
+	const repoPath = "/tmp/repo with space"
+	assertTarget := func(name, row, target string) {
+		t.Helper()
+		if !strings.Contains(row, ansi.SetHyperlink(target)) || !strings.Contains(row, ansi.ResetHyperlink()) {
+			t.Fatalf("%s row missing closed target %q: %q", name, target, row)
+		}
+	}
+
+	repoRow := renderRepoList([]scanner.Repo{{Path: repoPath, DisplayName: "repo"}}, 0, 0, 40, 1, "", nil)[0]
+	assertTarget("repo", repoRow, fileHyperlinkTarget(repoPath))
+
+	worktreePath := repoPath + "-worktrees/feature"
+	worktreeRow := renderWorktreePane([]gitquery.Worktree{{Path: worktreePath, BranchName: "feature"}}, 0, 0, 80, 1)[0]
+	assertTarget("worktree", worktreeRow, fileHyperlinkTarget(worktreePath))
+
+	branchRow := renderBranchPaneSelected([]gitquery.BranchRow{{Branch: gitquery.Branch{Name: "feature", IsWorktree: true}, WorktreePath: worktreePath}}, 0, 0, 80, 1, repoPath)[0]
+	assertTarget("branch", branchRow, fileHyperlinkTarget(worktreePath))
+
+	sessionRows := renderSessionPane([]sessions.SessionRecord{{Provider: sessions.ProviderCodex, Branch: "feature", WorktreePath: worktreePath, Status: "ended"}}, 0, 0, 100, 2)
+	assertTarget("session", sessionRows[1], fileHyperlinkTarget(worktreePath))
+
+	expansion := BeadExpansion{EpicID: "approach-epic", State: BeadExpansionLoaded, ReadinessKnown: true, Children: []beadsquery.Bead{{ID: "approach-child", Title: "Child"}}}
+	beadRows := renderBeadsPane([]beadsquery.Bead{{ID: "approach-epic", Priority: 2, Title: "Epic", IssueType: "epic"}}, 0, 0, 80, 3, expansion, repoPath)
+	assertTarget("top-level Bead", beadRows[0], beadHyperlinkTarget(repoPath, "approach-epic"))
+	assertTarget("child Bead", beadRows[1], beadHyperlinkTarget(repoPath, "approach-child"))
+	if !strings.Contains(beadRows[0], ansi.ResetHyperlink()+"  P2") {
+		t.Fatalf("top-level Bead link includes adjacent fields: %q", beadRows[0])
+	}
+	narrowBead := renderBeadsPane([]beadsquery.Bead{{ID: "approach-epic", Title: "Epic"}}, -1, 0, 10, 1, BeadExpansion{}, repoPath)[0]
+	if !strings.Contains(narrowBead, ansi.ResetHyperlink()) || ansi.StringWidth(narrowBead) > 10 {
+		t.Fatalf("truncated Bead link is not closed within width: %q", narrowBead)
+	}
+}
+
+func TestRenderPRBabysitterLinksPRAndBeadTargets(t *testing.T) {
+	const (
+		repoPath = "/tmp/approach"
+		prURL    = "https://github.com/approachcontrol/approach/pull/88"
+	)
+	row := PRBabysitterRow{
+		Flow: flowstore.FlowRecord{FlowID: "flow-1", RepoPath: repoPath, PR: flowstore.PullRequest{Number: 88, URL: prURL}},
+		Repo: "approach", Title: "PR #88", BeadID: "approach-5e7", Mergeability: "mergeable", Checks: "passing",
+	}
+	for _, selected := range []int{-1, 0} {
+		line := renderPRBabysitterPane([]PRBabysitterRow{row}, selected, 0, 120, 3, "", "", nil)[1]
+		for _, target := range []string{fileHyperlinkTarget(repoPath), prURL, beadHyperlinkTarget(repoPath, row.BeadID)} {
+			if !strings.Contains(line, ansi.SetHyperlink(target)) {
+				t.Fatalf("selected=%d row missing target %q: %q", selected, target, line)
+			}
+		}
+		if got := ansi.Strip(line); !strings.Contains(got, "PR #88") || !strings.Contains(got, row.BeadID) {
+			t.Fatalf("selected=%d visible text changed: %q", selected, got)
+		}
+	}
+}
+
+func TestEmbeddedTerminalFramePreservesClosedHyperlinkAtPaneEdge(t *testing.T) {
+	const target = "https://example.com/pull/8"
+	linked := hyperlink("abcdefgh", target)
+	for _, width := range []int{20, 8} {
+		lines := renderEmbeddedTerminalPane([]EmbeddedTerminalTab{{Number: 1, Provider: "sh", Active: true}}, []string{linked}, false, false, width, 4)
+		joined := strings.Join(lines, "\n")
+		if !strings.Contains(joined, ansi.SetHyperlink(target)) || !strings.Contains(joined, ansi.ResetHyperlink()) {
+			t.Fatalf("width %d frame dropped or leaked hyperlink: %q", width, joined)
+		}
+		for _, line := range lines {
+			if got := ansi.StringWidth(line); got != width {
+				t.Fatalf("width %d framed line width = %d: %q", width, got, line)
+			}
+		}
+	}
+}

--- a/ui/hyperlink_test.go
+++ b/ui/hyperlink_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -191,6 +192,34 @@ func TestFilesystemHyperlinkLabelsAreTerminalSafe(t *testing.T) {
 			}
 			if strings.ContainsAny(ansi.Strip(row), "\n\r\a\x1b") {
 				t.Fatalf("row contains an unsafe line or control character: %q", row)
+			}
+		})
+	}
+}
+
+func TestFilesystemHyperlinkLabelsPreservePrintableWhitespace(t *testing.T) {
+	const (
+		displayName = "repo  copy "
+		path        = "/tmp/repo  copy "
+	)
+	flow := flowstore.FlowRecord{
+		FlowID: "flow-1", Title: "Flow", Status: flowstore.StatusInProgress,
+		RepoPath: "/tmp/repo", WorktreePath: path,
+	}
+	rows := map[string]struct {
+		row  string
+		want string
+	}{
+		"repo":     {row: renderRepoList([]scanner.Repo{{Path: "/tmp/repo", DisplayName: displayName}}, 0, 0, 120, 1, "", nil)[0], want: displayName},
+		"worktree": {row: renderWorktreePane([]gitquery.Worktree{{Path: path, BranchName: "feature"}}, 0, 0, 240, 1)[0], want: path},
+		"branch":   {row: renderBranchPaneSelected([]gitquery.BranchRow{{Branch: gitquery.Branch{Name: "feature", IsWorktree: true}, WorktreePath: path}}, 0, 0, 240, 1, "/tmp/repo")[0], want: path},
+		"session":  {row: renderSessionPane([]sessions.SessionRecord{{Provider: sessions.ProviderCodex, WorktreePath: path, Status: "ended"}}, 0, 0, 240, 2)[1], want: filepath.Base(path)},
+		"flow":     {row: renderFlowPane([]flowstore.FlowRecord{flow}, 0, 0, 240, 2, "", "", nil, true, map[string]string{flow.RepoPath: displayName})[1], want: displayName},
+	}
+	for name, tt := range rows {
+		t.Run(name, func(t *testing.T) {
+			if got := ansi.Strip(tt.row); !strings.Contains(got, tt.want) {
+				t.Fatalf("row changed printable path whitespace: got %q, want substring %q", got, tt.want)
 			}
 		})
 	}

--- a/ui/hyperlink_test.go
+++ b/ui/hyperlink_test.go
@@ -44,8 +44,10 @@ func TestHyperlinkTargets(t *testing.T) {
 		{name: "reject non-HTTP PR", got: prHyperlinkTarget("javascript:alert(1)")},
 		{name: "reject relative PR", got: prHyperlinkTarget("github.com/approach/pull/8")},
 		{name: "absolute file", got: fileHyperlinkTarget("/tmp/space # percent%/界"), want: "file:///tmp/space%20%23%20percent%25/%E7%95%8C"},
+		{name: "file preserves trailing space", got: fileHyperlinkTarget("/tmp/repo "), want: "file:///tmp/repo%20"},
 		{name: "reject relative file", got: fileHyperlinkTarget("relative/path")},
 		{name: "repo-qualified Bead", got: beadHyperlinkTarget("/tmp/repo #1", "approach-5e7/child"), want: "bead://open?id=approach-5e7%2Fchild&repo=%2Ftmp%2Frepo+%231"},
+		{name: "Bead repo preserves trailing space", got: beadHyperlinkTarget("/tmp/repo ", "approach-5e7"), want: "bead://open?id=approach-5e7&repo=%2Ftmp%2Frepo+"},
 		{name: "missing Bead repo", got: beadHyperlinkTarget("", "approach-5e7")},
 		{name: "missing Bead ID", got: beadHyperlinkTarget("/tmp/repo", "")},
 	}
@@ -162,6 +164,35 @@ func TestRenderAuthoritativePathAndBeadTargets(t *testing.T) {
 	narrowBead := renderBeadsPane([]beadsquery.Bead{{ID: "approach-epic", Title: "Epic"}}, -1, 0, 10, 1, BeadExpansion{}, repoPath)[0]
 	if !strings.Contains(narrowBead, ansi.ResetHyperlink()) || ansi.StringWidth(narrowBead) > 10 {
 		t.Fatalf("truncated Bead link is not closed within width: %q", narrowBead)
+	}
+}
+
+func TestFilesystemHyperlinkLabelsAreTerminalSafe(t *testing.T) {
+	const evilTarget = "https://attacker.invalid"
+	injected := ansi.SetHyperlink(evilTarget) + "owned" + ansi.ResetHyperlink()
+	unsafeLabel := "repo" + injected + "\nnext"
+	unsafePath := "/tmp/work" + injected + "\nnext"
+
+	flow := flowstore.FlowRecord{
+		FlowID: "flow-1", Title: "Flow", Status: flowstore.StatusInProgress,
+		RepoPath: "/tmp/repo", WorktreePath: unsafePath,
+	}
+	rows := map[string]string{
+		"repo":     renderRepoList([]scanner.Repo{{Path: "/tmp/repo", DisplayName: unsafeLabel}}, 0, 0, 120, 1, "", nil)[0],
+		"worktree": renderWorktreePane([]gitquery.Worktree{{Path: unsafePath, BranchName: "feature"}}, 0, 0, 240, 1)[0],
+		"branch":   renderBranchPaneSelected([]gitquery.BranchRow{{Branch: gitquery.Branch{Name: "feature", IsWorktree: true}, WorktreePath: unsafePath}}, 0, 0, 240, 1, "/tmp/repo")[0],
+		"session":  renderSessionPane([]sessions.SessionRecord{{Provider: sessions.ProviderCodex, WorktreePath: unsafePath, Status: "ended"}}, 0, 0, 240, 2)[1],
+		"flow":     renderFlowPane([]flowstore.FlowRecord{flow}, 0, 0, 240, 2, "", "", nil, true, map[string]string{flow.RepoPath: unsafeLabel})[1],
+	}
+	for name, row := range rows {
+		t.Run(name, func(t *testing.T) {
+			if strings.Contains(row, ansi.SetHyperlink(evilTarget)) {
+				t.Fatalf("row contains injected hyperlink: %q", row)
+			}
+			if strings.ContainsAny(ansi.Strip(row), "\n\r\a\x1b") {
+				t.Fatalf("row contains an unsafe line or control character: %q", row)
+			}
+		})
 	}
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -2993,7 +2993,7 @@ func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, e
 	for i := 0; i < height; i++ {
 		idx := scroll + i
 		if idx < len(repos) {
-			name := repos[idx].DisplayName
+			name := terminalSafeSingleLine(repos[idx].DisplayName)
 			activeRepo := repoHasActiveTerminal(activeTerminalRepoPaths, repos[idx].Path)
 			activityMarker := ""
 			if showActivityColumn {
@@ -3029,7 +3029,7 @@ func renderCollapsedRepoPane(repos []scanner.Repo, selected, height int, showRes
 	lines = append(lines, restoreHint)
 	if selected >= 0 && selected < len(repos) {
 		target := fileHyperlinkTarget(repos[selected].Path)
-		for _, r := range repos[selected].DisplayName {
+		for _, r := range terminalSafeSingleLine(repos[selected].DisplayName) {
 			if len(lines) >= height {
 				break
 			}
@@ -3129,10 +3129,11 @@ func renderBranchPaneSelected(rows []gitquery.BranchRow, selected, scroll, width
 
 		var locationLabel string
 		if row.WorktreePath != "" {
+			worktreePath := terminalSafeSingleLine(row.WorktreePath)
 			if repoPath != "" && row.WorktreePath == repoPath {
 				locationLabel = " " + hyperlink(rootStyle.Render("[root]"), fileHyperlinkTarget(row.WorktreePath))
 			} else {
-				locationLabel = " " + hyperlink(commitStyle.Render(fmt.Sprintf("[%s]", row.WorktreePath)), fileHyperlinkTarget(row.WorktreePath))
+				locationLabel = " " + hyperlink(commitStyle.Render(fmt.Sprintf("[%s]", worktreePath)), fileHyperlinkTarget(row.WorktreePath))
 			}
 		}
 
@@ -3188,7 +3189,8 @@ func renderSelectedBranchRow(row gitquery.BranchRow, repoPath string, width int)
 		if repoPath != "" && row.WorktreePath == repoPath {
 			line += hyperlink(selectedSegment(rootStyle, "[root]"), fileHyperlinkTarget(row.WorktreePath))
 		} else {
-			line += hyperlink(selectedSegment(commitStyle, fmt.Sprintf("[%s]", row.WorktreePath)), fileHyperlinkTarget(row.WorktreePath))
+			worktreePath := terminalSafeSingleLine(row.WorktreePath)
+			line += hyperlink(selectedSegment(commitStyle, fmt.Sprintf("[%s]", worktreePath)), fileHyperlinkTarget(row.WorktreePath))
 		}
 	}
 	return renderSelectedRow(line, width)
@@ -3330,6 +3332,7 @@ func renderSessionPane(records []sessions.SessionRecord, selected, scroll, width
 		if worktree == "." || worktree == string(filepath.Separator) {
 			worktree = ""
 		}
+		worktree = terminalSafeSingleLine(worktree)
 		summary := sessionSummaryDisplayText(record.Summary)
 		line := formatSessionColumns("   ",
 			diffHdrStyle.Render(fitSessionColumn(provider, sessionProviderWidth)),
@@ -3779,7 +3782,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 		updated := flowUpdatedLabel(record)
 		repo := ""
 		if showRepo {
-			repo = flowRepoLabel(record, repoDisplayNames)
+			repo = terminalSafeSingleLine(flowRepoLabel(record, repoDisplayNames))
 		}
 		branch := record.Branch
 		if branch == "" {
@@ -3789,6 +3792,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 				branch = "missing-worktree"
 			}
 		}
+		branch = terminalSafeSingleLine(branch)
 		rowSelected := i == selected && selectedPhaseID == ""
 		statusCell := statusStyle.Render(fitSessionColumn(record.Status, flowStatusWidth))
 		targets := flowRowHyperlinkTargets{
@@ -4265,7 +4269,7 @@ func renderWorktreePaneWithSessions(worktrees []gitquery.Worktree, selected, scr
 			rootLabel = " " + rootStyle.Render("[root]")
 		}
 
-		path := " " + hyperlink(commitStyle.Render(wt.Path), fileHyperlinkTarget(wt.Path))
+		path := " " + hyperlink(commitStyle.Render(terminalSafeSingleLine(wt.Path)), fileHyperlinkTarget(wt.Path))
 
 		line := "   " + name + indicators + rootLabel + path
 		if i == selected {
@@ -4360,7 +4364,7 @@ func renderSelectedWorktreeRow(wt gitquery.Worktree, width int) string {
 		line += selectedSegment(rootStyle, "[root]")
 	}
 	line += selectedStyle.Render(" ")
-	line += hyperlink(selectedSegment(commitStyle, wt.Path), fileHyperlinkTarget(wt.Path))
+	line += hyperlink(selectedSegment(commitStyle, terminalSafeSingleLine(wt.Path)), fileHyperlinkTarget(wt.Path))
 	return renderSelectedRow(line, width)
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -2993,7 +2993,7 @@ func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, e
 	for i := 0; i < height; i++ {
 		idx := scroll + i
 		if idx < len(repos) {
-			name := terminalSafeSingleLine(repos[idx].DisplayName)
+			name := terminalSafeHyperlinkLabel(repos[idx].DisplayName)
 			activeRepo := repoHasActiveTerminal(activeTerminalRepoPaths, repos[idx].Path)
 			activityMarker := ""
 			if showActivityColumn {
@@ -3029,7 +3029,7 @@ func renderCollapsedRepoPane(repos []scanner.Repo, selected, height int, showRes
 	lines = append(lines, restoreHint)
 	if selected >= 0 && selected < len(repos) {
 		target := fileHyperlinkTarget(repos[selected].Path)
-		for _, r := range terminalSafeSingleLine(repos[selected].DisplayName) {
+		for _, r := range terminalSafeHyperlinkLabel(repos[selected].DisplayName) {
 			if len(lines) >= height {
 				break
 			}
@@ -3129,7 +3129,7 @@ func renderBranchPaneSelected(rows []gitquery.BranchRow, selected, scroll, width
 
 		var locationLabel string
 		if row.WorktreePath != "" {
-			worktreePath := terminalSafeSingleLine(row.WorktreePath)
+			worktreePath := terminalSafeHyperlinkLabel(row.WorktreePath)
 			if repoPath != "" && row.WorktreePath == repoPath {
 				locationLabel = " " + hyperlink(rootStyle.Render("[root]"), fileHyperlinkTarget(row.WorktreePath))
 			} else {
@@ -3189,7 +3189,7 @@ func renderSelectedBranchRow(row gitquery.BranchRow, repoPath string, width int)
 		if repoPath != "" && row.WorktreePath == repoPath {
 			line += hyperlink(selectedSegment(rootStyle, "[root]"), fileHyperlinkTarget(row.WorktreePath))
 		} else {
-			worktreePath := terminalSafeSingleLine(row.WorktreePath)
+			worktreePath := terminalSafeHyperlinkLabel(row.WorktreePath)
 			line += hyperlink(selectedSegment(commitStyle, fmt.Sprintf("[%s]", worktreePath)), fileHyperlinkTarget(row.WorktreePath))
 		}
 	}
@@ -3305,6 +3305,11 @@ func renderBeadsOpenPane(beads []beadsquery.Bead, selected, scroll, width, heigh
 }
 
 func terminalSafeSingleLine(text string) string {
+	text = terminalSafeHyperlinkLabel(text)
+	return strings.Join(strings.Fields(text), " ")
+}
+
+func terminalSafeHyperlinkLabel(text string) string {
 	text = ansi.Strip(text)
 	text = strings.Map(func(r rune) rune {
 		if unicode.IsControl(r) {
@@ -3312,7 +3317,7 @@ func terminalSafeSingleLine(text string) string {
 		}
 		return r
 	}, text)
-	return strings.Join(strings.Fields(text), " ")
+	return text
 }
 
 func renderSessionPane(records []sessions.SessionRecord, selected, scroll, width, height int) []string {
@@ -3332,7 +3337,7 @@ func renderSessionPane(records []sessions.SessionRecord, selected, scroll, width
 		if worktree == "." || worktree == string(filepath.Separator) {
 			worktree = ""
 		}
-		worktree = terminalSafeSingleLine(worktree)
+		worktree = terminalSafeHyperlinkLabel(worktree)
 		summary := sessionSummaryDisplayText(record.Summary)
 		line := formatSessionColumns("   ",
 			diffHdrStyle.Render(fitSessionColumn(provider, sessionProviderWidth)),
@@ -3782,7 +3787,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 		updated := flowUpdatedLabel(record)
 		repo := ""
 		if showRepo {
-			repo = terminalSafeSingleLine(flowRepoLabel(record, repoDisplayNames))
+			repo = terminalSafeHyperlinkLabel(flowRepoLabel(record, repoDisplayNames))
 		}
 		branch := record.Branch
 		if branch == "" {
@@ -3792,7 +3797,7 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 				branch = "missing-worktree"
 			}
 		}
-		branch = terminalSafeSingleLine(branch)
+		branch = terminalSafeHyperlinkLabel(branch)
 		rowSelected := i == selected && selectedPhaseID == ""
 		statusCell := statusStyle.Render(fitSessionColumn(record.Status, flowStatusWidth))
 		targets := flowRowHyperlinkTargets{
@@ -4269,7 +4274,7 @@ func renderWorktreePaneWithSessions(worktrees []gitquery.Worktree, selected, scr
 			rootLabel = " " + rootStyle.Render("[root]")
 		}
 
-		path := " " + hyperlink(commitStyle.Render(terminalSafeSingleLine(wt.Path)), fileHyperlinkTarget(wt.Path))
+		path := " " + hyperlink(commitStyle.Render(terminalSafeHyperlinkLabel(wt.Path)), fileHyperlinkTarget(wt.Path))
 
 		line := "   " + name + indicators + rootLabel + path
 		if i == selected {
@@ -4364,7 +4369,7 @@ func renderSelectedWorktreeRow(wt gitquery.Worktree, width int) string {
 		line += selectedSegment(rootStyle, "[root]")
 	}
 	line += selectedStyle.Render(" ")
-	line += hyperlink(selectedSegment(commitStyle, terminalSafeSingleLine(wt.Path)), fileHyperlinkTarget(wt.Path))
+	line += hyperlink(selectedSegment(commitStyle, terminalSafeHyperlinkLabel(wt.Path)), fileHyperlinkTarget(wt.Path))
 	return renderSelectedRow(line, width)
 }
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -970,7 +970,7 @@ func renderApplication(p RenderParams) string {
 		message := "Could not load " + beadsModeLabel(p.Mode) + " beads: " + terminalSafeSingleLine(p.BeadsError)
 		rightLines = renderPlaceholderPane(rightContentWidth, listHeight, message)
 	case IsBeadsMode(p.Mode) && len(p.BeadsOpen) > 0:
-		rightLines = renderBeadsPane(p.BeadsOpen, beadSel, p.BeadsOpenScroll, rightContentWidth, listHeight, p.BeadExpansion)
+		rightLines = renderBeadsPane(p.BeadsOpen, beadSel, p.BeadsOpenScroll, rightContentWidth, listHeight, p.BeadExpansion, repoPath)
 	case IsBeadsMode(p.Mode):
 		message := p.RightEmptyMessage
 		if message == "" {
@@ -1117,7 +1117,7 @@ func renderStackedModePane(p RenderParams, mode Mode, width, outerRows int, focu
 	case IsBeadsMode(mode) && p.BeadsError != "":
 		body = renderPlaceholderPane(width, bodyRows, "Could not load "+beadsModeLabel(mode)+" beads: "+terminalSafeSingleLine(p.BeadsError))
 	case IsBeadsMode(mode) && len(p.BeadsOpen) > 0:
-		body = renderBeadsPane(p.BeadsOpen, beadSel, p.BeadsOpenScroll, width, bodyRows, p.BeadExpansion)
+		body = renderBeadsPane(p.BeadsOpen, beadSel, p.BeadsOpenScroll, width, bodyRows, p.BeadExpansion, repoPath)
 	case IsBeadsMode(mode):
 		message := "beads not configured"
 		if repoPath == "" || p.BeadsOpenAvailable {
@@ -3002,10 +3002,11 @@ func renderRepoList(repos []scanner.Repo, selected, scroll, width, height int, e
 					activityMarker = "● "
 				}
 			}
+			target := fileHyperlinkTarget(repos[idx].Path)
 			if idx == selected {
-				lines[i] = renderSelectedRepoRow(name, activityMarker, activeRepo, showActivityColumn, width)
+				lines[i] = renderSelectedRepoRow(name, target, activityMarker, activeRepo, showActivityColumn, width)
 			} else {
-				lines[i] = renderRepoRow(name, activityMarker, activeRepo, showActivityColumn, width)
+				lines[i] = renderRepoRow(name, target, activityMarker, activeRepo, showActivityColumn, width)
 			}
 		} else {
 			lines[i] = strings.Repeat(" ", width)
@@ -3027,6 +3028,7 @@ func renderCollapsedRepoPane(repos []scanner.Repo, selected, height int, showRes
 	}
 	lines = append(lines, restoreHint)
 	if selected >= 0 && selected < len(repos) {
+		target := fileHyperlinkTarget(repos[selected].Path)
 		for _, r := range repos[selected].DisplayName {
 			if len(lines) >= height {
 				break
@@ -3035,7 +3037,7 @@ func renderCollapsedRepoPane(repos []scanner.Repo, selected, height int, showRes
 			if width <= 0 || width > contentWidth {
 				continue
 			}
-			line := string(r)
+			line := hyperlink(string(r), target)
 			if width < contentWidth {
 				line += strings.Repeat(" ", contentWidth-width)
 			}
@@ -3048,7 +3050,7 @@ func renderCollapsedRepoPane(repos []scanner.Repo, selected, height int, showRes
 	return lines
 }
 
-func renderSelectedRepoRow(name, activityMarker string, activeRepo, showActivityColumn bool, width int) string {
+func renderSelectedRepoRow(name, target, activityMarker string, activeRepo, showActivityColumn bool, width int) string {
 	line := selectedStyle.Render(" > ")
 	if showActivityColumn {
 		if activeRepo {
@@ -3057,11 +3059,11 @@ func renderSelectedRepoRow(name, activityMarker string, activeRepo, showActivity
 			line += selectedStyle.Render(activityMarker)
 		}
 	}
-	line += selectedStyle.Render(name)
+	line += hyperlink(selectedStyle.Render(name), target)
 	return renderSelectedRow(line, width)
 }
 
-func renderRepoRow(name, activityMarker string, activeRepo, showActivityColumn bool, width int) string {
+func renderRepoRow(name, target, activityMarker string, activeRepo, showActivityColumn bool, width int) string {
 	line := repoStyle.Render("   ")
 	if showActivityColumn {
 		if activeRepo {
@@ -3070,7 +3072,7 @@ func renderRepoRow(name, activityMarker string, activeRepo, showActivityColumn b
 			line += repoStyle.Render(activityMarker)
 		}
 	}
-	line += repoStyle.Render(name)
+	line += hyperlink(repoStyle.Render(name), target)
 	return renderStyledRow(line, repoStyle, width)
 }
 
@@ -3128,9 +3130,9 @@ func renderBranchPaneSelected(rows []gitquery.BranchRow, selected, scroll, width
 		var locationLabel string
 		if row.WorktreePath != "" {
 			if repoPath != "" && row.WorktreePath == repoPath {
-				locationLabel = " " + rootStyle.Render("[root]")
+				locationLabel = " " + hyperlink(rootStyle.Render("[root]"), fileHyperlinkTarget(row.WorktreePath))
 			} else {
-				locationLabel = " " + commitStyle.Render(fmt.Sprintf("[%s]", row.WorktreePath))
+				locationLabel = " " + hyperlink(commitStyle.Render(fmt.Sprintf("[%s]", row.WorktreePath)), fileHyperlinkTarget(row.WorktreePath))
 			}
 		}
 
@@ -3184,9 +3186,9 @@ func renderSelectedBranchRow(row gitquery.BranchRow, repoPath string, width int)
 	if row.WorktreePath != "" {
 		line += selectedStyle.Render(" ")
 		if repoPath != "" && row.WorktreePath == repoPath {
-			line += selectedSegment(rootStyle, "[root]")
+			line += hyperlink(selectedSegment(rootStyle, "[root]"), fileHyperlinkTarget(row.WorktreePath))
 		} else {
-			line += selectedSegment(commitStyle, fmt.Sprintf("[%s]", row.WorktreePath))
+			line += hyperlink(selectedSegment(commitStyle, fmt.Sprintf("[%s]", row.WorktreePath)), fileHyperlinkTarget(row.WorktreePath))
 		}
 	}
 	return renderSelectedRow(line, width)
@@ -3297,7 +3299,7 @@ func renderReflogPane(entries []gitquery.ReflogEntry, selected, scroll, width, h
 }
 
 func renderBeadsOpenPane(beads []beadsquery.Bead, selected, scroll, width, height int) []string {
-	return renderBeadsPane(beads, selected, scroll, width, height, BeadExpansion{})
+	return renderBeadsPane(beads, selected, scroll, width, height, BeadExpansion{}, "")
 }
 
 func terminalSafeSingleLine(text string) string {
@@ -3332,7 +3334,7 @@ func renderSessionPane(records []sessions.SessionRecord, selected, scroll, width
 		line := formatSessionColumns("   ",
 			diffHdrStyle.Render(fitSessionColumn(provider, sessionProviderWidth)),
 			branchStyle.Render(fitSessionColumn(record.Branch, sessionBranchWidth)),
-			stashDateStyle.Render(fitSessionColumn(worktree, sessionWorktreeWidth)),
+			hyperlinkColumn(worktree, fileHyperlinkTarget(record.WorktreePath), sessionWorktreeWidth, stashDateStyle),
 			statusStyle.Render(fitSessionColumn(record.Status, sessionStatusWidth)),
 			stashMsgStyle.Render(summary),
 		)
@@ -3340,7 +3342,7 @@ func renderSessionPane(records []sessions.SessionRecord, selected, scroll, width
 			selectedLine := truncateToWidth(formatSessionColumns(" > ",
 				provider,
 				record.Branch,
-				worktree,
+				hyperlink(worktree, fileHyperlinkTarget(record.WorktreePath)),
 				record.Status,
 				summary,
 			), width)
@@ -3711,18 +3713,18 @@ func renderPRBabysitterPane(rows []PRBabysitterRow, selected, scroll, width, hei
 			prefix,
 			prBabysitterStatusStyle(mergeability).Render(fitSessionColumn(mergeability, prBabysitterMergeabilityWidth)),
 			prBabysitterStatusStyle(checks).Render(fitSessionColumn(checks, prBabysitterChecksWidth)),
-			statusStyle.Render(fitSessionColumn(repo, prBabysitterRepoWidth)),
-			stashMsgStyle.Render(fitSessionColumn(title, prBabysitterFlowWidth)),
-			statusStyle.Render(fitSessionColumn(beadID, prBabysitterBeadWidth)),
+			hyperlinkColumn(repo, fileHyperlinkTarget(record.RepoPath), prBabysitterRepoWidth, statusStyle),
+			hyperlinkColumn(title, prHyperlinkTarget(record.PR.URL), prBabysitterFlowWidth, stashMsgStyle),
+			hyperlinkColumn(beadID, beadHyperlinkTarget(record.RepoPath, row.BeadID), prBabysitterBeadWidth, statusStyle),
 		)
 		if index == selected && selectedPhaseID == "" {
 			line = renderSelectedRow(formatPRBabysitterColumns(
 				selectedFlowRowPrefix(active.hasFlow(record.FlowID)),
 				selectedStyle.Render(fitSessionColumn(mergeability, prBabysitterMergeabilityWidth)),
 				selectedStyle.Render(fitSessionColumn(checks, prBabysitterChecksWidth)),
-				selectedStyle.Render(fitSessionColumn(repo, prBabysitterRepoWidth)),
-				selectedStyle.Render(fitSessionColumn(title, prBabysitterFlowWidth)),
-				selectedStyle.Render(fitSessionColumn(beadID, prBabysitterBeadWidth)),
+				hyperlinkColumn(repo, fileHyperlinkTarget(record.RepoPath), prBabysitterRepoWidth, selectedStyle),
+				hyperlinkColumn(title, prHyperlinkTarget(record.PR.URL), prBabysitterFlowWidth, selectedStyle),
+				hyperlinkColumn(beadID, beadHyperlinkTarget(record.RepoPath, row.BeadID), prBabysitterBeadWidth, selectedStyle),
 			), width)
 		}
 		visualRows = append(visualRows, truncateToWidth(line, width))
@@ -3789,12 +3791,17 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 		}
 		rowSelected := i == selected && selectedPhaseID == ""
 		statusCell := statusStyle.Render(fitSessionColumn(record.Status, flowStatusWidth))
-		repoCell := statusStyle.Render(fitSessionColumn(repo, flowRepoWidth))
-		branchCell := branchStyle.Render(fitSessionColumn(branch, flowBranchWidth))
+		targets := flowRowHyperlinkTargets{
+			repo:   fileHyperlinkTarget(record.RepoPath),
+			branch: fileHyperlinkTarget(record.WorktreePath),
+			pr:     prHyperlinkTarget(record.PR.URL),
+		}
+		repoCell := hyperlinkColumn(repo, targets.repo, flowRepoWidth, statusStyle)
+		branchCell := hyperlinkColumn(branch, targets.branch, flowBranchWidth, branchStyle)
 		phaseCell := diffHdrStyle.Render(fitSessionColumn(phase, flowPhaseWidth))
 		issueCell := statusStyle.Render(fitSessionColumn(issue, flowIssueWidth))
 		planCell := statusStyle.Render(fitSessionColumn(plan, flowPlanWidth))
-		prCell := statusStyle.Render(fitSessionColumn(pr, flowPRWidth))
+		prCell := hyperlinkColumn(pr, targets.pr, flowPRWidth, statusStyle)
 		updatedCell := stashDateStyle.Render(fitSessionColumn(updated, flowUpdatedWidth))
 		title := terminalSafeSingleLine(record.Title)
 		if reason := strings.TrimSpace(record.Closed.Reason); reason != "" && flowstore.FlowClosed(record) {
@@ -3823,7 +3830,8 @@ func renderFlowPane(records []flowstore.FlowRecord, selected, scroll, width, hei
 				pr,
 				updated,
 				title,
-				width)
+				width,
+				targets)
 		}
 		rows = append(rows, truncateToWidth(line, width))
 		if record.FlowID == expandedFlowID {
@@ -3874,7 +3882,8 @@ func renderFlowPhaseRows(record flowstore.FlowRecord, width int, selectedPhaseID
 				"",
 				"",
 				title,
-				width)
+				width,
+				flowRowHyperlinkTargets{})
 		}
 		rows = append(rows, truncateToWidth(line, width))
 	}
@@ -3977,15 +3986,21 @@ func formatFlowColumns(showRepo bool, prefix, status, repo, branch, phase, issue
 	)
 }
 
-func renderSelectedFlowColumns(showRepo bool, prefix, status, repo, branch, phase, issue, plan, pr, updated, title string, width int) string {
+type flowRowHyperlinkTargets struct {
+	repo   string
+	branch string
+	pr     string
+}
+
+func renderSelectedFlowColumns(showRepo bool, prefix, status, repo, branch, phase, issue, plan, pr, updated, title string, width int, targets flowRowHyperlinkTargets) string {
 	line := prefix
 	line += selectedStyle.Render(fitSessionColumn(status, flowStatusWidth))
 	line += selectedStyle.Render("  ")
 	if showRepo {
-		line += selectedStyle.Render(fitSessionColumn(repo, flowRepoWidth))
+		line += hyperlinkColumn(repo, targets.repo, flowRepoWidth, selectedStyle)
 		line += selectedStyle.Render("  ")
 	}
-	line += selectedStyle.Render(fitSessionColumn(branch, flowBranchWidth))
+	line += hyperlinkColumn(branch, targets.branch, flowBranchWidth, selectedStyle)
 	line += selectedStyle.Render("  ")
 	line += selectedStyle.Render(fitSessionColumn(phase, flowPhaseWidth))
 	line += selectedStyle.Render("  ")
@@ -3993,7 +4008,7 @@ func renderSelectedFlowColumns(showRepo bool, prefix, status, repo, branch, phas
 	line += selectedStyle.Render("  ")
 	line += selectedStyle.Render(fitSessionColumn(plan, flowPlanWidth))
 	line += selectedStyle.Render("  ")
-	line += selectedStyle.Render(fitSessionColumn(pr, flowPRWidth))
+	line += hyperlinkColumn(pr, targets.pr, flowPRWidth, selectedStyle)
 	line += selectedStyle.Render("  ")
 	line += selectedStyle.Render(fitSessionColumn(updated, flowUpdatedWidth))
 	line += selectedStyle.Render("  ")
@@ -4250,7 +4265,7 @@ func renderWorktreePaneWithSessions(worktrees []gitquery.Worktree, selected, scr
 			rootLabel = " " + rootStyle.Render("[root]")
 		}
 
-		path := " " + commitStyle.Render(wt.Path)
+		path := " " + hyperlink(commitStyle.Render(wt.Path), fileHyperlinkTarget(wt.Path))
 
 		line := "   " + name + indicators + rootLabel + path
 		if i == selected {
@@ -4345,7 +4360,7 @@ func renderSelectedWorktreeRow(wt gitquery.Worktree, width int) string {
 		line += selectedSegment(rootStyle, "[root]")
 	}
 	line += selectedStyle.Render(" ")
-	line += selectedSegment(commitStyle, wt.Path)
+	line += hyperlink(selectedSegment(commitStyle, wt.Path), fileHyperlinkTarget(wt.Path))
 	return renderSelectedRow(line, width)
 }
 

--- a/ui/ui_flow_test.go
+++ b/ui/ui_flow_test.go
@@ -462,7 +462,7 @@ func TestRender_ActiveFlowsSelectedActiveRowsPreserveSelectionAfterRepoColumn(t 
 	if !strings.Contains(flowRow, selectedSegment(flowTerminalStyle, "●")) {
 		t.Fatalf("selected active flow marker should keep semantic marker style:\n%q", flowRow)
 	}
-	if want := selectedStyle.Render(fitSessionColumn("approach", flowRepoWidth)); !strings.Contains(flowRow, want) {
+	if want := hyperlinkColumn("approach", fileHyperlinkTarget(flows[0].RepoPath), flowRepoWidth, selectedStyle); !strings.Contains(flowRow, want) {
 		t.Fatalf("selected active flow row should style repo column after marker:\n%q\nmissing %q", flowRow, want)
 	}
 


### PR DESCRIPTION
PR URLs, local paths, and Bead IDs currently render as plain text in the TUI, and links emitted by child processes can lose their targets in the embedded terminal.

This adds OSC 8 links wherever Approach has an authoritative target while preserving visible labels, styling, truncation, and column widths. It also keeps child-process hyperlinks intact through terminal emulation, scrollback, and dock rendering, and sanitizes path labels and hyperlink targets before composing terminal escape sequences.

Validation:
- make fmt-check
- make test
- make build