### PR TITLE
feat(tui): add OSC 9 desktop notifications

### DIFF
--- a/actions/tmux_mode.go
+++ b/actions/tmux_mode.go
@@ -106,6 +106,11 @@ const repoTmuxProbeTimeout = 2 * time.Second
 // so matching on the name alone would report a long-gone agent as live.
 const repoTmuxLiveWindowFormat = "#{window_name} #{pane_dead}"
 
+const (
+	repoTmuxLaunchMarker       = "@approach_launch_id"
+	repoTmuxLaunchMarkerFormat = "#{" + repoTmuxLaunchMarker + "} #{pane_dead}"
+)
+
 // tmuxProbeCommand builds a read-only tmux query. TMUX/ZELLIJ are stripped so a
 // TUI running inside a multiplexer still asks the default server rather than its
 // enclosing one.
@@ -185,6 +190,11 @@ func InsideMultiplexer() bool {
 	return insideMultiplexer(os.Getenv)
 }
 
+// InsideTmux reports whether Approach's current renderer is hosted by tmux.
+func InsideTmux() bool {
+	return os.Getenv("TMUX") != ""
+}
+
 func insideMultiplexer(getenv func(string) string) bool {
 	return getenv("TMUX") != "" || getenv("ZELLIJ") != ""
 }
@@ -193,6 +203,10 @@ func insideMultiplexer(getenv func(string) string) bool {
 // field the launch probe needs.
 func repoTmuxListWindowsArgs(repoPath string) []string {
 	return []string{"list-windows", "-t", tmuxExactWindowTarget(RepoAgentSessionName(repoPath)), "-F", repoTmuxLiveWindowFormat}
+}
+
+func repoTmuxListLaunchMarkersArgs(repoPath string) []string {
+	return []string{"list-windows", "-t", tmuxExactWindowTarget(RepoAgentSessionName(repoPath)), "-F", repoTmuxLaunchMarkerFormat}
 }
 
 // RepoTmuxLaunchWindowLive reports whether any of these launches still has a
@@ -211,8 +225,17 @@ func repoTmuxListWindowsArgs(repoPath string) []string {
 // proof the agent is gone, and must only call it on a user-initiated action: it
 // runs a tmux subprocess.
 func RepoTmuxLaunchWindowLive(repoPath string, launchIDs ...string) bool {
-	live, _ := RepoTmuxLaunchWindowStatus(repoPath, launchIDs...)
-	return live
+	suffixes := repoTmuxLaunchSuffixes(launchIDs)
+	if len(suffixes) == 0 || !TmuxAvailable() {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), repoTmuxProbeTimeout)
+	defer cancel()
+	out, err := tmuxProbeCommand(ctx, repoTmuxListWindowsArgs(repoPath)...).Output()
+	if err != nil {
+		return false
+	}
+	return launchWindowRunningInListing(string(out), suffixes)
 }
 
 // RepoTmuxLaunchWindowStatus reports whether any matching launch window is
@@ -220,8 +243,8 @@ func RepoTmuxLaunchWindowLive(repoPath string, launchIDs ...string) bool {
 // advisory boolean wrapper, a successful false result is safe to use as exit
 // evidence.
 func RepoTmuxLaunchWindowStatus(repoPath string, launchIDs ...string) (bool, error) {
-	suffixes := repoTmuxLaunchSuffixes(launchIDs)
-	if len(suffixes) == 0 {
+	launchIDs = normalizedLaunchIDs(launchIDs)
+	if len(launchIDs) == 0 {
 		return false, errors.New("tmux launch probe requires a matchable launch ID")
 	}
 	if !TmuxAvailable() {
@@ -229,7 +252,7 @@ func RepoTmuxLaunchWindowStatus(repoPath string, launchIDs ...string) (bool, err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), repoTmuxProbeTimeout)
 	defer cancel()
-	out, err := tmuxProbeCommand(ctx, repoTmuxListWindowsArgs(repoPath)...).Output()
+	out, err := tmuxProbeCommand(ctx, repoTmuxListLaunchMarkersArgs(repoPath)...).Output()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -239,12 +262,51 @@ func RepoTmuxLaunchWindowStatus(repoPath string, launchIDs ...string) (bool, err
 		}
 		return false, fmt.Errorf("probe tmux launch window: %w", err)
 	}
-	return launchWindowRunningInListing(string(out), suffixes), nil
+	live, _ := launchMarkerRunningInListing(string(out), launchIDs)
+	return live, nil
 }
 
 func tmuxLaunchProbeConfirmsAbsence(stderr string) bool {
 	stderr = strings.TrimSpace(stderr)
 	return strings.Contains(stderr, "can't find session:") || strings.Contains(stderr, "no server running on")
+}
+
+func normalizedLaunchIDs(launchIDs []string) []string {
+	seen := make(map[string]struct{}, len(launchIDs))
+	normalized := make([]string, 0, len(launchIDs))
+	for _, launchID := range launchIDs {
+		launchID = strings.TrimSpace(launchID)
+		if launchID == "" {
+			continue
+		}
+		if _, ok := seen[launchID]; ok {
+			continue
+		}
+		seen[launchID] = struct{}{}
+		normalized = append(normalized, launchID)
+	}
+	return normalized
+}
+
+func launchMarkerRunningInListing(listing string, launchIDs []string) (live, found bool) {
+	wanted := make(map[string]struct{}, len(launchIDs))
+	for _, launchID := range launchIDs {
+		wanted[launchID] = struct{}{}
+	}
+	for _, line := range strings.Split(listing, "\n") {
+		launchID, dead, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if !ok {
+			continue
+		}
+		if _, ok := wanted[launchID]; !ok {
+			continue
+		}
+		found = true
+		if strings.TrimSpace(dead) == "0" {
+			return true, true
+		}
+	}
+	return false, found
 }
 
 // launchWindowRunningInListing scans repoTmuxLiveWindowFormat output for a live
@@ -294,15 +356,29 @@ session=$1
 window=$2
 dir=$3
 cmd=$4
+launch_id=$5
+mark_window() {
+	if tmux set-option -w -t "=$session:=$window" @approach_launch_id "$launch_id"; then
+		return 0
+	fi
+	tmux kill-window -t "=$session:=$window" 2>/dev/null || true
+	return 1
+}
 if tmux has-session -t "=$session" 2>/dev/null; then
 	if tmux new-window -d -t "=$session:" -n "$window" -c "$dir" "$cmd" 2>/dev/null; then
-		exit 0
+		mark_window
+		exit $?
 	fi
 fi
 if tmux new-session -d -s "$session" -n "$window" -c "$dir" "$cmd" 2>/dev/null; then
-	exit 0
+	mark_window
+	exit $?
 fi
-exec tmux new-window -d -t "=$session:" -n "$window" -c "$dir" "$cmd"
+if tmux new-window -d -t "=$session:" -n "$window" -c "$dir" "$cmd"; then
+	mark_window
+	exit $?
+fi
+exit 1
 `
 
 // RepoTmuxAgentLaunch builds a CLI agent launch that runs in the repo's tmux
@@ -453,7 +529,7 @@ func repoTmuxAgentLaunchWithExecutable(ctx AgentLaunchContext, lookPath lookPath
 	if err != nil {
 		return RepoTmuxAgentSpec{}, err
 	}
-	tmuxCmd := exec.Command("sh", "-c", repoTmuxLaunchScript, "approach", sessionName, windowName, cmd.Dir, termCommand.shellCommand())
+	tmuxCmd := exec.Command("sh", "-c", repoTmuxLaunchScript, "approach", sessionName, windowName, cmd.Dir, termCommand.shellCommand(), ctx.LaunchID)
 	tmuxCmd.Env = envWithoutKeys(os.Environ(), "TMUX", "ZELLIJ")
 	// Without this the script's last attempt — the only one that does not
 	// suppress stderr — writes to /dev/null and every tmux failure reduces to

--- a/actions/tmux_mode.go
+++ b/actions/tmux_mode.go
@@ -211,17 +211,40 @@ func repoTmuxListWindowsArgs(repoPath string) []string {
 // proof the agent is gone, and must only call it on a user-initiated action: it
 // runs a tmux subprocess.
 func RepoTmuxLaunchWindowLive(repoPath string, launchIDs ...string) bool {
+	live, _ := RepoTmuxLaunchWindowStatus(repoPath, launchIDs...)
+	return live
+}
+
+// RepoTmuxLaunchWindowStatus reports whether any matching launch window is
+// live and returns an error when tmux could not answer conclusively. Unlike the
+// advisory boolean wrapper, a successful false result is safe to use as exit
+// evidence.
+func RepoTmuxLaunchWindowStatus(repoPath string, launchIDs ...string) (bool, error) {
 	suffixes := repoTmuxLaunchSuffixes(launchIDs)
-	if len(suffixes) == 0 || !TmuxAvailable() {
-		return false
+	if len(suffixes) == 0 {
+		return false, errors.New("tmux launch probe requires a matchable launch ID")
+	}
+	if !TmuxAvailable() {
+		return false, errors.New("tmux is unavailable")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), repoTmuxProbeTimeout)
 	defer cancel()
 	out, err := tmuxProbeCommand(ctx, repoTmuxListWindowsArgs(repoPath)...).Output()
 	if err != nil {
-		return false
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if tmuxLaunchProbeConfirmsAbsence(string(exitErr.Stderr)) {
+				return false, nil
+			}
+		}
+		return false, fmt.Errorf("probe tmux launch window: %w", err)
 	}
-	return launchWindowRunningInListing(string(out), suffixes)
+	return launchWindowRunningInListing(string(out), suffixes), nil
+}
+
+func tmuxLaunchProbeConfirmsAbsence(stderr string) bool {
+	stderr = strings.TrimSpace(stderr)
+	return strings.Contains(stderr, "can't find session:") || strings.Contains(stderr, "no server running on")
 }
 
 // launchWindowRunningInListing scans repoTmuxLiveWindowFormat output for a live

--- a/actions/tmux_mode_internal_test.go
+++ b/actions/tmux_mode_internal_test.go
@@ -743,6 +743,24 @@ func TestLaunchWindowRunningInListingMatchesAnyOfAPhasesLaunches(t *testing.T) {
 	}
 }
 
+func TestTmuxLaunchProbeConfirmsAbsenceOnlyForMissingSessionOrServer(t *testing.T) {
+	tests := []struct {
+		stderr string
+		want   bool
+	}{
+		{stderr: "can't find session: approach-alpha-1234", want: true},
+		{stderr: "no server running on /tmp/tmux-501/default", want: true},
+		{stderr: "error connecting to /tmp/tmux-501/default (Permission denied)"},
+		{stderr: "probe timed out"},
+		{stderr: ""},
+	}
+	for _, tc := range tests {
+		if got := tmuxLaunchProbeConfirmsAbsence(tc.stderr); got != tc.want {
+			t.Fatalf("tmuxLaunchProbeConfirmsAbsence(%q) = %t, want %t", tc.stderr, got, tc.want)
+		}
+	}
+}
+
 // TestRepoTmuxLaunchWindowLiveMatchesTheLaunchsOwnWindow pins the pairing the
 // liveness probe depends on: the window name a launch gets must be matchable
 // back to that launch ID, and must not match a different launch's window.

--- a/actions/tmux_mode_internal_test.go
+++ b/actions/tmux_mode_internal_test.go
@@ -213,7 +213,7 @@ func tmuxStub(t *testing.T, fail ...string) (dir string, invocations func() []st
 
 func runLaunchScript(t *testing.T, stubDir string) (string, error) {
 	t.Helper()
-	cmd := exec.Command("sh", "-c", repoTmuxLaunchScript, "approach", "sess", "win", stubDir, "agent")
+	cmd := exec.Command("sh", "-c", repoTmuxLaunchScript, "approach", "sess", "win", stubDir, "agent", "launch-1")
 	cmd.Env = append(os.Environ(), "PATH="+stubDir)
 	var stderr boundedBuffer
 	stderr.limit = repoTmuxStderrLimit
@@ -237,12 +237,20 @@ func TestRepoTmuxLaunchScriptCreatesReusesAndRetries(t *testing.T) {
 			// must never reach new-session.
 			name: "reuses an existing session",
 			fail: nil,
-			want: []string{"has-session -t =sess", "new-window -d -t =sess: -n win -c DIR agent"},
+			want: []string{
+				"has-session -t =sess",
+				"new-window -d -t =sess: -n win -c DIR agent",
+				"set-option -w -t =sess:=win @approach_launch_id launch-1",
+			},
 		},
 		{
 			name: "creates the session when absent",
 			fail: []string{"has-session"},
-			want: []string{"has-session -t =sess", "new-session -d -s sess -n win -c DIR agent"},
+			want: []string{
+				"has-session -t =sess",
+				"new-session -d -s sess -n win -c DIR agent",
+				"set-option -w -t =sess:=win @approach_launch_id launch-1",
+			},
 		},
 		{
 			// The session died between the probe and new-window: retry as a
@@ -253,6 +261,7 @@ func TestRepoTmuxLaunchScriptCreatesReusesAndRetries(t *testing.T) {
 				"has-session -t =sess",
 				"new-window -d -t =sess: -n win -c DIR agent",
 				"new-session -d -s sess -n win -c DIR agent",
+				"set-option -w -t =sess:=win @approach_launch_id launch-1",
 			},
 		},
 		{
@@ -264,6 +273,7 @@ func TestRepoTmuxLaunchScriptCreatesReusesAndRetries(t *testing.T) {
 				"has-session -t =sess",
 				"new-session -d -s sess -n win -c DIR agent",
 				"new-window -d -t =sess: -n win -c DIR agent",
+				"set-option -w -t =sess:=win @approach_launch_id launch-1",
 			},
 		},
 	}
@@ -300,6 +310,22 @@ func TestRepoTmuxLaunchScriptReportsTheFinalFailure(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "new-window refused") {
 		t.Fatalf("expected the final new-window's message, got %q", stderr)
+	}
+}
+
+func TestRepoTmuxLaunchScriptKillsUnmarkedWindow(t *testing.T) {
+	stubDir, invocations := tmuxStub(t, "set-option")
+	_, err := runLaunchScript(t, stubDir)
+	if err == nil {
+		t.Fatal("launch script succeeded without recording the immutable launch marker")
+	}
+	wantSuffix := []string{
+		"set-option -w -t =sess:=win @approach_launch_id launch-1",
+		"kill-window -t =sess:=win",
+	}
+	got := invocations()
+	if len(got) < len(wantSuffix) || strings.Join(got[len(got)-len(wantSuffix):], "|") != strings.Join(wantSuffix, "|") {
+		t.Fatalf("tmux invocations = %#v, want suffix %#v", got, wantSuffix)
 	}
 }
 
@@ -740,6 +766,17 @@ func TestLaunchWindowRunningInListingMatchesAnyOfAPhasesLaunches(t *testing.T) {
 	// window; otherwise a phase with one blank launch ID would never be resettable.
 	if launchWindowRunningInListing(listing, repoTmuxLaunchSuffixes([]string{"", "   "})) {
 		t.Fatal("blank launch IDs must not match any window")
+	}
+}
+
+func TestLaunchMarkerRunningInListingSurvivesWindowRename(t *testing.T) {
+	const launchID = "approach-1700000000000000000-aabbccddeeff"
+	live, found := launchMarkerRunningInListing(launchID+" 0\n", []string{launchID})
+	if !found || !live {
+		t.Fatalf("launch marker match = live %t, found %t, want both true", live, found)
+	}
+	if live, found := launchMarkerRunningInListing("another-launch 0\n", []string{launchID}); live || found {
+		t.Fatalf("foreign marker match = live %t, found %t, want both false", live, found)
 	}
 }
 

--- a/cmd/approach/main.go
+++ b/cmd/approach/main.go
@@ -600,6 +600,7 @@ func modelOptionsFromConfig(cfg config.Config, scanRepos func() ([]scanner.Repo,
 	launchOpts := actions.LaunchOptions{TerminalCommand: cfg.Terminal.Command}
 	flowPreset, _ := resolveConfiguredFlowPreset(cfg, "")
 	return model.Options{
+		NotificationsEnabled:  cfg.Notifications.Enabled,
 		AgentCommand:          cfg.Agent.Command,
 		CodexModel:            cfg.Agent.CodexModel,
 		ClaudeModel:           cfg.Agent.ClaudeModel,

--- a/cmd/approach/main_test.go
+++ b/cmd/approach/main_test.go
@@ -497,6 +497,17 @@ func TestModelOptionsFromConfigPassesClipboardOptions(t *testing.T) {
 	}
 }
 
+func TestModelOptionsFromConfigPassesNotificationsEnabled(t *testing.T) {
+	sessionStore, planStore, flowStore := testArtifactStores(t)
+	opts := modelOptionsFromConfig(config.Config{
+		Notifications: config.NotificationsConfig{Enabled: true},
+	}, nil, sessionStore, planStore, flowStore)
+
+	if !opts.NotificationsEnabled {
+		t.Fatal("NotificationsEnabled = false, want true")
+	}
+}
+
 func TestModelOptionsFromConfigPassesFlowPreset(t *testing.T) {
 	sessionStore, planStore, flowStore := testArtifactStores(t)
 	preset := flowstore.Preset{

--- a/config/config.go
+++ b/config/config.go
@@ -22,17 +22,18 @@ var acquireConfigFileLock = artifacts.AcquireFileLock
 
 // Config is approach's parsed configuration file.
 type Config struct {
-	Scan        ScanConfig       `toml:"scan"`
-	Editor      EditorConfig     `toml:"editor"`
-	Terminal    TerminalConfig   `toml:"terminal"`
-	Provider    ProviderConfig   `toml:"provider"`
-	Launch      LaunchConfig     `toml:"launch"`
-	Agent       AgentConfig      `toml:"agent"`
-	FlowPrompts FlowPromptConfig `toml:"flow_prompts"`
-	Flow        FlowConfig       `toml:"flow"`
-	Sessions    SessionsConfig   `toml:"sessions"`
-	Bootstrap   BootstrapConfig  `toml:"bootstrap"`
-	Clipboard   ClipboardConfig  `toml:"clipboard"`
+	Scan          ScanConfig          `toml:"scan"`
+	Editor        EditorConfig        `toml:"editor"`
+	Terminal      TerminalConfig      `toml:"terminal"`
+	Provider      ProviderConfig      `toml:"provider"`
+	Launch        LaunchConfig        `toml:"launch"`
+	Agent         AgentConfig         `toml:"agent"`
+	FlowPrompts   FlowPromptConfig    `toml:"flow_prompts"`
+	Flow          FlowConfig          `toml:"flow"`
+	Sessions      SessionsConfig      `toml:"sessions"`
+	Bootstrap     BootstrapConfig     `toml:"bootstrap"`
+	Clipboard     ClipboardConfig     `toml:"clipboard"`
+	Notifications NotificationsConfig `toml:"notifications"`
 }
 
 const (
@@ -47,6 +48,11 @@ const (
 type ClipboardConfig struct {
 	Method               string `toml:"method"`
 	OSC52MaxPayloadBytes int    `toml:"osc52_max_payload_bytes"`
+}
+
+// NotificationsConfig controls renderer-emitted desktop notifications.
+type NotificationsConfig struct {
+	Enabled bool `toml:"enabled"`
 }
 
 // ScanConfig configures repository discovery.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -52,6 +52,48 @@ func TestLoadFrom_AllowsMissingConfig(t *testing.T) {
 	if cfg.Launch.Backend != config.LaunchBackendEmbedded {
 		t.Fatalf("expected embedded launch backend by default, got %q", cfg.Launch.Backend)
 	}
+	if cfg.Notifications.Enabled {
+		t.Fatal("expected desktop notifications to be disabled by default")
+	}
+}
+
+func TestLoadFrom_ParsesNotificationsEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "section omitted", body: "", want: false},
+		{name: "enabled", body: "[notifications]\nenabled = true\n", want: true},
+		{name: "disabled", body: "[notifications]\nenabled = false\n", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if err := os.WriteFile(path, []byte(tt.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := config.LoadFrom(path)
+			if err != nil {
+				t.Fatalf("LoadFrom returned error: %v", err)
+			}
+			if cfg.Notifications.Enabled != tt.want {
+				t.Fatalf("notifications.enabled = %v, want %v", cfg.Notifications.Enabled, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadFrom_RejectsMalformedNotificationsEnabled(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[notifications]\nenabled = \"yes\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := config.LoadFrom(path); err == nil {
+		t.Fatal("expected notifications.enabled type error")
+	}
 }
 
 func TestLoadFrom_ParsesLaunchBackend(t *testing.T) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -28,6 +28,7 @@ exist:
 | Terminal command | `TERMINAL` | `[terminal].command` | platform fallback |
 | Clipboard method | none | `[clipboard].method` | `auto` |
 | OSC 52 encoded payload limit | none | `[clipboard].osc52_max_payload_bytes` | `100000` bytes |
+| Desktop notifications | none | `[notifications].enabled` | `false` |
 | Coding agent | none | `[agent].command` | unset |
 | Agent launch backend | none | `[launch].backend` | `embedded` |
 | Agent model | none | `[agent].codex_model` / `[agent].claude_model` | provider default |
@@ -65,6 +66,9 @@ command = "wezterm start"
 [clipboard]
 method = "auto"
 osc52_max_payload_bytes = 100000
+
+[notifications]
+enabled = false
 
 [provider]
 name = "github"
@@ -249,6 +253,21 @@ Approach emits tmux's passthrough form. Configure tmux to permit passthrough and
 clipboard writes, for example with `set -g allow-passthrough on` and
 `set -g set-clipboard on`. Approach sends one complete clipboard update and
 never splits or truncates the copied text.
+
+### `[notifications]`
+
+Controls desktop notifications emitted by the TUI.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `enabled` | boolean | Emit OSC 9 notifications for observed agent exits and Flow phases that newly become `completed`, `blocked`, or `needs_attention`. The default is `false`. |
+
+The terminal hosting Approach must support OSC 9 and allow desktop
+notifications. Unsupported terminals ignore the sequence. Approach reports
+only changes observed while the TUI is running, so startup does not replay old
+outcomes. In tmux launch mode, Approach checks watched windows on its periodic
+launch sweep. A notification may therefore arrive up to 30 seconds after the
+agent exits.
 
 ### `[provider]`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -265,9 +265,10 @@ Controls desktop notifications emitted by the TUI.
 The terminal hosting Approach must support OSC 9 and allow desktop
 notifications. Unsupported terminals ignore the sequence. Approach reports
 only changes observed while the TUI is running, so startup does not replay old
-outcomes. In tmux launch mode, Approach checks watched windows on its periodic
-launch sweep. A notification may therefore arrive up to 30 seconds after the
-agent exits.
+outcomes. When Approach itself runs inside tmux, it emits tmux's passthrough
+form; configure tmux with `set -g allow-passthrough on`. In tmux launch mode,
+Approach checks watched windows on its periodic launch sweep. A notification
+may therefore arrive up to 30 seconds after the agent exits.
 
 ### `[provider]`
 

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -400,6 +400,12 @@ sessions created by that embedded launch; detached tmux sessions are no longer
 owned by Approach and are not prompted for on quit. Embedded terminals are not
 restored after Approach restarts.
 
+When `[notifications].enabled = true`, Approach asks the host terminal to send
+a desktop notification when an Approach-launched agent exits and when a Flow
+phase newly becomes completed, blocked, or needs attention. The TUI emits OSC 9
+through its renderer, does not replay outcomes at startup, and does not repeat
+unchanged outcomes. See `docs/config.md` for terminal support and tmux timing.
+
 The global `ctrl+] l` picker applies the same cached-association rule as
 Sessions-pane `r` and the inline worktree list. All three submit one exact
 provider/session-ID lifecycle intent for cached Flow records. An authoritative

--- a/internal/flowlease/handoff_test.go
+++ b/internal/flowlease/handoff_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -241,6 +242,22 @@ func TestTmuxCreateTimeoutDoesNotRetrySameWindowName(t *testing.T) {
 				t.Fatalf("tmux command runs = %d, want %d without a duplicate mutation", runs, tc.wantRuns)
 			}
 		})
+	}
+}
+
+func TestTmuxCreateMarksWindowWithImmutableLaunchID(t *testing.T) {
+	spec := testPrivateSpec(t)
+	var calls [][]string
+	err := runTmuxWindowCreate(spec, func(args ...string) error {
+		calls = append(calls, append([]string(nil), args...))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("runTmuxWindowCreate() error = %v", err)
+	}
+	want := []string{"set-option", "-w", "-t", "=" + spec.SessionName + ":=" + spec.WindowName, "@approach_launch_id", spec.LaunchID}
+	if len(calls) != 3 || !slices.Equal(calls[2], want) {
+		t.Fatalf("tmux calls = %#v, want marker call %#v", calls, want)
 	}
 }
 
@@ -879,6 +896,7 @@ case "$1" in
     fi
     exit 0
     ;;
+  set-option) exit 0 ;;
   kill-window) exit 0 ;;
 esac
 exit 2

--- a/internal/flowlease/private.go
+++ b/internal/flowlease/private.go
@@ -734,7 +734,7 @@ func runTmuxWindowCreate(spec PrivateSpec, run func(...string) error) error {
 	if hasSessionErr == nil {
 		if err := run("new-window", "-d", "-t", "="+spec.SessionName+":", "-n", spec.WindowName, "-c", spec.CWD,
 			"exec sh "+shellQuote(spec.ScriptPath)); err == nil {
-			return nil
+			return markTmuxLaunchWindow(spec, run)
 		} else if errors.Is(err, errTmuxCommandTimeout) {
 			return err
 		}
@@ -743,11 +743,25 @@ func runTmuxWindowCreate(spec PrivateSpec, run func(...string) error) error {
 	}
 	command := "exec sh " + shellQuote(spec.ScriptPath)
 	if err := run("new-session", "-d", "-s", spec.SessionName, "-n", spec.WindowName, "-c", spec.CWD, command); err == nil {
-		return nil
+		return markTmuxLaunchWindow(spec, run)
 	} else if errors.Is(err, errTmuxCommandTimeout) {
 		return err
 	}
-	return run("new-window", "-d", "-t", "="+spec.SessionName+":", "-n", spec.WindowName, "-c", spec.CWD, command)
+	if err := run("new-window", "-d", "-t", "="+spec.SessionName+":", "-n", spec.WindowName, "-c", spec.CWD, command); err != nil {
+		return err
+	}
+	return markTmuxLaunchWindow(spec, run)
+}
+
+func markTmuxLaunchWindow(spec PrivateSpec, run func(...string) error) error {
+	target, err := ExactWindowTarget(spec.SessionName, spec.WindowName)
+	if err != nil {
+		return err
+	}
+	if err := run("set-option", "-w", "-t", target, "@approach_launch_id", spec.LaunchID); err != nil {
+		return fmt.Errorf("mark tmux launch window: %w", err)
+	}
+	return nil
 }
 
 func inspectLaunchScript(path string) error {

--- a/model/embedded_terminal.go
+++ b/model/embedded_terminal.go
@@ -140,6 +140,9 @@ type embeddedTerminalSlot struct {
 	// launch controller, so a slot that stays visible (a failed launch) is
 	// reconciled once, not on every tick.
 	ExitReconciled bool
+	// NotificationReported marks an ended agent process whose desktop
+	// notification has already been emitted.
+	NotificationReported bool
 }
 
 type embeddedSessionPickerSelectedMsg struct {

--- a/model/flow_advance_tick.go
+++ b/model/flow_advance_tick.go
@@ -103,6 +103,11 @@ func (m Model) handleAutoAdvanceResult(msg AutoAdvanceResultMsg) (Model, tea.Cmd
 	}
 
 	var cmds []tea.Cmd
+	if m.notificationsEnabled {
+		for _, event := range flowPhaseNotificationEvents(previous, current) {
+			cmds = append(cmds, m.notificationCmd(event))
+		}
+	}
 	var autoCmd tea.Cmd
 	var admittedAutoMerges []string
 	m, autoCmd, admittedAutoMerges = m.prepareAutoFlowPhaseLaunchForRequest(previous, current, msg.Request)

--- a/model/flow_launch_control.go
+++ b/model/flow_launch_control.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"sort"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -32,6 +33,7 @@ type launchSweepTickMsg struct {
 
 type launchSweepDoneMsg struct {
 	Generation uint64
+	Exited     []tmuxNotificationWatch
 }
 
 // launchExitReconcileDoneMsg reports a reconciliation the model requested for
@@ -44,7 +46,7 @@ type launchExitReconcileDoneMsg struct {
 }
 
 func (m Model) launchSweepTickCmd() tea.Cmd {
-	if m.sweepLaunches == nil {
+	if m.sweepLaunches == nil && (!m.notificationsEnabled || len(m.tmuxNotificationWatches) == 0) {
 		return nil
 	}
 	generation := m.launchSweepTickGen
@@ -56,15 +58,31 @@ func (m Model) launchSweepTickCmd() tea.Cmd {
 // startLaunchSweep runs the controller's sweep as a command, off the render
 // path, then re-arms the tick once it is done so sweeps never overlap.
 func (m Model) startLaunchSweep() (Model, tea.Cmd) {
-	if m.sweepLaunches == nil {
+	if m.sweepLaunches == nil && (!m.notificationsEnabled || len(m.tmuxNotificationWatches) == 0) {
 		return m, nil
 	}
 	m.launchSweepTickGen++
 	generation := m.launchSweepTickGen
 	sweep := m.sweepLaunches
+	probe := m.repoTmuxLaunchWindowLive
+	watches := make([]tmuxNotificationWatch, 0, len(m.tmuxNotificationWatches))
+	if m.notificationsEnabled {
+		for _, watch := range m.tmuxNotificationWatches {
+			watches = append(watches, watch)
+		}
+		sort.Slice(watches, func(i, j int) bool { return watches[i].LaunchID < watches[j].LaunchID })
+	}
 	return m, func() tea.Msg {
-		sweep()
-		return launchSweepDoneMsg{Generation: generation}
+		if sweep != nil {
+			sweep()
+		}
+		var exited []tmuxNotificationWatch
+		for _, watch := range watches {
+			if probe != nil && !probe(watch.RepoPath, watch.LaunchID) {
+				exited = append(exited, watch)
+			}
+		}
+		return launchSweepDoneMsg{Generation: generation, Exited: exited}
 	}
 }
 
@@ -72,7 +90,13 @@ func (m Model) handleLaunchSweepDone(msg launchSweepDoneMsg) (Model, tea.Cmd) {
 	if msg.Generation != m.launchSweepTickGen {
 		return m, nil
 	}
-	return m, m.launchSweepTickCmd()
+	m = m.withoutTmuxNotificationWatches(msg.Exited)
+	cmds := make([]tea.Cmd, 0, len(msg.Exited)+1)
+	for _, watch := range msg.Exited {
+		cmds = append(cmds, m.notificationCmd(agentExitNotification(watch.Provider, watch.RepoPath, "exited", 0, false)))
+	}
+	cmds = append(cmds, m.launchSweepTickCmd())
+	return m, batchNonNil(cmds...)
 }
 
 // reconcileExitedFlowEmbeddedTerminals emits one reconciliation command per

--- a/model/flow_launch_control.go
+++ b/model/flow_launch_control.go
@@ -64,7 +64,7 @@ func (m Model) startLaunchSweep() (Model, tea.Cmd) {
 	m.launchSweepTickGen++
 	generation := m.launchSweepTickGen
 	sweep := m.sweepLaunches
-	probe := m.repoTmuxLaunchWindowLive
+	probe := m.repoTmuxLaunchStatus
 	watches := make([]tmuxNotificationWatch, 0, len(m.tmuxNotificationWatches))
 	if m.notificationsEnabled {
 		for _, watch := range m.tmuxNotificationWatches {
@@ -78,7 +78,10 @@ func (m Model) startLaunchSweep() (Model, tea.Cmd) {
 		}
 		var exited []tmuxNotificationWatch
 		for _, watch := range watches {
-			if probe != nil && !probe(watch.RepoPath, watch.LaunchID) {
+			if probe == nil {
+				continue
+			}
+			if live, err := probe(watch.RepoPath, watch.LaunchID); err == nil && !live {
 				exited = append(exited, watch)
 			}
 		}

--- a/model/flow_launch_lifecycle.go
+++ b/model/flow_launch_lifecycle.go
@@ -1247,6 +1247,7 @@ func (m Model) handoffFlowLaunchTmux(attempt flowLaunchAttempt, msg flowLaunchEv
 		return m.failFlowLaunch(attempt, ctx, msg.RepoPath, "Flow launch handoff canceled before spawn")
 	}
 	m, launchCmd := m.runFlowLifecycleTmuxLaunchWithStatus(ctx, spec.Launch, msg.Release, withFallbackNote(tmuxLaunchStatus(spec), msg.WorktreeNote))
+	launchCmd = markTmuxAgentResult(launchCmd)
 	// Placed after the handoffPending transition above, so a handoff canceled
 	// before its spawn opens no window. It is a sibling command: it touches no
 	// attempt token, reservation, or AgentResultMsg field.

--- a/model/keyboard_v2_internal_test.go
+++ b/model/keyboard_v2_internal_test.go
@@ -45,7 +45,7 @@ func TestPasteFollowsSearchAndListOwnership(t *testing.T) {
 	}
 }
 
-func TestPasteWritesVerbatimToFocusedEmbeddedTerminal(t *testing.T) {
+func TestPastePreservesBracketedPasteForFocusedEmbeddedTerminal(t *testing.T) {
 	term := &recordingKeyboardTerminal{}
 	m := modelWithModeForTest(Model{
 		width:       120,
@@ -67,7 +67,7 @@ func TestPasteWritesVerbatimToFocusedEmbeddedTerminal(t *testing.T) {
 	if cmd != nil {
 		t.Fatalf("terminal paste returned command %T", cmd)
 	}
-	if got, want := term.writes, [][]byte{[]byte("echo α\n")}; !reflect.DeepEqual(got, want) {
+	if got, want := term.writes, [][]byte{[]byte("\x1b[200~echo α\n\x1b[201~")}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("terminal paste writes = %#v, want %#v", got, want)
 	}
 	if next.(Model).terminalPrefixActive {

--- a/model/model.go
+++ b/model/model.go
@@ -214,6 +214,7 @@ type Model struct {
 	repoTmuxLaunchStatus      func(string, ...string) (bool, error)
 	repoTmuxSessionAttached   func(string) bool
 	insideMultiplexer         func() bool
+	insideTmux                func() bool
 	// repoTmuxTerminalPending holds the repos whose first tmux-mode terminal
 	// window has been dispatched but has not reported back. It debounces two
 	// launches into one repo seconds apart, where the second would probe
@@ -431,6 +432,9 @@ type Options struct {
 	// InsideMultiplexer reports whether approach itself runs inside tmux or
 	// Zellij, where tmux mode opens no terminal window of its own.
 	InsideMultiplexer func() bool
+	// InsideTmux reports whether renderer control sequences need tmux DCS
+	// passthrough.
+	InsideTmux func() bool
 	// InspectFlowLease is the cheap non-blocking occupancy seam used by render,
 	// manual admission, and AutoMode. It must never invoke tmux or fork.
 	InspectFlowLease      func(root, flowID string) (flowlease.LeaseState, error)
@@ -939,6 +943,10 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if insideMultiplexer == nil {
 		insideMultiplexer = actions.InsideMultiplexer
 	}
+	insideTmux := opts.InsideTmux
+	if insideTmux == nil {
+		insideTmux = actions.InsideTmux
+	}
 	leaseInspectInjected := opts.InspectFlowLease != nil
 	inspectFlowLease := opts.InspectFlowLease
 	if inspectFlowLease == nil {
@@ -1138,6 +1146,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		repoTmuxLaunchStatus:      repoTmuxLaunchStatus,
 		repoTmuxSessionAttached:   repoTmuxSessionAttached,
 		insideMultiplexer:         insideMultiplexer,
+		insideTmux:                insideTmux,
 		inspectFlowLease:          inspectFlowLease,
 		leaseInspectInjected:      leaseInspectInjected,
 		tmuxAttachHint:            normalizeLaunchBackend(opts.LaunchBackend) == config.LaunchBackendTmux && tmuxLaunchAvailable(),

--- a/model/model.go
+++ b/model/model.go
@@ -99,6 +99,7 @@ type Model struct {
 	sessions                    pane.Pane[sessions.SessionRecord]
 	plans                       pane.Pane[planstore.PlanRecord]
 	flows                       pane.Pane[flowstore.FlowRecord]
+	notificationsEnabled        bool
 	activeFlowRecords           []flowstore.FlowRecord
 	latestFlowMutations         []cachedFlowMutation
 	pendingFlowHeadlessWrites   []pendingFlowHeadlessWrite
@@ -107,6 +108,7 @@ type Model struct {
 	prBabysitterRecords         []flowstore.FlowRecord
 	prBabysitterFlows           pane.Pane[flowstore.FlowRecord]
 	prBabysitterStatuses        map[string]actions.PullRequestStatus
+	tmuxNotificationWatches     map[string]tmuxNotificationWatch
 	beads                       [beadSubviewCount]beadSubviewState
 	beadExpansion               beadExpansionSnapshot
 	beadExpansionSeq            uint64
@@ -338,6 +340,7 @@ func agentConfigFromOptions(opts Options) agentConfig {
 // Options customizes production-only integrations while keeping New(repos)
 // simple for tests.
 type Options struct {
+	NotificationsEnabled      bool
 	AgentCommand              string
 	CodexModel                string
 	ClaudeModel               string
@@ -1134,6 +1137,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		launchControl:             opts.LaunchControl,
 		reconcileLaunchExit:       opts.ReconcileLaunchExit,
 		sweepLaunches:             opts.SweepLaunches,
+		notificationsEnabled:      opts.NotificationsEnabled,
 		bootstrapHookForRepo:      bootstrapHookForRepo,
 		runBootstrapHook:          runBootstrapHook,
 	}
@@ -2135,6 +2139,9 @@ func (m Model) Update(msg tea.Msg) (next tea.Model, cmd tea.Cmd) {
 		// Before dismissal, because a dismissed slot is gone from the model
 		// and its exit would never be reported.
 		var cmds []tea.Cmd
+		var notificationCmds []tea.Cmd
+		m, notificationCmds = m.collectEmbeddedExitNotifications()
+		cmds = append(cmds, notificationCmds...)
 		var reconcileCmds []tea.Cmd
 		m, reconcileCmds = m.reconcileExitedFlowEmbeddedTerminals()
 		cmds = append(cmds, reconcileCmds...)
@@ -2515,6 +2522,9 @@ func (m Model) handleAgentResultAfterFinalization(msg AgentResultMsg, finalizeEr
 	if resultErr != "" {
 		return m.startFlowLaunchFailure(msg.LaunchContext, resultErr)
 	} else if msg.Detached {
+		if msg.Tmux {
+			m = m.withTmuxNotificationWatch(ctx)
+		}
 		// Only detached launches carry a status here; an interactive launch's own
 		// status is set before the TTY handover, since this message lands when the
 		// user's session ends rather than when it starts.

--- a/model/model.go
+++ b/model/model.go
@@ -211,6 +211,7 @@ type Model struct {
 	launchRepoTmuxAgent       func(actions.AgentLaunchContext) (actions.RepoTmuxAgentSpec, error)
 	repoTmuxSessionExists     func(string) bool
 	repoTmuxLaunchWindowLive  func(string, ...string) bool
+	repoTmuxLaunchStatus      func(string, ...string) (bool, error)
 	repoTmuxSessionAttached   func(string) bool
 	insideMultiplexer         func() bool
 	// repoTmuxTerminalPending holds the repos whose first tmux-mode terminal
@@ -419,6 +420,10 @@ type Options struct {
 	// open tmux window. It is only consulted on user-initiated reset, resume,
 	// and repair.
 	RepoTmuxLaunchWindowLive func(repoPath string, launchIDs ...string) bool
+	// RepoTmuxLaunchStatus distinguishes a confirmed missing window from
+	// an inconclusive tmux probe. Notification sweeps consume watches only on a
+	// successful probe that reports no live window.
+	RepoTmuxLaunchStatus func(repoPath string, launchIDs ...string) (bool, error)
 	// RepoTmuxSessionAttached probes whether a terminal is already watching a
 	// repo's tmux session. It decides whether a tmux-mode launch opens the
 	// repo's first terminal window, and runs only inside a command goroutine.
@@ -922,6 +927,10 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 	if repoTmuxLaunchWindowLive == nil {
 		repoTmuxLaunchWindowLive = actions.RepoTmuxLaunchWindowLive
 	}
+	repoTmuxLaunchStatus := opts.RepoTmuxLaunchStatus
+	if repoTmuxLaunchStatus == nil {
+		repoTmuxLaunchStatus = actions.RepoTmuxLaunchWindowStatus
+	}
 	repoTmuxSessionAttached := opts.RepoTmuxSessionAttached
 	if repoTmuxSessionAttached == nil {
 		repoTmuxSessionAttached = actions.RepoTmuxSessionAttached
@@ -1126,6 +1135,7 @@ func NewWithOptions(repos []scanner.Repo, opts Options) Model {
 		launchRepoTmuxAgent:       launchRepoTmuxAgent,
 		repoTmuxSessionExists:     repoTmuxSessionExists,
 		repoTmuxLaunchWindowLive:  repoTmuxLaunchWindowLive,
+		repoTmuxLaunchStatus:      repoTmuxLaunchStatus,
 		repoTmuxSessionAttached:   repoTmuxSessionAttached,
 		insideMultiplexer:         insideMultiplexer,
 		inspectFlowLease:          inspectFlowLease,
@@ -2497,6 +2507,14 @@ func (m Model) handleAgentResultAfterFinalization(msg AgentResultMsg, finalizeEr
 		}
 	}
 	ctx := msg.LaunchContext
+	var interactiveExitCmd tea.Cmd
+	if !msg.Detached {
+		state, codeKnown := "exited", true
+		if msg.Err != "" {
+			state, codeKnown = "failed", false
+		}
+		interactiveExitCmd = m.notificationCmd(agentExitNotification(ctx.Command, ctx.RepoPath, state, 0, codeKnown))
+	}
 	// A slice-epic launch holds its preparation admission across the spawn, and
 	// its own result is what ends the hold. The exact LaunchID match is what
 	// stops a stale result — from a launch made before a repository or
@@ -2510,7 +2528,8 @@ func (m Model) handleAgentResultAfterFinalization(msg AgentResultMsg, finalizeEr
 	if attempt, ok := m.matchingFlowLaunchAttempt(ctx.FlowID, ctx.LaunchID, 0, flowLaunchStateHandoffPending); ok {
 		releaseFlowLaunchReservation(msg.FlowLaunchRelease)
 		if resultErr != "" {
-			return m.failFlowLaunch(attempt, ctx, ctx.RepoPath, resultErr)
+			m, cmd := m.failFlowLaunch(attempt, ctx, ctx.RepoPath, resultErr)
+			return m, batchNonNil(interactiveExitCmd, cmd)
 		}
 		m = m.releaseFlowLaunchAttempt(ctx.FlowID, ctx.LaunchID)
 	} else if msg.FlowLaunchRelease != nil {
@@ -2520,7 +2539,8 @@ func (m Model) handleAgentResultAfterFinalization(msg AgentResultMsg, finalizeEr
 		return m, nil
 	}
 	if resultErr != "" {
-		return m.startFlowLaunchFailure(msg.LaunchContext, resultErr)
+		m, cmd := m.startFlowLaunchFailure(msg.LaunchContext, resultErr)
+		return m, batchNonNil(interactiveExitCmd, cmd)
 	} else if msg.Detached {
 		if msg.Tmux {
 			m = m.withTmuxNotificationWatch(ctx)
@@ -2544,7 +2564,9 @@ func (m Model) handleAgentResultAfterFinalization(msg AgentResultMsg, finalizeEr
 		// An interactive launch's agent has ended with the TTY handed back; a
 		// tracked phase it left running has no result and is reconciled the
 		// same way an embedded terminal's exit is.
-		return m, cmd
+		return m, batchNonNil(interactiveExitCmd, cmd)
+	} else if !msg.Detached {
+		return m, interactiveExitCmd
 	}
 	return m, nil
 }

--- a/model/model_keys.go
+++ b/model/model_keys.go
@@ -170,7 +170,7 @@ func (m Model) handlePaste(content string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if m.terminalEffectivelyExpanded() && m.activePane != ui.PaneRepos && m.terminalFocus == terminalFocusTerminal && !m.terminalPrefixActive && m.hasActiveEmbeddedTerminal() {
-		return m.writeToActiveTerminal([]byte(content)), nil
+		return m.writeToActiveTerminal([]byte(embeddedPromptPasteStart + content + embeddedPromptPasteEnd)), nil
 	}
 	if !m.searchActive {
 		return m, nil

--- a/model/model_messages.go
+++ b/model/model_messages.go
@@ -532,6 +532,8 @@ type FlowPhaseAgentSettingsSetFailedMsg struct {
 type AgentResultMsg struct {
 	LaunchContext actions.AgentLaunchContext
 	Err           string
+	// Tmux marks a detached launch whose process runs in a watched tmux window.
+	Tmux bool
 	// FlowLaunchRelease is carried only by a lifecycle-owned tmux start result.
 	// The command must retain the cross-process reservation after it exits until
 	// a matching handoffPending attempt consumes this result.

--- a/model/notification.go
+++ b/model/notification.go
@@ -133,6 +133,9 @@ func (m Model) notificationCmd(event notificationEvent) tea.Cmd {
 	if sequence == "" {
 		return nil
 	}
+	if m.insideTmux != nil && m.insideTmux() {
+		sequence = tmuxPassthroughSequence(sequence)
+	}
 	return tea.Raw(sequence)
 }
 
@@ -222,6 +225,11 @@ func osc9NotificationSequence(message string) string {
 		return ""
 	}
 	return "\x1b]9;" + message + "\x07"
+}
+
+func tmuxPassthroughSequence(sequence string) string {
+	sequence = strings.ReplaceAll(sequence, "\x1b", "\x1b\x1b")
+	return "\x1bPtmux;" + sequence + "\x1b\\"
 }
 
 func sanitizeNotificationText(text string) string {

--- a/model/notification.go
+++ b/model/notification.go
@@ -1,0 +1,240 @@
+package model
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowstore"
+	"github.com/approachcontrol/approach/internal/artifacts"
+)
+
+const notificationMessageMaxRunes = 180
+
+type notificationEvent struct {
+	subject string
+	context string
+	result  string
+	joiner  string
+}
+
+type tmuxNotificationWatch struct {
+	LaunchID string
+	RepoPath string
+	Provider string
+}
+
+func flowPhaseNotification(phaseTitle, flowTitle, result string) notificationEvent {
+	return notificationEvent{subject: phaseTitle, context: flowTitle, result: result, joiner: "for"}
+}
+
+func flowPhaseNotificationEvents(previous, current []flowstore.FlowRecord) []notificationEvent {
+	previousFlows := make(map[string]flowstore.FlowRecord, len(previous))
+	for _, record := range previous {
+		if record.FlowID != "" {
+			previousFlows[record.FlowID] = record
+		}
+	}
+	type keyedEvent struct {
+		key   string
+		event notificationEvent
+	}
+	var found []keyedEvent
+	for _, record := range current {
+		prior, ok := previousFlows[record.FlowID]
+		if !ok {
+			continue
+		}
+		priorPhases := make(map[string]flowstore.FlowPhase, len(prior.Phases))
+		for _, phase := range prior.Phases {
+			if id := artifacts.NormalizePhaseID(phase.PhaseID); id != "" {
+				priorPhases[id] = phase
+			}
+		}
+		for _, phase := range record.Phases {
+			phaseID := artifacts.NormalizePhaseID(phase.PhaseID)
+			priorPhase, ok := priorPhases[phaseID]
+			if !ok || priorPhase.Status == phase.Status {
+				continue
+			}
+			result, ok := notificationPhaseResult(phase.Status)
+			if !ok {
+				continue
+			}
+			phaseTitle := strings.TrimSpace(phase.Title)
+			if phaseTitle == "" {
+				phaseTitle = phase.PhaseID
+			}
+			flowTitle := strings.TrimSpace(record.Title)
+			if flowTitle == "" {
+				flowTitle = record.FlowID
+			}
+			found = append(found, keyedEvent{
+				key:   record.FlowID + "\x00" + phaseID,
+				event: flowPhaseNotification(phaseTitle, flowTitle, result),
+			})
+		}
+	}
+	sort.Slice(found, func(i, j int) bool { return found[i].key < found[j].key })
+	events := make([]notificationEvent, len(found))
+	for i := range found {
+		events[i] = found[i].event
+	}
+	return events
+}
+
+func notificationPhaseResult(status flowstore.PhaseStatus) (string, bool) {
+	switch status {
+	case flowstore.PhaseCompleted:
+		return "completed", true
+	case flowstore.PhaseBlocked:
+		return "blocked", true
+	case flowstore.PhaseNeedsAttention:
+		return "needs attention", true
+	default:
+		return "", false
+	}
+}
+
+func agentExitNotification(provider, repoPath, state string, code int, codeKnown bool) notificationEvent {
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		provider = "agent"
+	}
+	result := "finished"
+	if state == "failed" || codeKnown && code != 0 {
+		result = "failed"
+		if codeKnown && code != 0 {
+			result = fmt.Sprintf("failed (exit %d)", code)
+		}
+	}
+	repoName := "repository"
+	if strings.TrimSpace(repoPath) != "" {
+		repoName = filepath.Base(filepath.Clean(repoPath))
+	}
+	return notificationEvent{
+		subject: provider + " session",
+		context: repoName,
+		result:  result,
+		joiner:  "in",
+	}
+}
+
+func (m Model) notificationCmd(event notificationEvent) tea.Cmd {
+	if !m.notificationsEnabled {
+		return nil
+	}
+	sequence := osc9NotificationSequence(notificationMessage(event))
+	if sequence == "" {
+		return nil
+	}
+	return tea.Raw(sequence)
+}
+
+func notificationMessage(event notificationEvent) string {
+	parts := []string{strings.TrimSpace(event.subject), strings.TrimSpace(event.result)}
+	if context := strings.TrimSpace(event.context); context != "" {
+		parts = append(parts, strings.TrimSpace(event.joiner), context)
+	}
+	body := strings.TrimSpace(strings.Join(parts, " "))
+	if body == "" {
+		return ""
+	}
+	return "Approach: " + body
+}
+
+func (m Model) collectEmbeddedExitNotifications() (Model, []tea.Cmd) {
+	if !m.notificationsEnabled {
+		return m, nil
+	}
+	var cmds []tea.Cmd
+	for i, slot := range m.embeddedTerminals {
+		if slot.Terminal == nil || slot.NotificationReported {
+			continue
+		}
+		state := slot.Terminal.State()
+		if state != "exited" && state != "failed" {
+			continue
+		}
+		code, known := embeddedTerminalExitCode(slot.Terminal)
+		m.embeddedTerminals[i].NotificationReported = true
+		cmds = append(cmds, m.notificationCmd(agentExitNotification(slot.Provider, slot.RepoPath, state, code, known)))
+	}
+	return m, cmds
+}
+
+func (m Model) withTmuxNotificationWatch(ctx actions.AgentLaunchContext) Model {
+	if !m.notificationsEnabled || strings.TrimSpace(ctx.LaunchID) == "" || strings.TrimSpace(ctx.RepoPath) == "" {
+		return m
+	}
+	watches := make(map[string]tmuxNotificationWatch, len(m.tmuxNotificationWatches)+1)
+	for id, watch := range m.tmuxNotificationWatches {
+		watches[id] = watch
+	}
+	watches[ctx.LaunchID] = tmuxNotificationWatch{
+		LaunchID: ctx.LaunchID,
+		RepoPath: ctx.RepoPath,
+		Provider: ctx.Command,
+	}
+	m.tmuxNotificationWatches = watches
+	return m
+}
+
+func (m Model) withoutTmuxNotificationWatches(exited []tmuxNotificationWatch) Model {
+	if len(exited) == 0 {
+		return m
+	}
+	watches := make(map[string]tmuxNotificationWatch, len(m.tmuxNotificationWatches))
+	for id, watch := range m.tmuxNotificationWatches {
+		watches[id] = watch
+	}
+	for _, watch := range exited {
+		if current, ok := watches[watch.LaunchID]; ok && current == watch {
+			delete(watches, watch.LaunchID)
+		}
+	}
+	m.tmuxNotificationWatches = watches
+	return m
+}
+
+func markTmuxAgentResult(cmd tea.Cmd) tea.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		msg := cmd()
+		if result, ok := msg.(AgentResultMsg); ok {
+			result.Tmux = true
+			return result
+		}
+		return msg
+	}
+}
+
+func osc9NotificationSequence(message string) string {
+	message = sanitizeNotificationText(message)
+	if message == "" {
+		return ""
+	}
+	return "\x1b]9;" + message + "\x07"
+}
+
+func sanitizeNotificationText(text string) string {
+	text = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, text)
+	text = strings.Join(strings.Fields(text), " ")
+	runes := []rune(text)
+	if len(runes) > notificationMessageMaxRunes {
+		text = string(runes[:notificationMessageMaxRunes])
+	}
+	return text
+}

--- a/model/notification_internal_test.go
+++ b/model/notification_internal_test.go
@@ -34,6 +34,21 @@ func TestNotificationCmdUsesOSC9ThroughRenderer(t *testing.T) {
 	}
 }
 
+func TestNotificationCmdUsesTmuxPassthrough(t *testing.T) {
+	event := flowPhaseNotification("Plan", "OSC 9 desktop notifications", "completed")
+	m := Model{notificationsEnabled: true, insideTmux: func() bool { return true }}
+
+	msg, ok := m.notificationCmd(event)().(tea.RawMsg)
+	if !ok {
+		t.Fatalf("notification command returned unexpected message")
+	}
+	const inner = "\x1b]9;Approach: Plan completed for OSC 9 desktop notifications\x07"
+	want := "\x1bPtmux;" + strings.ReplaceAll(inner, "\x1b", "\x1b\x1b") + "\x1b\\"
+	if msg.Msg != want {
+		t.Fatalf("tmux notification = %#v, want %#v", msg.Msg, want)
+	}
+}
+
 type notificationTestTerminal struct {
 	state string
 	err   error

--- a/model/notification_internal_test.go
+++ b/model/notification_internal_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"strings"
 	"testing"
@@ -134,14 +135,36 @@ func TestSuccessfulTmuxLaunchRegistersNotificationWatch(t *testing.T) {
 	}
 }
 
+func TestInteractiveAgentExitEmitsNotification(t *testing.T) {
+	ctx := actions.AgentLaunchContext{Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/approach"}
+	m := NewWithOptions(nil, Options{NotificationsEnabled: true})
+
+	_, cmd := m.handleAgentResultAfterFinalization(AgentResultMsg{LaunchContext: ctx}, nil)
+	got := rawNotificationStrings(cmd)
+	if len(got) != 1 || !strings.Contains(got[0], "codex session finished in approach") {
+		t.Fatalf("interactive exit notifications = %#v, want one successful codex notification", got)
+	}
+}
+
+func TestInteractiveAgentFailureEmitsNotification(t *testing.T) {
+	ctx := actions.AgentLaunchContext{Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/approach"}
+	m := NewWithOptions(nil, Options{NotificationsEnabled: true})
+
+	_, cmd := m.handleAgentResultAfterFinalization(AgentResultMsg{LaunchContext: ctx, Err: "exit status 7"}, nil)
+	got := rawNotificationStrings(cmd)
+	if len(got) != 1 || !strings.Contains(got[0], "codex session failed in approach") {
+		t.Fatalf("interactive failure notifications = %#v, want one failed codex notification", got)
+	}
+}
+
 func TestTmuxLaunchSweepNotifiesOnWindowDisappearance(t *testing.T) {
 	var probes int
 	m := NewWithOptions(nil, Options{
 		NotificationsEnabled: true,
 		SweepLaunches:        func() {},
-		RepoTmuxLaunchWindowLive: func(repoPath string, launchIDs ...string) bool {
+		RepoTmuxLaunchStatus: func(repoPath string, launchIDs ...string) (bool, error) {
 			probes++
-			return launchIDs[0] == "live"
+			return launchIDs[0] == "live", nil
 		},
 	})
 	m.tmuxNotificationWatches = map[string]tmuxNotificationWatch{
@@ -166,13 +189,36 @@ func TestTmuxLaunchSweepNotifiesOnWindowDisappearance(t *testing.T) {
 	}
 }
 
+func TestTmuxLaunchSweepRetainsWatchWhenProbeFails(t *testing.T) {
+	m := NewWithOptions(nil, Options{
+		NotificationsEnabled: true,
+		SweepLaunches:        func() {},
+		RepoTmuxLaunchStatus: func(string, ...string) (bool, error) {
+			return false, errors.New("tmux probe timed out")
+		},
+	})
+	m.tmuxNotificationWatches = map[string]tmuxNotificationWatch{
+		"launch-1": {LaunchID: "launch-1", RepoPath: "/dev/approach", Provider: "codex"},
+	}
+
+	next, sweepCmd := m.startLaunchSweep()
+	done := sweepCmd().(launchSweepDoneMsg)
+	next, notifyCmd := next.handleLaunchSweepDone(done)
+	if _, ok := next.tmuxNotificationWatches["launch-1"]; !ok {
+		t.Fatal("inconclusive tmux probe discarded the notification watch")
+	}
+	if got := rawNotificationStrings(notifyCmd); len(got) != 0 {
+		t.Fatalf("inconclusive tmux probe emitted notifications: %#v", got)
+	}
+}
+
 func TestDisabledNotificationsDoNotProbeTmuxWindows(t *testing.T) {
 	var probes int
 	m := NewWithOptions(nil, Options{
 		SweepLaunches: func() {},
-		RepoTmuxLaunchWindowLive: func(string, ...string) bool {
+		RepoTmuxLaunchStatus: func(string, ...string) (bool, error) {
 			probes++
-			return false
+			return false, nil
 		},
 	})
 	m.tmuxNotificationWatches = map[string]tmuxNotificationWatch{

--- a/model/notification_internal_test.go
+++ b/model/notification_internal_test.go
@@ -1,0 +1,301 @@
+package model
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/approachcontrol/approach/actions"
+	"github.com/approachcontrol/approach/flowstore"
+)
+
+func TestNotificationCmdUsesOSC9ThroughRenderer(t *testing.T) {
+	event := flowPhaseNotification("Plan", "OSC 9 desktop notifications", "completed")
+
+	if cmd := (Model{}).notificationCmd(event); cmd != nil {
+		t.Fatal("disabled notifications returned a command")
+	}
+
+	cmd := (Model{notificationsEnabled: true}).notificationCmd(event)
+	if cmd == nil {
+		t.Fatal("enabled notifications returned nil")
+	}
+	msg, ok := cmd().(tea.RawMsg)
+	if !ok {
+		t.Fatalf("notification command returned %T, want tea.RawMsg", cmd())
+	}
+	const want = "\x1b]9;Approach: Plan completed for OSC 9 desktop notifications\x07"
+	if msg.Msg != want {
+		t.Fatalf("raw notification = %#v, want %#v", msg.Msg, want)
+	}
+}
+
+type notificationTestTerminal struct {
+	state string
+	err   error
+}
+
+func (t notificationTestTerminal) VisibleLines(int, int) []string { return nil }
+func (t notificationTestTerminal) Write(p []byte) (int, error)    { return len(p), nil }
+func (t notificationTestTerminal) Resize(int, int) error          { return nil }
+func (t notificationTestTerminal) Terminate() error               { return nil }
+func (t notificationTestTerminal) Wait(context.Context) error     { return t.err }
+func (t notificationTestTerminal) State() string                  { return t.state }
+
+func TestEmbeddedExitNotificationsReportEachProcessOnce(t *testing.T) {
+	failed := exec.Command("sh", "-c", "exit 3").Run()
+	m := Model{notificationsEnabled: true}
+	m.embeddedTerminals = []embeddedTerminalSlot{
+		{Provider: "codex", RepoPath: "/dev/approach", Terminal: notificationTestTerminal{state: "exited"}},
+		{Provider: "claude", RepoPath: "/dev/client", Terminal: notificationTestTerminal{state: "failed", err: failed}},
+		{Provider: "cursor-agent", RepoPath: "/dev/live", Terminal: notificationTestTerminal{state: "running"}},
+	}
+
+	next, cmds := m.collectEmbeddedExitNotifications()
+	if len(cmds) != 2 {
+		t.Fatalf("notification commands = %d, want 2", len(cmds))
+	}
+	wants := []string{
+		"\x1b]9;Approach: codex session finished in approach\x07",
+		"\x1b]9;Approach: claude session failed (exit 3) in client\x07",
+	}
+	for i, cmd := range cmds {
+		msg := cmd().(tea.RawMsg)
+		if msg.Msg != wants[i] {
+			t.Fatalf("notification %d = %#v, want %#v", i, msg.Msg, wants[i])
+		}
+	}
+	if _, again := next.collectEmbeddedExitNotifications(); len(again) != 0 {
+		t.Fatalf("second pass emitted %d notifications", len(again))
+	}
+}
+
+func TestEmbeddedExitNotificationFollowsCurrentTickGenerationBeforeAutoDismiss(t *testing.T) {
+	m := NewWithOptions(nil, Options{NotificationsEnabled: true})
+	m.embeddedTerminalTickGen = 4
+	m.embeddedTerminals = []embeddedTerminalSlot{{
+		Scope: embeddedTerminalScopeFlow, Provider: "codex", RepoPath: "/dev/approach",
+		FlowID: "flow-1", FlowPhaseID: "plan", LaunchID: "launch-1",
+		Terminal: notificationTestTerminal{state: "exited"},
+	}}
+
+	stale, staleCmd := m.Update(embeddedTerminalTickMsg{Generation: 3})
+	if staleCmd != nil || stale.(Model).embeddedTerminals[0].NotificationReported {
+		t.Fatal("stale tick changed notification state")
+	}
+
+	next, cmd := m.Update(embeddedTerminalTickMsg{Generation: 4})
+	if len(next.(Model).embeddedTerminals) != 0 {
+		t.Fatal("exited Flow terminal was not auto-dismissed")
+	}
+	if got := rawNotificationStrings(cmd); len(got) != 1 || !strings.Contains(got[0], "codex session finished") {
+		t.Fatalf("tick raw notifications = %#v, want one agent exit", got)
+	}
+}
+
+func rawNotificationStrings(cmd tea.Cmd) []string {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var values []string
+		for _, nested := range batch {
+			values = append(values, rawNotificationStrings(nested)...)
+			if len(values) > 0 {
+				return values
+			}
+		}
+		return values
+	}
+	if raw, ok := msg.(tea.RawMsg); ok {
+		if value, ok := raw.Msg.(string); ok {
+			return []string{value}
+		}
+	}
+	return nil
+}
+
+func TestSuccessfulTmuxLaunchRegistersNotificationWatch(t *testing.T) {
+	ctx := actions.AgentLaunchContext{Command: "codex", LaunchID: "launch-1", RepoPath: "/dev/approach"}
+	m := NewWithOptions(nil, Options{NotificationsEnabled: true})
+
+	next, _ := m.handleAgentResultAfterFinalization(AgentResultMsg{LaunchContext: ctx, Detached: true, Tmux: true}, nil)
+	if watch, ok := next.tmuxNotificationWatches[ctx.LaunchID]; !ok || watch.RepoPath != ctx.RepoPath {
+		t.Fatalf("tmux notification watch = %#v, want launch-1 for /dev/approach", next.tmuxNotificationWatches)
+	}
+
+	failed, _ := m.handleAgentResultAfterFinalization(AgentResultMsg{LaunchContext: ctx, Detached: true, Tmux: true, Err: "spawn failed"}, nil)
+	if len(failed.tmuxNotificationWatches) != 0 {
+		t.Fatalf("failed launch registered watches: %#v", failed.tmuxNotificationWatches)
+	}
+}
+
+func TestTmuxLaunchSweepNotifiesOnWindowDisappearance(t *testing.T) {
+	var probes int
+	m := NewWithOptions(nil, Options{
+		NotificationsEnabled: true,
+		SweepLaunches:        func() {},
+		RepoTmuxLaunchWindowLive: func(repoPath string, launchIDs ...string) bool {
+			probes++
+			return launchIDs[0] == "live"
+		},
+	})
+	m.tmuxNotificationWatches = map[string]tmuxNotificationWatch{
+		"gone": {LaunchID: "gone", RepoPath: "/dev/approach", Provider: "codex"},
+		"live": {LaunchID: "live", RepoPath: "/dev/client", Provider: "claude"},
+	}
+
+	next, sweepCmd := m.startLaunchSweep()
+	done := sweepCmd().(launchSweepDoneMsg)
+	next, notifyCmd := next.handleLaunchSweepDone(done)
+	if probes != 2 {
+		t.Fatalf("tmux probes = %d, want 2", probes)
+	}
+	if _, ok := next.tmuxNotificationWatches["gone"]; ok {
+		t.Fatal("disappeared tmux watch was retained")
+	}
+	if _, ok := next.tmuxNotificationWatches["live"]; !ok {
+		t.Fatal("live tmux watch was discarded")
+	}
+	if got := rawNotificationStrings(notifyCmd); len(got) != 1 || !strings.Contains(got[0], "codex session finished in approach") {
+		t.Fatalf("sweep raw notifications = %#v", got)
+	}
+}
+
+func TestDisabledNotificationsDoNotProbeTmuxWindows(t *testing.T) {
+	var probes int
+	m := NewWithOptions(nil, Options{
+		SweepLaunches: func() {},
+		RepoTmuxLaunchWindowLive: func(string, ...string) bool {
+			probes++
+			return false
+		},
+	})
+	m.tmuxNotificationWatches = map[string]tmuxNotificationWatch{
+		"launch-1": {LaunchID: "launch-1", RepoPath: "/dev/approach", Provider: "codex"},
+	}
+
+	_, sweepCmd := m.startLaunchSweep()
+	_ = sweepCmd()
+	if probes != 0 {
+		t.Fatalf("disabled notifications made %d tmux probes", probes)
+	}
+}
+
+func TestFlowPhaseNotificationEventsReportSelectedOutcomeEdges(t *testing.T) {
+	previous := []flowstore.FlowRecord{{
+		FlowID: "flow-1", Title: "OSC 9 desktop notifications",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: " PLAN-REVIEW ", Title: "Plan review", Status: flowstore.PhaseRunning},
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseRunning},
+			{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseRunning},
+		},
+	}}
+	current := []flowstore.FlowRecord{{
+		FlowID: "flow-1", Title: "OSC 9 desktop notifications",
+		Phases: []flowstore.FlowPhase{
+			{PhaseID: "autoreview", Title: "Autoreview", Status: flowstore.PhaseNeedsAttention},
+			{PhaseID: "implementation", Title: "Implementation", Status: flowstore.PhaseBlocked},
+			{PhaseID: "plan-review", Title: "Plan review", Status: flowstore.PhaseCompleted},
+		},
+	}}
+
+	events := flowPhaseNotificationEvents(previous, current)
+	if len(events) != 3 {
+		t.Fatalf("notification events = %#v, want three", events)
+	}
+	wants := []string{
+		"Approach: Autoreview needs attention for OSC 9 desktop notifications",
+		"Approach: Implementation blocked for OSC 9 desktop notifications",
+		"Approach: Plan review completed for OSC 9 desktop notifications",
+	}
+	for i, event := range events {
+		if got := notificationMessage(event); got != wants[i] {
+			t.Fatalf("event %d message = %q, want %q", i, got, wants[i])
+		}
+	}
+}
+
+func TestFlowPhaseNotificationEventsPrimeAndReenterWithoutRepeats(t *testing.T) {
+	terminal := notificationFlow("flow-1", flowstore.PhaseCompleted)
+	running := notificationFlow("flow-1", flowstore.PhaseRunning)
+
+	if got := flowPhaseNotificationEvents(nil, []flowstore.FlowRecord{terminal}); len(got) != 0 {
+		t.Fatalf("startup emitted %d events", len(got))
+	}
+	if got := flowPhaseNotificationEvents([]flowstore.FlowRecord{terminal}, []flowstore.FlowRecord{terminal}); len(got) != 0 {
+		t.Fatalf("unchanged phase emitted %d events", len(got))
+	}
+	if got := flowPhaseNotificationEvents([]flowstore.FlowRecord{terminal}, []flowstore.FlowRecord{running}); len(got) != 0 {
+		t.Fatalf("restart emitted %d events", len(got))
+	}
+	if got := flowPhaseNotificationEvents([]flowstore.FlowRecord{running}, []flowstore.FlowRecord{terminal}); len(got) != 1 {
+		t.Fatalf("terminal re-entry emitted %d events, want 1", len(got))
+	}
+	newFlow := notificationFlow("flow-2", flowstore.PhaseBlocked)
+	if got := flowPhaseNotificationEvents([]flowstore.FlowRecord{terminal}, []flowstore.FlowRecord{terminal, newFlow}); len(got) != 0 {
+		t.Fatalf("newly discovered Flow emitted %d events", len(got))
+	}
+}
+
+func TestAutoAdvancePollEmitsFlowPhaseNotificationAndPreservesPartialBaseline(t *testing.T) {
+	previous := notificationFlow("flow-1", flowstore.PhaseRunning)
+	current := notificationFlow("flow-1", flowstore.PhaseNeedsAttention)
+	m := NewWithOptions(nil, Options{NotificationsEnabled: true})
+	m.autoAdvanceSnapshot = []flowstore.FlowRecord{previous}
+	m.autoAdvanceInFlight = 1
+
+	next, cmd := m.handleAutoAdvanceResult(AutoAdvanceResultMsg{Flows: []flowstore.FlowRecord{current}, Request: 1})
+	if got := rawNotificationStrings(cmd); len(got) != 1 || !strings.Contains(got[0], "Implementation needs attention") {
+		t.Fatalf("auto-advance notifications = %#v", got)
+	}
+
+	next.autoAdvanceInFlight = 2
+	before := cloneFlowRecords(next.autoAdvanceSnapshot)
+	partial := &flowstore.PartialListError{}
+	after, _ := next.handleAutoAdvanceResult(AutoAdvanceResultMsg{
+		Flows:       []flowstore.FlowRecord{notificationFlow("flow-1", flowstore.PhaseBlocked)},
+		Degradation: partial, Request: 2,
+	})
+	if got := after.autoAdvanceSnapshot[0].Phases[0].Status; got != before[0].Phases[0].Status {
+		t.Fatalf("partial poll baseline status = %q, want %q", got, before[0].Phases[0].Status)
+	}
+}
+
+func notificationFlow(id string, status flowstore.PhaseStatus) flowstore.FlowRecord {
+	return flowstore.FlowRecord{
+		FlowID: id,
+		Title:  "OSC 9 desktop notifications",
+		Phases: []flowstore.FlowPhase{{
+			PhaseID: "implementation",
+			Title:   "Implementation",
+			Status:  status,
+		}},
+	}
+}
+
+func TestNotificationCmdSuppressesEmptyMessage(t *testing.T) {
+	if cmd := (Model{notificationsEnabled: true}).notificationCmd(notificationEvent{}); cmd != nil {
+		t.Fatal("empty notification returned a command")
+	}
+}
+
+func TestNotificationTextStripsControlsAndNormalizesWhitespace(t *testing.T) {
+	input := "  codex\a\x1b]9;injected\u009b\tfinished\r\nin   approach  "
+	const want = "codex ]9;injected finished in approach"
+	if got := sanitizeNotificationText(input); got != want {
+		t.Fatalf("sanitized text = %q, want %q", got, want)
+	}
+}
+
+func TestNotificationTextHasDeterministicRuneLimit(t *testing.T) {
+	input := strings.Repeat("é", notificationMessageMaxRunes+20)
+	want := strings.Repeat("é", notificationMessageMaxRunes)
+	if got := sanitizeNotificationText(input); got != want {
+		t.Fatalf("sanitized text has %d runes, want %d", len([]rune(got)), notificationMessageMaxRunes)
+	}
+}

--- a/model/tmux_mode.go
+++ b/model/tmux_mode.go
@@ -147,6 +147,7 @@ func (m Model) launchAgentInRepoTmuxSession(ctx actions.AgentLaunchContext, rele
 		return m.startFlowLaunchFailure(ctx, err.Error())
 	}
 	m, launchCmd := m.runAgentLaunchWithStatus(ctx, spec.Launch, release, tmuxLaunchStatus(spec))
+	launchCmd = markTmuxAgentResult(launchCmd)
 	// The session name comes from the spec the launch actually used, so the
 	// terminal can never attach to a name this launch did not create.
 	m, terminalCmd := m.maybeOpenRepoTmuxTerminal(ctx.RepoPath, spec.SessionName)


### PR DESCRIPTION
The TUI currently gives no signal when a detached agent finishes or a Flow phase reaches a terminal state unless the user is watching it. This adds opt-in OSC 9 notifications so supported terminals can surface those events as desktop notifications.

The new notifications.enabled setting defaults to false. When enabled, the Bubble Tea renderer emits sanitized OSC 9 sequences for embedded and tmux agent exits, and for Flow phases entering completed, blocked, or needs_attention. Edge tracking suppresses startup replays and duplicate alerts. Tmux launches use immutable launch markers and DCS passthrough so notifications reach the host terminal without confusing the tmux session.

The implementation also preserves bracketed-paste framing while handling direct interactive exits and treats inconclusive tmux probes as unknown rather than falsely reporting completion.

Verification:
- make fmt-check
- make test
- make build
- scratch-root real-TTY tmux smoke test completed during implementation with no renderer corruption