### PR TITLE
perf(sessions): filter liveness records by launch

### DIFF
--- a/cmd/approach/main.go
+++ b/cmd/approach/main.go
@@ -555,16 +555,13 @@ func startProgram(repos []scanner.Repo, opts startProgramOptions) error {
 // launch whose latest end is a `clear` is continued, not ended.
 func sessionLivenessProbe(store *sessions.Store) launchcontrol.LivenessProbe {
 	return func(launchID string) (launchcontrol.LaunchLiveness, error) {
-		records, err := store.List(sessions.SessionFilter{})
+		records, err := store.List(sessions.SessionFilter{LaunchID: launchID})
 		if err != nil {
 			return launchcontrol.LaunchLiveness{}, err
 		}
 		liveness := launchcontrol.LaunchLiveness{Ended: true}
 		var latest sessions.SessionRecord
 		for _, record := range records {
-			if strings.TrimSpace(record.LaunchID) != launchID {
-				continue
-			}
 			liveness.RecordKnown = true
 			if sessions.IsActive(record.Status, record.EndedAt) || !sessionEndIsProcessEnd(record.Provider) {
 				liveness.Ended = false

--- a/sessions/store.go
+++ b/sessions/store.go
@@ -89,6 +89,7 @@ type SessionFilter struct {
 	WorktreePath string
 	Branch       string
 	Provider     Provider
+	LaunchID     string
 }
 
 type TranscriptEvent struct {
@@ -659,6 +660,9 @@ func matchesFilter(record SessionRecord, filter SessionFilter) bool {
 		return false
 	}
 	if filter.Provider != "" && record.Provider != filter.Provider {
+		return false
+	}
+	if launchID := strings.TrimSpace(filter.LaunchID); launchID != "" && strings.TrimSpace(record.LaunchID) != launchID {
 		return false
 	}
 	return true

--- a/sessions/store_test.go
+++ b/sessions/store_test.go
@@ -74,6 +74,41 @@ func TestStoreSavesAndListsSessionsByRepoPath(t *testing.T) {
 	}
 }
 
+func TestStoreListsSessionsByNormalizedLaunchID(t *testing.T) {
+	store, err := sessions.NewStore(sessions.StoreOptions{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+	for _, record := range []sessions.SessionRecord{
+		{Provider: sessions.ProviderCodex, SessionID: "target", LaunchID: " launch-1 ", Branch: "feature"},
+		{Provider: sessions.ProviderClaude, SessionID: "other-provider", LaunchID: "launch-1", Branch: "feature"},
+		{Provider: sessions.ProviderCodex, SessionID: "other-launch", LaunchID: "launch-2", Branch: "feature"},
+	} {
+		if err := store.Upsert(record); err != nil {
+			t.Fatalf("Upsert(%#v) error = %v", record, err)
+		}
+	}
+
+	records, err := store.List(sessions.SessionFilter{
+		LaunchID: " launch-1 ",
+		Provider: sessions.ProviderCodex,
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(records) != 1 || records[0].SessionID != "target" {
+		t.Fatalf("List() = %#v, want only target session", records)
+	}
+
+	records, err = store.List(sessions.SessionFilter{Provider: sessions.ProviderCodex})
+	if err != nil {
+		t.Fatalf("List() without LaunchID error = %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("List() without LaunchID returned %d records, want 2: %#v", len(records), records)
+	}
+}
+
 func TestStoreReadUsesExactProviderAndRawSessionID(t *testing.T) {
 	store, err := sessions.NewStore(sessions.StoreOptions{Root: t.TempDir()})
 	if err != nil {


### PR DESCRIPTION
The Flow liveness sweep queried every stored session once per launch, then discarded unrelated records in the caller. That made each sweep repeat a full session-store scan for every launch directory.

This change adds a normalized `LaunchID` field to `sessions.SessionFilter` and uses it in `sessionLivenessProbe`. Existing provider-aware reduction behavior and empty-filter behavior remain unchanged.

Tests cover LaunchID normalization, composition with provider filtering, and the existing behavior when LaunchID is omitted.

Verification:
- `go test ./sessions ./cmd/approach`
- `make fmt-check`
- Implementation phase: `make test` and `make build`